### PR TITLE
chore : Grafana 불필요 대시보드 정리

### DIFF
--- a/infra/helm/kube-prometheus-stack/values.yaml
+++ b/infra/helm/kube-prometheus-stack/values.yaml
@@ -24,8 +24,20 @@ kube-prometheus-stack:
       serviceMonitorSelectorNilUsesHelmValues: false
       podMonitorSelectorNilUsesHelmValues: false
 
+  coreDns:
+    enabled: false
+  kubeEtcd:
+    enabled: false
+  kubeApiServer:
+    enabled: false
+  kubeControllerManager:
+    enabled: false
+  kubelet:
+    enabled: false
+
   grafana:
     adminPassword: admin
+    defaultDashboardsEnabled: false
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
## 이슈
closes #139

## 작업 내용
- 불필요 컴포넌트 대시보드 5개 비활성화 (CoreDNS, etcd, API Server, Controller Manager, Kubelet)
- 기본 대시보드를 `Kubernetes` 폴더로 정리 (General에서 분리)