### PR TITLE
fix : jackson-core 3.1.1로 업그레이드하여 DocLen 취약점 수정

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -20,7 +20,7 @@ subprojects {
     }
 
     ext['jackson-2-bom.version'] = '2.21.1'
-    ext['jackson-bom.version'] = '3.1.0'
+    ext['jackson-bom.version'] = '3.1.1'
     ext['spring-security.version'] = '7.0.4'
 
     repositories {


### PR DESCRIPTION
## 이슈
closes #312 (추가 조치)

## 작업 내용

#313 머지 후에도 Trivy 스캔이 계속 실패하여 확인한 결과, jackson-core 3.1.0에도 HIGH 취약점이 남아있었음:

- **GHSA-2m67-wjpj-xhg9** (HIGH): `maxDocumentLength` 제약이 DataInput 파서에서 강제되지 않음 → DoS 위험
  - Vulnerable range: `>= 3.0.0, <= 3.1.0`
  - Jackson 3.1.1에서 수정됨 ("Fail parsing from DataInput if StreamReadConstraints.getMaxDocumentLength() set")

`ext['jackson-bom.version']`을 3.1.0 → 3.1.1로 업데이트.