### PR TITLE
fix : Image Updater CR에 이미지 설정 직접 정의

### DIFF
--- a/infra/argocd/applications/be-app.yaml
+++ b/infra/argocd/applications/be-app.yaml
@@ -3,12 +3,7 @@ kind: Application
 metadata:
   name: be
   namespace: argocd
-  annotations:
-    argocd-image-updater.argoproj.io/image-list: be=ghcr.io/wcorn/orino/be
-    argocd-image-updater.argoproj.io/be.update-strategy: digest
-    argocd-image-updater.argoproj.io/be.allow-tags: regexp:^latest$
-    argocd-image-updater.argoproj.io/be.helm.image-name: image.repository
-    argocd-image-updater.argoproj.io/be.helm.image-tag: image.tag
+  annotations: {}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/infra/argocd/applications/fe-app.yaml
+++ b/infra/argocd/applications/fe-app.yaml
@@ -3,12 +3,7 @@ kind: Application
 metadata:
   name: fe
   namespace: argocd
-  annotations:
-    argocd-image-updater.argoproj.io/image-list: fe=ghcr.io/wcorn/orino/fe
-    argocd-image-updater.argoproj.io/fe.update-strategy: digest
-    argocd-image-updater.argoproj.io/fe.allow-tags: regexp:^latest$
-    argocd-image-updater.argoproj.io/fe.helm.image-name: image.repository
-    argocd-image-updater.argoproj.io/fe.helm.image-tag: image.tag
+  annotations: {}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/infra/helm/argocd-image-updater/templates/imageupdater.yaml
+++ b/infra/helm/argocd-image-updater/templates/imageupdater.yaml
@@ -6,6 +6,24 @@ metadata:
 spec:
   applicationRefs:
     - namePattern: "be"
-      useAnnotations: true
+      images:
+        - alias: be
+          imageName: "ghcr.io/wcorn/orino/be:latest"
+          commonUpdateSettings:
+            updateStrategy: digest
+            allowTags: "^latest$"
+          manifestTargets:
+            helm:
+              name: image.repository
+              tag: image.tag
     - namePattern: "fe"
-      useAnnotations: true
+      images:
+        - alias: fe
+          imageName: "ghcr.io/wcorn/orino/fe:latest"
+          commonUpdateSettings:
+            updateStrategy: digest
+            allowTags: "^latest$"
+          manifestTargets:
+            helm:
+              name: image.repository
+              tag: image.tag


### PR DESCRIPTION
## 연관 이슈

- [x] ArgoCD Image Updater 이미지 감지 불가 문제

## 작업 내용

ImageUpdater CR의 `useAnnotations: true` 모드가 Application 어노테이션(`allow-tags`, `helm.image-name` 등)을
제대로 전달하지 못하는 버그로 인해 digest 전략이 동작하지 않던 문제를 수정합니다.

**원인:** CR 컨트롤러가 `useAnnotations: true`일 때 `allow-tags` constraint를 읽지 못해
`"cannot use update strategy 'digest' without a version constraint"` 에러 반복

**수정 방법:** `useAnnotations` 대신 CR spec에 이미지 설정을 직접 정의

- `imageupdater.yaml`: CR spec에 이미지명, digest 전략, allowTags, Helm 파라미터 매핑 직접 명시
- `be-app.yaml`, `fe-app.yaml`: 불필요해진 image-updater 어노테이션 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)