### PR TITLE
feat : FE E2E 테스트 환경 구축 (Playwright)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,10 @@ Active profiles: `local` (default, docker-compose), `prod`, `test`. 모두 `mysq
 
 ```bash
 cd fe
-npm test              # Run all tests
+npm test              # Run all tests (Vitest)
 npm run test:watch    # Watch mode
+npm run test:e2e      # E2E tests (Playwright)
+npm run test:e2e:ui   # E2E tests with UI
 ```
 
 | | BE | FE |

--- a/fe/.gitignore
+++ b/fe/.gitignore
@@ -4,3 +4,7 @@ dist-ssr
 *.local
 .env
 .env.production
+
+# Playwright
+test-results/
+playwright-report/

--- a/fe/e2e/auth.spec.ts
+++ b/fe/e2e/auth.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from "@playwright/test";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function mockAuthApi(page: import("@playwright/test").Page) {
+  return Promise.all([
+    page.route(`${API_BASE}/auth/login`, async (route) => {
+      const body = route.request().postDataJSON();
+      if (body.loginId === "admin" && body.password === "password") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            code: "OK",
+            data: { accessToken: "mock-access-token" },
+          }),
+        });
+      } else {
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({
+            code: "AUTH-ERR-001",
+            message: "아이디 또는 비밀번호가 올바르지 않습니다.",
+          }),
+        });
+      }
+    }),
+
+    page.route(`${API_BASE}/auth/reissue`, async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          code: "AUTH-ERR-002",
+          message: "유효하지 않은 토큰입니다.",
+        }),
+      });
+    }),
+
+    page.route(`${API_BASE}/auth/logout`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ code: "OK", data: null }),
+      });
+    }),
+  ]);
+}
+
+test.describe("인증 흐름", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAuthApi(page);
+  });
+
+  test("랜딩 페이지에서 시작하기 클릭 시 /login으로 이동한다", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByText("orino")).toBeVisible();
+    await page.getByRole("link", { name: /시작하기/ }).click();
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("미인증 시 /home 접근하면 /login으로 리다이렉트된다", async ({
+    page,
+  }) => {
+    await page.goto("/home");
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("로그인 성공 시 /home으로 이동한다", async ({ page }) => {
+    await page.goto("/login");
+
+    await page.getByLabel("아이디").fill("admin");
+    await page.getByLabel("비밀번호").fill("password");
+    await page.getByRole("button", { name: "로그인" }).click();
+
+    await expect(page).toHaveURL(/\/home/);
+    await expect(page.getByText("orino")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /로그아웃/ })
+    ).toBeVisible();
+  });
+
+  test("로그인 실패 시 /login에 머문다", async ({ page }) => {
+    await page.goto("/login");
+
+    await page.getByLabel("아이디").fill("wrong");
+    await page.getByLabel("비밀번호").fill("wrong");
+    await page.getByRole("button", { name: "로그인" }).click();
+
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("로그인 → 로그아웃 전체 흐름", async ({ page }) => {
+    // 로그인
+    await page.goto("/login");
+    await page.getByLabel("아이디").fill("admin");
+    await page.getByLabel("비밀번호").fill("password");
+    await page.getByRole("button", { name: "로그인" }).click();
+    await expect(page).toHaveURL(/\/home/);
+
+    // 로그아웃
+    await page.getByRole("button", { name: /로그아웃/ }).click();
+
+    // 로그아웃 후 인증이 필요 없는 페이지로 이동
+    await page.waitForURL(/\/(login)?$/);
+    await expect(page.getByText("orino")).toBeVisible();
+  });
+});

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1932,6 +1933,22 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
@@ -6837,6 +6854,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/fe/package.json
+++ b/fe/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
@@ -31,6 +33,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/fe/playwright.config.ts
+++ b/fe/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: "http://localhost:3000",
+    headless: true,
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: true,
+    timeout: 10_000,
+  },
+});


### PR DESCRIPTION
## 연관 이슈

- [x] #134

## 작업 내용

- Playwright 설치 및 `playwright.config.ts` 설정 (Chromium, headless, webServer 연동)
- 인증 흐름 E2E 테스트 5개 작성
  - 랜딩 페이지 → /login 이동
  - 미인증 시 /home → /login 리다이렉트
  - 로그인 성공 → /home 이동
  - 로그인 실패 → /login 유지
  - 로그인 → 로그아웃 전체 흐름
- `page.route()`로 API 인터셉트 (BE 서버 없이 실행)
- `npm run test:e2e` / `npm run test:e2e:ui` 스크립트 추가