### PR TITLE
BE: Study Planner Liquibase 스키마 마이그레이션

### DIFF
--- a/be/orino-app-api/src/main/resources/db/changelog/changes/002-create-category.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/002-create-category.yaml
@@ -1,0 +1,56 @@
+databaseChangeLog:
+  - changeSet:
+      id: 002-create-category
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: category
+      changes:
+        - createTable:
+            tableName: category
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_category_member
+                    references: member(id)
+              - column:
+                  name: name
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: color
+                  type: VARCHAR(7)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: icon
+                  type: VARCHAR(50)
+              - column:
+                  name: sort_order
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/003-create-user-preference.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/003-create-user-preference.yaml
@@ -1,0 +1,102 @@
+databaseChangeLog:
+  - changeSet:
+      id: 003-create-user-preference
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: user_preference
+      changes:
+        - createTable:
+            tableName: user_preference
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uk_user_preference_member
+                    foreignKeyName: fk_user_preference_member
+                    references: member(id)
+              - column:
+                  name: wake_time
+                  type: TIME
+                  defaultValue: "07:00:00"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: sleep_time
+                  type: TIME
+                  defaultValue: "24:00:00"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: daily_study_minutes
+                  type: INT
+                  defaultValueNumeric: 240
+                  constraints:
+                    nullable: false
+              - column:
+                  name: study_time_preference
+                  type: VARCHAR(10)
+                  defaultValue: MORNING
+                  constraints:
+                    nullable: false
+              - column:
+                  name: focus_minutes
+                  type: INT
+                  defaultValueNumeric: 50
+                  constraints:
+                    nullable: false
+              - column:
+                  name: break_minutes
+                  type: INT
+                  defaultValueNumeric: 10
+                  constraints:
+                    nullable: false
+              - column:
+                  name: rest_days
+                  type: VARCHAR(30)
+              - column:
+                  name: skip_holidays
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: default_review_intervals
+                  type: VARCHAR(50)
+                  defaultValue: "1,2,3,7,15,30"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: default_missed_policy
+                  type: VARCHAR(10)
+                  defaultValue: IMMEDIATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: streak_freeze_per_month
+                  type: INT
+                  defaultValueNumeric: 2
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/004-create-priority-rule.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/004-create-priority-rule.yaml
@@ -1,0 +1,51 @@
+databaseChangeLog:
+  - changeSet:
+      id: 004-create-priority-rule
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: priority_rule
+      changes:
+        - createTable:
+            tableName: priority_rule
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_priority_rule_member
+                    references: member(id)
+              - column:
+                  name: item_type
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: sort_order
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: priority_rule
+            columnNames: member_id, item_type
+            constraintName: uk_priority_rule_member_type

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/005-create-goal-milestone.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/005-create-goal-milestone.yaml
@@ -1,0 +1,127 @@
+databaseChangeLog:
+  - changeSet:
+      id: 005-create-goal
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: goal
+      changes:
+        - createTable:
+            tableName: goal
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_goal_member
+                    references: member(id)
+              - column:
+                  name: category_id
+                  type: BIGINT
+                  constraints:
+                    foreignKeyName: fk_goal_category
+                    references: category(id)
+              - column:
+                  name: title
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: TEXT
+              - column:
+                  name: period_type
+                  type: VARCHAR(15)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: start_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: deadline
+                  type: DATE
+              - column:
+                  name: status
+                  type: VARCHAR(10)
+                  defaultValue: ACTIVE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 005-create-milestone
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: milestone
+      changes:
+        - createTable:
+            tableName: milestone
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: goal_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_milestone_goal
+                    references: goal(id)
+              - column:
+                  name: title
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: deadline
+                  type: DATE
+              - column:
+                  name: status
+                  type: VARCHAR(10)
+                  defaultValue: PENDING
+                  constraints:
+                    nullable: false
+              - column:
+                  name: sort_order
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/006-create-fixed-schedule.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/006-create-fixed-schedule.yaml
@@ -1,0 +1,79 @@
+databaseChangeLog:
+  - changeSet:
+      id: 006-create-fixed-schedule
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: fixed_schedule
+      changes:
+        - createTable:
+            tableName: fixed_schedule
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_fixed_schedule_member
+                    references: member(id)
+              - column:
+                  name: title
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: category_id
+                  type: BIGINT
+                  constraints:
+                    foreignKeyName: fk_fixed_schedule_category
+                    references: category(id)
+              - column:
+                  name: start_time
+                  type: TIME
+                  constraints:
+                    nullable: false
+              - column:
+                  name: end_time
+                  type: TIME
+                  constraints:
+                    nullable: false
+              - column:
+                  name: schedule_date
+                  type: DATE
+              - column:
+                  name: recurrence_type
+                  type: VARCHAR(20)
+                  defaultValue: NONE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: recurrence_interval
+                  type: INT
+              - column:
+                  name: recurrence_days
+                  type: VARCHAR(50)
+              - column:
+                  name: recurrence_start
+                  type: DATE
+              - column:
+                  name: recurrence_end
+                  type: DATE
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/007-create-routine.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/007-create-routine.yaml
@@ -1,0 +1,175 @@
+databaseChangeLog:
+  - changeSet:
+      id: 007-create-routine
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: routine
+      changes:
+        - createTable:
+            tableName: routine
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_routine_member
+                    references: member(id)
+              - column:
+                  name: title
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: category_id
+                  type: BIGINT
+                  constraints:
+                    foreignKeyName: fk_routine_category
+                    references: category(id)
+              - column:
+                  name: duration_minutes
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: preferred_time
+                  type: TIME
+              - column:
+                  name: recurrence_type
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: recurrence_interval
+                  type: INT
+              - column:
+                  name: recurrence_days
+                  type: VARCHAR(50)
+              - column:
+                  name: start_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: end_date
+                  type: DATE
+              - column:
+                  name: skip_holidays
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(10)
+                  defaultValue: ACTIVE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 007-create-routine-check
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: routine_check
+      changes:
+        - createTable:
+            tableName: routine_check
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: routine_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_routine_check_routine
+                    references: routine(id)
+              - column:
+                  name: check_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: completed
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: routine_check
+            columnNames: routine_id, check_date
+            constraintName: uk_routine_check_routine_date
+
+  - changeSet:
+      id: 007-create-routine-exception
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: routine_exception
+      changes:
+        - createTable:
+            tableName: routine_exception
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: routine_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_routine_exception_routine
+                    references: routine(id)
+              - column:
+                  name: exception_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: routine_exception
+            columnNames: routine_id, exception_date
+            constraintName: uk_routine_exception_routine_date

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/008-create-todo.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/008-create-todo.yaml
@@ -1,0 +1,78 @@
+databaseChangeLog:
+  - changeSet:
+      id: 008-create-todo
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: todo
+      changes:
+        - createTable:
+            tableName: todo
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_todo_member
+                    references: member(id)
+              - column:
+                  name: title
+                  type: VARCHAR(200)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: TEXT
+              - column:
+                  name: category_id
+                  type: BIGINT
+                  constraints:
+                    foreignKeyName: fk_todo_category
+                    references: category(id)
+              - column:
+                  name: goal_id
+                  type: BIGINT
+                  constraints:
+                    foreignKeyName: fk_todo_goal
+                    references: goal(id)
+              - column:
+                  name: priority
+                  type: VARCHAR(10)
+                  defaultValue: MEDIUM
+                  constraints:
+                    nullable: false
+              - column:
+                  name: deadline
+                  type: DATE
+              - column:
+                  name: estimated_minutes
+                  type: INT
+              - column:
+                  name: status
+                  type: VARCHAR(10)
+                  defaultValue: PENDING
+                  constraints:
+                    nullable: false
+              - column:
+                  name: completed_at
+                  type: DATETIME(6)
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/009-create-study-material.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/009-create-study-material.yaml
@@ -1,0 +1,283 @@
+databaseChangeLog:
+  - changeSet:
+      id: 009-create-study-material
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: study_material
+      changes:
+        - createTable:
+            tableName: study_material
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_study_material_member
+                    references: member(id)
+              - column:
+                  name: title
+                  type: VARCHAR(200)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: type
+                  type: VARCHAR(10)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: category_id
+                  type: BIGINT
+                  constraints:
+                    foreignKeyName: fk_study_material_category
+                    references: category(id)
+              - column:
+                  name: goal_id
+                  type: BIGINT
+                  constraints:
+                    foreignKeyName: fk_study_material_goal
+                    references: goal(id)
+              - column:
+                  name: deadline
+                  type: DATE
+              - column:
+                  name: deadline_mode
+                  type: VARCHAR(10)
+                  defaultValue: FREE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(10)
+                  defaultValue: ACTIVE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 009-create-study-unit
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: study_unit
+      changes:
+        - createTable:
+            tableName: study_unit
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: material_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_study_unit_material
+                    references: study_material(id)
+              - column:
+                  name: title
+                  type: VARCHAR(200)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: sort_order
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: estimated_minutes
+                  type: INT
+                  defaultValueNumeric: 30
+                  constraints:
+                    nullable: false
+              - column:
+                  name: difficulty
+                  type: VARCHAR(10)
+              - column:
+                  name: status
+                  type: VARCHAR(10)
+                  defaultValue: PENDING
+                  constraints:
+                    nullable: false
+              - column:
+                  name: completed_at
+                  type: DATETIME(6)
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 009-create-material-allocation
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: material_allocation
+      changes:
+        - createTable:
+            tableName: material_allocation
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: material_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uk_material_allocation_material
+                    foreignKeyName: fk_material_allocation_material
+                    references: study_material(id)
+              - column:
+                  name: default_minutes
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 009-create-material-daily-override
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: material_daily_override
+      changes:
+        - createTable:
+            tableName: material_daily_override
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: material_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_material_daily_override_material
+                    references: study_material(id)
+              - column:
+                  name: override_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: minutes
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: material_daily_override
+            columnNames: material_id, override_date
+            constraintName: uk_material_daily_override_material_date
+
+  - changeSet:
+      id: 009-create-review-config
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: review_config
+      changes:
+        - createTable:
+            tableName: review_config
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: material_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uk_review_config_material
+                    foreignKeyName: fk_review_config_material
+                    references: study_material(id)
+              - column:
+                  name: intervals
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: missed_policy
+                  type: VARCHAR(10)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/010-create-review-schedule.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/010-create-review-schedule.yaml
@@ -1,0 +1,59 @@
+databaseChangeLog:
+  - changeSet:
+      id: 010-create-review-schedule
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: review_schedule
+      changes:
+        - createTable:
+            tableName: review_schedule
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: study_unit_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_review_schedule_study_unit
+                    references: study_unit(id)
+              - column:
+                  name: sequence
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: scheduled_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(10)
+                  defaultValue: PENDING
+                  constraints:
+                    nullable: false
+              - column:
+                  name: difficulty_feedback
+                  type: VARCHAR(10)
+              - column:
+                  name: completed_at
+                  type: DATETIME(6)
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/011-create-daily-schedule.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/011-create-daily-schedule.yaml
@@ -1,0 +1,144 @@
+databaseChangeLog:
+  - changeSet:
+      id: 011-create-daily-schedule
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: daily_schedule
+      changes:
+        - createTable:
+            tableName: daily_schedule
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_daily_schedule_member
+                    references: member(id)
+              - column:
+                  name: schedule_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: is_dirty
+                  type: BOOLEAN
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: generated_at
+                  type: DATETIME(6)
+              - column:
+                  name: total_blocks
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: completed_blocks
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: daily_schedule
+            columnNames: member_id, schedule_date
+            constraintName: uk_daily_schedule_member_date
+
+  - changeSet:
+      id: 011-create-schedule-block
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: schedule_block
+      changes:
+        - createTable:
+            tableName: schedule_block
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: daily_schedule_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_schedule_block_daily_schedule
+                    references: daily_schedule(id)
+              - column:
+                  name: block_type
+                  type: VARCHAR(15)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: reference_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: start_time
+                  type: TIME
+                  constraints:
+                    nullable: false
+              - column:
+                  name: end_time
+                  type: TIME
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(10)
+                  defaultValue: SCHEDULED
+                  constraints:
+                    nullable: false
+              - column:
+                  name: is_pinned
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: completed_at
+                  type: DATETIME(6)
+              - column:
+                  name: sort_order
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/012-create-streak-reflection.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/012-create-streak-reflection.yaml
@@ -1,0 +1,123 @@
+databaseChangeLog:
+  - changeSet:
+      id: 012-create-streak
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: streak
+      changes:
+        - createTable:
+            tableName: streak
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_streak_member
+                    references: member(id)
+              - column:
+                  name: streak_type
+                  type: VARCHAR(10)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: routine_id
+                  type: BIGINT
+                  constraints:
+                    foreignKeyName: fk_streak_routine
+                    references: routine(id)
+              - column:
+                  name: current_count
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: longest_count
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_achieved_date
+                  type: DATE
+              - column:
+                  name: freeze_used_this_month
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 012-create-daily-reflection
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: daily_reflection
+      changes:
+        - createTable:
+            tableName: daily_reflection
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_daily_reflection_member
+                    references: member(id)
+              - column:
+                  name: reflection_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: memo
+                  type: TEXT
+              - column:
+                  name: mood
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: daily_reflection
+            columnNames: member_id, reflection_date
+            constraintName: uk_daily_reflection_member_date

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/013-create-shedlock.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/013-create-shedlock.yaml
@@ -1,0 +1,34 @@
+databaseChangeLog:
+  - changeSet:
+      id: 013-create-shedlock
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: shedlock
+      changes:
+        - createTable:
+            tableName: shedlock
+            columns:
+              - column:
+                  name: name
+                  type: VARCHAR(64)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: lock_until
+                  type: TIMESTAMP(3)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: locked_at
+                  type: TIMESTAMP(3)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: locked_by
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/014-create-indexes.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/014-create-indexes.yaml
@@ -1,0 +1,61 @@
+databaseChangeLog:
+  - changeSet:
+      id: 014-create-indexes
+      author: wcorn
+      changes:
+        - createIndex:
+            tableName: fixed_schedule
+            indexName: idx_fixed_schedule_member_date
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: schedule_date
+        - createIndex:
+            tableName: fixed_schedule
+            indexName: idx_fixed_schedule_member_recurrence
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: recurrence_type
+        - createIndex:
+            tableName: study_unit
+            indexName: idx_study_unit_material_order
+            columns:
+              - column:
+                  name: material_id
+              - column:
+                  name: sort_order
+        - createIndex:
+            tableName: review_schedule
+            indexName: idx_review_schedule_date_status
+            columns:
+              - column:
+                  name: scheduled_date
+              - column:
+                  name: status
+        - createIndex:
+            tableName: review_schedule
+            indexName: idx_review_schedule_study_unit
+            columns:
+              - column:
+                  name: study_unit_id
+        - createIndex:
+            tableName: schedule_block
+            indexName: idx_schedule_block_daily_order
+            columns:
+              - column:
+                  name: daily_schedule_id
+              - column:
+                  name: sort_order
+        - createIndex:
+            tableName: streak
+            indexName: idx_streak_member_type_routine
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: streak_type
+              - column:
+                  name: routine_id

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,3 +1,29 @@
 databaseChangeLog:
   - include:
       file: db/changelog/changes/001-create-member.yaml
+  - include:
+      file: db/changelog/changes/002-create-category.yaml
+  - include:
+      file: db/changelog/changes/003-create-user-preference.yaml
+  - include:
+      file: db/changelog/changes/004-create-priority-rule.yaml
+  - include:
+      file: db/changelog/changes/005-create-goal-milestone.yaml
+  - include:
+      file: db/changelog/changes/006-create-fixed-schedule.yaml
+  - include:
+      file: db/changelog/changes/007-create-routine.yaml
+  - include:
+      file: db/changelog/changes/008-create-todo.yaml
+  - include:
+      file: db/changelog/changes/009-create-study-material.yaml
+  - include:
+      file: db/changelog/changes/010-create-review-schedule.yaml
+  - include:
+      file: db/changelog/changes/011-create-daily-schedule.yaml
+  - include:
+      file: db/changelog/changes/012-create-streak-reflection.yaml
+  - include:
+      file: db/changelog/changes/013-create-shedlock.yaml
+  - include:
+      file: db/changelog/changes/014-create-indexes.yaml


### PR DESCRIPTION
## 이슈
closes #135

## 작업 내용
Study Planner Data Model 위키 기반으로 전체 DB 스키마를 Liquibase 마이그레이션으로 생성한다.

### 테이블 (21개)
- 기초: category, user_preference, priority_rule
- 목표: goal, milestone
- 고정 일정: fixed_schedule
- 루틴: routine, routine_check, routine_exception
- 할 일: todo
- 학습 자료: study_material, study_unit, material_allocation, material_daily_override, review_config
- 복습: review_schedule
- 스케줄: daily_schedule, schedule_block
- 동기부여: streak, daily_reflection
- 배치: shedlock

### 인덱스 (7개)
- fixed_schedule (member_id, schedule_date), (member_id, recurrence_type)
- study_unit (material_id, sort_order)
- review_schedule (scheduled_date, status), (study_unit_id)
- schedule_block (daily_schedule_id, sort_order)
- streak (member_id, streak_type, routine_id)

### 설계 원칙
- 모든 테이블에 member_id FK 포함 (멀티유저 확장 대비)
- 반복 패턴은 규칙만 저장 (런타임 계산)
- preConditions으로 멱등성 보장