### PR TITLE
feat : cert-manager 배포 및 Let's Encrypt HTTPS 인증서 발급

### DIFF
--- a/infra/argocd/applications/cert-manager-app.yaml
+++ b/infra/argocd/applications/cert-manager-app.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: orino
+
+  source:
+    repoURL: https://github.com/wcorn/orino.git
+    targetRevision: main
+    path: infra/helm/cert-manager
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infra/argocd/project/project.yaml
+++ b/infra/argocd/project/project.yaml
@@ -26,6 +26,8 @@ spec:
       namespace: istio-ingress
     - server: https://kubernetes.default.svc
       namespace: cloudflared
+    - server: https://kubernetes.default.svc
+      namespace: cert-manager
 
   clusterResourceWhitelist:
     - group: "*"

--- a/infra/helm/cert-manager/Chart.lock
+++ b/infra/helm/cert-manager/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: cert-manager
+  repository: https://charts.jetstack.io
+  version: v1.20.1
+digest: sha256:1bf36eba44cf096b40355a697b8cffb302f07f9135374222aabdf686f017b7a9
+generated: "2026-04-02T01:42:42.053661+09:00"

--- a/infra/helm/cert-manager/Chart.yaml
+++ b/infra/helm/cert-manager/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: cert-manager
+description: cert-manager 인증서 자동 발급
+type: application
+version: 1.0.0
+appVersion: "v1.20.1"
+
+dependencies:
+  - name: cert-manager
+    version: v1.20.1
+    repository: https://charts.jetstack.io
+
+keywords:
+  - cert-manager
+  - tls
+  - letsencrypt

--- a/infra/helm/cert-manager/templates/clusterissuer.yaml
+++ b/infra/helm/cert-manager/templates/clusterissuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: wcorn@orino.dev
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    solvers:
+      - http01:
+          ingress:
+            class: istio

--- a/infra/helm/cert-manager/values.yaml
+++ b/infra/helm/cert-manager/values.yaml
@@ -1,0 +1,3 @@
+cert-manager:
+  crds:
+    enabled: true


### PR DESCRIPTION
## 이슈
closes #58
## 작업 내용
- cert-manager Helm wrapper chart 추가 (v1.20.1, CRD 포함)
- Let's Encrypt prod ClusterIssuer 구성 (HTTP-01 solver, istio class)
- ArgoCD Application 및 Project에 cert-manager 네임스페이스 추가
- Istio Gateway TLS 연동은 VirtualService PR(#59) 머지 후 별도 작업