### PR TITLE
chore : BE Init Container 추가 (DB/Redis 준비 대기)

### DIFF
--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -22,6 +22,27 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         fsGroup: 1000
+      initContainers:
+        - name: wait-mysql
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z {{ .Values.env.MYSQL_HOST }} 3306; do
+                echo "Waiting for MySQL..."
+                sleep 2
+              done
+        - name: wait-redis
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z {{ .Values.env.REDIS_HOST }} {{ .Values.env.REDIS_PORT }}; do
+                echo "Waiting for Redis..."
+                sleep 2
+              done
       containers:
         - name: be
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}


### PR DESCRIPTION
closes #235

## Summary
- `wait-mysql` Init Container: MySQL 3306 포트 TCP 연결 대기
- `wait-redis` Init Container: Redis 6379 포트 TCP 연결 대기
- 의존 서비스가 준비되지 않은 상태에서 BE 앱이 기동되어 CrashLoopBackOff 발생하는 문제 방지

## Test plan
- [ ] BE Pod 정상 기동 확인 (init container 완료 후 main container 시작)
- [ ] `kubectl describe pod` 로 init container 상태 확인
- [ ] MySQL 미기동 상태에서 init container가 대기하는지 확인