### PR TITLE
chore : SealedSecret 원본 비밀값 관리 체계 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ out/
 
 ### Environment ###
 be/.env
+.secrets
 
 ### Terraform ###
 **/.terraform/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,16 @@ infra/helm/<app>/
 └── Chart.lock     # dependency lock
 ```
 
+### Secrets 관리
+
+- SealedSecret 원본 비밀값은 `.secrets` 파일에 기록한다 (`.gitignore`로 추적 제외)
+- 새 SealedSecret 추가 시 `.secrets`에 원본값을 함께 기록한다
+- kubeseal 실행은 `ssh note1`에서 수행한다
+  ```bash
+  ssh note1 "echo -n '<값>' | kubeseal --raw --namespace <ns> --name <secret-name> \
+    --controller-name sealed-secrets --controller-namespace kube-system"
+  ```
+
 ## Git Workflow
 
 - main 브랜치에 직접 push 금지. 반드시 새 브랜치에서 PR을 통해 머지한다.


### PR DESCRIPTION
## 이슈
- SealedSecret 원본 비밀값을 로컬에서 관리할 수 있도록 체계 구성

## 작업 내용
- `.secrets` 파일 생성 (`.gitignore` 처리, Git 추적 제외)
- 기존 SealedSecret 전체 원본값 기록 위치 마련
  - MySQL, JWT, ArgoCD Notifications Discord, Longhorn S3, Alertmanager Discord, MinIO
- CLAUDE.md에 Secrets 관리 가이드 추가 (kubeseal 명령어, note1 SSH)