### PR TITLE
feat : FE 에러 트래킹 구축

### DIFF
--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -1,15 +1,18 @@
 import { BrowserRouter } from "react-router-dom";
 
+import { ErrorBoundary } from "../shared/error/ErrorBoundary";
 import { Providers } from "./providers";
 import { AppRouter } from "./router";
 
 function App() {
   return (
-    <BrowserRouter>
-      <Providers>
-        <AppRouter />
-      </Providers>
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <Providers>
+          <AppRouter />
+        </Providers>
+      </BrowserRouter>
+    </ErrorBoundary>
   );
 }
 

--- a/fe/src/main.tsx
+++ b/fe/src/main.tsx
@@ -4,9 +4,18 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import App from "./app/App.tsx";
+import { logUnhandledError } from "./shared/error/error-logger";
 import { initTheme } from "./shared/lib/theme";
 
 initTheme();
+
+window.addEventListener("error", (event) => {
+  logUnhandledError(event.error);
+});
+
+window.addEventListener("unhandledrejection", (event) => {
+  logUnhandledError(event.reason);
+});
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/fe/src/shared/api/client.ts
+++ b/fe/src/shared/api/client.ts
@@ -4,6 +4,7 @@ import {
   getAccessToken,
   setAccessToken,
 } from "../../features/auth/store/authStore";
+import { logApiError } from "../error/error-logger";
 
 const client = axios.create({
   baseURL: "https://api.orino.dev/api",
@@ -27,6 +28,7 @@ client.interceptors.response.use(
     const originalRequest = error.config;
 
     if (error.response?.status !== 401 || originalRequest._retry) {
+      logApiError(originalRequest?.url, error.response?.status, error.message);
       return Promise.reject(error);
     }
 

--- a/fe/src/shared/error/ErrorBoundary.tsx
+++ b/fe/src/shared/error/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+import { logRenderError } from "./error-logger";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    logRenderError(error);
+    console.error("ErrorBoundary caught:", error, info.componentStack);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback ?? (
+          <div className="flex min-h-svh flex-col items-center justify-center gap-4">
+            <p className="text-muted-foreground text-sm">
+              문제가 발생했습니다.
+            </p>
+            <button
+              onClick={() => window.location.reload()}
+              className="text-primary text-sm underline"
+            >
+              새로고침
+            </button>
+          </div>
+        )
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/fe/src/shared/error/error-logger.ts
+++ b/fe/src/shared/error/error-logger.ts
@@ -1,0 +1,55 @@
+interface ErrorLog {
+  type: "api" | "render" | "unhandled";
+  message: string;
+  url?: string;
+  status?: number;
+  stack?: string;
+  timestamp: string;
+}
+
+const ERROR_ENDPOINT = "/api/client-logs";
+
+function send(log: ErrorLog): void {
+  if (import.meta.env.DEV) {
+    console.error("[ErrorLog]", log);
+    return;
+  }
+  navigator.sendBeacon(
+    ERROR_ENDPOINT,
+    new Blob([JSON.stringify(log)], { type: "application/json" }),
+  );
+}
+
+export function logApiError(
+  url: string | undefined,
+  status: number | undefined,
+  message: string,
+): void {
+  send({
+    type: "api",
+    message,
+    url,
+    status,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+export function logRenderError(error: unknown): void {
+  const err = error instanceof Error ? error : new Error(String(error));
+  send({
+    type: "render",
+    message: err.message,
+    stack: err.stack,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+export function logUnhandledError(error: unknown): void {
+  const err = error instanceof Error ? error : new Error(String(error));
+  send({
+    type: "unhandled",
+    message: err.message,
+    stack: err.stack,
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   },
   "lint-staged": {
     "fe/src/**/*.{ts,tsx}": [
-      "prettier --write --config fe/.prettierrc",
-      "eslint --fix --config fe/eslint.config.js"
+      "bash -c 'cd fe && npx prettier --write --config .prettierrc \"$@\"' _",
+      "bash -c 'cd fe && npx eslint --fix --config eslint.config.js \"$@\"' _"
     ],
     "fe/e2e/**/*.ts": [
-      "prettier --write --config fe/.prettierrc"
+      "bash -c 'cd fe && npx prettier --write --config .prettierrc \"$@\"' _"
     ]
   },
   "scripts": {


### PR DESCRIPTION
## 연관 이슈

- [x] #204

## 작업 내용

### ErrorBoundary
- React 렌더링 에러를 캐치하여 폴백 UI 표시 ("문제가 발생했습니다" + 새로고침)
- App 최상위에 래핑

### error-logger 유틸리티
- `logApiError(url, status, message)` — API 호출 실패
- `logRenderError(error)` — React 렌더링 에러
- `logUnhandledError(error)` — 전역 미처리 에러
- dev 환경: `console.error` 출력
- prod 환경: `navigator.sendBeacon`으로 `/api/client-logs`에 JSON 전송

### Axios 인터셉터
- 401 외 API 에러 발생 시 `logApiError` 호출 추가

### 전역 에러 핸들러
- `window.error` + `unhandledrejection` 이벤트 리스너 등록 (main.tsx)

### lint-staged 수정
- `cd fe &&` 래핑으로 prettier plugin 해석 문제 해결 (CWD가 루트여서 fe/node_modules의 plugin을 못 찾는 문제)