### PR TITLE
feat : Refresh Token Redis 관리 구현

### DIFF
--- a/be/src/main/java/ds/project/orino/domain/auth/repository/RefreshTokenRepository.java
+++ b/be/src/main/java/ds/project/orino/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,32 @@
+package ds.project.orino.domain.auth.repository;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Repository
+public class RefreshTokenRepository {
+
+    private static final String KEY_PREFIX = "auth:refresh:";
+    private static final Duration TTL = Duration.ofDays(14);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public RefreshTokenRepository(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(Long memberId, String refreshToken) {
+        redisTemplate.opsForValue().set(KEY_PREFIX + memberId, refreshToken, TTL);
+    }
+
+    public Optional<String> findByMemberId(Long memberId) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(KEY_PREFIX + memberId));
+    }
+
+    public void deleteByMemberId(Long memberId) {
+        redisTemplate.delete(KEY_PREFIX + memberId);
+    }
+}

--- a/be/src/test/java/ds/project/orino/config/TestRedisConfig.java
+++ b/be/src/test/java/ds/project/orino/config/TestRedisConfig.java
@@ -1,0 +1,16 @@
+package ds.project.orino.config;
+
+import com.redis.testcontainers.RedisContainer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestRedisConfig {
+
+    @Bean
+    @ServiceConnection
+    public RedisContainer redisContainer() {
+        return new RedisContainer("redis:7");
+    }
+}

--- a/be/src/test/java/ds/project/orino/domain/auth/repository/RefreshTokenRepositoryTest.java
+++ b/be/src/test/java/ds/project/orino/domain/auth/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,61 @@
+package ds.project.orino.domain.auth.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import ds.project.orino.config.TestRedisConfig;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(TestRedisConfig.class)
+class RefreshTokenRepositoryTest {
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Test
+    @DisplayName("Refresh Token을 저장하고 조회한다")
+    void save_and_find() {
+        refreshTokenRepository.save(1L, "test-refresh-token");
+
+        Optional<String> found = refreshTokenRepository.findByMemberId(1L);
+
+        assertThat(found).isPresent();
+        assertThat(found.get()).isEqualTo("test-refresh-token");
+    }
+
+    @Test
+    @DisplayName("Refresh Token을 삭제한다")
+    void delete() {
+        refreshTokenRepository.save(2L, "to-be-deleted");
+
+        refreshTokenRepository.deleteByMemberId(2L);
+
+        assertThat(refreshTokenRepository.findByMemberId(2L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("새 토큰 저장 시 기존 토큰을 덮어쓴다")
+    void save_overwrite() {
+        refreshTokenRepository.save(3L, "old-token");
+        refreshTokenRepository.save(3L, "new-token");
+
+        Optional<String> found = refreshTokenRepository.findByMemberId(3L);
+
+        assertThat(found).isPresent();
+        assertThat(found.get()).isEqualTo("new-token");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 memberId 조회 시 빈 Optional을 반환한다")
+    void findByMemberId_notFound() {
+        assertThat(refreshTokenRepository.findByMemberId(999L)).isEmpty();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- [x] #31

## 작업 내용
- RefreshTokenRepository: Redis에 Refresh Token 저장/조회/삭제
  - 키 형식: `auth:refresh:{memberId}`, TTL 14일
  - 사용자당 1개 (새 발급 시 덮어쓰기)
- TestRedisConfig: Redis TestContainer 설정 추가
- 테스트 4건 (저장+조회, 삭제, 덮어쓰기, 미존재 조회)

> ⚠️ 이 PR은 #45 (JWT 토큰 유틸리티) 머지 후 머지해야 합니다.