### PR TITLE
feat : 블록 미루기 API

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/controller/CalendarController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/controller/CalendarController.java
@@ -4,6 +4,8 @@ import ds.project.orino.common.response.ApiResponse;
 import ds.project.orino.planner.calendar.dto.CompleteBlockResponse;
 import ds.project.orino.planner.calendar.dto.DailyScheduleResponse;
 import ds.project.orino.planner.calendar.dto.MonthlyScheduleResponse;
+import ds.project.orino.planner.calendar.dto.PostponeBlockRequest;
+import ds.project.orino.planner.calendar.dto.PostponeBlockResponse;
 import ds.project.orino.planner.calendar.dto.ReorderBlockRequest;
 import ds.project.orino.planner.calendar.dto.ReorderBlockResponse;
 import ds.project.orino.planner.calendar.dto.WeeklyScheduleResponse;
@@ -14,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -82,5 +85,15 @@ public class CalendarController {
         Long memberId = (Long) authentication.getPrincipal();
         return ResponseEntity.ok(ApiResponse.success(
                 calendarService.reorderBlock(memberId, blockId, request)));
+    }
+
+    @PostMapping("/blocks/{blockId}/postpone")
+    public ResponseEntity<ApiResponse<PostponeBlockResponse>> postpone(
+            Authentication authentication,
+            @PathVariable Long blockId,
+            @Valid @RequestBody PostponeBlockRequest request) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                calendarService.postponeBlock(memberId, blockId, request)));
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/PostponeBlockRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/PostponeBlockRequest.java
@@ -1,0 +1,7 @@
+package ds.project.orino.planner.calendar.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PostponeBlockRequest(
+        @NotNull PostponeStrategy strategy) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/PostponeBlockResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/PostponeBlockResponse.java
@@ -1,0 +1,9 @@
+package ds.project.orino.planner.calendar.dto;
+
+import java.time.LocalDate;
+
+public record PostponeBlockResponse(
+        Long blockId,
+        LocalDate postponedTo,
+        DailyProgress dailyProgress) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/PostponeStrategy.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/dto/PostponeStrategy.java
@@ -1,0 +1,5 @@
+package ds.project.orino.planner.calendar.dto;
+
+public enum PostponeStrategy {
+    TOMORROW, THIS_WEEK
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/service/CalendarService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/calendar/service/CalendarService.java
@@ -24,12 +24,16 @@ import ds.project.orino.planner.calendar.dto.DailyProgress;
 import ds.project.orino.planner.calendar.dto.DailyScheduleResponse;
 import ds.project.orino.planner.calendar.dto.MonthlyDayResponse;
 import ds.project.orino.planner.calendar.dto.MonthlyScheduleResponse;
+import ds.project.orino.planner.calendar.dto.PostponeBlockRequest;
+import ds.project.orino.planner.calendar.dto.PostponeBlockResponse;
+import ds.project.orino.planner.calendar.dto.PostponeStrategy;
 import ds.project.orino.planner.calendar.dto.ReorderBlockRequest;
 import ds.project.orino.planner.calendar.dto.ReorderBlockResponse;
 import ds.project.orino.planner.calendar.dto.ScheduleBlockResponse;
 import ds.project.orino.planner.calendar.dto.WarningResponse;
 import ds.project.orino.planner.calendar.dto.WeeklyDayResponse;
 import ds.project.orino.planner.calendar.dto.WeeklyScheduleResponse;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
 import ds.project.orino.planner.scheduling.engine.SchedulingEngine;
 import ds.project.orino.planner.scheduling.engine.model.SchedulingResult;
 import org.springframework.stereotype.Service;
@@ -62,6 +66,7 @@ public class CalendarService {
     private final ReviewScheduleRepository reviewScheduleRepository;
     private final RoutineRepository routineRepository;
     private final RoutineCheckRepository routineCheckRepository;
+    private final DirtyScheduleMarker dirtyScheduleMarker;
 
     public CalendarService(
             SchedulingEngine schedulingEngine,
@@ -73,7 +78,8 @@ public class CalendarService {
             StudyUnitRepository studyUnitRepository,
             ReviewScheduleRepository reviewScheduleRepository,
             RoutineRepository routineRepository,
-            RoutineCheckRepository routineCheckRepository) {
+            RoutineCheckRepository routineCheckRepository,
+            DirtyScheduleMarker dirtyScheduleMarker) {
         this.schedulingEngine = schedulingEngine;
         this.dailyScheduleRepository = dailyScheduleRepository;
         this.scheduleBlockRepository = scheduleBlockRepository;
@@ -84,19 +90,21 @@ public class CalendarService {
         this.reviewScheduleRepository = reviewScheduleRepository;
         this.routineRepository = routineRepository;
         this.routineCheckRepository = routineCheckRepository;
+        this.dirtyScheduleMarker = dirtyScheduleMarker;
     }
 
     @Transactional
     public DailyScheduleResponse getDaily(Long memberId, LocalDate date) {
         SchedulingResult result = schedulingEngine.generate(memberId, date);
         DailySchedule schedule = result.dailySchedule();
-        List<ScheduleBlock> sortedBlocks = schedule.getBlocks().stream()
+        List<ScheduleBlock> visibleBlocks = schedule.getBlocks().stream()
+                .filter(b -> b.getStatus() != BlockStatus.POSTPONED)
                 .sorted(Comparator.comparing(ScheduleBlock::getStartTime))
                 .toList();
         Map<Long, BlockMetadata> metadata =
-                metadataResolver.resolve(sortedBlocks);
+                metadataResolver.resolve(visibleBlocks);
 
-        List<ScheduleBlockResponse> blockResponses = sortedBlocks.stream()
+        List<ScheduleBlockResponse> blockResponses = visibleBlocks.stream()
                 .map(b -> toBlockResponse(b, metadata.get(b.getId())))
                 .toList();
         List<WarningResponse> warnings = result.warnings().stream()
@@ -118,12 +126,13 @@ public class CalendarService {
             LocalDate date = startDate.plusDays(i);
             SchedulingResult result = schedulingEngine.generate(memberId, date);
             DailySchedule schedule = result.dailySchedule();
-            List<ScheduleBlock> sortedBlocks = schedule.getBlocks().stream()
+            List<ScheduleBlock> visibleBlocks = schedule.getBlocks().stream()
+                    .filter(b -> b.getStatus() != BlockStatus.POSTPONED)
                     .sorted(Comparator.comparing(ScheduleBlock::getStartTime))
                     .toList();
             Map<Long, BlockMetadata> metadata =
-                    metadataResolver.resolve(sortedBlocks);
-            List<ScheduleBlockResponse> blockResponses = sortedBlocks.stream()
+                    metadataResolver.resolve(visibleBlocks);
+            List<ScheduleBlockResponse> blockResponses = visibleBlocks.stream()
                     .map(b -> toBlockResponse(b, metadata.get(b.getId())))
                     .toList();
             days.add(new WeeklyDayResponse(
@@ -147,7 +156,9 @@ public class CalendarService {
             DailySchedule schedule = result.dailySchedule();
             Set<BlockType> distinctTypes = new LinkedHashSet<>();
             for (ScheduleBlock block : schedule.getBlocks()) {
-                distinctTypes.add(block.getBlockType());
+                if (block.getStatus() != BlockStatus.POSTPONED) {
+                    distinctTypes.add(block.getBlockType());
+                }
             }
             days.add(new MonthlyDayResponse(
                     date,
@@ -161,7 +172,7 @@ public class CalendarService {
     @Transactional
     public CompleteBlockResponse completeBlock(Long memberId, Long blockId) {
         ScheduleBlock block = loadOwnedBlock(memberId, blockId);
-        if (block.getStatus() == BlockStatus.COMPLETED) {
+        if (block.getStatus() != BlockStatus.SCHEDULED) {
             throw new CustomException(ErrorCode.INVALID_STATE);
         }
 
@@ -169,16 +180,91 @@ public class CalendarService {
         block.complete();
 
         DailySchedule schedule = block.getDailySchedule();
-        int completed = (int) schedule.getBlocks().stream()
-                .filter(b -> b.getStatus() == BlockStatus.COMPLETED)
-                .count();
-        schedule.markGenerated(schedule.getBlocks().size(), completed);
+        int total = countActiveBlocks(schedule);
+        int completed = countCompletedBlocks(schedule);
+        schedule.markGenerated(total, completed);
 
         return new CompleteBlockResponse(
                 block.getId(),
                 block.getStatus(),
                 effect,
-                new DailyProgress(schedule.getBlocks().size(), completed));
+                new DailyProgress(total, completed));
+    }
+
+    @Transactional
+    public PostponeBlockResponse postponeBlock(
+            Long memberId, Long blockId, PostponeBlockRequest request) {
+        ScheduleBlock block = loadOwnedBlock(memberId, blockId);
+        if (block.getStatus() != BlockStatus.SCHEDULED) {
+            throw new CustomException(ErrorCode.INVALID_STATE);
+        }
+        if (block.getBlockType() == BlockType.FIXED
+                || block.getBlockType() == BlockType.ROUTINE) {
+            throw new CustomException(ErrorCode.INVALID_STATE);
+        }
+
+        LocalDate sourceDate = block.getDailySchedule().getScheduleDate();
+        LocalDate targetDate = resolveTargetDate(
+                memberId, sourceDate, request.strategy());
+
+        block.postpone();
+        if (block.getBlockType() == BlockType.REVIEW) {
+            ReviewSchedule review = reviewScheduleRepository
+                    .findById(block.getReferenceId())
+                    .orElseThrow(() -> new CustomException(
+                            ErrorCode.RESOURCE_NOT_FOUND));
+            review.reschedule(targetDate);
+        }
+
+        DailySchedule sourceSchedule = block.getDailySchedule();
+        int total = countActiveBlocks(sourceSchedule);
+        int completed = countCompletedBlocks(sourceSchedule);
+        sourceSchedule.markGenerated(total, completed);
+
+        dirtyScheduleMarker.markDirtyOn(memberId, targetDate);
+
+        return new PostponeBlockResponse(
+                block.getId(), targetDate,
+                new DailyProgress(total, completed));
+    }
+
+    private LocalDate resolveTargetDate(Long memberId, LocalDate sourceDate,
+                                        PostponeStrategy strategy) {
+        if (strategy == PostponeStrategy.TOMORROW) {
+            return sourceDate.plusDays(1);
+        }
+        LocalDate rangeStart = sourceDate.plusDays(1);
+        LocalDate rangeEnd = sourceDate.plusDays(6);
+        List<DailySchedule> existing = dailyScheduleRepository
+                .findByMemberIdAndScheduleDateBetween(
+                        memberId, rangeStart, rangeEnd);
+        Map<LocalDate, Integer> counts = new java.util.HashMap<>();
+        for (DailySchedule s : existing) {
+            counts.put(s.getScheduleDate(), countActiveBlocks(s));
+        }
+        LocalDate best = rangeStart;
+        int bestCount = counts.getOrDefault(rangeStart, 0);
+        for (LocalDate d = rangeStart.plusDays(1); !d.isAfter(rangeEnd);
+                d = d.plusDays(1)) {
+            int c = counts.getOrDefault(d, 0);
+            if (c < bestCount) {
+                best = d;
+                bestCount = c;
+            }
+        }
+        return best;
+    }
+
+    private int countActiveBlocks(DailySchedule schedule) {
+        return (int) schedule.getBlocks().stream()
+                .filter(b -> b.getStatus() != BlockStatus.POSTPONED)
+                .count();
+    }
+
+    private int countCompletedBlocks(DailySchedule schedule) {
+        return (int) schedule.getBlocks().stream()
+                .filter(b -> b.getStatus() == BlockStatus.COMPLETED)
+                .count();
     }
 
     @Transactional

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/SchedulingEngine.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/scheduling/engine/SchedulingEngine.java
@@ -119,7 +119,9 @@ public class SchedulingEngine {
 
         resortBlocks(dailySchedule);
 
-        int total = dailySchedule.getBlocks().size();
+        int total = (int) dailySchedule.getBlocks().stream()
+                .filter(b -> b.getStatus() != BlockStatus.POSTPONED)
+                .count();
         int completed = (int) dailySchedule.getBlocks().stream()
                 .filter(b -> b.getStatus() == BlockStatus.COMPLETED)
                 .count();
@@ -161,10 +163,13 @@ public class SchedulingEngine {
 
     private List<TimeSlot> subtractLockedFromFreeSlots(
             List<TimeSlot> freeSlots, List<ScheduleBlock> locked) {
-        if (locked.isEmpty()) {
+        List<ScheduleBlock> timeConsuming = locked.stream()
+                .filter(b -> b.getStatus() != BlockStatus.POSTPONED)
+                .toList();
+        if (timeConsuming.isEmpty()) {
             return freeSlots;
         }
-        List<TimeSlot> taken = locked.stream()
+        List<TimeSlot> taken = timeConsuming.stream()
                 .map(b -> new TimeSlot(b.getStartTime(), b.getEndTime()))
                 .sorted(Comparator.comparing(TimeSlot::start))
                 .toList();

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/calendar/controller/CalendarControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/calendar/controller/CalendarControllerTest.java
@@ -325,6 +325,102 @@ class CalendarControllerTest extends ApiTestSupport {
     }
 
     @Test
+    @DisplayName("POST postpone (TOMORROW) - 오늘에서 제외되고 내일로 이동")
+    void postponeBlock_tomorrow() throws Exception {
+        Todo todo = todoRepository.save(new Todo(
+                member, "리포트", null, null, null,
+                Priority.HIGH, null, 30));
+
+        MvcResult getResult = mockMvc.perform(get("/api/calendar/daily")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("date", targetDate.toString()))
+                .andReturn();
+        Integer blockId = com.jayway.jsonpath.JsonPath.read(
+                getResult.getResponse().getContentAsString(),
+                "$.data.blocks[0].id");
+        Integer initialTotal = com.jayway.jsonpath.JsonPath.read(
+                getResult.getResponse().getContentAsString(),
+                "$.data.totalBlocks");
+
+        mockMvc.perform(post("/api/calendar/blocks/" + blockId + "/postpone")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"strategy": "TOMORROW"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.blockId").value(blockId))
+                .andExpect(jsonPath("$.data.postponedTo")
+                        .value(targetDate.plusDays(1).toString()))
+                .andExpect(jsonPath("$.data.dailyProgress.totalBlocks")
+                        .value(initialTotal - 1));
+
+        // 오늘 조회 시 해당 블록이 보이지 않아야 함
+        mockMvc.perform(get("/api/calendar/daily")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("date", targetDate.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalBlocks")
+                        .value(initialTotal - 1));
+
+        org.assertj.core.api.Assertions.assertThat(todo.getId())
+                .isNotNull();
+    }
+
+    @Test
+    @DisplayName("POST postpone (THIS_WEEK) - 주 내 덜 바쁜 날로 이동")
+    void postponeBlock_thisWeek() throws Exception {
+        todoRepository.save(new Todo(
+                member, "과제", null, null, null,
+                Priority.MEDIUM, null, 30));
+
+        MvcResult getResult = mockMvc.perform(get("/api/calendar/daily")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("date", targetDate.toString()))
+                .andReturn();
+        Integer blockId = com.jayway.jsonpath.JsonPath.read(
+                getResult.getResponse().getContentAsString(),
+                "$.data.blocks[0].id");
+
+        mockMvc.perform(post("/api/calendar/blocks/" + blockId + "/postpone")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"strategy": "THIS_WEEK"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.blockId").value(blockId))
+                .andExpect(jsonPath("$.data.postponedTo", notNullValue()));
+    }
+
+    @Test
+    @DisplayName("POST postpone - 이미 완료된 블록은 409")
+    void postponeBlock_alreadyCompleted() throws Exception {
+        todoRepository.save(new Todo(member, "작업", null, null, null,
+                Priority.HIGH, null, 30));
+
+        MvcResult getResult = mockMvc.perform(get("/api/calendar/daily")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("date", targetDate.toString()))
+                .andReturn();
+        Integer blockId = com.jayway.jsonpath.JsonPath.read(
+                getResult.getResponse().getContentAsString(),
+                "$.data.blocks[0].id");
+
+        mockMvc.perform(patch("/api/calendar/blocks/" + blockId + "/complete")
+                .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/calendar/blocks/" + blockId + "/postpone")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"strategy": "TOMORROW"}
+                                """))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
     @DisplayName("PUT reorder - end가 start보다 빠르면 400")
     void reorderBlock_invalidTimeRange() throws Exception {
         todoRepository.save(new Todo(member, "작업", null, null, null,

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/entity/BlockStatus.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/entity/BlockStatus.java
@@ -1,5 +1,5 @@
 package ds.project.orino.domain.calendar.entity;
 
 public enum BlockStatus {
-    SCHEDULED, COMPLETED
+    SCHEDULED, COMPLETED, POSTPONED
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/entity/ScheduleBlock.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/entity/ScheduleBlock.java
@@ -84,6 +84,10 @@ public class ScheduleBlock {
         this.completedAt = LocalDateTime.now();
     }
 
+    public void postpone() {
+        this.status = BlockStatus.POSTPONED;
+    }
+
     public void reschedule(LocalTime startTime, LocalTime endTime) {
         this.startTime = startTime;
         this.endTime = endTime;
@@ -95,7 +99,9 @@ public class ScheduleBlock {
     }
 
     public boolean isLocked() {
-        return status == BlockStatus.COMPLETED || pinned;
+        return status == BlockStatus.COMPLETED
+                || status == BlockStatus.POSTPONED
+                || pinned;
     }
 
     public Long getId() {


### PR DESCRIPTION
closes #163

## 작업 내용
- `BlockStatus`에 `POSTPONED` 상태 추가
- `ScheduleBlock.postpone()` 메서드 추가 및 `isLocked()`에 POSTPONED 포함
- `POST /api/calendar/blocks/{blockId}/postpone` 엔드포인트 추가
- 미루기 전략 지원
  - `TOMORROW`: 다음 날로 이동
  - `THIS_WEEK`: 6일 이내 중 가장 여유로운 날짜 자동 선택
- REVIEW 블록 미루기 시 `ReviewSchedule.scheduledDate` 동기화
- POSTPONED 블록은 스케줄링 엔진 재생성 시 유지되어 동일 아이템 재수집 방지
  - 단, POSTPONED는 시간대를 점유하지 않으므로 freeSlot에서 제외하지 않음
- 대상 날짜는 `DirtyScheduleMarker`로 dirty 마킹하여 다음 조회 시 재생성

## 제약 조건
- `FIXED`, `ROUTINE` 블록은 미루기 불가 (400)
- `SCHEDULED` 상태가 아닌 블록은 미루기 불가 (400)

## 테스트
- `CalendarControllerTest`에 통합 테스트 3개 추가
  - `postponeBlock_tomorrow`: 내일로 미루기 성공
  - `postponeBlock_thisWeek`: 이번 주 내 최적 날짜로 미루기 성공
  - `postponeBlock_alreadyCompleted`: 완료된 블록 미루기 시 INVALID_STATE