### PR TITLE
feat : 목표/마일스톤 CRUD API 구현

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/controller/GoalController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/controller/GoalController.java
@@ -1,0 +1,127 @@
+package ds.project.orino.planner.goal.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.goal.dto.CreateGoalRequest;
+import ds.project.orino.planner.goal.dto.CreateMilestoneRequest;
+import ds.project.orino.planner.goal.dto.GoalDetailResponse;
+import ds.project.orino.planner.goal.dto.GoalResponse;
+import ds.project.orino.planner.goal.dto.GoalStatusRequest;
+import ds.project.orino.planner.goal.dto.MilestoneResponse;
+import ds.project.orino.planner.goal.dto.UpdateGoalRequest;
+import ds.project.orino.planner.goal.dto.UpdateMilestoneRequest;
+import ds.project.orino.planner.goal.service.GoalService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/goals")
+public class GoalController {
+
+    private final GoalService goalService;
+
+    public GoalController(GoalService goalService) {
+        this.goalService = goalService;
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<GoalResponse>>> getGoals(Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(goalService.getGoals(memberId)));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<GoalDetailResponse>> getGoal(
+            Authentication authentication, @PathVariable Long id) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(goalService.getGoal(memberId, id)));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<GoalResponse>> create(
+            Authentication authentication,
+            @Valid @RequestBody CreateGoalRequest request) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(goalService.create(memberId, request)));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<GoalResponse>> update(
+            Authentication authentication,
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateGoalRequest request) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(goalService.update(memberId, id, request)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> delete(
+            Authentication authentication, @PathVariable Long id) {
+        Long memberId = (Long) authentication.getPrincipal();
+        goalService.delete(memberId, id);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<ApiResponse<GoalResponse>> changeStatus(
+            Authentication authentication,
+            @PathVariable Long id,
+            @Valid @RequestBody GoalStatusRequest request) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(goalService.changeStatus(memberId, id, request.status())));
+    }
+
+    @PostMapping("/{id}/milestones")
+    public ResponseEntity<ApiResponse<MilestoneResponse>> createMilestone(
+            Authentication authentication,
+            @PathVariable Long id,
+            @Valid @RequestBody CreateMilestoneRequest request) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(goalService.createMilestone(memberId, id, request)));
+    }
+
+    @PutMapping("/{goalId}/milestones/{id}")
+    public ResponseEntity<ApiResponse<MilestoneResponse>> updateMilestone(
+            Authentication authentication,
+            @PathVariable Long goalId,
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateMilestoneRequest request) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                goalService.updateMilestone(memberId, goalId, id, request)));
+    }
+
+    @DeleteMapping("/{goalId}/milestones/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteMilestone(
+            Authentication authentication,
+            @PathVariable Long goalId,
+            @PathVariable Long id) {
+        Long memberId = (Long) authentication.getPrincipal();
+        goalService.deleteMilestone(memberId, goalId, id);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PatchMapping("/{goalId}/milestones/{id}/complete")
+    public ResponseEntity<ApiResponse<MilestoneResponse>> completeMilestone(
+            Authentication authentication,
+            @PathVariable Long goalId,
+            @PathVariable Long id) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                goalService.completeMilestone(memberId, goalId, id)));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/CreateGoalRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/CreateGoalRequest.java
@@ -1,0 +1,18 @@
+package ds.project.orino.planner.goal.dto;
+
+import ds.project.orino.domain.goal.entity.PeriodType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record CreateGoalRequest(
+        @NotBlank @Size(max = 100) String title,
+        String description,
+        Long categoryId,
+        @NotNull PeriodType periodType,
+        @NotNull LocalDate startDate,
+        LocalDate deadline
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/CreateMilestoneRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/CreateMilestoneRequest.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.goal.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record CreateMilestoneRequest(
+        @NotBlank @Size(max = 100) String title,
+        LocalDate deadline,
+        int sortOrder
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/GoalDetailResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/GoalDetailResponse.java
@@ -1,0 +1,39 @@
+package ds.project.orino.planner.goal.dto;
+
+import ds.project.orino.domain.goal.entity.Goal;
+import ds.project.orino.domain.goal.entity.GoalStatus;
+import ds.project.orino.domain.goal.entity.PeriodType;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record GoalDetailResponse(
+        Long id,
+        String title,
+        String description,
+        Long categoryId,
+        PeriodType periodType,
+        LocalDate startDate,
+        LocalDate deadline,
+        GoalStatus status,
+        List<MilestoneResponse> milestones
+) {
+
+    public static GoalDetailResponse from(Goal goal) {
+        List<MilestoneResponse> milestoneResponses = goal.getMilestones().stream()
+                .map(MilestoneResponse::from)
+                .toList();
+
+        return new GoalDetailResponse(
+                goal.getId(),
+                goal.getTitle(),
+                goal.getDescription(),
+                goal.getCategory() != null ? goal.getCategory().getId() : null,
+                goal.getPeriodType(),
+                goal.getStartDate(),
+                goal.getDeadline(),
+                goal.getStatus(),
+                milestoneResponses
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/GoalResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/GoalResponse.java
@@ -1,0 +1,42 @@
+package ds.project.orino.planner.goal.dto;
+
+import ds.project.orino.domain.goal.entity.Goal;
+import ds.project.orino.domain.goal.entity.GoalStatus;
+import ds.project.orino.domain.goal.entity.MilestoneStatus;
+import ds.project.orino.domain.goal.entity.PeriodType;
+
+import java.time.LocalDate;
+
+public record GoalResponse(
+        Long id,
+        String title,
+        String description,
+        Long categoryId,
+        PeriodType periodType,
+        LocalDate startDate,
+        LocalDate deadline,
+        GoalStatus status,
+        int milestoneCount,
+        int completedMilestoneCount
+) {
+
+    public static GoalResponse from(Goal goal) {
+        int total = goal.getMilestones().size();
+        int completed = (int) goal.getMilestones().stream()
+                .filter(m -> m.getStatus() == MilestoneStatus.COMPLETED)
+                .count();
+
+        return new GoalResponse(
+                goal.getId(),
+                goal.getTitle(),
+                goal.getDescription(),
+                goal.getCategory() != null ? goal.getCategory().getId() : null,
+                goal.getPeriodType(),
+                goal.getStartDate(),
+                goal.getDeadline(),
+                goal.getStatus(),
+                total,
+                completed
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/GoalStatusRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/GoalStatusRequest.java
@@ -1,0 +1,9 @@
+package ds.project.orino.planner.goal.dto;
+
+import ds.project.orino.domain.goal.entity.GoalStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record GoalStatusRequest(
+        @NotNull GoalStatus status
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/MilestoneResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/MilestoneResponse.java
@@ -1,0 +1,25 @@
+package ds.project.orino.planner.goal.dto;
+
+import ds.project.orino.domain.goal.entity.Milestone;
+import ds.project.orino.domain.goal.entity.MilestoneStatus;
+
+import java.time.LocalDate;
+
+public record MilestoneResponse(
+        Long id,
+        String title,
+        LocalDate deadline,
+        MilestoneStatus status,
+        int sortOrder
+) {
+
+    public static MilestoneResponse from(Milestone milestone) {
+        return new MilestoneResponse(
+                milestone.getId(),
+                milestone.getTitle(),
+                milestone.getDeadline(),
+                milestone.getStatus(),
+                milestone.getSortOrder()
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/UpdateGoalRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/UpdateGoalRequest.java
@@ -1,0 +1,18 @@
+package ds.project.orino.planner.goal.dto;
+
+import ds.project.orino.domain.goal.entity.PeriodType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record UpdateGoalRequest(
+        @NotBlank @Size(max = 100) String title,
+        String description,
+        Long categoryId,
+        @NotNull PeriodType periodType,
+        @NotNull LocalDate startDate,
+        LocalDate deadline
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/UpdateMilestoneRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/UpdateMilestoneRequest.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.goal.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record UpdateMilestoneRequest(
+        @NotBlank @Size(max = 100) String title,
+        LocalDate deadline,
+        int sortOrder
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/service/GoalService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/service/GoalService.java
@@ -1,0 +1,155 @@
+package ds.project.orino.planner.goal.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.category.entity.Category;
+import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.domain.goal.entity.Goal;
+import ds.project.orino.domain.goal.entity.GoalStatus;
+import ds.project.orino.domain.goal.entity.Milestone;
+import ds.project.orino.domain.goal.repository.GoalRepository;
+import ds.project.orino.domain.goal.repository.MilestoneRepository;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.planner.goal.dto.CreateGoalRequest;
+import ds.project.orino.planner.goal.dto.CreateMilestoneRequest;
+import ds.project.orino.planner.goal.dto.GoalDetailResponse;
+import ds.project.orino.planner.goal.dto.GoalResponse;
+import ds.project.orino.planner.goal.dto.MilestoneResponse;
+import ds.project.orino.planner.goal.dto.UpdateGoalRequest;
+import ds.project.orino.planner.goal.dto.UpdateMilestoneRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class GoalService {
+
+    private final GoalRepository goalRepository;
+    private final MilestoneRepository milestoneRepository;
+    private final MemberRepository memberRepository;
+    private final CategoryRepository categoryRepository;
+
+    public GoalService(GoalRepository goalRepository, MilestoneRepository milestoneRepository,
+                       MemberRepository memberRepository, CategoryRepository categoryRepository) {
+        this.goalRepository = goalRepository;
+        this.milestoneRepository = milestoneRepository;
+        this.memberRepository = memberRepository;
+        this.categoryRepository = categoryRepository;
+    }
+
+    public List<GoalResponse> getGoals(Long memberId) {
+        return goalRepository.findByMemberIdOrderByCreatedAtDesc(memberId)
+                .stream()
+                .map(GoalResponse::from)
+                .toList();
+    }
+
+    public GoalDetailResponse getGoal(Long memberId, Long goalId) {
+        Goal goal = goalRepository.findByIdAndMemberId(goalId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        return GoalDetailResponse.from(goal);
+    }
+
+    @Transactional
+    public GoalResponse create(Long memberId, CreateGoalRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        Category category = resolveCategory(request.categoryId(), memberId);
+
+        Goal goal = new Goal(member, category, request.title(), request.description(),
+                request.periodType(), request.startDate(), request.deadline());
+
+        return GoalResponse.from(goalRepository.save(goal));
+    }
+
+    @Transactional
+    public GoalResponse update(Long memberId, Long goalId, UpdateGoalRequest request) {
+        Goal goal = goalRepository.findByIdAndMemberId(goalId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        Category category = resolveCategory(request.categoryId(), memberId);
+
+        goal.update(category, request.title(), request.description(),
+                request.periodType(), request.startDate(), request.deadline());
+
+        return GoalResponse.from(goal);
+    }
+
+    @Transactional
+    public void delete(Long memberId, Long goalId) {
+        Goal goal = goalRepository.findByIdAndMemberId(goalId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        goalRepository.delete(goal);
+    }
+
+    @Transactional
+    public GoalResponse changeStatus(Long memberId, Long goalId, GoalStatus status) {
+        Goal goal = goalRepository.findByIdAndMemberId(goalId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        goal.changeStatus(status);
+
+        return GoalResponse.from(goal);
+    }
+
+    @Transactional
+    public MilestoneResponse createMilestone(Long memberId, Long goalId, CreateMilestoneRequest request) {
+        Goal goal = goalRepository.findByIdAndMemberId(goalId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        Milestone milestone = new Milestone(goal, request.title(), request.deadline(), request.sortOrder());
+
+        return MilestoneResponse.from(milestoneRepository.save(milestone));
+    }
+
+    @Transactional
+    public MilestoneResponse updateMilestone(Long memberId, Long goalId, Long milestoneId,
+                                             UpdateMilestoneRequest request) {
+        goalRepository.findByIdAndMemberId(goalId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        Milestone milestone = milestoneRepository.findByIdAndGoalId(milestoneId, goalId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        milestone.update(request.title(), request.deadline(), request.sortOrder());
+
+        return MilestoneResponse.from(milestone);
+    }
+
+    @Transactional
+    public void deleteMilestone(Long memberId, Long goalId, Long milestoneId) {
+        goalRepository.findByIdAndMemberId(goalId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        Milestone milestone = milestoneRepository.findByIdAndGoalId(milestoneId, goalId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        milestoneRepository.delete(milestone);
+    }
+
+    @Transactional
+    public MilestoneResponse completeMilestone(Long memberId, Long goalId, Long milestoneId) {
+        goalRepository.findByIdAndMemberId(goalId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        Milestone milestone = milestoneRepository.findByIdAndGoalId(milestoneId, goalId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        milestone.complete();
+
+        return MilestoneResponse.from(milestone);
+    }
+
+    private Category resolveCategory(Long categoryId, Long memberId) {
+        if (categoryId == null) {
+            return null;
+        }
+        return categoryRepository.findByIdAndMemberId(categoryId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/auth/controller/AuthControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/auth/controller/AuthControllerTest.java
@@ -1,6 +1,8 @@
 package ds.project.orino.auth.controller;
 
 import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.domain.goal.repository.GoalRepository;
+import ds.project.orino.domain.goal.repository.MilestoneRepository;
 import ds.project.orino.domain.member.repository.MemberRepository;
 import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.MemberFixture;
@@ -24,8 +26,16 @@ class AuthControllerTest extends ApiTestSupport {
     @Autowired
     private CategoryRepository categoryRepository;
 
+    @Autowired
+    private MilestoneRepository milestoneRepository;
+
+    @Autowired
+    private GoalRepository goalRepository;
+
     @BeforeEach
     void setUp() {
+        milestoneRepository.deleteAll();
+        goalRepository.deleteAll();
         categoryRepository.deleteAll();
         memberRepository.deleteAll();
         memberRepository.save(MemberFixture.create());

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/category/controller/CategoryControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/category/controller/CategoryControllerTest.java
@@ -1,6 +1,8 @@
 package ds.project.orino.planner.category.controller;
 
 import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.domain.goal.repository.GoalRepository;
+import ds.project.orino.domain.goal.repository.MilestoneRepository;
 import ds.project.orino.domain.member.repository.MemberRepository;
 import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.MemberFixture;
@@ -27,10 +29,18 @@ class CategoryControllerTest extends ApiTestSupport {
     @Autowired
     private CategoryRepository categoryRepository;
 
+    @Autowired
+    private MilestoneRepository milestoneRepository;
+
+    @Autowired
+    private GoalRepository goalRepository;
+
     private String accessToken;
 
     @BeforeEach
     void setUp() throws Exception {
+        milestoneRepository.deleteAll();
+        goalRepository.deleteAll();
         categoryRepository.deleteAll();
         memberRepository.deleteAll();
         memberRepository.save(MemberFixture.create());

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/goal/controller/GoalControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/goal/controller/GoalControllerTest.java
@@ -1,0 +1,357 @@
+package ds.project.orino.planner.goal.controller;
+
+import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.domain.goal.repository.GoalRepository;
+import ds.project.orino.domain.goal.repository.MilestoneRepository;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GoalControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private MilestoneRepository milestoneRepository;
+
+    @Autowired
+    private GoalRepository goalRepository;
+
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        milestoneRepository.deleteAll();
+        goalRepository.deleteAll();
+        categoryRepository.deleteAll();
+        memberRepository.deleteAll();
+        memberRepository.save(MemberFixture.create());
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId": "%s", "password": "%s"}
+                                """.formatted(MemberFixture.DEFAULT_LOGIN_ID, MemberFixture.DEFAULT_PASSWORD)))
+                .andReturn();
+
+        accessToken = com.jayway.jsonpath.JsonPath.read(
+                loginResult.getResponse().getContentAsString(), "$.data.accessToken");
+    }
+
+    @Test
+    @DisplayName("POST /api/goals - 목표를 생성한다")
+    void create() throws Exception {
+        mockMvc.perform(post("/api/goals")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "알고리즘 마스터", "periodType": "QUARTER",
+                                 "startDate": "2026-04-01", "deadline": "2026-06-30"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.title").value("알고리즘 마스터"))
+                .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    @DisplayName("GET /api/goals - 목표 목록을 조회한다")
+    void getGoals() throws Exception {
+        mockMvc.perform(post("/api/goals")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"title": "목표1", "periodType": "QUARTER",
+                         "startDate": "2026-04-01"}
+                        """));
+        mockMvc.perform(post("/api/goals")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"title": "목표2", "periodType": "YEAR",
+                         "startDate": "2026-01-01"}
+                        """));
+
+        mockMvc.perform(get("/api/goals")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(2)));
+    }
+
+    @Test
+    @DisplayName("GET /api/goals/{id} - 목표 상세를 조회한다")
+    void getGoal() throws Exception {
+        MvcResult createResult = mockMvc.perform(post("/api/goals")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "상세 목표", "description": "설명입니다",
+                                 "periodType": "HALF_YEAR", "startDate": "2026-01-01",
+                                 "deadline": "2026-06-30"}
+                                """))
+                .andReturn();
+
+        Integer goalId = com.jayway.jsonpath.JsonPath.read(
+                createResult.getResponse().getContentAsString(), "$.data.id");
+
+        mockMvc.perform(get("/api/goals/" + goalId)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("상세 목표"))
+                .andExpect(jsonPath("$.data.description").value("설명입니다"))
+                .andExpect(jsonPath("$.data.milestones").isArray());
+    }
+
+    @Test
+    @DisplayName("PUT /api/goals/{id} - 목표를 수정한다")
+    void update() throws Exception {
+        MvcResult createResult = mockMvc.perform(post("/api/goals")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "기존 목표", "periodType": "QUARTER",
+                                 "startDate": "2026-04-01"}
+                                """))
+                .andReturn();
+
+        Integer goalId = com.jayway.jsonpath.JsonPath.read(
+                createResult.getResponse().getContentAsString(), "$.data.id");
+
+        mockMvc.perform(put("/api/goals/" + goalId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "수정된 목표", "periodType": "YEAR",
+                                 "startDate": "2026-01-01", "deadline": "2026-12-31"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("수정된 목표"))
+                .andExpect(jsonPath("$.data.periodType").value("YEAR"));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/goals/{id} - 목표를 삭제한다")
+    void deleteGoal() throws Exception {
+        MvcResult createResult = mockMvc.perform(post("/api/goals")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "삭제대상", "periodType": "QUARTER",
+                                 "startDate": "2026-04-01"}
+                                """))
+                .andReturn();
+
+        Integer goalId = com.jayway.jsonpath.JsonPath.read(
+                createResult.getResponse().getContentAsString(), "$.data.id");
+
+        mockMvc.perform(delete("/api/goals/" + goalId)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/goals")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(jsonPath("$.data", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/goals/{id}/status - 목표 상태를 변경한다")
+    void changeStatus() throws Exception {
+        MvcResult createResult = mockMvc.perform(post("/api/goals")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "상태변경", "periodType": "QUARTER",
+                                 "startDate": "2026-04-01"}
+                                """))
+                .andReturn();
+
+        Integer goalId = com.jayway.jsonpath.JsonPath.read(
+                createResult.getResponse().getContentAsString(), "$.data.id");
+
+        mockMvc.perform(patch("/api/goals/" + goalId + "/status")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"status": "COMPLETED"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("COMPLETED"));
+    }
+
+    @Test
+    @DisplayName("POST /api/goals/{id}/milestones - 마일스톤을 추가한다")
+    void createMilestone() throws Exception {
+        MvcResult createResult = mockMvc.perform(post("/api/goals")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "목표", "periodType": "QUARTER",
+                                 "startDate": "2026-04-01"}
+                                """))
+                .andReturn();
+
+        Integer goalId = com.jayway.jsonpath.JsonPath.read(
+                createResult.getResponse().getContentAsString(), "$.data.id");
+
+        mockMvc.perform(post("/api/goals/" + goalId + "/milestones")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "중간 목표", "deadline": "2026-05-01", "sortOrder": 0}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.title").value("중간 목표"))
+                .andExpect(jsonPath("$.data.status").value("PENDING"));
+    }
+
+    @Test
+    @DisplayName("PUT /api/goals/{goalId}/milestones/{id} - 마일스톤을 수정한다")
+    void updateMilestone() throws Exception {
+        MvcResult goalResult = mockMvc.perform(post("/api/goals")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "목표", "periodType": "QUARTER",
+                                 "startDate": "2026-04-01"}
+                                """))
+                .andReturn();
+
+        Integer goalId = com.jayway.jsonpath.JsonPath.read(
+                goalResult.getResponse().getContentAsString(), "$.data.id");
+
+        MvcResult milestoneResult = mockMvc.perform(post("/api/goals/" + goalId + "/milestones")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "기존 마일스톤", "sortOrder": 0}
+                                """))
+                .andReturn();
+
+        Integer milestoneId = com.jayway.jsonpath.JsonPath.read(
+                milestoneResult.getResponse().getContentAsString(), "$.data.id");
+
+        mockMvc.perform(put("/api/goals/" + goalId + "/milestones/" + milestoneId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "수정된 마일스톤", "deadline": "2026-05-15", "sortOrder": 1}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("수정된 마일스톤"))
+                .andExpect(jsonPath("$.data.sortOrder").value(1));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/goals/{goalId}/milestones/{id} - 마일스톤을 삭제한다")
+    void deleteMilestone() throws Exception {
+        MvcResult goalResult = mockMvc.perform(post("/api/goals")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "목표", "periodType": "QUARTER",
+                                 "startDate": "2026-04-01"}
+                                """))
+                .andReturn();
+
+        Integer goalId = com.jayway.jsonpath.JsonPath.read(
+                goalResult.getResponse().getContentAsString(), "$.data.id");
+
+        MvcResult milestoneResult = mockMvc.perform(post("/api/goals/" + goalId + "/milestones")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "삭제대상", "sortOrder": 0}
+                                """))
+                .andReturn();
+
+        Integer milestoneId = com.jayway.jsonpath.JsonPath.read(
+                milestoneResult.getResponse().getContentAsString(), "$.data.id");
+
+        mockMvc.perform(delete("/api/goals/" + goalId + "/milestones/" + milestoneId)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/goals/" + goalId)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(jsonPath("$.data.milestones", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/goals/{goalId}/milestones/{id}/complete - 마일스톤을 완료 처리한다")
+    void completeMilestone() throws Exception {
+        MvcResult goalResult = mockMvc.perform(post("/api/goals")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "목표", "periodType": "QUARTER",
+                                 "startDate": "2026-04-01"}
+                                """))
+                .andReturn();
+
+        Integer goalId = com.jayway.jsonpath.JsonPath.read(
+                goalResult.getResponse().getContentAsString(), "$.data.id");
+
+        MvcResult milestoneResult = mockMvc.perform(post("/api/goals/" + goalId + "/milestones")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "완료할 마일스톤", "sortOrder": 0}
+                                """))
+                .andReturn();
+
+        Integer milestoneId = com.jayway.jsonpath.JsonPath.read(
+                milestoneResult.getResponse().getContentAsString(), "$.data.id");
+
+        mockMvc.perform(patch("/api/goals/" + goalId + "/milestones/" + milestoneId + "/complete")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("COMPLETED"));
+    }
+
+    @Test
+    @DisplayName("GET /api/goals/{id} - 존재하지 않는 목표이면 404를 반환한다")
+    void getGoal_notFound() throws Exception {
+        mockMvc.perform(get("/api/goals/999")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+    }
+
+    @Test
+    @DisplayName("POST /api/goals - 잘못된 periodType이면 400을 반환한다")
+    void create_invalidPeriodType() throws Exception {
+        mockMvc.perform(post("/api/goals")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "목표", "periodType": "INVALID",
+                                 "startDate": "2026-04-01"}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("인증 없이 요청하면 403을 반환한다")
+    void unauthorized() throws Exception {
+        mockMvc.perform(get("/api/goals"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/goal/service/GoalServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/goal/service/GoalServiceTest.java
@@ -1,0 +1,298 @@
+package ds.project.orino.planner.goal.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.category.entity.Category;
+import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.domain.goal.entity.Goal;
+import ds.project.orino.domain.goal.entity.GoalStatus;
+import ds.project.orino.domain.goal.entity.Milestone;
+import ds.project.orino.domain.goal.entity.MilestoneStatus;
+import ds.project.orino.domain.goal.entity.PeriodType;
+import ds.project.orino.domain.goal.repository.GoalRepository;
+import ds.project.orino.domain.goal.repository.MilestoneRepository;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.planner.goal.dto.CreateGoalRequest;
+import ds.project.orino.planner.goal.dto.CreateMilestoneRequest;
+import ds.project.orino.planner.goal.dto.GoalDetailResponse;
+import ds.project.orino.planner.goal.dto.GoalResponse;
+import ds.project.orino.planner.goal.dto.MilestoneResponse;
+import ds.project.orino.planner.goal.dto.UpdateGoalRequest;
+import ds.project.orino.planner.goal.dto.UpdateMilestoneRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GoalServiceTest {
+
+    private GoalService goalService;
+
+    @Mock
+    private GoalRepository goalRepository;
+
+    @Mock
+    private MilestoneRepository milestoneRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        goalService = new GoalService(goalRepository, milestoneRepository, memberRepository, categoryRepository);
+        member = new Member("admin", "encoded");
+    }
+
+    @Test
+    @DisplayName("목표 목록을 조회한다")
+    void getGoals() {
+        Goal goal = new Goal(member, null, "목표1", null, PeriodType.QUARTER,
+                LocalDate.of(2026, 4, 1), LocalDate.of(2026, 6, 30));
+
+        given(goalRepository.findByMemberIdOrderByCreatedAtDesc(1L))
+                .willReturn(List.of(goal));
+
+        List<GoalResponse> result = goalService.getGoals(1L);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).title()).isEqualTo("목표1");
+    }
+
+    @Test
+    @DisplayName("목표 상세를 조회한다")
+    void getGoal() {
+        Goal goal = new Goal(member, null, "목표1", "설명", PeriodType.YEAR,
+                LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31));
+
+        given(goalRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(goal));
+
+        GoalDetailResponse result = goalService.getGoal(1L, 1L);
+
+        assertThat(result.title()).isEqualTo("목표1");
+        assertThat(result.description()).isEqualTo("설명");
+    }
+
+    @Test
+    @DisplayName("목표를 생성한다")
+    void create() {
+        Goal saved = new Goal(member, null, "새 목표", null, PeriodType.QUARTER,
+                LocalDate.of(2026, 4, 1), LocalDate.of(2026, 6, 30));
+
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+        given(goalRepository.save(any(Goal.class))).willReturn(saved);
+
+        GoalResponse result = goalService.create(1L,
+                new CreateGoalRequest("새 목표", null, null, PeriodType.QUARTER,
+                        LocalDate.of(2026, 4, 1), LocalDate.of(2026, 6, 30)));
+
+        assertThat(result.title()).isEqualTo("새 목표");
+        assertThat(result.periodType()).isEqualTo(PeriodType.QUARTER);
+    }
+
+    @Test
+    @DisplayName("카테고리를 지정하여 목표를 생성한다")
+    void create_withCategory() {
+        Category category = new Category(member, "프로그래밍", "#FF9800", "code", 0);
+        Goal saved = new Goal(member, category, "새 목표", null, PeriodType.QUARTER,
+                LocalDate.of(2026, 4, 1), null);
+
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+        given(categoryRepository.findByIdAndMemberId(1L, 1L)).willReturn(Optional.of(category));
+        given(goalRepository.save(any(Goal.class))).willReturn(saved);
+
+        GoalResponse result = goalService.create(1L,
+                new CreateGoalRequest("새 목표", null, 1L, PeriodType.QUARTER,
+                        LocalDate.of(2026, 4, 1), null));
+
+        assertThat(result.title()).isEqualTo("새 목표");
+        verify(categoryRepository).findByIdAndMemberId(1L, 1L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원으로 목표 생성 시 예외를 던진다")
+    void create_memberNotFound() {
+        given(memberRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> goalService.create(999L,
+                new CreateGoalRequest("테스트", null, null, PeriodType.QUARTER,
+                        LocalDate.of(2026, 4, 1), null)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("목표를 수정한다")
+    void update() {
+        Goal goal = new Goal(member, null, "기존 목표", null, PeriodType.QUARTER,
+                LocalDate.of(2026, 4, 1), null);
+
+        given(goalRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(goal));
+
+        GoalResponse result = goalService.update(1L, 1L,
+                new UpdateGoalRequest("수정된 목표", "새 설명", null, PeriodType.YEAR,
+                        LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31)));
+
+        assertThat(result.title()).isEqualTo("수정된 목표");
+        assertThat(result.periodType()).isEqualTo(PeriodType.YEAR);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 목표 수정 시 예외를 던진다")
+    void update_notFound() {
+        given(goalRepository.findByIdAndMemberId(999L, 1L))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> goalService.update(1L, 999L,
+                new UpdateGoalRequest("이름", null, null, PeriodType.QUARTER,
+                        LocalDate.of(2026, 4, 1), null)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("목표를 삭제한다")
+    void delete() {
+        Goal goal = new Goal(member, null, "삭제대상", null, PeriodType.QUARTER,
+                LocalDate.of(2026, 4, 1), null);
+
+        given(goalRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(goal));
+
+        goalService.delete(1L, 1L);
+
+        verify(goalRepository).delete(goal);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 목표 삭제 시 예외를 던진다")
+    void delete_notFound() {
+        given(goalRepository.findByIdAndMemberId(999L, 1L))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> goalService.delete(1L, 999L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("목표 상태를 변경한다")
+    void changeStatus() {
+        Goal goal = new Goal(member, null, "목표", null, PeriodType.QUARTER,
+                LocalDate.of(2026, 4, 1), null);
+
+        given(goalRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(goal));
+
+        GoalResponse result = goalService.changeStatus(1L, 1L, GoalStatus.COMPLETED);
+
+        assertThat(result.status()).isEqualTo(GoalStatus.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("마일스톤을 추가한다")
+    void createMilestone() {
+        Goal goal = new Goal(member, null, "목표", null, PeriodType.QUARTER,
+                LocalDate.of(2026, 4, 1), null);
+        Milestone saved = new Milestone(goal, "마일스톤1", LocalDate.of(2026, 5, 1), 0);
+
+        given(goalRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(goal));
+        given(milestoneRepository.save(any(Milestone.class))).willReturn(saved);
+
+        MilestoneResponse result = goalService.createMilestone(1L, 1L,
+                new CreateMilestoneRequest("마일스톤1", LocalDate.of(2026, 5, 1), 0));
+
+        assertThat(result.title()).isEqualTo("마일스톤1");
+        assertThat(result.status()).isEqualTo(MilestoneStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("마일스톤을 수정한다")
+    void updateMilestone() {
+        Goal goal = new Goal(member, null, "목표", null, PeriodType.QUARTER,
+                LocalDate.of(2026, 4, 1), null);
+        Milestone milestone = new Milestone(goal, "기존", null, 0);
+
+        given(goalRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(goal));
+        given(milestoneRepository.findByIdAndGoalId(1L, 1L))
+                .willReturn(Optional.of(milestone));
+
+        MilestoneResponse result = goalService.updateMilestone(1L, 1L, 1L,
+                new UpdateMilestoneRequest("수정됨", LocalDate.of(2026, 5, 15), 2));
+
+        assertThat(result.title()).isEqualTo("수정됨");
+        assertThat(result.sortOrder()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("마일스톤을 삭제한다")
+    void deleteMilestone() {
+        Goal goal = new Goal(member, null, "목표", null, PeriodType.QUARTER,
+                LocalDate.of(2026, 4, 1), null);
+        Milestone milestone = new Milestone(goal, "삭제대상", null, 0);
+
+        given(goalRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(goal));
+        given(milestoneRepository.findByIdAndGoalId(1L, 1L))
+                .willReturn(Optional.of(milestone));
+
+        goalService.deleteMilestone(1L, 1L, 1L);
+
+        verify(milestoneRepository).delete(milestone);
+    }
+
+    @Test
+    @DisplayName("마일스톤을 완료 처리한다")
+    void completeMilestone() {
+        Goal goal = new Goal(member, null, "목표", null, PeriodType.QUARTER,
+                LocalDate.of(2026, 4, 1), null);
+        Milestone milestone = new Milestone(goal, "마일스톤", null, 0);
+
+        given(goalRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(goal));
+        given(milestoneRepository.findByIdAndGoalId(1L, 1L))
+                .willReturn(Optional.of(milestone));
+
+        MilestoneResponse result = goalService.completeMilestone(1L, 1L, 1L);
+
+        assertThat(result.status()).isEqualTo(MilestoneStatus.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 목표의 마일스톤 추가 시 예외를 던진다")
+    void createMilestone_goalNotFound() {
+        given(goalRepository.findByIdAndMemberId(999L, 1L))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> goalService.createMilestone(1L, 999L,
+                new CreateMilestoneRequest("마일스톤", null, 0)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/security/SecurityConfigTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/security/SecurityConfigTest.java
@@ -1,6 +1,8 @@
 package ds.project.orino.security;
 
 import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.domain.goal.repository.GoalRepository;
+import ds.project.orino.domain.goal.repository.MilestoneRepository;
 import ds.project.orino.domain.member.repository.MemberRepository;
 import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.MemberFixture;
@@ -24,8 +26,16 @@ class SecurityConfigTest extends ApiTestSupport {
     @Autowired
     private CategoryRepository categoryRepository;
 
+    @Autowired
+    private MilestoneRepository milestoneRepository;
+
+    @Autowired
+    private GoalRepository goalRepository;
+
     @BeforeEach
     void setUp() {
+        milestoneRepository.deleteAll();
+        goalRepository.deleteAll();
         categoryRepository.deleteAll();
         memberRepository.deleteAll();
         memberRepository.save(MemberFixture.create());

--- a/be/orino-core-web/src/main/java/ds/project/orino/core/web/GlobalExceptionHandler.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/web/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -56,5 +57,13 @@ public class GlobalExceptionHandler {
         log.error("handleTypeMismatch: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(ErrorCode.BAD_REQUEST, e));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleMessageNotReadable(
+            HttpMessageNotReadableException e) {
+        log.error("handleMessageNotReadable: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(ErrorCode.BAD_REQUEST));
     }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/goal/entity/Goal.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/goal/entity/Goal.java
@@ -1,0 +1,148 @@
+package ds.project.orino.domain.goal.entity;
+
+import ds.project.orino.domain.category.entity.Category;
+import ds.project.orino.domain.member.entity.Member;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Goal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 15, nullable = false)
+    private PeriodType periodType;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    private LocalDate deadline;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10, nullable = false)
+    private GoalStatus status = GoalStatus.ACTIVE;
+
+    @OneToMany(mappedBy = "goal", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Milestone> milestones = new ArrayList<>();
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected Goal() {
+    }
+
+    public Goal(Member member, Category category, String title, String description,
+                PeriodType periodType, LocalDate startDate, LocalDate deadline) {
+        this.member = member;
+        this.category = category;
+        this.title = title;
+        this.description = description;
+        this.periodType = periodType;
+        this.startDate = startDate;
+        this.deadline = deadline;
+    }
+
+    public void update(Category category, String title, String description,
+                       PeriodType periodType, LocalDate startDate, LocalDate deadline) {
+        this.category = category;
+        this.title = title;
+        this.description = description;
+        this.periodType = periodType;
+        this.startDate = startDate;
+        this.deadline = deadline;
+    }
+
+    public void changeStatus(GoalStatus status) {
+        this.status = status;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public PeriodType getPeriodType() {
+        return periodType;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public LocalDate getDeadline() {
+        return deadline;
+    }
+
+    public GoalStatus getStatus() {
+        return status;
+    }
+
+    public List<Milestone> getMilestones() {
+        return milestones;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/goal/entity/GoalStatus.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/goal/entity/GoalStatus.java
@@ -1,0 +1,5 @@
+package ds.project.orino.domain.goal.entity;
+
+public enum GoalStatus {
+    ACTIVE, COMPLETED, ARCHIVED
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/goal/entity/Milestone.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/goal/entity/Milestone.java
@@ -1,0 +1,104 @@
+package ds.project.orino.domain.goal.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Milestone {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "goal_id", nullable = false)
+    private Goal goal;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    private LocalDate deadline;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10, nullable = false)
+    private MilestoneStatus status = MilestoneStatus.PENDING;
+
+    @Column(nullable = false)
+    private int sortOrder;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected Milestone() {
+    }
+
+    public Milestone(Goal goal, String title, LocalDate deadline, int sortOrder) {
+        this.goal = goal;
+        this.title = title;
+        this.deadline = deadline;
+        this.sortOrder = sortOrder;
+    }
+
+    public void update(String title, LocalDate deadline, int sortOrder) {
+        this.title = title;
+        this.deadline = deadline;
+        this.sortOrder = sortOrder;
+    }
+
+    public void complete() {
+        this.status = MilestoneStatus.COMPLETED;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Goal getGoal() {
+        return goal;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public LocalDate getDeadline() {
+        return deadline;
+    }
+
+    public MilestoneStatus getStatus() {
+        return status;
+    }
+
+    public int getSortOrder() {
+        return sortOrder;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/goal/entity/MilestoneStatus.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/goal/entity/MilestoneStatus.java
@@ -1,0 +1,5 @@
+package ds.project.orino.domain.goal.entity;
+
+public enum MilestoneStatus {
+    PENDING, COMPLETED
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/goal/entity/PeriodType.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/goal/entity/PeriodType.java
@@ -1,0 +1,5 @@
+package ds.project.orino.domain.goal.entity;
+
+public enum PeriodType {
+    YEAR, HALF_YEAR, QUARTER
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/goal/repository/GoalRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/goal/repository/GoalRepository.java
@@ -1,0 +1,14 @@
+package ds.project.orino.domain.goal.repository;
+
+import ds.project.orino.domain.goal.entity.Goal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GoalRepository extends JpaRepository<Goal, Long> {
+
+    List<Goal> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+    Optional<Goal> findByIdAndMemberId(Long id, Long memberId);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/goal/repository/MilestoneRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/goal/repository/MilestoneRepository.java
@@ -1,0 +1,11 @@
+package ds.project.orino.domain.goal.repository;
+
+import ds.project.orino.domain.goal.entity.Milestone;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MilestoneRepository extends JpaRepository<Milestone, Long> {
+
+    Optional<Milestone> findByIdAndGoalId(Long id, Long goalId);
+}


### PR DESCRIPTION
## 이슈
closes #137
## 작업 내용
- Goal, Milestone 엔티티 및 Enum (GoalStatus, PeriodType, MilestoneStatus) 구현
- GoalRepository, MilestoneRepository 구현
- GoalService: 목표 CRUD, 상태 변경(ACTIVE/COMPLETED/ARCHIVED), 마일스톤 CRUD/완료
- GoalController: 10개 REST API 엔드포인트
  - GET/POST/PUT/DELETE /api/goals
  - PATCH /api/goals/{id}/status
  - POST/PUT/DELETE /api/goals/{id}/milestones
  - PATCH /api/goals/{goalId}/milestones/{id}/complete
- GoalServiceTest 단위 테스트 16건 (Mockito)
- GoalControllerTest 통합 테스트 14건 (MockMvc + TestContainers)
- GlobalExceptionHandler에 HttpMessageNotReadableException 핸들러 추가 (잘못된 enum 값 → 400)
- 기존 테스트 FK 제약조건 정리