### PR TITLE
chore : argocd 네임스페이스 LimitRange/ResourceQuota 적용

### DIFF
--- a/infra/helm/platform-policies/values.yaml
+++ b/infra/helm/platform-policies/values.yaml
@@ -41,3 +41,22 @@ namespaces:
       limits:
         cpu: "8"
         memory: 16Gi
+
+  - name: argocd
+    limitRange:
+      enabled: true
+      default:
+        cpu: 100m
+        memory: 128Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 32Mi
+    resourceQuota:
+      enabled: true
+      # 현재 requests 합계 ~640m/1120Mi + 업그레이드 surge 대비 여유
+      requests:
+        cpu: "2"
+        memory: 3Gi
+      limits:
+        cpu: "4"
+        memory: 4Gi


### PR DESCRIPTION
## 변경 사항

\`platform-policies\` 차트에 \`argocd\` 네임스페이스 정책을 추가한다.

### LimitRange (경량 컴포넌트 기준)
| 항목 | 값 |
|---|---|
| default (limits) | 100m / 128Mi |
| defaultRequest | 10m / 32Mi |

### ResourceQuota
| 항목 | 값 | 근거 |
|---|---|---|
| requests.cpu | 2 | 현재 640m + 업그레이드 surge 여유 |
| requests.memory | 3Gi | 현재 1120Mi + 여유 |
| limits.cpu | 4 | 설정된 limits 합계 1750m 대비 여유 |
| limits.memory | 4Gi | 설정된 limits 합계 2304Mi 대비 여유 |

## 선행 작업

#295 (ArgoCD 컴포넌트 resources 설정)가 먼저 배포되어야 한다. resources가 미설정인 상태에서 quota를 적용하면 신규 pod 생성 실패 가능.

## 검증

\`\`\`bash
$ helm template infra/helm/platform-policies | grep -A 8 'namespace: argocd'
# LimitRange, ResourceQuota 정상 렌더링 확인
\`\`\`

closes #290