### PR TITLE
fix : tomcat-embed-core 11.0.18 → 11.0.21 CVE 수정

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -22,6 +22,7 @@ subprojects {
     ext['jackson-2-bom.version'] = '2.21.1'
     ext['jackson-bom.version'] = '3.1.1'
     ext['spring-security.version'] = '7.0.4'
+    ext['tomcat.version'] = '11.0.21'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## 이슈
closes #335

## 작업 내용

Trivy 스캔이 감지한 `tomcat-embed-core 11.0.18`의 CRITICAL/HIGH 취약점 4건을 BOM 오버라이드로 수정.

| 심각도 | CVE | Fixed Version |
|---|---|---|
| CRITICAL | CVE-2026-29145 | 11.0.20 |
| HIGH | CVE-2026-29129 | 11.0.20 |
| HIGH | CVE-2026-34483 | 11.0.21 |
| HIGH | CVE-2026-34487 | 11.0.21 |

- `be/build.gradle`의 ext 블록에 `tomcat.version = '11.0.21'` 추가 (#319 jackson, #312 spring-security 오버라이드와 동일 패턴)
- 의존성 트리 확인: `tomcat-embed-core:11.0.18 -> 11.0.21` 적용 검증 완료
- `./gradlew clean build` 통과 (전체 모듈 테스트 + checkstyle 포함)