### PR TITLE
chore : BE/FE Graceful Shutdown 설정

### DIFF
--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -12,6 +12,7 @@ spec:
       labels:
         app: be
     spec:
+      terminationGracePeriodSeconds: 60
       containers:
         - name: be
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -50,6 +51,10 @@ spec:
               value: {{ .Values.env.OTEL_EXPORTER_OTLP_ENDPOINT | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
           readinessProbe:
             httpGet:
               path: /health/readiness

--- a/infra/helm/fe/templates/deployment.yaml
+++ b/infra/helm/fe/templates/deployment.yaml
@@ -12,6 +12,7 @@ spec:
       labels:
         app: fe
     spec:
+      terminationGracePeriodSeconds: 30
       containers:
         - name: fe
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -19,6 +20,10 @@ spec:
             - containerPort: 80
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
closes #230

## Summary
- BE: `terminationGracePeriodSeconds: 60`, `preStop: sleep 5` 설정
- FE: `terminationGracePeriodSeconds: 30`, `preStop: sleep 5` 설정
- preStop sleep으로 kube-proxy/Istio endpoint 제거 전파 시간을 확보하여 배포 중 요청 유실 방지

## Test plan
- [ ] BE 배포 시 진행 중 요청이 정상 완료되는지 확인
- [ ] FE 배포 시 서비스 중단 없는지 확인
- [ ] Pod 삭제 후 terminationGracePeriodSeconds 이내에 종료되는지 확인