### PR TITLE
fix : Tempo extraEnv 경로 수정

### DIFF
--- a/infra/helm/tempo/values.yaml
+++ b/infra/helm/tempo/values.yaml
@@ -9,6 +9,17 @@ tempo:
           region: ap-northeast-2
         wal:
           path: /var/tempo/wal
+    extraEnv:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: observability-s3-secret
+            key: AWS_ACCESS_KEY_ID
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: observability-s3-secret
+            key: AWS_SECRET_ACCESS_KEY
     receivers:
       otlp:
         protocols:
@@ -17,18 +28,6 @@ tempo:
           http:
             endpoint: 0.0.0.0:4318
     retention: 720h  # 30일
-
-  extraEnv:
-    - name: AWS_ACCESS_KEY_ID
-      valueFrom:
-        secretKeyRef:
-          name: observability-s3-secret
-          key: AWS_ACCESS_KEY_ID
-    - name: AWS_SECRET_ACCESS_KEY
-      valueFrom:
-        secretKeyRef:
-          name: observability-s3-secret
-          key: AWS_SECRET_ACCESS_KEY
 
   persistence:
     enabled: true


### PR DESCRIPTION
## Summary

- `tempo.extraEnv` → `tempo.tempo.extraEnv`로 경로 수정
- 환경변수가 컨테이너에 주입되지 않아 S3 인증 실패하던 문제 해결

## Related Issues

- [x] #199