### PR TITLE
chore : istio-gateway HA 구성

### DIFF
--- a/infra/helm/istio-gateway/values.yaml
+++ b/infra/helm/istio-gateway/values.yaml
@@ -1,5 +1,24 @@
 gateway:
   service:
     type: ClusterIP
+
+  # 외부 트래픽 진입점이므로 HA 구성 (최소 2 replica)
+  replicaCount: 2
+
   autoscaling:
-    enabled: false
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+
+  # 최소 1개 유지하여 노드 재시작/롤링 업데이트 중 트래픽 단절 방지
+  podDisruptionBudget:
+    minAvailable: 1
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi


### PR DESCRIPTION
## 변경 사항

istio-gateway를 단일 replica에서 HA 구성으로 전환한다.

| 항목 | Before | After |
|---|---|---|
| replicaCount | 1 (SPOF) | 2 |
| HPA | 미사용 | min 2, max 5, CPU 70% |
| PDB | 없음 | minAvailable: 1 |
| resources | 미설정 (default 2 CPU limit) | req 100m/128Mi, lim 500m/256Mi |

## 기대 효과

- 노드 재시작 시 외부 트래픽 단절 제거
- 롤링 업데이트 중 무중단 유지 (PDB 보장)
- 트래픽 스파이크 대응 (HPA 스케일아웃)
- 리소스 사용량 상한 관리

## 검증

```bash
$ helm template infra/helm/istio-gateway
# Deployment, HPA, PDB 모두 정상 렌더링 확인
```

closes #286