### PR TITLE
feat : Alloy Faro receiver + telemetry.orino.dev 노출

### DIFF
--- a/infra/helm/alloy/templates/sealedsecret-faro.yaml
+++ b/infra/helm/alloy/templates/sealedsecret-faro.yaml
@@ -1,0 +1,12 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: alloy-faro-secret
+  namespace: monitoring
+spec:
+  encryptedData:
+    FARO_API_KEY: AgCcZuH0NqK+1nOrZTjXfWYlnv6mntWj4y5qd/o/VICqVQANtoUjTTM6H6FpS2UDTL9y3I625aNm+tM6/wen4Hq6PTqGCdLUrk4YwFnQ6Jbu2/pJdC7nH1PnkjWMQ846eUrptKY+aSa0sHAla/AFPvo4uBiW0P/vHIXIrq9KOadBOZKe8MJYjYQfkxsPk5Snl/2NU6cKodmDerqfhbxlVRH1E5RNgVz/9U3EtqYiqG6WUWYUonNti6h7JfS7ZsN3yhLfElG7XfRKlUSlP0FFZi3BwfH4VJYnBdGUjlXCAJQKm1q6ANalE7YD1SMR71rJCEqxbJ42lSKLemeg0hW+eH4I83PJZs8v+wDZ93roHGjZneCco0GeNpqf0CyAQwYIV0NE3nd3n6/BaTrqA+YC/SitY/tFVPOd/qWojOyqdjc5yoMbZLamd6waABWFwNAowV2N9N/LyAKR/oXAbj/kvW5YmT/H/1v+pR4ExDXPx/JUHW4KtpBFdTtxdKYRPvzIT55FSZDobrerQsDyNbYcSwq/bU9VlrzkMNyB4A8A5l9NPAoTdTaayLAX8h+oroGj6NVbHvN5J4X5jCJQL9tKPdxCbD6yyzSe6Rk19Nn4+iwB025jUDokP7j8UVZt9Kl0urc+hPLQABg4+7oAM9p/XoMAkaNU+eNMvwgJb5IaLLuG+jra9eBu+Ug3f6XUywLBCQJOltmXPsf+RIC+dJf7h+DleEZX44xYo4PhAYCFnMtJnM52COdZsSI0akfzZKp6fMSdqycYQG1useXpT03Y+H1w
+  template:
+    metadata:
+      name: alloy-faro-secret
+      namespace: monitoring

--- a/infra/helm/alloy/values.yaml
+++ b/infra/helm/alloy/values.yaml
@@ -28,6 +28,27 @@ alloy:
         }
 
         // ========================
+        // Faro receiver (FE 텔레메트리 수신)
+        // ========================
+        faro.receiver "app_receiver" {
+          server {
+            listen_address           = "0.0.0.0"
+            listen_port              = 12347
+            cors_allowed_origins     = ["https://orino.dev"]
+            api_key                  = sys.env("FARO_API_KEY")
+            max_allowed_payload_size = "10MiB"
+            rate_limiting {
+              rate = 100
+            }
+          }
+
+          output {
+            logs   = [loki.process.json_parse.receiver]
+            traces = [otelcol.exporter.otlp.tempo.input]
+          }
+        }
+
+        // ========================
         // Kubernetes Pod 로그 수집
         // ========================
         discovery.kubernetes "pods" {
@@ -103,6 +124,11 @@ alloy:
           }
         }
 
+    # FARO_API_KEY 환경변수 주입 (alloy-faro-secret)
+    envFrom:
+      - secretRef:
+          name: alloy-faro-secret
+
     extraPorts:
       - name: otlp-grpc
         port: 4317
@@ -111,6 +137,10 @@ alloy:
       - name: otlp-http
         port: 4318
         targetPort: 4318
+        protocol: TCP
+      - name: faro
+        port: 12347
+        targetPort: 12347
         protocol: TCP
 
   controller:

--- a/infra/helm/cloudflared/values.yaml
+++ b/infra/helm/cloudflared/values.yaml
@@ -20,6 +20,8 @@ cloudflared:
       service: http://istio-gateway.istio-ingress.svc.cluster.local:80
     - hostname: api.orino.dev
       service: http://istio-gateway.istio-ingress.svc.cluster.local:80
+    - hostname: telemetry.orino.dev
+      service: http://istio-gateway.istio-ingress.svc.cluster.local:80
     - service: http_status:404
 
   resources:

--- a/infra/helm/istio-gateway/templates/virtualservice-telemetry.yaml
+++ b/infra/helm/istio-gateway/templates/virtualservice-telemetry.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: telemetry
+  namespace: istio-ingress
+spec:
+  hosts:
+    - "telemetry.orino.dev"
+  gateways:
+    - orino-gateway
+  http:
+    - corsPolicy:
+        allowOrigins:
+          - exact: "https://orino.dev"
+        allowMethods:
+          - POST
+          - OPTIONS
+        allowHeaders:
+          - Content-Type
+          - X-API-Key
+          - X-Faro-Session-Id
+        maxAge: "86400s"
+      timeout: 10s
+      route:
+        - destination:
+            host: alloy.monitoring.svc.cluster.local
+            port:
+              number: 12347


### PR DESCRIPTION
## 이슈
closes #296

## 작업 내용
FE (Grafana Faro Web SDK) 텔레메트리를 수신하는 Alloy faro.receiver를 추가하고, 외부 진입 경로로 `telemetry.orino.dev`를 노출한다.

### 변경 사항
- **alloy values.yaml**
  - `faro.receiver "app_receiver"` 컴포넌트 추가
    - `listen_port = 12347`
    - `cors_allowed_origins = ["https://orino.dev"]`
    - `api_key = sys.env("FARO_API_KEY")`
    - `max_allowed_payload_size = "10MiB"`
    - `rate_limiting { rate = 100 }`
  - output: 기존 Loki (`loki.process.json_parse`) + Tempo (`otelcol.exporter.otlp.tempo`) 파이프라인 재사용
  - `extraPorts`에 `faro:12347` 추가
  - `envFrom`으로 `alloy-faro-secret` 주입
- **alloy SealedSecret** (신규) `alloy-faro-secret` (namespace: monitoring, key: `FARO_API_KEY`)
- **istio-gateway VirtualService** (신규) `telemetry` — `telemetry.orino.dev` → `alloy.monitoring.svc:12347`, CORS 포함
- **cloudflared values.yaml** — `telemetry.orino.dev` → istio-gateway 라우팅 추가

### 아키텍처
```
브라우저 (orino.dev)
  │ POST /collect (X-API-Key)
  ▼
telemetry.orino.dev (Cloudflare Tunnel)
  │
  ▼
istio-gateway:80 → VS(telemetry) → alloy:12347
  │
  ▼ faro.receiver
  ├─ logs   → loki.process.json_parse → Loki
  └─ traces → otelcol.exporter.otlp.tempo → Tempo
```

## 배포 후 수동 작업
- [ ] note1에서 DNS 라우팅 추가:
  \`\`\`bash
  cloudflared tunnel route dns orino telemetry.orino.dev
  \`\`\`
- [ ] 동작 확인:
  \`\`\`bash
  curl -i -X POST https://telemetry.orino.dev/collect \
    -H "Content-Type: application/json" \
    -H "X-API-Key: <FARO_API_KEY>" \
    -d '{}'
  \`\`\`
- [ ] Grafana Loki에서 FE 로그 조회 확인
- [ ] Grafana Tempo에서 FE span 조회 확인