### PR TITLE
feat : dirty flag 기반 스케줄 재생성

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/fixedschedule/service/FixedScheduleService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/fixedschedule/service/FixedScheduleService.java
@@ -12,6 +12,7 @@ import ds.project.orino.domain.member.repository.MemberRepository;
 import ds.project.orino.planner.fixedschedule.dto.CreateFixedScheduleRequest;
 import ds.project.orino.planner.fixedschedule.dto.FixedScheduleResponse;
 import ds.project.orino.planner.fixedschedule.dto.UpdateFixedScheduleRequest;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,13 +25,16 @@ public class FixedScheduleService {
     private final FixedScheduleRepository fixedScheduleRepository;
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
+    private final DirtyScheduleMarker dirtyScheduleMarker;
 
     public FixedScheduleService(FixedScheduleRepository fixedScheduleRepository,
                                 MemberRepository memberRepository,
-                                CategoryRepository categoryRepository) {
+                                CategoryRepository categoryRepository,
+                                DirtyScheduleMarker dirtyScheduleMarker) {
         this.fixedScheduleRepository = fixedScheduleRepository;
         this.memberRepository = memberRepository;
         this.categoryRepository = categoryRepository;
+        this.dirtyScheduleMarker = dirtyScheduleMarker;
     }
 
     public List<FixedScheduleResponse> getFixedSchedules(Long memberId) {
@@ -58,7 +62,10 @@ public class FixedScheduleService {
                 request.recurrenceInterval(), request.recurrenceDays(),
                 request.recurrenceStart(), request.recurrenceEnd());
 
-        return FixedScheduleResponse.from(fixedScheduleRepository.save(schedule));
+        FixedScheduleResponse response = FixedScheduleResponse.from(
+                fixedScheduleRepository.save(schedule));
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
+        return response;
     }
 
     @Transactional
@@ -79,6 +86,7 @@ public class FixedScheduleService {
                 request.recurrenceInterval(), request.recurrenceDays(),
                 request.recurrenceStart(), request.recurrenceEnd());
 
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
         return FixedScheduleResponse.from(schedule);
     }
 
@@ -89,6 +97,7 @@ public class FixedScheduleService {
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
 
         fixedScheduleRepository.delete(schedule);
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
     }
 
     private void validateRecurrence(RecurrenceType type,

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/MaterialService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/MaterialService.java
@@ -33,6 +33,7 @@ import ds.project.orino.planner.material.dto.ReviewConfigResponse;
 import ds.project.orino.planner.material.dto.UnitResponse;
 import ds.project.orino.planner.material.dto.UpdateMaterialRequest;
 import ds.project.orino.planner.material.dto.UpdateUnitRequest;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,6 +52,7 @@ public class MaterialService {
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
     private final GoalRepository goalRepository;
+    private final DirtyScheduleMarker dirtyScheduleMarker;
 
     public MaterialService(
             StudyMaterialRepository materialRepository,
@@ -60,7 +62,8 @@ public class MaterialService {
             ReviewConfigRepository reviewConfigRepository,
             MemberRepository memberRepository,
             CategoryRepository categoryRepository,
-            GoalRepository goalRepository) {
+            GoalRepository goalRepository,
+            DirtyScheduleMarker dirtyScheduleMarker) {
         this.materialRepository = materialRepository;
         this.unitRepository = unitRepository;
         this.allocationRepository = allocationRepository;
@@ -69,6 +72,7 @@ public class MaterialService {
         this.memberRepository = memberRepository;
         this.categoryRepository = categoryRepository;
         this.goalRepository = goalRepository;
+        this.dirtyScheduleMarker = dirtyScheduleMarker;
     }
 
     public List<MaterialResponse> getMaterials(Long memberId) {
@@ -114,6 +118,7 @@ public class MaterialService {
             }
         }
 
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
         return MaterialResponse.from(material);
     }
 
@@ -130,6 +135,7 @@ public class MaterialService {
                 category, goal,
                 request.deadline(), request.deadlineMode());
 
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
         return MaterialResponse.from(material);
     }
 
@@ -137,6 +143,7 @@ public class MaterialService {
     public void delete(Long memberId, Long materialId) {
         StudyMaterial material = findMaterial(materialId, memberId);
         materialRepository.delete(material);
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
     }
 
     @Transactional
@@ -146,6 +153,7 @@ public class MaterialService {
             throw new CustomException(ErrorCode.INVALID_STATE);
         }
         material.pause();
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
         return MaterialResponse.from(material);
     }
 
@@ -156,6 +164,7 @@ public class MaterialService {
             throw new CustomException(ErrorCode.INVALID_STATE);
         }
         material.resume();
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
         return MaterialResponse.from(material);
     }
 
@@ -168,7 +177,9 @@ public class MaterialService {
         StudyUnit unit = new StudyUnit(
                 material, request.title(), request.sortOrder(),
                 request.estimatedMinutes(), request.difficulty());
-        return UnitResponse.from(unitRepository.save(unit));
+        UnitResponse response = UnitResponse.from(unitRepository.save(unit));
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
+        return response;
     }
 
     @Transactional
@@ -176,7 +187,7 @@ public class MaterialService {
             Long memberId, Long materialId,
             CreateUnitBatchRequest request) {
         StudyMaterial material = findMaterial(materialId, memberId);
-        return request.units().stream()
+        List<UnitResponse> response = request.units().stream()
                 .map(req -> {
                     StudyUnit unit = new StudyUnit(
                             material, req.title(), req.sortOrder(),
@@ -184,6 +195,8 @@ public class MaterialService {
                     return UnitResponse.from(unitRepository.save(unit));
                 })
                 .toList();
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
+        return response;
     }
 
     @Transactional
@@ -197,6 +210,7 @@ public class MaterialService {
                         ErrorCode.RESOURCE_NOT_FOUND));
         unit.update(request.title(), request.sortOrder(),
                 request.estimatedMinutes(), request.difficulty());
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
         return UnitResponse.from(unit);
     }
 
@@ -209,6 +223,7 @@ public class MaterialService {
                 .orElseThrow(() -> new CustomException(
                         ErrorCode.RESOURCE_NOT_FOUND));
         unitRepository.delete(unit);
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
     }
 
     // --- Allocation ---
@@ -228,6 +243,7 @@ public class MaterialService {
         } else {
             allocation.update(request.defaultMinutes());
         }
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
         return AllocationResponse.from(allocation);
     }
 
@@ -258,6 +274,7 @@ public class MaterialService {
         } else {
             override.update(request.minutes());
         }
+        dirtyScheduleMarker.markDirtyOn(memberId, date);
         return DailyOverrideResponse.from(override);
     }
 
@@ -270,6 +287,7 @@ public class MaterialService {
                 .orElseThrow(() -> new CustomException(
                         ErrorCode.RESOURCE_NOT_FOUND));
         dailyOverrideRepository.delete(override);
+        dirtyScheduleMarker.markDirtyOn(memberId, date);
     }
 
     // --- Review Config ---
@@ -291,6 +309,7 @@ public class MaterialService {
             config.update(request.intervals(),
                     request.missedPolicy());
         }
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
         return ReviewConfigResponse.from(config);
     }
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/preference/service/PreferenceService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/preference/service/PreferenceService.java
@@ -14,6 +14,7 @@ import ds.project.orino.planner.preference.dto.PriorityRuleRequest;
 import ds.project.orino.planner.preference.dto.PriorityRuleResponse;
 import ds.project.orino.planner.preference.dto.UpdatePreferenceRequest;
 import ds.project.orino.planner.preference.dto.UpdatePriorityRulesRequest;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,14 +27,17 @@ public class PreferenceService {
     private final UserPreferenceRepository preferenceRepository;
     private final PriorityRuleRepository ruleRepository;
     private final MemberRepository memberRepository;
+    private final DirtyScheduleMarker dirtyScheduleMarker;
 
     public PreferenceService(
             UserPreferenceRepository preferenceRepository,
             PriorityRuleRepository ruleRepository,
-            MemberRepository memberRepository) {
+            MemberRepository memberRepository,
+            DirtyScheduleMarker dirtyScheduleMarker) {
         this.preferenceRepository = preferenceRepository;
         this.ruleRepository = ruleRepository;
         this.memberRepository = memberRepository;
+        this.dirtyScheduleMarker = dirtyScheduleMarker;
     }
 
     @Transactional
@@ -61,6 +65,7 @@ public class PreferenceService {
                 request.defaultMissedPolicy(),
                 request.streakFreezePerMonth());
 
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
         return PreferenceResponse.from(pref);
     }
 
@@ -98,11 +103,13 @@ public class PreferenceService {
             rule.updateSortOrder(ruleReq.sortOrder());
         }
 
-        return ruleRepository
+        List<PriorityRuleResponse> response = ruleRepository
                 .findByMemberIdOrderBySortOrder(memberId)
                 .stream()
                 .map(PriorityRuleResponse::from)
                 .toList();
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
+        return response;
     }
 
     private UserPreference createDefault(Long memberId) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/service/RoutineService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/routine/service/RoutineService.java
@@ -13,6 +13,7 @@ import ds.project.orino.domain.routine.entity.RoutineStatus;
 import ds.project.orino.domain.routine.repository.RoutineCheckRepository;
 import ds.project.orino.domain.routine.repository.RoutineExceptionRepository;
 import ds.project.orino.domain.routine.repository.RoutineRepository;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
 import ds.project.orino.planner.routine.dto.CreateRoutineRequest;
 import ds.project.orino.planner.routine.dto.RoutineCheckRequest;
 import ds.project.orino.planner.routine.dto.RoutineCheckResponse;
@@ -38,17 +39,20 @@ public class RoutineService {
     private final RoutineExceptionRepository routineExceptionRepository;
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
+    private final DirtyScheduleMarker dirtyScheduleMarker;
 
     public RoutineService(RoutineRepository routineRepository,
                           RoutineCheckRepository routineCheckRepository,
                           RoutineExceptionRepository routineExceptionRepository,
                           MemberRepository memberRepository,
-                          CategoryRepository categoryRepository) {
+                          CategoryRepository categoryRepository,
+                          DirtyScheduleMarker dirtyScheduleMarker) {
         this.routineRepository = routineRepository;
         this.routineCheckRepository = routineCheckRepository;
         this.routineExceptionRepository = routineExceptionRepository;
         this.memberRepository = memberRepository;
         this.categoryRepository = categoryRepository;
+        this.dirtyScheduleMarker = dirtyScheduleMarker;
     }
 
     public List<RoutineResponse> getRoutines(Long memberId) {
@@ -79,6 +83,7 @@ public class RoutineService {
                 Boolean.TRUE.equals(request.skipHolidays()));
 
         Routine saved = routineRepository.save(routine);
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
         return RoutineResponse.from(saved, new StreakInfo(0, 0));
     }
 
@@ -97,6 +102,7 @@ public class RoutineService {
                 request.endDate(),
                 Boolean.TRUE.equals(request.skipHolidays()));
 
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
         return RoutineResponse.from(routine, calculateStreak(routine));
     }
 
@@ -105,6 +111,7 @@ public class RoutineService {
         Routine routine = routineRepository.findByIdAndMemberId(routineId, memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
         routineRepository.delete(routine);
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
     }
 
     @Transactional
@@ -113,6 +120,7 @@ public class RoutineService {
         Routine routine = routineRepository.findByIdAndMemberId(routineId, memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
         routine.changeStatus(status);
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
         return RoutineResponse.from(routine, calculateStreak(routine));
     }
 
@@ -147,8 +155,10 @@ public class RoutineService {
 
         RoutineException exception = new RoutineException(
                 routine, request.exceptionDate());
-        return RoutineExceptionResponse.from(
+        RoutineExceptionResponse response = RoutineExceptionResponse.from(
                 routineExceptionRepository.save(exception));
+        dirtyScheduleMarker.markDirtyOn(memberId, request.exceptionDate());
+        return response;
     }
 
     @Transactional
@@ -161,7 +171,9 @@ public class RoutineService {
                 .findByIdAndRoutineId(exceptionId, routineId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
 
+        LocalDate exceptionDate = exception.getExceptionDate();
         routineExceptionRepository.delete(exception);
+        dirtyScheduleMarker.markDirtyOn(memberId, exceptionDate);
     }
 
     private StreakInfo calculateStreak(Routine routine) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/dirty/DirtyScheduleMarker.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/dirty/DirtyScheduleMarker.java
@@ -1,0 +1,46 @@
+package ds.project.orino.planner.scheduling.dirty;
+
+import ds.project.orino.domain.calendar.repository.DailyScheduleRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+/**
+ * 스케줄에 영향을 주는 데이터가 변경되었을 때 해당 사용자의 DailySchedule을
+ * dirty 마킹한다. 이후 스케줄 조회 시 SchedulingEngine이 lazy 재생성한다.
+ */
+@Component
+public class DirtyScheduleMarker {
+
+    private final DailyScheduleRepository dailyScheduleRepository;
+
+    public DirtyScheduleMarker(DailyScheduleRepository dailyScheduleRepository) {
+        this.dailyScheduleRepository = dailyScheduleRepository;
+    }
+
+    /**
+     * 오늘부터 미래의 모든 DailySchedule을 dirty 마킹한다.
+     * (루틴/고정 일정/설정 변경 등 반복/지속적인 변경에 사용)
+     */
+    @Transactional
+    public void markDirtyFromToday(Long memberId) {
+        markDirtyFrom(memberId, LocalDate.now());
+    }
+
+    /**
+     * 지정한 날짜부터 미래의 모든 DailySchedule을 dirty 마킹한다.
+     */
+    @Transactional
+    public void markDirtyFrom(Long memberId, LocalDate fromDate) {
+        dailyScheduleRepository.markDirtyFromDate(memberId, fromDate);
+    }
+
+    /**
+     * 특정 날짜의 DailySchedule만 dirty 마킹한다.
+     */
+    @Transactional
+    public void markDirtyOn(Long memberId, LocalDate date) {
+        dailyScheduleRepository.markDirtyByDate(memberId, date);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/SchedulingEngine.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/SchedulingEngine.java
@@ -77,6 +77,11 @@ public class SchedulingEngine {
             return new SchedulingResult(dailySchedule, List.of());
         }
 
+        if (!dailySchedule.isDirty()) {
+            dailySchedule.getBlocks().size();
+            return new SchedulingResult(dailySchedule, List.of());
+        }
+
         UserPreference preference = preferenceRepository
                 .findByMemberId(memberId)
                 .orElseGet(() -> createDefaultPreference(memberId));

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/todo/service/TodoService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/todo/service/TodoService.java
@@ -13,6 +13,7 @@ import ds.project.orino.domain.todo.entity.Todo;
 import ds.project.orino.domain.todo.entity.TodoStatus;
 import ds.project.orino.domain.todo.repository.TodoRepository;
 import ds.project.orino.domain.todo.repository.TodoSpecification;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
 import ds.project.orino.planner.todo.dto.CreateTodoRequest;
 import ds.project.orino.planner.todo.dto.TodoResponse;
 import ds.project.orino.planner.todo.dto.UpdateTodoRequest;
@@ -30,15 +31,18 @@ public class TodoService {
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
     private final GoalRepository goalRepository;
+    private final DirtyScheduleMarker dirtyScheduleMarker;
 
     public TodoService(TodoRepository todoRepository,
                        MemberRepository memberRepository,
                        CategoryRepository categoryRepository,
-                       GoalRepository goalRepository) {
+                       GoalRepository goalRepository,
+                       DirtyScheduleMarker dirtyScheduleMarker) {
         this.todoRepository = todoRepository;
         this.memberRepository = memberRepository;
         this.categoryRepository = categoryRepository;
         this.goalRepository = goalRepository;
+        this.dirtyScheduleMarker = dirtyScheduleMarker;
     }
 
     public List<TodoResponse> getTodos(Long memberId, TodoStatus status,
@@ -76,7 +80,9 @@ public class TodoService {
                 category, goal, request.priority(),
                 request.deadline(), request.estimatedMinutes());
 
-        return TodoResponse.from(todoRepository.save(todo));
+        TodoResponse response = TodoResponse.from(todoRepository.save(todo));
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
+        return response;
     }
 
     @Transactional
@@ -92,6 +98,7 @@ public class TodoService {
                 category, goal, request.priority(),
                 request.deadline(), request.estimatedMinutes());
 
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
         return TodoResponse.from(todo);
     }
 
@@ -100,6 +107,7 @@ public class TodoService {
         Todo todo = todoRepository.findByIdAndMemberId(todoId, memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
         todoRepository.delete(todo);
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
     }
 
     @Transactional

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/fixedschedule/service/FixedScheduleServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/fixedschedule/service/FixedScheduleServiceTest.java
@@ -11,6 +11,7 @@ import ds.project.orino.domain.member.repository.MemberRepository;
 import ds.project.orino.planner.fixedschedule.dto.CreateFixedScheduleRequest;
 import ds.project.orino.planner.fixedschedule.dto.FixedScheduleResponse;
 import ds.project.orino.planner.fixedschedule.dto.UpdateFixedScheduleRequest;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,12 +44,16 @@ class FixedScheduleServiceTest {
     @Mock
     private CategoryRepository categoryRepository;
 
+    @Mock
+    private DirtyScheduleMarker dirtyScheduleMarker;
+
     private Member member;
 
     @BeforeEach
     void setUp() {
         service = new FixedScheduleService(
-                fixedScheduleRepository, memberRepository, categoryRepository);
+                fixedScheduleRepository, memberRepository, categoryRepository,
+                dirtyScheduleMarker);
         member = new Member("admin", "encoded");
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/service/MaterialServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/service/MaterialServiceTest.java
@@ -37,6 +37,7 @@ import ds.project.orino.planner.material.dto.ReviewConfigResponse;
 import ds.project.orino.planner.material.dto.UnitResponse;
 import ds.project.orino.planner.material.dto.UpdateMaterialRequest;
 import ds.project.orino.planner.material.dto.UpdateUnitRequest;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -67,6 +68,7 @@ class MaterialServiceTest {
     @Mock private MemberRepository memberRepository;
     @Mock private CategoryRepository categoryRepository;
     @Mock private GoalRepository goalRepository;
+    @Mock private DirtyScheduleMarker dirtyScheduleMarker;
 
     private Member member;
 
@@ -76,7 +78,8 @@ class MaterialServiceTest {
                 materialRepository, unitRepository,
                 allocationRepository, dailyOverrideRepository,
                 reviewConfigRepository, memberRepository,
-                categoryRepository, goalRepository);
+                categoryRepository, goalRepository,
+                dirtyScheduleMarker);
         member = new Member("admin", "encoded");
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/preference/service/PreferenceServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/preference/service/PreferenceServiceTest.java
@@ -14,6 +14,7 @@ import ds.project.orino.planner.preference.dto.PriorityRuleRequest;
 import ds.project.orino.planner.preference.dto.PriorityRuleResponse;
 import ds.project.orino.planner.preference.dto.UpdatePreferenceRequest;
 import ds.project.orino.planner.preference.dto.UpdatePriorityRulesRequest;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,7 @@ class PreferenceServiceTest {
     @Mock private UserPreferenceRepository preferenceRepository;
     @Mock private PriorityRuleRepository ruleRepository;
     @Mock private MemberRepository memberRepository;
+    @Mock private DirtyScheduleMarker dirtyScheduleMarker;
 
     private Member member;
 
@@ -45,7 +47,7 @@ class PreferenceServiceTest {
     void setUp() {
         preferenceService = new PreferenceService(
                 preferenceRepository, ruleRepository,
-                memberRepository);
+                memberRepository, dirtyScheduleMarker);
         member = new Member("admin", "encoded");
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/routine/service/RoutineServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/routine/service/RoutineServiceTest.java
@@ -20,6 +20,7 @@ import ds.project.orino.planner.routine.dto.RoutineExceptionRequest;
 import ds.project.orino.planner.routine.dto.RoutineExceptionResponse;
 import ds.project.orino.planner.routine.dto.RoutineResponse;
 import ds.project.orino.planner.routine.dto.UpdateRoutineRequest;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,13 +48,15 @@ class RoutineServiceTest {
     @Mock private RoutineExceptionRepository routineExceptionRepository;
     @Mock private MemberRepository memberRepository;
     @Mock private CategoryRepository categoryRepository;
+    @Mock private DirtyScheduleMarker dirtyScheduleMarker;
 
     private Member member;
 
     @BeforeEach
     void setUp() {
         service = new RoutineService(routineRepository, routineCheckRepository,
-                routineExceptionRepository, memberRepository, categoryRepository);
+                routineExceptionRepository, memberRepository, categoryRepository,
+                dirtyScheduleMarker);
         member = new Member("admin", "encoded");
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/scheduling/dirty/DirtyScheduleMarkerIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/scheduling/dirty/DirtyScheduleMarkerIntegrationTest.java
@@ -1,0 +1,136 @@
+package ds.project.orino.planner.scheduling.dirty;
+
+import ds.project.orino.domain.calendar.entity.DailySchedule;
+import ds.project.orino.domain.calendar.repository.DailyScheduleRepository;
+import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.domain.fixedschedule.repository.FixedScheduleRepository;
+import ds.project.orino.domain.goal.repository.GoalRepository;
+import ds.project.orino.domain.goal.repository.MilestoneRepository;
+import ds.project.orino.domain.material.repository.MaterialAllocationRepository;
+import ds.project.orino.domain.material.repository.MaterialDailyOverrideRepository;
+import ds.project.orino.domain.material.repository.ReviewConfigRepository;
+import ds.project.orino.domain.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.material.repository.StudyUnitRepository;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.preference.repository.PriorityRuleRepository;
+import ds.project.orino.domain.preference.repository.UserPreferenceRepository;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import ds.project.orino.domain.routine.repository.RoutineCheckRepository;
+import ds.project.orino.domain.routine.repository.RoutineExceptionRepository;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
+import ds.project.orino.domain.todo.repository.TodoRepository;
+import ds.project.orino.support.IntegrationTest;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class DirtyScheduleMarkerIntegrationTest {
+
+    @Autowired private DirtyScheduleMarker marker;
+    @Autowired private DailyScheduleRepository dailyScheduleRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private UserPreferenceRepository userPreferenceRepository;
+    @Autowired private PriorityRuleRepository priorityRuleRepository;
+    @Autowired private ReviewScheduleRepository reviewScheduleRepository;
+    @Autowired private ReviewConfigRepository reviewConfigRepository;
+    @Autowired private MaterialDailyOverrideRepository dailyOverrideRepository;
+    @Autowired private MaterialAllocationRepository allocationRepository;
+    @Autowired private StudyUnitRepository unitRepository;
+    @Autowired private StudyMaterialRepository materialRepository;
+    @Autowired private RoutineExceptionRepository routineExceptionRepository;
+    @Autowired private RoutineCheckRepository routineCheckRepository;
+    @Autowired private RoutineRepository routineRepository;
+    @Autowired private FixedScheduleRepository fixedScheduleRepository;
+    @Autowired private TodoRepository todoRepository;
+    @Autowired private MilestoneRepository milestoneRepository;
+    @Autowired private GoalRepository goalRepository;
+    @Autowired private CategoryRepository categoryRepository;
+
+    private Member member;
+    private LocalDate today;
+
+    @BeforeEach
+    void setUp() {
+        dailyScheduleRepository.deleteAll();
+        reviewScheduleRepository.deleteAll();
+        priorityRuleRepository.deleteAll();
+        userPreferenceRepository.deleteAll();
+        reviewConfigRepository.deleteAll();
+        dailyOverrideRepository.deleteAll();
+        allocationRepository.deleteAll();
+        unitRepository.deleteAll();
+        materialRepository.deleteAll();
+        routineExceptionRepository.deleteAll();
+        routineCheckRepository.deleteAll();
+        routineRepository.deleteAll();
+        fixedScheduleRepository.deleteAll();
+        todoRepository.deleteAll();
+        milestoneRepository.deleteAll();
+        goalRepository.deleteAll();
+        categoryRepository.deleteAll();
+        memberRepository.deleteAll();
+        member = memberRepository.save(MemberFixture.create());
+        today = LocalDate.now();
+    }
+
+    @Test
+    @DisplayName("markDirtyFromToday - 오늘 이후의 모든 스케줄을 dirty=true로 변경한다")
+    void markDirtyFromToday_updatesFutureSchedules() {
+        DailySchedule past = saveCleanSchedule(today.minusDays(1));
+        DailySchedule todaySchedule = saveCleanSchedule(today);
+        DailySchedule future = saveCleanSchedule(today.plusDays(5));
+
+        marker.markDirtyFromToday(member.getId());
+
+        assertThat(reload(past).isDirty()).isFalse();
+        assertThat(reload(todaySchedule).isDirty()).isTrue();
+        assertThat(reload(future).isDirty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("markDirtyOn - 지정 날짜의 스케줄만 dirty=true로 변경한다")
+    void markDirtyOn_updatesSingleDate() {
+        DailySchedule day1 = saveCleanSchedule(today);
+        DailySchedule day2 = saveCleanSchedule(today.plusDays(1));
+
+        marker.markDirtyOn(member.getId(), today.plusDays(1));
+
+        assertThat(reload(day1).isDirty()).isFalse();
+        assertThat(reload(day2).isDirty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 스케줄은 영향을 받지 않는다")
+    void doesNotAffectOtherMembers() {
+        Member other = memberRepository.save(new Member("other", "pw"));
+        DailySchedule mine = saveCleanSchedule(today);
+        DailySchedule theirs = saveCleanScheduleFor(other, today);
+
+        marker.markDirtyFromToday(member.getId());
+
+        assertThat(reload(mine).isDirty()).isTrue();
+        assertThat(reload(theirs).isDirty()).isFalse();
+    }
+
+    private DailySchedule saveCleanSchedule(LocalDate date) {
+        return saveCleanScheduleFor(member, date);
+    }
+
+    private DailySchedule saveCleanScheduleFor(Member m, LocalDate date) {
+        DailySchedule schedule = new DailySchedule(m, date);
+        schedule.markGenerated(0, 0);
+        return dailyScheduleRepository.save(schedule);
+    }
+
+    private DailySchedule reload(DailySchedule schedule) {
+        return dailyScheduleRepository.findById(schedule.getId()).orElseThrow();
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/scheduling/engine/SchedulingEngineIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/scheduling/engine/SchedulingEngineIntegrationTest.java
@@ -5,6 +5,7 @@ import ds.project.orino.domain.calendar.entity.BlockType;
 import ds.project.orino.domain.calendar.entity.DailySchedule;
 import ds.project.orino.domain.calendar.entity.ScheduleBlock;
 import ds.project.orino.domain.calendar.repository.DailyScheduleRepository;
+import ds.project.orino.domain.calendar.repository.ScheduleBlockRepository;
 import ds.project.orino.domain.fixedschedule.entity.FixedSchedule;
 import ds.project.orino.domain.fixedschedule.entity.RecurrenceType;
 import ds.project.orino.domain.fixedschedule.repository.FixedScheduleRepository;
@@ -36,6 +37,7 @@ import ds.project.orino.domain.todo.repository.TodoRepository;
 import ds.project.orino.domain.goal.repository.GoalRepository;
 import ds.project.orino.domain.goal.repository.MilestoneRepository;
 import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
 import ds.project.orino.planner.scheduling.engine.model.SchedulingResult;
 import ds.project.orino.support.IntegrationTest;
 import ds.project.orino.support.MemberFixture;
@@ -56,6 +58,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SchedulingEngineIntegrationTest {
 
     @Autowired private SchedulingEngine engine;
+    @Autowired private DirtyScheduleMarker dirtyScheduleMarker;
     @Autowired private MemberRepository memberRepository;
     @Autowired private UserPreferenceRepository preferenceRepository;
     @Autowired private PriorityRuleRepository priorityRuleRepository;
@@ -71,6 +74,7 @@ class SchedulingEngineIntegrationTest {
     @Autowired private ReviewConfigRepository reviewConfigRepository;
     @Autowired private ReviewScheduleRepository reviewRepository;
     @Autowired private DailyScheduleRepository dailyScheduleRepository;
+    @Autowired private ScheduleBlockRepository scheduleBlockRepository;
     @Autowired private GoalRepository goalRepository;
     @Autowired private MilestoneRepository milestoneRepository;
     @Autowired private CategoryRepository categoryRepository;
@@ -258,6 +262,80 @@ class SchedulingEngineIntegrationTest {
         assertThat(sorted.get(0).getReferenceId()).isEqualTo(urgent.getId());
         assertThat(sorted.get(1).getReferenceId())
                 .isEqualTo(noDeadline.getId());
+    }
+
+    @Test
+    @DisplayName("dirty=false 인 스케줄은 재생성하지 않고 기존 블록을 반환한다")
+    void cleanScheduleIsNotRegenerated() {
+        saveDefaultPreference();
+
+        StudyMaterial material = materialRepository.save(new StudyMaterial(
+                member, "알고리즘", MaterialType.BOOK, null, null,
+                null, DeadlineMode.FREE));
+        unitRepository.save(new StudyUnit(material, "챕터1", 1, 30, null));
+
+        SchedulingResult first = engine.generate(member.getId(), targetDate);
+        int firstBlockCount = first.dailySchedule().getBlocks().size();
+        assertThat(first.dailySchedule().isDirty()).isFalse();
+
+        // 데이터 변경 후 dirty 마킹은 하지 않음
+        unitRepository.save(new StudyUnit(material, "챕터2", 2, 30, null));
+
+        // 재호출 시 dirty=false 이므로 재생성하지 않음
+        SchedulingResult second = engine.generate(member.getId(), targetDate);
+        assertThat(second.dailySchedule().getBlocks()).hasSize(firstBlockCount);
+    }
+
+    @Test
+    @DisplayName("dirty=true 마킹하면 다음 호출에서 재생성한다")
+    void dirtyScheduleIsRegenerated() {
+        saveDefaultPreference();
+
+        StudyMaterial material = materialRepository.save(new StudyMaterial(
+                member, "알고리즘", MaterialType.BOOK, null, null,
+                null, DeadlineMode.FREE));
+        unitRepository.save(new StudyUnit(material, "챕터1", 1, 30, null));
+
+        SchedulingResult first = engine.generate(member.getId(), targetDate);
+        int firstBlockCount = first.dailySchedule().getBlocks().size();
+
+        unitRepository.save(new StudyUnit(material, "챕터2", 2, 30, null));
+        dirtyScheduleMarker.markDirtyFromToday(member.getId());
+
+        SchedulingResult second = engine.generate(member.getId(), targetDate);
+        assertThat(second.dailySchedule().getBlocks())
+                .hasSize(firstBlockCount + 1);
+    }
+
+    @Test
+    @DisplayName("완료/pinned 블록은 dirty 재생성 시에도 유지된다")
+    void lockedBlocksPreservedOnRegeneration() {
+        saveDefaultPreference();
+
+        StudyMaterial material = materialRepository.save(new StudyMaterial(
+                member, "알고리즘", MaterialType.BOOK, null, null,
+                null, DeadlineMode.FREE));
+        unitRepository.save(new StudyUnit(material, "챕터1", 1, 30, null));
+
+        SchedulingResult first = engine.generate(member.getId(), targetDate);
+        ScheduleBlock firstBlock = first.dailySchedule().getBlocks().get(0);
+        Long completedBlockId = firstBlock.getId();
+        LocalTime originalStart = firstBlock.getStartTime();
+        // DB에 COMPLETED 상태를 반영
+        ScheduleBlock managed = scheduleBlockRepository
+                .findById(completedBlockId).orElseThrow();
+        managed.complete();
+        scheduleBlockRepository.save(managed);
+
+        unitRepository.save(new StudyUnit(material, "챕터2", 2, 30, null));
+        dirtyScheduleMarker.markDirtyFromToday(member.getId());
+
+        SchedulingResult second = engine.generate(member.getId(), targetDate);
+        ScheduleBlock preserved = second.dailySchedule().getBlocks().stream()
+                .filter(b -> b.getId().equals(completedBlockId))
+                .findFirst().orElseThrow();
+        assertThat(preserved.getStatus()).isEqualTo(BlockStatus.COMPLETED);
+        assertThat(preserved.getStartTime()).isEqualTo(originalStart);
     }
 
     private UserPreference saveDefaultPreference() {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/todo/service/TodoServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/todo/service/TodoServiceTest.java
@@ -13,6 +13,7 @@ import ds.project.orino.domain.todo.entity.Priority;
 import ds.project.orino.domain.todo.entity.Todo;
 import ds.project.orino.domain.todo.entity.TodoStatus;
 import ds.project.orino.domain.todo.repository.TodoRepository;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
 import ds.project.orino.planner.todo.dto.CreateTodoRequest;
 import ds.project.orino.planner.todo.dto.TodoResponse;
 import ds.project.orino.planner.todo.dto.UpdateTodoRequest;
@@ -51,12 +52,15 @@ class TodoServiceTest {
     @Mock
     private GoalRepository goalRepository;
 
+    @Mock
+    private DirtyScheduleMarker dirtyScheduleMarker;
+
     private Member member;
 
     @BeforeEach
     void setUp() {
         todoService = new TodoService(todoRepository, memberRepository,
-                categoryRepository, goalRepository);
+                categoryRepository, goalRepository, dirtyScheduleMarker);
         member = new Member("admin", "encoded");
     }
 

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/repository/DailyScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/repository/DailyScheduleRepository.java
@@ -2,6 +2,9 @@ package ds.project.orino.domain.calendar.repository;
 
 import ds.project.orino.domain.calendar.entity.DailySchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -15,4 +18,18 @@ public interface DailyScheduleRepository
 
     List<DailySchedule> findByMemberIdAndScheduleDateBetween(
             Long memberId, LocalDate from, LocalDate to);
+
+    @Modifying
+    @Query("UPDATE DailySchedule ds SET ds.dirty = true "
+            + "WHERE ds.member.id = :memberId "
+            + "AND ds.scheduleDate >= :fromDate")
+    int markDirtyFromDate(@Param("memberId") Long memberId,
+                          @Param("fromDate") LocalDate fromDate);
+
+    @Modifying
+    @Query("UPDATE DailySchedule ds SET ds.dirty = true "
+            + "WHERE ds.member.id = :memberId "
+            + "AND ds.scheduleDate = :date")
+    int markDirtyByDate(@Param("memberId") Long memberId,
+                        @Param("date") LocalDate date);
 }


### PR DESCRIPTION
closes #155

## Description

스케줄 재생성을 필요한 시점에만 수행하도록 dirty flag 기반 lazy 재생성 구조를 도입했습니다.

## 주요 변경사항

### 1. DirtyScheduleMarker 컴포넌트 추가
- `planner/scheduling/dirty/DirtyScheduleMarker.java` (신규)
- `markDirtyFromToday(memberId)`: 오늘 이후의 모든 스케줄을 dirty=true로 변경
- `markDirtyFrom(memberId, fromDate)`: 특정 날짜 이후 스케줄 dirty 마킹
- `markDirtyOn(memberId, date)`: 지정 날짜 스케줄만 dirty 마킹

### 2. DailyScheduleRepository bulk UPDATE 쿼리
- `markDirtyFromDate` / `markDirtyByDate` @Modifying JPQL 추가

### 3. SchedulingEngine lazy regeneration
- 스케줄 조회 시 `dirty=false`면 재생성을 스킵하고 기존 블록을 그대로 반환
- `dirty=true`인 경우에만 재생성 수행 (기존 완료/pinned 블록은 유지)

### 4. 데이터 변경 서비스에서 dirty 마킹 수행
- `FixedScheduleService` - 고정 일정 CRUD
- `TodoService` - 할 일 CRUD
- `RoutineService` - 루틴 CRUD/상태변경/예외일
- `MaterialService` - 학습 자료/단위/할당/복습설정/일일오버라이드
- `PreferenceService` - 사용자 설정/우선순위 규칙

### 5. 테스트
- `DirtyScheduleMarkerIntegrationTest` 신규 (3개 케이스)
- `SchedulingEngineIntegrationTest`에 dirty 재생성/스킵/완료블록 보존 3 케이스 추가
- 기존 Mockito 테스트들에 DirtyScheduleMarker mock 주입

## Follow-up
- `ReviewScheduleGenerator`의 dirty 마킹은 PR #275 머지 이후 후속 작업으로 진행

## Test plan
- [x] `./gradlew build` 전체 빌드/테스트 통과 확인