### PR TITLE
feat : Loki, Thanos 장기저장용 S3 버킷 및 IAM 생성

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -36,3 +36,52 @@ resource "aws_iam_user_policy" "longhorn" {
 resource "aws_iam_access_key" "longhorn" {
   user = aws_iam_user.longhorn.name
 }
+
+# Loki logs S3 bucket
+module "loki_logs" {
+  source = "./modules/s3"
+
+  bucket_name = "orino-loki-logs"
+}
+
+# Thanos metrics S3 bucket
+module "thanos_metrics" {
+  source = "./modules/s3"
+
+  bucket_name = "orino-thanos-metrics"
+}
+
+# IAM user for observability S3 access (Loki + Thanos)
+resource "aws_iam_user" "observability" {
+  name = "observability-s3"
+}
+
+resource "aws_iam_user_policy" "observability" {
+  name = "observability-s3"
+  user = aws_iam_user.observability.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          module.loki_logs.bucket_arn,
+          "${module.loki_logs.bucket_arn}/*",
+          module.thanos_metrics.bucket_arn,
+          "${module.thanos_metrics.bucket_arn}/*",
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_access_key" "observability" {
+  user = aws_iam_user.observability.name
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -18,3 +18,24 @@ output "longhorn_iam_secret_access_key" {
   value       = aws_iam_access_key.longhorn.secret
   sensitive   = true
 }
+
+output "loki_logs_bucket" {
+  description = "Loki logs S3 bucket name"
+  value       = module.loki_logs.bucket_name
+}
+
+output "thanos_metrics_bucket" {
+  description = "Thanos metrics S3 bucket name"
+  value       = module.thanos_metrics.bucket_name
+}
+
+output "observability_iam_access_key_id" {
+  description = "IAM access key ID for observability (Loki + Thanos)"
+  value       = aws_iam_access_key.observability.id
+}
+
+output "observability_iam_secret_access_key" {
+  description = "IAM secret access key for observability (Loki + Thanos)"
+  value       = aws_iam_access_key.observability.secret
+  sensitive   = true
+}


### PR DESCRIPTION
## 이슈
closes #182

## 작업 내용
- `orino-loki-logs` S3 버킷 생성 (AES256 암호화, public access 차단)
- `orino-thanos-metrics` S3 버킷 생성 (AES256 암호화, public access 차단)
- `observability-s3` IAM 유저 생성 (Loki + Thanos 공용, PutObject/GetObject/DeleteObject/ListBucket)
- 기존 S3 모듈 재사용

## 참고
- 머지 후 `terraform apply` 실행 필요
- apply 후 생성되는 IAM access key는 `.secrets`에 기록하고 SealedSecret으로 클러스터에 주입