### PR TITLE
fix : Faro 로그에 app/kind 라벨 부여

### DIFF
--- a/infra/helm/alloy/values.yaml
+++ b/infra/helm/alloy/values.yaml
@@ -43,9 +43,29 @@ alloy:
           }
 
           output {
-            logs   = [loki.process.json_parse.receiver]
+            logs   = [loki.process.faro.receiver]
             traces = [otelcol.exporter.otlp.tempo.input]
           }
+        }
+
+        // Faro 로그 전용 파이프라인: logfmt 파싱 후 app/kind를 스트림 라벨로 승격
+        // 나머지 필드(session_id, trace_id, view_name 등)는 high-cardinality이므로 로그 내용에만 남김
+        loki.process "faro" {
+          stage.logfmt {
+            mapping = {
+              app  = "app_name",
+              kind = "",
+            }
+          }
+
+          stage.labels {
+            values = {
+              app  = "",
+              kind = "",
+            }
+          }
+
+          forward_to = [loki.write.default.receiver]
         }
 
         // ========================


### PR DESCRIPTION
## 이슈
closes #

## 배경
PR #308에서 Faro receiver가 Loki에 로그를 쓰긴 하지만 stream label이 `service_name=unknown_service` 하나뿐이라 Grafana에서 효율적으로 필터링하기 어려웠다.

## 변경 사항
- `faro.receiver`의 logs 출력을 기존 `loki.process.json_parse` → 신규 `loki.process.faro`로 변경
- 신규 `loki.process "faro"`:
  - `stage.logfmt`로 Faro 로그 파싱
  - `app_name` → `app` 라벨로 승격
  - `kind` → `kind` 라벨로 승격 (log/error/event/measurement)

## 라벨 설계
**승격 (low cardinality):**
- `app` ← `app_name` (orino-fe 등 몇 개)
- `kind` (log/error/event/measurement 4개 고정)

**승격 안 함 (high cardinality, 로그 내용에만):**
- `session_id`, `trace_id`, `user_id`, `view_name` 등

## 쿼리 예시 (개선 전→후)
```
# Before
{service_name="unknown_service"} |~ "app_name=orino-fe"

# After
{app="orino-fe"}                   # FE 전체 로그
{app="orino-fe", kind="error"}     # FE 에러만
{app="orino-fe", kind="measurement"} # Web Vitals만
```

## 기존 k8s 로그와 일관성
- k8s pod 로그: `{app="be"}`, `{app="istio-gateway"}` 등
- Faro 로그: `{app="orino-fe"}`
- 동일한 `app` 라벨 체계로 Grafana 대시보드 통일 가능