### PR TITLE
chore : CI 컨테이너 이미지 보안 스캔 추가

### DIFF
--- a/.github/workflows/be-cd.yml
+++ b/.github/workflows/be-cd.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
 
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +37,31 @@ jobs:
             type=sha,prefix=
             type=raw,value=latest
 
-      - name: Build and push
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: be
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: Push image
         uses: docker/build-push-action@v6
         with:
           context: be

--- a/.github/workflows/fe-cd.yml
+++ b/.github/workflows/fe-cd.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
 
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +37,31 @@ jobs:
             type=sha,prefix=
             type=raw,value=latest
 
-      - name: Build and push
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: fe
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: Push image
         uses: docker/build-push-action@v6
         with:
           context: fe


### PR DESCRIPTION
closes #238

## Summary
- BE/FE CD 워크플로우를 Build → Trivy Scan → Push 순서로 재구성
- CRITICAL/HIGH 취약점 발견 시 이미지 push 차단 (`exit-code: 1`)
- 스캔 결과를 GitHub Security 탭에 SARIF 형식으로 업로드
- `security-events: write` 권한 추가

## Test plan
- [ ] BE 코드 변경 후 main push 시 Trivy 스캔 동작 확인
- [ ] GitHub Security 탭에서 스캔 결과 확인
- [ ] 취약점 없을 시 이미지 정상 push 확인