### PR TITLE
fix : Actuator 보안 설정 management context 로드 수정

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/OrinoApplication.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/OrinoApplication.java
@@ -1,11 +1,16 @@
 package ds.project.orino;
 
+import ds.project.orino.core.security.ActuatorSecurityConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@ComponentScan(excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE, classes = ActuatorSecurityConfig.class))
 public class OrinoApplication {
     public static void main(String[] args) {
         SpringApplication.run(OrinoApplication.class, args);

--- a/be/orino-core-web/src/main/java/ds/project/orino/core/security/ActuatorSecurityConfig.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/security/ActuatorSecurityConfig.java
@@ -1,9 +1,11 @@
 package ds.project.orino.core.security;
 
+import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
+@ManagementContextConfiguration(proxyBeanMethods = false)
 public class ActuatorSecurityConfig {
 
     @Bean


### PR DESCRIPTION
## 연관 이슈

- [x] #110

## 작업 내용

- `ActuatorSecurityConfig`에 `@ManagementContextConfiguration` 복원하여 management child context에서 `SecurityFilterChain` 로드 보장
- `OrinoApplication`에서 `ActuatorSecurityConfig`를 component scan 대상에서 제외하여 main context의 `UnreachableFilterChainException` 방지
- 별도 management port(9090)에서 Actuator 엔드포인트 403 반환 문제 수정