### PR TITLE
feat : Istio CORS 정책 설정 (FE → BE cross-origin)

### DIFF
--- a/infra/helm/istio-gateway/templates/virtualservice-be.yaml
+++ b/infra/helm/istio-gateway/templates/virtualservice-be.yaml
@@ -9,7 +9,23 @@ spec:
   gateways:
     - orino-gateway
   http:
-    - route:
+    - corsPolicy:
+        allowOrigins:
+          - exact: "https://orino.dev"
+          - exact: "http://orino.dev"
+        allowMethods:
+          - GET
+          - POST
+          - PUT
+          - DELETE
+          - PATCH
+          - OPTIONS
+        allowHeaders:
+          - Authorization
+          - Content-Type
+        allowCredentials: true
+        maxAge: "86400s"
+      route:
         - destination:
             host: be.orino.svc.cluster.local
             port:


### PR DESCRIPTION
## 연관 이슈

- [x] #63

## 작업 내용

BE VirtualService에 CORS 정책을 추가하여 FE(orino.dev)에서 BE(api.orino.dev)로의 cross-origin 요청을 허용합니다.

- `allowOrigins`: https://orino.dev, http://orino.dev
- `allowMethods`: GET, POST, PUT, DELETE, PATCH, OPTIONS
- `allowHeaders`: Authorization, Content-Type
- `allowCredentials`: true (Refresh Token HttpOnly Cookie 전송용)
- `maxAge`: 86400s (preflight 캐시 24시간)

🤖 Generated with [Claude Code](https://claude.com/claude-code)