### PR TITLE
chore : Alloy JSON 로그 파싱 파이프라인 설정

### DIFF
--- a/infra/helm/alloy/values.yaml
+++ b/infra/helm/alloy/values.yaml
@@ -45,6 +45,30 @@ alloy:
 
         loki.source.kubernetes "pods" {
           targets    = discovery.relabel.pods.output
+          forward_to = [loki.process.json_parse.receiver]
+        }
+
+        // JSON 로그 파싱 (BE prod 로그: LogstashEncoder)
+        loki.process "json_parse" {
+          // JSON에서 level 필드 추출
+          stage.json {
+            expressions = {
+              level      = "level",
+              logger     = "logger_name",
+              request_id = "requestId",
+              user_id    = "userId",
+              trace_id   = "traceId",
+            }
+          }
+
+          // level을 Loki 라벨로 설정
+          stage.labels {
+            values = {
+              level = "",
+            }
+          }
+
+          // 비JSON 로그는 파싱 실패해도 그대로 통과
           forward_to = [loki.write.default.receiver]
         }
 


### PR DESCRIPTION
## Summary

- BE JSON 로그(LogstashEncoder)에서 level, logger, requestId, userId, traceId 필드 추출
- level을 Loki 라벨로 설정하여 `{level="ERROR"}` 등 레벨별 쿼리 가능
- 비JSON 로그(Istio proxy 등)는 파싱 실패해도 그대로 전달

## Related Issues

- [x] #197