### PR TITLE
feat : Istio 트래픽 제어 및 장애 격리 설정

### DIFF
--- a/infra/helm/istio-gateway/templates/destinationrule-be.yaml
+++ b/infra/helm/istio-gateway/templates/destinationrule-be.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: be
+  namespace: istio-ingress
+spec:
+  host: be.orino.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        h2UpgradePolicy: DEFAULT
+        http1MaxPendingRequests: 50
+        http2MaxRequests: 100
+    outlierDetection:
+      consecutiveGatewayErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50

--- a/infra/helm/istio-gateway/templates/envoyfilter-ratelimit.yaml
+++ b/infra/helm/istio-gateway/templates/envoyfilter-ratelimit.yaml
@@ -1,0 +1,62 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: ratelimit-be
+  namespace: istio-ingress
+spec:
+  workloadSelector:
+    labels:
+      istio: gateway
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: envoy.filters.network.http_connection_manager
+              subFilter:
+                name: envoy.filters.http.router
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.local_ratelimit
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            value:
+              stat_prefix: http_local_rate_limiter
+    - applyTo: HTTP_ROUTE
+      match:
+        context: GATEWAY
+        routeConfiguration:
+          vhost:
+            name: api.orino.dev:80
+      patch:
+        operation: MERGE
+        value:
+          typed_per_filter_config:
+            envoy.filters.http.local_ratelimit:
+              "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+              type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              value:
+                stat_prefix: http_local_rate_limiter
+                token_bucket:
+                  max_tokens: 100
+                  tokens_per_fill: 100
+                  fill_interval: 60s
+                filter_enabled:
+                  runtime_key: local_rate_limit_enabled
+                  default_value:
+                    numerator: 100
+                    denominator: HUNDRED
+                filter_enforced:
+                  runtime_key: local_rate_limit_enforced
+                  default_value:
+                    numerator: 100
+                    denominator: HUNDRED
+                response_headers_to_add:
+                  - append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                    header:
+                      key: X-RateLimit-Limit
+                      value: "100"

--- a/infra/helm/istio-gateway/templates/virtualservice-be.yaml
+++ b/infra/helm/istio-gateway/templates/virtualservice-be.yaml
@@ -25,6 +25,11 @@ spec:
           - Content-Type
         allowCredentials: true
         maxAge: "86400s"
+      timeout: 10s
+      retries:
+        attempts: 2
+        retryOn: 5xx,reset,connect-failure
+        perTryTimeout: 3s
       route:
         - destination:
             host: be.orino.svc.cluster.local


### PR DESCRIPTION
## 이슈
closes #96

## 작업 내용
- **Rate Limiting**: BE API에 local rate limiting 적용 (100req/min, EnvoyFilter)
- **Circuit Breaker**: BE DestinationRule 추가 (연속 5xx 5회 → 30s 차단, 최대 50% ejection)
- **Retry/Timeout**: BE VirtualService에 timeout 10s, retry 2회 (5xx, reset, connect-failure) 설정
- FE는 정적 서빙이므로 별도 설정 없음