### PR TITLE
chore : BE에 OTLP exporter endpoint 환경변수 추가

### DIFF
--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
               value: {{ .Values.env.REDIS_HOST | quote }}
             - name: REDIS_PORT
               value: {{ .Values.env.REDIS_PORT | quote }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.env.OTEL_EXPORTER_OTLP_ENDPOINT | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           readinessProbe:

--- a/infra/helm/be/values.yaml
+++ b/infra/helm/be/values.yaml
@@ -10,6 +10,7 @@ env:
   MYSQL_USERNAME: orino_app
   REDIS_HOST: redis.orino.svc.cluster.local
   REDIS_PORT: "6379"
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://alloy.monitoring.svc.cluster.local:4318
 
 resources:
   requests:


### PR DESCRIPTION
## Summary

- BE Deployment에 `OTEL_EXPORTER_OTLP_ENDPOINT` 환경변수 추가
- Alloy OTLP receiver(`alloy.monitoring.svc.cluster.local:4318`)로 트레이스 전송
- PR #213 (Micrometer Tracing 연동)과 PR #214 (Alloy OTLP receiver) 머지 후 트레이싱 파이프라인 완성

## Related Issues

- [x] #201