### PR TITLE
fix : ArgoCD Image Updater Helm 파라미터 매핑 추가

### DIFF
--- a/infra/argocd/applications/be-app.yaml
+++ b/infra/argocd/applications/be-app.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     argocd-image-updater.argoproj.io/image-list: be=ghcr.io/wcorn/orino/be
     argocd-image-updater.argoproj.io/be.update-strategy: digest
+    argocd-image-updater.argoproj.io/be.helm.image-name: image.repository
+    argocd-image-updater.argoproj.io/be.helm.image-tag: image.tag
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/infra/argocd/applications/fe-app.yaml
+++ b/infra/argocd/applications/fe-app.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     argocd-image-updater.argoproj.io/image-list: fe=ghcr.io/wcorn/orino/fe
     argocd-image-updater.argoproj.io/fe.update-strategy: digest
+    argocd-image-updater.argoproj.io/fe.helm.image-name: image.repository
+    argocd-image-updater.argoproj.io/fe.helm.image-tag: image.tag
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:


### PR DESCRIPTION
## 연관 이슈

- [x] ArgoCD Image Updater GHCR 이미지 감지 불가 문제

## 작업 내용

Image Updater가 Helm 파라미터를 오버라이드할 때 기본값(`image.name`)을 사용하는데,
실제 차트는 `image.repository`를 사용하여 이미지 업데이트가 반영되지 않던 문제를 수정합니다.

**변경사항:**
- `be-app.yaml`: `helm.image-name: image.repository`, `helm.image-tag: image.tag` 어노테이션 추가
- `fe-app.yaml`: 동일 어노테이션 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)