### PR TITLE
fix : Image Updater digest 전략에 allow-tags constraint 추가

### DIFF
--- a/infra/argocd/applications/be-app.yaml
+++ b/infra/argocd/applications/be-app.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     argocd-image-updater.argoproj.io/image-list: be=ghcr.io/wcorn/orino/be
     argocd-image-updater.argoproj.io/be.update-strategy: digest
+    argocd-image-updater.argoproj.io/be.allow-tags: regexp:^latest$
     argocd-image-updater.argoproj.io/be.helm.image-name: image.repository
     argocd-image-updater.argoproj.io/be.helm.image-tag: image.tag
   finalizers:

--- a/infra/argocd/applications/fe-app.yaml
+++ b/infra/argocd/applications/fe-app.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     argocd-image-updater.argoproj.io/image-list: fe=ghcr.io/wcorn/orino/fe
     argocd-image-updater.argoproj.io/fe.update-strategy: digest
+    argocd-image-updater.argoproj.io/fe.allow-tags: regexp:^latest$
     argocd-image-updater.argoproj.io/fe.helm.image-name: image.repository
     argocd-image-updater.argoproj.io/fe.helm.image-tag: image.tag
   finalizers:


### PR DESCRIPTION
## 연관 이슈

- [x] ArgoCD Image Updater digest 전략 에러 수정

## 작업 내용

Image Updater 로그에서 반복 발생하던 에러를 수정합니다:
```
cannot use update strategy 'digest' without a version constraint
```

`digest` 전략은 어떤 태그의 digest를 추적할지 `allow-tags` constraint가 필수입니다.
`latest` 태그를 추적하도록 `allow-tags: regexp:^latest$` 어노테이션을 추가합니다.

**변경사항:**
- `be-app.yaml`: `allow-tags: regexp:^latest$` 어노테이션 추가
- `fe-app.yaml`: 동일 어노테이션 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)