### PR TITLE
fix : argocd-server NodePort 30080 복원

### DIFF
--- a/infra/helm/argocd/values.yaml
+++ b/infra/helm/argocd/values.yaml
@@ -25,7 +25,8 @@ server:
   extraArgs:
     - --loglevel=info
   service:
-    type: ClusterIP
+    type: NodePort
+    nodePortHttp: 30080
   resources:
     requests:
       cpu: 250m


### PR DESCRIPTION
## 이슈
closes #

## 작업 내용
- PR #295에서 `server.service.type: ClusterIP`로 변경했던 것을 되돌림
- LAN 접근 경로 복원 (http://192.168.0.18:30080)
- 원래 설치 시 사용하던 NodePort 30080 유지

## 배포 후 수동 작업
- note1에서 helm upgrade 실행:
  \`\`\`bash
  ssh note1 "helm upgrade argocd argo/argo-cd --namespace argocd --version 9.4.10 -f values.yaml"
  \`\`\`