### PR TITLE
fix : Longhorn BackupTarget CRD로 백업 설정 변경

### DIFF
--- a/infra/helm/longhorn/templates/backuptarget.yaml
+++ b/infra/helm/longhorn/templates/backuptarget.yaml
@@ -1,0 +1,9 @@
+apiVersion: longhorn.io/v1beta2
+kind: BackupTarget
+metadata:
+  name: default
+  namespace: longhorn-system
+spec:
+  backupTargetURL: "s3://orino-longhorn-backup@ap-northeast-2/"
+  credentialSecret: "longhorn-backup-s3"
+  pollInterval: "5m0s"

--- a/infra/helm/longhorn/values.yaml
+++ b/infra/helm/longhorn/values.yaml
@@ -4,8 +4,8 @@ longhorn:
     defaultReplicaCount: 2
     storageReservedPercentageForDefaultDisk: 5
     guaranteedInstanceManagerCPU: 2
-    backupTarget: s3://orino-longhorn-backup@ap-northeast-2/
-    backupTargetCredentialSecret: longhorn-backup-s3
+    backupTarget: ""
+    backupTargetCredentialSecret: ""
 
   persistence:
     defaultClassReplicaCount: 2


### PR DESCRIPTION
## 연관 이슈

- [x] #90

## 작업 내용

- Longhorn v1.11에서 `defaultSettings.backupTarget`이 기존 설치 환경에 적용되지 않는 문제 수정
- `BackupTarget` CRD 템플릿 추가하여 S3 백업 대상 직접 설정
- `defaultSettings`에서 미사용 backup 관련 값 제거