### PR TITLE
feat : Study Planner v1 데이터 모델 마이그레이션 추가

### DIFF
--- a/be/orino-app-api/src/main/resources/db/changelog/changes/016-create-study-material.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/016-create-study-material.yaml
@@ -1,0 +1,61 @@
+databaseChangeLog:
+  - changeSet:
+      id: 016-create-study-material
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: study_material
+      changes:
+        - createTable:
+            tableName: study_material
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_study_material_member
+                    references: member(id)
+              - column:
+                  name: title
+                  type: VARCHAR(200)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: type
+                  type: VARCHAR(10)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(10)
+                  defaultValue: ACTIVE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: study_material
+            indexName: idx_study_material_member_status
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: status

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/017-create-study-unit.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/017-create-study-unit.yaml
@@ -1,0 +1,80 @@
+databaseChangeLog:
+  - changeSet:
+      id: 017-create-study-unit
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: study_unit
+      changes:
+        - createTable:
+            tableName: study_unit
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_study_unit_member
+                    references: member(id)
+              - column:
+                  name: material_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_study_unit_material
+                    references: study_material(id)
+                    deleteCascade: true
+              - column:
+                  name: title
+                  type: VARCHAR(200)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: sort_order
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(10)
+                  defaultValue: PENDING
+                  constraints:
+                    nullable: false
+              - column:
+                  name: completed_at
+                  type: DATETIME(6)
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: study_unit
+            indexName: idx_study_unit_material_order
+            columns:
+              - column:
+                  name: material_id
+              - column:
+                  name: sort_order
+        - createIndex:
+            tableName: study_unit
+            indexName: idx_study_unit_material_status
+            columns:
+              - column:
+                  name: material_id
+              - column:
+                  name: status

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/018-create-review-schedule.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/018-create-review-schedule.yaml
@@ -1,0 +1,99 @@
+databaseChangeLog:
+  - changeSet:
+      id: 018-create-review-schedule
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: review_schedule
+      changes:
+        - createTable:
+            tableName: review_schedule
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_review_schedule_member
+                    references: member(id)
+              - column:
+                  name: study_unit_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_review_schedule_study_unit
+                    references: study_unit(id)
+                    deleteCascade: true
+              - column:
+                  name: sequence
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: scheduled_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: interval_days
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: ease_factor
+                  type: DECIMAL(4,2)
+                  defaultValueNumeric: 2.50
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(10)
+                  defaultValue: PENDING
+                  constraints:
+                    nullable: false
+              - column:
+                  name: rating
+                  type: VARCHAR(10)
+              - column:
+                  name: elapsed_days
+                  type: INT
+              - column:
+                  name: completed_at
+                  type: DATETIME(6)
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: review_schedule
+            indexName: idx_review_schedule_member_date_status
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: scheduled_date
+              - column:
+                  name: status
+        - createIndex:
+            tableName: review_schedule
+            indexName: idx_review_schedule_unit_sequence
+            columns:
+              - column:
+                  name: study_unit_id
+              - column:
+                  name: sequence

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -29,3 +29,9 @@ databaseChangeLog:
       file: db/changelog/changes/014-create-indexes.yaml
   - include:
       file: db/changelog/changes/015-drop-planner-tables.yaml
+  - include:
+      file: db/changelog/changes/016-create-study-material.yaml
+  - include:
+      file: db/changelog/changes/017-create-study-unit.yaml
+  - include:
+      file: db/changelog/changes/018-create-review-schedule.yaml


### PR DESCRIPTION
## 이슈
closes #323

## 작업 내용
- `016-create-study-material.yaml`: 학습 자료 테이블 (BOOK / LECTURE / WORKBOOK / MOOC)
- `017-create-study-unit.yaml`: 학습 단위 테이블 (material과 ON DELETE CASCADE)
- `018-create-review-schedule.yaml`: 복습 일정 테이블 (study_unit과 ON DELETE CASCADE, SM-2 파라미터 컬럼)
- `db.changelog-master.yaml`에 016~018 include 추가

### 스키마 요약
| 테이블 | 핵심 컬럼 | 인덱스 |
|---|---|---|
| `study_material` | id, member_id, title, type, status | `(member_id, status)` |
| `study_unit` | id, member_id, material_id, title, sort_order, status, completed_at | `(material_id, sort_order)`, `(material_id, status)` |
| `review_schedule` | id, member_id, study_unit_id, sequence, scheduled_date, interval_days, ease_factor, status, rating, elapsed_days, completed_at | `(member_id, scheduled_date, status)`, `(study_unit_id, sequence)` |

### 검증
- `./gradlew clean build` 통과 (체크스타일 + 전체 테스트 + Jacoco)
- `SchemaValidationTest` 통과 — TestContainers MySQL 8.4.4에서 001 → 018 전체 changeset이 정상 적용됨
- v1 범위 외 테이블(카테고리/목표/루틴/할일/사용자 선호/일간 스케줄 등)은 v2 이후로 보류

### 참고
- 설계: [Study-Planner-Data-Model (Wiki)](https://github.com/wcorn/orino/wiki/Study-Planner-Data-Model)
- 이후 #324 (material CRUD) / #325 (unit CRUD) / #326 (SM-2) / #327 (오늘 복습) BE 작업이 본 PR에 의존