### PR TITLE
feat : 리스케줄링 API

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/rescheduling/controller/ReschedulingController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/rescheduling/controller/ReschedulingController.java
@@ -1,0 +1,43 @@
+package ds.project.orino.planner.rescheduling.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.rescheduling.dto.ApplyRescheduleRequest;
+import ds.project.orino.planner.rescheduling.dto.ApplyRescheduleResponse;
+import ds.project.orino.planner.rescheduling.dto.RescheduleOptionsResponse;
+import ds.project.orino.planner.rescheduling.service.ReschedulingService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/rescheduling")
+public class ReschedulingController {
+
+    private final ReschedulingService reschedulingService;
+
+    public ReschedulingController(ReschedulingService reschedulingService) {
+        this.reschedulingService = reschedulingService;
+    }
+
+    @GetMapping("/options")
+    public ResponseEntity<ApiResponse<RescheduleOptionsResponse>> getOptions(
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                reschedulingService.getOptions(memberId)));
+    }
+
+    @PostMapping("/apply")
+    public ResponseEntity<ApiResponse<ApplyRescheduleResponse>> apply(
+            Authentication authentication,
+            @Valid @RequestBody ApplyRescheduleRequest request) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                reschedulingService.apply(memberId, request.strategy())));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/rescheduling/dto/ApplyRescheduleRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/rescheduling/dto/ApplyRescheduleRequest.java
@@ -1,0 +1,7 @@
+package ds.project.orino.planner.rescheduling.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ApplyRescheduleRequest(
+        @NotNull RescheduleStrategy strategy) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/rescheduling/dto/ApplyRescheduleResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/rescheduling/dto/ApplyRescheduleResponse.java
@@ -1,0 +1,7 @@
+package ds.project.orino.planner.rescheduling.dto;
+
+public record ApplyRescheduleResponse(
+        RescheduleStrategy strategy,
+        int affectedDays,
+        int newDailyStudyMinutes) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/rescheduling/dto/RescheduleOption.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/rescheduling/dto/RescheduleOption.java
@@ -1,0 +1,16 @@
+package ds.project.orino.planner.rescheduling.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDate;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RescheduleOption(
+        RescheduleStrategy strategy,
+        String label,
+        String description,
+        boolean deadlineFeasible,
+        LocalDate newEstimatedCompletion,
+        Integer dailyIncreasePercent,
+        String warning) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/rescheduling/dto/RescheduleOptionsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/rescheduling/dto/RescheduleOptionsResponse.java
@@ -1,0 +1,9 @@
+package ds.project.orino.planner.rescheduling.dto;
+
+import java.util.List;
+
+public record RescheduleOptionsResponse(
+        int missedDays,
+        int missedItems,
+        List<RescheduleOption> options) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/rescheduling/dto/RescheduleStrategy.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/rescheduling/dto/RescheduleStrategy.java
@@ -1,0 +1,7 @@
+package ds.project.orino.planner.rescheduling.dto;
+
+public enum RescheduleStrategy {
+    POSTPONE,
+    COMPRESS,
+    KEEP_DEADLINE
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/rescheduling/service/ReschedulingService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/rescheduling/service/ReschedulingService.java
@@ -1,0 +1,392 @@
+package ds.project.orino.planner.rescheduling.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.calendar.entity.DailySchedule;
+import ds.project.orino.domain.calendar.repository.DailyScheduleRepository;
+import ds.project.orino.domain.material.entity.DeadlineMode;
+import ds.project.orino.domain.material.entity.MaterialAllocation;
+import ds.project.orino.domain.material.entity.MaterialStatus;
+import ds.project.orino.domain.material.entity.StudyMaterial;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.entity.UnitStatus;
+import ds.project.orino.domain.material.repository.MaterialAllocationRepository;
+import ds.project.orino.domain.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.domain.preference.repository.UserPreferenceRepository;
+import ds.project.orino.planner.rescheduling.dto.ApplyRescheduleResponse;
+import ds.project.orino.planner.rescheduling.dto.RescheduleOption;
+import ds.project.orino.planner.rescheduling.dto.RescheduleOptionsResponse;
+import ds.project.orino.planner.rescheduling.dto.RescheduleStrategy;
+import ds.project.orino.planner.scheduling.dirty.DirtyScheduleMarker;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 연속 미완료 감지 + 리스케줄링 선택지 시뮬레이션/적용.
+ *
+ * missedDays: 오늘 이전부터 역순으로, totalBlocks>0 && completedBlocks<totalBlocks
+ *   인 날들의 연속 구간 길이.
+ * 대상 과목: deadline_mode=DEADLINE, status=ACTIVE, deadline>=today, PENDING 단위 존재.
+ */
+@Service
+@Transactional(readOnly = true)
+public class ReschedulingService {
+
+    /** 연속 미완료 감지 최대 조회 범위(일). */
+    private static final int MISSED_LOOKBACK_DAYS = 14;
+    /** 과목 할당 fallback 시 최소값. */
+    private static final int MIN_FALLBACK_MINUTES = 30;
+
+    private final DailyScheduleRepository dailyScheduleRepository;
+    private final StudyMaterialRepository materialRepository;
+    private final MaterialAllocationRepository allocationRepository;
+    private final UserPreferenceRepository preferenceRepository;
+    private final DirtyScheduleMarker dirtyScheduleMarker;
+
+    public ReschedulingService(
+            DailyScheduleRepository dailyScheduleRepository,
+            StudyMaterialRepository materialRepository,
+            MaterialAllocationRepository allocationRepository,
+            UserPreferenceRepository preferenceRepository,
+            DirtyScheduleMarker dirtyScheduleMarker) {
+        this.dailyScheduleRepository = dailyScheduleRepository;
+        this.materialRepository = materialRepository;
+        this.allocationRepository = allocationRepository;
+        this.preferenceRepository = preferenceRepository;
+        this.dirtyScheduleMarker = dirtyScheduleMarker;
+    }
+
+    public RescheduleOptionsResponse getOptions(Long memberId) {
+        LocalDate today = LocalDate.now();
+        MissSummary miss = computeMissSummary(memberId, today);
+        List<MaterialContext> contexts = collectMaterialContexts(
+                memberId, today);
+        UserPreference preference = loadPreference(memberId);
+        int dailyCap = preference.getDailyStudyMinutes();
+
+        List<RescheduleOption> options;
+        if (contexts.isEmpty()) {
+            options = List.of();
+        } else {
+            options = List.of(
+                    buildPostponeOption(miss.missedDays(), contexts),
+                    buildCompressOption(miss.missedDays(), contexts, dailyCap),
+                    buildKeepDeadlineOption(contexts, dailyCap));
+        }
+        return new RescheduleOptionsResponse(
+                miss.missedDays(), miss.missedItems(), options);
+    }
+
+    @Transactional
+    public ApplyRescheduleResponse apply(
+            Long memberId, RescheduleStrategy strategy) {
+        if (strategy == null) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        LocalDate today = LocalDate.now();
+        MissSummary miss = computeMissSummary(memberId, today);
+        List<MaterialContext> contexts = collectMaterialContexts(
+                memberId, today);
+        if (contexts.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_STATE);
+        }
+        UserPreference preference = loadPreference(memberId);
+        int dailyCap = preference.getDailyStudyMinutes();
+
+        switch (strategy) {
+            case POSTPONE -> applyPostpone(contexts, miss.missedDays());
+            case COMPRESS -> applyCompress(
+                    contexts, miss.missedDays(), dailyCap);
+            case KEEP_DEADLINE -> applyKeepDeadline(contexts, dailyCap);
+            default -> throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        dirtyScheduleMarker.markDirtyFromToday(memberId);
+
+        int affectedDays = computeAffectedDays(contexts, today);
+        int newDailyStudyMinutes = contexts.stream()
+                .mapToInt(MaterialContext::currentRate)
+                .sum();
+        return new ApplyRescheduleResponse(
+                strategy, affectedDays, newDailyStudyMinutes);
+    }
+
+    private MissSummary computeMissSummary(Long memberId, LocalDate today) {
+        LocalDate from = today.minusDays(MISSED_LOOKBACK_DAYS);
+        LocalDate to = today.minusDays(1);
+        if (to.isBefore(from)) {
+            return new MissSummary(0, 0);
+        }
+        List<DailySchedule> past = dailyScheduleRepository
+                .findByMemberIdAndScheduleDateBetween(memberId, from, to);
+        java.util.Map<LocalDate, DailySchedule> byDate = new java.util.HashMap<>();
+        for (DailySchedule s : past) {
+            byDate.put(s.getScheduleDate(), s);
+        }
+        int streak = 0;
+        int missedItems = 0;
+        for (LocalDate d = to; !d.isBefore(from); d = d.minusDays(1)) {
+            DailySchedule s = byDate.get(d);
+            if (s == null || s.getTotalBlocks() == 0
+                    || s.getCompletedBlocks() >= s.getTotalBlocks()) {
+                break;
+            }
+            streak++;
+            missedItems += s.getTotalBlocks() - s.getCompletedBlocks();
+        }
+        return new MissSummary(streak, missedItems);
+    }
+
+    private List<MaterialContext> collectMaterialContexts(
+            Long memberId, LocalDate today) {
+        List<StudyMaterial> materials = materialRepository
+                .findByMemberIdOrderByCreatedAtDesc(memberId);
+        List<MaterialContext> contexts = new ArrayList<>();
+        int deadlineBoundCount = 0;
+        int totalUserMinutes = loadPreference(memberId).getDailyStudyMinutes();
+        for (StudyMaterial m : materials) {
+            if (m.getStatus() != MaterialStatus.ACTIVE) {
+                continue;
+            }
+            if (m.getDeadlineMode() != DeadlineMode.DEADLINE) {
+                continue;
+            }
+            if (m.getDeadline() == null || m.getDeadline().isBefore(today)) {
+                continue;
+            }
+            int remaining = m.getUnits().stream()
+                    .filter(u -> u.getStatus() == UnitStatus.PENDING)
+                    .mapToInt(StudyUnit::getEstimatedMinutes)
+                    .sum();
+            if (remaining <= 0) {
+                continue;
+            }
+            deadlineBoundCount++;
+            contexts.add(new MaterialContext(m, remaining, today));
+        }
+        if (deadlineBoundCount == 0) {
+            return contexts;
+        }
+        int fallback = Math.max(MIN_FALLBACK_MINUTES,
+                totalUserMinutes / deadlineBoundCount);
+        for (MaterialContext ctx : contexts) {
+            ctx.initializeRate(fallback);
+        }
+        return contexts;
+    }
+
+    private UserPreference loadPreference(Long memberId) {
+        return preferenceRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new CustomException(
+                        ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    private RescheduleOption buildPostponeOption(
+            int missedDays, List<MaterialContext> contexts) {
+        LocalDate latest = null;
+        boolean feasible = true;
+        for (MaterialContext ctx : contexts) {
+            int rate = Math.max(1, ctx.currentRate());
+            int days = (int) Math.ceil(
+                    (double) ctx.remainingMinutes() / rate);
+            LocalDate estimate = ctx.today().plusDays(days);
+            if (latest == null || estimate.isAfter(latest)) {
+                latest = estimate;
+            }
+            if (estimate.isAfter(ctx.deadline())) {
+                feasible = false;
+            }
+        }
+        String description = "전체 일정 " + missedDays + "일 후퇴";
+        return new RescheduleOption(
+                RescheduleStrategy.POSTPONE, "뒤로 밀기", description,
+                feasible, latest, null, null);
+    }
+
+    private RescheduleOption buildCompressOption(
+            int missedDays, List<MaterialContext> contexts, int dailyCap) {
+        int maxIncrease = 0;
+        int totalNewRate = 0;
+        boolean feasible = true;
+        LocalDate latest = null;
+        for (MaterialContext ctx : contexts) {
+            int currentRate = Math.max(1, ctx.currentRate());
+            long daysRemaining = Math.max(1,
+                    ctx.today().until(ctx.deadline()).getDays());
+            int missedMinutes = missedDays * currentRate;
+            int extra = (int) Math.ceil(
+                    (double) missedMinutes / daysRemaining);
+            int newRate = currentRate + extra;
+            int pct = Math.round((extra * 100f) / currentRate);
+            totalNewRate += newRate;
+            if (pct > maxIncrease) {
+                maxIncrease = pct;
+            }
+            if (newRate > dailyCap) {
+                feasible = false;
+            }
+            if (latest == null || ctx.deadline().isAfter(latest)) {
+                latest = ctx.deadline();
+            }
+        }
+        if (totalNewRate > dailyCap) {
+            feasible = false;
+        }
+        return new RescheduleOption(
+                RescheduleStrategy.COMPRESS, "압축",
+                "남은 기간에 밀린 양 분산",
+                feasible, latest, maxIncrease, null);
+    }
+
+    private RescheduleOption buildKeepDeadlineOption(
+            List<MaterialContext> contexts, int dailyCap) {
+        int maxIncrease = 0;
+        int totalNewRate = 0;
+        boolean feasible = true;
+        LocalDate latest = null;
+        for (MaterialContext ctx : contexts) {
+            long daysRemaining = Math.max(1,
+                    ctx.today().until(ctx.deadline()).getDays());
+            int currentRate = Math.max(1, ctx.currentRate());
+            int newRate = (int) Math.ceil(
+                    (double) ctx.remainingMinutes() / daysRemaining);
+            int extra = Math.max(0, newRate - currentRate);
+            int pct = Math.round((extra * 100f) / currentRate);
+            totalNewRate += newRate;
+            if (pct > maxIncrease) {
+                maxIncrease = pct;
+            }
+            if (newRate > dailyCap) {
+                feasible = false;
+            }
+            if (latest == null || ctx.deadline().isAfter(latest)) {
+                latest = ctx.deadline();
+            }
+        }
+        if (totalNewRate > dailyCap) {
+            feasible = false;
+        }
+        String warning = feasible ? null
+                : "하루 가용시간 대비 학습량이 과다합니다";
+        return new RescheduleOption(
+                RescheduleStrategy.KEEP_DEADLINE, "데드라인 고정",
+                "하루 학습량 증가로 기존 일정 유지",
+                feasible, latest, maxIncrease, warning);
+    }
+
+    private void applyPostpone(
+            List<MaterialContext> contexts, int missedDays) {
+        for (MaterialContext ctx : contexts) {
+            ctx.material().shiftDeadline(missedDays);
+        }
+    }
+
+    private void applyCompress(
+            List<MaterialContext> contexts, int missedDays, int dailyCap) {
+        for (MaterialContext ctx : contexts) {
+            int currentRate = Math.max(1, ctx.currentRate());
+            long daysRemaining = Math.max(1,
+                    ctx.today().until(ctx.deadline()).getDays());
+            int missedMinutes = missedDays * currentRate;
+            int extra = (int) Math.ceil(
+                    (double) missedMinutes / daysRemaining);
+            int newRate = Math.min(dailyCap, currentRate + extra);
+            updateAllocation(ctx, newRate);
+        }
+    }
+
+    private void applyKeepDeadline(
+            List<MaterialContext> contexts, int dailyCap) {
+        for (MaterialContext ctx : contexts) {
+            long daysRemaining = Math.max(1,
+                    ctx.today().until(ctx.deadline()).getDays());
+            int newRate = (int) Math.ceil(
+                    (double) ctx.remainingMinutes() / daysRemaining);
+            int capped = Math.min(dailyCap, newRate);
+            updateAllocation(ctx, capped);
+        }
+    }
+
+    private void updateAllocation(MaterialContext ctx, int newRate) {
+        StudyMaterial material = ctx.material();
+        MaterialAllocation allocation = allocationRepository
+                .findByMaterialId(material.getId())
+                .orElse(null);
+        if (allocation == null) {
+            allocation = new MaterialAllocation(material, newRate);
+            allocationRepository.save(allocation);
+        } else {
+            allocation.update(newRate);
+        }
+        ctx.setCurrentRate(newRate);
+    }
+
+    private int computeAffectedDays(
+            List<MaterialContext> contexts, LocalDate today) {
+        LocalDate latest = null;
+        for (MaterialContext ctx : contexts) {
+            LocalDate deadline = ctx.material().getDeadline();
+            if (deadline == null) {
+                continue;
+            }
+            if (latest == null || deadline.isAfter(latest)) {
+                latest = deadline;
+            }
+        }
+        if (latest == null) {
+            return 0;
+        }
+        return (int) today.until(latest).getDays();
+    }
+
+    private record MissSummary(int missedDays, int missedItems) {
+    }
+
+    private static final class MaterialContext {
+        private final StudyMaterial material;
+        private final int remainingMinutes;
+        private final LocalDate today;
+        private int currentRate;
+
+        MaterialContext(StudyMaterial material, int remainingMinutes,
+                        LocalDate today) {
+            this.material = material;
+            this.remainingMinutes = remainingMinutes;
+            this.today = today;
+        }
+
+        void initializeRate(int fallback) {
+            MaterialAllocation allocation = material.getAllocation();
+            this.currentRate = allocation != null
+                    ? allocation.getDefaultMinutes() : fallback;
+        }
+
+        void setCurrentRate(int newRate) {
+            this.currentRate = newRate;
+        }
+
+        StudyMaterial material() {
+            return material;
+        }
+
+        int remainingMinutes() {
+            return remainingMinutes;
+        }
+
+        LocalDate today() {
+            return today;
+        }
+
+        LocalDate deadline() {
+            return material.getDeadline();
+        }
+
+        int currentRate() {
+            return currentRate;
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/rescheduling/controller/ReschedulingControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/rescheduling/controller/ReschedulingControllerTest.java
@@ -1,0 +1,255 @@
+package ds.project.orino.planner.rescheduling.controller;
+
+import ds.project.orino.domain.calendar.entity.DailySchedule;
+import ds.project.orino.domain.calendar.repository.DailyScheduleRepository;
+import ds.project.orino.domain.category.entity.Category;
+import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.domain.goal.repository.GoalRepository;
+import ds.project.orino.domain.goal.repository.MilestoneRepository;
+import ds.project.orino.domain.material.entity.DeadlineMode;
+import ds.project.orino.domain.material.entity.MaterialAllocation;
+import ds.project.orino.domain.material.entity.MaterialType;
+import ds.project.orino.domain.material.entity.StudyMaterial;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.repository.MaterialAllocationRepository;
+import ds.project.orino.domain.material.repository.MaterialDailyOverrideRepository;
+import ds.project.orino.domain.material.repository.ReviewConfigRepository;
+import ds.project.orino.domain.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.material.repository.StudyUnitRepository;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.domain.preference.repository.PriorityRuleRepository;
+import ds.project.orino.domain.preference.repository.UserPreferenceRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDate;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ReschedulingControllerTest extends ApiTestSupport {
+
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private MilestoneRepository milestoneRepository;
+    @Autowired private GoalRepository goalRepository;
+    @Autowired private ReviewConfigRepository reviewConfigRepository;
+    @Autowired private MaterialDailyOverrideRepository dailyOverrideRepository;
+    @Autowired private MaterialAllocationRepository allocationRepository;
+    @Autowired private StudyUnitRepository unitRepository;
+    @Autowired private StudyMaterialRepository materialRepository;
+    @Autowired private PriorityRuleRepository priorityRuleRepository;
+    @Autowired private UserPreferenceRepository userPreferenceRepository;
+    @Autowired private DailyScheduleRepository dailyScheduleRepository;
+
+    private String accessToken;
+    private Member member;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dailyScheduleRepository.deleteAll();
+        priorityRuleRepository.deleteAll();
+        userPreferenceRepository.deleteAll();
+        reviewConfigRepository.deleteAll();
+        dailyOverrideRepository.deleteAll();
+        allocationRepository.deleteAll();
+        unitRepository.deleteAll();
+        materialRepository.deleteAll();
+        milestoneRepository.deleteAll();
+        goalRepository.deleteAll();
+        categoryRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        member = memberRepository.save(MemberFixture.create());
+
+        UserPreference preference = new UserPreference(member);
+        ReflectionTestUtils.setField(preference, "dailyStudyMinutes", 240);
+        userPreferenceRepository.save(preference);
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId": "%s", "password": "%s"}
+                                """.formatted(
+                                MemberFixture.DEFAULT_LOGIN_ID,
+                                MemberFixture.DEFAULT_PASSWORD)))
+                .andReturn();
+
+        accessToken = com.jayway.jsonpath.JsonPath.read(
+                loginResult.getResponse().getContentAsString(),
+                "$.data.accessToken");
+    }
+
+    @AfterEach
+    void tearDown() {
+        dailyScheduleRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("GET /api/rescheduling/options - 연속 미완료일 및 3가지 전략 반환")
+    void getOptions_returnsAllStrategies() throws Exception {
+        createMissedDays(3);
+        createDeadlineMaterial("알고리즘", 30, 4, 60);
+
+        mockMvc.perform(get("/api/rescheduling/options")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.missedDays").value(3))
+                .andExpect(jsonPath("$.data.missedItems")
+                        .value(greaterThan(0)))
+                .andExpect(jsonPath("$.data.options.length()").value(3))
+                .andExpect(jsonPath("$.data.options[0].strategy")
+                        .value("POSTPONE"))
+                .andExpect(jsonPath("$.data.options[0].label").value("뒤로 밀기"))
+                .andExpect(jsonPath(
+                        "$.data.options[0].newEstimatedCompletion",
+                        notNullValue()))
+                .andExpect(jsonPath("$.data.options[1].strategy")
+                        .value("COMPRESS"))
+                .andExpect(jsonPath(
+                        "$.data.options[1].dailyIncreasePercent",
+                        notNullValue()))
+                .andExpect(jsonPath("$.data.options[2].strategy")
+                        .value("KEEP_DEADLINE"));
+    }
+
+    @Test
+    @DisplayName("GET /api/rescheduling/options - 미완료일 없으면 missedDays=0, options=[]")
+    void getOptions_noMissedDays() throws Exception {
+        createDeadlineMaterial("알고리즘", 30, 4, 60);
+
+        mockMvc.perform(get("/api/rescheduling/options")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.missedDays").value(0))
+                .andExpect(jsonPath("$.data.missedItems").value(0));
+    }
+
+    @Test
+    @DisplayName("POST /api/rescheduling/apply (POSTPONE) - 데드라인이 N일 뒤로 밀린다")
+    void apply_postpone_shiftsDeadline() throws Exception {
+        createMissedDays(3);
+        LocalDate originalDeadline = LocalDate.now().plusDays(30);
+        StudyMaterial material = createDeadlineMaterial(
+                "알고리즘", 30, 4, 60);
+        ReflectionTestUtils.setField(material, "deadline", originalDeadline);
+        materialRepository.save(material);
+
+        mockMvc.perform(post("/api/rescheduling/apply")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"strategy": "POSTPONE"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.strategy").value("POSTPONE"))
+                .andExpect(jsonPath("$.data.affectedDays")
+                        .value(greaterThan(0)));
+
+        StudyMaterial updated = materialRepository.findById(material.getId())
+                .orElseThrow();
+        org.assertj.core.api.Assertions.assertThat(updated.getDeadline())
+                .isEqualTo(originalDeadline.plusDays(3));
+    }
+
+    @Test
+    @DisplayName("POST /api/rescheduling/apply (COMPRESS) - 할당이 증가한다")
+    void apply_compress_updatesAllocation() throws Exception {
+        createMissedDays(3);
+        StudyMaterial material = createDeadlineMaterial(
+                "알고리즘", 30, 4, 60);
+
+        mockMvc.perform(post("/api/rescheduling/apply")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"strategy": "COMPRESS"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.strategy").value("COMPRESS"))
+                .andExpect(jsonPath("$.data.newDailyStudyMinutes")
+                        .value(greaterThan(60)));
+
+        MaterialAllocation allocation = allocationRepository
+                .findByMaterialId(material.getId()).orElseThrow();
+        org.assertj.core.api.Assertions.assertThat(
+                allocation.getDefaultMinutes()).isGreaterThan(60);
+    }
+
+    @Test
+    @DisplayName("POST /api/rescheduling/apply (KEEP_DEADLINE) - 강한 일일 증가")
+    void apply_keepDeadline_updatesAllocation() throws Exception {
+        createMissedDays(3);
+        StudyMaterial material = createDeadlineMaterial(
+                "알고리즘", 30, 4, 60);
+
+        mockMvc.perform(post("/api/rescheduling/apply")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"strategy": "KEEP_DEADLINE"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.strategy").value("KEEP_DEADLINE"))
+                .andExpect(jsonPath("$.data.newDailyStudyMinutes")
+                        .value(greaterThan(0)));
+
+        MaterialAllocation allocation = allocationRepository
+                .findByMaterialId(material.getId()).orElseThrow();
+        org.assertj.core.api.Assertions.assertThat(
+                allocation.getDefaultMinutes()).isGreaterThan(60);
+    }
+
+    @Test
+    @DisplayName("POST /api/rescheduling/apply - 데드라인 과목 없으면 INVALID_STATE")
+    void apply_noDeadlineMaterials() throws Exception {
+        mockMvc.perform(post("/api/rescheduling/apply")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"strategy": "COMPRESS"}
+                                """))
+                .andExpect(status().isConflict());
+    }
+
+    private void createMissedDays(int days) {
+        LocalDate today = LocalDate.now();
+        for (int i = 1; i <= days; i++) {
+            DailySchedule schedule = new DailySchedule(
+                    member, today.minusDays(i));
+            schedule.markGenerated(4, 1);
+            dailyScheduleRepository.save(schedule);
+        }
+    }
+
+    private StudyMaterial createDeadlineMaterial(
+            String title, int unitMinutes, int unitCount,
+            int allocationMinutes) {
+        Category category = categoryRepository.save(
+                new Category(member, "공부", "#8b00ff", null, 1));
+        StudyMaterial material = materialRepository.save(new StudyMaterial(
+                member, title, MaterialType.BOOK, category, null,
+                LocalDate.now().plusDays(30), DeadlineMode.DEADLINE));
+        for (int i = 1; i <= unitCount; i++) {
+            unitRepository.save(new StudyUnit(
+                    material, "챕터" + i, i, unitMinutes, null));
+        }
+        allocationRepository.save(new MaterialAllocation(
+                material, allocationMinutes));
+        return material;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/material/entity/StudyMaterial.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/material/entity/StudyMaterial.java
@@ -115,6 +115,12 @@ public class StudyMaterial {
                 ? deadlineMode : DeadlineMode.FREE;
     }
 
+    public void shiftDeadline(int days) {
+        if (this.deadline != null) {
+            this.deadline = this.deadline.plusDays(days);
+        }
+    }
+
     public void pause() {
         this.status = MaterialStatus.PAUSED;
     }


### PR DESCRIPTION
closes #162

## 작업 내용

### GET /api/rescheduling/options
연속 미완료 상태와 3가지 리스케줄링 선택지를 시뮬레이션하여 반환한다.

- `missedDays`: 오늘 이전부터 역순으로 `totalBlocks>0 && completedBlocks<totalBlocks`인 날의 연속 구간 길이 (최대 14일 조회)
- `missedItems`: 해당 미완료 일수 동안의 미완료 블록 합계
- 시뮬레이션 대상: `deadline_mode=DEADLINE`, `status=ACTIVE`, `deadline >= today`이고 PENDING StudyUnit이 있는 과목

전략별 계산:
- **POSTPONE (뒤로 밀기)**: 현재 페이스 C 유지. `daysNeeded = ceil(R / C)`, 새 완료 예상일 = `today + daysNeeded`
- **COMPRESS (압축)**: 밀린 양을 남은 기간에 분산. `extra = ceil(missedDays × C / daysRemaining)`, `newRate = C + extra`
- **KEEP_DEADLINE (데드라인 고정)**: 강제 일정 유지. `newRate = ceil(R / daysRemaining)`, 일일 한도 초과 시 warning

과목별로 계산 후 worst-case로 집계 (가장 늦은 완료일, 최대 증가율, 모두 feasible일 때만 feasible=true).

### POST /api/rescheduling/apply
- **POSTPONE**: 데드라인-바인드 과목의 `deadline += missedDays`
- **COMPRESS/KEEP_DEADLINE**: 과목별 `MaterialAllocation.defaultMinutes`를 새 rate로 업데이트 (없으면 생성). 일일 한도로 상한 적용
- 적용 후 `DirtyScheduleMarker.markDirtyFromToday` 호출로 차기 조회 시 스케줄 재생성

응답에는 `affectedDays`(오늘부터 가장 늦은 데드라인까지 일수)와 `newDailyStudyMinutes`(모든 데드라인 과목 할당 합계) 반환.

## 엔티티 변경
- `StudyMaterial.shiftDeadline(int days)` 메서드 추가 (POSTPONE용)

## 테스트
- `ReschedulingControllerTest` 통합 테스트 5개
  - options: 3전략 반환 / 미완료일 없을 때 빈 배열
  - apply: POSTPONE 데드라인 이동 / COMPRESS 할당 증가 / KEEP_DEADLINE 할당 증가 / 과목 없을 때 409