### PR TITLE
fix : Tempo S3 인증을 환경변수 방식으로 수정

### DIFF
--- a/infra/helm/tempo/values.yaml
+++ b/infra/helm/tempo/values.yaml
@@ -5,10 +5,10 @@ tempo:
         backend: s3
         s3:
           bucket: orino-tempo-traces
-          endpoint: s3.ap-northeast-2.amazonaws.com
+          endpoint: s3.dualstack.ap-northeast-2.amazonaws.com
           region: ap-northeast-2
-          access_key: ${AWS_ACCESS_KEY_ID}
-          secret_key: ${AWS_SECRET_ACCESS_KEY}
+        wal:
+          path: /var/tempo/wal
     receivers:
       otlp:
         protocols:


### PR DESCRIPTION
## Summary

- Tempo config에서 access_key/secret_key 제거 (AWS SDK가 환경변수 자동 참조)
- extraEnv로 observability-s3-secret에서 자격증명 주입

## Related Issues

- [x] #199