### PR TITLE
chore : MySQL 논리 백업 CronJob 구성

### DIFF
--- a/infra/argocd/applications/mysql-backup-app.yaml
+++ b/infra/argocd/applications/mysql-backup-app.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mysql-backup
+  namespace: argocd
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-failed.discord: ""
+    notifications.argoproj.io/subscribe.on-health-degraded.discord: ""
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: orino
+
+  source:
+    repoURL: https://github.com/wcorn/orino.git
+    targetRevision: main
+    path: infra/helm/mysql-backup
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: orino
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infra/helm/mysql-backup/Chart.yaml
+++ b/infra/helm/mysql-backup/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: mysql-backup
+description: MySQL 논리 백업 CronJob
+type: application
+version: 1.0.0
+appVersion: "8.4"
+
+keywords:
+  - mysql
+  - backup
+  - cronjob

--- a/infra/helm/mysql-backup/templates/cronjob.yaml
+++ b/infra/helm/mysql-backup/templates/cronjob.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mysql-backup
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: backup
+              image: {{ .Values.mysql.image }}
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+                  TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+                  BACKUP_FILE="/tmp/orino-${TIMESTAMP}.sql.gz"
+
+                  echo "Starting mysqldump..."
+                  mysqldump -h ${MYSQL_HOST} -u ${MYSQL_USER} -p${MYSQL_PASSWORD} \
+                    --single-transaction --routines --triggers ${MYSQL_DATABASE} \
+                    | gzip > ${BACKUP_FILE}
+                  echo "Dump completed: $(du -h ${BACKUP_FILE} | cut -f1)"
+
+                  echo "Downloading mc..."
+                  curl -sLo /tmp/mc https://dl.min.io/client/mc/release/linux-amd64/mc
+                  chmod +x /tmp/mc
+
+                  echo "Uploading to MinIO..."
+                  /tmp/mc alias set backup http://${MINIO_ENDPOINT} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY}
+                  /tmp/mc cp ${BACKUP_FILE} backup/${MINIO_BUCKET}/backup/mysql/
+
+                  echo "Cleaning up backups older than ${RETENTION_DAYS} days..."
+                  /tmp/mc rm --recursive --force --older-than ${RETENTION_DAYS}d backup/${MINIO_BUCKET}/backup/mysql/ || true
+
+                  echo "Backup completed successfully"
+              env:
+                - name: MYSQL_HOST
+                  value: {{ .Values.mysql.host | quote }}
+                - name: MYSQL_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: mysql-secret
+                      key: MYSQL_DATABASE
+                - name: MYSQL_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: mysql-secret
+                      key: MYSQL_USER
+                - name: MYSQL_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: mysql-secret
+                      key: MYSQL_PASSWORD
+                - name: MINIO_ENDPOINT
+                  value: {{ .Values.minio.endpoint | quote }}
+                - name: MINIO_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-secret
+                      key: rootUser
+                - name: MINIO_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-secret
+                      key: rootPassword
+                - name: MINIO_BUCKET
+                  value: {{ .Values.minio.bucket | quote }}
+                - name: RETENTION_DAYS
+                  value: {{ .Values.retention.days | quote }}
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}

--- a/infra/helm/mysql-backup/values.yaml
+++ b/infra/helm/mysql-backup/values.yaml
@@ -1,0 +1,20 @@
+schedule: "0 3 * * *"
+
+mysql:
+  host: mysql.orino.svc.cluster.local
+  image: mysql:8.4
+
+minio:
+  endpoint: minio-minio.orino.svc.cluster.local:9000
+  bucket: orino
+
+retention:
+  days: 7
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi


### PR DESCRIPTION
closes #231

## Summary
- `infra/helm/mysql-backup/` Helm 차트 신규 작성
- 매일 03:00 mysqldump 실행 → gzip 압축 → MinIO `orino/backup/mysql/`에 업로드
- 7일 초과 백업 자동 삭제 (retention)
- `infra/argocd/applications/mysql-backup-app.yaml` ArgoCD Application 추가

## Test plan
- [ ] CronJob 수동 실행 (`kubectl create job --from=cronjob/mysql-backup test-backup`)으로 백업 생성 확인
- [ ] MinIO 콘솔에서 백업 파일 존재 확인
- [ ] 백업 파일 다운로드 후 `gunzip | mysql`로 복원 테스트
- [ ] MinIO endpoint(`minio-minio.orino.svc.cluster.local:9000`) 접근 가능 여부 확인