### PR TITLE
chore : BE/FE Rolling Update 전략 설정

### DIFF
--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -4,6 +4,11 @@ metadata:
   name: be
 spec:
   replicas: {{ .Values.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: be

--- a/infra/helm/fe/templates/deployment.yaml
+++ b/infra/helm/fe/templates/deployment.yaml
@@ -4,6 +4,11 @@ metadata:
   name: fe
 spec:
   replicas: {{ .Values.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: fe


### PR DESCRIPTION
closes #232

## Summary
- BE/FE Deployment에 `strategy.rollingUpdate` 명시적 설정
- `maxSurge: 1` — 배포 시 새 Pod 1개를 먼저 생성
- `maxUnavailable: 0` — 기존 Pod는 새 Pod가 Ready된 후에만 제거

## Test plan
- [ ] BE 배포 시 서비스 중단 없이 롤링 업데이트 되는지 확인
- [ ] FE 배포 시 서비스 중단 없이 롤링 업데이트 되는지 확인
- [ ] `kubectl rollout status` 로 롤아웃 진행 상태 확인