### PR TITLE
feat : BE 커스텀 비즈니스 메트릭 추가

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/auth/service/AuthService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/auth/service/AuthService.java
@@ -8,6 +8,8 @@ import ds.project.orino.core.jwt.JwtTokenProvider;
 import ds.project.orino.domain.member.entity.Member;
 import ds.project.orino.domain.member.repository.MemberRepository;
 import ds.project.orino.redis.auth.RefreshTokenRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -18,13 +20,31 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final Counter loginSuccessCounter;
+    private final Counter loginFailureCounter;
+    private final Counter logoutCounter;
 
-    public AuthService(MemberRepository memberRepository, RefreshTokenRepository refreshTokenRepository,
-                       JwtTokenProvider jwtTokenProvider, BCryptPasswordEncoder passwordEncoder) {
+    public AuthService(
+            MemberRepository memberRepository,
+            RefreshTokenRepository refreshTokenRepository,
+            JwtTokenProvider jwtTokenProvider,
+            BCryptPasswordEncoder passwordEncoder,
+            MeterRegistry registry) {
         this.memberRepository = memberRepository;
         this.refreshTokenRepository = refreshTokenRepository;
         this.jwtTokenProvider = jwtTokenProvider;
         this.passwordEncoder = passwordEncoder;
+        this.loginSuccessCounter = Counter.builder("auth.login")
+                .tag("result", "success")
+                .description("Successful login count")
+                .register(registry);
+        this.loginFailureCounter = Counter.builder("auth.login")
+                .tag("result", "failure")
+                .description("Failed login count")
+                .register(registry);
+        this.logoutCounter = Counter.builder("auth.logout")
+                .description("Logout count")
+                .register(registry);
     }
 
     public record LoginResult(TokenResponse tokenResponse, String refreshToken) {
@@ -32,9 +52,13 @@ public class AuthService {
 
     public LoginResult login(LoginRequest request) {
         Member member = memberRepository.findByLoginId(request.loginId())
-                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_CREDENTIALS));
+                .orElseThrow(() -> {
+                    loginFailureCounter.increment();
+                    return new CustomException(ErrorCode.INVALID_CREDENTIALS);
+                });
 
         if (!passwordEncoder.matches(request.password(), member.getPassword())) {
+            loginFailureCounter.increment();
             throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
         }
 
@@ -42,6 +66,7 @@ public class AuthService {
         String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
         refreshTokenRepository.save(member.getId(), refreshToken);
 
+        loginSuccessCounter.increment();
         return new LoginResult(new TokenResponse(accessToken), refreshToken);
     }
 
@@ -69,6 +94,7 @@ public class AuthService {
         if (jwtTokenProvider.validate(refreshToken)) {
             Long memberId = jwtTokenProvider.getMemberId(refreshToken);
             refreshTokenRepository.deleteByMemberId(memberId);
+            logoutCounter.increment();
         }
     }
 }

--- a/be/orino-app-api/src/main/resources/application-actuator.yml
+++ b/be/orino-app-api/src/main/resources/application-actuator.yml
@@ -4,6 +4,8 @@ management:
   endpoints:
     web:
       base-path: /
+      exposure:
+        include: health, prometheus
   endpoint:
     health:
       show-details: always
@@ -19,3 +21,7 @@ management:
       enabled: true
     readinessstate:
       enabled: true
+  prometheus:
+    metrics:
+      export:
+        enabled: true

--- a/be/orino-app-api/src/test/java/ds/project/orino/auth/service/AuthServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/auth/service/AuthServiceTest.java
@@ -7,10 +7,11 @@ import ds.project.orino.core.jwt.JwtTokenProvider;
 import ds.project.orino.domain.member.entity.Member;
 import ds.project.orino.domain.member.repository.MemberRepository;
 import ds.project.orino.redis.auth.RefreshTokenRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -27,7 +28,6 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
-    @InjectMocks
     private AuthService authService;
 
     @Mock
@@ -41,6 +41,16 @@ class AuthServiceTest {
 
     @Mock
     private BCryptPasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService(
+                memberRepository,
+                refreshTokenRepository,
+                jwtTokenProvider,
+                passwordEncoder,
+                new SimpleMeterRegistry());
+    }
 
     @Test
     @DisplayName("로그인 성공 시 AT와 RT를 반환한다")


### PR DESCRIPTION
## 연관 이슈

- [x] #203

## 작업 내용

### Actuator Prometheus endpoint 활성화
- `management.endpoints.web.exposure.include`에 `prometheus` 추가
- `management.prometheus.metrics.export.enabled=true`

### 커스텀 비즈니스 메트릭
| 메트릭 | 타입 | 태그 | 설명 |
|--------|------|------|------|
| `auth_login_total` | Counter | `result=success\|failure` | 로그인 성공/실패 횟수 |
| `auth_logout_total` | Counter | — | 로그아웃 횟수 |

### 테스트 수정
- `AuthServiceTest`에서 `@InjectMocks` 대신 `@BeforeEach`에서 `SimpleMeterRegistry`를 직접 주입하도록 변경

### Prometheus 스크래핑 확인
`GET :9090/prometheus`로 메트릭 노출 확인 가능:
```
auth_login_total{result="success"} 5.0
auth_login_total{result="failure"} 2.0
auth_logout_total 3.0
```