### PR TITLE
fix : auth API 호출을 client 인스턴스로 통일

### DIFF
--- a/fe/src/features/auth/api/auth.ts
+++ b/fe/src/features/auth/api/auth.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import client from "../../../shared/api/client";
 import { setAccessToken } from "../store/authStore";
 
@@ -13,13 +12,13 @@ interface TokenResponse {
 }
 
 export async function login(request: LoginRequest): Promise<void> {
-  const { data } = await axios.post<TokenResponse>("/api/auth/login", request);
+  const { data } = await client.post<TokenResponse>("/auth/login", request);
   setAccessToken(data.data.accessToken);
 }
 
 export async function reissue(): Promise<boolean> {
   try {
-    const { data } = await axios.post<TokenResponse>("/api/auth/reissue");
+    const { data } = await client.post<TokenResponse>("/auth/reissue");
     setAccessToken(data.data.accessToken);
     return true;
   } catch {


### PR DESCRIPTION
## 연관 이슈

- `POST /api/auth/reissue` 405 — `axios`를 직접 사용하여 baseURL이 적용되지 않음

## 작업 내용

- `auth.ts`의 `login`, `reissue` 함수가 `axios.post`를 직접 호출하여 `baseURL`(`https://api.orino.dev/api`)이 적용되지 않던 문제 수정
- `client` 인스턴스를 사용하도록 변경하여 baseURL 자동 적용