### PR TITLE
feat : 데드라인 역산 로직 추가

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/DeadlineProjectionResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/DeadlineProjectionResponse.java
@@ -1,0 +1,19 @@
+package ds.project.orino.planner.material.dto;
+
+import ds.project.orino.domain.material.entity.PaceStatus;
+
+import java.time.LocalDate;
+
+public record DeadlineProjectionResponse(
+        LocalDate deadline,
+        int totalUnits,
+        int completedUnits,
+        int remainingUnits,
+        int remainingMinutes,
+        int availableDays,
+        int requiredUnitsPerDay,
+        int requiredMinutesPerDay,
+        int allocatedMinutesPerDay,
+        PaceStatus paceStatus
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialDetailResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialDetailResponse.java
@@ -19,10 +19,16 @@ public record MaterialDetailResponse(
         MaterialStatus status,
         List<UnitResponse> units,
         AllocationResponse allocation,
-        ReviewConfigResponse reviewConfig
+        ReviewConfigResponse reviewConfig,
+        DeadlineProjectionResponse deadlineProjection
 ) {
 
     public static MaterialDetailResponse from(StudyMaterial m) {
+        return from(m, null);
+    }
+
+    public static MaterialDetailResponse from(
+            StudyMaterial m, DeadlineProjectionResponse projection) {
         return new MaterialDetailResponse(
                 m.getId(),
                 m.getTitle(),
@@ -42,7 +48,8 @@ public record MaterialDetailResponse(
                         : null,
                 m.getReviewConfig() != null
                         ? ReviewConfigResponse.from(m.getReviewConfig())
-                        : null
+                        : null,
+                projection
         );
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/DeadlineCalculator.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/DeadlineCalculator.java
@@ -1,0 +1,167 @@
+package ds.project.orino.planner.material.service;
+
+import ds.project.orino.domain.material.entity.DeadlineMode;
+import ds.project.orino.domain.material.entity.MaterialAllocation;
+import ds.project.orino.domain.material.entity.PaceStatus;
+import ds.project.orino.domain.material.entity.StudyMaterial;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.entity.UnitStatus;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.planner.material.dto.DeadlineProjectionResponse;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * 학습 자료의 데드라인 역산을 수행한다.
+ * 남은 단위, 가용 학습일, 하루 필요량, 현재 페이스 상태를 계산한다.
+ */
+@Component
+public class DeadlineCalculator {
+
+    /**
+     * 학습 자료의 데드라인 역산 정보를 계산한다.
+     *
+     * @param material   대상 학습 자료 (units 로딩 필요)
+     * @param preference 사용자 설정 (restDays, dailyStudyMinutes)
+     * @param today      기준 날짜
+     * @return deadlineMode=DEADLINE 이고 deadline 이 설정된 경우 역산 결과,
+     *         그렇지 않으면 null
+     */
+    public DeadlineProjectionResponse calculate(StudyMaterial material,
+                                                UserPreference preference,
+                                                LocalDate today) {
+        if (material.getDeadlineMode() != DeadlineMode.DEADLINE
+                || material.getDeadline() == null) {
+            return null;
+        }
+
+        int totalUnits = material.getUnits().size();
+        int completedUnits = (int) material.getUnits().stream()
+                .filter(u -> u.getStatus() == UnitStatus.COMPLETED)
+                .count();
+        int remainingUnits = totalUnits - completedUnits;
+        int remainingMinutes = material.getUnits().stream()
+                .filter(u -> u.getStatus() != UnitStatus.COMPLETED)
+                .mapToInt(StudyUnit::getEstimatedMinutes)
+                .sum();
+
+        int availableDays = countAvailableDays(
+                today, material.getDeadline(), preference);
+
+        int allocatedMinutesPerDay = resolveAllocatedMinutes(
+                material.getAllocation(), preference);
+
+        int requiredUnitsPerDay;
+        int requiredMinutesPerDay;
+        if (availableDays <= 0) {
+            requiredUnitsPerDay = remainingUnits;
+            requiredMinutesPerDay = remainingMinutes;
+        } else {
+            requiredUnitsPerDay = ceilDiv(remainingUnits, availableDays);
+            requiredMinutesPerDay = ceilDiv(remainingMinutes, availableDays);
+        }
+
+        PaceStatus paceStatus = judgePace(
+                remainingUnits, availableDays,
+                requiredMinutesPerDay, allocatedMinutesPerDay);
+
+        return new DeadlineProjectionResponse(
+                material.getDeadline(),
+                totalUnits,
+                completedUnits,
+                remainingUnits,
+                remainingMinutes,
+                availableDays,
+                requiredUnitsPerDay,
+                requiredMinutesPerDay,
+                allocatedMinutesPerDay,
+                paceStatus);
+    }
+
+    private int countAvailableDays(LocalDate today, LocalDate deadline,
+                                   UserPreference preference) {
+        if (deadline.isBefore(today)) {
+            return 0;
+        }
+        Set<DayOfWeek> restDays = parseRestDays(
+                preference != null ? preference.getRestDays() : null);
+        int count = 0;
+        LocalDate cursor = today;
+        while (!cursor.isAfter(deadline)) {
+            if (!restDays.contains(cursor.getDayOfWeek())) {
+                count++;
+            }
+            cursor = cursor.plusDays(1);
+        }
+        return count;
+    }
+
+    private int resolveAllocatedMinutes(MaterialAllocation allocation,
+                                        UserPreference preference) {
+        if (allocation != null) {
+            return allocation.getDefaultMinutes();
+        }
+        return preference != null ? preference.getDailyStudyMinutes() : 0;
+    }
+
+    private PaceStatus judgePace(int remainingUnits, int availableDays,
+                                 int requiredMinutesPerDay,
+                                 int allocatedMinutesPerDay) {
+        if (remainingUnits <= 0) {
+            return PaceStatus.AHEAD;
+        }
+        if (availableDays <= 0) {
+            return PaceStatus.BEHIND;
+        }
+        if (allocatedMinutesPerDay <= 0) {
+            return requiredMinutesPerDay > 0
+                    ? PaceStatus.BEHIND : PaceStatus.ON_TRACK;
+        }
+        if (requiredMinutesPerDay > allocatedMinutesPerDay) {
+            return PaceStatus.BEHIND;
+        }
+        if (requiredMinutesPerDay < allocatedMinutesPerDay) {
+            return PaceStatus.AHEAD;
+        }
+        return PaceStatus.ON_TRACK;
+    }
+
+    private Set<DayOfWeek> parseRestDays(String restDays) {
+        if (restDays == null || restDays.isBlank()) {
+            return EnumSet.noneOf(DayOfWeek.class);
+        }
+        Set<DayOfWeek> result = EnumSet.noneOf(DayOfWeek.class);
+        Arrays.stream(restDays.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(this::parseDayOfWeek)
+                .filter(d -> d != null)
+                .forEach(result::add);
+        return result;
+    }
+
+    private DayOfWeek parseDayOfWeek(String token) {
+        return switch (token.toUpperCase()) {
+            case "MON" -> DayOfWeek.MONDAY;
+            case "TUE" -> DayOfWeek.TUESDAY;
+            case "WED" -> DayOfWeek.WEDNESDAY;
+            case "THU" -> DayOfWeek.THURSDAY;
+            case "FRI" -> DayOfWeek.FRIDAY;
+            case "SAT" -> DayOfWeek.SATURDAY;
+            case "SUN" -> DayOfWeek.SUNDAY;
+            default -> null;
+        };
+    }
+
+    private int ceilDiv(int dividend, int divisor) {
+        if (divisor == 0) {
+            return 0;
+        }
+        return (dividend + divisor - 1) / divisor;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/MaterialService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/MaterialService.java
@@ -19,6 +19,8 @@ import ds.project.orino.domain.material.repository.StudyMaterialRepository;
 import ds.project.orino.domain.material.repository.StudyUnitRepository;
 import ds.project.orino.domain.member.entity.Member;
 import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.domain.preference.repository.UserPreferenceRepository;
 import ds.project.orino.planner.material.dto.AllocationRequest;
 import ds.project.orino.planner.material.dto.AllocationResponse;
 import ds.project.orino.planner.material.dto.CreateMaterialRequest;
@@ -26,6 +28,7 @@ import ds.project.orino.planner.material.dto.CreateUnitBatchRequest;
 import ds.project.orino.planner.material.dto.CreateUnitRequest;
 import ds.project.orino.planner.material.dto.DailyOverrideRequest;
 import ds.project.orino.planner.material.dto.DailyOverrideResponse;
+import ds.project.orino.planner.material.dto.DeadlineProjectionResponse;
 import ds.project.orino.planner.material.dto.MaterialDetailResponse;
 import ds.project.orino.planner.material.dto.MaterialResponse;
 import ds.project.orino.planner.material.dto.ReviewConfigRequest;
@@ -52,6 +55,8 @@ public class MaterialService {
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
     private final GoalRepository goalRepository;
+    private final UserPreferenceRepository preferenceRepository;
+    private final DeadlineCalculator deadlineCalculator;
     private final DirtyScheduleMarker dirtyScheduleMarker;
 
     public MaterialService(
@@ -63,6 +68,8 @@ public class MaterialService {
             MemberRepository memberRepository,
             CategoryRepository categoryRepository,
             GoalRepository goalRepository,
+            UserPreferenceRepository preferenceRepository,
+            DeadlineCalculator deadlineCalculator,
             DirtyScheduleMarker dirtyScheduleMarker) {
         this.materialRepository = materialRepository;
         this.unitRepository = unitRepository;
@@ -72,6 +79,8 @@ public class MaterialService {
         this.memberRepository = memberRepository;
         this.categoryRepository = categoryRepository;
         this.goalRepository = goalRepository;
+        this.preferenceRepository = preferenceRepository;
+        this.deadlineCalculator = deadlineCalculator;
         this.dirtyScheduleMarker = dirtyScheduleMarker;
     }
 
@@ -86,7 +95,12 @@ public class MaterialService {
     public MaterialDetailResponse getMaterial(Long memberId,
                                               Long materialId) {
         StudyMaterial material = findMaterial(materialId, memberId);
-        return MaterialDetailResponse.from(material);
+        UserPreference preference = preferenceRepository
+                .findByMemberId(memberId)
+                .orElse(null);
+        DeadlineProjectionResponse projection = deadlineCalculator
+                .calculate(material, preference, LocalDate.now());
+        return MaterialDetailResponse.from(material, projection);
     }
 
     @Transactional

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/MaterialControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/MaterialControllerTest.java
@@ -166,7 +166,14 @@ class MaterialControllerTest extends ApiTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.title")
                         .value("이펙티브 자바"))
-                .andExpect(jsonPath("$.data.units").isArray());
+                .andExpect(jsonPath("$.data.units").isArray())
+                .andExpect(jsonPath("$.data.deadlineProjection").exists())
+                .andExpect(jsonPath(
+                        "$.data.deadlineProjection.deadline")
+                        .value("2026-07-01"))
+                .andExpect(jsonPath(
+                        "$.data.deadlineProjection.paceStatus")
+                        .value("AHEAD"));
     }
 
     @Test

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/service/DeadlineCalculatorTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/service/DeadlineCalculatorTest.java
@@ -1,0 +1,223 @@
+package ds.project.orino.planner.material.service;
+
+import ds.project.orino.domain.material.entity.DeadlineMode;
+import ds.project.orino.domain.material.entity.MaterialAllocation;
+import ds.project.orino.domain.material.entity.MaterialType;
+import ds.project.orino.domain.material.entity.PaceStatus;
+import ds.project.orino.domain.material.entity.StudyMaterial;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.entity.UnitStatus;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.planner.material.dto.DeadlineProjectionResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeadlineCalculatorTest {
+
+    private DeadlineCalculator calculator;
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        calculator = new DeadlineCalculator();
+        member = new Member("user", "pw");
+    }
+
+    @Test
+    @DisplayName("deadlineMode=FREE 이면 null을 반환한다")
+    void returnsNull_whenFreeMode() {
+        StudyMaterial material = new StudyMaterial(
+                member, "자유모드", MaterialType.BOOK, null, null,
+                null, DeadlineMode.FREE);
+        addUnit(material, 1, 30, UnitStatus.PENDING);
+
+        DeadlineProjectionResponse result = calculator.calculate(
+                material, preference(null), LocalDate.of(2026, 4, 1));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("deadline이 null이면 null을 반환한다")
+    void returnsNull_whenDeadlineNull() {
+        StudyMaterial material = new StudyMaterial(
+                member, "마감없음", MaterialType.BOOK, null, null,
+                null, DeadlineMode.DEADLINE);
+
+        DeadlineProjectionResponse result = calculator.calculate(
+                material, preference(null), LocalDate.of(2026, 4, 1));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("남은 단위와 가용 학습일로 하루 필요량을 계산한다")
+    void calculatesDailyRequirement() {
+        // 2026-04-06(월) ~ 2026-04-12(일) = 7일, restDays 없음 → 7일
+        StudyMaterial material = deadlineMaterial(LocalDate.of(2026, 4, 12));
+        addUnit(material, 1, 30, UnitStatus.PENDING);
+        addUnit(material, 2, 30, UnitStatus.PENDING);
+        addUnit(material, 3, 30, UnitStatus.PENDING);
+        addUnit(material, 4, 30, UnitStatus.PENDING);
+        addUnit(material, 5, 30, UnitStatus.PENDING);
+        addUnit(material, 6, 30, UnitStatus.PENDING);
+        addUnit(material, 7, 30, UnitStatus.PENDING);
+        setAllocation(material, 30);
+
+        DeadlineProjectionResponse result = calculator.calculate(
+                material, preference(null), LocalDate.of(2026, 4, 6));
+
+        assertThat(result.availableDays()).isEqualTo(7);
+        assertThat(result.remainingUnits()).isEqualTo(7);
+        assertThat(result.remainingMinutes()).isEqualTo(210);
+        assertThat(result.requiredUnitsPerDay()).isEqualTo(1);
+        assertThat(result.requiredMinutesPerDay()).isEqualTo(30);
+        assertThat(result.paceStatus()).isEqualTo(PaceStatus.ON_TRACK);
+    }
+
+    @Test
+    @DisplayName("restDays에 포함된 요일은 가용 학습일에서 제외된다")
+    void excludesRestDays() {
+        // 2026-04-06(월) ~ 2026-04-12(일) = 7일
+        // restDays=SAT,SUN → 5일만 가용
+        StudyMaterial material = deadlineMaterial(LocalDate.of(2026, 4, 12));
+        addUnit(material, 1, 30, UnitStatus.PENDING);
+
+        DeadlineProjectionResponse result = calculator.calculate(
+                material, preference("SAT,SUN"), LocalDate.of(2026, 4, 6));
+
+        assertThat(result.availableDays()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("완료된 단위는 remainingUnits 에서 제외된다")
+    void excludesCompletedUnits() {
+        StudyMaterial material = deadlineMaterial(LocalDate.of(2026, 4, 10));
+        addUnit(material, 1, 30, UnitStatus.COMPLETED);
+        addUnit(material, 2, 30, UnitStatus.COMPLETED);
+        addUnit(material, 3, 60, UnitStatus.PENDING);
+
+        DeadlineProjectionResponse result = calculator.calculate(
+                material, preference(null), LocalDate.of(2026, 4, 6));
+
+        assertThat(result.totalUnits()).isEqualTo(3);
+        assertThat(result.completedUnits()).isEqualTo(2);
+        assertThat(result.remainingUnits()).isEqualTo(1);
+        assertThat(result.remainingMinutes()).isEqualTo(60);
+    }
+
+    @Test
+    @DisplayName("필요량이 할당량보다 적으면 AHEAD 상태다")
+    void ahead_whenRequiredLessThanAllocated() {
+        StudyMaterial material = deadlineMaterial(LocalDate.of(2026, 4, 12));
+        addUnit(material, 1, 30, UnitStatus.PENDING);
+        setAllocation(material, 120);
+
+        DeadlineProjectionResponse result = calculator.calculate(
+                material, preference(null), LocalDate.of(2026, 4, 6));
+
+        assertThat(result.paceStatus()).isEqualTo(PaceStatus.AHEAD);
+    }
+
+    @Test
+    @DisplayName("필요량이 할당량보다 많으면 BEHIND 상태다")
+    void behind_whenRequiredExceedsAllocated() {
+        StudyMaterial material = deadlineMaterial(LocalDate.of(2026, 4, 7));
+        addUnit(material, 1, 120, UnitStatus.PENDING);
+        addUnit(material, 2, 120, UnitStatus.PENDING);
+        setAllocation(material, 60);
+
+        DeadlineProjectionResponse result = calculator.calculate(
+                material, preference(null), LocalDate.of(2026, 4, 6));
+
+        assertThat(result.paceStatus()).isEqualTo(PaceStatus.BEHIND);
+    }
+
+    @Test
+    @DisplayName("deadline이 이미 지났고 남은 단위가 있으면 BEHIND")
+    void behind_whenDeadlinePassed() {
+        StudyMaterial material = deadlineMaterial(LocalDate.of(2026, 4, 1));
+        addUnit(material, 1, 30, UnitStatus.PENDING);
+        setAllocation(material, 60);
+
+        DeadlineProjectionResponse result = calculator.calculate(
+                material, preference(null), LocalDate.of(2026, 4, 6));
+
+        assertThat(result.availableDays()).isZero();
+        assertThat(result.paceStatus()).isEqualTo(PaceStatus.BEHIND);
+        assertThat(result.requiredMinutesPerDay()).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("남은 단위가 없으면 AHEAD")
+    void ahead_whenNoRemaining() {
+        StudyMaterial material = deadlineMaterial(LocalDate.of(2026, 4, 10));
+        addUnit(material, 1, 30, UnitStatus.COMPLETED);
+        addUnit(material, 2, 30, UnitStatus.COMPLETED);
+        setAllocation(material, 60);
+
+        DeadlineProjectionResponse result = calculator.calculate(
+                material, preference(null), LocalDate.of(2026, 4, 6));
+
+        assertThat(result.remainingUnits()).isZero();
+        assertThat(result.paceStatus()).isEqualTo(PaceStatus.AHEAD);
+    }
+
+    @Test
+    @DisplayName("allocation이 없으면 preference.dailyStudyMinutes 를 기준으로 판정")
+    void fallsBackToPreferenceDailyStudyMinutes() {
+        StudyMaterial material = deadlineMaterial(LocalDate.of(2026, 4, 10));
+        addUnit(material, 1, 60, UnitStatus.PENDING);
+        // allocation 설정 안 함
+
+        UserPreference preference = preference(null);
+        ReflectionTestUtils.setField(
+                preference, "dailyStudyMinutes", 120);
+
+        DeadlineProjectionResponse result = calculator.calculate(
+                material, preference, LocalDate.of(2026, 4, 6));
+
+        assertThat(result.allocatedMinutesPerDay()).isEqualTo(120);
+        assertThat(result.paceStatus()).isEqualTo(PaceStatus.AHEAD);
+    }
+
+    // --- helpers ---
+
+    private StudyMaterial deadlineMaterial(LocalDate deadline) {
+        return new StudyMaterial(
+                member, "교재", MaterialType.BOOK, null, null,
+                deadline, DeadlineMode.DEADLINE);
+    }
+
+    private void addUnit(StudyMaterial material, int order,
+                         int minutes, UnitStatus status) {
+        StudyUnit unit = new StudyUnit(
+                material, "단위" + order, order, minutes, null);
+        if (status == UnitStatus.COMPLETED) {
+            ReflectionTestUtils.setField(unit, "status",
+                    UnitStatus.COMPLETED);
+        }
+        material.getUnits().add(unit);
+    }
+
+    private void setAllocation(StudyMaterial material, int minutes) {
+        MaterialAllocation allocation =
+                new MaterialAllocation(material, minutes);
+        ReflectionTestUtils.setField(material, "allocation", allocation);
+    }
+
+    private UserPreference preference(String restDays) {
+        UserPreference preference = new UserPreference(member);
+        if (restDays != null) {
+            ReflectionTestUtils.setField(preference, "restDays", restDays);
+        }
+        return preference;
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/service/MaterialServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/service/MaterialServiceTest.java
@@ -23,6 +23,7 @@ import ds.project.orino.domain.material.repository.StudyMaterialRepository;
 import ds.project.orino.domain.material.repository.StudyUnitRepository;
 import ds.project.orino.domain.member.entity.Member;
 import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.preference.repository.UserPreferenceRepository;
 import ds.project.orino.planner.material.dto.AllocationRequest;
 import ds.project.orino.planner.material.dto.AllocationResponse;
 import ds.project.orino.planner.material.dto.CreateMaterialRequest;
@@ -68,17 +69,21 @@ class MaterialServiceTest {
     @Mock private MemberRepository memberRepository;
     @Mock private CategoryRepository categoryRepository;
     @Mock private GoalRepository goalRepository;
+    @Mock private UserPreferenceRepository preferenceRepository;
     @Mock private DirtyScheduleMarker dirtyScheduleMarker;
+    private DeadlineCalculator deadlineCalculator;
 
     private Member member;
 
     @BeforeEach
     void setUp() {
+        deadlineCalculator = new DeadlineCalculator();
         materialService = new MaterialService(
                 materialRepository, unitRepository,
                 allocationRepository, dailyOverrideRepository,
                 reviewConfigRepository, memberRepository,
                 categoryRepository, goalRepository,
+                preferenceRepository, deadlineCalculator,
                 dirtyScheduleMarker);
         member = new Member("admin", "encoded");
     }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/material/entity/PaceStatus.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/material/entity/PaceStatus.java
@@ -1,0 +1,5 @@
+package ds.project.orino.domain.material.entity;
+
+public enum PaceStatus {
+    AHEAD, ON_TRACK, BEHIND
+}


### PR DESCRIPTION
closes #156

## Description

학습 자료의 목표일 기준으로 하루 필요 학습량을 자동 계산하고, 현재 할당량과 비교해 페이스 상태를 판정하는 역산 로직을 추가했습니다.

## 주요 변경사항

### 1. PaceStatus enum 추가
- `domain/material/entity/PaceStatus.java` — `AHEAD` / `ON_TRACK` / `BEHIND`

### 2. DeadlineCalculator 컴포넌트 구현
- `planner/material/service/DeadlineCalculator.java` (신규)
- 오늘 ~ deadline 사이 가용 학습일 계산 (`UserPreference.restDays` 제외)
- 하루 필요 단위 수 = `ceil(remainingUnits / availableDays)`
- 하루 필요 분 = `ceil(remainingMinutes / availableDays)`
- `MaterialAllocation.defaultMinutes` (없으면 `preference.dailyStudyMinutes`) 대비 필요량 비교로 페이스 판정

### 3. DeadlineProjectionResponse DTO
- totalUnits, completedUnits, remainingUnits, remainingMinutes
- availableDays, requiredUnitsPerDay, requiredMinutesPerDay, allocatedMinutesPerDay, paceStatus

### 4. 학습 자료 상세 조회 API 확장
- `MaterialService.getMaterial` 에서 `UserPreference` 조회 후 `DeadlineCalculator` 호출
- `MaterialDetailResponse.deadlineProjection` 필드로 응답 포함
- `DeadlineMode=DEADLINE` 이고 deadline 이 설정된 경우에만 계산

### 5. 테스트
- `DeadlineCalculatorTest` 신규 — 10개 케이스
  - FREE 모드 / deadline null 반환
  - 가용 학습일 계산, restDays 제외
  - 완료 단위 제외
  - AHEAD/ON_TRACK/BEHIND 판정
  - deadline 지남 / 남은 단위 0 / allocation 없을 때 preference fallback
- `MaterialControllerTest.getMaterial` — deadlineProjection 응답 검증
- 기존 `MaterialServiceTest` — DeadlineCalculator 주입

## Test plan
- [x] `./gradlew build` 전체 빌드/테스트 통과