### PR TITLE
feat : JWT 토큰 유틸리티 구현

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -33,6 +33,11 @@ dependencies {
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
     // DB
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/be/src/main/java/ds/project/orino/OrinoApplication.java
+++ b/be/src/main/java/ds/project/orino/OrinoApplication.java
@@ -2,8 +2,10 @@ package ds.project.orino;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class OrinoApplication {
     public static void main(String[] args) {
         SpringApplication.run(OrinoApplication.class, args);

--- a/be/src/main/java/ds/project/orino/config/jwt/JwtProperties.java
+++ b/be/src/main/java/ds/project/orino/config/jwt/JwtProperties.java
@@ -1,0 +1,11 @@
+package ds.project.orino.config.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        long accessTokenExpiration,
+        long refreshTokenExpiration
+) {
+}

--- a/be/src/main/java/ds/project/orino/config/jwt/JwtTokenProvider.java
+++ b/be/src/main/java/ds/project/orino/config/jwt/JwtTokenProvider.java
@@ -1,0 +1,64 @@
+package ds.project.orino.config.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+    private final long accessTokenExpiration;
+    private final long refreshTokenExpiration;
+
+    public JwtTokenProvider(JwtProperties properties) {
+        this.secretKey = Keys.hmacShaKeyFor(properties.secret().getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpiration = properties.accessTokenExpiration();
+        this.refreshTokenExpiration = properties.refreshTokenExpiration();
+    }
+
+    public String createAccessToken(Long memberId) {
+        return createToken(memberId, accessTokenExpiration);
+    }
+
+    public String createRefreshToken(Long memberId) {
+        return createToken(memberId, refreshTokenExpiration);
+    }
+
+    public Long getMemberId(String token) {
+        return parseClaims(token).get("memberId", Long.class);
+    }
+
+    public boolean validate(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private String createToken(Long memberId, long expiration) {
+        Date now = new Date();
+        return Jwts.builder()
+                .claim("memberId", memberId)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -6,3 +6,8 @@ spring:
       - mysql
       - actuator
       - redis
+
+jwt:
+  secret: ${JWT_SECRET:default-dev-secret-key-must-be-at-least-256-bits-long-for-hs256}
+  access-token-expiration: 1800000
+  refresh-token-expiration: 1209600000

--- a/be/src/test/java/ds/project/orino/config/jwt/JwtTokenProviderTest.java
+++ b/be/src/test/java/ds/project/orino/config/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,76 @@
+package ds.project.orino.config.jwt;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties properties = new JwtProperties(
+                "test-secret-key-must-be-at-least-256-bits-long-for-hs256-algorithm",
+                1800000,
+                1209600000
+        );
+        jwtTokenProvider = new JwtTokenProvider(properties);
+    }
+
+    @Test
+    @DisplayName("Access Token을 생성하고 memberId를 추출한다")
+    void createAccessToken_and_getMemberId() {
+        String token = jwtTokenProvider.createAccessToken(1L);
+
+        assertThat(jwtTokenProvider.validate(token)).isTrue();
+        assertThat(jwtTokenProvider.getMemberId(token)).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("Refresh Token을 생성하고 memberId를 추출한다")
+    void createRefreshToken_and_getMemberId() {
+        String token = jwtTokenProvider.createRefreshToken(1L);
+
+        assertThat(jwtTokenProvider.validate(token)).isTrue();
+        assertThat(jwtTokenProvider.getMemberId(token)).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("잘못된 토큰은 검증에 실패한다")
+    void validate_invalidToken() {
+        assertThat(jwtTokenProvider.validate("invalid.token.value")).isFalse();
+    }
+
+    @Test
+    @DisplayName("다른 키로 서명된 토큰은 검증에 실패한다")
+    void validate_differentKey() {
+        JwtProperties otherProperties = new JwtProperties(
+                "other-secret-key-must-be-at-least-256-bits-long-for-hs256-algorithm!",
+                1800000,
+                1209600000
+        );
+        JwtTokenProvider otherProvider = new JwtTokenProvider(otherProperties);
+
+        String token = otherProvider.createAccessToken(1L);
+
+        assertThat(jwtTokenProvider.validate(token)).isFalse();
+    }
+
+    @Test
+    @DisplayName("만료된 토큰은 검증에 실패한다")
+    void validate_expiredToken() {
+        JwtProperties expiredProperties = new JwtProperties(
+                "test-secret-key-must-be-at-least-256-bits-long-for-hs256-algorithm",
+                -1000,
+                -1000
+        );
+        JwtTokenProvider expiredProvider = new JwtTokenProvider(expiredProperties);
+
+        String token = expiredProvider.createAccessToken(1L);
+
+        assertThat(jwtTokenProvider.validate(token)).isFalse();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- [x] #30

## 작업 내용
- jjwt 0.12.6 의존성 추가
- JwtProperties: ConfigurationProperties로 JWT 설정 바인딩
- JwtTokenProvider: Access Token(30분), Refresh Token(14일) 생성/검증/memberId 추출
- 단위 테스트 5건 (생성+추출, 잘못된 토큰, 다른 키, 만료 토큰)

> ⚠️ 이 PR은 #43 (Spring Security 도입) 머지 후 머지해야 합니다.