### PR TITLE
feat : 복습 피드백 API

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
@@ -1,0 +1,35 @@
+package ds.project.orino.planner.review.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.review.dto.SubmitFeedbackRequest;
+import ds.project.orino.planner.review.dto.SubmitFeedbackResponse;
+import ds.project.orino.planner.review.service.ReviewService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reviews")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    public ReviewController(ReviewService reviewService) {
+        this.reviewService = reviewService;
+    }
+
+    @PostMapping("/{id}/feedback")
+    public ResponseEntity<ApiResponse<SubmitFeedbackResponse>> submitFeedback(
+            Authentication authentication,
+            @PathVariable Long id,
+            @Valid @RequestBody SubmitFeedbackRequest request) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                reviewService.submitFeedback(memberId, id, request)));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/SubmitFeedbackRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/SubmitFeedbackRequest.java
@@ -1,0 +1,9 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.review.entity.DifficultyFeedback;
+import jakarta.validation.constraints.NotNull;
+
+public record SubmitFeedbackRequest(
+        @NotNull DifficultyFeedback feedback
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/SubmitFeedbackResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/SubmitFeedbackResponse.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.review.entity.DifficultyFeedback;
+import ds.project.orino.domain.review.entity.ReviewStatus;
+
+import java.time.LocalDate;
+
+public record SubmitFeedbackResponse(
+        Long reviewId,
+        ReviewStatus status,
+        DifficultyFeedback feedback,
+        LocalDate nextReviewDate,
+        Integer nextSequence
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewService.java
@@ -1,0 +1,81 @@
+package ds.project.orino.planner.review.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.review.entity.DifficultyFeedback;
+import ds.project.orino.domain.review.entity.ReviewSchedule;
+import ds.project.orino.domain.review.entity.ReviewStatus;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import ds.project.orino.planner.review.dto.SubmitFeedbackRequest;
+import ds.project.orino.planner.review.dto.SubmitFeedbackResponse;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final ReviewScheduleRepository reviewScheduleRepository;
+    private final ReviewFeedbackProcessor reviewFeedbackProcessor;
+    private final DirtyScheduleMarker dirtyScheduleMarker;
+
+    public ReviewService(
+            ReviewScheduleRepository reviewScheduleRepository,
+            ReviewFeedbackProcessor reviewFeedbackProcessor,
+            DirtyScheduleMarker dirtyScheduleMarker) {
+        this.reviewScheduleRepository = reviewScheduleRepository;
+        this.reviewFeedbackProcessor = reviewFeedbackProcessor;
+        this.dirtyScheduleMarker = dirtyScheduleMarker;
+    }
+
+    @Transactional
+    public SubmitFeedbackResponse submitFeedback(
+            Long memberId, Long reviewId, SubmitFeedbackRequest request) {
+        ReviewSchedule review = loadOwnedReview(memberId, reviewId);
+        if (review.getStatus() == ReviewStatus.COMPLETED
+                || review.getStatus() == ReviewStatus.SKIPPED) {
+            throw new CustomException(ErrorCode.INVALID_STATE);
+        }
+
+        DifficultyFeedback feedback = request.feedback();
+        review.complete(feedback);
+        reviewFeedbackProcessor.applyFeedback(review, feedback);
+
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
+
+        ReviewSchedule next = findNextReview(review);
+        return new SubmitFeedbackResponse(
+                review.getId(),
+                review.getStatus(),
+                review.getDifficultyFeedback(),
+                next != null ? next.getScheduledDate() : null,
+                next != null ? next.getSequence() : null);
+    }
+
+    private ReviewSchedule findNextReview(ReviewSchedule current) {
+        List<ReviewSchedule> upcoming = reviewScheduleRepository
+                .findUpcomingByStudyUnit(
+                        current.getStudyUnit().getId(),
+                        current.getSequence(),
+                        ReviewStatus.PENDING);
+        return upcoming.stream()
+                .min((a, b) -> a.getScheduledDate()
+                        .compareTo(b.getScheduledDate()))
+                .orElse(null);
+    }
+
+    private ReviewSchedule loadOwnedReview(Long memberId, Long reviewId) {
+        ReviewSchedule review = reviewScheduleRepository.findById(reviewId)
+                .orElseThrow(() -> new CustomException(
+                        ErrorCode.RESOURCE_NOT_FOUND));
+        Long ownerId = review.getStudyUnit().getMaterial()
+                .getMember().getId();
+        if (!ownerId.equals(memberId)) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+        return review;
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/service/ReviewServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/service/ReviewServiceTest.java
@@ -1,0 +1,274 @@
+package ds.project.orino.planner.review.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.material.entity.DeadlineMode;
+import ds.project.orino.domain.material.entity.MaterialType;
+import ds.project.orino.domain.material.entity.StudyMaterial;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.review.entity.DifficultyFeedback;
+import ds.project.orino.domain.review.entity.ReviewSchedule;
+import ds.project.orino.domain.review.entity.ReviewStatus;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import ds.project.orino.planner.review.dto.SubmitFeedbackRequest;
+import ds.project.orino.planner.review.dto.SubmitFeedbackResponse;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+    @Mock private ReviewScheduleRepository reviewScheduleRepository;
+    @Mock private ReviewFeedbackProcessor reviewFeedbackProcessor;
+    @Mock private DirtyScheduleMarker dirtyScheduleMarker;
+
+    private ReviewService reviewService;
+
+    private Member owner;
+    private StudyUnit unit;
+
+    @BeforeEach
+    void setUp() {
+        reviewService = new ReviewService(
+                reviewScheduleRepository,
+                reviewFeedbackProcessor,
+                dirtyScheduleMarker);
+        owner = new Member("user", "pw");
+        ReflectionTestUtils.setField(owner, "id", 1L);
+        StudyMaterial material = new StudyMaterial(
+                owner, "자료", MaterialType.BOOK, null, null,
+                null, DeadlineMode.FREE);
+        ReflectionTestUtils.setField(material, "id", 10L);
+        unit = new StudyUnit(material, "단원1", 1, 30, null);
+        ReflectionTestUtils.setField(unit, "id", 20L);
+    }
+
+    @Test
+    @DisplayName("NORMAL 피드백을 제출하면 COMPLETED로 전환되고 다음 복습 정보를 반환한다")
+    void submitFeedback_normal_success() {
+        ReviewSchedule review = review(1, LocalDate.of(2026, 4, 6));
+        ReflectionTestUtils.setField(review, "id", 100L);
+        ReviewSchedule next = review(2, LocalDate.of(2026, 4, 10));
+        ReflectionTestUtils.setField(next, "id", 101L);
+        given(reviewScheduleRepository.findById(100L))
+                .willReturn(Optional.of(review));
+        given(reviewScheduleRepository.findUpcomingByStudyUnit(
+                eq(20L), eq(1), eq(ReviewStatus.PENDING)))
+                .willReturn(List.of(next));
+
+        SubmitFeedbackResponse result = reviewService.submitFeedback(
+                1L, 100L,
+                new SubmitFeedbackRequest(DifficultyFeedback.NORMAL));
+
+        assertThat(result.reviewId()).isEqualTo(100L);
+        assertThat(result.status()).isEqualTo(ReviewStatus.COMPLETED);
+        assertThat(result.feedback())
+                .isEqualTo(DifficultyFeedback.NORMAL);
+        assertThat(result.nextReviewDate())
+                .isEqualTo(LocalDate.of(2026, 4, 10));
+        assertThat(result.nextSequence()).isEqualTo(2);
+        assertThat(review.getStatus()).isEqualTo(ReviewStatus.COMPLETED);
+        verify(reviewFeedbackProcessor)
+                .applyFeedback(review, DifficultyFeedback.NORMAL);
+        verify(dirtyScheduleMarker).markDirtyFromToday(1L);
+    }
+
+    @Test
+    @DisplayName("EASY 피드백을 제출하면 processor 에 EASY 로 위임한다")
+    void submitFeedback_easy_delegatesToProcessor() {
+        ReviewSchedule review = review(1, LocalDate.of(2026, 4, 6));
+        ReflectionTestUtils.setField(review, "id", 100L);
+        given(reviewScheduleRepository.findById(100L))
+                .willReturn(Optional.of(review));
+        given(reviewScheduleRepository.findUpcomingByStudyUnit(
+                anyLong(), anyInt(), any()))
+                .willReturn(List.of());
+
+        SubmitFeedbackResponse result = reviewService.submitFeedback(
+                1L, 100L,
+                new SubmitFeedbackRequest(DifficultyFeedback.EASY));
+
+        assertThat(result.feedback())
+                .isEqualTo(DifficultyFeedback.EASY);
+        assertThat(result.nextReviewDate()).isNull();
+        assertThat(result.nextSequence()).isNull();
+        verify(reviewFeedbackProcessor)
+                .applyFeedback(review, DifficultyFeedback.EASY);
+    }
+
+    @Test
+    @DisplayName("HARD 피드백을 제출하면 processor 에 HARD 로 위임한다")
+    void submitFeedback_hard_delegatesToProcessor() {
+        ReviewSchedule review = review(1, LocalDate.of(2026, 4, 6));
+        ReflectionTestUtils.setField(review, "id", 100L);
+        given(reviewScheduleRepository.findById(100L))
+                .willReturn(Optional.of(review));
+        given(reviewScheduleRepository.findUpcomingByStudyUnit(
+                anyLong(), anyInt(), any()))
+                .willReturn(List.of());
+
+        reviewService.submitFeedback(
+                1L, 100L,
+                new SubmitFeedbackRequest(DifficultyFeedback.HARD));
+
+        verify(reviewFeedbackProcessor)
+                .applyFeedback(review, DifficultyFeedback.HARD);
+    }
+
+    @Test
+    @DisplayName("가장 가까운 scheduledDate 의 복습을 다음 복습으로 반환한다")
+    void submitFeedback_returnsEarliestUpcoming() {
+        ReviewSchedule review = review(1, LocalDate.of(2026, 4, 6));
+        ReflectionTestUtils.setField(review, "id", 100L);
+        ReviewSchedule later = review(3, LocalDate.of(2026, 4, 20));
+        ReviewSchedule earlier = review(2, LocalDate.of(2026, 4, 10));
+        given(reviewScheduleRepository.findById(100L))
+                .willReturn(Optional.of(review));
+        given(reviewScheduleRepository.findUpcomingByStudyUnit(
+                eq(20L), eq(1), eq(ReviewStatus.PENDING)))
+                .willReturn(List.of(later, earlier));
+
+        SubmitFeedbackResponse result = reviewService.submitFeedback(
+                1L, 100L,
+                new SubmitFeedbackRequest(DifficultyFeedback.NORMAL));
+
+        assertThat(result.nextReviewDate())
+                .isEqualTo(LocalDate.of(2026, 4, 10));
+        assertThat(result.nextSequence()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("이미 COMPLETED 된 복습에 피드백을 제출하면 INVALID_STATE")
+    void submitFeedback_alreadyCompleted_throws() {
+        ReviewSchedule review = review(1, LocalDate.of(2026, 4, 6));
+        ReflectionTestUtils.setField(review, "id", 100L);
+        review.complete(DifficultyFeedback.NORMAL);
+        given(reviewScheduleRepository.findById(100L))
+                .willReturn(Optional.of(review));
+
+        assertThatThrownBy(() -> reviewService.submitFeedback(
+                1L, 100L,
+                new SubmitFeedbackRequest(DifficultyFeedback.NORMAL)))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue(
+                        "errorCode", ErrorCode.INVALID_STATE);
+        verify(reviewFeedbackProcessor, never())
+                .applyFeedback(any(), any());
+        verify(dirtyScheduleMarker, never())
+                .markDirtyFromToday(anyLong());
+    }
+
+    @Test
+    @DisplayName("SKIPPED 된 복습에 피드백을 제출하면 INVALID_STATE")
+    void submitFeedback_skipped_throws() {
+        ReviewSchedule review = review(1, LocalDate.of(2026, 4, 6));
+        ReflectionTestUtils.setField(review, "id", 100L);
+        review.skip();
+        given(reviewScheduleRepository.findById(100L))
+                .willReturn(Optional.of(review));
+
+        assertThatThrownBy(() -> reviewService.submitFeedback(
+                1L, 100L,
+                new SubmitFeedbackRequest(DifficultyFeedback.NORMAL)))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue(
+                        "errorCode", ErrorCode.INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("OVERDUE 복습에는 피드백을 제출할 수 있다")
+    void submitFeedback_overdue_success() {
+        ReviewSchedule review = review(1, LocalDate.of(2026, 4, 3));
+        ReflectionTestUtils.setField(review, "id", 100L);
+        review.markOverdue();
+        given(reviewScheduleRepository.findById(100L))
+                .willReturn(Optional.of(review));
+        given(reviewScheduleRepository.findUpcomingByStudyUnit(
+                anyLong(), anyInt(), any()))
+                .willReturn(List.of());
+
+        SubmitFeedbackResponse result = reviewService.submitFeedback(
+                1L, 100L,
+                new SubmitFeedbackRequest(DifficultyFeedback.NORMAL));
+
+        assertThat(result.status()).isEqualTo(ReviewStatus.COMPLETED);
+        verify(reviewFeedbackProcessor)
+                .applyFeedback(review, DifficultyFeedback.NORMAL);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 복습은 RESOURCE_NOT_FOUND")
+    void submitFeedback_notFound_throws() {
+        given(reviewScheduleRepository.findById(100L))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> reviewService.submitFeedback(
+                1L, 100L,
+                new SubmitFeedbackRequest(DifficultyFeedback.NORMAL)))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue(
+                        "errorCode", ErrorCode.RESOURCE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 복습에 피드백을 제출하면 RESOURCE_NOT_FOUND")
+    void submitFeedback_notOwner_throws() {
+        ReviewSchedule review = review(1, LocalDate.of(2026, 4, 6));
+        ReflectionTestUtils.setField(review, "id", 100L);
+        given(reviewScheduleRepository.findById(100L))
+                .willReturn(Optional.of(review));
+
+        assertThatThrownBy(() -> reviewService.submitFeedback(
+                999L, 100L,
+                new SubmitFeedbackRequest(DifficultyFeedback.NORMAL)))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue(
+                        "errorCode", ErrorCode.RESOURCE_NOT_FOUND);
+        verify(reviewFeedbackProcessor, never())
+                .applyFeedback(any(), any());
+    }
+
+    @Test
+    @DisplayName("다음 복습이 없으면 응답의 nextReviewDate/nextSequence 는 null")
+    void submitFeedback_noUpcoming_returnsNulls() {
+        ReviewSchedule review = review(5, LocalDate.of(2026, 4, 6));
+        ReflectionTestUtils.setField(review, "id", 100L);
+        given(reviewScheduleRepository.findById(100L))
+                .willReturn(Optional.of(review));
+        given(reviewScheduleRepository.findUpcomingByStudyUnit(
+                eq(20L), eq(5), eq(ReviewStatus.PENDING)))
+                .willReturn(List.of());
+
+        SubmitFeedbackResponse result = reviewService.submitFeedback(
+                1L, 100L,
+                new SubmitFeedbackRequest(DifficultyFeedback.NORMAL));
+
+        assertThat(result.nextReviewDate()).isNull();
+        assertThat(result.nextSequence()).isNull();
+    }
+
+    private ReviewSchedule review(int sequence, LocalDate date) {
+        return new ReviewSchedule(unit, sequence, date);
+    }
+}


### PR DESCRIPTION
closes #160

## Description
복습 완료 후 난이도 피드백을 제출하는 API를 구현한다.

## 변경사항
- `POST /api/reviews/{id}/feedback` 엔드포인트 추가
  - Request: `{ feedback: EASY | NORMAL | HARD }`
  - Response: `reviewId`, `status`, `feedback`, `nextReviewDate`, `nextSequence`
- `ReviewService.submitFeedback()`
  - 복습을 COMPLETED 로 전환하고 `difficultyFeedback` 기록
  - `ReviewFeedbackProcessor` 에 위임하여 난이도 기반 간격 조절
    - EASY: 남은 복습 간격 ×1.5
    - HARD: 남은 복습 간격 ×0.7 + 추가 복습 1회 삽입
    - NORMAL: 간격 유지
  - `DirtyScheduleMarker` 로 오늘 이후 스케줄 dirty 마킹
  - 다음 예정된 PENDING 복습 중 가장 빠른 일정 반환
- 예외 처리
  - 존재하지 않거나 타 사용자 소유: `RESOURCE_NOT_FOUND`
  - 이미 COMPLETED/SKIPPED: `INVALID_STATE`

## Todo
- [x] POST /api/reviews/{id}/feedback — 피드백 제출 (EASY/NORMAL/HARD)
- [x] 피드백에 따른 다음 복습 간격 조절
- [x] 응답에 다음 복습 일정 정보 포함
- [x] 영향받는 날짜 dirty 마킹

## Test
- `ReviewServiceTest` (단위)
  - EASY/NORMAL/HARD 피드백 제출 성공
  - OVERDUE 복습에도 피드백 제출 가능
  - 가장 빠른 upcoming 복습을 반환
  - COMPLETED/SKIPPED 상태일 때 INVALID_STATE
  - 존재하지 않거나 타인 소유 복습은 RESOURCE_NOT_FOUND
  - 다음 복습이 없으면 null 반환
- ./gradlew build 성공