### PR TITLE
fix : argocd repo-server OOM 방지

### DIFF
--- a/infra/helm/argocd/values.yaml
+++ b/infra/helm/argocd/values.yaml
@@ -35,15 +35,16 @@ server:
       cpu: 500m
       memory: 512Mi
 
-# Git 클론/렌더링 담당. 실 사용량 ~16m / ~74Mi
+# Git 클론/렌더링 담당. 평상시 ~16m / ~74Mi
+# 단, kube-prometheus-stack/alloy 등 큰 차트 렌더링 시 메모리 spike 발생 (OOM 방지 위해 여유있게 설정)
 repoServer:
   resources:
     requests:
       cpu: 50m
       memory: 128Mi
     limits:
-      cpu: 200m
-      memory: 256Mi
+      cpu: 500m
+      memory: 768Mi
 
 # ApplicationSet 미사용 중이지만 App of Apps 보완재로 구동
 applicationSet:


### PR DESCRIPTION
## 이슈
closes #

## 작업 내용
- PR #295에서 설정한 repoServer memory limit 256Mi가 너무 낮아 OOMKill (exit 137) 발생
- 원인: kube-prometheus-stack, alloy 등 큰 차트 렌더링 시 메모리 spike
- 증상: \`alloy\`, \`kube-prometheus-stack\` Application이 \`ComparisonError\`로 Unknown 상태
- memory limit 256Mi → 768Mi
- cpu limit 200m → 500m (렌더링 속도 개선)

## 배포 후 수동 작업
- note1에서 helm upgrade 실행 (main pull 후):
  \`\`\`bash
  helm upgrade argocd argo/argo-cd -n argocd --version 9.4.10 \
    -f /home/dongseok/orino/infra/helm/argocd/values.yaml
  \`\`\`