### PR TITLE
feat : BE 테스트 인프라 구조화

### DIFF
--- a/be/orino-app-api/build.gradle
+++ b/be/orino-app-api/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
     testImplementation 'org.testcontainers:testcontainers-mysql'

--- a/be/orino-app-api/src/test/java/ds/project/orino/domain/member/repository/MemberRepositoryTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/domain/member/repository/MemberRepositoryTest.java
@@ -1,22 +1,17 @@
 package ds.project.orino.domain.member.repository;
 
-import ds.project.orino.config.TestRedisConfig;
 import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.support.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-@ActiveProfiles("test")
-@Import(TestRedisConfig.class)
+@IntegrationTest
 @Transactional
 class MemberRepositoryTest {
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/redis/auth/RefreshTokenRepositoryTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/redis/auth/RefreshTokenRepositoryTest.java
@@ -1,20 +1,15 @@
 package ds.project.orino.redis.auth;
 
-import ds.project.orino.config.TestRedisConfig;
+import ds.project.orino.support.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-@ActiveProfiles("test")
-@Import(TestRedisConfig.class)
+@IntegrationTest
 class RefreshTokenRepositoryTest {
 
     @Autowired

--- a/be/orino-app-api/src/test/java/ds/project/orino/schema/SchemaValidationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/schema/SchemaValidationTest.java
@@ -1,11 +1,8 @@
 package ds.project.orino.schema;
 
-import ds.project.orino.config.TestRedisConfig;
+import ds.project.orino.support.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
 /**
@@ -14,9 +11,7 @@ import org.springframework.test.context.TestPropertySource;
  * Liquibase가 changelog를 적용한 뒤, Hibernate validate가
  * 엔티티와 DB 스키마를 비교한다. 불일치 시 컨텍스트 로딩 실패 → 테스트 실패.
  */
-@SpringBootTest
-@ActiveProfiles("test")
-@Import(TestRedisConfig.class)
+@IntegrationTest
 @TestPropertySource(properties = {
         "spring.jpa.hibernate.ddl-auto=validate",
         "spring.liquibase.enabled=true",

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/ApiTestSupport.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/ApiTestSupport.java
@@ -1,0 +1,25 @@
+package ds.project.orino.support;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+@IntegrationTest
+public abstract class ApiTestSupport {
+
+    protected MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @BeforeEach
+    void setUpMockMvc() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/IntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/IntegrationTest.java
@@ -1,0 +1,19 @@
+package ds.project.orino.support;
+
+import ds.project.orino.config.TestRedisConfig;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@ActiveProfiles("test")
+@Import(TestRedisConfig.class)
+public @interface IntegrationTest {
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/MemberFixture.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/MemberFixture.java
@@ -1,0 +1,20 @@
+package ds.project.orino.support;
+
+import ds.project.orino.domain.member.entity.Member;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class MemberFixture {
+
+    private static final BCryptPasswordEncoder ENCODER = new BCryptPasswordEncoder();
+
+    public static final String DEFAULT_LOGIN_ID = "admin";
+    public static final String DEFAULT_PASSWORD = "password";
+
+    public static Member create() {
+        return create(DEFAULT_LOGIN_ID, DEFAULT_PASSWORD);
+    }
+
+    public static Member create(String loginId, String rawPassword) {
+        return new Member(loginId, ENCODER.encode(rawPassword));
+    }
+}


### PR DESCRIPTION
## 연관 이슈

- [x] #123

## 작업 내용

- `@IntegrationTest` 커스텀 어노테이션 추가 — `@SpringBootTest` + `@ActiveProfiles("test")` + `@Import(TestRedisConfig.class)` 통합
- `ApiTestSupport` 추상 클래스 추가 — MockMvc + Spring Security 설정을 상속으로 제공
- `MemberFixture` 테스트 픽스처 클래스 추가
- 기존 테스트(SchemaValidationTest, RefreshTokenRepositoryTest, MemberRepositoryTest) `@IntegrationTest` 적용으로 리팩터링
- `spring-security-test` 의존성 추가