### PR TITLE
fix : Thanos Query 플래그 및 컨테이너 권한 수정

### DIFF
--- a/infra/helm/thanos/templates/compactor-statefulset.yaml
+++ b/infra/helm/thanos/templates/compactor-statefulset.yaml
@@ -18,6 +18,8 @@ spec:
         app.kubernetes.io/name: thanos
         app.kubernetes.io/component: compactor
     spec:
+      securityContext:
+        fsGroup: 1001
       containers:
         - name: thanos-compactor
           image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/infra/helm/thanos/templates/query-deployment.yaml
+++ b/infra/helm/thanos/templates/query-deployment.yaml
@@ -25,7 +25,7 @@ spec:
             - --http-address=0.0.0.0:9090
             - --grpc-address=0.0.0.0:10901
             {{- range .Values.query.stores }}
-            - --store={{ . }}
+            - --endpoint={{ . }}
             {{- end }}
           ports:
             - name: http

--- a/infra/helm/thanos/templates/storegateway-statefulset.yaml
+++ b/infra/helm/thanos/templates/storegateway-statefulset.yaml
@@ -18,6 +18,8 @@ spec:
         app.kubernetes.io/name: thanos
         app.kubernetes.io/component: storegateway
     spec:
+      securityContext:
+        fsGroup: 1001
       containers:
         - name: thanos-storegateway
           image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}


### PR DESCRIPTION
## Summary

- Query: `--store` → `--endpoint` (v0.41.0에서 플래그명 변경)
- Compactor, Store Gateway: `fsGroup: 1001` 추가로 PVC 쓰기 권한 해결

## Related Issues

- [x] #189