### PR TITLE
feat : Grafana SLO 대시보드 ConfigMap 추가

### DIFF
--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/slo-overview.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/slo-overview.json
@@ -1,0 +1,349 @@
+{
+  "uid": "slo-overview",
+  "title": "SLO Overview",
+  "tags": ["orino", "slo"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "label": "Service",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "query": "label_values(slo:availability:error_ratio:rate5m, destination_service_name)",
+        "refresh": 2,
+        "multi": false,
+        "includeAll": false,
+        "current": {"text": "be", "value": "be"}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "가용성 SLI (30m)",
+      "gridPos": {"x": 0, "y": 0, "w": 6, "h": 6},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "1 - slo:availability:error_ratio:rate30m{destination_service_name=\"$service\"}",
+          "legendFormat": "availability",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 0.99},
+              {"color": "green", "value": 0.999}
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "지연 SLI (30m, p95<500ms 비율)",
+      "gridPos": {"x": 6, "y": 0, "w": 6, "h": 6},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "1 - slo:latency:slow_ratio:rate30m{destination_service_name=\"$service\"}",
+          "legendFormat": "fast_ratio",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 0.95},
+              {"color": "green", "value": 0.99}
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    },
+    {
+      "id": 3,
+      "type": "gauge",
+      "title": "Availability burn rate (1h)",
+      "gridPos": {"x": 12, "y": 0, "w": 6, "h": 6},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "slo:availability:error_ratio:rate1h{destination_service_name=\"$service\"} / 0.01",
+          "legendFormat": "burn_rate",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 2,
+          "min": 0,
+          "max": 20,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 6},
+              {"color": "red", "value": 14.4}
+            ]
+          }
+        }
+      },
+      "options": {
+        "showThresholdLabels": true,
+        "showThresholdMarkers": true,
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    },
+    {
+      "id": 4,
+      "type": "gauge",
+      "title": "Latency burn rate (1h)",
+      "gridPos": {"x": 18, "y": 0, "w": 6, "h": 6},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "slo:latency:slow_ratio:rate1h{destination_service_name=\"$service\"} / 0.05",
+          "legendFormat": "burn_rate",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 2,
+          "min": 0,
+          "max": 20,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 6},
+              {"color": "red", "value": 14.4}
+            ]
+          }
+        }
+      },
+      "options": {
+        "showThresholdLabels": true,
+        "showThresholdMarkers": true,
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Availability error ratio (multi-window)",
+      "gridPos": {"x": 0, "y": 6, "w": 12, "h": 8},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "slo:availability:error_ratio:rate5m{destination_service_name=\"$service\"}", "legendFormat": "5m", "refId": "A"},
+        {"expr": "slo:availability:error_ratio:rate30m{destination_service_name=\"$service\"}", "legendFormat": "30m", "refId": "B"},
+        {"expr": "slo:availability:error_ratio:rate1h{destination_service_name=\"$service\"}", "legendFormat": "1h", "refId": "C"},
+        {"expr": "slo:availability:error_ratio:rate6h{destination_service_name=\"$service\"}", "legendFormat": "6h", "refId": "D"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 4,
+          "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 10}
+        }
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "mean", "max"]},
+        "tooltip": {"mode": "multi"}
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Latency slow ratio (multi-window)",
+      "gridPos": {"x": 12, "y": 6, "w": 12, "h": 8},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "slo:latency:slow_ratio:rate5m{destination_service_name=\"$service\"}", "legendFormat": "5m", "refId": "A"},
+        {"expr": "slo:latency:slow_ratio:rate30m{destination_service_name=\"$service\"}", "legendFormat": "30m", "refId": "B"},
+        {"expr": "slo:latency:slow_ratio:rate1h{destination_service_name=\"$service\"}", "legendFormat": "1h", "refId": "C"},
+        {"expr": "slo:latency:slow_ratio:rate6h{destination_service_name=\"$service\"}", "legendFormat": "6h", "refId": "D"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 4,
+          "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 10}
+        }
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "mean", "max"]},
+        "tooltip": {"mode": "multi"}
+      }
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "30일 누적 가용성",
+      "gridPos": {"x": 0, "y": 14, "w": 6, "h": 6},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "1 - (sum(rate(istio_requests_total{destination_service_name=\"$service\",reporter=\"destination\",response_code=~\"5..\"}[30d])) / sum(rate(istio_requests_total{destination_service_name=\"$service\",reporter=\"destination\"}[30d])))",
+          "legendFormat": "30d availability",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 0.99},
+              {"color": "green", "value": 0.999}
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "30일 누적 지연 (p95<500ms 비율)",
+      "gridPos": {"x": 6, "y": 14, "w": 6, "h": 6},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "1 - ((sum(rate(istio_request_duration_milliseconds_count{destination_service_name=\"$service\",reporter=\"destination\"}[30d])) - sum(rate(istio_request_duration_milliseconds_bucket{destination_service_name=\"$service\",reporter=\"destination\",le=\"500\"}[30d]))) / sum(rate(istio_request_duration_milliseconds_count{destination_service_name=\"$service\",reporter=\"destination\"}[30d])))",
+          "legendFormat": "30d fast_ratio",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 0.95},
+              {"color": "green", "value": 0.99}
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "월 에러 예산 사용률 (가용성, 30일)",
+      "gridPos": {"x": 12, "y": 14, "w": 6, "h": 6},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "30일 윈도우 누적 에러율을 SLO 1% 예산 대비 환산. 100%면 예산 소진.",
+      "targets": [
+        {
+          "expr": "(sum(rate(istio_requests_total{destination_service_name=\"$service\",reporter=\"destination\",response_code=~\"5..\"}[30d])) / sum(rate(istio_requests_total{destination_service_name=\"$service\",reporter=\"destination\"}[30d]))) / 0.01",
+          "legendFormat": "budget_used",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 0.5},
+              {"color": "red", "value": 1.0}
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    },
+    {
+      "id": 10,
+      "type": "stat",
+      "title": "월 에러 예산 사용률 (지연, 30일)",
+      "gridPos": {"x": 18, "y": 14, "w": 6, "h": 6},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "30일 윈도우 누적 위반율을 SLO 5% 예산 대비 환산.",
+      "targets": [
+        {
+          "expr": "((sum(rate(istio_request_duration_milliseconds_count{destination_service_name=\"$service\",reporter=\"destination\"}[30d])) - sum(rate(istio_request_duration_milliseconds_bucket{destination_service_name=\"$service\",reporter=\"destination\",le=\"500\"}[30d]))) / sum(rate(istio_request_duration_milliseconds_count{destination_service_name=\"$service\",reporter=\"destination\"}[30d]))) / 0.05",
+          "legendFormat": "budget_used",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 0.5},
+              {"color": "red", "value": 1.0}
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    }
+  ]
+}

--- a/infra/helm/kube-prometheus-stack/templates/dashboard-slo.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/dashboard-slo.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-slo-overview
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  slo-overview.json: |-
+{{ .Files.Get "grafana-dashboards/slo-overview.json" | indent 4 }}


### PR DESCRIPTION
closes #301

## Description

#301 Part 2 — Grafana SLO Overview 대시보드를 ConfigMap 형태로 추가한다.

PR #338에서 추가한 SLO recording rules와 multi-window burn rate alerts를 시각화하는 대시보드. Grafana sidecar가 `grafana_dashboard: "1"` 라벨로 자동 로드한다.

## 대시보드 구성

| Row | Panel | Window |
|---|---|---|
| 현재 SLI | 가용성 stat | 30m |
| | 지연시간 stat | 30m |
| Burn Rate | 가용성 burn rate gauge | 1h |
| | 지연시간 burn rate gauge | 1h |
| 다중 Window | 가용성 error ratio timeseries | 5m/30m/1h/6h |
| | 지연시간 slow ratio timeseries | 5m/30m/1h/6h |
| 누적 SLI | 30일 가용성 누적 | 30d |
| | 30일 지연시간 누적 | 30d |
| Error Budget | 가용성 budget 소진율 | 30d |
| | 지연시간 budget 소진율 | 30d |

## 변경 사항

- `infra/helm/kube-prometheus-stack/grafana-dashboards/slo-overview.json`: 대시보드 정의 (10 panels, \$service 템플릿 변수로 BE/FE 선택)
- `infra/helm/kube-prometheus-stack/templates/dashboard-slo.yaml`: ConfigMap (`.Files.Get`로 JSON 임베드, sidecar 라벨)

## 검증

- JSON 문법 검증 (python3 -m json.tool)
- helm template 렌더링 검증 (ConfigMap 생성 + JSON 임베드 확인)
- 배포 후 Grafana에서 SLO Overview 대시보드 자동 로드 확인 필요
- \$service 변수로 BE/FE 선택 시 패널 정상 표시 확인 필요

## Todo

- [x] dashboard JSON 작성
- [x] ConfigMap 템플릿 작성
- [x] helm template 검증
- [ ] 배포 후 대시보드 자동 로드 확인 (사용자)
- [ ] 1주일 운영 후 SLO 임계값 튜닝 (#301)