### PR TITLE
fix : Observability 스택 버그 3건 수정

### DIFF
--- a/be/orino-app-api/build.gradle
+++ b/be/orino-app-api/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-liquibase'
     implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
     implementation 'org.springframework.boot:spring-boot-starter-opentelemetry'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/be/orino-app-api/src/main/resources/application.yml
+++ b/be/orino-app-api/src/main/resources/application.yml
@@ -24,4 +24,4 @@ management:
     tracing:
       export:
         otlp:
-          endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
+          endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces

--- a/be/orino-app-api/src/main/resources/logback-spring.xml
+++ b/be/orino-app-api/src/main/resources/logback-spring.xml
@@ -21,8 +21,10 @@
     <springProfile name="prod">
         <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-                <excludeJsonFieldName>@version</excludeJsonFieldName>
-                <excludeJsonFieldName>level_value</excludeJsonFieldName>
+                <fieldNames>
+                    <version>[ignore]</version>
+                    <levelValue>[ignore]</levelValue>
+                </fieldNames>
                 <timeZone>Asia/Seoul</timeZone>
                 <shortenedLoggerNameLength>36</shortenedLoggerNameLength>
             </encoder>

--- a/be/orino-app-api/src/test/java/ds/project/orino/actuator/ActuatorSecurityTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/actuator/ActuatorSecurityTest.java
@@ -1,0 +1,52 @@
+package ds.project.orino.actuator;
+
+import ds.project.orino.config.TestRedisConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        properties = "management.server.port="
+)
+@ActiveProfiles("test")
+@Import(TestRedisConfig.class)
+class ActuatorSecurityTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    @DisplayName("Actuator /health 엔드포인트에 인증 없이 접근할 수 있다")
+    void health_accessible_without_auth() throws Exception {
+        mockMvc.perform(get("/health"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Actuator /prometheus 엔드포인트에 인증 없이 접근할 수 있다")
+    void prometheus_accessible_without_auth() throws Exception {
+        mockMvc.perform(get("/prometheus"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## 이슈
closes #225
## 작업 내용
- logback-spring.xml: LogstashEncoder 8.0에서 deprecated된 `<excludeJsonFieldName>`을 `<fieldNames>` 문법으로 변경하여 `@version`, `level_value` 필드 제거
- application.yml: OTLP trace endpoint에서 `/v1/traces` 경로를 env var 밖으로 분리하여 404 해결
- build.gradle: `micrometer-registry-prometheus` 의존성 추가하여 `/prometheus` 엔드포인트 등록 및 403 해결
- ActuatorSecurityTest: actuator health/prometheus 엔드포인트 인증 없이 접근 가능 테스트 추가