### PR TITLE
docs : 인증 모듈 설계 및 프로젝트 관리 체계 구성

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ orino/
 - 구현 작업 시 관련 GitHub Issue를 확인하고, 완료 후 프로젝트 보드 상태를 업데이트한다
 - 설계 변경이 발생하면 GitHub Wiki 문서도 함께 업데이트한다
 - 새로운 기능 작업 시 GitHub Issue가 없으면 먼저 생성한다
+- Issue/PR 생성 시 assignee를 항상 `wcorn`으로 설정한다
 
 ## Backend (be/)
 


### PR DESCRIPTION
## 이슈
- 인증 모듈 설계 및 프로젝트 관리 체계 구성

## 작업 내용
- CLAUDE.md에 Documentation & Project Management 섹션 추가
- 자동 관리 규칙 추가 (이슈/Wiki/프로젝트 보드 자동 관리, assignee 자동 설정)
- 역할별 슬래시 커맨드 추가 (`/be-fe`, `/infra`, `/planning`)
- 인증 모듈 설계 문서 GitHub Wiki 등록
- GitHub Projects 칸반 보드 생성 및 이슈 연결