### PR TITLE
chore : orino/monitoring 네임스페이스 LimitRange/ResourceQuota 적용

### DIFF
--- a/infra/argocd/applications/platform-policies-app.yaml
+++ b/infra/argocd/applications/platform-policies-app.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: platform-policies
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: orino
+
+  source:
+    repoURL: https://github.com/wcorn/orino.git
+    targetRevision: main
+    path: infra/helm/platform-policies
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        maxDuration: 2m
+        factor: 2

--- a/infra/helm/platform-policies/Chart.yaml
+++ b/infra/helm/platform-policies/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: platform-policies
+description: 네임스페이스별 LimitRange 및 ResourceQuota 거버넌스 정책
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+
+keywords:
+  - limitrange
+  - resourcequota
+  - governance

--- a/infra/helm/platform-policies/templates/limitrange.yaml
+++ b/infra/helm/platform-policies/templates/limitrange.yaml
@@ -1,0 +1,19 @@
+{{- range .Values.namespaces }}
+{{- if .limitRange.enabled }}
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-limits
+  namespace: {{ .name }}
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: {{ .limitRange.default.cpu }}
+        memory: {{ .limitRange.default.memory }}
+      defaultRequest:
+        cpu: {{ .limitRange.defaultRequest.cpu }}
+        memory: {{ .limitRange.defaultRequest.memory }}
+{{- end }}
+{{- end }}

--- a/infra/helm/platform-policies/templates/resourcequota.yaml
+++ b/infra/helm/platform-policies/templates/resourcequota.yaml
@@ -1,0 +1,16 @@
+{{- range .Values.namespaces }}
+{{- if .resourceQuota.enabled }}
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: compute-quota
+  namespace: {{ .name }}
+spec:
+  hard:
+    requests.cpu: {{ .resourceQuota.requests.cpu | quote }}
+    requests.memory: {{ .resourceQuota.requests.memory }}
+    limits.cpu: {{ .resourceQuota.limits.cpu | quote }}
+    limits.memory: {{ .resourceQuota.limits.memory }}
+{{- end }}
+{{- end }}

--- a/infra/helm/platform-policies/values.yaml
+++ b/infra/helm/platform-policies/values.yaml
@@ -1,0 +1,43 @@
+# 네임스페이스별 정책 정의
+# - limitRange: 컨테이너 default/defaultRequest 값 (기존 파드 영향 없음, 신규 파드 안전망)
+# - resourceQuota: 네임스페이스 총량 한도 (requests/limits 누적 합계)
+#
+# 신규 네임스페이스 추가 시 아래 namespaces 리스트에 항목을 추가한다.
+# resourceQuota.enabled=false로 설정하면 해당 네임스페이스에는 LimitRange만 적용된다.
+
+namespaces:
+  - name: orino
+    limitRange:
+      enabled: true
+      default:
+        cpu: 500m
+        memory: 512Mi
+      defaultRequest:
+        cpu: 100m
+        memory: 128Mi
+    resourceQuota:
+      enabled: true
+      requests:
+        cpu: "2"
+        memory: 4Gi
+      limits:
+        cpu: "8"
+        memory: 12Gi
+
+  - name: monitoring
+    limitRange:
+      enabled: true
+      default:
+        cpu: 500m
+        memory: 512Mi
+      defaultRequest:
+        cpu: 100m
+        memory: 128Mi
+    resourceQuota:
+      enabled: true
+      requests:
+        cpu: "2"
+        memory: 8Gi
+      limits:
+        cpu: "8"
+        memory: 16Gi


### PR DESCRIPTION
## 이슈
closes #270

## 작업 내용
### 신규 Wrapper Chart
- `infra/helm/platform-policies/` — LimitRange/ResourceQuota 거버넌스 관리 전용 차트
- 네임스페이스 생성은 건드리지 않음 (기존 \`CreateNamespace=true\` 유지)
- ArgoCD Application 등록 (sync-wave 10, 앱 배포 이후 적용)

### LimitRange (안전망)
컨테이너가 resources를 명시하지 않을 때 기본값 자동 주입. 기존 파드는 영향 없음.
- `default`: cpu 500m / memory 512Mi
- `defaultRequest`: cpu 100m / memory 128Mi
- min/max는 미설정 (기존 파드 거부 방지)

### ResourceQuota (총량 한도)
| 네임스페이스 | requests.cpu | requests.memory | limits.cpu | limits.memory |
|---|---|---|---|---|
| orino | 2 | 4Gi | 8 | 12Gi |
| monitoring | 2 | 8Gi | 8 | 16Gi |

**산정 근거 (orino 기준)**
- 현재 requests 합계(BE HPA 최대 3): ~1300m CPU, ~2.5Gi memory
- 현재 limits 합계(BE HPA 최대 3): ~5400m CPU, ~5Gi memory
- 50% 여유 두고 확정

## 적용 범위 제외
- `kube-system`, `istio-*`, `longhorn-system`: 업스트림 컴포넌트 충돌 위험
- `argocd`: ArgoCD 자체 pod resources 미확인, Quota 적용 시 ArgoCD 재시작 실패 가능성
  - 향후 별도 이슈로 ArgoCD 네임스페이스 정책 검토

## 검증
- `helm template`, `helm lint` 통과
- `yamllint` 통과