### PR TITLE
fix : Trivy HIGH/CRITICAL 취약점 수정

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -20,6 +20,8 @@ subprojects {
     }
 
     ext['jackson-2-bom.version'] = '2.21.1'
+    ext['jackson-bom.version'] = '3.1.0'
+    ext['spring-security.version'] = '7.0.4'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## 이슈
closes #312

## 작업 내용

- `spring-security` 버전 오버라이드 추가: 7.0.3 → 7.0.4 (CVE-2026-22732)
- `jackson-bom` 버전 오버라이드 추가: 3.0.4 → 3.1.0 (CVE-2026-29062, GHSA-2m67-wjpj-xhg9)

Spring Boot 4.0.3 BOM이 취약한 버전을 끌어오므로 `build.gradle`에서 `ext['...version']`로 오버라이드.