### PR TITLE
fix : 퍼블릭 라우트에서 불필요한 reissue 호출 제거

### DIFF
--- a/fe/src/app/providers.tsx
+++ b/fe/src/app/providers.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { useLocation } from "react-router-dom";
 import { reissue } from "../features/auth/api/auth";
 import { getAccessToken } from "../features/auth/store/authStore";
 
@@ -27,17 +28,24 @@ export function useAuth(): AuthContextType {
   return useContext(AuthContext);
 }
 
+const PUBLIC_ROUTES = ["/", "/login"];
+
 function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [version, setVersion] = useState(0);
+  const { pathname } = useLocation();
 
   useEffect(() => {
     if (getAccessToken()) {
       setLoading(false);
       return;
     }
+    if (PUBLIC_ROUTES.includes(pathname)) {
+      setLoading(false);
+      return;
+    }
     reissue().finally(() => setLoading(false));
-  }, [version]);
+  }, [version, pathname]);
 
   const isAuthenticated = getAccessToken() !== null;
   const refresh = () => setVersion((v) => v + 1);


### PR DESCRIPTION
## 연관 이슈

- [x] #112

## 작업 내용

- AuthProvider에서 퍼블릭 라우트(`/`, `/login`)일 때 reissue 호출을 스킵
- 로그인한 적 없는 사용자가 사이트 접근 시 불필요한 401 응답 방지