### PR TITLE
feat : 일간 캘린더 API 구현

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/controller/CalendarController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/controller/CalendarController.java
@@ -1,0 +1,63 @@
+package ds.project.orino.planner.calendar.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.calendar.dto.CompleteBlockResponse;
+import ds.project.orino.planner.calendar.dto.DailyScheduleResponse;
+import ds.project.orino.planner.calendar.dto.ReorderBlockRequest;
+import ds.project.orino.planner.calendar.dto.ReorderBlockResponse;
+import ds.project.orino.planner.calendar.service.CalendarService;
+import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/calendar")
+public class CalendarController {
+
+    private final CalendarService calendarService;
+
+    public CalendarController(CalendarService calendarService) {
+        this.calendarService = calendarService;
+    }
+
+    @GetMapping("/daily")
+    public ResponseEntity<ApiResponse<DailyScheduleResponse>> getDaily(
+            Authentication authentication,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        Long memberId = (Long) authentication.getPrincipal();
+        LocalDate target = date != null ? date : LocalDate.now();
+        return ResponseEntity.ok(ApiResponse.success(
+                calendarService.getDaily(memberId, target)));
+    }
+
+    @PatchMapping("/blocks/{blockId}/complete")
+    public ResponseEntity<ApiResponse<CompleteBlockResponse>> complete(
+            Authentication authentication,
+            @PathVariable Long blockId) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                calendarService.completeBlock(memberId, blockId)));
+    }
+
+    @PutMapping("/blocks/{blockId}/reorder")
+    public ResponseEntity<ApiResponse<ReorderBlockResponse>> reorder(
+            Authentication authentication,
+            @PathVariable Long blockId,
+            @Valid @RequestBody ReorderBlockRequest request) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                calendarService.reorderBlock(memberId, blockId, request)));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/BlockEffect.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/BlockEffect.java
@@ -1,0 +1,50 @@
+package ds.project.orino.planner.calendar.dto;
+
+import java.time.LocalDate;
+
+/**
+ * 블록 완료 시 발생하는 후속 처리 결과.
+ * type에 따라 채워지는 필드가 달라진다.
+ *
+ * <ul>
+ *   <li>REVIEW_CREATED: STUDY 완료 → 복습 일정 자동 생성 (nextReviewDate, message)</li>
+ *   <li>STREAK_UPDATED: ROUTINE 완료 → 루틴 체크 기록</li>
+ *   <li>FEEDBACK_REQUIRED: REVIEW 완료 → 난이도 피드백 필요 (reviewId)</li>
+ *   <li>TODO_COMPLETED: TODO 완료</li>
+ *   <li>FIXED_COMPLETED: FIXED 일정 완료</li>
+ * </ul>
+ */
+public record BlockEffect(
+        String type,
+        String message,
+        LocalDate nextReviewDate,
+        Long reviewId,
+        Boolean feedbackRequired) {
+
+    public static BlockEffect reviewCreated(LocalDate nextReviewDate, int count) {
+        String message = String.format(
+                "복습 %d회가 자동 생성되었습니다.", count);
+        return new BlockEffect("REVIEW_CREATED", message,
+                nextReviewDate, null, null);
+    }
+
+    public static BlockEffect streakUpdated() {
+        return new BlockEffect("STREAK_UPDATED",
+                "루틴 체크가 기록되었습니다.", null, null, null);
+    }
+
+    public static BlockEffect feedbackRequired(Long reviewId) {
+        return new BlockEffect("FEEDBACK_REQUIRED",
+                "난이도 피드백이 필요합니다.", null, reviewId, true);
+    }
+
+    public static BlockEffect todoCompleted() {
+        return new BlockEffect("TODO_COMPLETED",
+                "할 일이 완료되었습니다.", null, null, null);
+    }
+
+    public static BlockEffect fixedCompleted() {
+        return new BlockEffect("FIXED_COMPLETED",
+                "고정 일정이 완료되었습니다.", null, null, null);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/CompleteBlockResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/CompleteBlockResponse.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.calendar.dto;
+
+import ds.project.orino.domain.calendar.entity.BlockStatus;
+
+public record CompleteBlockResponse(
+        Long blockId,
+        BlockStatus status,
+        BlockEffect effect,
+        DailyProgress dailyProgress) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/DailyProgress.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/DailyProgress.java
@@ -1,0 +1,4 @@
+package ds.project.orino.planner.calendar.dto;
+
+public record DailyProgress(int totalBlocks, int completedBlocks) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/DailyScheduleResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/DailyScheduleResponse.java
@@ -1,0 +1,12 @@
+package ds.project.orino.planner.calendar.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record DailyScheduleResponse(
+        LocalDate date,
+        int totalBlocks,
+        int completedBlocks,
+        List<ScheduleBlockResponse> blocks,
+        List<WarningResponse> warnings) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/ReorderBlockRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/ReorderBlockRequest.java
@@ -1,0 +1,16 @@
+package ds.project.orino.planner.calendar.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalTime;
+
+public record ReorderBlockRequest(
+        @NotNull
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime startTime,
+
+        @NotNull
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime endTime) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/ReorderBlockResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/ReorderBlockResponse.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.calendar.dto;
+
+import java.time.LocalTime;
+
+public record ReorderBlockResponse(
+        Long blockId,
+        LocalTime startTime,
+        LocalTime endTime,
+        boolean isPinned) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/ScheduleBlockResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/ScheduleBlockResponse.java
@@ -1,0 +1,19 @@
+package ds.project.orino.planner.calendar.dto;
+
+import ds.project.orino.domain.calendar.entity.BlockStatus;
+import ds.project.orino.domain.calendar.entity.BlockType;
+
+import java.time.LocalTime;
+
+public record ScheduleBlockResponse(
+        Long id,
+        BlockType blockType,
+        Long referenceId,
+        String title,
+        String categoryName,
+        String categoryColor,
+        LocalTime startTime,
+        LocalTime endTime,
+        BlockStatus status,
+        boolean isPinned) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/WarningResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/WarningResponse.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.calendar.dto;
+
+import ds.project.orino.planner.scheduling.engine.model.SchedulingWarning;
+
+public record WarningResponse(String type, String message) {
+
+    public static WarningResponse from(SchedulingWarning warning) {
+        return new WarningResponse(warning.type().name(), warning.message());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/service/BlockMetadata.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/service/BlockMetadata.java
@@ -1,0 +1,16 @@
+package ds.project.orino.planner.calendar.service;
+
+/**
+ * 블록 표시용 메타정보. title/category는 blockType+referenceId 기반으로
+ * 각 도메인 엔티티에서 조회한다.
+ */
+public record BlockMetadata(String title, String categoryName,
+                            String categoryColor) {
+
+    private static final String UNKNOWN_TITLE = "(알 수 없음)";
+    private static final String DEFAULT_COLOR = "#888888";
+
+    public static BlockMetadata unknown() {
+        return new BlockMetadata(UNKNOWN_TITLE, null, DEFAULT_COLOR);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/service/BlockMetadataResolver.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/service/BlockMetadataResolver.java
@@ -1,0 +1,160 @@
+package ds.project.orino.planner.calendar.service;
+
+import ds.project.orino.domain.calendar.entity.BlockType;
+import ds.project.orino.domain.calendar.entity.ScheduleBlock;
+import ds.project.orino.domain.category.entity.Category;
+import ds.project.orino.domain.fixedschedule.entity.FixedSchedule;
+import ds.project.orino.domain.fixedschedule.repository.FixedScheduleRepository;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.repository.StudyUnitRepository;
+import ds.project.orino.domain.review.entity.ReviewSchedule;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import ds.project.orino.domain.routine.entity.Routine;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
+import ds.project.orino.domain.todo.entity.Todo;
+import ds.project.orino.domain.todo.repository.TodoRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * blockType + referenceId 조합으로 표시용 메타정보(title, category)를 조회한다.
+ * 블록 단위로 N+1 쿼리가 발생하지 않도록 type별로 묶어 in-query로 한번에 가져온다.
+ */
+@Component
+public class BlockMetadataResolver {
+
+    private final TodoRepository todoRepository;
+    private final FixedScheduleRepository fixedScheduleRepository;
+    private final RoutineRepository routineRepository;
+    private final StudyUnitRepository studyUnitRepository;
+    private final ReviewScheduleRepository reviewScheduleRepository;
+
+    public BlockMetadataResolver(
+            TodoRepository todoRepository,
+            FixedScheduleRepository fixedScheduleRepository,
+            RoutineRepository routineRepository,
+            StudyUnitRepository studyUnitRepository,
+            ReviewScheduleRepository reviewScheduleRepository) {
+        this.todoRepository = todoRepository;
+        this.fixedScheduleRepository = fixedScheduleRepository;
+        this.routineRepository = routineRepository;
+        this.studyUnitRepository = studyUnitRepository;
+        this.reviewScheduleRepository = reviewScheduleRepository;
+    }
+
+    public Map<Long, BlockMetadata> resolve(List<ScheduleBlock> blocks) {
+        Map<BlockType, List<Long>> byType = groupReferenceIdsByType(blocks);
+        Map<BlockType, Map<Long, BlockMetadata>> metaByType =
+                new EnumMap<>(BlockType.class);
+        for (Map.Entry<BlockType, List<Long>> entry : byType.entrySet()) {
+            metaByType.put(entry.getKey(),
+                    resolveByType(entry.getKey(), entry.getValue()));
+        }
+
+        Map<Long, BlockMetadata> result = new HashMap<>();
+        for (ScheduleBlock block : blocks) {
+            BlockMetadata meta = metaByType
+                    .getOrDefault(block.getBlockType(), Map.of())
+                    .get(block.getReferenceId());
+            result.put(block.getId(),
+                    meta != null ? meta : BlockMetadata.unknown());
+        }
+        return result;
+    }
+
+    private Map<BlockType, List<Long>> groupReferenceIdsByType(
+            List<ScheduleBlock> blocks) {
+        Map<BlockType, List<Long>> result = new EnumMap<>(BlockType.class);
+        for (ScheduleBlock block : blocks) {
+            result.computeIfAbsent(block.getBlockType(),
+                    k -> new ArrayList<>()).add(block.getReferenceId());
+        }
+        return result;
+    }
+
+    private Map<Long, BlockMetadata> resolveByType(BlockType type,
+                                                   List<Long> ids) {
+        return switch (type) {
+            case FIXED -> resolveFixed(ids);
+            case ROUTINE -> resolveRoutine(ids);
+            case TODO -> resolveTodo(ids);
+            case STUDY -> resolveStudy(ids);
+            case REVIEW -> resolveReview(ids);
+        };
+    }
+
+    private Map<Long, BlockMetadata> resolveFixed(List<Long> ids) {
+        Map<Long, BlockMetadata> result = new HashMap<>();
+        for (FixedSchedule f : fixedScheduleRepository.findAllById(ids)) {
+            result.put(f.getId(), new BlockMetadata(
+                    f.getTitle(),
+                    categoryName(f.getCategory()),
+                    categoryColor(f.getCategory())));
+        }
+        return result;
+    }
+
+    private Map<Long, BlockMetadata> resolveRoutine(List<Long> ids) {
+        Map<Long, BlockMetadata> result = new HashMap<>();
+        for (Routine r : routineRepository.findAllById(ids)) {
+            result.put(r.getId(), new BlockMetadata(
+                    r.getTitle(),
+                    categoryName(r.getCategory()),
+                    categoryColor(r.getCategory())));
+        }
+        return result;
+    }
+
+    private Map<Long, BlockMetadata> resolveTodo(List<Long> ids) {
+        Map<Long, BlockMetadata> result = new HashMap<>();
+        for (Todo t : todoRepository.findAllById(ids)) {
+            result.put(t.getId(), new BlockMetadata(
+                    t.getTitle(),
+                    categoryName(t.getCategory()),
+                    categoryColor(t.getCategory())));
+        }
+        return result;
+    }
+
+    private Map<Long, BlockMetadata> resolveStudy(List<Long> ids) {
+        Map<Long, BlockMetadata> result = new HashMap<>();
+        for (StudyUnit u : studyUnitRepository.findAllById(ids)) {
+            Category category = u.getMaterial().getCategory();
+            String title = u.getMaterial().getTitle() + " - " + u.getTitle();
+            result.put(u.getId(), new BlockMetadata(
+                    title,
+                    categoryName(category),
+                    categoryColor(category)));
+        }
+        return result;
+    }
+
+    private Map<Long, BlockMetadata> resolveReview(List<Long> ids) {
+        Map<Long, BlockMetadata> result = new HashMap<>();
+        for (ReviewSchedule r : reviewScheduleRepository.findAllById(ids)) {
+            StudyUnit unit = r.getStudyUnit();
+            Category category = unit.getMaterial().getCategory();
+            String title = String.format("[복습 %d회] %s - %s",
+                    r.getSequence(),
+                    unit.getMaterial().getTitle(), unit.getTitle());
+            result.put(r.getId(), new BlockMetadata(
+                    title,
+                    categoryName(category),
+                    categoryColor(category)));
+        }
+        return result;
+    }
+
+    private String categoryName(Category category) {
+        return category != null ? category.getName() : null;
+    }
+
+    private String categoryColor(Category category) {
+        return category != null ? category.getColor() : "#888888";
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/service/CalendarService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/service/CalendarService.java
@@ -1,0 +1,245 @@
+package ds.project.orino.planner.calendar.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.calendar.entity.BlockStatus;
+import ds.project.orino.domain.calendar.entity.DailySchedule;
+import ds.project.orino.domain.calendar.entity.ScheduleBlock;
+import ds.project.orino.domain.calendar.repository.DailyScheduleRepository;
+import ds.project.orino.domain.calendar.repository.ScheduleBlockRepository;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.repository.StudyUnitRepository;
+import ds.project.orino.domain.review.entity.ReviewSchedule;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import ds.project.orino.domain.routine.entity.Routine;
+import ds.project.orino.domain.routine.entity.RoutineCheck;
+import ds.project.orino.domain.routine.repository.RoutineCheckRepository;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
+import ds.project.orino.domain.todo.entity.Todo;
+import ds.project.orino.domain.todo.repository.TodoRepository;
+import ds.project.orino.planner.calendar.dto.BlockEffect;
+import ds.project.orino.planner.calendar.dto.CompleteBlockResponse;
+import ds.project.orino.planner.calendar.dto.DailyProgress;
+import ds.project.orino.planner.calendar.dto.DailyScheduleResponse;
+import ds.project.orino.planner.calendar.dto.ReorderBlockRequest;
+import ds.project.orino.planner.calendar.dto.ReorderBlockResponse;
+import ds.project.orino.planner.calendar.dto.ScheduleBlockResponse;
+import ds.project.orino.planner.calendar.dto.WarningResponse;
+import ds.project.orino.planner.scheduling.engine.SchedulingEngine;
+import ds.project.orino.planner.scheduling.engine.model.SchedulingResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 일간 캘린더 조회 및 블록 상태 변경 서비스.
+ * 엔진 호출·메타정보 조회·블록 완료/재배치 처리를 담당한다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class CalendarService {
+
+    private final SchedulingEngine schedulingEngine;
+    private final DailyScheduleRepository dailyScheduleRepository;
+    private final ScheduleBlockRepository scheduleBlockRepository;
+    private final BlockMetadataResolver metadataResolver;
+    private final ReviewScheduleGenerator reviewScheduleGenerator;
+    private final TodoRepository todoRepository;
+    private final StudyUnitRepository studyUnitRepository;
+    private final ReviewScheduleRepository reviewScheduleRepository;
+    private final RoutineRepository routineRepository;
+    private final RoutineCheckRepository routineCheckRepository;
+
+    public CalendarService(
+            SchedulingEngine schedulingEngine,
+            DailyScheduleRepository dailyScheduleRepository,
+            ScheduleBlockRepository scheduleBlockRepository,
+            BlockMetadataResolver metadataResolver,
+            ReviewScheduleGenerator reviewScheduleGenerator,
+            TodoRepository todoRepository,
+            StudyUnitRepository studyUnitRepository,
+            ReviewScheduleRepository reviewScheduleRepository,
+            RoutineRepository routineRepository,
+            RoutineCheckRepository routineCheckRepository) {
+        this.schedulingEngine = schedulingEngine;
+        this.dailyScheduleRepository = dailyScheduleRepository;
+        this.scheduleBlockRepository = scheduleBlockRepository;
+        this.metadataResolver = metadataResolver;
+        this.reviewScheduleGenerator = reviewScheduleGenerator;
+        this.todoRepository = todoRepository;
+        this.studyUnitRepository = studyUnitRepository;
+        this.reviewScheduleRepository = reviewScheduleRepository;
+        this.routineRepository = routineRepository;
+        this.routineCheckRepository = routineCheckRepository;
+    }
+
+    @Transactional
+    public DailyScheduleResponse getDaily(Long memberId, LocalDate date) {
+        SchedulingResult result = schedulingEngine.generate(memberId, date);
+        DailySchedule schedule = result.dailySchedule();
+        List<ScheduleBlock> sortedBlocks = schedule.getBlocks().stream()
+                .sorted(Comparator.comparing(ScheduleBlock::getStartTime))
+                .toList();
+        Map<Long, BlockMetadata> metadata =
+                metadataResolver.resolve(sortedBlocks);
+
+        List<ScheduleBlockResponse> blockResponses = sortedBlocks.stream()
+                .map(b -> toBlockResponse(b, metadata.get(b.getId())))
+                .toList();
+        List<WarningResponse> warnings = result.warnings().stream()
+                .map(WarningResponse::from).toList();
+
+        return new DailyScheduleResponse(
+                schedule.getScheduleDate(),
+                schedule.getTotalBlocks(),
+                schedule.getCompletedBlocks(),
+                blockResponses,
+                warnings);
+    }
+
+    @Transactional
+    public CompleteBlockResponse completeBlock(Long memberId, Long blockId) {
+        ScheduleBlock block = loadOwnedBlock(memberId, blockId);
+        if (block.getStatus() == BlockStatus.COMPLETED) {
+            throw new CustomException(ErrorCode.INVALID_STATE);
+        }
+
+        BlockEffect effect = applyCompletionEffect(memberId, block);
+        block.complete();
+
+        DailySchedule schedule = block.getDailySchedule();
+        int completed = (int) schedule.getBlocks().stream()
+                .filter(b -> b.getStatus() == BlockStatus.COMPLETED)
+                .count();
+        schedule.markGenerated(schedule.getBlocks().size(), completed);
+
+        return new CompleteBlockResponse(
+                block.getId(),
+                block.getStatus(),
+                effect,
+                new DailyProgress(schedule.getBlocks().size(), completed));
+    }
+
+    @Transactional
+    public ReorderBlockResponse reorderBlock(Long memberId, Long blockId,
+                                             ReorderBlockRequest request) {
+        ScheduleBlock block = loadOwnedBlock(memberId, blockId);
+        if (!request.endTime().isAfter(request.startTime())) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        if (hasTimeConflict(block, request)) {
+            throw new CustomException(ErrorCode.INVALID_STATE);
+        }
+        block.reschedule(request.startTime(), request.endTime());
+        return new ReorderBlockResponse(
+                block.getId(),
+                block.getStartTime(),
+                block.getEndTime(),
+                block.isPinned());
+    }
+
+    private ScheduleBlock loadOwnedBlock(Long memberId, Long blockId) {
+        ScheduleBlock block = scheduleBlockRepository.findById(blockId)
+                .orElseThrow(() -> new CustomException(
+                        ErrorCode.RESOURCE_NOT_FOUND));
+        if (!block.getDailySchedule().getMember().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+        return block;
+    }
+
+    private boolean hasTimeConflict(ScheduleBlock target,
+                                    ReorderBlockRequest request) {
+        return target.getDailySchedule().getBlocks().stream()
+                .filter(b -> !b.getId().equals(target.getId()))
+                .anyMatch(b -> overlaps(
+                        b.getStartTime(), b.getEndTime(),
+                        request.startTime(), request.endTime()));
+    }
+
+    private boolean overlaps(java.time.LocalTime aStart, java.time.LocalTime aEnd,
+                             java.time.LocalTime bStart, java.time.LocalTime bEnd) {
+        return aStart.isBefore(bEnd) && bStart.isBefore(aEnd);
+    }
+
+    private BlockEffect applyCompletionEffect(Long memberId, ScheduleBlock block) {
+        return switch (block.getBlockType()) {
+            case FIXED -> BlockEffect.fixedCompleted();
+            case ROUTINE -> completeRoutine(memberId, block);
+            case TODO -> completeTodo(memberId, block);
+            case STUDY -> completeStudy(memberId, block);
+            case REVIEW -> completeReview(block);
+        };
+    }
+
+    private BlockEffect completeRoutine(Long memberId, ScheduleBlock block) {
+        Routine routine = routineRepository.findByIdAndMemberId(
+                        block.getReferenceId(), memberId)
+                .orElseThrow(() -> new CustomException(
+                        ErrorCode.RESOURCE_NOT_FOUND));
+        LocalDate checkDate = block.getDailySchedule().getScheduleDate();
+        if (routineCheckRepository
+                .findByRoutineIdAndCheckDate(routine.getId(), checkDate)
+                .isEmpty()) {
+            routineCheckRepository.save(new RoutineCheck(routine, checkDate));
+        }
+        return BlockEffect.streakUpdated();
+    }
+
+    private BlockEffect completeTodo(Long memberId, ScheduleBlock block) {
+        Todo todo = todoRepository.findById(block.getReferenceId())
+                .orElseThrow(() -> new CustomException(
+                        ErrorCode.RESOURCE_NOT_FOUND));
+        if (!todo.getMember().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+        todo.complete();
+        return BlockEffect.todoCompleted();
+    }
+
+    private BlockEffect completeStudy(Long memberId, ScheduleBlock block) {
+        StudyUnit unit = studyUnitRepository.findById(block.getReferenceId())
+                .orElseThrow(() -> new CustomException(
+                        ErrorCode.RESOURCE_NOT_FOUND));
+        if (!unit.getMaterial().getMember().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+        unit.complete();
+        LocalDate completedDate = block.getDailySchedule().getScheduleDate();
+        ReviewScheduleGenerator.Result result = reviewScheduleGenerator
+                .generate(memberId, unit, completedDate);
+        if (result.count() == 0) {
+            return BlockEffect.todoCompleted();
+        }
+        return BlockEffect.reviewCreated(
+                result.firstReviewDate(), result.count());
+    }
+
+    private BlockEffect completeReview(ScheduleBlock block) {
+        ReviewSchedule review = reviewScheduleRepository
+                .findById(block.getReferenceId())
+                .orElseThrow(() -> new CustomException(
+                        ErrorCode.RESOURCE_NOT_FOUND));
+        return BlockEffect.feedbackRequired(review.getId());
+    }
+
+    private ScheduleBlockResponse toBlockResponse(ScheduleBlock block,
+                                                  BlockMetadata metadata) {
+        BlockMetadata m = metadata != null ? metadata : BlockMetadata.unknown();
+        return new ScheduleBlockResponse(
+                block.getId(),
+                block.getBlockType(),
+                block.getReferenceId(),
+                m.title(),
+                m.categoryName(),
+                m.categoryColor(),
+                block.getStartTime(),
+                block.getEndTime(),
+                block.getStatus(),
+                block.isPinned());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/service/ReviewScheduleGenerator.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/service/ReviewScheduleGenerator.java
@@ -1,0 +1,84 @@
+package ds.project.orino.planner.calendar.service;
+
+import ds.project.orino.domain.material.entity.ReviewConfig;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.repository.ReviewConfigRepository;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.domain.preference.repository.UserPreferenceRepository;
+import ds.project.orino.domain.review.entity.ReviewSchedule;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * STUDY 단위 완료 시 복습 일정(ReviewSchedule)을 자동 생성한다.
+ *
+ * 간격 우선순위: material 전용 ReviewConfig.intervals
+ *  → UserPreference.defaultReviewIntervals (기본 "1,2,3,7,15,30")
+ */
+@Component
+public class ReviewScheduleGenerator {
+
+    private static final String FALLBACK_INTERVALS = "1,2,3,7,15,30";
+
+    private final ReviewConfigRepository reviewConfigRepository;
+    private final UserPreferenceRepository userPreferenceRepository;
+    private final ReviewScheduleRepository reviewScheduleRepository;
+
+    public ReviewScheduleGenerator(
+            ReviewConfigRepository reviewConfigRepository,
+            UserPreferenceRepository userPreferenceRepository,
+            ReviewScheduleRepository reviewScheduleRepository) {
+        this.reviewConfigRepository = reviewConfigRepository;
+        this.userPreferenceRepository = userPreferenceRepository;
+        this.reviewScheduleRepository = reviewScheduleRepository;
+    }
+
+    public Result generate(Long memberId, StudyUnit unit, LocalDate completedDate) {
+        List<Integer> intervals = resolveIntervals(memberId, unit.getMaterial().getId());
+        List<ReviewSchedule> created = new ArrayList<>();
+        int sequence = 1;
+        for (int days : intervals) {
+            LocalDate scheduledDate = completedDate.plusDays(days);
+            created.add(new ReviewSchedule(unit, sequence, scheduledDate));
+            sequence++;
+        }
+        reviewScheduleRepository.saveAll(created);
+
+        LocalDate firstReviewDate = intervals.isEmpty()
+                ? null : completedDate.plusDays(intervals.get(0));
+        return new Result(created.size(), firstReviewDate);
+    }
+
+    private List<Integer> resolveIntervals(Long memberId, Long materialId) {
+        return reviewConfigRepository.findByMaterialId(materialId)
+                .map(ReviewConfig::getIntervals)
+                .map(this::parseIntervals)
+                .orElseGet(() -> parseIntervals(
+                        defaultIntervalsOf(memberId)));
+    }
+
+    private String defaultIntervalsOf(Long memberId) {
+        return userPreferenceRepository.findByMemberId(memberId)
+                .map(UserPreference::getDefaultReviewIntervals)
+                .orElse(FALLBACK_INTERVALS);
+    }
+
+    private List<Integer> parseIntervals(String csv) {
+        if (csv == null || csv.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(Integer::parseInt)
+                .toList();
+    }
+
+    public record Result(int count, LocalDate firstReviewDate) {
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/calendar/controller/CalendarControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/calendar/controller/CalendarControllerTest.java
@@ -1,0 +1,285 @@
+package ds.project.orino.planner.calendar.controller;
+
+import ds.project.orino.domain.calendar.repository.DailyScheduleRepository;
+import ds.project.orino.domain.category.entity.Category;
+import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.domain.fixedschedule.repository.FixedScheduleRepository;
+import ds.project.orino.domain.goal.repository.GoalRepository;
+import ds.project.orino.domain.goal.repository.MilestoneRepository;
+import ds.project.orino.domain.material.entity.DeadlineMode;
+import ds.project.orino.domain.material.entity.MaterialType;
+import ds.project.orino.domain.material.entity.StudyMaterial;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.repository.MaterialAllocationRepository;
+import ds.project.orino.domain.material.repository.MaterialDailyOverrideRepository;
+import ds.project.orino.domain.material.repository.ReviewConfigRepository;
+import ds.project.orino.domain.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.material.repository.StudyUnitRepository;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.preference.entity.StudyTimePreference;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.domain.preference.repository.PriorityRuleRepository;
+import ds.project.orino.domain.preference.repository.UserPreferenceRepository;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import ds.project.orino.domain.routine.repository.RoutineCheckRepository;
+import ds.project.orino.domain.routine.repository.RoutineExceptionRepository;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
+import ds.project.orino.domain.todo.entity.Priority;
+import ds.project.orino.domain.todo.entity.Todo;
+import ds.project.orino.domain.todo.repository.TodoRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class CalendarControllerTest extends ApiTestSupport {
+
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private MilestoneRepository milestoneRepository;
+    @Autowired private GoalRepository goalRepository;
+    @Autowired private FixedScheduleRepository fixedScheduleRepository;
+    @Autowired private RoutineCheckRepository routineCheckRepository;
+    @Autowired private RoutineExceptionRepository routineExceptionRepository;
+    @Autowired private RoutineRepository routineRepository;
+    @Autowired private TodoRepository todoRepository;
+    @Autowired private ReviewConfigRepository reviewConfigRepository;
+    @Autowired private MaterialDailyOverrideRepository dailyOverrideRepository;
+    @Autowired private MaterialAllocationRepository allocationRepository;
+    @Autowired private StudyUnitRepository unitRepository;
+    @Autowired private StudyMaterialRepository materialRepository;
+    @Autowired private PriorityRuleRepository priorityRuleRepository;
+    @Autowired private UserPreferenceRepository userPreferenceRepository;
+    @Autowired private ReviewScheduleRepository reviewScheduleRepository;
+    @Autowired private DailyScheduleRepository dailyScheduleRepository;
+
+    private String accessToken;
+    private Member member;
+    private LocalDate targetDate;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dailyScheduleRepository.deleteAll();
+        reviewScheduleRepository.deleteAll();
+        priorityRuleRepository.deleteAll();
+        userPreferenceRepository.deleteAll();
+        reviewConfigRepository.deleteAll();
+        dailyOverrideRepository.deleteAll();
+        allocationRepository.deleteAll();
+        unitRepository.deleteAll();
+        materialRepository.deleteAll();
+        routineExceptionRepository.deleteAll();
+        routineCheckRepository.deleteAll();
+        routineRepository.deleteAll();
+        fixedScheduleRepository.deleteAll();
+        todoRepository.deleteAll();
+        milestoneRepository.deleteAll();
+        goalRepository.deleteAll();
+        categoryRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        member = memberRepository.save(MemberFixture.create());
+        targetDate = LocalDate.now().plusDays(7);
+
+        UserPreference preference = new UserPreference(member);
+        ReflectionTestUtils.setField(preference, "wakeTime",
+                LocalTime.of(7, 0));
+        ReflectionTestUtils.setField(preference, "sleepTime",
+                LocalTime.of(23, 0));
+        ReflectionTestUtils.setField(preference, "focusMinutes", 50);
+        ReflectionTestUtils.setField(preference, "breakMinutes", 10);
+        ReflectionTestUtils.setField(preference, "studyTimePreference",
+                StudyTimePreference.MORNING);
+        userPreferenceRepository.save(preference);
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId": "%s", "password": "%s"}
+                                """.formatted(
+                                MemberFixture.DEFAULT_LOGIN_ID,
+                                MemberFixture.DEFAULT_PASSWORD)))
+                .andReturn();
+
+        accessToken = com.jayway.jsonpath.JsonPath.read(
+                loginResult.getResponse().getContentAsString(),
+                "$.data.accessToken");
+    }
+
+    @AfterEach
+    void tearDown() {
+        dailyScheduleRepository.deleteAll();
+        reviewScheduleRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("GET /api/calendar/daily - 일정을 생성하여 반환한다")
+    void getDaily_generatesSchedule() throws Exception {
+        Category category = categoryRepository.save(
+                new Category(member, "공부", "#8b00ff", null, 1));
+        StudyMaterial material = materialRepository.save(new StudyMaterial(
+                member, "알고리즘", MaterialType.BOOK, category, null,
+                null, DeadlineMode.FREE));
+        unitRepository.save(new StudyUnit(material, "챕터1", 1, 30, null));
+
+        mockMvc.perform(get("/api/calendar/daily")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("date", targetDate.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.date").value(targetDate.toString()))
+                .andExpect(jsonPath("$.data.totalBlocks")
+                        .value(greaterThan(0)))
+                .andExpect(jsonPath("$.data.blocks[0].blockType").value("STUDY"))
+                .andExpect(jsonPath("$.data.blocks[0].categoryName").value("공부"))
+                .andExpect(jsonPath("$.data.blocks[0].categoryColor").value("#8b00ff"))
+                .andExpect(jsonPath("$.data.blocks[0].title", notNullValue()));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/calendar/blocks/{id}/complete (TODO) - 할 일 완료")
+    void completeBlock_todo() throws Exception {
+        Todo todo = todoRepository.save(new Todo(
+                member, "리포트 작성", null, null, null,
+                Priority.HIGH, targetDate.plusDays(1), 30));
+
+        MvcResult getResult = mockMvc.perform(get("/api/calendar/daily")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("date", targetDate.toString()))
+                .andExpect(status().isOk())
+                .andReturn();
+        Integer blockId = com.jayway.jsonpath.JsonPath.read(
+                getResult.getResponse().getContentAsString(),
+                "$.data.blocks[0].id");
+        Integer todoIdInBlock = com.jayway.jsonpath.JsonPath.read(
+                getResult.getResponse().getContentAsString(),
+                "$.data.blocks[0].referenceId");
+        org.assertj.core.api.Assertions.assertThat(todoIdInBlock.longValue())
+                .isEqualTo(todo.getId());
+
+        mockMvc.perform(patch("/api/calendar/blocks/" + blockId + "/complete")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.data.effect.type").value("TODO_COMPLETED"))
+                .andExpect(jsonPath("$.data.dailyProgress.completedBlocks")
+                        .value(1));
+    }
+
+    @Test
+    @DisplayName("PATCH complete (STUDY) - 복습 일정이 자동 생성된다")
+    void completeBlock_studyCreatesReviews() throws Exception {
+        StudyMaterial material = materialRepository.save(new StudyMaterial(
+                member, "영어", MaterialType.BOOK, null, null,
+                null, DeadlineMode.FREE));
+        unitRepository.save(new StudyUnit(material, "Unit1", 1, 30, null));
+
+        MvcResult getResult = mockMvc.perform(get("/api/calendar/daily")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("date", targetDate.toString()))
+                .andReturn();
+        Integer blockId = com.jayway.jsonpath.JsonPath.read(
+                getResult.getResponse().getContentAsString(),
+                "$.data.blocks[0].id");
+
+        mockMvc.perform(patch("/api/calendar/blocks/" + blockId + "/complete")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.effect.type").value("REVIEW_CREATED"))
+                .andExpect(jsonPath("$.data.effect.nextReviewDate")
+                        .value(targetDate.plusDays(1).toString()));
+
+        org.assertj.core.api.Assertions.assertThat(
+                reviewScheduleRepository.findAll()).hasSize(6);
+    }
+
+    @Test
+    @DisplayName("PATCH complete - 이미 완료된 블록은 INVALID_STATE 오류")
+    void completeBlock_alreadyCompleted() throws Exception {
+        todoRepository.save(new Todo(member, "작업", null, null, null,
+                Priority.HIGH, targetDate.plusDays(1), 30));
+
+        MvcResult getResult = mockMvc.perform(get("/api/calendar/daily")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("date", targetDate.toString()))
+                .andReturn();
+        Integer blockId = com.jayway.jsonpath.JsonPath.read(
+                getResult.getResponse().getContentAsString(),
+                "$.data.blocks[0].id");
+
+        mockMvc.perform(patch("/api/calendar/blocks/" + blockId + "/complete")
+                .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(patch("/api/calendar/blocks/" + blockId + "/complete")
+                .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("PUT /api/calendar/blocks/{id}/reorder - 블록 시간 변경하면 pinned=true")
+    void reorderBlock() throws Exception {
+        todoRepository.save(new Todo(member, "작업", null, null, null,
+                Priority.MEDIUM, targetDate.plusDays(1), 30));
+
+        MvcResult getResult = mockMvc.perform(get("/api/calendar/daily")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("date", targetDate.toString()))
+                .andReturn();
+        Integer blockId = com.jayway.jsonpath.JsonPath.read(
+                getResult.getResponse().getContentAsString(),
+                "$.data.blocks[0].id");
+
+        mockMvc.perform(put("/api/calendar/blocks/" + blockId + "/reorder")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"startTime": "14:00", "endTime": "14:30"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.startTime").value("14:00:00"))
+                .andExpect(jsonPath("$.data.endTime").value("14:30:00"))
+                .andExpect(jsonPath("$.data.isPinned").value(true));
+    }
+
+    @Test
+    @DisplayName("PUT reorder - end가 start보다 빠르면 400")
+    void reorderBlock_invalidTimeRange() throws Exception {
+        todoRepository.save(new Todo(member, "작업", null, null, null,
+                Priority.MEDIUM, targetDate.plusDays(1), 30));
+
+        MvcResult getResult = mockMvc.perform(get("/api/calendar/daily")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("date", targetDate.toString()))
+                .andReturn();
+        Integer blockId = com.jayway.jsonpath.JsonPath.read(
+                getResult.getResponse().getContentAsString(),
+                "$.data.blocks[0].id");
+
+        mockMvc.perform(put("/api/calendar/blocks/" + blockId + "/reorder")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"startTime": "15:00", "endTime": "14:00"}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/calendar/service/ReviewScheduleGeneratorTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/calendar/service/ReviewScheduleGeneratorTest.java
@@ -1,0 +1,124 @@
+package ds.project.orino.planner.calendar.service;
+
+import ds.project.orino.domain.material.entity.MissedPolicy;
+import ds.project.orino.domain.material.entity.ReviewConfig;
+import ds.project.orino.domain.material.entity.StudyMaterial;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.repository.ReviewConfigRepository;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.domain.preference.repository.UserPreferenceRepository;
+import ds.project.orino.domain.review.entity.ReviewSchedule;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewScheduleGeneratorTest {
+
+    @Mock private ReviewConfigRepository reviewConfigRepository;
+    @Mock private UserPreferenceRepository userPreferenceRepository;
+    @Mock private ReviewScheduleRepository reviewScheduleRepository;
+
+    private ReviewScheduleGenerator generator;
+    private StudyMaterial material;
+    private StudyUnit unit;
+
+    @BeforeEach
+    void setUp() {
+        generator = new ReviewScheduleGenerator(
+                reviewConfigRepository, userPreferenceRepository,
+                reviewScheduleRepository);
+
+        material = new StudyMaterial(null, "수학", null,
+                null, null, null, null);
+        ReflectionTestUtils.setField(material, "id", 100L);
+        unit = new StudyUnit(material, "챕터1", 1, 30, null);
+        ReflectionTestUtils.setField(unit, "id", 200L);
+    }
+
+    @Test
+    @DisplayName("material 전용 ReviewConfig가 있으면 해당 간격을 사용한다")
+    void usesMaterialConfig() {
+        given(reviewConfigRepository.findByMaterialId(100L))
+                .willReturn(Optional.of(new ReviewConfig(
+                        material, "1,3,7", MissedPolicy.IMMEDIATE)));
+
+        ReviewScheduleGenerator.Result result = generator.generate(
+                1L, unit, LocalDate.of(2026, 4, 10));
+
+        assertThat(result.count()).isEqualTo(3);
+        assertThat(result.firstReviewDate()).isEqualTo(LocalDate.of(2026, 4, 11));
+    }
+
+    @Test
+    @DisplayName("material config가 없으면 UserPreference 기본값을 사용한다")
+    void usesUserDefault() {
+        given(reviewConfigRepository.findByMaterialId(100L))
+                .willReturn(Optional.empty());
+        UserPreference pref = new UserPreference(null);
+        ReflectionTestUtils.setField(pref, "defaultReviewIntervals",
+                "2,5,10");
+        given(userPreferenceRepository.findByMemberId(1L))
+                .willReturn(Optional.of(pref));
+
+        ReviewScheduleGenerator.Result result = generator.generate(
+                1L, unit, LocalDate.of(2026, 4, 10));
+
+        assertThat(result.count()).isEqualTo(3);
+        assertThat(result.firstReviewDate())
+                .isEqualTo(LocalDate.of(2026, 4, 12));
+    }
+
+    @Test
+    @DisplayName("생성된 ReviewSchedule의 sequence는 1부터 순차 증가한다")
+    void assignsSequence() {
+        given(reviewConfigRepository.findByMaterialId(100L))
+                .willReturn(Optional.of(new ReviewConfig(
+                        material, "1,2,3", MissedPolicy.IMMEDIATE)));
+
+        generator.generate(1L, unit, LocalDate.of(2026, 4, 10));
+
+        ArgumentCaptor<List<ReviewSchedule>> captor =
+                ArgumentCaptor.forClass(List.class);
+        verify(reviewScheduleRepository).saveAll(captor.capture());
+        List<ReviewSchedule> saved = captor.getValue();
+        assertThat(saved).hasSize(3);
+        assertThat(saved.get(0).getSequence()).isEqualTo(1);
+        assertThat(saved.get(1).getSequence()).isEqualTo(2);
+        assertThat(saved.get(2).getSequence()).isEqualTo(3);
+        assertThat(saved.get(0).getScheduledDate())
+                .isEqualTo(LocalDate.of(2026, 4, 11));
+        assertThat(saved.get(2).getScheduledDate())
+                .isEqualTo(LocalDate.of(2026, 4, 13));
+    }
+
+    @Test
+    @DisplayName("설정이 모두 없으면 기본 fallback(1,2,3,7,15,30)을 사용한다")
+    void fallbackIntervals() {
+        given(reviewConfigRepository.findByMaterialId(100L))
+                .willReturn(Optional.empty());
+        given(userPreferenceRepository.findByMemberId(1L))
+                .willReturn(Optional.empty());
+
+        ReviewScheduleGenerator.Result result = generator.generate(
+                1L, unit, LocalDate.of(2026, 4, 10));
+
+        assertThat(result.count()).isEqualTo(6);
+        verify(reviewScheduleRepository).saveAll(any());
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/material/entity/StudyUnit.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/material/entity/StudyUnit.java
@@ -80,6 +80,11 @@ public class StudyUnit {
         this.difficulty = difficulty;
     }
 
+    public void complete() {
+        this.status = UnitStatus.COMPLETED;
+        this.completedAt = LocalDateTime.now();
+    }
+
     public Long getId() {
         return id;
     }


### PR DESCRIPTION
## Description

일간 캘린더 조회 및 블록 상태 변경 REST API를 구현했습니다.

### Endpoints
- `GET /api/calendar/daily?date=YYYY-MM-DD` — 스케줄링 엔진을 호출하여 해당 날짜의 블록 목록 반환
- `PATCH /api/calendar/blocks/{blockId}/complete` — 블록 완료 처리, 타입별 부수효과 수행
- `PUT /api/calendar/blocks/{blockId}/reorder` — 블록 시간 변경 (`pinned=true` 자동 세팅)

### 블록 완료 부수효과 (BlockType별)
| BlockType | 효과 |
|-----------|------|
| FIXED | 단순 완료 처리 |
| ROUTINE | `RoutineCheck` 생성 → `STREAK_UPDATED` |
| TODO | `Todo.complete()` → `TODO_COMPLETED` |
| STUDY | `StudyUnit.complete()` + 복습 일정 자동 생성 → `REVIEW_CREATED` |
| REVIEW | `FEEDBACK_REQUIRED` (피드백 요청) |

### 주요 구성요소
- `CalendarService` — 엔진 호출, 메타정보 조회, 완료/재배치 처리
- `BlockMetadataResolver` — 블록을 타입별로 그룹화하여 배치 조회 (N+1 방지)
- `ReviewScheduleGenerator` — SRS 간격으로 복습 일정 생성
  - 우선순위: `ReviewConfig.intervals` → `UserPreference.defaultReviewIntervals` → fallback `1,2,3,7,15,30`

## Test

- `ReviewScheduleGeneratorTest`: Mockito 단위 테스트 4건 (material config, user default, sequence, fallback)
- `CalendarControllerTest`: MockMvc + TestContainers 통합 테스트 6건
  - GET daily 스케줄 생성/반환
  - TODO 블록 완료 → `TODO_COMPLETED` 효과
  - STUDY 블록 완료 → `REVIEW_CREATED` 효과 + 6개 `ReviewSchedule` 생성
  - 중복 완료 시 409 Conflict
  - reorder 시 `pinned=true`
  - reorder 유효하지 않은 시간 범위 → 400

closes #157