### PR TITLE
feat : BE/Istio 메트릭 기반 알림 규칙 추가

### DIFF
--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
     metadata:
       labels:
         app: be
+      annotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: "9090"
     spec:
       terminationGracePeriodSeconds: 60
       securityContext:
@@ -49,7 +51,10 @@ spec:
         - name: be
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           ports:
-            - containerPort: 8080
+            - name: http
+              containerPort: 8080
+            - name: actuator
+              containerPort: 9090
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/infra/helm/be/templates/service.yaml
+++ b/infra/helm/be/templates/service.yaml
@@ -2,10 +2,16 @@ apiVersion: v1
 kind: Service
 metadata:
   name: be
+  labels:
+    app: be
 spec:
   type: ClusterIP
   selector:
     app: be
   ports:
-    - port: 8080
-      targetPort: 8080
+    - name: http
+      port: 8080
+      targetPort: http
+    - name: actuator
+      port: 9090
+      targetPort: actuator

--- a/infra/helm/be/templates/servicemonitor.yaml
+++ b/infra/helm/be/templates/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: be
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: be
+  endpoints:
+    - port: actuator
+      path: /prometheus
+      interval: 30s

--- a/infra/helm/istiod/templates/podmonitor.yaml
+++ b/infra/helm/istiod/templates/podmonitor.yaml
@@ -1,0 +1,40 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: istio-proxies
+  namespace: istio-system
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector: {}
+  namespaceSelector:
+    any: true
+  podMetricsEndpoints:
+    - port: http-envoy-prom
+      path: /stats/prometheus
+      interval: 30s
+      relabelings:
+        - action: keep
+          sourceLabels: [__meta_kubernetes_pod_container_name]
+          regex: istio-proxy
+        - sourceLabels: [__meta_kubernetes_namespace]
+          action: replace
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          action: replace
+          targetLabel: pod
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istiod
+  namespace: istio-system
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      istio: pilot
+  endpoints:
+    - port: http-monitoring
+      interval: 30s

--- a/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
@@ -160,3 +160,110 @@ spec:
           annotations:
             summary: "PVC {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }} 용량 부족"
             description: "PVC 사용률 {{ "{{" }} $value | printf \"%.0f\" {{ "}}" }}% (80% 초과)"
+
+    - name: app-metrics
+      rules:
+        - alert: BackendHighErrorRate
+          expr: |
+            sum(rate(http_server_requests_seconds_count{namespace="orino",status=~"5.."}[5m]))
+              / sum(rate(http_server_requests_seconds_count{namespace="orino"}[5m])) > 0.05
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "BE 5xx 에러율 높음"
+            description: "BE 5xx 비율이 5분간 5% 초과 (현재: {{ "{{" }} $value | printf \"%.2f\" {{ "}}" }})"
+
+        - alert: BackendJvmHeapHigh
+          expr: |
+            sum(jvm_memory_used_bytes{namespace="orino",area="heap"})
+              / sum(jvm_memory_max_bytes{namespace="orino",area="heap"}) > 0.85
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "BE JVM heap 사용률 높음"
+            description: "JVM heap 사용률 10분간 85% 초과 (현재: {{ "{{" }} $value | printf \"%.2f\" {{ "}}" }})"
+
+        - alert: BackendDbPoolExhausted
+          expr: |
+            max(hikaricp_connections_active{namespace="orino"})
+              / max(hikaricp_connections_max{namespace="orino"}) > 0.9
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "BE DB 커넥션 풀 고갈 임박"
+            description: "HikariCP active / max 비율이 5분간 90% 초과 (현재: {{ "{{" }} $value | printf \"%.2f\" {{ "}}" }})"
+
+    - name: istio
+      rules:
+        - alert: IstioServiceErrorRateHigh
+          expr: |
+            sum by (destination_service) (rate(istio_requests_total{reporter="destination",response_code=~"5.."}[5m]))
+              / sum by (destination_service) (rate(istio_requests_total{reporter="destination"}[5m])) > 0.05
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Istio 서비스 5xx 비율 높음: {{ "{{" }} $labels.destination_service {{ "}}" }}"
+            description: "destination 5xx 비율이 5분간 5% 초과 (현재: {{ "{{" }} $value | printf \"%.2f\" {{ "}}" }})"
+
+        - alert: IstioServiceLatencyP99High
+          expr: |
+            histogram_quantile(0.99,
+              sum by (destination_service, le) (rate(istio_request_duration_milliseconds_bucket{reporter="destination"}[5m]))
+            ) > 2000
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Istio 서비스 p99 지연 높음: {{ "{{" }} $labels.destination_service {{ "}}" }}"
+            description: "p99 레이턴시가 10분간 2초 초과 (현재: {{ "{{" }} $value | printf \"%.0f\" {{ "}}" }}ms)"
+
+    - name: observability-self
+      rules:
+        - alert: PrometheusDown
+          expr: absent(kube_pod_status_ready{namespace="monitoring", pod=~"prometheus-kube-prometheus-stack-prometheus-.*", condition="true"} == 1)
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Prometheus 다운"
+            description: "Prometheus Pod가 1분 이상 Ready 상태가 아님"
+
+        - alert: LokiDown
+          expr: absent(kube_pod_status_ready{namespace="monitoring", pod=~"loki-.*", condition="true"} == 1)
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Loki 다운"
+            description: "Loki Pod가 1분 이상 Ready 상태가 아님"
+
+        - alert: TempoDown
+          expr: absent(kube_pod_status_ready{namespace="monitoring", pod=~"tempo-.*", condition="true"} == 1)
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Tempo 다운"
+            description: "Tempo Pod가 1분 이상 Ready 상태가 아님"
+
+        - alert: AlloyDown
+          expr: absent(kube_pod_status_ready{namespace="monitoring", pod=~"alloy-.*", condition="true"} == 1)
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Alloy 다운"
+            description: "Alloy Pod가 1분 이상 Ready 상태가 아님"
+
+        - alert: ScrapeTargetDown
+          expr: up == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Prometheus scrape target 다운: {{ "{{" }} $labels.job {{ "}}" }}/{{ "{{" }} $labels.instance {{ "}}" }}"
+            description: "scrape target이 5분 이상 up=0 상태"


### PR DESCRIPTION
closes #300

## Summary

BE 애플리케이션(Micrometer)과 Istio RED 메트릭 기반 알림 규칙을 추가했다. 기존 Pod/Node/PVC 인프라 알림에서 애플리케이션 계층까지 커버리지를 확장한다.

## 변경 사항

**BE Actuator 포트 노출**
- `deployment.yaml`: containerPort 9090 에 `actuator` 이름 부여, `traffic.sidecar.istio.io/excludeInboundPorts: "9090"` 로 Istio 우회
- `service.yaml`: `actuator` 포트(9090) 추가
- `servicemonitor.yaml`: BE `/prometheus` 엔드포인트 스크래이프

**Istio 메트릭 수집**
- `istiod/templates/podmonitor.yaml`:
  - PodMonitor: 모든 네임스페이스의 `istio-proxy` 사이드카 `http-envoy-prom`(15090) 포트 스크래이프
  - ServiceMonitor: `istiod` 컨트롤 플레인 `http-monitoring`(15014) 스크래이프

**PrometheusRule 알림 그룹 추가**
- `app-metrics`
  - `BackendHighErrorRate`: BE 5xx 비율 > 5% (5m)
  - `BackendJvmHeapHigh`: heap used/max > 85% (10m)
  - `BackendDbPoolExhausted`: HikariCP active/max > 90% (5m, critical)
- `istio`
  - `IstioServiceErrorRateHigh`: destination 5xx 비율 > 5% (5m)
  - `IstioServiceLatencyP99High`: p99 > 2s (10m)
- `observability-self`
  - `PrometheusDown` / `LokiDown` / `TempoDown` / `AlloyDown`: Pod Ready 아님 1분 이상 (critical)
  - `ScrapeTargetDown`: `up == 0` 5분 이상 (warning)

## 스코프에서 제외

- **BackendHighLatencyP95**: BE Micrometer 히스토그램 버킷 미발행 상태. 별도 BE 설정 변경 필요 (`management.metrics.distribution.percentiles-histogram.http.server.requests=true`)
- **cert-manager 알림**: cert-manager 미배포 상태
- **BackendThreadPoolRejected**: 메트릭 노출 여부 추가 확인 필요

## Test plan

- [x] `helm template` 렌더링 정상
- [x] `helm lint` 정상
- [x] BE `/prometheus` 엔드포인트 메트릭 수집 확인 (http_server_requests_seconds_count, jvm_memory_*, hikaricp_*)
- [x] Istio sidecar `:15090/stats/prometheus` 에서 `istio_requests_total`, `istio_request_duration_milliseconds_bucket` 확인
- [ ] ArgoCD sync 후 Prometheus Targets 에서 be/istio-proxies/istiod 스크래이프 정상 확인
- [ ] Prometheus Alerts 에서 새 알림 그룹 3개 로드 확인
- [ ] 의도적 5xx 유도 → Discord 알림 수신 확인