### PR TITLE
feat : 인증 API 구현 (login, reissue, logout)

### DIFF
--- a/be/src/main/java/ds/project/orino/common/response/api/ApiResponse.java
+++ b/be/src/main/java/ds/project/orino/common/response/api/ApiResponse.java
@@ -1,0 +1,28 @@
+package ds.project.orino.common.response.api;
+
+public class ApiResponse<T> {
+
+    private final String code;
+    private final T data;
+
+    private ApiResponse(String code, T data) {
+        this.code = code;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(CustomResponseCode.SUCCESS.getMessage(), data);
+    }
+
+    public static ApiResponse<Void> success() {
+        return new ApiResponse<>(CustomResponseCode.SUCCESS.getMessage(), null);
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public T getData() {
+        return data;
+    }
+}

--- a/be/src/main/java/ds/project/orino/common/response/exception/ErrorCode.java
+++ b/be/src/main/java/ds/project/orino/common/response/exception/ErrorCode.java
@@ -1,18 +1,26 @@
 package ds.project.orino.common.response.exception;
 
+import org.springframework.http.HttpStatus;
+
 public enum ErrorCode {
 
     // GLOBAL
-    BAD_REQUEST("GLB-ERR-001", "잘못된 요청입니다."),
-    METHOD_NOT_ALLOWED("GLB-ERR-002", "허용되지 않은 메서드입니다."),
-    INTERNAL_SERVER_ERROR("GLB-ERR-003", "내부 서버 오류입니다.");
+    BAD_REQUEST("GLB-ERR-001", "잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+    METHOD_NOT_ALLOWED("GLB-ERR-002", "허용되지 않은 메서드입니다.", HttpStatus.METHOD_NOT_ALLOWED),
+    INTERNAL_SERVER_ERROR("GLB-ERR-003", "내부 서버 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+    // AUTH
+    INVALID_CREDENTIALS("AUTH-ERR-001", "아이디 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_TOKEN("AUTH-ERR-002", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED);
 
     private final String code;
     private final String message;
+    private final HttpStatus httpStatus;
 
-    ErrorCode(String code, String message) {
+    ErrorCode(String code, String message, HttpStatus httpStatus) {
         this.code = code;
         this.message = message;
+        this.httpStatus = httpStatus;
     }
 
     public String getCode() {
@@ -25,6 +33,10 @@ public enum ErrorCode {
 
     public String getMessage(Throwable e) {
         return message + " - " + e.getMessage();
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
     }
 
     public String getMessage(String additionalMessage) {

--- a/be/src/main/java/ds/project/orino/common/response/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/ds/project/orino/common/response/exception/GlobalExceptionHandler.java
@@ -25,7 +25,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
         log.error("handleCustomException: {}", e.getErrorCode().toString());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(ErrorResponse.of(e.getErrorCode()));
     }
 

--- a/be/src/main/java/ds/project/orino/domain/auth/controller/AuthController.java
+++ b/be/src/main/java/ds/project/orino/domain/auth/controller/AuthController.java
@@ -1,0 +1,78 @@
+package ds.project.orino.domain.auth.controller;
+
+import ds.project.orino.common.response.api.ApiResponse;
+import ds.project.orino.domain.auth.dto.LoginRequest;
+import ds.project.orino.domain.auth.dto.TokenResponse;
+import ds.project.orino.domain.auth.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private static final String REFRESH_TOKEN_COOKIE = "refreshToken";
+    private static final String COOKIE_PATH = "/api/auth";
+    private static final long COOKIE_MAX_AGE = 14 * 24 * 60 * 60;
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<TokenResponse>> login(@Valid @RequestBody LoginRequest request) {
+        AuthService.LoginResult result = authService.login(request);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, createRefreshTokenCookie(result.refreshToken()).toString())
+                .body(ApiResponse.success(result.tokenResponse()));
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<TokenResponse>> reissue(
+            @CookieValue(name = REFRESH_TOKEN_COOKIE) String refreshToken) {
+        AuthService.LoginResult result = authService.reissue(refreshToken);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, createRefreshTokenCookie(result.refreshToken()).toString())
+                .body(ApiResponse.success(result.tokenResponse()));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @CookieValue(name = REFRESH_TOKEN_COOKIE, required = false) String refreshToken) {
+        if (refreshToken != null) {
+            authService.logout(refreshToken);
+        }
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, clearRefreshTokenCookie().toString())
+                .body(ApiResponse.success());
+    }
+
+    private ResponseCookie createRefreshTokenCookie(String token) {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE, token)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path(COOKIE_PATH)
+                .maxAge(COOKIE_MAX_AGE)
+                .build();
+    }
+
+    private ResponseCookie clearRefreshTokenCookie() {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE, "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path(COOKIE_PATH)
+                .maxAge(0)
+                .build();
+    }
+}

--- a/be/src/main/java/ds/project/orino/domain/auth/dto/LoginRequest.java
+++ b/be/src/main/java/ds/project/orino/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package ds.project.orino.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "아이디를 입력해주세요.") String loginId,
+        @NotBlank(message = "비밀번호를 입력해주세요.") String password
+) {
+}

--- a/be/src/main/java/ds/project/orino/domain/auth/dto/TokenResponse.java
+++ b/be/src/main/java/ds/project/orino/domain/auth/dto/TokenResponse.java
@@ -1,0 +1,4 @@
+package ds.project.orino.domain.auth.dto;
+
+public record TokenResponse(String accessToken) {
+}

--- a/be/src/main/java/ds/project/orino/domain/auth/service/AuthService.java
+++ b/be/src/main/java/ds/project/orino/domain/auth/service/AuthService.java
@@ -1,0 +1,74 @@
+package ds.project.orino.domain.auth.service;
+
+import ds.project.orino.common.response.exception.CustomException;
+import ds.project.orino.common.response.exception.ErrorCode;
+import ds.project.orino.config.jwt.JwtTokenProvider;
+import ds.project.orino.domain.auth.dto.LoginRequest;
+import ds.project.orino.domain.auth.dto.TokenResponse;
+import ds.project.orino.domain.auth.repository.RefreshTokenRepository;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public AuthService(MemberRepository memberRepository, RefreshTokenRepository refreshTokenRepository,
+                       JwtTokenProvider jwtTokenProvider, BCryptPasswordEncoder passwordEncoder) {
+        this.memberRepository = memberRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public record LoginResult(TokenResponse tokenResponse, String refreshToken) {
+    }
+
+    public LoginResult login(LoginRequest request) {
+        Member member = memberRepository.findByLoginId(request.loginId())
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(request.password(), member.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+        refreshTokenRepository.save(member.getId(), refreshToken);
+
+        return new LoginResult(new TokenResponse(accessToken), refreshToken);
+    }
+
+    public LoginResult reissue(String refreshToken) {
+        if (!jwtTokenProvider.validate(refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        Long memberId = jwtTokenProvider.getMemberId(refreshToken);
+        String stored = refreshTokenRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));
+
+        if (!stored.equals(refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(memberId);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(memberId);
+        refreshTokenRepository.save(memberId, newRefreshToken);
+
+        return new LoginResult(new TokenResponse(newAccessToken), newRefreshToken);
+    }
+
+    public void logout(String refreshToken) {
+        if (jwtTokenProvider.validate(refreshToken)) {
+            Long memberId = jwtTokenProvider.getMemberId(refreshToken);
+            refreshTokenRepository.deleteByMemberId(memberId);
+        }
+    }
+}

--- a/be/src/test/java/ds/project/orino/domain/auth/service/AuthServiceTest.java
+++ b/be/src/test/java/ds/project/orino/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,119 @@
+package ds.project.orino.domain.auth.service;
+
+import ds.project.orino.common.response.exception.CustomException;
+import ds.project.orino.common.response.exception.ErrorCode;
+import ds.project.orino.config.jwt.JwtTokenProvider;
+import ds.project.orino.domain.auth.dto.LoginRequest;
+import ds.project.orino.domain.auth.repository.RefreshTokenRepository;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("로그인 성공 시 AT와 RT를 반환한다")
+    void login_success() {
+        Member member = new Member("admin", "encoded");
+        given(memberRepository.findByLoginId("admin")).willReturn(Optional.of(member));
+        given(passwordEncoder.matches("password", "encoded")).willReturn(true);
+        given(jwtTokenProvider.createAccessToken(any())).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(any())).willReturn("refresh-token");
+
+        AuthService.LoginResult result = authService.login(new LoginRequest("admin", "password"));
+
+        assertThat(result.tokenResponse().accessToken()).isEqualTo("access-token");
+        assertThat(result.refreshToken()).isEqualTo("refresh-token");
+        verify(refreshTokenRepository).save(any(), eq("refresh-token"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 아이디로 로그인 시 예외를 던진다")
+    void login_invalidLoginId() {
+        given(memberRepository.findByLoginId("unknown")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.login(new LoginRequest("unknown", "password")))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.INVALID_CREDENTIALS));
+    }
+
+    @Test
+    @DisplayName("비밀번호 불일치 시 예외를 던진다")
+    void login_invalidPassword() {
+        Member member = new Member("admin", "encoded");
+        given(memberRepository.findByLoginId("admin")).willReturn(Optional.of(member));
+        given(passwordEncoder.matches("wrong", "encoded")).willReturn(false);
+
+        assertThatThrownBy(() -> authService.login(new LoginRequest("admin", "wrong")))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.INVALID_CREDENTIALS));
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 성공 시 새 AT와 RT를 반환한다")
+    void reissue_success() {
+        given(jwtTokenProvider.validate("old-rt")).willReturn(true);
+        given(jwtTokenProvider.getMemberId("old-rt")).willReturn(1L);
+        given(refreshTokenRepository.findByMemberId(1L)).willReturn(Optional.of("old-rt"));
+        given(jwtTokenProvider.createAccessToken(1L)).willReturn("new-at");
+        given(jwtTokenProvider.createRefreshToken(1L)).willReturn("new-rt");
+
+        AuthService.LoginResult result = authService.reissue("old-rt");
+
+        assertThat(result.tokenResponse().accessToken()).isEqualTo("new-at");
+        assertThat(result.refreshToken()).isEqualTo("new-rt");
+        verify(refreshTokenRepository).save(1L, "new-rt");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 RT로 갱신 시 예외를 던진다")
+    void reissue_invalidToken() {
+        given(jwtTokenProvider.validate("invalid")).willReturn(false);
+
+        assertThatThrownBy(() -> authService.reissue("invalid"))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.INVALID_TOKEN));
+    }
+
+    @Test
+    @DisplayName("로그아웃 시 RT를 삭제한다")
+    void logout_success() {
+        given(jwtTokenProvider.validate("rt")).willReturn(true);
+        given(jwtTokenProvider.getMemberId("rt")).willReturn(1L);
+
+        authService.logout("rt");
+
+        verify(refreshTokenRepository).deleteByMemberId(1L);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- [x] #33

## 작업 내용
- `POST /api/auth/login`: 아이디/비밀번호 검증 → AT 응답 + RT HttpOnly Cookie
- `POST /api/auth/reissue`: RT 검증 → AT+RT 재발급 (Rotation)
- `POST /api/auth/logout`: RT 삭제 + Cookie 제거
- ErrorCode에 AUTH-ERR-001(401), AUTH-ERR-002(401) 추가
- ErrorCode에 HttpStatus 필드 추가, GlobalExceptionHandler 연동
- ApiResponse 성공 응답 래퍼 추가
- AuthService 단위 테스트 6건

> ⚠️ 이 PR은 #47 (JWT 인증 필터) 머지 후 머지해야 합니다.