### PR TITLE
fix : orino 네임스페이스 ResourceQuota 초과 해결

### DIFF
--- a/infra/helm/istiod/values.yaml
+++ b/infra/helm/istiod/values.yaml
@@ -18,3 +18,13 @@ istiod:
       limits:
         cpu: 1000m
         memory: 4096Mi
+
+  global:
+    proxy:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi

--- a/infra/helm/platform-policies/values.yaml
+++ b/infra/helm/platform-policies/values.yaml
@@ -21,7 +21,7 @@ namespaces:
         cpu: "2"
         memory: 4Gi
       limits:
-        cpu: "8"
+        cpu: "12"
         memory: 12Gi
 
   - name: monitoring


### PR DESCRIPTION
## 이슈
#270

## 문제 상황
PR #276 머지 후 `orino` 네임스페이스에서 **ResourceQuota limits.cpu 초과** 발생:
- 사용량: **15400m / 8000m** (192%)
- \`minio-post-job\` 등 신규 파드 생성이 매 분마다 실패 중

## 근본 원인
기존 ResourceQuota 설계 시 **istio-proxy 사이드카 리소스를 누락**.
orino 네임스페이스에 \`istio-injection=enabled\` 라벨이 있어 6개 앱 파드에 istio-proxy 사이드카가 주입되며, 업스트림 기본값이 **limits 2000m CPU / 1Gi memory**로 과도함.

사이드카 부하: 6 pods × 2 CPU = 12 CPU

## 작업 내용
### 1. istio-proxy 사이드카 리소스 하향 (istiod 차트)
| | 기존 | 변경 |
|---|---|---|
| requests | 100m / 128Mi | 50m / 64Mi |
| limits | 2000m / 1Gi | 500m / 256Mi |

소규모 클러스터 + 저트래픽 환경 기준으로 하향 조정. 트래픽 증가 시 재조정 필요.

### 2. orino limits.cpu 상향 (platform-policies 차트)
- \`limits.cpu\`: **8 → 12**
- HPA peak(BE 3 replicas) + 배치 작업 고려

## 수정 후 예상 사용량
| 상태 | limits.cpu 사용 예상 | 12 CPU quota |
|---|---|---|
| 정상 (BE=1) | ~6.4 CPU | ✓ 53% |
| HPA peak (BE=3) | ~9.4 CPU | ✓ 78% |
| peak + minio-post-job | ~10.4 CPU | ✓ 87% |

## 검증
- \`helm template\`, \`helm lint\` 통과
- istiod의 injection-template ConfigMap에 새 사이드카 resources가 반영됨을 확인