### PR TITLE
fix : Actuator 엔드포인트 403 수정

### DIFF
--- a/be/orino-core-web/build.gradle
+++ b/be/orino-core-web/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     api project(':orino-common')
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/be/orino-core-web/src/main/java/ds/project/orino/core/security/SecurityConfig.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/security/SecurityConfig.java
@@ -1,7 +1,9 @@
 package ds.project.orino.core.security;
 
+import org.springframework.boot.security.autoconfigure.actuate.web.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -19,6 +21,16 @@ public class SecurityConfig {
     }
 
     @Bean
+    @Order(0)
+    public SecurityFilterChain managementSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher(EndpointRequest.toAnyEndpoint())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+
+    @Bean
+    @Order(1)
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## 연관 이슈

- [x] #108

## 작업 내용

- management 포트(9090) readiness probe 403 Forbidden 수정
- EndpointRequest 매처로 Actuator 전용 SecurityFilterChain 추가 (permitAll)
- orino-core-web에 spring-boot-starter-actuator 의존성 추가