### PR TITLE
fix : Infra CI 파이프라인 오류 수정

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -86,6 +86,6 @@ jobs:
             if [ -f "$chart/Chart.yaml" ]; then
               echo "Validating $chart"
               helm dependency build "$chart" 2>/dev/null || true
-              helm template "$chart" | kubeconform -strict -summary
+              helm template "$chart" | kubeconform -strict -ignore-missing-schemas -summary
             fi
           done

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,8 @@
 extends: default
 
+ignore:
+  - "infra/helm/*/templates/"
+
 rules:
   line-length:
     max: 200


### PR DESCRIPTION
## 연관 이슈

- [x] #65

## 작업 내용

Infra CI 파이프라인 실패 원인 2가지를 수정합니다.

- **yamllint**: Helm 템플릿(`templates/`)의 Go 템플릿 구문(`{{ }}`)을 YAML 문법 오류로 인식 → ignore 처리
- **kubeconform**: SealedSecret 등 CRD 스키마 미존재 시 실패 → `--ignore-missing-schemas` 적용