### PR TITLE
fix : Thanos 이미지를 upstream quay.io로 변경

### DIFF
--- a/infra/helm/thanos/values.yaml
+++ b/infra/helm/thanos/values.yaml
@@ -1,4 +1,9 @@
 thanos:
+  image:
+    registry: quay.io
+    repository: thanos/thanos
+    tag: v0.39.2
+
   existingObjstoreSecret: thanos-objstore-secret
 
   query:


### PR DESCRIPTION
## Summary

- Bitnami Docker Hub에서 Debian 기반 이미지 제거로 Thanos Pod ImagePullBackOff 발생
- upstream `quay.io/thanos/thanos:v0.39.2`로 이미지 오버라이드

## Related Issues

- [x] #189

## Changes

- `infra/helm/thanos/values.yaml` — image registry/repository/tag 오버라이드 추가