### PR TITLE
feat : Grafana Exemplar 연동 (로그-트레이스-메트릭 연결)

### DIFF
--- a/infra/helm/kube-prometheus-stack/values.yaml
+++ b/infra/helm/kube-prometheus-stack/values.yaml
@@ -6,6 +6,8 @@ kube-prometheus-stack:
     thanosService:
       enabled: true
     prometheusSpec:
+      enableFeatures:
+        - exemplar-storage
       retention: 7d
       thanos:
         objectStorageConfig:
@@ -62,19 +64,43 @@ kube-prometheus-stack:
     additionalDataSources:
       - name: Loki
         type: loki
+        uid: loki
         url: http://loki.monitoring.svc.cluster.local:3100
         access: proxy
         isDefault: false
+        jsonData:
+          derivedFields:
+            - name: traceId
+              matcherRegex: '"traceId":"([a-f0-9]+)"'
+              url: "$${__value.raw}"
+              datasourceUid: tempo
+              urlDisplayLabel: Tempo
       - name: Thanos
         type: prometheus
         url: http://thanos-query.monitoring.svc.cluster.local:9090
         access: proxy
         isDefault: false
+        jsonData:
+          exemplarTraceIdDestinations:
+            - name: traceID
+              datasourceUid: tempo
       - name: Tempo
         type: tempo
+        uid: tempo
         url: http://tempo.monitoring.svc.cluster.local:3100
         access: proxy
         isDefault: false
+        jsonData:
+          tracesToLogsV2:
+            datasourceUid: loki
+            filterByTraceID: true
+            tags:
+              - key: namespace
+              - key: pod
+          nodeGraph:
+            enabled: true
+          serviceMap:
+            datasourceUid: prometheus
 
   alertmanager:
     config:


### PR DESCRIPTION
## Summary

- Prometheus `exemplar-storage` feature flag 활성화
- Grafana 데이터소스 간 correlation 설정으로 원클릭 탐색 가능
  - 메트릭 → 트레이스: Prometheus/Thanos exemplar에서 traceID로 Tempo 점프
  - 로그 → 트레이스: Loki JSON 로그의 traceId 필드에서 Tempo 링크
  - 트레이스 → 로그: Tempo에서 namespace/pod 기반 Loki 로그 조회
- Tempo nodeGraph, serviceMap 활성화

## Related Issues

- [x] #205