### PR TITLE
feat : Flyway DB 마이그레이션 도입

### DIFF
--- a/be/orino-app-api/build.gradle
+++ b/be/orino-app-api/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/be/orino-app-api/src/main/resources/application-mysql.yml
+++ b/be/orino-app-api/src/main/resources/application-mysql.yml
@@ -7,6 +7,12 @@ spring:
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  flyway:
+    baseline-on-migrate: true
+    baseline-version: 0
 ---
 spring:
   config:
@@ -18,11 +24,16 @@ spring:
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
+    hibernate:
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true
         highlight_sql: true
         generate_statistics: true
+  flyway:
+    baseline-on-migrate: true
+    baseline-version: 0
 
 logging:
   level:
@@ -42,3 +53,5 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+  flyway:
+    enabled: false

--- a/be/orino-app-api/src/main/resources/db/migration/V1__create_member.sql
+++ b/be/orino-app-api/src/main/resources/db/migration/V1__create_member.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS member (
+    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    login_id   VARCHAR(50)  NOT NULL,
+    password   VARCHAR(255) NOT NULL,
+    created_at DATETIME(6)  NOT NULL,
+    updated_at DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_member_login_id (login_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## 연관 이슈
- [x] #101

## 작업 내용

### Flyway 의존성
- `flyway-core`, `flyway-mysql` 추가 (orino-app-api)

### Profile별 설정
| Profile | ddl-auto | Flyway | 설명 |
|---------|----------|--------|------|
| local | validate | 활성화 | Flyway가 스키마 관리, Hibernate는 검증만 |
| prod | validate | 활성화 | 동일 |
| test | create-drop | 비활성화 | TestContainers가 매번 새 DB 생성 |

### 마이그레이션
- `V1__create_member.sql`: member 테이블 생성 (CREATE TABLE IF NOT EXISTS)
- `baseline-on-migrate: true` + `baseline-version: 0`으로 기존 운영 DB 호환

### 향후 사용법
테이블 추가/변경 시 `db/migration/V2__xxx.sql` 파일 추가 → 앱 시작 시 자동 실행