### PR TITLE
fix : BE health check 경로 수정

### DIFF
--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -45,13 +45,13 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /actuator/health
+              path: /health/readiness
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /actuator/health
+              path: /health/liveness
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 30


### PR DESCRIPTION
## 이슈
closes #11

## 작업 내용
- actuator base-path가 `/`이므로 probe 경로를 `/health/readiness`, `/health/liveness`로 수정