### PR TITLE
chore : redis/mysql 헬스체크 probe 추가

### DIFF
--- a/infra/helm/mysql/templates/statefulset.yaml
+++ b/infra/helm/mysql/templates/statefulset.yaml
@@ -26,6 +26,23 @@ spec:
               mountPath: /var/lib/mysql
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            exec:
+              command: ["mysqladmin", "ping", "-h", "127.0.0.1"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SELECT 1"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: mysql-data
           persistentVolumeClaim:

--- a/infra/helm/redis/templates/deployment.yaml
+++ b/infra/helm/redis/templates/deployment.yaml
@@ -19,3 +19,17 @@ spec:
             - containerPort: 6379
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3


### PR DESCRIPTION
## 변경 사항

`orino` 네임스페이스의 데이터 서비스에 liveness/readiness probe를 추가한다.

### redis
| Probe | 명령 | 주기 |
|---|---|---|
| liveness | `redis-cli ping` | 10s period, init 10s |
| readiness | `redis-cli ping` | 5s period, init 5s |

### mysql
| Probe | 명령 | 주기 |
|---|---|---|
| liveness | `mysqladmin ping -h 127.0.0.1` | 10s period, init 30s |
| readiness | `mysql -uroot -p$MYSQL_ROOT_PASSWORD -e "SELECT 1"` | 10s period, init 10s |

## minio 제외 사유

upstream chart `minio/minio 5.4.0`의 deployment 템플릿이 probe 필드를 지원하지 않는다. 대응 방안(chart 교체 vs post-render)은 별도 후속 이슈로 분리.

## 검증

```bash
$ helm template infra/helm/redis | grep -A 5 livenessProbe
$ helm template infra/helm/mysql | grep -A 5 livenessProbe
# 정상 렌더링 확인
```

closes #287