### PR TITLE
feat : SLO recording rules + multi-window burn rate alerts

### DIFF
--- a/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
@@ -143,6 +143,129 @@ spec:
             summary: "SealedSecrets master key 신규 생성 감지"
             description: "최근 24시간 내 신규 sealed-secrets-key가 생성됨 — 1Password에 백업 갱신 필요 (Backup-Recovery §4.3)"
 
+    # SLO recording rules — Istio destination 메트릭 기반.
+    # service 라벨(destination_service_name=be|fe)이 결과 series에 자동 전파되어
+    # 동일 alert가 BE/FE 각각 발동된다.
+    - name: slo-recording-rules
+      interval: 30s
+      rules:
+        # 가용성 SLI: 5xx / 전체 요청 비율
+        - record: slo:availability:error_ratio:rate5m
+          expr: |
+            sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination",response_code=~"5.."}[5m]))
+            /
+            sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination"}[5m]))
+        - record: slo:availability:error_ratio:rate30m
+          expr: |
+            sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination",response_code=~"5.."}[30m]))
+            /
+            sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination"}[30m]))
+        - record: slo:availability:error_ratio:rate1h
+          expr: |
+            sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination",response_code=~"5.."}[1h]))
+            /
+            sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination"}[1h]))
+        - record: slo:availability:error_ratio:rate6h
+          expr: |
+            sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination",response_code=~"5.."}[6h]))
+            /
+            sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination"}[6h]))
+
+        # 지연 SLI: p95 임계 500ms 초과 요청 비율 = 1 - bucket(le=500)/total
+        - record: slo:latency:slow_ratio:rate5m
+          expr: |
+            (
+              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[5m]))
+              -
+              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_bucket{destination_service_name=~"be|fe",reporter="destination",le="500"}[5m]))
+            )
+            /
+            sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[5m]))
+        - record: slo:latency:slow_ratio:rate30m
+          expr: |
+            (
+              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[30m]))
+              -
+              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_bucket{destination_service_name=~"be|fe",reporter="destination",le="500"}[30m]))
+            )
+            /
+            sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[30m]))
+        - record: slo:latency:slow_ratio:rate1h
+          expr: |
+            (
+              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[1h]))
+              -
+              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_bucket{destination_service_name=~"be|fe",reporter="destination",le="500"}[1h]))
+            )
+            /
+            sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[1h]))
+        - record: slo:latency:slow_ratio:rate6h
+          expr: |
+            (
+              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[6h]))
+              -
+              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_bucket{destination_service_name=~"be|fe",reporter="destination",le="500"}[6h]))
+            )
+            /
+            sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[6h]))
+
+    # SLO burn rate alerts — multi-window multi-burn-rate (Google SRE 패턴).
+    # SLO 99.0% 가용성 → error budget 1% → fast 14.4×=0.144, slow 6×=0.06
+    # SLO 95% (p95<500ms) → error budget 5%   → fast 14.4×=0.72,  slow 6×=0.30
+    - name: slo-burn-rate-alerts
+      rules:
+        - alert: AvailabilityBurnRateFast
+          expr: |
+            slo:availability:error_ratio:rate1h > 0.144
+            and
+            slo:availability:error_ratio:rate5m > 0.144
+          for: 2m
+          labels:
+            severity: critical
+            slo: availability
+          annotations:
+            summary: "{{ "{{" }} $labels.destination_service_name {{ "}}" }} 가용성 SLO fast burn (14.4×)"
+            description: "1h+5m 윈도우 모두 14.4× burn rate 초과 — 현재 속도면 월 예산 ~2일에 소진 (SLO 99.0%)"
+
+        - alert: AvailabilityBurnRateSlow
+          expr: |
+            slo:availability:error_ratio:rate6h > 0.06
+            and
+            slo:availability:error_ratio:rate30m > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            slo: availability
+          annotations:
+            summary: "{{ "{{" }} $labels.destination_service_name {{ "}}" }} 가용성 SLO slow burn (6×)"
+            description: "6h+30m 윈도우 모두 6× burn rate 초과 — 현재 속도면 월 예산 ~5일에 소진 (SLO 99.0%)"
+
+        - alert: LatencyBurnRateFast
+          expr: |
+            slo:latency:slow_ratio:rate1h > 0.72
+            and
+            slo:latency:slow_ratio:rate5m > 0.72
+          for: 2m
+          labels:
+            severity: critical
+            slo: latency
+          annotations:
+            summary: "{{ "{{" }} $labels.destination_service_name {{ "}}" }} 지연 SLO fast burn (14.4×)"
+            description: "1h+5m 윈도우 모두 p95<500ms 위반 비율 14.4× 초과 — SLO 95% 위협"
+
+        - alert: LatencyBurnRateSlow
+          expr: |
+            slo:latency:slow_ratio:rate6h > 0.30
+            and
+            slo:latency:slow_ratio:rate30m > 0.30
+          for: 15m
+          labels:
+            severity: warning
+            slo: latency
+          annotations:
+            summary: "{{ "{{" }} $labels.destination_service_name {{ "}}" }} 지연 SLO slow burn (6×)"
+            description: "6h+30m 윈도우 모두 p95<500ms 위반 비율 6× 초과"
+
     - name: app-alerts
       rules:
         - alert: BackendDown


### PR DESCRIPTION
## 이슈
refs #301

## 작업 내용
\`infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml\`에 다음 두 그룹을 신설했다.

### \`slo-recording-rules\` (interval 30s)
Istio destination 메트릭 기반 SLI 8개. \`destination_service_name=~\"be|fe\"\` + \`reporter=\"destination\"\` 필터, \`sum by (destination_service_name)\`로 라벨 보존.

| Recording rule | 의미 | 윈도우 |
|---|---|---|
| \`slo:availability:error_ratio:rate{5m,30m,1h,6h}\` | 5xx / 전체 | 4종 |
| \`slo:latency:slow_ratio:rate{5m,30m,1h,6h}\` | (total - bucket\\{le=\"500\"\\}) / total | 4종 |

### \`slo-burn-rate-alerts\`
Multi-window multi-burn-rate (Google SRE 패턴). \`destination_service_name\` 라벨이 결과 series에 전파되어 BE/FE 각각 발동.

| Alert | Burn rate | 윈도우 | Severity | 임계값 |
|---|---|---|---|---|
| AvailabilityBurnRateFast | 14.4× | 1h ∧ 5m | critical | error_ratio > 0.144 (월 예산 ~2일 소진) |
| AvailabilityBurnRateSlow | 6× | 6h ∧ 30m | warning | error_ratio > 0.06 (월 예산 ~5일 소진) |
| LatencyBurnRateFast | 14.4× | 1h ∧ 5m | critical | slow_ratio > 0.72 |
| LatencyBurnRateSlow | 6× | 6h ∧ 30m | warning | slow_ratio > 0.30 |

### SLO 기준 (Wiki [Observability §11.2](https://github.com/wcorn/orino/wiki/Observability#112-지표와-목표-초기))
- 가용성: **99.0%** (월 에러 예산 7h 18m)
- 지연: p95 < 500ms 95% of time (에러 예산 5%)

## 검증
- [x] \`helm template\` 렌더링 성공 (recording rules 8종 + alerts 4종 + Go template escape 정상)
- [ ] (배포 후) Prometheus UI에서 recording rule 결과 series가 BE/FE 각각 생성되는지 확인
- [ ] (배포 후) 의도적 5xx 유도 → AvailabilityBurnRateFast 발동 확인
- [ ] 1주 운영 후 burn rate 임계값(특히 LatencyBurnRateFast 0.72)이 노이즈 없이 동작하는지 평가

## 후속 작업
- **Grafana SLO 대시보드** ConfigMap 추가: 별도 PR로 진행 (#301에 묶임)

## 참고
- [Google SRE Workbook — Alerting on SLOs](https://sre.google/workbook/alerting-on-slos/)
- 도구 선택: 본 PR은 **수동 작성**. Sloth generator 도입은 운영 부담을 보고 향후 결정