### PR TITLE
feat : Istio Gateway TLS 설정 (cert-manager 연동)

### DIFF
--- a/infra/helm/istio-gateway/templates/certificate.yaml
+++ b/infra/helm/istio-gateway/templates/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: orino-tls
+  namespace: istio-ingress
+spec:
+  secretName: orino-tls-credential
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - "orino.dev"
+    - "*.orino.dev"

--- a/infra/helm/istio-gateway/templates/gateway.yaml
+++ b/infra/helm/istio-gateway/templates/gateway.yaml
@@ -8,9 +8,21 @@ spec:
     istio: gateway
   servers:
     - port:
+        number: 443
+        name: https
+        protocol: HTTPS
+      tls:
+        mode: SIMPLE
+        credentialName: orino-tls-credential
+      hosts:
+        - "orino.dev"
+        - "*.orino.dev"
+    - port:
         number: 80
         name: http
         protocol: HTTP
+      tls:
+        httpsRedirect: true
       hosts:
         - "orino.dev"
         - "*.orino.dev"


### PR DESCRIPTION
## 연관 이슈

- [x] #61

## 작업 내용

cert-manager가 발급한 Let's Encrypt 인증서를 Istio Gateway에 연동하여 HTTPS를 활성화합니다.

- **Certificate 리소스**: `orino.dev`, `*.orino.dev` 와일드카드 인증서 발급 (letsencrypt-prod ClusterIssuer 사용)
- **Gateway HTTPS**: 443 포트에 TLS SIMPLE 모드, credentialName으로 인증서 Secret 참조
- **HTTP → HTTPS 리다이렉트**: 80 포트에 httpsRedirect 설정

🤖 Generated with [Claude Code](https://claude.com/claude-code)