### PR TITLE
chore : minio deployment strategy Recreate로 변경

### DIFF
--- a/infra/helm/minio/values.yaml
+++ b/infra/helm/minio/values.yaml
@@ -3,6 +3,11 @@ minio:
 
   existingSecret: minio-secret
 
+  # RWO PVC(longhorn) 단일 replica 구성이므로 Recreate로 롤아웃 교착 방지
+  # - maxSurge 100% + RWO 조합은 Multi-Attach error로 롤아웃이 멈춘다
+  deploymentUpdate:
+    type: Recreate
+
   persistence:
     enabled: true
     storageClass: longhorn


### PR DESCRIPTION
## 변경 사항

minio deployment의 업데이트 전략을 `RollingUpdate`에서 `Recreate`로 변경한다.

## 배경

upstream minio chart의 기본값은 `maxSurge: 100%, maxUnavailable: 0`인데, 단일 RWO PVC(`longhorn`) + 단일 replica 구성과 충돌한다.

롤링 업데이트 시:
1. 신규 pod가 먼저 생성됨 (maxSurge: 100%)
2. 신규 pod가 기존 RWO PVC에 attach 시도 → `Multi-Attach error`
3. `maxUnavailable: 0`이라 기존 pod는 종료되지 않음
4. 롤아웃 교착

실제로 istio-proxy 리소스 변경 반영을 위한 롤아웃 중 이 문제가 발생했고, 수동으로 기존 ReplicaSet을 scale 0으로 내려야 했다.

## 검증

```bash
$ helm template infra/helm/minio | grep -A 2 'strategy:'
  strategy:
    type: Recreate
```

closes #283