### PR TITLE
feat : 주간/월간 캘린더 API

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/controller/CalendarController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/controller/CalendarController.java
@@ -3,8 +3,10 @@ package ds.project.orino.planner.calendar.controller;
 import ds.project.orino.common.response.ApiResponse;
 import ds.project.orino.planner.calendar.dto.CompleteBlockResponse;
 import ds.project.orino.planner.calendar.dto.DailyScheduleResponse;
+import ds.project.orino.planner.calendar.dto.MonthlyScheduleResponse;
 import ds.project.orino.planner.calendar.dto.ReorderBlockRequest;
 import ds.project.orino.planner.calendar.dto.ReorderBlockResponse;
+import ds.project.orino.planner.calendar.dto.WeeklyScheduleResponse;
 import ds.project.orino.planner.calendar.service.CalendarService;
 import jakarta.validation.Valid;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -40,6 +42,27 @@ public class CalendarController {
         LocalDate target = date != null ? date : LocalDate.now();
         return ResponseEntity.ok(ApiResponse.success(
                 calendarService.getDaily(memberId, target)));
+    }
+
+    @GetMapping("/weekly")
+    public ResponseEntity<ApiResponse<WeeklyScheduleResponse>> getWeekly(
+            Authentication authentication,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        Long memberId = (Long) authentication.getPrincipal();
+        LocalDate target = date != null ? date : LocalDate.now();
+        return ResponseEntity.ok(ApiResponse.success(
+                calendarService.getWeekly(memberId, target)));
+    }
+
+    @GetMapping("/monthly")
+    public ResponseEntity<ApiResponse<MonthlyScheduleResponse>> getMonthly(
+            Authentication authentication,
+            @RequestParam int year,
+            @RequestParam int month) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                calendarService.getMonthly(memberId, year, month)));
     }
 
     @PatchMapping("/blocks/{blockId}/complete")

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/MonthlyDayResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/MonthlyDayResponse.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.calendar.dto;
+
+import ds.project.orino.domain.calendar.entity.BlockType;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record MonthlyDayResponse(
+        LocalDate date,
+        int totalBlocks,
+        int completedBlocks,
+        List<BlockType> blockTypes) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/MonthlyScheduleResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/MonthlyScheduleResponse.java
@@ -1,0 +1,9 @@
+package ds.project.orino.planner.calendar.dto;
+
+import java.util.List;
+
+public record MonthlyScheduleResponse(
+        int year,
+        int month,
+        List<MonthlyDayResponse> days) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/WeeklyDayResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/WeeklyDayResponse.java
@@ -1,0 +1,11 @@
+package ds.project.orino.planner.calendar.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record WeeklyDayResponse(
+        LocalDate date,
+        int totalBlocks,
+        int completedBlocks,
+        List<ScheduleBlockResponse> blocks) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/WeeklyScheduleResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/WeeklyScheduleResponse.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.calendar.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record WeeklyScheduleResponse(
+        LocalDate startDate,
+        LocalDate endDate,
+        List<WeeklyDayResponse> days) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/service/CalendarService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/service/CalendarService.java
@@ -3,6 +3,7 @@ package ds.project.orino.planner.calendar.service;
 import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
 import ds.project.orino.domain.calendar.entity.BlockStatus;
+import ds.project.orino.domain.calendar.entity.BlockType;
 import ds.project.orino.domain.calendar.entity.DailySchedule;
 import ds.project.orino.domain.calendar.entity.ScheduleBlock;
 import ds.project.orino.domain.calendar.repository.DailyScheduleRepository;
@@ -21,19 +22,27 @@ import ds.project.orino.planner.calendar.dto.BlockEffect;
 import ds.project.orino.planner.calendar.dto.CompleteBlockResponse;
 import ds.project.orino.planner.calendar.dto.DailyProgress;
 import ds.project.orino.planner.calendar.dto.DailyScheduleResponse;
+import ds.project.orino.planner.calendar.dto.MonthlyDayResponse;
+import ds.project.orino.planner.calendar.dto.MonthlyScheduleResponse;
 import ds.project.orino.planner.calendar.dto.ReorderBlockRequest;
 import ds.project.orino.planner.calendar.dto.ReorderBlockResponse;
 import ds.project.orino.planner.calendar.dto.ScheduleBlockResponse;
 import ds.project.orino.planner.calendar.dto.WarningResponse;
+import ds.project.orino.planner.calendar.dto.WeeklyDayResponse;
+import ds.project.orino.planner.calendar.dto.WeeklyScheduleResponse;
 import ds.project.orino.planner.scheduling.engine.SchedulingEngine;
 import ds.project.orino.planner.scheduling.engine.model.SchedulingResult;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * 일간 캘린더 조회 및 블록 상태 변경 서비스.
@@ -99,6 +108,54 @@ public class CalendarService {
                 schedule.getCompletedBlocks(),
                 blockResponses,
                 warnings);
+    }
+
+    @Transactional
+    public WeeklyScheduleResponse getWeekly(Long memberId, LocalDate startDate) {
+        LocalDate endDate = startDate.plusDays(6);
+        List<WeeklyDayResponse> days = new ArrayList<>(7);
+        for (int i = 0; i < 7; i++) {
+            LocalDate date = startDate.plusDays(i);
+            SchedulingResult result = schedulingEngine.generate(memberId, date);
+            DailySchedule schedule = result.dailySchedule();
+            List<ScheduleBlock> sortedBlocks = schedule.getBlocks().stream()
+                    .sorted(Comparator.comparing(ScheduleBlock::getStartTime))
+                    .toList();
+            Map<Long, BlockMetadata> metadata =
+                    metadataResolver.resolve(sortedBlocks);
+            List<ScheduleBlockResponse> blockResponses = sortedBlocks.stream()
+                    .map(b -> toBlockResponse(b, metadata.get(b.getId())))
+                    .toList();
+            days.add(new WeeklyDayResponse(
+                    date,
+                    schedule.getTotalBlocks(),
+                    schedule.getCompletedBlocks(),
+                    blockResponses));
+        }
+        return new WeeklyScheduleResponse(startDate, endDate, days);
+    }
+
+    @Transactional
+    public MonthlyScheduleResponse getMonthly(Long memberId, int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDate firstDay = yearMonth.atDay(1);
+        LocalDate lastDay = yearMonth.atEndOfMonth();
+        List<MonthlyDayResponse> days = new ArrayList<>();
+        for (LocalDate date = firstDay; !date.isAfter(lastDay);
+                date = date.plusDays(1)) {
+            SchedulingResult result = schedulingEngine.generate(memberId, date);
+            DailySchedule schedule = result.dailySchedule();
+            Set<BlockType> distinctTypes = new LinkedHashSet<>();
+            for (ScheduleBlock block : schedule.getBlocks()) {
+                distinctTypes.add(block.getBlockType());
+            }
+            days.add(new MonthlyDayResponse(
+                    date,
+                    schedule.getTotalBlocks(),
+                    schedule.getCompletedBlocks(),
+                    new ArrayList<>(distinctTypes)));
+        }
+        return new MonthlyScheduleResponse(year, month, days);
     }
 
     @Transactional

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/calendar/controller/CalendarControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/calendar/controller/CalendarControllerTest.java
@@ -155,6 +155,70 @@ class CalendarControllerTest extends ApiTestSupport {
     }
 
     @Test
+    @DisplayName("GET /api/calendar/weekly - 7일분 스케줄을 반환한다")
+    void getWeekly_returnsSevenDays() throws Exception {
+        Category category = categoryRepository.save(
+                new Category(member, "공부", "#8b00ff", null, 1));
+        StudyMaterial material = materialRepository.save(new StudyMaterial(
+                member, "알고리즘", MaterialType.BOOK, category, null,
+                null, DeadlineMode.FREE));
+        unitRepository.save(new StudyUnit(material, "챕터1", 1, 30, null));
+
+        mockMvc.perform(get("/api/calendar/weekly")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("date", targetDate.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.startDate")
+                        .value(targetDate.toString()))
+                .andExpect(jsonPath("$.data.endDate")
+                        .value(targetDate.plusDays(6).toString()))
+                .andExpect(jsonPath("$.data.days.length()").value(7))
+                .andExpect(jsonPath("$.data.days[0].date")
+                        .value(targetDate.toString()))
+                .andExpect(jsonPath("$.data.days[6].date")
+                        .value(targetDate.plusDays(6).toString()))
+                .andExpect(jsonPath("$.data.days[0].totalBlocks")
+                        .value(greaterThan(0)))
+                .andExpect(jsonPath("$.data.days[0].blocks[0].blockType")
+                        .value("STUDY"));
+    }
+
+    @Test
+    @DisplayName("GET /api/calendar/weekly - date 파라미터가 없으면 오늘부터 7일")
+    void getWeekly_defaultsToToday() throws Exception {
+        mockMvc.perform(get("/api/calendar/weekly")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.startDate")
+                        .value(LocalDate.now().toString()))
+                .andExpect(jsonPath("$.data.days.length()").value(7));
+    }
+
+    @Test
+    @DisplayName("GET /api/calendar/monthly - 해당 월의 모든 날짜를 반환한다")
+    void getMonthly_returnsAllDaysOfMonth() throws Exception {
+        Category category = categoryRepository.save(
+                new Category(member, "공부", "#8b00ff", null, 1));
+        StudyMaterial material = materialRepository.save(new StudyMaterial(
+                member, "알고리즘", MaterialType.BOOK, category, null,
+                null, DeadlineMode.FREE));
+        unitRepository.save(new StudyUnit(material, "챕터1", 1, 30, null));
+
+        int year = targetDate.getYear();
+        int month = targetDate.getMonthValue();
+        int expectedDays = targetDate.lengthOfMonth();
+
+        mockMvc.perform(get("/api/calendar/monthly")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("year", String.valueOf(year))
+                        .param("month", String.valueOf(month)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.year").value(year))
+                .andExpect(jsonPath("$.data.month").value(month))
+                .andExpect(jsonPath("$.data.days.length()").value(expectedDays));
+    }
+
+    @Test
     @DisplayName("PATCH /api/calendar/blocks/{id}/complete (TODO) - 할 일 완료")
     void completeBlock_todo() throws Exception {
         Todo todo = todoRepository.save(new Todo(


### PR DESCRIPTION
closes #164

## Description
주간/월간 캘린더 조회 API를 구현한다.

## 변경사항
- `GET /api/calendar/weekly?date=YYYY-MM-DD` 추가
  - `date` 로부터 7일분 스케줄 반환 (요청일 미지정 시 오늘 기준)
  - 각 날짜의 블록 목록 + `totalBlocks`/`completedBlocks` 달성률 포함
  - 응답: `{ startDate, endDate, days: [{ date, totalBlocks, completedBlocks, blocks }] }`
- `GET /api/calendar/monthly?year=YYYY&month=MM` 추가
  - 해당 월의 모든 날짜 요약 반환
  - 날짜별 `totalBlocks`, `completedBlocks`, `blockTypes`(distinct) 만 포함
  - 블록 상세는 미포함 (도트 표시용)
  - 응답: `{ year, month, days: [{ date, totalBlocks, completedBlocks, blockTypes }] }`
- 기존 `SchedulingEngine.generate()` 재활용
  - dirty 스케줄은 자동 재생성, 과거 날짜는 기존 데이터 유지

## Todo
- [x] GET /api/calendar/weekly?date= — 주간 스케줄 조회 (7일분 전체 블록 반환, 일별 달성률 포함)
- [x] GET /api/calendar/monthly?year=&month= — 월간 요약 조회 (날짜별 유형 도트 + 달성률만, 블록 상세 미포함)

## Test
- `CalendarControllerTest` (통합)
  - 주간: 7일치 반환, 시작/종료일 확인, date 미지정 시 오늘 기본값
  - 월간: 해당 월 전체 일수 반환, year/month 필드 확인
- ./gradlew build 성공