### PR TITLE
feat : 스케줄링 엔진 구현

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/AvailabilityCalculator.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/AvailabilityCalculator.java
@@ -1,0 +1,156 @@
+package ds.project.orino.planner.scheduling.engine;
+
+import ds.project.orino.domain.calendar.entity.BlockType;
+import ds.project.orino.domain.fixedschedule.entity.FixedSchedule;
+import ds.project.orino.domain.fixedschedule.repository.FixedScheduleRepository;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.domain.routine.entity.Routine;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
+import ds.project.orino.planner.scheduling.engine.model.AvailabilityResult;
+import ds.project.orino.planner.scheduling.engine.model.PlacedBlock;
+import ds.project.orino.planner.scheduling.engine.model.TimeSlot;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * 하루의 자유 시간 블록을 계산한다.
+ * wake~sleep 윈도우에서 고정 일정과 루틴이 점유하는 시간을 차감한다.
+ */
+@Component
+public class AvailabilityCalculator {
+
+    /** 취침 시각이 자정(00:00)인 경우 하루 끝 시각으로 사용한다. */
+    private static final LocalTime END_OF_DAY = LocalTime.of(23, 59);
+
+    private final FixedScheduleRepository fixedScheduleRepository;
+    private final RoutineRepository routineRepository;
+    private final RecurrenceCalculator recurrenceCalculator;
+
+    public AvailabilityCalculator(
+            FixedScheduleRepository fixedScheduleRepository,
+            RoutineRepository routineRepository,
+            RecurrenceCalculator recurrenceCalculator) {
+        this.fixedScheduleRepository = fixedScheduleRepository;
+        this.routineRepository = routineRepository;
+        this.recurrenceCalculator = recurrenceCalculator;
+    }
+
+    public AvailabilityResult calculate(Long memberId, LocalDate date,
+                                        UserPreference preference) {
+        LocalTime wake = preference.getWakeTime();
+        LocalTime sleep = resolveSleepTime(preference.getSleepTime(), wake);
+        TimeSlot window = new TimeSlot(wake, sleep);
+
+        List<PlacedBlock> preplaced = new ArrayList<>();
+
+        // 1. 고정 일정 배치
+        List<FixedSchedule> fixedSchedules = fixedScheduleRepository
+                .findByMemberIdOrderByStartTime(memberId);
+        for (FixedSchedule fs : fixedSchedules) {
+            if (!recurrenceCalculator.applies(fs, date)) {
+                continue;
+            }
+            TimeSlot slot = intersect(window,
+                    new TimeSlot(fs.getStartTime(), fs.getEndTime()));
+            if (slot == null) {
+                continue;
+            }
+            preplaced.add(new PlacedBlock(
+                    BlockType.FIXED, fs.getId(),
+                    slot.start(), slot.end(), fs.getTitle()));
+        }
+
+        // 2. 루틴 배치
+        List<Routine> routines = routineRepository
+                .findByMemberIdOrderByCreatedAtDesc(memberId);
+        LocalTime cursor = wake;
+        for (Routine routine : routines) {
+            if (!recurrenceCalculator.applies(routine, date)) {
+                continue;
+            }
+            PlacedBlock placed = placeRoutine(routine, window,
+                    preplaced, cursor);
+            if (placed != null) {
+                preplaced.add(placed);
+                if (routine.getPreferredTime() == null) {
+                    cursor = placed.end();
+                }
+            }
+        }
+
+        // 3. preplaced로 window를 쪼개서 free slot 계산
+        preplaced.sort(Comparator.comparing(PlacedBlock::start));
+        List<TimeSlot> freeSlots = subtract(window, preplaced);
+
+        return new AvailabilityResult(freeSlots, preplaced);
+    }
+
+    private PlacedBlock placeRoutine(Routine routine, TimeSlot window,
+                                     List<PlacedBlock> preplaced,
+                                     LocalTime cursor) {
+        int duration = routine.getDurationMinutes();
+        LocalTime preferred = routine.getPreferredTime();
+
+        LocalTime start = preferred != null ? preferred : cursor;
+        if (start.isBefore(window.start())) {
+            start = window.start();
+        }
+        LocalTime end = start.plusMinutes(duration);
+        if (end.isAfter(window.end()) || !start.isBefore(window.end())) {
+            return null;
+        }
+        TimeSlot proposed = new TimeSlot(start, end);
+        for (PlacedBlock p : preplaced) {
+            TimeSlot occupied = new TimeSlot(p.start(), p.end());
+            if (proposed.overlaps(occupied)) {
+                return null;
+            }
+        }
+        return new PlacedBlock(BlockType.ROUTINE, routine.getId(),
+                start, end, routine.getTitle());
+    }
+
+    private TimeSlot intersect(TimeSlot a, TimeSlot b) {
+        LocalTime start = a.start().isAfter(b.start())
+                ? a.start() : b.start();
+        LocalTime end = a.end().isBefore(b.end())
+                ? a.end() : b.end();
+        if (!start.isBefore(end)) {
+            return null;
+        }
+        return new TimeSlot(start, end);
+    }
+
+    private List<TimeSlot> subtract(TimeSlot window,
+                                    List<PlacedBlock> taken) {
+        List<TimeSlot> result = new ArrayList<>();
+        LocalTime cursor = window.start();
+        for (PlacedBlock block : taken) {
+            if (!block.start().isAfter(cursor)) {
+                if (block.end().isAfter(cursor)) {
+                    cursor = block.end();
+                }
+                continue;
+            }
+            result.add(new TimeSlot(cursor, block.start()));
+            cursor = block.end();
+        }
+        if (cursor.isBefore(window.end())) {
+            result.add(new TimeSlot(cursor, window.end()));
+        }
+        return result;
+    }
+
+    private LocalTime resolveSleepTime(LocalTime sleepTime, LocalTime wake) {
+        if (sleepTime == null || sleepTime.equals(LocalTime.MIDNIGHT)
+                || !sleepTime.isAfter(wake)) {
+            return END_OF_DAY;
+        }
+        return sleepTime;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/BlockPlacer.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/BlockPlacer.java
@@ -1,0 +1,184 @@
+package ds.project.orino.planner.scheduling.engine;
+
+import ds.project.orino.domain.material.entity.MaterialAllocation;
+import ds.project.orino.domain.material.entity.MaterialDailyOverride;
+import ds.project.orino.domain.material.repository.MaterialAllocationRepository;
+import ds.project.orino.domain.material.repository.MaterialDailyOverrideRepository;
+import ds.project.orino.domain.preference.entity.StudyTimePreference;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.planner.scheduling.engine.model.OverflowItem;
+import ds.project.orino.planner.scheduling.engine.model.OverflowItem.OverflowReason;
+import ds.project.orino.planner.scheduling.engine.model.PlacedBlock;
+import ds.project.orino.planner.scheduling.engine.model.PlacementResult;
+import ds.project.orino.planner.scheduling.engine.model.SchedulableItem;
+import ds.project.orino.planner.scheduling.engine.model.TimeSlot;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 우선순위 정렬된 항목을 자유 시간 블록에 배치한다.
+ * 집중시간/휴식, 선호 시간대, 학습 자료별 시간 할당을 반영한다.
+ */
+@Component
+public class BlockPlacer {
+
+    private final MaterialAllocationRepository allocationRepository;
+    private final MaterialDailyOverrideRepository overrideRepository;
+
+    public BlockPlacer(MaterialAllocationRepository allocationRepository,
+                       MaterialDailyOverrideRepository overrideRepository) {
+        this.allocationRepository = allocationRepository;
+        this.overrideRepository = overrideRepository;
+    }
+
+    public PlacementResult place(List<SchedulableItem> items,
+                                 List<TimeSlot> initialSlots,
+                                 UserPreference preference,
+                                 LocalDate date) {
+        int focus = Math.max(1, preference.getFocusMinutes());
+        int breakMin = Math.max(0, preference.getBreakMinutes());
+        StudyTimePreference timePref =
+                preference.getStudyTimePreference();
+
+        List<MutableSlot> slots = toMutable(initialSlots);
+        Map<Long, Integer> allocationCaps = new HashMap<>();
+        Map<Long, Integer> allocationUsed = new HashMap<>();
+
+        List<PlacedBlock> placed = new ArrayList<>();
+        List<OverflowItem> overflows = new ArrayList<>();
+
+        for (SchedulableItem item : items) {
+            Integer cap = resolveAllocationCap(item.materialId(), date,
+                    allocationCaps);
+            int used = allocationUsed.getOrDefault(
+                    Optional.ofNullable(item.materialId()).orElse(-1L), 0);
+            int remaining = item.estimatedMinutes();
+            if (cap != null) {
+                int allowed = Math.max(0, cap - used);
+                if (allowed == 0) {
+                    overflows.add(new OverflowItem(item, remaining,
+                            OverflowReason.ALLOCATION_EXCEEDED));
+                    continue;
+                }
+                if (remaining > allowed) {
+                    overflows.add(new OverflowItem(item,
+                            remaining - allowed,
+                            OverflowReason.ALLOCATION_EXCEEDED));
+                    remaining = allowed;
+                }
+            }
+
+            int placedMinutes = 0;
+            while (remaining > 0) {
+                int chunkSize = Math.min(focus, remaining);
+                MutableSlot slot = findSlotFitting(slots, chunkSize,
+                        timePref);
+                if (slot == null) {
+                    overflows.add(new OverflowItem(item, remaining,
+                            OverflowReason.SLOT_EXHAUSTED));
+                    break;
+                }
+                LocalTime start = slot.start;
+                LocalTime end = start.plusMinutes(chunkSize);
+                placed.add(new PlacedBlock(
+                        item.blockType(), item.referenceId(),
+                        start, end, item.title()));
+                LocalTime newStart = end.plusMinutes(breakMin);
+                if (!newStart.isBefore(slot.end)) {
+                    slot.start = slot.end;
+                } else {
+                    slot.start = newStart;
+                }
+                remaining -= chunkSize;
+                placedMinutes += chunkSize;
+            }
+
+            if (placedMinutes > 0 && item.materialId() != null) {
+                allocationUsed.merge(item.materialId(), placedMinutes,
+                        Integer::sum);
+            }
+        }
+
+        return new PlacementResult(placed, overflows);
+    }
+
+    private List<MutableSlot> toMutable(List<TimeSlot> slots) {
+        List<MutableSlot> list = new ArrayList<>();
+        for (TimeSlot s : slots) {
+            list.add(new MutableSlot(s.start(), s.end()));
+        }
+        return list;
+    }
+
+    private MutableSlot findSlotFitting(List<MutableSlot> slots,
+                                        int minutes,
+                                        StudyTimePreference pref) {
+        List<MutableSlot> fitting = slots.stream()
+                .filter(s -> s.remaining() >= minutes)
+                .sorted(preferenceComparator(pref))
+                .toList();
+        if (fitting.isEmpty()) {
+            return null;
+        }
+        return fitting.get(0);
+    }
+
+    private Comparator<MutableSlot> preferenceComparator(
+            StudyTimePreference pref) {
+        return switch (pref) {
+            case EVENING -> Comparator.comparing(
+                    (MutableSlot s) -> s.start).reversed();
+            case MORNING, AFTERNOON -> Comparator.comparing(
+                    (MutableSlot s) -> s.start);
+        };
+    }
+
+    private Integer resolveAllocationCap(Long materialId, LocalDate date,
+                                         Map<Long, Integer> cache) {
+        if (materialId == null) {
+            return null;
+        }
+        if (cache.containsKey(materialId)) {
+            return cache.get(materialId);
+        }
+        Optional<MaterialDailyOverride> override = overrideRepository
+                .findByMaterialIdAndOverrideDate(materialId, date);
+        if (override.isPresent()) {
+            int minutes = override.get().getMinutes();
+            cache.put(materialId, minutes);
+            return minutes;
+        }
+        Optional<MaterialAllocation> allocation = allocationRepository
+                .findByMaterialId(materialId);
+        Integer cap = allocation
+                .map(MaterialAllocation::getDefaultMinutes)
+                .orElse(null);
+        cache.put(materialId, cap);
+        return cap;
+    }
+
+    private static final class MutableSlot {
+        LocalTime start;
+        final LocalTime end;
+
+        MutableSlot(LocalTime start, LocalTime end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        int remaining() {
+            if (!start.isBefore(end)) {
+                return 0;
+            }
+            return (int) java.time.Duration.between(start, end).toMinutes();
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/ItemCollector.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/ItemCollector.java
@@ -1,0 +1,176 @@
+package ds.project.orino.planner.scheduling.engine;
+
+import ds.project.orino.domain.calendar.entity.BlockType;
+import ds.project.orino.domain.material.entity.DeadlineMode;
+import ds.project.orino.domain.material.entity.MaterialStatus;
+import ds.project.orino.domain.material.entity.StudyMaterial;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.entity.UnitStatus;
+import ds.project.orino.domain.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.review.entity.ReviewSchedule;
+import ds.project.orino.domain.review.entity.ReviewStatus;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import ds.project.orino.domain.todo.entity.Todo;
+import ds.project.orino.domain.todo.entity.TodoStatus;
+import ds.project.orino.domain.todo.repository.TodoRepository;
+import ds.project.orino.domain.todo.repository.TodoSpecification;
+import ds.project.orino.planner.scheduling.engine.model.ItemCategory;
+import ds.project.orino.planner.scheduling.engine.model.SchedulableItem;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * 주어진 날짜에 스케줄링할 항목을 수집한다.
+ * 밀린 복습 / 오늘 복습 / 마감 임박 할 일 / 학습 단위 / 기한 없는 할 일.
+ */
+@Component
+public class ItemCollector {
+
+    /** 할 일 마감 임박 기준일수. */
+    private static final int URGENT_TODO_DAYS = 3;
+    /** 학습 단위 기본 소요시간 (없을 때 사용). */
+    private static final int DEFAULT_UNIT_MINUTES = 30;
+
+    private final ReviewScheduleRepository reviewRepository;
+    private final TodoRepository todoRepository;
+    private final StudyMaterialRepository materialRepository;
+
+    public ItemCollector(ReviewScheduleRepository reviewRepository,
+                         TodoRepository todoRepository,
+                         StudyMaterialRepository materialRepository) {
+        this.reviewRepository = reviewRepository;
+        this.todoRepository = todoRepository;
+        this.materialRepository = materialRepository;
+    }
+
+    public List<SchedulableItem> collect(Long memberId, LocalDate date) {
+        List<SchedulableItem> items = new ArrayList<>();
+        items.addAll(collectReviews(memberId, date));
+        items.addAll(collectTodos(memberId, date));
+        items.addAll(collectStudyUnits(memberId));
+        return items;
+    }
+
+    private List<SchedulableItem> collectReviews(Long memberId,
+                                                 LocalDate date) {
+        List<ReviewSchedule> due = reviewRepository.findDueByMember(
+                memberId, date,
+                List.of(ReviewStatus.PENDING, ReviewStatus.OVERDUE));
+
+        List<SchedulableItem> result = new ArrayList<>();
+        for (ReviewSchedule r : due) {
+            boolean overdue = r.getScheduledDate().isBefore(date)
+                    || r.getStatus() == ReviewStatus.OVERDUE;
+            ItemCategory category = overdue
+                    ? ItemCategory.OVERDUE_REVIEW
+                    : ItemCategory.TODAY_REVIEW;
+            StudyUnit unit = r.getStudyUnit();
+            int minutes = Math.max(1, unit.getEstimatedMinutes() / 2);
+            int subOrder = toDayOrdinal(r.getScheduledDate());
+            result.add(SchedulableItem.builder()
+                    .category(category)
+                    .blockType(BlockType.REVIEW)
+                    .referenceId(r.getId())
+                    .estimatedMinutes(minutes)
+                    .due(r.getScheduledDate())
+                    .subOrder(subOrder)
+                    .materialId(unit.getMaterial().getId())
+                    .title(unit.getTitle() + " 복습 " + r.getSequence() + "회차")
+                    .build());
+        }
+        return result;
+    }
+
+    private List<SchedulableItem> collectTodos(Long memberId,
+                                               LocalDate date) {
+        Specification<Todo> spec = Specification
+                .where(TodoSpecification.memberIdEquals(memberId))
+                .and(TodoSpecification.statusEquals(TodoStatus.PENDING));
+        List<Todo> todos = todoRepository.findAll(spec);
+
+        LocalDate urgentBy = date.plusDays(URGENT_TODO_DAYS);
+        List<SchedulableItem> result = new ArrayList<>();
+        for (Todo todo : todos) {
+            int minutes = todo.getEstimatedMinutes() != null
+                    ? todo.getEstimatedMinutes() : DEFAULT_UNIT_MINUTES;
+            LocalDate deadline = todo.getDeadline();
+            ItemCategory category;
+            int subOrder;
+            if (deadline != null && !deadline.isAfter(urgentBy)) {
+                category = ItemCategory.URGENT_TODO;
+                subOrder = toDayOrdinal(deadline);
+            } else {
+                category = ItemCategory.NO_DEADLINE_TODO;
+                subOrder = deadline != null
+                        ? toDayOrdinal(deadline) : Integer.MAX_VALUE;
+            }
+            result.add(SchedulableItem.builder()
+                    .category(category)
+                    .blockType(BlockType.TODO)
+                    .referenceId(todo.getId())
+                    .estimatedMinutes(minutes)
+                    .due(deadline)
+                    .subOrder(subOrder)
+                    .title(todo.getTitle())
+                    .build());
+        }
+        return result;
+    }
+
+    private List<SchedulableItem> collectStudyUnits(Long memberId) {
+        List<StudyMaterial> materials = materialRepository
+                .findByMemberIdOrderByCreatedAtDesc(memberId);
+        List<SchedulableItem> result = new ArrayList<>();
+        for (StudyMaterial material : materials) {
+            if (material.getStatus() != MaterialStatus.ACTIVE) {
+                continue;
+            }
+            List<StudyUnit> pending = material.getUnits().stream()
+                    .filter(u -> u.getStatus() == UnitStatus.PENDING)
+                    .sorted(Comparator.comparingInt(StudyUnit::getSortOrder))
+                    .toList();
+            boolean hasDeadline =
+                    material.getDeadlineMode() == DeadlineMode.DEADLINE
+                            && material.getDeadline() != null;
+            ItemCategory category = hasDeadline
+                    ? ItemCategory.DEADLINE_STUDY
+                    : ItemCategory.NEW_STUDY;
+            for (StudyUnit unit : pending) {
+                int subOrder = hasDeadline
+                        ? toDayOrdinal(material.getDeadline()) * 10000
+                        + unit.getSortOrder()
+                        : unit.getSortOrder();
+                result.add(SchedulableItem.builder()
+                        .category(category)
+                        .blockType(BlockType.STUDY)
+                        .referenceId(unit.getId())
+                        .estimatedMinutes(unit.getEstimatedMinutes())
+                        .due(material.getDeadline())
+                        .subOrder(subOrder)
+                        .materialId(material.getId())
+                        .title(material.getTitle() + " - " + unit.getTitle())
+                        .build());
+            }
+        }
+        return result;
+    }
+
+    private int toDayOrdinal(LocalDate date) {
+        if (date == null) {
+            return Integer.MAX_VALUE;
+        }
+        long epoch = date.toEpochDay();
+        if (epoch > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        if (epoch < Integer.MIN_VALUE) {
+            return Integer.MIN_VALUE;
+        }
+        return (int) epoch;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/ItemPrioritizer.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/ItemPrioritizer.java
@@ -1,0 +1,26 @@
+package ds.project.orino.planner.scheduling.engine;
+
+import ds.project.orino.planner.scheduling.engine.model.SchedulableItem;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * 수집된 항목을 우선순위에 따라 정렬한다.
+ *
+ * 현재 버전은 ItemCategory의 ordinal 순서(기본 우선순위)를 사용한다.
+ * 사용자별 PriorityRule과의 연동은 추후 #143의 enum 정비 후 구현한다.
+ */
+@Component
+public class ItemPrioritizer {
+
+    public List<SchedulableItem> prioritize(List<SchedulableItem> items) {
+        return items.stream()
+                .sorted(Comparator
+                        .comparing((SchedulableItem i) -> i.category().ordinal())
+                        .thenComparingInt(SchedulableItem::subOrder)
+                        .thenComparingLong(SchedulableItem::referenceId))
+                .toList();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/OverflowHandler.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/OverflowHandler.java
@@ -1,0 +1,89 @@
+package ds.project.orino.planner.scheduling.engine;
+
+import ds.project.orino.planner.scheduling.engine.model.OverflowItem;
+import ds.project.orino.planner.scheduling.engine.model.SchedulingWarning;
+import ds.project.orino.planner.scheduling.engine.model.SchedulingWarning.WarningType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 자유시간에 배치하지 못한 항목을 처리한다.
+ * 데드라인 경고 / 용량 초과 알림을 생성한다.
+ *
+ * 실제 이월(다음 날 재배치)은 dirty flag 방식이므로 별도 처리하지 않는다.
+ * 다음 날 스케줄링 시 OVERDUE/미완료 항목으로 다시 수집된다.
+ */
+@Component
+public class OverflowHandler {
+
+    private static final Logger log =
+            LoggerFactory.getLogger(OverflowHandler.class);
+
+    public List<SchedulingWarning> handle(List<OverflowItem> overflows,
+                                          LocalDate date) {
+        List<SchedulingWarning> warnings = new ArrayList<>();
+        for (OverflowItem overflow : overflows) {
+            switch (overflow.reason()) {
+                case SLOT_EXHAUSTED -> {
+                    warnings.add(buildCapacityWarning(overflow, date));
+                    if (hasDeadlineRisk(overflow, date)) {
+                        warnings.add(buildDeadlineWarning(overflow, date));
+                    }
+                }
+                case ALLOCATION_EXCEEDED -> warnings.add(
+                        buildAllocationWarning(overflow));
+                default -> { /* no-op */ }
+            }
+            log.info(
+                    "overflow: item={} reason={} minutes={} due={}",
+                    overflow.item().title(), overflow.reason(),
+                    overflow.remainingMinutes(), overflow.item().due());
+        }
+        return warnings;
+    }
+
+    private boolean hasDeadlineRisk(OverflowItem overflow, LocalDate date) {
+        LocalDate due = overflow.item().due();
+        return due != null && !due.isBefore(date);
+    }
+
+    private SchedulingWarning buildCapacityWarning(OverflowItem overflow,
+                                                   LocalDate date) {
+        String msg = String.format(
+                "'%s' 항목이 자유시간 부족으로 다음 날로 이월됩니다 (%d분 남음)",
+                overflow.item().title(), overflow.remainingMinutes());
+        return new SchedulingWarning(
+                WarningType.CAPACITY_EXCEEDED,
+                msg,
+                overflow.item().referenceId());
+    }
+
+    private SchedulingWarning buildDeadlineWarning(OverflowItem overflow,
+                                                   LocalDate date) {
+        LocalDate due = overflow.item().due();
+        long days = ChronoUnit.DAYS.between(date, due);
+        String msg = String.format(
+                "'%s' 데드라인까지 여유가 %d일 남았습니다",
+                overflow.item().title(), days);
+        return new SchedulingWarning(
+                WarningType.DEADLINE_RISK,
+                msg,
+                overflow.item().referenceId());
+    }
+
+    private SchedulingWarning buildAllocationWarning(OverflowItem overflow) {
+        String msg = String.format(
+                "'%s' 항목이 학습 자료 시간 할당을 초과하여 %d분이 이월됩니다",
+                overflow.item().title(), overflow.remainingMinutes());
+        return new SchedulingWarning(
+                WarningType.ALLOCATION_EXCEEDED,
+                msg,
+                overflow.item().referenceId());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/RecurrenceCalculator.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/RecurrenceCalculator.java
@@ -1,0 +1,165 @@
+package ds.project.orino.planner.scheduling.engine;
+
+import ds.project.orino.domain.fixedschedule.entity.FixedSchedule;
+import ds.project.orino.domain.fixedschedule.entity.RecurrenceType;
+import ds.project.orino.domain.routine.entity.Routine;
+import ds.project.orino.domain.routine.entity.RoutineStatus;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 반복 규칙을 런타임에 계산하여 특정 날짜에 적용되는지 판정한다.
+ * fixed_schedule / routine의 반복 패턴을 공통으로 처리한다.
+ */
+@Component
+public class RecurrenceCalculator {
+
+    public boolean applies(FixedSchedule schedule, LocalDate date) {
+        RecurrenceType type = schedule.getRecurrenceType();
+        if (type == RecurrenceType.NONE) {
+            return date.equals(schedule.getScheduleDate());
+        }
+        if (!withinRange(date,
+                schedule.getRecurrenceStart(),
+                schedule.getRecurrenceEnd())) {
+            return false;
+        }
+        return matchesPattern(type,
+                schedule.getRecurrenceInterval(),
+                schedule.getRecurrenceDays(),
+                schedule.getRecurrenceStart(), date);
+    }
+
+    public boolean applies(Routine routine, LocalDate date) {
+        if (routine.getStatus() != RoutineStatus.ACTIVE) {
+            return false;
+        }
+        if (!withinRange(date,
+                routine.getStartDate(),
+                routine.getEndDate())) {
+            return false;
+        }
+        if (routine.isSkipHolidays() && isWeekend(date)) {
+            return false;
+        }
+        boolean excluded = routine.getExceptions().stream()
+                .anyMatch(e -> e.getExceptionDate() != null
+                        && e.getExceptionDate().equals(date));
+        if (excluded) {
+            return false;
+        }
+        return matchesPattern(routine.getRecurrenceType(),
+                routine.getRecurrenceInterval(),
+                routine.getRecurrenceDays(),
+                routine.getStartDate(), date);
+    }
+
+    private boolean withinRange(LocalDate date, LocalDate start,
+                                LocalDate end) {
+        if (start != null && date.isBefore(start)) {
+            return false;
+        }
+        if (end != null && date.isAfter(end)) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean matchesPattern(RecurrenceType type, Integer interval,
+                                   String days, LocalDate anchor,
+                                   LocalDate date) {
+        return switch (type) {
+            case NONE -> false;
+            case DAILY -> true;
+            case EVERY_N_DAYS -> matchesEveryNDays(interval, anchor, date);
+            case WEEKLY -> matchesWeekly(days, date);
+            case MONTHLY_DATE -> matchesMonthlyDate(days, date);
+            case MONTHLY_NTH_DAY -> matchesMonthlyNthDay(days, date);
+        };
+    }
+
+    private boolean matchesEveryNDays(Integer interval, LocalDate anchor,
+                                      LocalDate date) {
+        if (interval == null || interval <= 0 || anchor == null) {
+            return false;
+        }
+        long diff = ChronoUnit.DAYS.between(anchor, date);
+        return diff >= 0 && diff % interval == 0;
+    }
+
+    private boolean matchesWeekly(String days, LocalDate date) {
+        if (days == null || days.isBlank()) {
+            return false;
+        }
+        Set<DayOfWeek> allowed = Arrays.stream(days.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(this::parseDayOfWeek)
+                .collect(Collectors.toSet());
+        return allowed.contains(date.getDayOfWeek());
+    }
+
+    private boolean matchesMonthlyDate(String days, LocalDate date) {
+        if (days == null || days.isBlank()) {
+            return false;
+        }
+        int dayOfMonth = date.getDayOfMonth();
+        return Arrays.stream(days.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(Integer::parseInt)
+                .anyMatch(d -> d == dayOfMonth);
+    }
+
+    private boolean matchesMonthlyNthDay(String days, LocalDate date) {
+        if (days == null || days.isBlank()) {
+            return false;
+        }
+        for (String token : days.split(",")) {
+            String t = token.trim();
+            if (t.isEmpty()) {
+                continue;
+            }
+            String[] parts = t.split("-");
+            if (parts.length != 2) {
+                continue;
+            }
+            int nth = Integer.parseInt(parts[0].trim());
+            DayOfWeek dow = parseDayOfWeek(parts[1].trim());
+            if (date.getDayOfWeek() == dow
+                    && nthOccurrenceInMonth(date) == nth) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private int nthOccurrenceInMonth(LocalDate date) {
+        return (date.getDayOfMonth() - 1) / 7 + 1;
+    }
+
+    private boolean isWeekend(LocalDate date) {
+        DayOfWeek d = date.getDayOfWeek();
+        return d == DayOfWeek.SATURDAY || d == DayOfWeek.SUNDAY;
+    }
+
+    private DayOfWeek parseDayOfWeek(String token) {
+        return switch (token.toUpperCase()) {
+            case "MON" -> DayOfWeek.MONDAY;
+            case "TUE" -> DayOfWeek.TUESDAY;
+            case "WED" -> DayOfWeek.WEDNESDAY;
+            case "THU" -> DayOfWeek.THURSDAY;
+            case "FRI" -> DayOfWeek.FRIDAY;
+            case "SAT" -> DayOfWeek.SATURDAY;
+            case "SUN" -> DayOfWeek.SUNDAY;
+            default -> throw new IllegalArgumentException(
+                    "알 수 없는 요일: " + token);
+        };
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/SchedulingEngine.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/SchedulingEngine.java
@@ -1,0 +1,241 @@
+package ds.project.orino.planner.scheduling.engine;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.calendar.entity.BlockStatus;
+import ds.project.orino.domain.calendar.entity.DailySchedule;
+import ds.project.orino.domain.calendar.entity.ScheduleBlock;
+import ds.project.orino.domain.calendar.repository.DailyScheduleRepository;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.domain.preference.repository.UserPreferenceRepository;
+import ds.project.orino.planner.scheduling.engine.model.AvailabilityResult;
+import ds.project.orino.planner.scheduling.engine.model.PlacedBlock;
+import ds.project.orino.planner.scheduling.engine.model.PlacementResult;
+import ds.project.orino.planner.scheduling.engine.model.SchedulableItem;
+import ds.project.orino.planner.scheduling.engine.model.SchedulingResult;
+import ds.project.orino.planner.scheduling.engine.model.SchedulingWarning;
+import ds.project.orino.planner.scheduling.engine.model.TimeSlot;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 스케줄링 엔진. 5단계 파이프라인을 오케스트레이션하고 DailySchedule을 저장한다.
+ *
+ * 재생성 시 COMPLETED 또는 pinned 블록은 유지하고, 나머지만 재배치한다.
+ * 과거 날짜는 재생성하지 않는다.
+ */
+@Component
+public class SchedulingEngine {
+
+    private final DailyScheduleRepository dailyScheduleRepository;
+    private final UserPreferenceRepository preferenceRepository;
+    private final MemberRepository memberRepository;
+    private final AvailabilityCalculator availabilityCalculator;
+    private final ItemCollector itemCollector;
+    private final ItemPrioritizer itemPrioritizer;
+    private final BlockPlacer blockPlacer;
+    private final OverflowHandler overflowHandler;
+
+    public SchedulingEngine(
+            DailyScheduleRepository dailyScheduleRepository,
+            UserPreferenceRepository preferenceRepository,
+            MemberRepository memberRepository,
+            AvailabilityCalculator availabilityCalculator,
+            ItemCollector itemCollector,
+            ItemPrioritizer itemPrioritizer,
+            BlockPlacer blockPlacer,
+            OverflowHandler overflowHandler) {
+        this.dailyScheduleRepository = dailyScheduleRepository;
+        this.preferenceRepository = preferenceRepository;
+        this.memberRepository = memberRepository;
+        this.availabilityCalculator = availabilityCalculator;
+        this.itemCollector = itemCollector;
+        this.itemPrioritizer = itemPrioritizer;
+        this.blockPlacer = blockPlacer;
+        this.overflowHandler = overflowHandler;
+    }
+
+    @Transactional
+    public SchedulingResult generate(Long memberId, LocalDate date) {
+        LocalDate today = LocalDate.now();
+        DailySchedule dailySchedule = dailyScheduleRepository
+                .findByMemberIdAndScheduleDate(memberId, date)
+                .orElseGet(() -> createDailySchedule(memberId, date));
+
+        if (date.isBefore(today)) {
+            dailySchedule.getBlocks().size();
+            return new SchedulingResult(dailySchedule, List.of());
+        }
+
+        UserPreference preference = preferenceRepository
+                .findByMemberId(memberId)
+                .orElseGet(() -> createDefaultPreference(memberId));
+
+        List<ScheduleBlock> lockedBlocks = extractLockedBlocks(dailySchedule);
+        dailySchedule.clearBlocks();
+        reinsertLocked(dailySchedule, lockedBlocks);
+
+        AvailabilityResult availability = availabilityCalculator
+                .calculate(memberId, date, preference);
+        List<TimeSlot> freeSlots = subtractLockedFromFreeSlots(
+                availability.freeSlots(), lockedBlocks);
+
+        Set<ItemKey> locked = lockedReferenceKeys(lockedBlocks);
+
+        List<SchedulableItem> collected = itemCollector.collect(memberId, date);
+        List<SchedulableItem> remaining = collected.stream()
+                .filter(i -> !locked.contains(
+                        new ItemKey(i.blockType(), i.referenceId())))
+                .toList();
+        List<SchedulableItem> prioritized = itemPrioritizer.prioritize(remaining);
+
+        PlacementResult placement = blockPlacer.place(
+                prioritized, freeSlots, preference, date);
+
+        List<ScheduleBlock> newBlocks = new ArrayList<>();
+        newBlocks.addAll(toScheduleBlocks(dailySchedule,
+                availability.preplacedBlocks(), nextSortOrder(dailySchedule)));
+        newBlocks.addAll(toScheduleBlocks(dailySchedule,
+                placement.placedBlocks(),
+                nextSortOrder(dailySchedule) + availability.preplacedBlocks().size()));
+        for (ScheduleBlock block : newBlocks) {
+            dailySchedule.addBlock(block);
+        }
+
+        resortBlocks(dailySchedule);
+
+        int total = dailySchedule.getBlocks().size();
+        int completed = (int) dailySchedule.getBlocks().stream()
+                .filter(b -> b.getStatus() == BlockStatus.COMPLETED)
+                .count();
+        dailySchedule.markGenerated(total, completed);
+
+        List<SchedulingWarning> warnings = overflowHandler.handle(
+                placement.overflows(), date);
+
+        return new SchedulingResult(dailySchedule, warnings);
+    }
+
+    private DailySchedule createDailySchedule(Long memberId, LocalDate date) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(
+                        ErrorCode.RESOURCE_NOT_FOUND));
+        return dailyScheduleRepository.save(
+                new DailySchedule(member, date));
+    }
+
+    private UserPreference createDefaultPreference(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(
+                        ErrorCode.RESOURCE_NOT_FOUND));
+        return preferenceRepository.save(new UserPreference(member));
+    }
+
+    private List<ScheduleBlock> extractLockedBlocks(DailySchedule schedule) {
+        return schedule.getBlocks().stream()
+                .filter(ScheduleBlock::isLocked)
+                .toList();
+    }
+
+    private void reinsertLocked(DailySchedule schedule,
+                                List<ScheduleBlock> locked) {
+        for (ScheduleBlock block : locked) {
+            schedule.addBlock(block);
+        }
+    }
+
+    private List<TimeSlot> subtractLockedFromFreeSlots(
+            List<TimeSlot> freeSlots, List<ScheduleBlock> locked) {
+        if (locked.isEmpty()) {
+            return freeSlots;
+        }
+        List<TimeSlot> taken = locked.stream()
+                .map(b -> new TimeSlot(b.getStartTime(), b.getEndTime()))
+                .sorted(Comparator.comparing(TimeSlot::start))
+                .toList();
+        List<TimeSlot> result = new ArrayList<>();
+        for (TimeSlot slot : freeSlots) {
+            result.addAll(subtractFromSlot(slot, taken));
+        }
+        return result;
+    }
+
+    private List<TimeSlot> subtractFromSlot(TimeSlot slot,
+                                            List<TimeSlot> taken) {
+        List<TimeSlot> result = new ArrayList<>();
+        LocalTime cursor = slot.start();
+        for (TimeSlot t : taken) {
+            if (!t.start().isBefore(slot.end())
+                    || !t.end().isAfter(slot.start())) {
+                continue;
+            }
+            LocalTime tStart = t.start().isAfter(cursor)
+                    ? t.start() : cursor;
+            if (tStart.isAfter(cursor)) {
+                result.add(new TimeSlot(cursor, tStart));
+            }
+            if (t.end().isAfter(cursor)) {
+                cursor = t.end();
+            }
+        }
+        if (cursor.isBefore(slot.end())) {
+            result.add(new TimeSlot(cursor, slot.end()));
+        }
+        return result;
+    }
+
+    private Set<ItemKey> lockedReferenceKeys(List<ScheduleBlock> locked) {
+        Set<ItemKey> set = new HashSet<>();
+        for (ScheduleBlock block : locked) {
+            set.add(new ItemKey(block.getBlockType(),
+                    block.getReferenceId()));
+        }
+        return set;
+    }
+
+    private List<ScheduleBlock> toScheduleBlocks(DailySchedule schedule,
+                                                 List<PlacedBlock> placed,
+                                                 int startingSortOrder) {
+        List<ScheduleBlock> blocks = new ArrayList<>();
+        int order = startingSortOrder;
+        List<PlacedBlock> sorted = placed.stream()
+                .sorted(Comparator.comparing(PlacedBlock::start))
+                .toList();
+        for (PlacedBlock p : sorted) {
+            blocks.add(new ScheduleBlock(schedule, p.blockType(),
+                    p.referenceId(), p.start(), p.end(), order++));
+        }
+        return blocks;
+    }
+
+    private int nextSortOrder(DailySchedule schedule) {
+        return schedule.getBlocks().stream()
+                .mapToInt(ScheduleBlock::getSortOrder)
+                .max()
+                .orElse(-1) + 1;
+    }
+
+    private void resortBlocks(DailySchedule schedule) {
+        List<ScheduleBlock> sorted = schedule.getBlocks().stream()
+                .sorted(Comparator.comparing(ScheduleBlock::getStartTime))
+                .toList();
+        for (int i = 0; i < sorted.size(); i++) {
+            sorted.get(i).updateSortOrder(i);
+        }
+    }
+
+    private record ItemKey(
+            ds.project.orino.domain.calendar.entity.BlockType type,
+            Long referenceId) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/AvailabilityResult.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/AvailabilityResult.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.scheduling.engine.model;
+
+import java.util.List;
+
+/**
+ * AvailabilityCalculator의 결과.
+ * 자유 시간 블록과, 고정 일정/루틴으로 미리 배치된 블록을 함께 담는다.
+ */
+public record AvailabilityResult(
+        List<TimeSlot> freeSlots,
+        List<PlacedBlock> preplacedBlocks
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/ItemCategory.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/ItemCategory.java
@@ -1,0 +1,14 @@
+package ds.project.orino.planner.scheduling.engine.model;
+
+/**
+ * 스케줄링 대상 항목의 분류.
+ * 기본 우선순위 순서대로 정의한다 (1이 가장 높음).
+ */
+public enum ItemCategory {
+    OVERDUE_REVIEW,
+    TODAY_REVIEW,
+    URGENT_TODO,
+    DEADLINE_STUDY,
+    NEW_STUDY,
+    NO_DEADLINE_TODO
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/OverflowItem.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/OverflowItem.java
@@ -1,0 +1,17 @@
+package ds.project.orino.planner.scheduling.engine.model;
+
+/**
+ * 자유시간에 배치되지 못한 항목.
+ */
+public record OverflowItem(
+        SchedulableItem item,
+        int remainingMinutes,
+        OverflowReason reason
+) {
+    public enum OverflowReason {
+        /** 자유시간 전부 소진 */
+        SLOT_EXHAUSTED,
+        /** 시간 할당(하루 총 학습시간 등) 초과 */
+        ALLOCATION_EXCEEDED
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/PlacedBlock.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/PlacedBlock.java
@@ -1,0 +1,17 @@
+package ds.project.orino.planner.scheduling.engine.model;
+
+import ds.project.orino.domain.calendar.entity.BlockType;
+
+import java.time.LocalTime;
+
+/**
+ * 엔진이 배치하기로 결정한 블록. 아직 DB에 저장되지 않은 상태.
+ */
+public record PlacedBlock(
+        BlockType blockType,
+        long referenceId,
+        LocalTime start,
+        LocalTime end,
+        String title
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/PlacementResult.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/PlacementResult.java
@@ -1,0 +1,12 @@
+package ds.project.orino.planner.scheduling.engine.model;
+
+import java.util.List;
+
+/**
+ * BlockPlacer가 리턴하는 결과. 배치된 블록과 이월 항목을 함께 담는다.
+ */
+public record PlacementResult(
+        List<PlacedBlock> placedBlocks,
+        List<OverflowItem> overflows
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/SchedulableItem.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/SchedulableItem.java
@@ -1,0 +1,133 @@
+package ds.project.orino.planner.scheduling.engine.model;
+
+import ds.project.orino.domain.calendar.entity.BlockType;
+
+import java.time.LocalDate;
+
+/**
+ * 스케줄링 엔진이 배치할 항목 하나.
+ * 내부 분류(category), 참조 엔티티(blockType/referenceId),
+ * 소요 시간, 정렬 보조 키를 담는다.
+ */
+public final class SchedulableItem {
+
+    private final ItemCategory category;
+    private final BlockType blockType;
+    private final long referenceId;
+    private final int estimatedMinutes;
+    /** 데드라인/예정일 (없으면 null). 가까운 순으로 정렬. */
+    private final LocalDate due;
+    /** 카테고리 내 보조 정렬 키 (낮을수록 먼저). */
+    private final int subOrder;
+    /** 연관 학습 자료 id (시간 할당 조회용, 없으면 null). */
+    private final Long materialId;
+    /** 디스플레이/디버그용. */
+    private final String title;
+
+    private SchedulableItem(Builder b) {
+        this.category = b.category;
+        this.blockType = b.blockType;
+        this.referenceId = b.referenceId;
+        this.estimatedMinutes = b.estimatedMinutes;
+        this.due = b.due;
+        this.subOrder = b.subOrder;
+        this.materialId = b.materialId;
+        this.title = b.title;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public ItemCategory category() {
+        return category;
+    }
+
+    public BlockType blockType() {
+        return blockType;
+    }
+
+    public long referenceId() {
+        return referenceId;
+    }
+
+    public int estimatedMinutes() {
+        return estimatedMinutes;
+    }
+
+    public LocalDate due() {
+        return due;
+    }
+
+    public int subOrder() {
+        return subOrder;
+    }
+
+    public Long materialId() {
+        return materialId;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public static final class Builder {
+        private ItemCategory category;
+        private BlockType blockType;
+        private long referenceId;
+        private int estimatedMinutes;
+        private LocalDate due;
+        private int subOrder;
+        private Long materialId;
+        private String title;
+
+        public Builder category(ItemCategory category) {
+            this.category = category;
+            return this;
+        }
+
+        public Builder blockType(BlockType blockType) {
+            this.blockType = blockType;
+            return this;
+        }
+
+        public Builder referenceId(long referenceId) {
+            this.referenceId = referenceId;
+            return this;
+        }
+
+        public Builder estimatedMinutes(int estimatedMinutes) {
+            this.estimatedMinutes = estimatedMinutes;
+            return this;
+        }
+
+        public Builder due(LocalDate due) {
+            this.due = due;
+            return this;
+        }
+
+        public Builder subOrder(int subOrder) {
+            this.subOrder = subOrder;
+            return this;
+        }
+
+        public Builder materialId(Long materialId) {
+            this.materialId = materialId;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public SchedulableItem build() {
+            if (category == null || blockType == null
+                    || estimatedMinutes <= 0) {
+                throw new IllegalStateException(
+                        "필수 필드 누락: category/blockType/estimatedMinutes");
+            }
+            return new SchedulableItem(this);
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/SchedulingResult.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/SchedulingResult.java
@@ -1,0 +1,14 @@
+package ds.project.orino.planner.scheduling.engine.model;
+
+import ds.project.orino.domain.calendar.entity.DailySchedule;
+
+import java.util.List;
+
+/**
+ * 스케줄링 엔진 실행 결과.
+ */
+public record SchedulingResult(
+        DailySchedule dailySchedule,
+        List<SchedulingWarning> warnings
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/SchedulingWarning.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/SchedulingWarning.java
@@ -1,0 +1,20 @@
+package ds.project.orino.planner.scheduling.engine.model;
+
+/**
+ * 스케줄링 과정에서 발생한 경고.
+ * 용량 초과, 데드라인 임박 이월 등을 포함한다.
+ */
+public record SchedulingWarning(
+        WarningType type,
+        String message,
+        Long referenceId
+) {
+    public enum WarningType {
+        /** 배치 못한 항목이 다음 날로 이월됨 (데드라인 경고) */
+        DEADLINE_RISK,
+        /** 자유시간 부족으로 일부 항목 이월 */
+        CAPACITY_EXCEEDED,
+        /** 학습 자료 시간 할당 초과 */
+        ALLOCATION_EXCEEDED
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/TimeSlot.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/model/TimeSlot.java
@@ -1,0 +1,41 @@
+package ds.project.orino.planner.scheduling.engine.model;
+
+import java.time.Duration;
+import java.time.LocalTime;
+
+/**
+ * 자유 시간 블록을 표현한다. start는 포함, end는 제외한다.
+ */
+public record TimeSlot(LocalTime start, LocalTime end) {
+
+    public TimeSlot {
+        if (start == null || end == null) {
+            throw new IllegalArgumentException("start/end는 null일 수 없다");
+        }
+        if (!start.isBefore(end)) {
+            throw new IllegalArgumentException(
+                    "start는 end보다 이전이어야 한다: "
+                            + start + " / " + end);
+        }
+    }
+
+    public int minutes() {
+        return (int) Duration.between(start, end).toMinutes();
+    }
+
+    public boolean contains(LocalTime time) {
+        return !time.isBefore(start) && time.isBefore(end);
+    }
+
+    public boolean overlaps(TimeSlot other) {
+        return start.isBefore(other.end) && other.start.isBefore(end);
+    }
+
+    public TimeSlot withStart(LocalTime newStart) {
+        return new TimeSlot(newStart, end);
+    }
+
+    public TimeSlot withEnd(LocalTime newEnd) {
+        return new TimeSlot(start, newEnd);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/scheduling/engine/BlockPlacerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/scheduling/engine/BlockPlacerTest.java
@@ -1,0 +1,185 @@
+package ds.project.orino.planner.scheduling.engine;
+
+import ds.project.orino.domain.calendar.entity.BlockType;
+import ds.project.orino.domain.material.entity.MaterialAllocation;
+import ds.project.orino.domain.material.repository.MaterialAllocationRepository;
+import ds.project.orino.domain.material.repository.MaterialDailyOverrideRepository;
+import ds.project.orino.domain.preference.entity.StudyTimePreference;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.planner.scheduling.engine.model.ItemCategory;
+import ds.project.orino.planner.scheduling.engine.model.OverflowItem;
+import ds.project.orino.planner.scheduling.engine.model.PlacementResult;
+import ds.project.orino.planner.scheduling.engine.model.SchedulableItem;
+import ds.project.orino.planner.scheduling.engine.model.TimeSlot;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class BlockPlacerTest {
+
+    private BlockPlacer placer;
+
+    @Mock private MaterialAllocationRepository allocationRepository;
+    @Mock private MaterialDailyOverrideRepository overrideRepository;
+
+    private UserPreference preference;
+    private final LocalDate date = LocalDate.of(2026, 4, 10);
+
+    @BeforeEach
+    void setUp() {
+        placer = new BlockPlacer(allocationRepository, overrideRepository);
+        preference = new UserPreference(null);
+        ReflectionTestUtils.setField(preference, "focusMinutes", 50);
+        ReflectionTestUtils.setField(preference, "breakMinutes", 10);
+        ReflectionTestUtils.setField(preference, "studyTimePreference",
+                StudyTimePreference.MORNING);
+    }
+
+    @Test
+    @DisplayName("단일 항목을 자유슬롯에 배치한다")
+    void placeSingleItem() {
+        List<TimeSlot> slots = List.of(slot(7, 0, 10, 0));
+        SchedulableItem item = studyItem(30, 1L, null);
+
+        PlacementResult result = placer.place(
+                List.of(item), slots, preference, date);
+
+        assertThat(result.placedBlocks()).hasSize(1);
+        assertThat(result.overflows()).isEmpty();
+        assertThat(result.placedBlocks().get(0).start())
+                .isEqualTo(LocalTime.of(7, 0));
+        assertThat(result.placedBlocks().get(0).end())
+                .isEqualTo(LocalTime.of(7, 30));
+    }
+
+    @Test
+    @DisplayName("focusMinutes보다 긴 항목은 집중시간 단위로 분할한다")
+    void splitByFocusMinutes() {
+        List<TimeSlot> slots = List.of(slot(7, 0, 10, 0));
+        SchedulableItem item = studyItem(100, 1L, null);
+
+        PlacementResult result = placer.place(
+                List.of(item), slots, preference, date);
+
+        assertThat(result.placedBlocks()).hasSize(2);
+        assertThat(result.placedBlocks().get(0).start())
+                .isEqualTo(LocalTime.of(7, 0));
+        assertThat(result.placedBlocks().get(0).end())
+                .isEqualTo(LocalTime.of(7, 50));
+        // 10분 휴식 후
+        assertThat(result.placedBlocks().get(1).start())
+                .isEqualTo(LocalTime.of(8, 0));
+        assertThat(result.placedBlocks().get(1).end())
+                .isEqualTo(LocalTime.of(8, 50));
+    }
+
+    @Test
+    @DisplayName("집중시간 청크가 맞는 슬롯이 없으면 overflow로 처리된다")
+    void overflowOnSlotExhausted() {
+        // focus=50, 슬롯은 40분 → 50분 청크가 들어가지 못함
+        List<TimeSlot> slots = List.of(slot(7, 0, 7, 40));
+        SchedulableItem item = studyItem(120, 1L, null);
+
+        PlacementResult result = placer.place(
+                List.of(item), slots, preference, date);
+
+        assertThat(result.placedBlocks()).isEmpty();
+        assertThat(result.overflows()).hasSize(1);
+        assertThat(result.overflows().get(0).remainingMinutes())
+                .isEqualTo(120);
+        assertThat(result.overflows().get(0).reason())
+                .isEqualTo(OverflowItem.OverflowReason.SLOT_EXHAUSTED);
+    }
+
+    @Test
+    @DisplayName("나머지 시간이 focus보다 작으면 나머지만큼 배치한다")
+    void lastChunkSmallerThanFocus() {
+        List<TimeSlot> slots = List.of(slot(7, 0, 8, 0));
+        SchedulableItem item = studyItem(20, 1L, null);
+
+        PlacementResult result = placer.place(
+                List.of(item), slots, preference, date);
+
+        assertThat(result.placedBlocks()).hasSize(1);
+        assertThat(result.placedBlocks().get(0).start())
+                .isEqualTo(LocalTime.of(7, 0));
+        assertThat(result.placedBlocks().get(0).end())
+                .isEqualTo(LocalTime.of(7, 20));
+    }
+
+    @Test
+    @DisplayName("학습 자료 할당시간을 초과하면 ALLOCATION_EXCEEDED overflow")
+    void allocationCap() {
+        MaterialAllocation allocation = new MaterialAllocation(null, 60);
+        given(allocationRepository.findByMaterialId(10L))
+                .willReturn(Optional.of(allocation));
+        given(overrideRepository
+                .findByMaterialIdAndOverrideDate(10L, date))
+                .willReturn(Optional.empty());
+
+        List<TimeSlot> slots = List.of(slot(7, 0, 12, 0));
+        SchedulableItem item = studyItem(120, 1L, 10L);
+
+        PlacementResult result = placer.place(
+                List.of(item), slots, preference, date);
+
+        // 할당은 60분 → 1 chunk 50min + 1 chunk 10min
+        int placedMinutes = result.placedBlocks().stream()
+                .mapToInt(b -> (int) java.time.Duration.between(
+                        b.start(), b.end()).toMinutes())
+                .sum();
+        assertThat(placedMinutes).isEqualTo(60);
+        assertThat(result.overflows()).hasSize(1);
+        assertThat(result.overflows().get(0).remainingMinutes())
+                .isEqualTo(60);
+        assertThat(result.overflows().get(0).reason())
+                .isEqualTo(OverflowItem.OverflowReason.ALLOCATION_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("EVENING 선호는 가장 늦은 슬롯부터 채운다")
+    void eveningPreference() {
+        ReflectionTestUtils.setField(preference, "studyTimePreference",
+                StudyTimePreference.EVENING);
+
+        List<TimeSlot> slots = List.of(
+                slot(7, 0, 8, 0), slot(20, 0, 22, 0));
+        SchedulableItem item = studyItem(30, 1L, null);
+
+        PlacementResult result = placer.place(
+                List.of(item), slots, preference, date);
+
+        assertThat(result.placedBlocks().get(0).start())
+                .isEqualTo(LocalTime.of(20, 0));
+    }
+
+    private TimeSlot slot(int startH, int startM, int endH, int endM) {
+        return new TimeSlot(
+                LocalTime.of(startH, startM), LocalTime.of(endH, endM));
+    }
+
+    private SchedulableItem studyItem(int minutes, long refId,
+                                      Long materialId) {
+        return SchedulableItem.builder()
+                .category(ItemCategory.NEW_STUDY)
+                .blockType(BlockType.STUDY)
+                .referenceId(refId)
+                .estimatedMinutes(minutes)
+                .materialId(materialId)
+                .title("study-" + refId)
+                .build();
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/scheduling/engine/ItemPrioritizerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/scheduling/engine/ItemPrioritizerTest.java
@@ -1,0 +1,58 @@
+package ds.project.orino.planner.scheduling.engine;
+
+import ds.project.orino.domain.calendar.entity.BlockType;
+import ds.project.orino.planner.scheduling.engine.model.ItemCategory;
+import ds.project.orino.planner.scheduling.engine.model.SchedulableItem;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ItemPrioritizerTest {
+
+    private final ItemPrioritizer prioritizer = new ItemPrioritizer();
+
+    @Test
+    @DisplayName("카테고리 우선순위 순서대로 정렬한다")
+    void sortByCategory() {
+        SchedulableItem noDeadline = itemOf(
+                ItemCategory.NO_DEADLINE_TODO, 1, 1L);
+        SchedulableItem overdue = itemOf(
+                ItemCategory.OVERDUE_REVIEW, 1, 2L);
+        SchedulableItem urgent = itemOf(
+                ItemCategory.URGENT_TODO, 1, 3L);
+
+        List<SchedulableItem> result = prioritizer.prioritize(
+                List.of(noDeadline, overdue, urgent));
+
+        assertThat(result).containsExactly(overdue, urgent, noDeadline);
+    }
+
+    @Test
+    @DisplayName("같은 카테고리 내에서는 subOrder로 정렬한다")
+    void sortBySubOrder() {
+        SchedulableItem later = itemOf(
+                ItemCategory.URGENT_TODO, 20, 1L);
+        SchedulableItem earlier = itemOf(
+                ItemCategory.URGENT_TODO, 10, 2L);
+
+        List<SchedulableItem> result = prioritizer.prioritize(
+                List.of(later, earlier));
+
+        assertThat(result).containsExactly(earlier, later);
+    }
+
+    private SchedulableItem itemOf(ItemCategory category, int subOrder,
+                                   long refId) {
+        return SchedulableItem.builder()
+                .category(category)
+                .blockType(BlockType.TODO)
+                .referenceId(refId)
+                .estimatedMinutes(30)
+                .subOrder(subOrder)
+                .title("test" + refId)
+                .build();
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/scheduling/engine/RecurrenceCalculatorTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/scheduling/engine/RecurrenceCalculatorTest.java
@@ -1,0 +1,150 @@
+package ds.project.orino.planner.scheduling.engine;
+
+import ds.project.orino.domain.fixedschedule.entity.FixedSchedule;
+import ds.project.orino.domain.fixedschedule.entity.RecurrenceType;
+import ds.project.orino.domain.routine.entity.Routine;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecurrenceCalculatorTest {
+
+    private final RecurrenceCalculator calc = new RecurrenceCalculator();
+
+    @Test
+    @DisplayName("NONE 타입은 scheduleDate에만 적용된다")
+    void none() {
+        LocalDate target = LocalDate.of(2026, 4, 10);
+        FixedSchedule fs = new FixedSchedule(
+                null, "단발", null,
+                LocalTime.of(9, 0), LocalTime.of(10, 0),
+                target, RecurrenceType.NONE,
+                null, null, null, null);
+
+        assertThat(calc.applies(fs, target)).isTrue();
+        assertThat(calc.applies(fs, target.plusDays(1))).isFalse();
+    }
+
+    @Test
+    @DisplayName("DAILY 타입은 recurrence_start~end 사이 매일 적용된다")
+    void daily() {
+        FixedSchedule fs = new FixedSchedule(
+                null, "매일", null,
+                LocalTime.of(9, 0), LocalTime.of(10, 0),
+                null, RecurrenceType.DAILY,
+                null, null,
+                LocalDate.of(2026, 4, 1),
+                LocalDate.of(2026, 4, 30));
+
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 15))).isTrue();
+        assertThat(calc.applies(fs, LocalDate.of(2026, 3, 31))).isFalse();
+        assertThat(calc.applies(fs, LocalDate.of(2026, 5, 1))).isFalse();
+    }
+
+    @Test
+    @DisplayName("EVERY_N_DAYS는 anchor부터 N일 간격으로 적용된다")
+    void everyNDays() {
+        FixedSchedule fs = new FixedSchedule(
+                null, "격일", null,
+                LocalTime.of(9, 0), LocalTime.of(10, 0),
+                null, RecurrenceType.EVERY_N_DAYS,
+                2, null,
+                LocalDate.of(2026, 4, 1), null);
+
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 1))).isTrue();
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 2))).isFalse();
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 3))).isTrue();
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 5))).isTrue();
+    }
+
+    @Test
+    @DisplayName("WEEKLY는 지정된 요일에만 적용된다")
+    void weekly() {
+        FixedSchedule fs = new FixedSchedule(
+                null, "월수금", null,
+                LocalTime.of(9, 0), LocalTime.of(10, 0),
+                null, RecurrenceType.WEEKLY,
+                null, "MON,WED,FRI",
+                LocalDate.of(2026, 4, 1), null);
+
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 6))).isTrue();
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 7))).isFalse();
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 8))).isTrue();
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 10))).isTrue();
+    }
+
+    @Test
+    @DisplayName("MONTHLY_DATE는 지정된 날짜에만 적용된다")
+    void monthlyDate() {
+        FixedSchedule fs = new FixedSchedule(
+                null, "1일,15일", null,
+                LocalTime.of(9, 0), LocalTime.of(10, 0),
+                null, RecurrenceType.MONTHLY_DATE,
+                null, "1,15",
+                LocalDate.of(2026, 1, 1), null);
+
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 1))).isTrue();
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 15))).isTrue();
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 16))).isFalse();
+    }
+
+    @Test
+    @DisplayName("MONTHLY_NTH_DAY는 매월 n번째 요일에만 적용된다")
+    void monthlyNthDay() {
+        FixedSchedule fs = new FixedSchedule(
+                null, "첫째 월요일", null,
+                LocalTime.of(9, 0), LocalTime.of(10, 0),
+                null, RecurrenceType.MONTHLY_NTH_DAY,
+                null, "1-MON",
+                LocalDate.of(2026, 1, 1), null);
+
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 6))).isTrue();
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 13))).isFalse();
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 7))).isFalse();
+    }
+
+    @Test
+    @DisplayName("recurrence_end 이후에는 적용되지 않는다")
+    void endedRecurrence() {
+        FixedSchedule fs = new FixedSchedule(
+                null, "매일", null,
+                LocalTime.of(9, 0), LocalTime.of(10, 0),
+                null, RecurrenceType.DAILY,
+                null, null,
+                LocalDate.of(2026, 4, 1),
+                LocalDate.of(2026, 4, 10));
+
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 10))).isTrue();
+        assertThat(calc.applies(fs, LocalDate.of(2026, 4, 11))).isFalse();
+    }
+
+    @Test
+    @DisplayName("PAUSED 상태의 루틴은 적용되지 않는다")
+    void pausedRoutine() {
+        Routine routine = new Routine(
+                null, "운동", null, 30, LocalTime.of(7, 0),
+                RecurrenceType.DAILY, null, null,
+                LocalDate.of(2026, 4, 1), null, false);
+        routine.changeStatus(
+                ds.project.orino.domain.routine.entity.RoutineStatus.PAUSED);
+
+        assertThat(calc.applies(routine, LocalDate.of(2026, 4, 5))).isFalse();
+    }
+
+    @Test
+    @DisplayName("skipHolidays=true인 루틴은 주말에 적용되지 않는다")
+    void skipHolidays() {
+        Routine routine = new Routine(
+                null, "운동", null, 30, LocalTime.of(7, 0),
+                RecurrenceType.DAILY, null, null,
+                LocalDate.of(2026, 4, 1), null, true);
+
+        // 2026-04-11 = 토요일, 2026-04-13 = 월요일
+        assertThat(calc.applies(routine, LocalDate.of(2026, 4, 11))).isFalse();
+        assertThat(calc.applies(routine, LocalDate.of(2026, 4, 13))).isTrue();
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/scheduling/engine/SchedulingEngineIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/scheduling/engine/SchedulingEngineIntegrationTest.java
@@ -1,0 +1,280 @@
+package ds.project.orino.planner.scheduling.engine;
+
+import ds.project.orino.domain.calendar.entity.BlockStatus;
+import ds.project.orino.domain.calendar.entity.BlockType;
+import ds.project.orino.domain.calendar.entity.DailySchedule;
+import ds.project.orino.domain.calendar.entity.ScheduleBlock;
+import ds.project.orino.domain.calendar.repository.DailyScheduleRepository;
+import ds.project.orino.domain.fixedschedule.entity.FixedSchedule;
+import ds.project.orino.domain.fixedschedule.entity.RecurrenceType;
+import ds.project.orino.domain.fixedschedule.repository.FixedScheduleRepository;
+import ds.project.orino.domain.material.entity.DeadlineMode;
+import ds.project.orino.domain.material.entity.MaterialAllocation;
+import ds.project.orino.domain.material.entity.MaterialType;
+import ds.project.orino.domain.material.entity.StudyMaterial;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.repository.MaterialAllocationRepository;
+import ds.project.orino.domain.material.repository.MaterialDailyOverrideRepository;
+import ds.project.orino.domain.material.repository.ReviewConfigRepository;
+import ds.project.orino.domain.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.material.repository.StudyUnitRepository;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.preference.entity.StudyTimePreference;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.domain.preference.repository.PriorityRuleRepository;
+import ds.project.orino.domain.preference.repository.UserPreferenceRepository;
+import ds.project.orino.domain.review.entity.ReviewSchedule;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import ds.project.orino.domain.routine.entity.Routine;
+import ds.project.orino.domain.routine.repository.RoutineCheckRepository;
+import ds.project.orino.domain.routine.repository.RoutineExceptionRepository;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
+import ds.project.orino.domain.todo.entity.Priority;
+import ds.project.orino.domain.todo.entity.Todo;
+import ds.project.orino.domain.todo.repository.TodoRepository;
+import ds.project.orino.domain.goal.repository.GoalRepository;
+import ds.project.orino.domain.goal.repository.MilestoneRepository;
+import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.planner.scheduling.engine.model.SchedulingResult;
+import ds.project.orino.support.IntegrationTest;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class SchedulingEngineIntegrationTest {
+
+    @Autowired private SchedulingEngine engine;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private UserPreferenceRepository preferenceRepository;
+    @Autowired private PriorityRuleRepository priorityRuleRepository;
+    @Autowired private FixedScheduleRepository fixedScheduleRepository;
+    @Autowired private RoutineRepository routineRepository;
+    @Autowired private RoutineCheckRepository routineCheckRepository;
+    @Autowired private RoutineExceptionRepository routineExceptionRepository;
+    @Autowired private TodoRepository todoRepository;
+    @Autowired private StudyMaterialRepository materialRepository;
+    @Autowired private StudyUnitRepository unitRepository;
+    @Autowired private MaterialAllocationRepository allocationRepository;
+    @Autowired private MaterialDailyOverrideRepository overrideRepository;
+    @Autowired private ReviewConfigRepository reviewConfigRepository;
+    @Autowired private ReviewScheduleRepository reviewRepository;
+    @Autowired private DailyScheduleRepository dailyScheduleRepository;
+    @Autowired private GoalRepository goalRepository;
+    @Autowired private MilestoneRepository milestoneRepository;
+    @Autowired private CategoryRepository categoryRepository;
+
+    private Member member;
+    private LocalDate targetDate;
+
+    @BeforeEach
+    void setUp() {
+        dailyScheduleRepository.deleteAll();
+        reviewRepository.deleteAll();
+        priorityRuleRepository.deleteAll();
+        preferenceRepository.deleteAll();
+        reviewConfigRepository.deleteAll();
+        overrideRepository.deleteAll();
+        allocationRepository.deleteAll();
+        unitRepository.deleteAll();
+        materialRepository.deleteAll();
+        routineExceptionRepository.deleteAll();
+        routineCheckRepository.deleteAll();
+        routineRepository.deleteAll();
+        fixedScheduleRepository.deleteAll();
+        todoRepository.deleteAll();
+        milestoneRepository.deleteAll();
+        goalRepository.deleteAll();
+        categoryRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        member = memberRepository.save(MemberFixture.create());
+        targetDate = LocalDate.now().plusDays(7);
+    }
+
+    @AfterEach
+    void tearDown() {
+        dailyScheduleRepository.deleteAll();
+        reviewRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("학습 단위 3개를 자유시간에 순서대로 배치한다")
+    void placesStudyUnits() {
+        saveDefaultPreference();
+
+        StudyMaterial material = materialRepository.save(new StudyMaterial(
+                member, "알고리즘", MaterialType.BOOK, null, null,
+                null, DeadlineMode.FREE));
+        unitRepository.save(new StudyUnit(material, "챕터1", 1, 30, null));
+        unitRepository.save(new StudyUnit(material, "챕터2", 2, 30, null));
+        unitRepository.save(new StudyUnit(material, "챕터3", 3, 30, null));
+
+        SchedulingResult result = engine.generate(member.getId(), targetDate);
+
+        DailySchedule schedule = result.dailySchedule();
+        assertThat(schedule.getBlocks()).hasSize(3);
+        assertThat(schedule.getBlocks()).allMatch(
+                b -> b.getBlockType() == BlockType.STUDY);
+        assertThat(schedule.getBlocks().get(0).getStartTime())
+                .isEqualTo(LocalTime.of(7, 0));
+    }
+
+    @Test
+    @DisplayName("고정 일정은 자유시간에서 제외되고 preplaced로 배치된다")
+    void fixedScheduleBlocksTime() {
+        saveDefaultPreference();
+
+        fixedScheduleRepository.save(new FixedSchedule(
+                member, "영어회화", null,
+                LocalTime.of(9, 0), LocalTime.of(10, 0),
+                null, RecurrenceType.DAILY,
+                null, null, targetDate.minusDays(1), null));
+
+        StudyMaterial material = materialRepository.save(new StudyMaterial(
+                member, "수학", MaterialType.BOOK, null, null,
+                null, DeadlineMode.FREE));
+        unitRepository.save(new StudyUnit(material, "단위1", 1, 30, null));
+
+        SchedulingResult result = engine.generate(member.getId(), targetDate);
+
+        List<ScheduleBlock> blocks = result.dailySchedule().getBlocks()
+                .stream().sorted((a, b) -> a.getStartTime()
+                        .compareTo(b.getStartTime())).toList();
+        assertThat(blocks).hasSizeGreaterThanOrEqualTo(2);
+        ScheduleBlock fixed = blocks.stream()
+                .filter(b -> b.getBlockType() == BlockType.FIXED)
+                .findFirst().orElseThrow();
+        assertThat(fixed.getStartTime()).isEqualTo(LocalTime.of(9, 0));
+        assertThat(fixed.getEndTime()).isEqualTo(LocalTime.of(10, 0));
+
+        // 학습 블록은 9~10시 범위와 겹치지 않아야 함
+        ScheduleBlock study = blocks.stream()
+                .filter(b -> b.getBlockType() == BlockType.STUDY)
+                .findFirst().orElseThrow();
+        boolean overlap = !(study.getEndTime().isBefore(
+                LocalTime.of(9, 0))
+                || study.getStartTime().isAfter(LocalTime.of(10, 0)));
+        if (overlap) {
+            assertThat(study.getEndTime())
+                    .isBeforeOrEqualTo(LocalTime.of(9, 0));
+        }
+    }
+
+    @Test
+    @DisplayName("밀린 복습이 최우선으로 배치된다")
+    void overdueReviewFirst() {
+        saveDefaultPreference();
+
+        StudyMaterial material = materialRepository.save(new StudyMaterial(
+                member, "역사", MaterialType.BOOK, null, null,
+                null, DeadlineMode.FREE));
+        StudyUnit unit = unitRepository.save(
+                new StudyUnit(material, "단원1", 1, 30, null));
+        unitRepository.save(new StudyUnit(material, "단원2", 2, 30, null));
+
+        reviewRepository.save(new ReviewSchedule(
+                unit, 1, targetDate.minusDays(2)));
+
+        SchedulingResult result = engine.generate(member.getId(), targetDate);
+
+        ScheduleBlock first = result.dailySchedule().getBlocks().stream()
+                .filter(b -> !b.isPinned() && b.getStatus() != BlockStatus.COMPLETED)
+                .min((a, b) -> a.getStartTime().compareTo(b.getStartTime()))
+                .orElseThrow();
+        assertThat(first.getBlockType()).isEqualTo(BlockType.REVIEW);
+    }
+
+    @Test
+    @DisplayName("학습 자료 시간 할당을 초과한 분량은 이월된다")
+    void materialAllocationLimit() {
+        saveDefaultPreference();
+
+        StudyMaterial material = materialRepository.save(new StudyMaterial(
+                member, "영어", MaterialType.BOOK, null, null,
+                null, DeadlineMode.FREE));
+        unitRepository.save(new StudyUnit(material, "챕터1", 1, 60, null));
+        unitRepository.save(new StudyUnit(material, "챕터2", 2, 60, null));
+        unitRepository.save(new StudyUnit(material, "챕터3", 3, 60, null));
+        allocationRepository.save(new MaterialAllocation(material, 60));
+
+        SchedulingResult result = engine.generate(member.getId(), targetDate);
+
+        int studyMinutes = result.dailySchedule().getBlocks().stream()
+                .filter(b -> b.getBlockType() == BlockType.STUDY)
+                .mapToInt(b -> (int) java.time.Duration.between(
+                        b.getStartTime(), b.getEndTime()).toMinutes())
+                .sum();
+        assertThat(studyMinutes).isEqualTo(60);
+        assertThat(result.warnings()).anyMatch(w -> w.message()
+                .contains("이월"));
+    }
+
+    @Test
+    @DisplayName("과거 날짜는 재생성하지 않는다")
+    void pastDateNotRegenerated() {
+        saveDefaultPreference();
+        LocalDate pastDate = LocalDate.now().minusDays(3);
+
+        DailySchedule existing = dailyScheduleRepository.save(
+                new DailySchedule(member, pastDate));
+
+        SchedulingResult result = engine.generate(member.getId(), pastDate);
+
+        assertThat(result.dailySchedule().getId()).isEqualTo(existing.getId());
+        assertThat(result.dailySchedule().getBlocks()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("할 일의 마감 임박 여부에 따라 우선순위가 달라진다")
+    void urgentTodoPriority() {
+        saveDefaultPreference();
+
+        Todo urgent = todoRepository.save(new Todo(
+                member, "urgent", null, null, null, Priority.HIGH,
+                targetDate.plusDays(1), 30));
+        Todo noDeadline = todoRepository.save(new Todo(
+                member, "noDeadline", null, null, null, Priority.LOW,
+                null, 30));
+
+        SchedulingResult result = engine.generate(member.getId(), targetDate);
+
+        List<ScheduleBlock> sorted = result.dailySchedule().getBlocks().stream()
+                .filter(b -> b.getBlockType() == BlockType.TODO)
+                .sorted((a, b) -> a.getStartTime().compareTo(b.getStartTime()))
+                .toList();
+        assertThat(sorted).hasSize(2);
+        assertThat(sorted.get(0).getReferenceId()).isEqualTo(urgent.getId());
+        assertThat(sorted.get(1).getReferenceId())
+                .isEqualTo(noDeadline.getId());
+    }
+
+    private UserPreference saveDefaultPreference() {
+        UserPreference preference = new UserPreference(member);
+        ReflectionTestUtils.setField(preference, "wakeTime",
+                LocalTime.of(7, 0));
+        ReflectionTestUtils.setField(preference, "sleepTime",
+                LocalTime.of(23, 0));
+        ReflectionTestUtils.setField(preference, "focusMinutes", 50);
+        ReflectionTestUtils.setField(preference, "breakMinutes", 10);
+        ReflectionTestUtils.setField(preference, "studyTimePreference",
+                StudyTimePreference.MORNING);
+        return preferenceRepository.save(preference);
+    }
+
+    @SuppressWarnings("unused")
+    private Routine anyRoutine() {
+        return routineRepository.findAll().stream().findFirst().orElse(null);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/scheduling/engine/model/TimeSlotTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/scheduling/engine/model/TimeSlotTest.java
@@ -1,0 +1,62 @@
+package ds.project.orino.planner.scheduling.engine.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TimeSlotTest {
+
+    @Test
+    @DisplayName("start와 end로 TimeSlot을 생성한다")
+    void create() {
+        TimeSlot slot = new TimeSlot(
+                LocalTime.of(7, 0), LocalTime.of(10, 0));
+        assertThat(slot.minutes()).isEqualTo(180);
+    }
+
+    @Test
+    @DisplayName("start가 end보다 이전이 아니면 예외")
+    void invalidRange() {
+        assertThatThrownBy(() -> new TimeSlot(
+                LocalTime.of(10, 0), LocalTime.of(7, 0)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new TimeSlot(
+                LocalTime.of(10, 0), LocalTime.of(10, 0)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("null은 허용하지 않는다")
+    void nullNotAllowed() {
+        assertThatThrownBy(() -> new TimeSlot(null, LocalTime.of(1, 0)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("시간 포함 여부를 판단한다")
+    void contains() {
+        TimeSlot slot = new TimeSlot(
+                LocalTime.of(7, 0), LocalTime.of(10, 0));
+        assertThat(slot.contains(LocalTime.of(7, 0))).isTrue();
+        assertThat(slot.contains(LocalTime.of(8, 30))).isTrue();
+        assertThat(slot.contains(LocalTime.of(10, 0))).isFalse();
+        assertThat(slot.contains(LocalTime.of(6, 59))).isFalse();
+    }
+
+    @Test
+    @DisplayName("슬롯 겹침을 판단한다")
+    void overlaps() {
+        TimeSlot a = new TimeSlot(
+                LocalTime.of(7, 0), LocalTime.of(10, 0));
+        TimeSlot b = new TimeSlot(
+                LocalTime.of(9, 0), LocalTime.of(12, 0));
+        TimeSlot c = new TimeSlot(
+                LocalTime.of(10, 0), LocalTime.of(12, 0));
+        assertThat(a.overlaps(b)).isTrue();
+        assertThat(a.overlaps(c)).isFalse();
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/entity/BlockStatus.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/entity/BlockStatus.java
@@ -1,0 +1,5 @@
+package ds.project.orino.domain.calendar.entity;
+
+public enum BlockStatus {
+    SCHEDULED, COMPLETED
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/entity/BlockType.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/entity/BlockType.java
@@ -1,0 +1,5 @@
+package ds.project.orino.domain.calendar.entity;
+
+public enum BlockType {
+    FIXED, ROUTINE, TODO, STUDY, REVIEW
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/entity/DailySchedule.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/entity/DailySchedule.java
@@ -1,0 +1,138 @@
+package ds.project.orino.domain.calendar.entity;
+
+import ds.project.orino.domain.member.entity.Member;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "daily_schedule",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_daily_schedule_member_date",
+                columnNames = {"member_id", "schedule_date"}))
+@EntityListeners(AuditingEntityListener.class)
+public class DailySchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "schedule_date", nullable = false)
+    private LocalDate scheduleDate;
+
+    @Column(name = "is_dirty", nullable = false)
+    private boolean dirty = true;
+
+    private LocalDateTime generatedAt;
+
+    @Column(nullable = false)
+    private int totalBlocks;
+
+    @Column(nullable = false)
+    private int completedBlocks;
+
+    @OneToMany(mappedBy = "dailySchedule",
+            cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ScheduleBlock> blocks = new ArrayList<>();
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected DailySchedule() {
+    }
+
+    public DailySchedule(Member member, LocalDate scheduleDate) {
+        this.member = member;
+        this.scheduleDate = scheduleDate;
+    }
+
+    public void markDirty() {
+        this.dirty = true;
+    }
+
+    public void markGenerated(int totalBlocks, int completedBlocks) {
+        this.dirty = false;
+        this.totalBlocks = totalBlocks;
+        this.completedBlocks = completedBlocks;
+        this.generatedAt = LocalDateTime.now();
+    }
+
+    public void addBlock(ScheduleBlock block) {
+        blocks.add(block);
+    }
+
+    public void removeBlocks(List<ScheduleBlock> toRemove) {
+        blocks.removeAll(toRemove);
+    }
+
+    public void clearBlocks() {
+        blocks.clear();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public LocalDate getScheduleDate() {
+        return scheduleDate;
+    }
+
+    public boolean isDirty() {
+        return dirty;
+    }
+
+    public LocalDateTime getGeneratedAt() {
+        return generatedAt;
+    }
+
+    public int getTotalBlocks() {
+        return totalBlocks;
+    }
+
+    public int getCompletedBlocks() {
+        return completedBlocks;
+    }
+
+    public List<ScheduleBlock> getBlocks() {
+        return blocks;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/entity/ScheduleBlock.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/entity/ScheduleBlock.java
@@ -1,0 +1,148 @@
+package ds.project.orino.domain.calendar.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "schedule_block")
+@EntityListeners(AuditingEntityListener.class)
+public class ScheduleBlock {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_schedule_id", nullable = false)
+    private DailySchedule dailySchedule;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "block_type", length = 15, nullable = false)
+    private BlockType blockType;
+
+    @Column(name = "reference_id", nullable = false)
+    private Long referenceId;
+
+    @Column(nullable = false)
+    private LocalTime startTime;
+
+    @Column(nullable = false)
+    private LocalTime endTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10, nullable = false)
+    private BlockStatus status = BlockStatus.SCHEDULED;
+
+    @Column(name = "is_pinned", nullable = false)
+    private boolean pinned;
+
+    private LocalDateTime completedAt;
+
+    @Column(nullable = false)
+    private int sortOrder;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected ScheduleBlock() {
+    }
+
+    public ScheduleBlock(DailySchedule dailySchedule, BlockType blockType,
+                         Long referenceId, LocalTime startTime,
+                         LocalTime endTime, int sortOrder) {
+        this.dailySchedule = dailySchedule;
+        this.blockType = blockType;
+        this.referenceId = referenceId;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.sortOrder = sortOrder;
+    }
+
+    public void complete() {
+        this.status = BlockStatus.COMPLETED;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public void reschedule(LocalTime startTime, LocalTime endTime) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.pinned = true;
+    }
+
+    public void updateSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public boolean isLocked() {
+        return status == BlockStatus.COMPLETED || pinned;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public DailySchedule getDailySchedule() {
+        return dailySchedule;
+    }
+
+    public BlockType getBlockType() {
+        return blockType;
+    }
+
+    public Long getReferenceId() {
+        return referenceId;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
+    }
+
+    public BlockStatus getStatus() {
+        return status;
+    }
+
+    public boolean isPinned() {
+        return pinned;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+
+    public int getSortOrder() {
+        return sortOrder;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/repository/DailyScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/repository/DailyScheduleRepository.java
@@ -1,0 +1,18 @@
+package ds.project.orino.domain.calendar.repository;
+
+import ds.project.orino.domain.calendar.entity.DailySchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface DailyScheduleRepository
+        extends JpaRepository<DailySchedule, Long> {
+
+    Optional<DailySchedule> findByMemberIdAndScheduleDate(
+            Long memberId, LocalDate scheduleDate);
+
+    List<DailySchedule> findByMemberIdAndScheduleDateBetween(
+            Long memberId, LocalDate from, LocalDate to);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/repository/ScheduleBlockRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/repository/ScheduleBlockRepository.java
@@ -1,0 +1,13 @@
+package ds.project.orino.domain.calendar.repository;
+
+import ds.project.orino.domain.calendar.entity.ScheduleBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ScheduleBlockRepository
+        extends JpaRepository<ScheduleBlock, Long> {
+
+    List<ScheduleBlock> findByDailyScheduleIdOrderBySortOrder(
+            Long dailyScheduleId);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/review/entity/DifficultyFeedback.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/review/entity/DifficultyFeedback.java
@@ -1,0 +1,5 @@
+package ds.project.orino.domain.review.entity;
+
+public enum DifficultyFeedback {
+    EASY, NORMAL, HARD
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/review/entity/ReviewSchedule.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/review/entity/ReviewSchedule.java
@@ -1,0 +1,123 @@
+package ds.project.orino.domain.review.entity;
+
+import ds.project.orino.domain.material.entity.StudyUnit;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "review_schedule")
+@EntityListeners(AuditingEntityListener.class)
+public class ReviewSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_unit_id", nullable = false)
+    private StudyUnit studyUnit;
+
+    @Column(name = "sequence", nullable = false)
+    private int sequence;
+
+    @Column(nullable = false)
+    private LocalDate scheduledDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10, nullable = false)
+    private ReviewStatus status = ReviewStatus.PENDING;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10)
+    private DifficultyFeedback difficultyFeedback;
+
+    private LocalDateTime completedAt;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected ReviewSchedule() {
+    }
+
+    public ReviewSchedule(StudyUnit studyUnit, int sequence,
+                          LocalDate scheduledDate) {
+        this.studyUnit = studyUnit;
+        this.sequence = sequence;
+        this.scheduledDate = scheduledDate;
+    }
+
+    public void markOverdue() {
+        this.status = ReviewStatus.OVERDUE;
+    }
+
+    public void complete(DifficultyFeedback feedback) {
+        this.status = ReviewStatus.COMPLETED;
+        this.difficultyFeedback = feedback;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public void skip() {
+        this.status = ReviewStatus.SKIPPED;
+    }
+
+    public void reschedule(LocalDate scheduledDate) {
+        this.scheduledDate = scheduledDate;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public StudyUnit getStudyUnit() {
+        return studyUnit;
+    }
+
+    public int getSequence() {
+        return sequence;
+    }
+
+    public LocalDate getScheduledDate() {
+        return scheduledDate;
+    }
+
+    public ReviewStatus getStatus() {
+        return status;
+    }
+
+    public DifficultyFeedback getDifficultyFeedback() {
+        return difficultyFeedback;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/review/entity/ReviewStatus.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/review/entity/ReviewStatus.java
@@ -1,0 +1,5 @@
+package ds.project.orino.domain.review.entity;
+
+public enum ReviewStatus {
+    PENDING, COMPLETED, OVERDUE, SKIPPED
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/review/repository/ReviewScheduleRepository.java
@@ -1,0 +1,35 @@
+package ds.project.orino.domain.review.repository;
+
+import ds.project.orino.domain.review.entity.ReviewSchedule;
+import ds.project.orino.domain.review.entity.ReviewStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ReviewScheduleRepository
+        extends JpaRepository<ReviewSchedule, Long> {
+
+    @Query("select r from ReviewSchedule r " +
+            "join r.studyUnit u " +
+            "join u.material m " +
+            "where m.member.id = :memberId " +
+            "and r.status in :statuses " +
+            "and r.scheduledDate <= :dueDate " +
+            "order by r.scheduledDate asc, r.sequence asc")
+    List<ReviewSchedule> findDueByMember(@Param("memberId") Long memberId,
+                                         @Param("dueDate") LocalDate dueDate,
+                                         @Param("statuses") List<ReviewStatus> statuses);
+
+    @Query("select r from ReviewSchedule r " +
+            "join r.studyUnit u " +
+            "join u.material m " +
+            "where m.member.id = :memberId " +
+            "and r.scheduledDate = :date " +
+            "and r.status = :status")
+    List<ReviewSchedule> findByMemberAndDateAndStatus(@Param("memberId") Long memberId,
+                                                      @Param("date") LocalDate date,
+                                                      @Param("status") ReviewStatus status);
+}


### PR DESCRIPTION
## Summary
Study Planner의 핵심 비즈니스 로직인 스케줄링 엔진을 구현했습니다.

## 엔진 파이프라인 (5단계)
1. **AvailabilityCalculator**: wake/sleep 시간 기준 자유슬롯을 계산하고 고정일정·루틴을 차감
2. **ItemCollector**: 복습(OVERDUE/TODAY)·할일(URGENT/NO_DEADLINE)·학습(DEADLINE/NEW) 항목 수집
3. **ItemPrioritizer**: `ItemCategory` 우선순위 → subOrder → referenceId 순 정렬
4. **BlockPlacer**: `focusMinutes` 단위 청킹, 휴식 간격 삽입, 자료별 할당 캡 적용, 시간대 선호(MORNING/EVENING/AFTERNOON) 반영
5. **OverflowHandler**: `SLOT_EXHAUSTED`/`ALLOCATION_EXCEEDED` 경고 생성

## 주요 설계
- **재생성 정책**: `COMPLETED` 또는 `pinned` 블록은 유지하고 나머지만 재배치
- **과거 날짜**: 기존 DailySchedule을 그대로 반환 (재생성 없음)
- **반복 계산**: `RecurrenceCalculator`가 `NONE`/`DAILY`/`EVERY_N_DAYS`/`WEEKLY`/`MONTHLY_DATE`/`MONTHLY_NTH_DAY` 런타임 계산 (`skipHolidays`, `PAUSED` 상태 포함)
- **할당 3계층**: `material_daily_override` > `material_allocation` > `user_preference.daily_study_minutes`

## 도메인 추가
- **Calendar**: `DailySchedule`, `ScheduleBlock` 엔티티/리포지토리
- **Review**: `ReviewSchedule`, `ReviewStatus`, `DifficultyFeedback`

## Test plan
- [x] `TimeSlotTest` - VO 경계값 검증
- [x] `ItemPrioritizerTest` - 카테고리/subOrder 정렬
- [x] `RecurrenceCalculatorTest` - 9개 반복 패턴 검증
- [x] `BlockPlacerTest` - 청킹/overflow/할당 캡/시간대 선호
- [x] `SchedulingEngineIntegrationTest` - 전체 파이프라인 E2E (TestContainers MySQL)
- [x] 전체 BE 빌드/테스트 통과 (209 테스트)

closes #154