### PR TITLE
feat : 대시보드 API

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dashboard/controller/DashboardController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dashboard/controller/DashboardController.java
@@ -1,0 +1,68 @@
+package ds.project.orino.planner.dashboard.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.dashboard.dto.DashboardHeatmapResponse;
+import ds.project.orino.planner.dashboard.dto.DashboardStatisticsResponse;
+import ds.project.orino.planner.dashboard.dto.DashboardStreaksResponse;
+import ds.project.orino.planner.dashboard.dto.DashboardSummaryResponse;
+import ds.project.orino.planner.dashboard.dto.StatisticsPeriod;
+import ds.project.orino.planner.dashboard.service.DashboardService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/dashboard")
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    public DashboardController(DashboardService dashboardService) {
+        this.dashboardService = dashboardService;
+    }
+
+    @GetMapping("/summary")
+    public ResponseEntity<ApiResponse<DashboardSummaryResponse>> getSummary(
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                dashboardService.getSummary(memberId)));
+    }
+
+    @GetMapping("/streaks")
+    public ResponseEntity<ApiResponse<DashboardStreaksResponse>> getStreaks(
+            Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                dashboardService.getStreaks(memberId)));
+    }
+
+    @GetMapping("/heatmap")
+    public ResponseEntity<ApiResponse<DashboardHeatmapResponse>> getHeatmap(
+            Authentication authentication,
+            @RequestParam(required = false) Integer year) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                dashboardService.getHeatmap(memberId, year)));
+    }
+
+    @GetMapping("/statistics")
+    public ResponseEntity<ApiResponse<DashboardStatisticsResponse>> getStatistics(
+            Authentication authentication,
+            @RequestParam(required = false) StatisticsPeriod period,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                dashboardService.getStatistics(
+                        memberId, period, startDate, endDate)));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dashboard/dto/DashboardHeatmapResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dashboard/dto/DashboardHeatmapResponse.java
@@ -1,0 +1,14 @@
+package ds.project.orino.planner.dashboard.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record DashboardHeatmapResponse(
+        int year,
+        List<DayAchievement> days) {
+
+    public record DayAchievement(
+            LocalDate date,
+            int achievementRate) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dashboard/dto/DashboardStatisticsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dashboard/dto/DashboardStatisticsResponse.java
@@ -1,0 +1,19 @@
+package ds.project.orino.planner.dashboard.dto;
+
+import java.util.List;
+
+public record DashboardStatisticsResponse(
+        StatisticsPeriod period,
+        int totalStudyMinutes,
+        int totalReviewMinutes,
+        int reviewCompletionRate,
+        List<CategoryBreakdown> categoryBreakdown) {
+
+    public record CategoryBreakdown(
+            Long categoryId,
+            String name,
+            String color,
+            int minutes,
+            int percent) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dashboard/dto/DashboardStreaksResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dashboard/dto/DashboardStreaksResponse.java
@@ -1,0 +1,21 @@
+package ds.project.orino.planner.dashboard.dto;
+
+import java.util.List;
+
+public record DashboardStreaksResponse(
+        Overall overall,
+        List<RoutineStreak> routines,
+        int freezeRemaining) {
+
+    public record Overall(
+            int currentCount,
+            int longestCount) {
+    }
+
+    public record RoutineStreak(
+            Long routineId,
+            String title,
+            int currentCount,
+            int longestCount) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dashboard/dto/DashboardSummaryResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dashboard/dto/DashboardSummaryResponse.java
@@ -1,0 +1,43 @@
+package ds.project.orino.planner.dashboard.dto;
+
+import java.util.List;
+
+public record DashboardSummaryResponse(
+        List<GoalSummary> goals,
+        ThisWeek thisWeek,
+        Streaks streaks,
+        TodayProgress todayProgress) {
+
+    public record GoalSummary(
+            Long id,
+            String title,
+            int progressPercent,
+            String paceStatus) {
+    }
+
+    public record ThisWeek(
+            int studyMinutes,
+            int reviewCompletionRate) {
+    }
+
+    public record Streaks(
+            OverallStreak overall,
+            List<RoutineStreak> routines) {
+    }
+
+    public record OverallStreak(
+            int currentCount,
+            int longestCount) {
+    }
+
+    public record RoutineStreak(
+            Long routineId,
+            String title,
+            int currentCount) {
+    }
+
+    public record TodayProgress(
+            int totalBlocks,
+            int completedBlocks) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dashboard/dto/StatisticsPeriod.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dashboard/dto/StatisticsPeriod.java
@@ -1,0 +1,5 @@
+package ds.project.orino.planner.dashboard.dto;
+
+public enum StatisticsPeriod {
+    DAILY, WEEKLY, MONTHLY
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dashboard/service/DashboardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dashboard/service/DashboardService.java
@@ -1,0 +1,394 @@
+package ds.project.orino.planner.dashboard.service;
+
+import ds.project.orino.domain.calendar.entity.BlockStatus;
+import ds.project.orino.domain.calendar.entity.BlockType;
+import ds.project.orino.domain.calendar.entity.DailySchedule;
+import ds.project.orino.domain.calendar.entity.ScheduleBlock;
+import ds.project.orino.domain.calendar.repository.DailyScheduleRepository;
+import ds.project.orino.domain.calendar.repository.ScheduleBlockRepository;
+import ds.project.orino.domain.category.entity.Category;
+import ds.project.orino.domain.goal.entity.Goal;
+import ds.project.orino.domain.goal.entity.Milestone;
+import ds.project.orino.domain.goal.entity.MilestoneStatus;
+import ds.project.orino.domain.goal.repository.GoalRepository;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.repository.StudyUnitRepository;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.domain.preference.repository.UserPreferenceRepository;
+import ds.project.orino.domain.review.entity.ReviewSchedule;
+import ds.project.orino.domain.review.repository.ReviewScheduleRepository;
+import ds.project.orino.domain.streak.entity.Streak;
+import ds.project.orino.domain.streak.entity.StreakType;
+import ds.project.orino.domain.streak.repository.StreakRepository;
+import ds.project.orino.planner.dashboard.dto.DashboardHeatmapResponse;
+import ds.project.orino.planner.dashboard.dto.DashboardStatisticsResponse;
+import ds.project.orino.planner.dashboard.dto.DashboardStreaksResponse;
+import ds.project.orino.planner.dashboard.dto.DashboardSummaryResponse;
+import ds.project.orino.planner.dashboard.dto.StatisticsPeriod;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class DashboardService {
+
+    private static final String DEFAULT_PACE_STATUS = "ON_TRACK";
+
+    private final GoalRepository goalRepository;
+    private final DailyScheduleRepository dailyScheduleRepository;
+    private final ScheduleBlockRepository scheduleBlockRepository;
+    private final StreakRepository streakRepository;
+    private final UserPreferenceRepository userPreferenceRepository;
+    private final StudyUnitRepository studyUnitRepository;
+    private final ReviewScheduleRepository reviewScheduleRepository;
+
+    public DashboardService(
+            GoalRepository goalRepository,
+            DailyScheduleRepository dailyScheduleRepository,
+            ScheduleBlockRepository scheduleBlockRepository,
+            StreakRepository streakRepository,
+            UserPreferenceRepository userPreferenceRepository,
+            StudyUnitRepository studyUnitRepository,
+            ReviewScheduleRepository reviewScheduleRepository) {
+        this.goalRepository = goalRepository;
+        this.dailyScheduleRepository = dailyScheduleRepository;
+        this.scheduleBlockRepository = scheduleBlockRepository;
+        this.streakRepository = streakRepository;
+        this.userPreferenceRepository = userPreferenceRepository;
+        this.studyUnitRepository = studyUnitRepository;
+        this.reviewScheduleRepository = reviewScheduleRepository;
+    }
+
+    public DashboardSummaryResponse getSummary(Long memberId) {
+        LocalDate today = LocalDate.now();
+        LocalDate weekStart = today.with(
+                TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate weekEnd = weekStart.plusDays(6);
+
+        List<DashboardSummaryResponse.GoalSummary> goals = buildGoalSummaries(memberId);
+        DashboardSummaryResponse.ThisWeek thisWeek = buildThisWeek(
+                memberId, weekStart, weekEnd);
+        DashboardSummaryResponse.Streaks streaks = buildSummaryStreaks(memberId);
+        DashboardSummaryResponse.TodayProgress todayProgress =
+                buildTodayProgress(memberId, today);
+
+        return new DashboardSummaryResponse(
+                goals, thisWeek, streaks, todayProgress);
+    }
+
+    public DashboardStreaksResponse getStreaks(Long memberId) {
+        Streak overallStreak = streakRepository
+                .findByMemberIdAndStreakTypeAndRoutineIsNull(
+                        memberId, StreakType.OVERALL)
+                .orElse(null);
+
+        List<Streak> routineStreaks = streakRepository
+                .findByMemberIdAndStreakType(memberId, StreakType.ROUTINE);
+
+        int freezeUsed = overallStreak != null
+                ? overallStreak.getFreezeUsedThisMonth() : 0;
+        int freezeTotal = userPreferenceRepository.findByMemberId(memberId)
+                .map(UserPreference::getStreakFreezePerMonth)
+                .orElse(0);
+        int freezeRemaining = Math.max(0, freezeTotal - freezeUsed);
+
+        List<DashboardStreaksResponse.RoutineStreak> routines = routineStreaks.stream()
+                .filter(s -> s.getRoutine() != null)
+                .map(s -> new DashboardStreaksResponse.RoutineStreak(
+                        s.getRoutine().getId(),
+                        s.getRoutine().getTitle(),
+                        s.getCurrentCount(),
+                        s.getLongestCount()))
+                .toList();
+
+        DashboardStreaksResponse.Overall overall = overallStreak != null
+                ? new DashboardStreaksResponse.Overall(
+                        overallStreak.getCurrentCount(),
+                        overallStreak.getLongestCount())
+                : new DashboardStreaksResponse.Overall(0, 0);
+
+        return new DashboardStreaksResponse(overall, routines, freezeRemaining);
+    }
+
+    public DashboardHeatmapResponse getHeatmap(Long memberId, Integer year) {
+        int targetYear = year != null ? year : LocalDate.now().getYear();
+        LocalDate start = LocalDate.of(targetYear, 1, 1);
+        LocalDate end = LocalDate.of(targetYear, 12, 31);
+
+        List<DailySchedule> schedules = dailyScheduleRepository
+                .findByMemberIdAndScheduleDateBetween(memberId, start, end);
+
+        List<DashboardHeatmapResponse.DayAchievement> days = schedules.stream()
+                .sorted(Comparator.comparing(DailySchedule::getScheduleDate))
+                .map(s -> new DashboardHeatmapResponse.DayAchievement(
+                        s.getScheduleDate(),
+                        computeAchievementRate(
+                                s.getTotalBlocks(), s.getCompletedBlocks())))
+                .toList();
+
+        return new DashboardHeatmapResponse(targetYear, days);
+    }
+
+    public DashboardStatisticsResponse getStatistics(
+            Long memberId, StatisticsPeriod period,
+            LocalDate startDate, LocalDate endDate) {
+        StatisticsPeriod resolvedPeriod = period != null
+                ? period : StatisticsPeriod.WEEKLY;
+        LocalDate[] range = resolveDateRange(resolvedPeriod, startDate, endDate);
+        LocalDate from = range[0];
+        LocalDate to = range[1];
+
+        List<ScheduleBlock> blocks = scheduleBlockRepository
+                .findByMemberIdAndDateBetween(memberId, from, to);
+
+        int totalStudyMinutes = sumCompletedMinutes(blocks, BlockType.STUDY);
+        int totalReviewMinutes = sumCompletedMinutes(blocks, BlockType.REVIEW);
+        int reviewCompletionRate = computeReviewCompletionRate(blocks);
+        List<DashboardStatisticsResponse.CategoryBreakdown> breakdown =
+                buildCategoryBreakdown(blocks);
+
+        return new DashboardStatisticsResponse(
+                resolvedPeriod, totalStudyMinutes, totalReviewMinutes,
+                reviewCompletionRate, breakdown);
+    }
+
+    private List<DashboardSummaryResponse.GoalSummary> buildGoalSummaries(
+            Long memberId) {
+        List<Goal> goals = goalRepository
+                .findByMemberIdOrderByCreatedAtDesc(memberId);
+        List<DashboardSummaryResponse.GoalSummary> result = new ArrayList<>();
+        for (Goal goal : goals) {
+            List<Milestone> milestones = goal.getMilestones();
+            int total = milestones.size();
+            int completed = (int) milestones.stream()
+                    .filter(m -> m.getStatus() == MilestoneStatus.COMPLETED)
+                    .count();
+            int progressPercent = total > 0 ? completed * 100 / total : 0;
+            result.add(new DashboardSummaryResponse.GoalSummary(
+                    goal.getId(), goal.getTitle(),
+                    progressPercent, DEFAULT_PACE_STATUS));
+        }
+        return result;
+    }
+
+    private DashboardSummaryResponse.ThisWeek buildThisWeek(
+            Long memberId, LocalDate weekStart, LocalDate weekEnd) {
+        List<ScheduleBlock> blocks = scheduleBlockRepository
+                .findByMemberIdAndDateBetween(memberId, weekStart, weekEnd);
+        int studyMinutes = blocks.stream()
+                .filter(b -> b.getStatus() == BlockStatus.COMPLETED)
+                .filter(b -> b.getBlockType() == BlockType.STUDY
+                        || b.getBlockType() == BlockType.REVIEW)
+                .mapToInt(DashboardService::blockDurationMinutes)
+                .sum();
+        int reviewRate = computeReviewCompletionRate(blocks);
+        return new DashboardSummaryResponse.ThisWeek(studyMinutes, reviewRate);
+    }
+
+    private DashboardSummaryResponse.Streaks buildSummaryStreaks(Long memberId) {
+        Streak overall = streakRepository
+                .findByMemberIdAndStreakTypeAndRoutineIsNull(
+                        memberId, StreakType.OVERALL)
+                .orElse(null);
+        DashboardSummaryResponse.OverallStreak overallDto = overall != null
+                ? new DashboardSummaryResponse.OverallStreak(
+                        overall.getCurrentCount(), overall.getLongestCount())
+                : new DashboardSummaryResponse.OverallStreak(0, 0);
+
+        List<DashboardSummaryResponse.RoutineStreak> routines = streakRepository
+                .findByMemberIdAndStreakType(memberId, StreakType.ROUTINE)
+                .stream()
+                .filter(s -> s.getRoutine() != null)
+                .map(s -> new DashboardSummaryResponse.RoutineStreak(
+                        s.getRoutine().getId(),
+                        s.getRoutine().getTitle(),
+                        s.getCurrentCount()))
+                .toList();
+
+        return new DashboardSummaryResponse.Streaks(overallDto, routines);
+    }
+
+    private DashboardSummaryResponse.TodayProgress buildTodayProgress(
+            Long memberId, LocalDate today) {
+        return dailyScheduleRepository
+                .findByMemberIdAndScheduleDate(memberId, today)
+                .map(s -> new DashboardSummaryResponse.TodayProgress(
+                        s.getTotalBlocks(), s.getCompletedBlocks()))
+                .orElse(new DashboardSummaryResponse.TodayProgress(0, 0));
+    }
+
+    private LocalDate[] resolveDateRange(StatisticsPeriod period,
+                                         LocalDate startDate,
+                                         LocalDate endDate) {
+        if (startDate != null && endDate != null) {
+            return new LocalDate[]{startDate, endDate};
+        }
+        LocalDate today = LocalDate.now();
+        return switch (period) {
+            case DAILY -> new LocalDate[]{today, today};
+            case WEEKLY -> {
+                LocalDate monday = today.with(
+                        TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+                yield new LocalDate[]{monday, monday.plusDays(6)};
+            }
+            case MONTHLY -> {
+                LocalDate first = today.withDayOfMonth(1);
+                LocalDate last = today.with(
+                        TemporalAdjusters.lastDayOfMonth());
+                yield new LocalDate[]{first, last};
+            }
+        };
+    }
+
+    private int sumCompletedMinutes(List<ScheduleBlock> blocks,
+                                    BlockType blockType) {
+        return blocks.stream()
+                .filter(b -> b.getBlockType() == blockType)
+                .filter(b -> b.getStatus() == BlockStatus.COMPLETED)
+                .mapToInt(DashboardService::blockDurationMinutes)
+                .sum();
+    }
+
+    private int computeReviewCompletionRate(List<ScheduleBlock> blocks) {
+        List<ScheduleBlock> reviews = blocks.stream()
+                .filter(b -> b.getBlockType() == BlockType.REVIEW)
+                .toList();
+        if (reviews.isEmpty()) {
+            return 0;
+        }
+        long completed = reviews.stream()
+                .filter(b -> b.getStatus() == BlockStatus.COMPLETED)
+                .count();
+        return (int) (completed * 100 / reviews.size());
+    }
+
+    private List<DashboardStatisticsResponse.CategoryBreakdown>
+            buildCategoryBreakdown(List<ScheduleBlock> blocks) {
+        List<ScheduleBlock> studyReview = blocks.stream()
+                .filter(b -> b.getStatus() == BlockStatus.COMPLETED)
+                .filter(b -> b.getBlockType() == BlockType.STUDY
+                        || b.getBlockType() == BlockType.REVIEW)
+                .toList();
+        if (studyReview.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, Long> reviewIdToUnitId = loadReviewToUnitMap(studyReview);
+        Map<Long, Category> unitIdToCategory = loadStudyUnitCategories(
+                studyReview, reviewIdToUnitId);
+
+        Map<Long, Integer> minutesByCategory = new LinkedHashMap<>();
+        Map<Long, Category> categoryLookup = new HashMap<>();
+        int totalMinutes = 0;
+        for (ScheduleBlock block : studyReview) {
+            Long unitId = resolveStudyUnitId(block, reviewIdToUnitId);
+            if (unitId == null) {
+                continue;
+            }
+            Category category = unitIdToCategory.get(unitId);
+            if (category == null) {
+                continue;
+            }
+            int minutes = blockDurationMinutes(block);
+            totalMinutes += minutes;
+            minutesByCategory.merge(category.getId(), minutes, Integer::sum);
+            categoryLookup.putIfAbsent(category.getId(), category);
+        }
+
+        if (totalMinutes == 0) {
+            return List.of();
+        }
+
+        int totalForPercent = totalMinutes;
+        return minutesByCategory.entrySet().stream()
+                .sorted(Map.Entry.<Long, Integer>comparingByValue().reversed())
+                .map(e -> {
+                    Category c = categoryLookup.get(e.getKey());
+                    int minutes = e.getValue();
+                    int percent = minutes * 100 / totalForPercent;
+                    return new DashboardStatisticsResponse.CategoryBreakdown(
+                            c.getId(), c.getName(), c.getColor(),
+                            minutes, percent);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private Map<Long, Long> loadReviewToUnitMap(
+            List<ScheduleBlock> studyReviewBlocks) {
+        Set<Long> reviewIds = studyReviewBlocks.stream()
+                .filter(b -> b.getBlockType() == BlockType.REVIEW)
+                .map(ScheduleBlock::getReferenceId)
+                .collect(Collectors.toSet());
+        if (reviewIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, Long> result = new HashMap<>();
+        for (ReviewSchedule r : reviewScheduleRepository.findAllById(reviewIds)) {
+            result.put(r.getId(), r.getStudyUnit().getId());
+        }
+        return result;
+    }
+
+    private Map<Long, Category> loadStudyUnitCategories(
+            List<ScheduleBlock> studyReviewBlocks,
+            Map<Long, Long> reviewIdToUnitId) {
+        Set<Long> studyUnitIds = studyReviewBlocks.stream()
+                .filter(b -> b.getBlockType() == BlockType.STUDY)
+                .map(ScheduleBlock::getReferenceId)
+                .collect(Collectors.toSet());
+        studyUnitIds.addAll(reviewIdToUnitId.values());
+
+        if (studyUnitIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, Category> result = new HashMap<>();
+        for (StudyUnit unit : studyUnitRepository.findAllById(studyUnitIds)) {
+            Category category = unit.getMaterial().getCategory();
+            if (category != null) {
+                result.put(unit.getId(), category);
+            }
+        }
+        return result;
+    }
+
+    private Long resolveStudyUnitId(ScheduleBlock block,
+                                    Map<Long, Long> reviewIdToUnitId) {
+        if (block.getBlockType() == BlockType.STUDY) {
+            return block.getReferenceId();
+        }
+        if (block.getBlockType() == BlockType.REVIEW) {
+            return reviewIdToUnitId.get(block.getReferenceId());
+        }
+        return null;
+    }
+
+    private static int computeAchievementRate(int total, int completed) {
+        if (total == 0) {
+            return 0;
+        }
+        return completed * 100 / total;
+    }
+
+    private static int blockDurationMinutes(ScheduleBlock block) {
+        long minutes = Duration.between(
+                block.getStartTime(), block.getEndTime()).toMinutes();
+        if (minutes < 0) {
+            minutes += 24 * 60;
+        }
+        return (int) minutes;
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dashboard/controller/DashboardControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dashboard/controller/DashboardControllerTest.java
@@ -1,0 +1,259 @@
+package ds.project.orino.planner.dashboard.controller;
+
+import ds.project.orino.domain.calendar.entity.BlockType;
+import ds.project.orino.domain.calendar.entity.DailySchedule;
+import ds.project.orino.domain.calendar.entity.ScheduleBlock;
+import ds.project.orino.domain.calendar.repository.DailyScheduleRepository;
+import ds.project.orino.domain.calendar.repository.ScheduleBlockRepository;
+import ds.project.orino.domain.category.entity.Category;
+import ds.project.orino.domain.category.repository.CategoryRepository;
+import ds.project.orino.domain.fixedschedule.entity.RecurrenceType;
+import ds.project.orino.domain.goal.entity.Goal;
+import ds.project.orino.domain.goal.entity.Milestone;
+import ds.project.orino.domain.goal.entity.PeriodType;
+import ds.project.orino.domain.goal.repository.GoalRepository;
+import ds.project.orino.domain.goal.repository.MilestoneRepository;
+import ds.project.orino.domain.material.entity.DeadlineMode;
+import ds.project.orino.domain.material.entity.MaterialType;
+import ds.project.orino.domain.material.entity.StudyMaterial;
+import ds.project.orino.domain.material.entity.StudyUnit;
+import ds.project.orino.domain.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.material.repository.StudyUnitRepository;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.preference.entity.UserPreference;
+import ds.project.orino.domain.preference.repository.PriorityRuleRepository;
+import ds.project.orino.domain.preference.repository.UserPreferenceRepository;
+import ds.project.orino.domain.routine.entity.Routine;
+import ds.project.orino.domain.routine.repository.RoutineRepository;
+import ds.project.orino.domain.streak.entity.Streak;
+import ds.project.orino.domain.streak.repository.StreakRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class DashboardControllerTest extends ApiTestSupport {
+
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private MilestoneRepository milestoneRepository;
+    @Autowired private GoalRepository goalRepository;
+    @Autowired private RoutineRepository routineRepository;
+    @Autowired private StudyUnitRepository unitRepository;
+    @Autowired private StudyMaterialRepository materialRepository;
+    @Autowired private PriorityRuleRepository priorityRuleRepository;
+    @Autowired private UserPreferenceRepository userPreferenceRepository;
+    @Autowired private DailyScheduleRepository dailyScheduleRepository;
+    @Autowired private ScheduleBlockRepository scheduleBlockRepository;
+    @Autowired private StreakRepository streakRepository;
+
+    private String accessToken;
+    private Member member;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        streakRepository.deleteAll();
+        scheduleBlockRepository.deleteAll();
+        dailyScheduleRepository.deleteAll();
+        priorityRuleRepository.deleteAll();
+        userPreferenceRepository.deleteAll();
+        unitRepository.deleteAll();
+        materialRepository.deleteAll();
+        routineRepository.deleteAll();
+        milestoneRepository.deleteAll();
+        goalRepository.deleteAll();
+        categoryRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        member = memberRepository.save(MemberFixture.create());
+        UserPreference pref = new UserPreference(member);
+        ReflectionTestUtils.setField(pref, "streakFreezePerMonth", 3);
+        userPreferenceRepository.save(pref);
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId": "%s", "password": "%s"}
+                                """.formatted(
+                                MemberFixture.DEFAULT_LOGIN_ID,
+                                MemberFixture.DEFAULT_PASSWORD)))
+                .andReturn();
+        accessToken = com.jayway.jsonpath.JsonPath.read(
+                loginResult.getResponse().getContentAsString(),
+                "$.data.accessToken");
+    }
+
+    @AfterEach
+    void tearDown() {
+        streakRepository.deleteAll();
+        scheduleBlockRepository.deleteAll();
+        dailyScheduleRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("GET /api/dashboard/summary - 빈 상태는 기본값 반환")
+    void summary_empty() throws Exception {
+        mockMvc.perform(get("/api/dashboard/summary")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.goals").isArray())
+                .andExpect(jsonPath("$.data.thisWeek.studyMinutes").value(0))
+                .andExpect(jsonPath("$.data.thisWeek.reviewCompletionRate").value(0))
+                .andExpect(jsonPath("$.data.streaks.overall.currentCount").value(0))
+                .andExpect(jsonPath("$.data.streaks.overall.longestCount").value(0))
+                .andExpect(jsonPath("$.data.streaks.routines").isArray())
+                .andExpect(jsonPath("$.data.todayProgress.totalBlocks").value(0))
+                .andExpect(jsonPath("$.data.todayProgress.completedBlocks").value(0));
+    }
+
+    @Test
+    @DisplayName("GET /api/dashboard/summary - 목표 진행률과 오늘 블록 반환")
+    void summary_withGoalsAndToday() throws Exception {
+        Goal goal = goalRepository.save(new Goal(
+                member, null, "백엔드 취업", "설명",
+                PeriodType.YEAR, LocalDate.now(), LocalDate.now().plusMonths(6)));
+        Milestone m1 = new Milestone(goal, "JPA 완성", LocalDate.now(), 0);
+        m1.complete();
+        milestoneRepository.save(m1);
+        milestoneRepository.save(new Milestone(
+                goal, "Spring Security", LocalDate.now(), 1));
+
+        DailySchedule today = dailyScheduleRepository.save(
+                new DailySchedule(member, LocalDate.now()));
+        today.markGenerated(4, 2);
+        dailyScheduleRepository.save(today);
+
+        mockMvc.perform(get("/api/dashboard/summary")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.goals", hasSize(1)))
+                .andExpect(jsonPath("$.data.goals[0].title").value("백엔드 취업"))
+                .andExpect(jsonPath("$.data.goals[0].progressPercent").value(50))
+                .andExpect(jsonPath("$.data.goals[0].paceStatus").value("ON_TRACK"))
+                .andExpect(jsonPath("$.data.todayProgress.totalBlocks").value(4))
+                .andExpect(jsonPath("$.data.todayProgress.completedBlocks").value(2));
+    }
+
+    @Test
+    @DisplayName("GET /api/dashboard/streaks - 스트릭과 프리즈 잔여 반환")
+    void streaks_withOverallAndRoutine() throws Exception {
+        Streak overall = Streak.overall(member);
+        ReflectionTestUtils.setField(overall, "currentCount", 10);
+        ReflectionTestUtils.setField(overall, "longestCount", 20);
+        ReflectionTestUtils.setField(overall, "freezeUsedThisMonth", 1);
+        streakRepository.save(overall);
+
+        Routine routine = routineRepository.save(new Routine(
+                member, "헬스", null, 60, LocalTime.of(7, 0),
+                RecurrenceType.WEEKLY,
+                null, "MON,WED,FRI", LocalDate.now(), null, false));
+        Streak routineStreak = Streak.routine(member, routine);
+        ReflectionTestUtils.setField(routineStreak, "currentCount", 5);
+        ReflectionTestUtils.setField(routineStreak, "longestCount", 8);
+        streakRepository.save(routineStreak);
+
+        mockMvc.perform(get("/api/dashboard/streaks")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.overall.currentCount").value(10))
+                .andExpect(jsonPath("$.data.overall.longestCount").value(20))
+                .andExpect(jsonPath("$.data.routines", hasSize(1)))
+                .andExpect(jsonPath("$.data.routines[0].title").value("헬스"))
+                .andExpect(jsonPath("$.data.routines[0].currentCount").value(5))
+                .andExpect(jsonPath("$.data.routines[0].longestCount").value(8))
+                .andExpect(jsonPath("$.data.freezeRemaining").value(2));
+    }
+
+    @Test
+    @DisplayName("GET /api/dashboard/heatmap - 연간 일별 달성률 반환")
+    void heatmap_returnsDaysForYear() throws Exception {
+        int year = LocalDate.now().getYear();
+        LocalDate d1 = LocalDate.of(year, 6, 1);
+        LocalDate d2 = LocalDate.of(year, 6, 2);
+
+        DailySchedule s1 = dailyScheduleRepository.save(
+                new DailySchedule(member, d1));
+        s1.markGenerated(5, 5);
+        dailyScheduleRepository.save(s1);
+
+        DailySchedule s2 = dailyScheduleRepository.save(
+                new DailySchedule(member, d2));
+        s2.markGenerated(4, 2);
+        dailyScheduleRepository.save(s2);
+
+        mockMvc.perform(get("/api/dashboard/heatmap")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("year", String.valueOf(year)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.year").value(year))
+                .andExpect(jsonPath("$.data.days", hasSize(greaterThanOrEqualTo(2))))
+                .andExpect(jsonPath("$.data.days[0].date").value(d1.toString()))
+                .andExpect(jsonPath("$.data.days[0].achievementRate").value(100))
+                .andExpect(jsonPath("$.data.days[1].date").value(d2.toString()))
+                .andExpect(jsonPath("$.data.days[1].achievementRate").value(50));
+    }
+
+    @Test
+    @DisplayName("GET /api/dashboard/statistics - 주간 통계와 카테고리 분배 반환")
+    void statistics_weeklyBreakdown() throws Exception {
+        Category category = categoryRepository.save(
+                new Category(member, "프로그래밍", "#FF9800", null, 0));
+
+        StudyMaterial material = materialRepository.save(new StudyMaterial(
+                member, "JPA 책", MaterialType.BOOK, category, null,
+                null, DeadlineMode.FREE));
+        StudyUnit unit = unitRepository.save(new StudyUnit(
+                material, "1장", 0, 60, null));
+
+        LocalDate monday = LocalDate.now().with(
+                TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        DailySchedule ds = dailyScheduleRepository.save(
+                new DailySchedule(member, monday));
+        ScheduleBlock block = new ScheduleBlock(ds, BlockType.STUDY,
+                unit.getId(), LocalTime.of(9, 0), LocalTime.of(10, 0), 0);
+        block.complete();
+        scheduleBlockRepository.save(block);
+
+        mockMvc.perform(get("/api/dashboard/statistics")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("period", "WEEKLY"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.period").value("WEEKLY"))
+                .andExpect(jsonPath("$.data.totalStudyMinutes").value(60))
+                .andExpect(jsonPath("$.data.totalReviewMinutes").value(0))
+                .andExpect(jsonPath("$.data.categoryBreakdown", hasSize(1)))
+                .andExpect(jsonPath("$.data.categoryBreakdown[0].name")
+                        .value("프로그래밍"))
+                .andExpect(jsonPath("$.data.categoryBreakdown[0].minutes").value(60))
+                .andExpect(jsonPath("$.data.categoryBreakdown[0].percent").value(100));
+    }
+
+    @Test
+    @DisplayName("GET /api/dashboard/statistics - 기본값 WEEKLY로 동작")
+    void statistics_defaultPeriodWeekly() throws Exception {
+        mockMvc.perform(get("/api/dashboard/statistics")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.period").value("WEEKLY"))
+                .andExpect(jsonPath("$.data.totalStudyMinutes").value(0));
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/repository/ScheduleBlockRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/calendar/repository/ScheduleBlockRepository.java
@@ -2,7 +2,10 @@ package ds.project.orino.domain.calendar.repository;
 
 import ds.project.orino.domain.calendar.entity.ScheduleBlock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ScheduleBlockRepository
@@ -10,4 +13,12 @@ public interface ScheduleBlockRepository
 
     List<ScheduleBlock> findByDailyScheduleIdOrderBySortOrder(
             Long dailyScheduleId);
+
+    @Query("SELECT b FROM ScheduleBlock b "
+            + "WHERE b.dailySchedule.member.id = :memberId "
+            + "AND b.dailySchedule.scheduleDate BETWEEN :fromDate AND :toDate")
+    List<ScheduleBlock> findByMemberIdAndDateBetween(
+            @Param("memberId") Long memberId,
+            @Param("fromDate") LocalDate fromDate,
+            @Param("toDate") LocalDate toDate);
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/streak/entity/Streak.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/streak/entity/Streak.java
@@ -1,0 +1,141 @@
+package ds.project.orino.domain.streak.entity;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.routine.entity.Routine;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "streak")
+@EntityListeners(AuditingEntityListener.class)
+public class Streak {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "streak_type", length = 10, nullable = false)
+    private StreakType streakType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "routine_id")
+    private Routine routine;
+
+    @Column(name = "current_count", nullable = false)
+    private int currentCount;
+
+    @Column(name = "longest_count", nullable = false)
+    private int longestCount;
+
+    @Column(name = "last_achieved_date")
+    private LocalDate lastAchievedDate;
+
+    @Column(name = "freeze_used_this_month", nullable = false)
+    private int freezeUsedThisMonth;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected Streak() {
+    }
+
+    public Streak(Member member, StreakType streakType, Routine routine) {
+        this.member = member;
+        this.streakType = streakType;
+        this.routine = routine;
+    }
+
+    public static Streak overall(Member member) {
+        return new Streak(member, StreakType.OVERALL, null);
+    }
+
+    public static Streak routine(Member member, Routine routine) {
+        return new Streak(member, StreakType.ROUTINE, routine);
+    }
+
+    public void increment(LocalDate achievedDate) {
+        this.currentCount += 1;
+        if (this.currentCount > this.longestCount) {
+            this.longestCount = this.currentCount;
+        }
+        this.lastAchievedDate = achievedDate;
+    }
+
+    public void reset() {
+        this.currentCount = 0;
+    }
+
+    public void useFreeze() {
+        this.freezeUsedThisMonth += 1;
+    }
+
+    public void resetMonthlyFreeze() {
+        this.freezeUsedThisMonth = 0;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public StreakType getStreakType() {
+        return streakType;
+    }
+
+    public Routine getRoutine() {
+        return routine;
+    }
+
+    public int getCurrentCount() {
+        return currentCount;
+    }
+
+    public int getLongestCount() {
+        return longestCount;
+    }
+
+    public LocalDate getLastAchievedDate() {
+        return lastAchievedDate;
+    }
+
+    public int getFreezeUsedThisMonth() {
+        return freezeUsedThisMonth;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/streak/entity/StreakType.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/streak/entity/StreakType.java
@@ -1,0 +1,5 @@
+package ds.project.orino.domain.streak.entity;
+
+public enum StreakType {
+    OVERALL, ROUTINE
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/streak/repository/StreakRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/streak/repository/StreakRepository.java
@@ -1,0 +1,20 @@
+package ds.project.orino.domain.streak.repository;
+
+import ds.project.orino.domain.streak.entity.Streak;
+import ds.project.orino.domain.streak.entity.StreakType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StreakRepository extends JpaRepository<Streak, Long> {
+
+    Optional<Streak> findByMemberIdAndStreakTypeAndRoutineIsNull(
+            Long memberId, StreakType streakType);
+
+    Optional<Streak> findByMemberIdAndStreakTypeAndRoutineId(
+            Long memberId, StreakType streakType, Long routineId);
+
+    List<Streak> findByMemberIdAndStreakType(
+            Long memberId, StreakType streakType);
+}


### PR DESCRIPTION
## 이슈
closes #168
## 작업 내용
- Streak 엔티티/리포지토리 추가 (overall, routine 타입)
- `GET /api/dashboard/summary` - 목표 진행률, 이번주 학습/복습, 스트릭, 오늘 진행률
- `GET /api/dashboard/streaks` - 전체/루틴 스트릭, 프리즈 잔여
- `GET /api/dashboard/heatmap?year=` - 연간 일별 달성률
- `GET /api/dashboard/statistics?period=&startDate=&endDate=` - 기간별 통계, 카테고리 분배
- `ScheduleBlockRepository.findByMemberIdAndDateBetween` 추가
- DashboardControllerTest 통합 테스트 (6개)