### PR TITLE
trivy-action supply chain 공격 대응: @master → @v0.35.0 고정

### DIFF
--- a/.github/workflows/be-cd.yml
+++ b/.github/workflows/be-cd.yml
@@ -47,7 +47,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           format: sarif

--- a/.github/workflows/fe-cd.yml
+++ b/.github/workflows/fe-cd.yml
@@ -47,7 +47,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           format: sarif


### PR DESCRIPTION
## Summary
- `aquasecurity/trivy-action@master` → `@v0.35.0`으로 고정 (be-cd, fe-cd)
- 2026-03-19 supply chain 공격으로 `@master` 참조가 credential-stealing 악성코드를 실행
- `v0.35.0`은 GitHub immutable releases로 보호되어 안전한 버전

## Reference
- https://github.com/aquasecurity/trivy/discussions/10425
- https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23

closes #263