### PR TITLE
feat : Istio → Tempo 트레이싱 연동

### DIFF
--- a/infra/helm/istiod/templates/telemetry.yaml
+++ b/infra/helm/istiod/templates/telemetry.yaml
@@ -1,0 +1,10 @@
+apiVersion: telemetry.istio.io/v1
+kind: Telemetry
+metadata:
+  name: mesh-default
+  namespace: istio-system
+spec:
+  tracing:
+    - providers:
+        - name: tempo
+      randomSamplingPercentage: 100

--- a/infra/helm/istiod/values.yaml
+++ b/infra/helm/istiod/values.yaml
@@ -1,1 +1,11 @@
-istiod: {}
+istiod:
+  meshConfig:
+    enablePrometheusMerge: true
+    defaultConfig:
+      tracing:
+        sampling: 100
+    extensionProviders:
+      - name: tempo
+        opentelemetry:
+          service: tempo.monitoring.svc.cluster.local
+          port: 4317


### PR DESCRIPTION
## Summary

- Istio meshConfig에 Tempo를 OpenTelemetry extensionProvider로 등록
- Telemetry API로 메시 전체 트레이싱 활성화 (샘플링 100%)
- Istio sidecar 프록시가 자동으로 Tempo(gRPC 4317)에 트레이스 전송

## Related Issues

- [x] #200

## Changes

- `infra/helm/istiod/values.yaml` — meshConfig extensionProviders 추가
- `infra/helm/istiod/templates/telemetry.yaml` — Telemetry API 리소스 생성