### PR TITLE
feat : SealedSecrets master key 신규 생성 감지 알림 추가

### DIFF
--- a/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
@@ -132,6 +132,17 @@ spec:
             summary: "MySQL 백업 CronJob이 30시간 이상 실행되지 않음"
             description: "mysql-backup CronJob의 마지막 스케줄 시각으로부터 {{ "{{" }} $value | humanizeDuration {{ "}}" }} 경과 — controller·suspend 상태 점검"
 
+    - name: sealed-secrets-alerts
+      rules:
+        - alert: SealedSecretsKeyRotated
+          expr: max(kube_secret_created{namespace="kube-system",secret=~"sealed-secrets-key.*"}) > (time() - 86400)
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "SealedSecrets master key 신규 생성 감지"
+            description: "최근 24시간 내 신규 sealed-secrets-key가 생성됨 — 1Password에 백업 갱신 필요 (Backup-Recovery §4.3)"
+
     - name: app-alerts
       rules:
         - alert: BackendDown


### PR DESCRIPTION
## 이슈
refs #316

## 작업 내용
- \`infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml\`에 \`sealed-secrets-alerts\` 그룹 신설
- **SealedSecretsKeyRotated**
  - \`max(kube_secret_created{namespace=\"kube-system\",secret=~\"sealed-secrets-key.*\"}) > (time() - 86400)\`
  - for: 0m, severity: warning
  - 최근 24시간 내 신규 sealed-secrets-key 생성 시 발동 → 24h 후 자동 해제

## 동작 방식
- sealed-secrets controller는 기본 30일마다 새 active master key를 secret으로 자동 생성
- 신규 secret 생성 직후 24h 동안 alert가 켜져 운영자가 1Password 백업을 갱신하도록 유도
- Wiki [Backup-Recovery §4.3](https://github.com/wcorn/orino/wiki/Backup-Recovery#43-sealedsecret-master-key-백업) 절차로 추출/저장 진행

## 검증
- [x] \`helm template\` 렌더링 성공 (alert/expr 정상 출력)
- [ ] (사용자) Wiki §4.3 절차로 최초 master key를 1Password에 백업
- [ ] (사용자) 임시 클러스터에서 master key 복원 리허설 1회

## 관련
- 본 이슈의 절차 문서화는 [Wiki commit](https://github.com/wcorn/orino/wiki/Backup-Recovery)으로 완료 (Backup-Recovery §4.3 보강)