### PR TITLE
feat : 랜딩 페이지 구현

### DIFF
--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -1,17 +1,19 @@
 import { Route, Routes } from "react-router-dom";
 import { PrivateRoute } from "../features/auth/components/PrivateRoute";
 import { PublicRoute } from "../features/auth/components/PublicRoute";
+import { LandingPage } from "../pages/LandingPage";
 import { LoginPage } from "../pages/LoginPage";
 import { MainPage } from "../pages/MainPage";
 
 export function AppRouter() {
   return (
     <Routes>
+      <Route path="/" element={<LandingPage />} />
       <Route element={<PublicRoute />}>
         <Route path="/login" element={<LoginPage />} />
       </Route>
       <Route element={<PrivateRoute />}>
-        <Route path="/" element={<MainPage />} />
+        <Route path="/home" element={<MainPage />} />
       </Route>
     </Routes>
   );

--- a/fe/src/features/auth/components/PublicRoute.tsx
+++ b/fe/src/features/auth/components/PublicRoute.tsx
@@ -3,5 +3,5 @@ import { useAuth } from "../../../app/providers";
 
 export function PublicRoute() {
   const { isAuthenticated } = useAuth();
-  return isAuthenticated ? <Navigate to="/" replace /> : <Outlet />;
+  return isAuthenticated ? <Navigate to="/home" replace /> : <Outlet />;
 }

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -79,6 +79,51 @@ body {
   text-align: center;
 }
 
+/* Landing */
+.landing-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.landing-content {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.landing-title {
+  font-size: 48px;
+  font-weight: 800;
+  color: #111;
+  letter-spacing: -1px;
+}
+
+.landing-description {
+  font-size: 16px;
+  color: #666;
+  line-height: 1.6;
+}
+
+.landing-login-button {
+  display: inline-block;
+  padding: 14px 48px;
+  background: #111;
+  color: #fff;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s;
+}
+
+.landing-login-button:hover {
+  background: #333;
+}
+
 /* Main */
 .main-container {
   min-height: 100vh;

--- a/fe/src/pages/LandingPage.tsx
+++ b/fe/src/pages/LandingPage.tsx
@@ -1,0 +1,24 @@
+import { Link, Navigate } from "react-router-dom";
+import { useAuth } from "../app/providers";
+
+export function LandingPage() {
+  const { isAuthenticated } = useAuth();
+
+  if (isAuthenticated) {
+    return <Navigate to="/home" replace />;
+  }
+
+  return (
+    <div className="landing-container">
+      <div className="landing-content">
+        <h1 className="landing-title">orino</h1>
+        <p className="landing-description">
+          나만의 학습 플래너로 효율적인 공부를 시작하세요.
+        </p>
+        <Link to="/login" className="landing-login-button">
+          로그인하기
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/pages/LoginPage.tsx
+++ b/fe/src/pages/LoginPage.tsx
@@ -19,7 +19,7 @@ export function LoginPage() {
     try {
       await login({ loginId, password });
       refresh();
-      navigate("/", { replace: true });
+      navigate("/home", { replace: true });
     } catch {
       setError("아이디 또는 비밀번호가 올바르지 않습니다.");
     } finally {

--- a/fe/src/pages/MainPage.tsx
+++ b/fe/src/pages/MainPage.tsx
@@ -9,7 +9,7 @@ export function MainPage() {
   const handleLogout = async () => {
     await logout();
     refresh();
-    navigate("/login", { replace: true });
+    navigate("/", { replace: true });
   };
 
   return (


### PR DESCRIPTION
## 연관 이슈
- [x] #87 FE: 랜딩 페이지 구현

## 작업 내용
- 루트 경로(/)에 랜딩 페이지 추가 (서비스 소개 + 로그인하기 버튼)
- 라우팅 변경: / → LandingPage, /login → LoginPage, /home → MainPage
- 인증된 사용자가 / 접속 시 /home으로 자동 이동
- 로그아웃 시 랜딩 페이지로 이동