### PR TITLE
feat : BE JWT Secret 추가

### DIFF
--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -37,6 +37,11 @@ spec:
                 secretKeyRef:
                   name: mysql-secret
                   key: MYSQL_PASSWORD
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: jwt-secret
+                  key: JWT_SECRET
             - name: REDIS_HOST
               value: {{ .Values.env.REDIS_HOST | quote }}
             - name: REDIS_PORT

--- a/infra/helm/be/templates/sealedsecret-jwt.yaml
+++ b/infra/helm/be/templates/sealedsecret-jwt.yaml
@@ -1,0 +1,12 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: jwt-secret
+  namespace: orino
+spec:
+  encryptedData:
+    JWT_SECRET: AgBf/eadkYZ8JGDDWisHFO8yqDX7XAgEZBaRjZJC8pJP83JZSOrWFWXF/5rsD1A3LXHcCb3/uTq2vlyntcfxFCHqcY3ZVD6hhwHekRsYfcb8DpY5sWlP7jxgKXrs7tDRdganEXzfbgWvkGLG4HEhYXzt32rRbWxpLHOZJ9TU2FKnwEEFTOFm5tcx2fnyfJPQgtupSQc/AQbIFw/exEip/MuF/Otcf0khG9Vzo3S53UC9FOrButZNYkCpuEA/U1iX6SKxQr4GUtjsPQAwWalxXn8xYYDa9anBjWM1r8piw/8nMNWfJJ6R8nE8EOtkLw0bx4D8N+a5osdeknQ1MsQB4IMK5aIhji5rC4Cn0KHCRuOjYa5QsW+4LF/nacgNXezlrBxLnEGnozF+kDhh7NOYuIDnVBv9Cyg6TdSQk5OjqdqYqQpGKBY33UEJ+aOmJdoB5okd14Oo7OPvNFoiHFVUnPNfht+T9q1sur/QEmc0mbo9+z4KmhtP7eeh62Atw6K7SkdkdpRUeDGqFDLPDte1KhUk9ehgcXNjlM7QLbFkCM9HPwEX+UWiqlngbvlagyxf6y1UrgRhgvGO9O8O+3ydJTAmbZ6P0FMdl9/ZWP3w3z5/NsXqqwH37GelxQXyLs1GIxXLI30SJC1Oqkjek4fyEOFsxMA6c9DZmq+G6pDDSrVhq3JQjwBNdVPp9r9qIl/Yf6Pg144ArDmR2P4B/dgHv9EKFAvGN/QA3gJc36fLbwwSLs8yDLq4QH7VaTpoADXG504fmZ0qLRk7/JsHoVKMBorm
+  template:
+    metadata:
+      name: jwt-secret
+      namespace: orino


### PR DESCRIPTION
## 이슈
closes #62
## 작업 내용
- JWT SealedSecret 작성 (jwt-secret, orino 네임스페이스)
- BE Deployment에 JWT_SECRET 환경변수 주입
- 인증 모듈에서 고정된 JWT 키를 사용하도록 보장