### PR TITLE
feat : 복습 난이도 피드백 및 놓침 정책 처리

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/MissedReviewProcessor.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/MissedReviewProcessor.java
@@ -1,0 +1,88 @@
+package ds.project.orino.planner.review.service;
+
+import ds.project.orino.domain.material.entity.MissedPolicy;
+import ds.project.orino.domain.material.entity.ReviewConfig;
+import ds.project.orino.domain.material.entity.StudyMaterial;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.repository.ReviewConfigRepository;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.domain.preference.repository.UserPreferenceRepository;
+import ds.project.orino.domain.review.entity.ReviewSchedule;
+import ds.project.orino.domain.review.entity.ReviewStatus;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import ds.project.orino.planner.calendar.service.ReviewScheduleGenerator;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * OVERDUE 상태의 복습에 대한 놓침 정책(missedPolicy) 을 적용한다.
+ *
+ * <ul>
+ *     <li>IMMEDIATE: OVERDUE 유지 (ItemCollector 가 다음 날 최우선 배치)</li>
+ *     <li>SKIP: SKIPPED 로 전환, 이후 예정된 복습은 그대로 유지</li>
+ *     <li>RESET: 같은 StudyUnit 의 PENDING/OVERDUE 복습 전부 삭제 후 오늘 기준으로 재생성</li>
+ * </ul>
+ *
+ * 정책 우선순위: 자료별 {@link ReviewConfig#getMissedPolicy()}
+ *              → 사용자 {@link UserPreference#getDefaultMissedPolicy()}
+ *              → {@link MissedPolicy#IMMEDIATE} (최종 폴백)
+ */
+@Component
+public class MissedReviewProcessor {
+
+    private final ReviewConfigRepository reviewConfigRepository;
+    private final UserPreferenceRepository userPreferenceRepository;
+    private final ReviewScheduleRepository reviewScheduleRepository;
+    private final ReviewScheduleGenerator reviewScheduleGenerator;
+
+    public MissedReviewProcessor(
+            ReviewConfigRepository reviewConfigRepository,
+            UserPreferenceRepository userPreferenceRepository,
+            ReviewScheduleRepository reviewScheduleRepository,
+            ReviewScheduleGenerator reviewScheduleGenerator) {
+        this.reviewConfigRepository = reviewConfigRepository;
+        this.userPreferenceRepository = userPreferenceRepository;
+        this.reviewScheduleRepository = reviewScheduleRepository;
+        this.reviewScheduleGenerator = reviewScheduleGenerator;
+    }
+
+    public MissedPolicy apply(Long memberId, ReviewSchedule overdueReview,
+                              LocalDate today) {
+        MissedPolicy policy = resolvePolicy(memberId, overdueReview);
+        switch (policy) {
+            case IMMEDIATE -> {
+                // OVERDUE 그대로 유지
+            }
+            case SKIP -> overdueReview.skip();
+            case RESET -> resetReviews(memberId, overdueReview, today);
+            default -> {
+                // no-op
+            }
+        }
+        return policy;
+    }
+
+    private MissedPolicy resolvePolicy(Long memberId, ReviewSchedule review) {
+        StudyMaterial material = review.getStudyUnit().getMaterial();
+        return reviewConfigRepository.findByMaterialId(material.getId())
+                .map(ReviewConfig::getMissedPolicy)
+                .orElseGet(() -> userPreferenceRepository
+                        .findByMemberId(memberId)
+                        .map(UserPreference::getDefaultMissedPolicy)
+                        .orElse(MissedPolicy.IMMEDIATE));
+    }
+
+    private void resetReviews(Long memberId, ReviewSchedule review,
+                              LocalDate today) {
+        StudyUnit unit = review.getStudyUnit();
+        List<ReviewSchedule> remaining = reviewScheduleRepository
+                .findByStudyUnitIdAndStatusIn(
+                        unit.getId(),
+                        List.of(ReviewStatus.PENDING, ReviewStatus.OVERDUE));
+        reviewScheduleRepository.deleteAll(remaining);
+        reviewScheduleRepository.flush();
+        reviewScheduleGenerator.generate(memberId, unit, today);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewFeedbackProcessor.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewFeedbackProcessor.java
@@ -1,0 +1,93 @@
+package ds.project.orino.planner.review.service;
+
+import ds.project.orino.domain.review.entity.DifficultyFeedback;
+import ds.project.orino.domain.review.entity.ReviewSchedule;
+import ds.project.orino.domain.review.entity.ReviewStatus;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+/**
+ * 복습 난이도 피드백에 따라 남은 복습 간격을 조절한다.
+ *
+ * <ul>
+ *     <li>EASY: 남은 간격 × 1.5 (올림)</li>
+ *     <li>NORMAL: 변경 없음</li>
+ *     <li>HARD: 남은 간격 × 0.7 (올림) + 추가 복습 1회 삽입</li>
+ * </ul>
+ *
+ * 간격 스케일은 완료된 복습의 scheduledDate 를 기준으로 재계산하여
+ * 각 PENDING 복습의 scheduledDate 를 업데이트한다.
+ */
+@Component
+public class ReviewFeedbackProcessor {
+
+    private static final BigDecimal EASY_FACTOR = new BigDecimal("1.5");
+    private static final BigDecimal HARD_FACTOR = new BigDecimal("0.7");
+    private static final int HARD_EXTRA_INTERVAL_DAYS = 2;
+
+    private final ReviewScheduleRepository reviewScheduleRepository;
+
+    public ReviewFeedbackProcessor(
+            ReviewScheduleRepository reviewScheduleRepository) {
+        this.reviewScheduleRepository = reviewScheduleRepository;
+    }
+
+    public void applyFeedback(ReviewSchedule completed,
+                              DifficultyFeedback feedback) {
+        if (feedback == null || feedback == DifficultyFeedback.NORMAL) {
+            return;
+        }
+        LocalDate baseDate = completed.getScheduledDate();
+        List<ReviewSchedule> upcoming = reviewScheduleRepository
+                .findUpcomingByStudyUnit(
+                        completed.getStudyUnit().getId(),
+                        completed.getSequence(),
+                        ReviewStatus.PENDING);
+        switch (feedback) {
+            case EASY -> scaleIntervals(upcoming, baseDate, EASY_FACTOR);
+            case HARD -> {
+                scaleIntervals(upcoming, baseDate, HARD_FACTOR);
+                insertExtraReview(completed, baseDate);
+            }
+            default -> {
+            }
+        }
+    }
+
+    private void scaleIntervals(List<ReviewSchedule> reviews,
+                                LocalDate baseDate, BigDecimal factor) {
+        for (ReviewSchedule r : reviews) {
+            long originalGap = ChronoUnit.DAYS.between(
+                    baseDate, r.getScheduledDate());
+            if (originalGap <= 0) {
+                continue;
+            }
+            long scaledGap = BigDecimal.valueOf(originalGap)
+                    .multiply(factor)
+                    .setScale(0, RoundingMode.CEILING)
+                    .longValueExact();
+            if (scaledGap < 1) {
+                scaledGap = 1;
+            }
+            r.reschedule(baseDate.plusDays(scaledGap));
+        }
+    }
+
+    private void insertExtraReview(ReviewSchedule completed,
+                                   LocalDate baseDate) {
+        int maxSequence = reviewScheduleRepository
+                .findMaxSequenceByStudyUnit(
+                        completed.getStudyUnit().getId());
+        ReviewSchedule extra = new ReviewSchedule(
+                completed.getStudyUnit(),
+                maxSequence + 1,
+                baseDate.plusDays(HARD_EXTRA_INTERVAL_DAYS));
+        reviewScheduleRepository.save(extra);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/service/MissedReviewProcessorTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/service/MissedReviewProcessorTest.java
@@ -1,0 +1,163 @@
+package ds.project.orino.planner.review.service;
+
+import ds.project.orino.domain.material.entity.DeadlineMode;
+import ds.project.orino.domain.material.entity.MaterialType;
+import ds.project.orino.domain.material.entity.MissedPolicy;
+import ds.project.orino.domain.material.entity.ReviewConfig;
+import ds.project.orino.domain.material.entity.StudyMaterial;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.repository.ReviewConfigRepository;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.domain.preference.repository.UserPreferenceRepository;
+import ds.project.orino.domain.review.entity.ReviewSchedule;
+import ds.project.orino.domain.review.entity.ReviewStatus;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import ds.project.orino.planner.calendar.service.ReviewScheduleGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MissedReviewProcessorTest {
+
+    @Mock private ReviewConfigRepository reviewConfigRepository;
+    @Mock private UserPreferenceRepository userPreferenceRepository;
+    @Mock private ReviewScheduleRepository reviewScheduleRepository;
+    @Mock private ReviewScheduleGenerator reviewScheduleGenerator;
+
+    private MissedReviewProcessor processor;
+
+    private StudyMaterial material;
+    private StudyUnit unit;
+
+    @BeforeEach
+    void setUp() {
+        processor = new MissedReviewProcessor(
+                reviewConfigRepository, userPreferenceRepository,
+                reviewScheduleRepository, reviewScheduleGenerator);
+        Member member = new Member("user", "pw");
+        material = new StudyMaterial(
+                member, "자료", MaterialType.BOOK, null, null,
+                null, DeadlineMode.FREE);
+        ReflectionTestUtils.setField(material, "id", 10L);
+        unit = new StudyUnit(material, "단원1", 1, 30, null);
+        ReflectionTestUtils.setField(unit, "id", 20L);
+    }
+
+    @Test
+    @DisplayName("IMMEDIATE 정책은 상태를 변경하지 않는다")
+    void immediate_keepsOverdue() {
+        ReviewSchedule overdue = overdueReview();
+        given(reviewConfigRepository.findByMaterialId(10L))
+                .willReturn(Optional.of(config(MissedPolicy.IMMEDIATE)));
+
+        MissedPolicy result = processor.apply(
+                1L, overdue, LocalDate.of(2026, 4, 6));
+
+        assertThat(result).isEqualTo(MissedPolicy.IMMEDIATE);
+        assertThat(overdue.getStatus()).isEqualTo(ReviewStatus.OVERDUE);
+        verify(reviewScheduleRepository, never())
+                .deleteAll(any());
+        verify(reviewScheduleGenerator, never())
+                .generate(anyLong(), any(), any());
+    }
+
+    @Test
+    @DisplayName("SKIP 정책은 SKIPPED 상태로 전환한다")
+    void skip_marksSkipped() {
+        ReviewSchedule overdue = overdueReview();
+        given(reviewConfigRepository.findByMaterialId(10L))
+                .willReturn(Optional.of(config(MissedPolicy.SKIP)));
+
+        MissedPolicy result = processor.apply(
+                1L, overdue, LocalDate.of(2026, 4, 6));
+
+        assertThat(result).isEqualTo(MissedPolicy.SKIP);
+        assertThat(overdue.getStatus()).isEqualTo(ReviewStatus.SKIPPED);
+    }
+
+    @Test
+    @DisplayName("RESET 정책은 남은 복습을 삭제 후 재생성한다")
+    void reset_regeneratesAll() {
+        ReviewSchedule overdue = overdueReview();
+        ReviewSchedule other = new ReviewSchedule(
+                unit, 3, LocalDate.of(2026, 4, 20));
+        given(reviewConfigRepository.findByMaterialId(10L))
+                .willReturn(Optional.of(config(MissedPolicy.RESET)));
+        given(reviewScheduleRepository.findByStudyUnitIdAndStatusIn(
+                eq(20L), any()))
+                .willReturn(List.of(overdue, other));
+
+        LocalDate today = LocalDate.of(2026, 4, 6);
+        MissedPolicy result = processor.apply(1L, overdue, today);
+
+        assertThat(result).isEqualTo(MissedPolicy.RESET);
+        verify(reviewScheduleRepository)
+                .deleteAll(List.of(overdue, other));
+        verify(reviewScheduleRepository).flush();
+        verify(reviewScheduleGenerator).generate(1L, unit, today);
+    }
+
+    @Test
+    @DisplayName("ReviewConfig가 없으면 UserPreference 기본 정책을 사용한다")
+    void fallsBackToUserPreference() {
+        ReviewSchedule overdue = overdueReview();
+        given(reviewConfigRepository.findByMaterialId(10L))
+                .willReturn(Optional.empty());
+        UserPreference preference = new UserPreference(material.getMember());
+        ReflectionTestUtils.setField(
+                preference, "defaultMissedPolicy", MissedPolicy.SKIP);
+        given(userPreferenceRepository.findByMemberId(1L))
+                .willReturn(Optional.of(preference));
+
+        MissedPolicy result = processor.apply(
+                1L, overdue, LocalDate.of(2026, 4, 6));
+
+        assertThat(result).isEqualTo(MissedPolicy.SKIP);
+        assertThat(overdue.getStatus()).isEqualTo(ReviewStatus.SKIPPED);
+    }
+
+    @Test
+    @DisplayName("설정과 Preference가 모두 없으면 IMMEDIATE 폴백")
+    void fallsBackToImmediate_whenNoSettings() {
+        ReviewSchedule overdue = overdueReview();
+        given(reviewConfigRepository.findByMaterialId(10L))
+                .willReturn(Optional.empty());
+        given(userPreferenceRepository.findByMemberId(1L))
+                .willReturn(Optional.empty());
+
+        MissedPolicy result = processor.apply(
+                1L, overdue, LocalDate.of(2026, 4, 6));
+
+        assertThat(result).isEqualTo(MissedPolicy.IMMEDIATE);
+        assertThat(overdue.getStatus()).isEqualTo(ReviewStatus.OVERDUE);
+    }
+
+    private ReviewSchedule overdueReview() {
+        ReviewSchedule review = new ReviewSchedule(
+                unit, 1, LocalDate.of(2026, 4, 4));
+        review.markOverdue();
+        return review;
+    }
+
+    private ReviewConfig config(MissedPolicy policy) {
+        return new ReviewConfig(material, "1,2,3,7,15,30", policy);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/service/ReviewFeedbackProcessorTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/service/ReviewFeedbackProcessorTest.java
@@ -1,0 +1,159 @@
+package ds.project.orino.planner.review.service;
+
+import ds.project.orino.domain.material.entity.DeadlineMode;
+import ds.project.orino.domain.material.entity.MaterialType;
+import ds.project.orino.domain.material.entity.StudyMaterial;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.review.entity.DifficultyFeedback;
+import ds.project.orino.domain.review.entity.ReviewSchedule;
+import ds.project.orino.domain.review.entity.ReviewStatus;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewFeedbackProcessorTest {
+
+    @Mock private ReviewScheduleRepository reviewScheduleRepository;
+    private ReviewFeedbackProcessor processor;
+
+    private StudyUnit unit;
+
+    @BeforeEach
+    void setUp() {
+        processor = new ReviewFeedbackProcessor(reviewScheduleRepository);
+        Member member = new Member("user", "pw");
+        StudyMaterial material = new StudyMaterial(
+                member, "자료", MaterialType.BOOK, null, null,
+                null, DeadlineMode.FREE);
+        ReflectionTestUtils.setField(material, "id", 10L);
+        unit = new StudyUnit(material, "단원1", 1, 30, null);
+        ReflectionTestUtils.setField(unit, "id", 20L);
+    }
+
+    @Test
+    @DisplayName("NORMAL 피드백은 간격을 변경하지 않는다")
+    void normalFeedback_doesNothing() {
+        ReviewSchedule completed = review(1, LocalDate.of(2026, 4, 6));
+
+        processor.applyFeedback(completed, DifficultyFeedback.NORMAL);
+
+        verify(reviewScheduleRepository, never())
+                .findUpcomingByStudyUnit(anyLong(), anyInt(), any());
+        verify(reviewScheduleRepository, never())
+                .save(any(ReviewSchedule.class));
+    }
+
+    @Test
+    @DisplayName("null 피드백은 아무것도 하지 않는다")
+    void nullFeedback_doesNothing() {
+        ReviewSchedule completed = review(1, LocalDate.of(2026, 4, 6));
+
+        processor.applyFeedback(completed, null);
+
+        verify(reviewScheduleRepository, never())
+                .findUpcomingByStudyUnit(anyLong(), anyInt(), any());
+    }
+
+    @Test
+    @DisplayName("EASY 피드백은 남은 간격을 1.5배로 늘린다")
+    void easyFeedback_scalesBy1_5() {
+        // baseDate=2026-04-06
+        // sequence=2: 2026-04-10 (간격 4일 → 6일) → 2026-04-12
+        // sequence=3: 2026-04-20 (간격 14일 → 21일) → 2026-04-27
+        LocalDate baseDate = LocalDate.of(2026, 4, 6);
+        ReviewSchedule completed = review(1, baseDate);
+        ReviewSchedule next1 = review(2, LocalDate.of(2026, 4, 10));
+        ReviewSchedule next2 = review(3, LocalDate.of(2026, 4, 20));
+        given(reviewScheduleRepository.findUpcomingByStudyUnit(
+                eq(20L), eq(1), eq(ReviewStatus.PENDING)))
+                .willReturn(List.of(next1, next2));
+
+        processor.applyFeedback(completed, DifficultyFeedback.EASY);
+
+        assertThat(next1.getScheduledDate())
+                .isEqualTo(LocalDate.of(2026, 4, 12));
+        assertThat(next2.getScheduledDate())
+                .isEqualTo(LocalDate.of(2026, 4, 27));
+        verify(reviewScheduleRepository, never())
+                .save(any(ReviewSchedule.class));
+    }
+
+    @Test
+    @DisplayName("HARD 피드백은 간격을 0.7배로 줄이고 추가 복습을 삽입한다")
+    void hardFeedback_scalesBy0_7_andInsertsExtra() {
+        // baseDate=2026-04-06
+        // sequence=2: 2026-04-10 (간격 4일 → ceil(2.8)=3일) → 2026-04-09
+        // sequence=3: 2026-04-20 (간격 14일 → ceil(9.8)=10일) → 2026-04-16
+        // 추가 복습: sequence=max+1, 2026-04-08 (baseDate + 2)
+        LocalDate baseDate = LocalDate.of(2026, 4, 6);
+        ReviewSchedule completed = review(1, baseDate);
+        ReviewSchedule next1 = review(2, LocalDate.of(2026, 4, 10));
+        ReviewSchedule next2 = review(3, LocalDate.of(2026, 4, 20));
+        given(reviewScheduleRepository.findUpcomingByStudyUnit(
+                eq(20L), eq(1), eq(ReviewStatus.PENDING)))
+                .willReturn(new ArrayList<>(List.of(next1, next2)));
+        given(reviewScheduleRepository.findMaxSequenceByStudyUnit(20L))
+                .willReturn(3);
+
+        processor.applyFeedback(completed, DifficultyFeedback.HARD);
+
+        assertThat(next1.getScheduledDate())
+                .isEqualTo(LocalDate.of(2026, 4, 9));
+        assertThat(next2.getScheduledDate())
+                .isEqualTo(LocalDate.of(2026, 4, 16));
+
+        ArgumentCaptor<ReviewSchedule> captor =
+                ArgumentCaptor.forClass(ReviewSchedule.class);
+        verify(reviewScheduleRepository).save(captor.capture());
+        ReviewSchedule extra = captor.getValue();
+        assertThat(extra.getSequence()).isEqualTo(4);
+        assertThat(extra.getScheduledDate())
+                .isEqualTo(LocalDate.of(2026, 4, 8));
+    }
+
+    @Test
+    @DisplayName("HARD 피드백 시 남은 복습이 없어도 추가 복습은 삽입된다")
+    void hardFeedback_withNoUpcoming_stillInsertsExtra() {
+        LocalDate baseDate = LocalDate.of(2026, 4, 6);
+        ReviewSchedule completed = review(3, baseDate);
+        given(reviewScheduleRepository.findUpcomingByStudyUnit(
+                eq(20L), eq(3), eq(ReviewStatus.PENDING)))
+                .willReturn(List.of());
+        given(reviewScheduleRepository.findMaxSequenceByStudyUnit(20L))
+                .willReturn(3);
+
+        processor.applyFeedback(completed, DifficultyFeedback.HARD);
+
+        ArgumentCaptor<ReviewSchedule> captor =
+                ArgumentCaptor.forClass(ReviewSchedule.class);
+        verify(reviewScheduleRepository).save(captor.capture());
+        assertThat(captor.getValue().getSequence()).isEqualTo(4);
+        assertThat(captor.getValue().getScheduledDate())
+                .isEqualTo(LocalDate.of(2026, 4, 8));
+    }
+
+    private ReviewSchedule review(int sequence, LocalDate date) {
+        return new ReviewSchedule(unit, sequence, date);
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/review/repository/ReviewScheduleRepository.java
@@ -32,4 +32,27 @@ public interface ReviewScheduleRepository
     List<ReviewSchedule> findByMemberAndDateAndStatus(@Param("memberId") Long memberId,
                                                       @Param("date") LocalDate date,
                                                       @Param("status") ReviewStatus status);
+
+    @Query("select r from ReviewSchedule r " +
+            "where r.studyUnit.id = :studyUnitId " +
+            "and r.status in :statuses " +
+            "order by r.sequence asc")
+    List<ReviewSchedule> findByStudyUnitIdAndStatusIn(
+            @Param("studyUnitId") Long studyUnitId,
+            @Param("statuses") List<ReviewStatus> statuses);
+
+    @Query("select r from ReviewSchedule r " +
+            "where r.studyUnit.id = :studyUnitId " +
+            "and r.sequence > :sequence " +
+            "and r.status = :status " +
+            "order by r.sequence asc")
+    List<ReviewSchedule> findUpcomingByStudyUnit(
+            @Param("studyUnitId") Long studyUnitId,
+            @Param("sequence") int sequence,
+            @Param("status") ReviewStatus status);
+
+    @Query("select coalesce(max(r.sequence), 0) from ReviewSchedule r " +
+            "where r.studyUnit.id = :studyUnitId")
+    int findMaxSequenceByStudyUnit(
+            @Param("studyUnitId") Long studyUnitId);
 }


### PR DESCRIPTION
closes #159

## Description

학습 단위 완료 시 복습 일정 생성은 PR #275 에서 이미 구현되어 있습니다. 본 PR 에서는 **난이도 피드백에 따른 간격 조절**과 **놓침 정책(missedPolicy) 처리** 로직을 추가합니다.

## 주요 변경사항

### 1. ReviewFeedbackProcessor (신규)
`planner/review/service/ReviewFeedbackProcessor.java`

복습 완료 시 난이도 피드백에 따라 같은 StudyUnit 의 이후 PENDING 복습 간격을 조정합니다.

- **EASY**: 남은 간격 × 1.5 (올림)
- **NORMAL**: 변경 없음
- **HARD**: 남은 간격 × 0.7 (올림) + 완료 기준일 + 2일 지점에 추가 복습 1회 삽입

간격 스케일은 완료된 복습의 `scheduledDate`를 baseDate 로 사용해 재계산합니다.

### 2. MissedReviewProcessor (신규)
`planner/review/service/MissedReviewProcessor.java`

OVERDUE 상태의 복습에 대해 놓침 정책을 적용합니다.

- **IMMEDIATE**: OVERDUE 그대로 유지 (ItemCollector 가 다음 날 최우선 배치)
- **SKIP**: SKIPPED 상태로 전환
- **RESET**: 같은 StudyUnit 의 PENDING/OVERDUE 복습 전부 삭제 후 오늘 기준으로 재생성

정책 우선순위: `ReviewConfig.missedPolicy` → `UserPreference.defaultMissedPolicy` → `IMMEDIATE` 폴백

### 3. ReviewScheduleRepository 쿼리 추가
- `findByStudyUnitIdAndStatusIn` — RESET 대상 조회
- `findUpcomingByStudyUnit` — 피드백 적용 대상 조회
- `findMaxSequenceByStudyUnit` — HARD 추가 복습 sequence 계산

### 4. 단위 테스트
- `ReviewFeedbackProcessorTest` (5개 케이스) — NORMAL/null/EASY/HARD/HARD-no-upcoming
- `MissedReviewProcessorTest` (5개 케이스) — IMMEDIATE/SKIP/RESET, preference fallback, no-settings fallback

## 후속 작업 (out of scope)
- OVERDUE 상태 전이 배치: #161
- 복습 피드백 API 엔드포인트 (ReviewFeedbackProcessor 호출): #160

## Test plan
- [x] `./gradlew build` 전체 빌드/테스트 통과