### PR TITLE
chore : Uptime Kuma 모니터링 구성

### DIFF
--- a/infra/argocd/applications/uptime-kuma-app.yaml
+++ b/infra/argocd/applications/uptime-kuma-app.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: uptime-kuma
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: orino
+
+  source:
+    repoURL: https://github.com/wcorn/orino.git
+    targetRevision: main
+    path: infra/helm/uptime-kuma
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infra/helm/uptime-kuma/Chart.yaml
+++ b/infra/helm/uptime-kuma/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: uptime-kuma
+description: Uptime Kuma 서비스 모니터링
+type: application
+version: 1.0.0
+appVersion: "1"
+
+keywords:
+  - uptime
+  - monitoring

--- a/infra/helm/uptime-kuma/templates/deployment.yaml
+++ b/infra/helm/uptime-kuma/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: uptime-kuma
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: uptime-kuma
+  template:
+    metadata:
+      labels:
+        app: uptime-kuma
+    spec:
+      containers:
+        - name: uptime-kuma
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          ports:
+            - containerPort: 3001
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3001
+            initialDelaySeconds: 15
+            periodSeconds: 30
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: uptime-kuma-pvc

--- a/infra/helm/uptime-kuma/templates/pvc.yaml
+++ b/infra/helm/uptime-kuma/templates/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: uptime-kuma-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.storage.storageClassName }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.size }}

--- a/infra/helm/uptime-kuma/templates/service.yaml
+++ b/infra/helm/uptime-kuma/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: uptime-kuma
+spec:
+  type: ClusterIP
+  selector:
+    app: uptime-kuma
+  ports:
+    - port: 3001
+      targetPort: 3001

--- a/infra/helm/uptime-kuma/values.yaml
+++ b/infra/helm/uptime-kuma/values.yaml
@@ -1,0 +1,15 @@
+image:
+  repository: louislam/uptime-kuma
+  tag: "1"
+
+storage:
+  size: 1Gi
+  storageClassName: longhorn
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi


### PR DESCRIPTION
closes #239

## Summary
- Uptime Kuma Helm 차트 신규 작성 (Deployment, Service, PVC)
- `monitoring` 네임스페이스에 배포, Longhorn PVC 1Gi로 데이터 영속화
- ArgoCD Application 추가

## Test plan
- [ ] Uptime Kuma Pod 정상 기동 확인
- [ ] Uptime Kuma 웹 UI 접근 확인 (port-forward 또는 NodePort)
- [ ] BE/FE health 엔드포인트 모니터링 등록
- [ ] Discord 알림 연동 설정

## 참고
- 클러스터 내부 배포이므로 클러스터 전체 장애 시에는 알림 불가 — 외부 모니터링은 별도 구성 필요