### PR TITLE
fix : Thanos StatefulSet ArgoCD OutOfSync 해소

### DIFF
--- a/infra/helm/thanos/templates/compactor-statefulset.yaml
+++ b/infra/helm/thanos/templates/compactor-statefulset.yaml
@@ -53,11 +53,14 @@ spec:
           secret:
             secretName: {{ .Values.objstoreSecret }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
         storageClassName: {{ .Values.compactor.storageClass }}
+        volumeMode: Filesystem
         resources:
           requests:
             storage: {{ .Values.compactor.storageSize }}

--- a/infra/helm/thanos/templates/storegateway-statefulset.yaml
+++ b/infra/helm/thanos/templates/storegateway-statefulset.yaml
@@ -52,11 +52,14 @@ spec:
           secret:
             secretName: {{ .Values.objstoreSecret }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
         storageClassName: {{ .Values.storegateway.storageClass }}
+        volumeMode: Filesystem
         resources:
           requests:
             storage: {{ .Values.storegateway.storageSize }}


### PR DESCRIPTION
## Summary

- StatefulSet volumeClaimTemplates에 apiVersion, kind, volumeMode 명시
- K8s가 자동 추가하는 기본값과 일치시켜 ArgoCD OutOfSync diff 해소

## Related Issues

- [x] #189