### PR TITLE
feat : 루틴 CRUD / 체크 / 예외일 API 구현

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/controller/RoutineController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/controller/RoutineController.java
@@ -1,0 +1,138 @@
+package ds.project.orino.planner.routine.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.routine.dto.CreateRoutineRequest;
+import ds.project.orino.planner.routine.dto.RoutineCheckRequest;
+import ds.project.orino.planner.routine.dto.RoutineCheckResponse;
+import ds.project.orino.planner.routine.dto.RoutineDetailResponse;
+import ds.project.orino.planner.routine.dto.RoutineExceptionRequest;
+import ds.project.orino.planner.routine.dto.RoutineExceptionResponse;
+import ds.project.orino.planner.routine.dto.RoutineResponse;
+import ds.project.orino.planner.routine.dto.RoutineStatusRequest;
+import ds.project.orino.planner.routine.dto.UpdateRoutineRequest;
+import ds.project.orino.planner.routine.service.RoutineService;
+import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/routines")
+public class RoutineController {
+
+    private final RoutineService routineService;
+
+    public RoutineController(RoutineService routineService) {
+        this.routineService = routineService;
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<RoutineResponse>>> getRoutines(
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(
+                ApiResponse.success(routineService.getRoutines(memberId)));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<RoutineDetailResponse>> getRoutine(
+            Authentication authentication, @PathVariable Long id) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(
+                ApiResponse.success(routineService.getRoutine(memberId, id)));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<RoutineResponse>> create(
+            Authentication authentication,
+            @Valid @RequestBody CreateRoutineRequest request) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(
+                        routineService.create(memberId, request)));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<RoutineResponse>> update(
+            Authentication authentication,
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateRoutineRequest request) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                routineService.update(memberId, id, request)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> delete(
+            Authentication authentication, @PathVariable Long id) {
+        Long memberId = (Long) authentication.getPrincipal();
+        routineService.delete(memberId, id);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<ApiResponse<RoutineResponse>> changeStatus(
+            Authentication authentication,
+            @PathVariable Long id,
+            @Valid @RequestBody RoutineStatusRequest request) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                routineService.changeStatus(memberId, id, request.status())));
+    }
+
+    @PostMapping("/{id}/check")
+    public ResponseEntity<ApiResponse<RoutineCheckResponse>> check(
+            Authentication authentication,
+            @PathVariable Long id,
+            @Valid @RequestBody RoutineCheckRequest request) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                routineService.check(memberId, id, request)));
+    }
+
+    @DeleteMapping("/{id}/check")
+    public ResponseEntity<ApiResponse<Void>> uncheck(
+            Authentication authentication,
+            @PathVariable Long id,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate checkDate) {
+        Long memberId = (Long) authentication.getPrincipal();
+        routineService.uncheckByDate(memberId, id, checkDate);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PostMapping("/{id}/exceptions")
+    public ResponseEntity<ApiResponse<RoutineExceptionResponse>> addException(
+            Authentication authentication,
+            @PathVariable Long id,
+            @Valid @RequestBody RoutineExceptionRequest request) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(
+                        routineService.addException(memberId, id, request)));
+    }
+
+    @DeleteMapping("/{id}/exceptions/{exceptionId}")
+    public ResponseEntity<ApiResponse<Void>> removeException(
+            Authentication authentication,
+            @PathVariable Long id,
+            @PathVariable Long exceptionId) {
+        Long memberId = (Long) authentication.getPrincipal();
+        routineService.removeException(memberId, id, exceptionId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/CreateRoutineRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/CreateRoutineRequest.java
@@ -1,0 +1,24 @@
+package ds.project.orino.planner.routine.dto;
+
+import ds.project.orino.domain.fixedschedule.entity.RecurrenceType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record CreateRoutineRequest(
+        @NotBlank @Size(max = 100) String title,
+        Long categoryId,
+        @NotNull @Positive Integer durationMinutes,
+        LocalTime preferredTime,
+        @NotNull RecurrenceType recurrenceType,
+        Integer recurrenceInterval,
+        String recurrenceDays,
+        @NotNull LocalDate startDate,
+        LocalDate endDate,
+        Boolean skipHolidays
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/RoutineCheckRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/RoutineCheckRequest.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.routine.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record RoutineCheckRequest(
+        @NotNull LocalDate checkDate
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/RoutineCheckResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/RoutineCheckResponse.java
@@ -1,0 +1,22 @@
+package ds.project.orino.planner.routine.dto;
+
+import ds.project.orino.domain.routine.entity.RoutineCheck;
+
+import java.time.LocalDate;
+
+public record RoutineCheckResponse(
+        Long id,
+        Long routineId,
+        LocalDate checkDate,
+        boolean completed
+) {
+
+    public static RoutineCheckResponse from(RoutineCheck check) {
+        return new RoutineCheckResponse(
+                check.getId(),
+                check.getRoutine().getId(),
+                check.getCheckDate(),
+                check.isCompleted()
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/RoutineDetailResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/RoutineDetailResponse.java
@@ -1,0 +1,45 @@
+package ds.project.orino.planner.routine.dto;
+
+import ds.project.orino.domain.fixedschedule.entity.RecurrenceType;
+import ds.project.orino.domain.routine.entity.Routine;
+import ds.project.orino.domain.routine.entity.RoutineStatus;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record RoutineDetailResponse(
+        Long id,
+        String title,
+        Long categoryId,
+        int durationMinutes,
+        LocalTime preferredTime,
+        RecurrenceType recurrenceType,
+        Integer recurrenceInterval,
+        String recurrenceDays,
+        LocalDate startDate,
+        LocalDate endDate,
+        boolean skipHolidays,
+        RoutineStatus status,
+        StreakInfo streak
+) {
+
+    public static RoutineDetailResponse from(Routine routine,
+                                             StreakInfo streak) {
+        return new RoutineDetailResponse(
+                routine.getId(),
+                routine.getTitle(),
+                routine.getCategory() != null
+                        ? routine.getCategory().getId() : null,
+                routine.getDurationMinutes(),
+                routine.getPreferredTime(),
+                routine.getRecurrenceType(),
+                routine.getRecurrenceInterval(),
+                routine.getRecurrenceDays(),
+                routine.getStartDate(),
+                routine.getEndDate(),
+                routine.isSkipHolidays(),
+                routine.getStatus(),
+                streak
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/RoutineExceptionRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/RoutineExceptionRequest.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.routine.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record RoutineExceptionRequest(
+        @NotNull LocalDate exceptionDate
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/RoutineExceptionResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/RoutineExceptionResponse.java
@@ -1,0 +1,20 @@
+package ds.project.orino.planner.routine.dto;
+
+import ds.project.orino.domain.routine.entity.RoutineException;
+
+import java.time.LocalDate;
+
+public record RoutineExceptionResponse(
+        Long id,
+        Long routineId,
+        LocalDate exceptionDate
+) {
+
+    public static RoutineExceptionResponse from(RoutineException exception) {
+        return new RoutineExceptionResponse(
+                exception.getId(),
+                exception.getRoutine().getId(),
+                exception.getExceptionDate()
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/RoutineResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/RoutineResponse.java
@@ -1,0 +1,31 @@
+package ds.project.orino.planner.routine.dto;
+
+import ds.project.orino.domain.fixedschedule.entity.RecurrenceType;
+import ds.project.orino.domain.routine.entity.Routine;
+import ds.project.orino.domain.routine.entity.RoutineStatus;
+
+public record RoutineResponse(
+        Long id,
+        String title,
+        Long categoryId,
+        int durationMinutes,
+        RecurrenceType recurrenceType,
+        String recurrenceDays,
+        RoutineStatus status,
+        StreakInfo streak
+) {
+
+    public static RoutineResponse from(Routine routine, StreakInfo streak) {
+        return new RoutineResponse(
+                routine.getId(),
+                routine.getTitle(),
+                routine.getCategory() != null
+                        ? routine.getCategory().getId() : null,
+                routine.getDurationMinutes(),
+                routine.getRecurrenceType(),
+                routine.getRecurrenceDays(),
+                routine.getStatus(),
+                streak
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/RoutineStatusRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/RoutineStatusRequest.java
@@ -1,0 +1,9 @@
+package ds.project.orino.planner.routine.dto;
+
+import ds.project.orino.domain.routine.entity.RoutineStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record RoutineStatusRequest(
+        @NotNull RoutineStatus status
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/StreakInfo.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/StreakInfo.java
@@ -1,0 +1,7 @@
+package ds.project.orino.planner.routine.dto;
+
+public record StreakInfo(
+        int currentCount,
+        int longestCount
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/UpdateRoutineRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/dto/UpdateRoutineRequest.java
@@ -1,0 +1,24 @@
+package ds.project.orino.planner.routine.dto;
+
+import ds.project.orino.domain.fixedschedule.entity.RecurrenceType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record UpdateRoutineRequest(
+        @NotBlank @Size(max = 100) String title,
+        Long categoryId,
+        @NotNull @Positive Integer durationMinutes,
+        LocalTime preferredTime,
+        @NotNull RecurrenceType recurrenceType,
+        Integer recurrenceInterval,
+        String recurrenceDays,
+        @NotNull LocalDate startDate,
+        LocalDate endDate,
+        Boolean skipHolidays
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/service/RoutineService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/service/RoutineService.java
@@ -1,0 +1,217 @@
+package ds.project.orino.planner.routine.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.category.entity.Category;
+import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.routine.entity.Routine;
+import ds.project.orino.domain.routine.entity.RoutineCheck;
+import ds.project.orino.domain.routine.entity.RoutineException;
+import ds.project.orino.domain.routine.entity.RoutineStatus;
+import ds.project.orino.domain.routine.repository.RoutineCheckRepository;
+import ds.project.orino.domain.routine.repository.RoutineExceptionRepository;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
+import ds.project.orino.planner.routine.dto.CreateRoutineRequest;
+import ds.project.orino.planner.routine.dto.RoutineCheckRequest;
+import ds.project.orino.planner.routine.dto.RoutineCheckResponse;
+import ds.project.orino.planner.routine.dto.RoutineDetailResponse;
+import ds.project.orino.planner.routine.dto.RoutineExceptionRequest;
+import ds.project.orino.planner.routine.dto.RoutineExceptionResponse;
+import ds.project.orino.planner.routine.dto.RoutineResponse;
+import ds.project.orino.planner.routine.dto.StreakInfo;
+import ds.project.orino.planner.routine.dto.UpdateRoutineRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class RoutineService {
+
+    private final RoutineRepository routineRepository;
+    private final RoutineCheckRepository routineCheckRepository;
+    private final RoutineExceptionRepository routineExceptionRepository;
+    private final MemberRepository memberRepository;
+    private final CategoryRepository categoryRepository;
+
+    public RoutineService(RoutineRepository routineRepository,
+                          RoutineCheckRepository routineCheckRepository,
+                          RoutineExceptionRepository routineExceptionRepository,
+                          MemberRepository memberRepository,
+                          CategoryRepository categoryRepository) {
+        this.routineRepository = routineRepository;
+        this.routineCheckRepository = routineCheckRepository;
+        this.routineExceptionRepository = routineExceptionRepository;
+        this.memberRepository = memberRepository;
+        this.categoryRepository = categoryRepository;
+    }
+
+    public List<RoutineResponse> getRoutines(Long memberId) {
+        return routineRepository.findByMemberIdOrderByCreatedAtDesc(memberId)
+                .stream()
+                .map(r -> RoutineResponse.from(r, calculateStreak(r)))
+                .toList();
+    }
+
+    public RoutineDetailResponse getRoutine(Long memberId, Long routineId) {
+        Routine routine = routineRepository.findByIdAndMemberId(routineId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        return RoutineDetailResponse.from(routine, calculateStreak(routine));
+    }
+
+    @Transactional
+    public RoutineResponse create(Long memberId, CreateRoutineRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        Category category = resolveCategory(request.categoryId(), memberId);
+
+        Routine routine = new Routine(member, request.title(), category,
+                request.durationMinutes(), request.preferredTime(),
+                request.recurrenceType(), request.recurrenceInterval(),
+                request.recurrenceDays(), request.startDate(),
+                request.endDate(),
+                Boolean.TRUE.equals(request.skipHolidays()));
+
+        Routine saved = routineRepository.save(routine);
+        return RoutineResponse.from(saved, new StreakInfo(0, 0));
+    }
+
+    @Transactional
+    public RoutineResponse update(Long memberId, Long routineId,
+                                  UpdateRoutineRequest request) {
+        Routine routine = routineRepository.findByIdAndMemberId(routineId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        Category category = resolveCategory(request.categoryId(), memberId);
+
+        routine.update(request.title(), category,
+                request.durationMinutes(), request.preferredTime(),
+                request.recurrenceType(), request.recurrenceInterval(),
+                request.recurrenceDays(), request.startDate(),
+                request.endDate(),
+                Boolean.TRUE.equals(request.skipHolidays()));
+
+        return RoutineResponse.from(routine, calculateStreak(routine));
+    }
+
+    @Transactional
+    public void delete(Long memberId, Long routineId) {
+        Routine routine = routineRepository.findByIdAndMemberId(routineId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        routineRepository.delete(routine);
+    }
+
+    @Transactional
+    public RoutineResponse changeStatus(Long memberId, Long routineId,
+                                        RoutineStatus status) {
+        Routine routine = routineRepository.findByIdAndMemberId(routineId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        routine.changeStatus(status);
+        return RoutineResponse.from(routine, calculateStreak(routine));
+    }
+
+    @Transactional
+    public RoutineCheckResponse check(Long memberId, Long routineId,
+                                      RoutineCheckRequest request) {
+        Routine routine = routineRepository.findByIdAndMemberId(routineId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        RoutineCheck check = new RoutineCheck(routine, request.checkDate());
+        return RoutineCheckResponse.from(routineCheckRepository.save(check));
+    }
+
+    @Transactional
+    public void uncheckByDate(Long memberId, Long routineId,
+                              LocalDate checkDate) {
+        routineRepository.findByIdAndMemberId(routineId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        RoutineCheck check = routineCheckRepository
+                .findByRoutineIdAndCheckDate(routineId, checkDate)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        routineCheckRepository.delete(check);
+    }
+
+    @Transactional
+    public RoutineExceptionResponse addException(Long memberId, Long routineId,
+                                                 RoutineExceptionRequest request) {
+        Routine routine = routineRepository.findByIdAndMemberId(routineId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        RoutineException exception = new RoutineException(
+                routine, request.exceptionDate());
+        return RoutineExceptionResponse.from(
+                routineExceptionRepository.save(exception));
+    }
+
+    @Transactional
+    public void removeException(Long memberId, Long routineId,
+                                Long exceptionId) {
+        routineRepository.findByIdAndMemberId(routineId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        RoutineException exception = routineExceptionRepository
+                .findByIdAndRoutineId(exceptionId, routineId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        routineExceptionRepository.delete(exception);
+    }
+
+    private StreakInfo calculateStreak(Routine routine) {
+        List<LocalDate> checkedDates = routine.getChecks().stream()
+                .filter(RoutineCheck::isCompleted)
+                .map(RoutineCheck::getCheckDate)
+                .sorted(Comparator.reverseOrder())
+                .toList();
+
+        if (checkedDates.isEmpty()) {
+            return new StreakInfo(0, 0);
+        }
+
+        int currentStreak = 0;
+        LocalDate expected = LocalDate.now();
+        for (LocalDate date : checkedDates) {
+            if (date.equals(expected) || date.equals(expected.minusDays(1))) {
+                currentStreak++;
+                expected = date.minusDays(1);
+            } else if (currentStreak == 0 && date.equals(LocalDate.now().minusDays(1))) {
+                currentStreak++;
+                expected = date.minusDays(1);
+            } else {
+                break;
+            }
+        }
+
+        int longestStreak = 0;
+        int streak = 1;
+        List<LocalDate> sorted = checkedDates.stream()
+                .sorted()
+                .toList();
+        for (int i = 1; i < sorted.size(); i++) {
+            if (sorted.get(i).equals(sorted.get(i - 1).plusDays(1))) {
+                streak++;
+            } else {
+                longestStreak = Math.max(longestStreak, streak);
+                streak = 1;
+            }
+        }
+        longestStreak = Math.max(longestStreak, streak);
+
+        return new StreakInfo(currentStreak, longestStreak);
+    }
+
+    private Category resolveCategory(Long categoryId, Long memberId) {
+        if (categoryId == null) {
+            return null;
+        }
+        return categoryRepository.findByIdAndMemberId(categoryId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/auth/controller/AuthControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/auth/controller/AuthControllerTest.java
@@ -5,6 +5,9 @@ import ds.project.orino.domain.fixedschedule.repository.FixedScheduleRepository;
 import ds.project.orino.domain.goal.repository.GoalRepository;
 import ds.project.orino.domain.goal.repository.MilestoneRepository;
 import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.routine.repository.RoutineCheckRepository;
+import ds.project.orino.domain.routine.repository.RoutineExceptionRepository;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
 import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.MemberFixture;
 import jakarta.servlet.http.Cookie;
@@ -36,8 +39,20 @@ class AuthControllerTest extends ApiTestSupport {
     @Autowired
     private FixedScheduleRepository fixedScheduleRepository;
 
+    @Autowired
+    private RoutineExceptionRepository routineExceptionRepository;
+
+    @Autowired
+    private RoutineCheckRepository routineCheckRepository;
+
+    @Autowired
+    private RoutineRepository routineRepository;
+
     @BeforeEach
     void setUp() {
+        routineExceptionRepository.deleteAll();
+        routineCheckRepository.deleteAll();
+        routineRepository.deleteAll();
         fixedScheduleRepository.deleteAll();
         milestoneRepository.deleteAll();
         goalRepository.deleteAll();

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/category/controller/CategoryControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/category/controller/CategoryControllerTest.java
@@ -5,6 +5,9 @@ import ds.project.orino.domain.fixedschedule.repository.FixedScheduleRepository;
 import ds.project.orino.domain.goal.repository.GoalRepository;
 import ds.project.orino.domain.goal.repository.MilestoneRepository;
 import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.routine.repository.RoutineCheckRepository;
+import ds.project.orino.domain.routine.repository.RoutineExceptionRepository;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
 import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.MemberFixture;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,10 +42,22 @@ class CategoryControllerTest extends ApiTestSupport {
     @Autowired
     private FixedScheduleRepository fixedScheduleRepository;
 
+    @Autowired
+    private RoutineExceptionRepository routineExceptionRepository;
+
+    @Autowired
+    private RoutineCheckRepository routineCheckRepository;
+
+    @Autowired
+    private RoutineRepository routineRepository;
+
     private String accessToken;
 
     @BeforeEach
     void setUp() throws Exception {
+        routineExceptionRepository.deleteAll();
+        routineCheckRepository.deleteAll();
+        routineRepository.deleteAll();
         fixedScheduleRepository.deleteAll();
         milestoneRepository.deleteAll();
         goalRepository.deleteAll();

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/fixedschedule/controller/FixedScheduleControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/fixedschedule/controller/FixedScheduleControllerTest.java
@@ -5,6 +5,9 @@ import ds.project.orino.domain.fixedschedule.repository.FixedScheduleRepository;
 import ds.project.orino.domain.goal.repository.GoalRepository;
 import ds.project.orino.domain.goal.repository.MilestoneRepository;
 import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.routine.repository.RoutineCheckRepository;
+import ds.project.orino.domain.routine.repository.RoutineExceptionRepository;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
 import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.MemberFixture;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,10 +42,22 @@ class FixedScheduleControllerTest extends ApiTestSupport {
     @Autowired
     private FixedScheduleRepository fixedScheduleRepository;
 
+    @Autowired
+    private RoutineExceptionRepository routineExceptionRepository;
+
+    @Autowired
+    private RoutineCheckRepository routineCheckRepository;
+
+    @Autowired
+    private RoutineRepository routineRepository;
+
     private String accessToken;
 
     @BeforeEach
     void setUp() throws Exception {
+        routineExceptionRepository.deleteAll();
+        routineCheckRepository.deleteAll();
+        routineRepository.deleteAll();
         fixedScheduleRepository.deleteAll();
         milestoneRepository.deleteAll();
         goalRepository.deleteAll();

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/goal/controller/GoalControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/goal/controller/GoalControllerTest.java
@@ -5,6 +5,9 @@ import ds.project.orino.domain.fixedschedule.repository.FixedScheduleRepository;
 import ds.project.orino.domain.goal.repository.GoalRepository;
 import ds.project.orino.domain.goal.repository.MilestoneRepository;
 import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.routine.repository.RoutineCheckRepository;
+import ds.project.orino.domain.routine.repository.RoutineExceptionRepository;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
 import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.MemberFixture;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,10 +43,22 @@ class GoalControllerTest extends ApiTestSupport {
     @Autowired
     private FixedScheduleRepository fixedScheduleRepository;
 
+    @Autowired
+    private RoutineExceptionRepository routineExceptionRepository;
+
+    @Autowired
+    private RoutineCheckRepository routineCheckRepository;
+
+    @Autowired
+    private RoutineRepository routineRepository;
+
     private String accessToken;
 
     @BeforeEach
     void setUp() throws Exception {
+        routineExceptionRepository.deleteAll();
+        routineCheckRepository.deleteAll();
+        routineRepository.deleteAll();
         fixedScheduleRepository.deleteAll();
         milestoneRepository.deleteAll();
         goalRepository.deleteAll();

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/routine/controller/RoutineControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/routine/controller/RoutineControllerTest.java
@@ -1,0 +1,260 @@
+package ds.project.orino.planner.routine.controller;
+
+import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.domain.fixedschedule.repository.FixedScheduleRepository;
+import ds.project.orino.domain.goal.repository.GoalRepository;
+import ds.project.orino.domain.goal.repository.MilestoneRepository;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.routine.repository.RoutineCheckRepository;
+import ds.project.orino.domain.routine.repository.RoutineExceptionRepository;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RoutineControllerTest extends ApiTestSupport {
+
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private MilestoneRepository milestoneRepository;
+    @Autowired private GoalRepository goalRepository;
+    @Autowired private FixedScheduleRepository fixedScheduleRepository;
+    @Autowired private RoutineCheckRepository routineCheckRepository;
+    @Autowired private RoutineExceptionRepository routineExceptionRepository;
+    @Autowired private RoutineRepository routineRepository;
+
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        routineExceptionRepository.deleteAll();
+        routineCheckRepository.deleteAll();
+        routineRepository.deleteAll();
+        fixedScheduleRepository.deleteAll();
+        milestoneRepository.deleteAll();
+        goalRepository.deleteAll();
+        categoryRepository.deleteAll();
+        memberRepository.deleteAll();
+        memberRepository.save(MemberFixture.create());
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId": "%s", "password": "%s"}
+                                """.formatted(
+                                MemberFixture.DEFAULT_LOGIN_ID,
+                                MemberFixture.DEFAULT_PASSWORD)))
+                .andReturn();
+
+        accessToken = com.jayway.jsonpath.JsonPath.read(
+                loginResult.getResponse().getContentAsString(),
+                "$.data.accessToken");
+    }
+
+    private Integer createRoutine() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/routines")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "운동", "durationMinutes": 30,
+                                 "recurrenceType": "DAILY",
+                                 "startDate": "2026-04-01"}
+                                """))
+                .andReturn();
+        return com.jayway.jsonpath.JsonPath.read(
+                result.getResponse().getContentAsString(), "$.data.id");
+    }
+
+    @Test
+    @DisplayName("POST /api/routines - 루틴을 생성한다")
+    void create() throws Exception {
+        mockMvc.perform(post("/api/routines")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "독서", "durationMinutes": 60,
+                                 "recurrenceType": "WEEKLY",
+                                 "recurrenceDays": "MON,WED,FRI",
+                                 "startDate": "2026-04-01",
+                                 "skipHolidays": true}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.title").value("독서"))
+                .andExpect(jsonPath("$.data.durationMinutes").value(60))
+                .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    @DisplayName("GET /api/routines - 루틴 목록을 조회한다")
+    void getRoutines() throws Exception {
+        createRoutine();
+
+        mockMvc.perform(get("/api/routines")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(1)))
+                .andExpect(jsonPath("$.data[0].streak").exists());
+    }
+
+    @Test
+    @DisplayName("GET /api/routines/{id} - 루틴 상세를 조회한다")
+    void getRoutine() throws Exception {
+        Integer id = createRoutine();
+
+        mockMvc.perform(get("/api/routines/" + id)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("운동"))
+                .andExpect(jsonPath("$.data.streak").exists());
+    }
+
+    @Test
+    @DisplayName("PUT /api/routines/{id} - 루틴을 수정한다")
+    void update() throws Exception {
+        Integer id = createRoutine();
+
+        mockMvc.perform(put("/api/routines/" + id)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "수정됨", "durationMinutes": 45,
+                                 "recurrenceType": "WEEKLY",
+                                 "recurrenceDays": "MON,FRI",
+                                 "startDate": "2026-04-01"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("수정됨"))
+                .andExpect(jsonPath("$.data.durationMinutes").value(45));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/routines/{id} - 루틴을 삭제한다")
+    void deleteRoutine() throws Exception {
+        Integer id = createRoutine();
+
+        mockMvc.perform(delete("/api/routines/" + id)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/routines")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(jsonPath("$.data", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/routines/{id}/status - 루틴 상태를 변경한다")
+    void changeStatus() throws Exception {
+        Integer id = createRoutine();
+
+        mockMvc.perform(patch("/api/routines/" + id + "/status")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"status": "PAUSED"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("PAUSED"));
+    }
+
+    @Test
+    @DisplayName("POST /api/routines/{id}/check - 루틴을 체크한다")
+    void check() throws Exception {
+        Integer id = createRoutine();
+
+        mockMvc.perform(post("/api/routines/" + id + "/check")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"checkDate": "2026-04-04"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.completed").value(true));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/routines/{id}/check - 루틴 체크를 취소한다")
+    void uncheck() throws Exception {
+        Integer id = createRoutine();
+
+        mockMvc.perform(post("/api/routines/" + id + "/check")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {"checkDate": "2026-04-04"}
+                        """));
+
+        mockMvc.perform(delete("/api/routines/" + id + "/check")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("checkDate", "2026-04-04"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("POST /api/routines/{id}/exceptions - 예외일을 추가한다")
+    void addException() throws Exception {
+        Integer id = createRoutine();
+
+        mockMvc.perform(post("/api/routines/" + id + "/exceptions")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"exceptionDate": "2026-04-10"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.exceptionDate")
+                        .value("2026-04-10"));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/routines/{id}/exceptions/{exceptionId} - 예외일을 삭제한다")
+    void removeException() throws Exception {
+        Integer routineId = createRoutine();
+
+        MvcResult excResult = mockMvc.perform(
+                        post("/api/routines/" + routineId + "/exceptions")
+                                .header("Authorization", "Bearer " + accessToken)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {"exceptionDate": "2026-04-10"}
+                                        """))
+                .andReturn();
+
+        Integer exceptionId = com.jayway.jsonpath.JsonPath.read(
+                excResult.getResponse().getContentAsString(), "$.data.id");
+
+        mockMvc.perform(delete("/api/routines/" + routineId
+                        + "/exceptions/" + exceptionId)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 루틴 조회 시 404를 반환한다")
+    void getRoutine_notFound() throws Exception {
+        mockMvc.perform(get("/api/routines/999")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+    }
+
+    @Test
+    @DisplayName("인증 없이 요청하면 403을 반환한다")
+    void unauthorized() throws Exception {
+        mockMvc.perform(get("/api/routines"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/routine/service/RoutineServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/routine/service/RoutineServiceTest.java
@@ -1,0 +1,246 @@
+package ds.project.orino.planner.routine.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.domain.fixedschedule.entity.RecurrenceType;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.routine.entity.Routine;
+import ds.project.orino.domain.routine.entity.RoutineCheck;
+import ds.project.orino.domain.routine.entity.RoutineException;
+import ds.project.orino.domain.routine.entity.RoutineStatus;
+import ds.project.orino.domain.routine.repository.RoutineCheckRepository;
+import ds.project.orino.domain.routine.repository.RoutineExceptionRepository;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
+import ds.project.orino.planner.routine.dto.CreateRoutineRequest;
+import ds.project.orino.planner.routine.dto.RoutineCheckRequest;
+import ds.project.orino.planner.routine.dto.RoutineCheckResponse;
+import ds.project.orino.planner.routine.dto.RoutineExceptionRequest;
+import ds.project.orino.planner.routine.dto.RoutineExceptionResponse;
+import ds.project.orino.planner.routine.dto.RoutineResponse;
+import ds.project.orino.planner.routine.dto.UpdateRoutineRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RoutineServiceTest {
+
+    private RoutineService service;
+
+    @Mock private RoutineRepository routineRepository;
+    @Mock private RoutineCheckRepository routineCheckRepository;
+    @Mock private RoutineExceptionRepository routineExceptionRepository;
+    @Mock private MemberRepository memberRepository;
+    @Mock private CategoryRepository categoryRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        service = new RoutineService(routineRepository, routineCheckRepository,
+                routineExceptionRepository, memberRepository, categoryRepository);
+        member = new Member("admin", "encoded");
+    }
+
+    @Test
+    @DisplayName("루틴 목록을 조회한다")
+    void getRoutines() {
+        Routine routine = new Routine(member, "운동", null, 30, null,
+                RecurrenceType.DAILY, null, null,
+                LocalDate.of(2026, 4, 1), null, false);
+
+        given(routineRepository.findByMemberIdOrderByCreatedAtDesc(1L))
+                .willReturn(List.of(routine));
+
+        List<RoutineResponse> result = service.getRoutines(1L);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).title()).isEqualTo("운동");
+    }
+
+    @Test
+    @DisplayName("루틴을 생성한다")
+    void create() {
+        Routine saved = new Routine(member, "독서", null, 60, null,
+                RecurrenceType.DAILY, null, null,
+                LocalDate.of(2026, 4, 1), null, false);
+
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+        given(routineRepository.save(any(Routine.class))).willReturn(saved);
+
+        RoutineResponse result = service.create(1L,
+                new CreateRoutineRequest("독서", null, 60, null,
+                        RecurrenceType.DAILY, null, null,
+                        LocalDate.of(2026, 4, 1), null, false));
+
+        assertThat(result.title()).isEqualTo("독서");
+        assertThat(result.durationMinutes()).isEqualTo(60);
+    }
+
+    @Test
+    @DisplayName("루틴을 수정한다")
+    void update() {
+        Routine routine = new Routine(member, "기존", null, 30, null,
+                RecurrenceType.DAILY, null, null,
+                LocalDate.of(2026, 4, 1), null, false);
+
+        given(routineRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(routine));
+
+        RoutineResponse result = service.update(1L, 1L,
+                new UpdateRoutineRequest("수정됨", null, 45, null,
+                        RecurrenceType.WEEKLY, null, "MON,WED,FRI",
+                        LocalDate.of(2026, 4, 1), null, false));
+
+        assertThat(result.title()).isEqualTo("수정됨");
+        assertThat(result.durationMinutes()).isEqualTo(45);
+    }
+
+    @Test
+    @DisplayName("루틴을 삭제한다")
+    void delete() {
+        Routine routine = new Routine(member, "삭제대상", null, 30, null,
+                RecurrenceType.DAILY, null, null,
+                LocalDate.of(2026, 4, 1), null, false);
+
+        given(routineRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(routine));
+
+        service.delete(1L, 1L);
+
+        verify(routineRepository).delete(routine);
+    }
+
+    @Test
+    @DisplayName("루틴 상태를 변경한다")
+    void changeStatus() {
+        Routine routine = new Routine(member, "루틴", null, 30, null,
+                RecurrenceType.DAILY, null, null,
+                LocalDate.of(2026, 4, 1), null, false);
+
+        given(routineRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(routine));
+
+        RoutineResponse result = service.changeStatus(1L, 1L,
+                RoutineStatus.PAUSED);
+
+        assertThat(result.status()).isEqualTo(RoutineStatus.PAUSED);
+    }
+
+    @Test
+    @DisplayName("루틴을 체크한다")
+    void check() {
+        Routine routine = new Routine(member, "루틴", null, 30, null,
+                RecurrenceType.DAILY, null, null,
+                LocalDate.of(2026, 4, 1), null, false);
+        RoutineCheck saved = new RoutineCheck(routine, LocalDate.of(2026, 4, 4));
+
+        given(routineRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(routine));
+        given(routineCheckRepository.save(any(RoutineCheck.class)))
+                .willReturn(saved);
+
+        RoutineCheckResponse result = service.check(1L, 1L,
+                new RoutineCheckRequest(LocalDate.of(2026, 4, 4)));
+
+        assertThat(result.completed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("루틴 체크를 취소한다")
+    void uncheck() {
+        Routine routine = new Routine(member, "루틴", null, 30, null,
+                RecurrenceType.DAILY, null, null,
+                LocalDate.of(2026, 4, 1), null, false);
+        RoutineCheck check = new RoutineCheck(routine, LocalDate.of(2026, 4, 4));
+
+        given(routineRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(routine));
+        given(routineCheckRepository.findByRoutineIdAndCheckDate(
+                1L, LocalDate.of(2026, 4, 4)))
+                .willReturn(Optional.of(check));
+
+        service.uncheckByDate(1L, 1L, LocalDate.of(2026, 4, 4));
+
+        verify(routineCheckRepository).delete(check);
+    }
+
+    @Test
+    @DisplayName("예외일을 추가한다")
+    void addException() {
+        Routine routine = new Routine(member, "루틴", null, 30, null,
+                RecurrenceType.DAILY, null, null,
+                LocalDate.of(2026, 4, 1), null, false);
+        RoutineException saved = new RoutineException(
+                routine, LocalDate.of(2026, 4, 10));
+
+        given(routineRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(routine));
+        given(routineExceptionRepository.save(any(RoutineException.class)))
+                .willReturn(saved);
+
+        RoutineExceptionResponse result = service.addException(1L, 1L,
+                new RoutineExceptionRequest(LocalDate.of(2026, 4, 10)));
+
+        assertThat(result.exceptionDate())
+                .isEqualTo(LocalDate.of(2026, 4, 10));
+    }
+
+    @Test
+    @DisplayName("예외일을 삭제한다")
+    void removeException() {
+        Routine routine = new Routine(member, "루틴", null, 30, null,
+                RecurrenceType.DAILY, null, null,
+                LocalDate.of(2026, 4, 1), null, false);
+        RoutineException exception = new RoutineException(
+                routine, LocalDate.of(2026, 4, 10));
+
+        given(routineRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(routine));
+        given(routineExceptionRepository.findByIdAndRoutineId(1L, 1L))
+                .willReturn(Optional.of(exception));
+
+        service.removeException(1L, 1L, 1L);
+
+        verify(routineExceptionRepository).delete(exception);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 루틴 조회 시 예외를 던진다")
+    void getRoutine_notFound() {
+        given(routineRepository.findByIdAndMemberId(999L, 1L))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getRoutine(1L, 999L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 루틴 삭제 시 예외를 던진다")
+    void delete_notFound() {
+        given(routineRepository.findByIdAndMemberId(999L, 1L))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.delete(1L, 999L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/security/SecurityConfigTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/security/SecurityConfigTest.java
@@ -5,6 +5,9 @@ import ds.project.orino.domain.fixedschedule.repository.FixedScheduleRepository;
 import ds.project.orino.domain.goal.repository.GoalRepository;
 import ds.project.orino.domain.goal.repository.MilestoneRepository;
 import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.routine.repository.RoutineCheckRepository;
+import ds.project.orino.domain.routine.repository.RoutineExceptionRepository;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
 import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.MemberFixture;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,8 +39,20 @@ class SecurityConfigTest extends ApiTestSupport {
     @Autowired
     private FixedScheduleRepository fixedScheduleRepository;
 
+    @Autowired
+    private RoutineExceptionRepository routineExceptionRepository;
+
+    @Autowired
+    private RoutineCheckRepository routineCheckRepository;
+
+    @Autowired
+    private RoutineRepository routineRepository;
+
     @BeforeEach
     void setUp() {
+        routineExceptionRepository.deleteAll();
+        routineCheckRepository.deleteAll();
+        routineRepository.deleteAll();
         fixedScheduleRepository.deleteAll();
         milestoneRepository.deleteAll();
         goalRepository.deleteAll();

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/routine/entity/Routine.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/routine/entity/Routine.java
@@ -1,0 +1,200 @@
+package ds.project.orino.domain.routine.entity;
+
+import ds.project.orino.domain.category.entity.Category;
+import ds.project.orino.domain.fixedschedule.entity.RecurrenceType;
+import ds.project.orino.domain.member.entity.Member;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Routine {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Column(nullable = false)
+    private int durationMinutes;
+
+    private LocalTime preferredTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private RecurrenceType recurrenceType;
+
+    private Integer recurrenceInterval;
+
+    @Column(length = 50)
+    private String recurrenceDays;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    @Column(nullable = false)
+    private boolean skipHolidays;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10, nullable = false)
+    private RoutineStatus status = RoutineStatus.ACTIVE;
+
+    @OneToMany(mappedBy = "routine", cascade = CascadeType.ALL,
+            orphanRemoval = true)
+    private List<RoutineCheck> checks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "routine", cascade = CascadeType.ALL,
+            orphanRemoval = true)
+    private List<RoutineException> exceptions = new ArrayList<>();
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected Routine() {
+    }
+
+    public Routine(Member member, String title, Category category,
+                   int durationMinutes, LocalTime preferredTime,
+                   RecurrenceType recurrenceType, Integer recurrenceInterval,
+                   String recurrenceDays, LocalDate startDate, LocalDate endDate,
+                   boolean skipHolidays) {
+        this.member = member;
+        this.title = title;
+        this.category = category;
+        this.durationMinutes = durationMinutes;
+        this.preferredTime = preferredTime;
+        this.recurrenceType = recurrenceType;
+        this.recurrenceInterval = recurrenceInterval;
+        this.recurrenceDays = recurrenceDays;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.skipHolidays = skipHolidays;
+    }
+
+    public void update(String title, Category category,
+                       int durationMinutes, LocalTime preferredTime,
+                       RecurrenceType recurrenceType,
+                       Integer recurrenceInterval, String recurrenceDays,
+                       LocalDate startDate, LocalDate endDate,
+                       boolean skipHolidays) {
+        this.title = title;
+        this.category = category;
+        this.durationMinutes = durationMinutes;
+        this.preferredTime = preferredTime;
+        this.recurrenceType = recurrenceType;
+        this.recurrenceInterval = recurrenceInterval;
+        this.recurrenceDays = recurrenceDays;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.skipHolidays = skipHolidays;
+    }
+
+    public void changeStatus(RoutineStatus status) {
+        this.status = status;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public int getDurationMinutes() {
+        return durationMinutes;
+    }
+
+    public LocalTime getPreferredTime() {
+        return preferredTime;
+    }
+
+    public RecurrenceType getRecurrenceType() {
+        return recurrenceType;
+    }
+
+    public Integer getRecurrenceInterval() {
+        return recurrenceInterval;
+    }
+
+    public String getRecurrenceDays() {
+        return recurrenceDays;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public boolean isSkipHolidays() {
+        return skipHolidays;
+    }
+
+    public RoutineStatus getStatus() {
+        return status;
+    }
+
+    public List<RoutineCheck> getChecks() {
+        return checks;
+    }
+
+    public List<RoutineException> getExceptions() {
+        return exceptions;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/routine/entity/RoutineCheck.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/routine/entity/RoutineCheck.java
@@ -1,0 +1,73 @@
+package ds.project.orino.domain.routine.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(uniqueConstraints = @UniqueConstraint(
+        name = "uk_routine_check_routine_date",
+        columnNames = {"routine_id", "check_date"}))
+@EntityListeners(AuditingEntityListener.class)
+public class RoutineCheck {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "routine_id", nullable = false)
+    private Routine routine;
+
+    @Column(nullable = false)
+    private LocalDate checkDate;
+
+    @Column(nullable = false)
+    private boolean completed = true;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    protected RoutineCheck() {
+    }
+
+    public RoutineCheck(Routine routine, LocalDate checkDate) {
+        this.routine = routine;
+        this.checkDate = checkDate;
+        this.completed = true;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Routine getRoutine() {
+        return routine;
+    }
+
+    public LocalDate getCheckDate() {
+        return checkDate;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/routine/entity/RoutineException.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/routine/entity/RoutineException.java
@@ -1,0 +1,65 @@
+package ds.project.orino.domain.routine.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(uniqueConstraints = @UniqueConstraint(
+        name = "uk_routine_exception_routine_date",
+        columnNames = {"routine_id", "exception_date"}))
+@EntityListeners(AuditingEntityListener.class)
+public class RoutineException {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "routine_id", nullable = false)
+    private Routine routine;
+
+    @Column(nullable = false)
+    private LocalDate exceptionDate;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    protected RoutineException() {
+    }
+
+    public RoutineException(Routine routine, LocalDate exceptionDate) {
+        this.routine = routine;
+        this.exceptionDate = exceptionDate;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Routine getRoutine() {
+        return routine;
+    }
+
+    public LocalDate getExceptionDate() {
+        return exceptionDate;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/routine/entity/RoutineStatus.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/routine/entity/RoutineStatus.java
@@ -1,0 +1,5 @@
+package ds.project.orino.domain.routine.entity;
+
+public enum RoutineStatus {
+    ACTIVE, PAUSED, ARCHIVED
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/routine/repository/RoutineCheckRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/routine/repository/RoutineCheckRepository.java
@@ -1,0 +1,13 @@
+package ds.project.orino.domain.routine.repository;
+
+import ds.project.orino.domain.routine.entity.RoutineCheck;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface RoutineCheckRepository extends JpaRepository<RoutineCheck, Long> {
+
+    Optional<RoutineCheck> findByRoutineIdAndCheckDate(Long routineId,
+                                                       LocalDate checkDate);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/routine/repository/RoutineExceptionRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/routine/repository/RoutineExceptionRepository.java
@@ -1,0 +1,11 @@
+package ds.project.orino.domain.routine.repository;
+
+import ds.project.orino.domain.routine.entity.RoutineException;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoutineExceptionRepository extends JpaRepository<RoutineException, Long> {
+
+    Optional<RoutineException> findByIdAndRoutineId(Long id, Long routineId);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/routine/repository/RoutineRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/routine/repository/RoutineRepository.java
@@ -1,0 +1,14 @@
+package ds.project.orino.domain.routine.repository;
+
+import ds.project.orino.domain.routine.entity.Routine;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RoutineRepository extends JpaRepository<Routine, Long> {
+
+    List<Routine> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+    Optional<Routine> findByIdAndMemberId(Long id, Long memberId);
+}


### PR DESCRIPTION
## 이슈
closes #140
## 작업 내용
- Routine, RoutineCheck, RoutineException 엔티티 및 RoutineStatus Enum
- RoutineRepository, RoutineCheckRepository, RoutineExceptionRepository
- RoutineService: CRUD, 상태 변경(ACTIVE/PAUSED/ARCHIVED), 체크/체크취소, 예외일 추가/삭제, 스트릭 계산
- RoutineController: 10개 REST API 엔드포인트
  - GET/POST/PUT/DELETE /api/routines
  - PATCH /api/routines/{id}/status
  - POST/DELETE /api/routines/{id}/check
  - POST /api/routines/{id}/exceptions
  - DELETE /api/routines/{id}/exceptions/{exceptionId}
- RoutineServiceTest 단위 테스트 12건 (Mockito)
- RoutineControllerTest 통합 테스트 12건 (MockMvc + TestContainers)
- 기존 테스트 FK 제약조건 정리