### PR TITLE
feat : MySQL 백업 실패 Alertmanager rule 추가

### DIFF
--- a/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
@@ -112,6 +112,26 @@ spec:
             summary: "Longhorn 볼륨 Degraded: {{ "{{" }} $labels.volume {{ "}}" }}"
             description: "볼륨 {{ "{{" }} $labels.volume {{ "}}" }}이 Degraded 상태"
 
+    - name: mysql-backup-alerts
+      rules:
+        - alert: MysqlBackupFailed
+          expr: kube_job_status_failed{namespace="orino",job_name=~"mysql-backup-.*"} > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "MySQL 백업 실패: {{ "{{" }} $labels.job_name {{ "}}" }}"
+            description: "MySQL 백업 Job {{ "{{" }} $labels.job_name {{ "}}" }}이 5분 이상 실패 상태 — RPO 24h 위협"
+
+        - alert: MysqlBackupNotScheduled
+          expr: time() - kube_cronjob_status_last_schedule_time{namespace="orino",cronjob="mysql-backup"} > 30 * 3600
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "MySQL 백업 CronJob이 30시간 이상 실행되지 않음"
+            description: "mysql-backup CronJob의 마지막 스케줄 시각으로부터 {{ "{{" }} $value | humanizeDuration {{ "}}" }} 경과 — controller·suspend 상태 점검"
+
     - name: app-alerts
       rules:
         - alert: BackendDown


### PR DESCRIPTION
## 이슈
closes #315

## 작업 내용
- \`infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml\`에 \`mysql-backup-alerts\` 그룹 신설
- **MysqlBackupFailed**
  - \`kube_job_status_failed{namespace=\"orino\",job_name=~\"mysql-backup-.*\"} > 0\`
  - for: 5m, severity: critical
- **MysqlBackupNotScheduled**
  - \`time() - kube_cronjob_status_last_schedule_time{namespace=\"orino\",cronjob=\"mysql-backup\"} > 30 * 3600\`
  - for: 10m, severity: critical
  - daily schedule 기준 24h + 6h 여유 → controller 이슈 / suspend 상태 감지

## 검증
- [x] \`helm template\`으로 렌더링 성공 (group/alert/expr 정상 출력)
- [ ] (배포 후 사용자 수동 검증) CronJob 고의 실패 → Discord critical 알림 수신 확인
  - 예: \`kubectl create job --from=cronjob/mysql-backup mysql-backup-fail-test -n orino\` 후 잘못된 자격증명 등으로 실패 유도
- [ ] (선택) 30h 임계값이 운영상 적절한지 1주일 관찰 후 조정

## 의존
- #314 (mysql-backup CronJob) 머지 전제 — 차트 PR(#322) 머지됨