### PR TITLE
fix : Istio 배포 OutOfSync 및 Progressing 해결

### DIFF
--- a/infra/argocd/applications/istio-base-app.yaml
+++ b/infra/argocd/applications/istio-base-app.yaml
@@ -19,6 +19,12 @@ spec:
     server: https://kubernetes.default.svc
     namespace: istio-system
 
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      jqPathExpressions:
+        - .webhooks[]?.failurePolicy
+
   syncPolicy:
     automated:
       prune: true

--- a/infra/argocd/applications/istiod-app.yaml
+++ b/infra/argocd/applications/istiod-app.yaml
@@ -19,6 +19,12 @@ spec:
     server: https://kubernetes.default.svc
     namespace: istio-system
 
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      jqPathExpressions:
+        - .webhooks[]?.failurePolicy
+
   syncPolicy:
     automated:
       prune: true

--- a/infra/helm/istio-base/values.yaml
+++ b/infra/helm/istio-base/values.yaml
@@ -1,2 +1,3 @@
 base:
   defaultRevision: default
+  validationPolicy: SKIP

--- a/infra/helm/istio-gateway/values.yaml
+++ b/infra/helm/istio-gateway/values.yaml
@@ -1,3 +1,5 @@
 gateway:
   service:
     type: LoadBalancer
+  autoscaling:
+    enabled: false


### PR DESCRIPTION
## 이슈
closes #50
## 작업 내용
- istio-base: `validationPolicy: SKIP`으로 ValidatingWebhookConfiguration 충돌 해결
- istio-base, istiod: `ignoreDifferences`로 webhook failurePolicy 차이 무시
- istio-gateway: HPA 비활성화 (metrics-server 미설치 환경)