### PR TITLE
chore : ArgoCD 컴포넌트 resources 설정

### DIFF
--- a/infra/helm/argocd/values.yaml
+++ b/infra/helm/argocd/values.yaml
@@ -1,0 +1,82 @@
+# ArgoCD 본체는 chicken-and-egg 문제로 GitOps 관리 밖이다.
+# 배포/업그레이드는 note1에서 수동으로 실행한다:
+#
+#   ssh note1 "helm repo update argo && \
+#     helm upgrade argocd argo/argo-cd --namespace argocd --version 9.4.10 \
+#       -f values.yaml"
+#
+# values 변경 시 이 파일을 먼저 갱신한 뒤 수동 apply.
+
+configs:
+  params:
+    server.insecure: true
+
+# StatefulSet: 실 사용량 ~80m CPU / ~370Mi — 여유 있게 설정
+controller:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+server:
+  extraArgs:
+    - --loglevel=info
+  service:
+    type: ClusterIP
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# Git 클론/렌더링 담당. 실 사용량 ~16m / ~74Mi
+repoServer:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+# ApplicationSet 미사용 중이지만 App of Apps 보완재로 구동
+applicationSet:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
+dex:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 50m
+      memory: 64Mi
+
+notifications:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
+redis:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi


### PR DESCRIPTION
## 변경 사항

ArgoCD 본체 배포의 \`values.yaml\`을 git에 저장하고, 누락됐던 컴포넌트의 resources를 설정한다.

### 배경
ArgoCD 본체는 self-manage 시 닭-달걀 문제(업그레이드 실패 시 복구 어려움)로 **GitOps 관리 밖**에서 수동 \`helm upgrade\`로 운영한다. values 내용은 git에 저장하여 드리프트를 최소화한다.

### 추가된 resources 설정
| 컴포넌트 | Requests | Limits |
|---|---|---|
| controller (StatefulSet) | 250m / 512Mi | 500m / 1Gi |
| server | 250m / 256Mi | 500m / 512Mi (기 설정) |
| repoServer | 50m / 128Mi | 200m / 256Mi |
| applicationSet | 10m / 64Mi | 100m / 128Mi |
| dex | 10m / 32Mi | 50m / 64Mi |
| notifications | 10m / 32Mi | 100m / 128Mi |
| redis | 10m / 32Mi | 100m / 64Mi |

### 적용 완료
\`\`\`bash
$ ssh note1 "helm upgrade argocd argo/argo-cd --namespace argocd --version 9.4.10 -f values.yaml"
STATUS: deployed
REVISION: 2
\`\`\`

모든 pod Running 확인 완료.

closes #288