### PR TITLE
fix : Image Updater allowTags regexp 접두사 추가

### DIFF
--- a/infra/argocd/app-of-apps/root-app.yaml
+++ b/infra/argocd/app-of-apps/root-app.yaml
@@ -22,6 +22,8 @@ spec:
       kind: Application
       jsonPointers:
         - /metadata/finalizers
+        - /spec/source/helm
+        - /spec/source/helm
 
   syncPolicy:
     automated:

--- a/infra/helm/argocd-image-updater/templates/imageupdater.yaml
+++ b/infra/helm/argocd-image-updater/templates/imageupdater.yaml
@@ -11,7 +11,7 @@ spec:
           imageName: "ghcr.io/wcorn/orino/be:latest"
           commonUpdateSettings:
             updateStrategy: digest
-            allowTags: "^latest$"
+            allowTags: "regexp:^latest$"
           manifestTargets:
             helm:
               name: image.repository
@@ -22,7 +22,7 @@ spec:
           imageName: "ghcr.io/wcorn/orino/fe:latest"
           commonUpdateSettings:
             updateStrategy: digest
-            allowTags: "^latest$"
+            allowTags: "regexp:^latest$"
           manifestTargets:
             helm:
               name: image.repository


### PR DESCRIPTION
## 연관 이슈

- [x] #68

## 작업 내용

Image Updater가 이미지 변경을 감지하고 자동 롤아웃하지 못하던 2가지 문제를 수정합니다.

**문제 1: allowTags 형식 오류**
- CR의 `allowTags`에 `regexp:` 접두사가 누락되어 digest 비교가 무효화됨
- `"^latest$"` → `"regexp:^latest$"`

**문제 2: root-app selfHeal이 helm 파라미터 오버라이드 롤백**
- Image Updater가 Application spec에 추가한 helm 파라미터 오버라이드를 root-app이 Git 상태로 되돌림
- root-app의 `ignoreDifferences`에 `/spec/source/helm` 추가

클러스터에서 두 패치 적용 후 `images_updated=2 errors=0` 및 되돌림 없음 확인 완료