### PR TITLE
Loki S3 인증 실패 수정

### DIFF
--- a/infra/helm/loki/values.yaml
+++ b/infra/helm/loki/values.yaml
@@ -30,6 +30,8 @@ loki:
 
   singleBinary:
     replicas: 1
+    extraArgs:
+      - -config.expand-env=true
     extraEnv:
       - name: AWS_ACCESS_KEY_ID
         valueFrom:


### PR DESCRIPTION
## Summary

closes #266

- Loki singleBinary에 `-config.expand-env=true` extraArgs 추가
- config.yaml의 `${AWS_ACCESS_KEY_ID}`, `${AWS_SECRET_ACCESS_KEY}` 환경변수가 실제 값으로 확장되도록 수정

## Plan

- [ ] ArgoCD Sync 후 Loki Pod 재시작 확인
- [ ] `kubectl logs -n monitoring loki-0 -c loki` 에서 S3 에러 없는지 확인
- [ ] Grafana Loki 대시보드에서 로그 조회 정상 확인