### PR TITLE
chore : 누락된 infra 컴포넌트 pod resources 설정

### DIFF
--- a/infra/helm/argocd-image-updater/values.yaml
+++ b/infra/helm/argocd-image-updater/values.yaml
@@ -5,3 +5,11 @@ argocd-image-updater:
         api_url: https://ghcr.io
         prefix: ghcr.io
         default: true
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi

--- a/infra/helm/istiod/values.yaml
+++ b/infra/helm/istiod/values.yaml
@@ -9,3 +9,12 @@ istiod:
         opentelemetry:
           service: tempo.monitoring.svc.cluster.local
           port: 4317
+
+  pilot:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 2048Mi
+      limits:
+        cpu: 1000m
+        memory: 4096Mi

--- a/infra/helm/sealed-secrets/values.yaml
+++ b/infra/helm/sealed-secrets/values.yaml
@@ -1,1 +1,8 @@
-sealed-secrets: {}
+sealed-secrets:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi


### PR DESCRIPTION
## 이슈
closes #98

## 작업 내용
### 신규 resources 설정
- **argocd-image-updater**: `resources: {}` 이었음
  - requests: 50m CPU / 64Mi memory
  - limits: 200m CPU / 128Mi memory
- **sealed-secrets**: `resources: limits/requests: {}` 이었음
  - requests: 50m CPU / 64Mi memory
  - limits: 200m CPU / 128Mi memory

### 기존 설정 보완
- **istiod**: requests만 있었음 (500m/2Gi) → limits 추가 (1000m/4Gi)

## 범위 제외
- **istio-gateway**: 이미 requests/limits 존재 (100m/128Mi ~ 2000m/1024Mi), 과도해 보이나 gateway 성능에 영향 가능해 별도 튜닝 필요
- **cloudflared**: values.yaml에 설정되어 있으나 업스트림 차트(`cloudflare-tunnel-remote` v0.1.2) 템플릿이 `.Values.resources`를 참조하지 않아 적용 안 됨 — 업스트림 이슈
- **longhorn**: 자체 리소스 관리(`guaranteedInstanceManagerCPU`) 사용, 임의 변경 위험
- **LimitRange / ResourceQuota**: 별도 이슈 #270으로 분리

## 검증
- `helm template` 3개 차트 모두 정상 렌더링
- `helm lint` 모두 통과