### PR TITLE
fix : Spring Security health 엔드포인트 403 차단 수정

### DIFF
--- a/be/orino-core-web/src/main/java/ds/project/orino/core/security/SecurityConfig.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/security/SecurityConfig.java
@@ -26,7 +26,6 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/**",
-                                "/actuator/health",
                                 "/health/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**"


### PR DESCRIPTION
## 연관 이슈
- [x] #77 fix : Spring Security health 엔드포인트 403 차단 수정

## 작업 내용
- SecurityConfig permitAll 경로에 `/health/**` 추가
- actuator `base-path: /` 설정으로 probe 경로가 `/health/readiness`, `/health/liveness`로 노출되나 Security에서 차단되던 문제 수정