### PR TITLE
chore : BE/FE Pod SecurityContext 적용

### DIFF
--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -18,11 +18,23 @@ spec:
         app: be
     spec:
       terminationGracePeriodSeconds: 60
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: be
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           ports:
             - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: {{ .Values.env.SPRING_PROFILES_ACTIVE | quote }}
@@ -72,3 +84,6 @@ spec:
               port: 9090
             initialDelaySeconds: 60
             periodSeconds: 30
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/infra/helm/fe/templates/deployment.yaml
+++ b/infra/helm/fe/templates/deployment.yaml
@@ -23,6 +23,19 @@ spec:
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           ports:
             - containerPort: 80
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+              add: [CHOWN, SETUID, SETGID]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           lifecycle:
@@ -41,3 +54,10 @@ spec:
               port: 80
             initialDelaySeconds: 10
             periodSeconds: 30
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}


### PR DESCRIPTION
closes #229

## Summary
- BE: `runAsNonRoot`, `readOnlyRootFilesystem`, `drop ALL capabilities` 적용, `/tmp` emptyDir 마운트
- FE: `readOnlyRootFilesystem`, `drop ALL` + `add CHOWN/SETUID/SETGID` (nginx 프로세스 관리용), `/tmp`, `/var/cache/nginx`, `/var/run` emptyDir 마운트

## Test plan
- [ ] BE Pod 정상 기동 및 API 응답 확인
- [ ] FE Pod 정상 기동 및 페이지 로딩 확인
- [ ] `kubectl exec`로 컨테이너 내 root 쓰기 불가 확인