### PR TITLE
fix : Liquibase auto-configuration 미동작 수정

### DIFF
--- a/be/orino-app-api/build.gradle
+++ b/be/orino-app-api/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.liquibase:liquibase-core'
+    implementation 'org.springframework.boot:spring-boot-starter-liquibase'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
## 연관 이슈
- [x] #101

## 작업 내용

### 문제
운영 배포 시 `Schema validation: missing table [member]` 에러로 앱 시작 실패.
Liquibase가 실행되지 않아 테이블이 생성되지 않음.

### 원인
`liquibase-core`만 추가하면 Spring Boot의 Liquibase auto-configuration(`spring-boot-liquibase`)이 포함되지 않음.
→ Liquibase가 아예 실행되지 않고 Hibernate validate만 동작.

### 수정
`liquibase-core` → `spring-boot-starter-liquibase`로 변경.
starter에 auto-configuration + liquibase-core가 함께 포함됨.

### 검증
- `SchemaValidationTest` 통과 (Liquibase changelog 적용 → Hibernate validate 성공)