### PR TITLE
BE: Study Planner 에러 코드 정의

### DIFF
--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -9,7 +9,13 @@ public enum ErrorCode {
 
     // AUTH
     INVALID_CREDENTIALS("AUTH-ERR-001", "아이디 또는 비밀번호가 올바르지 않습니다.", 401),
-    INVALID_TOKEN("AUTH-ERR-002", "유효하지 않은 토큰입니다.", 401);
+    INVALID_TOKEN("AUTH-ERR-002", "유효하지 않은 토큰입니다.", 401),
+
+    // STUDY PLANNER
+    RESOURCE_NOT_FOUND("SP-ERR-001", "존재하지 않는 리소스입니다.", 404),
+    INVALID_REQUEST("SP-ERR-002", "유효하지 않은 요청입니다.", 400),
+    REFERENCED_DATA_EXISTS("SP-ERR-003", "참조하는 데이터가 존재하여 삭제할 수 없습니다.", 409),
+    INVALID_STATE("SP-ERR-004", "현재 상태에서 수행할 수 없는 작업입니다.", 409);
 
     private final String code;
     private final String message;


### PR DESCRIPTION
## 이슈
closes #144

## 작업 내용
- ErrorCode enum에 Study Planner 에러 코드 4건 추가
- SP-ERR-001: 존재하지 않는 리소스 (404)
- SP-ERR-002: 유효하지 않은 요청 (400)
- SP-ERR-003: 참조 데이터 존재로 삭제 불가 (409)
- SP-ERR-004: 현재 상태에서 작업 불가 (409)