### PR TITLE
fix : Trivy SARIF 스캔에 severity 필터 적용

### DIFF
--- a/.github/workflows/be-cd.yml
+++ b/.github/workflows/be-cd.yml
@@ -53,6 +53,7 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           exit-code: '1'
 
       - name: Upload Trivy scan results


### PR DESCRIPTION
## 이슈
closes #312 (근본 원인)

## 작업 내용

### 근본 원인

`aquasecurity/trivy-action@v0.35.0`의 entrypoint 동작:

\`\`\`bash
if [ "\${TRIVY_FORMAT:-}" = "sarif" ]; then
  if [ "\${INPUT_LIMIT_SEVERITIES_FOR_SARIF:-false,,}" != "true" ]; then
    echo "Building SARIF report with all severities"
    unset TRIVY_SEVERITY   # ← severity 필터 제거!
  fi
fi
\`\`\`

`format: sarif` 사용 시 기본적으로 `TRIVY_SEVERITY`를 unset하여 모든 심각도로 스캔한다. `exit-code: 1`도 전체 심각도 기준으로 트리거되므로, `severity: CRITICAL,HIGH`를 지정했음에도 **MEDIUM/LOW 취약점만으로도 파이프라인이 실패**했다.

실제로 현재 이미지는 아래 9개 MEDIUM/LOW만 가지고 있음 (HIGH/CRITICAL 0개):
- ubuntu: libexpat (MEDIUM), libgcrypt (LOW), systemd (MEDIUM), shadow-utils (LOW), tar (MEDIUM)
- jar: spring-webmvc CVE-2026-22737 (MEDIUM), CVE-2026-22735 (LOW)

### 수정

`limit-severities-for-sarif: true` 추가 → SARIF와 exit-code 모두 CRITICAL/HIGH만 대상으로 제한.

### 검증

동일 이미지에 대해 로컬 Trivy 0.69.3 실행 결과:
- `--severity CRITICAL,HIGH`: exit code 0 ✓
- severity 필터 없음 (trivy-action 기본 동작): exit code 1 ✗