### PR TITLE
feat : 학습 자료(material) CRUD API 구현

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/controller/StudyMaterialController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/controller/StudyMaterialController.java
@@ -1,0 +1,73 @@
+package ds.project.orino.planner.material.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.domain.planner.material.entity.MaterialStatus;
+import ds.project.orino.planner.material.dto.MaterialCreateRequest;
+import ds.project.orino.planner.material.dto.MaterialDetailResponse;
+import ds.project.orino.planner.material.dto.MaterialListResponse;
+import ds.project.orino.planner.material.dto.MaterialSummaryResponse;
+import ds.project.orino.planner.material.dto.MaterialUpdateRequest;
+import ds.project.orino.planner.material.service.StudyMaterialService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/planner/materials")
+public class StudyMaterialController {
+
+    private final StudyMaterialService studyMaterialService;
+
+    public StudyMaterialController(StudyMaterialService studyMaterialService) {
+        this.studyMaterialService = studyMaterialService;
+    }
+
+    @GetMapping
+    public ApiResponse<MaterialListResponse> list(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam(required = false) MaterialStatus status) {
+        return ApiResponse.success(new MaterialListResponse(
+                studyMaterialService.findAll(memberId, status)));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<MaterialSummaryResponse>> create(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody MaterialCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(studyMaterialService.create(memberId, request)));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<MaterialDetailResponse> detail(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id) {
+        return ApiResponse.success(studyMaterialService.findOne(memberId, id));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponse<MaterialSummaryResponse> update(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @Valid @RequestBody MaterialUpdateRequest request) {
+        return ApiResponse.success(studyMaterialService.update(memberId, id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id) {
+        studyMaterialService.delete(memberId, id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialCreateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialCreateRequest.java
@@ -1,0 +1,16 @@
+package ds.project.orino.planner.material.dto;
+
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record MaterialCreateRequest(
+        @NotBlank(message = "제목을 입력해주세요.")
+        @Size(min = 1, max = 200, message = "제목은 1~200자여야 합니다.")
+        String title,
+
+        @NotNull(message = "자료 타입을 입력해주세요.")
+        MaterialType type
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialDetailResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialDetailResponse.java
@@ -1,0 +1,40 @@
+package ds.project.orino.planner.material.dto;
+
+import ds.project.orino.domain.planner.material.entity.MaterialStatus;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import ds.project.orino.domain.planner.unit.entity.UnitStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MaterialDetailResponse(
+        Long id,
+        String title,
+        MaterialType type,
+        MaterialStatus status,
+        long totalUnits,
+        long completedUnits,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        List<UnitSummaryResponse> units
+) {
+
+    public static MaterialDetailResponse of(StudyMaterial material, List<StudyUnit> units) {
+        long completed = units.stream()
+                .filter(u -> u.getStatus() == UnitStatus.COMPLETED)
+                .count();
+        return new MaterialDetailResponse(
+                material.getId(),
+                material.getTitle(),
+                material.getType(),
+                material.getStatus(),
+                units.size(),
+                completed,
+                material.getCreatedAt(),
+                material.getUpdatedAt(),
+                units.stream().map(UnitSummaryResponse::from).toList()
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialListResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialListResponse.java
@@ -1,0 +1,6 @@
+package ds.project.orino.planner.material.dto;
+
+import java.util.List;
+
+public record MaterialListResponse(List<MaterialSummaryResponse> materials) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialSummaryResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialSummaryResponse.java
@@ -1,0 +1,32 @@
+package ds.project.orino.planner.material.dto;
+
+import ds.project.orino.domain.planner.material.entity.MaterialStatus;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+
+import java.time.LocalDateTime;
+
+public record MaterialSummaryResponse(
+        Long id,
+        String title,
+        MaterialType type,
+        MaterialStatus status,
+        long totalUnits,
+        long completedUnits,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static MaterialSummaryResponse of(StudyMaterial material, long totalUnits, long completedUnits) {
+        return new MaterialSummaryResponse(
+                material.getId(),
+                material.getTitle(),
+                material.getType(),
+                material.getStatus(),
+                totalUnits,
+                completedUnits,
+                material.getCreatedAt(),
+                material.getUpdatedAt()
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialUpdateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialUpdateRequest.java
@@ -1,0 +1,12 @@
+package ds.project.orino.planner.material.dto;
+
+import ds.project.orino.domain.planner.material.entity.MaterialStatus;
+import jakarta.validation.constraints.Size;
+
+public record MaterialUpdateRequest(
+        @Size(min = 1, max = 200, message = "제목은 1~200자여야 합니다.")
+        String title,
+
+        MaterialStatus status
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/UnitSummaryResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/UnitSummaryResponse.java
@@ -1,0 +1,25 @@
+package ds.project.orino.planner.material.dto;
+
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import ds.project.orino.domain.planner.unit.entity.UnitStatus;
+
+import java.time.LocalDateTime;
+
+public record UnitSummaryResponse(
+        Long id,
+        String title,
+        Integer sortOrder,
+        UnitStatus status,
+        LocalDateTime completedAt
+) {
+
+    public static UnitSummaryResponse from(StudyUnit unit) {
+        return new UnitSummaryResponse(
+                unit.getId(),
+                unit.getTitle(),
+                unit.getSortOrder(),
+                unit.getStatus(),
+                unit.getCompletedAt()
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyMaterialService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyMaterialService.java
@@ -1,0 +1,105 @@
+package ds.project.orino.planner.material.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.material.entity.MaterialStatus;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import ds.project.orino.domain.planner.unit.repository.StudyUnitRepository;
+import ds.project.orino.planner.material.dto.MaterialCreateRequest;
+import ds.project.orino.planner.material.dto.MaterialDetailResponse;
+import ds.project.orino.planner.material.dto.MaterialSummaryResponse;
+import ds.project.orino.planner.material.dto.MaterialUpdateRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class StudyMaterialService {
+
+    private final StudyMaterialRepository studyMaterialRepository;
+    private final StudyUnitRepository studyUnitRepository;
+
+    public StudyMaterialService(StudyMaterialRepository studyMaterialRepository,
+                                StudyUnitRepository studyUnitRepository) {
+        this.studyMaterialRepository = studyMaterialRepository;
+        this.studyUnitRepository = studyUnitRepository;
+    }
+
+    public List<MaterialSummaryResponse> findAll(Long memberId, MaterialStatus status) {
+        List<StudyMaterial> materials = (status == null)
+                ? studyMaterialRepository.findAllByMemberIdOrderByCreatedAtDesc(memberId)
+                : studyMaterialRepository.findAllByMemberIdAndStatusOrderByCreatedAtDesc(memberId, status);
+
+        if (materials.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> materialIds = materials.stream().map(StudyMaterial::getId).toList();
+        Map<Long, StudyUnitRepository.UnitCountProjection> countByMaterial = studyUnitRepository
+                .countByMaterialIds(materialIds).stream()
+                .collect(Collectors.toMap(
+                        StudyUnitRepository.UnitCountProjection::getMaterialId,
+                        Function.identity()));
+
+        return materials.stream()
+                .map(m -> {
+                    StudyUnitRepository.UnitCountProjection counts = countByMaterial.get(m.getId());
+                    long total = counts == null ? 0L : counts.getTotalUnits();
+                    long completed = counts == null ? 0L : counts.getCompletedUnits();
+                    return MaterialSummaryResponse.of(m, total, completed);
+                })
+                .toList();
+    }
+
+    public MaterialDetailResponse findOne(Long memberId, Long materialId) {
+        StudyMaterial material = getOwnedMaterial(memberId, materialId);
+        List<StudyUnit> units = studyUnitRepository.findAllByMaterialIdOrderBySortOrderAsc(material.getId());
+        return MaterialDetailResponse.of(material, units);
+    }
+
+    @Transactional
+    public MaterialSummaryResponse create(Long memberId, MaterialCreateRequest request) {
+        StudyMaterial saved = studyMaterialRepository.save(
+                new StudyMaterial(memberId, request.title(), request.type()));
+        return MaterialSummaryResponse.of(saved, 0L, 0L);
+    }
+
+    @Transactional
+    public MaterialSummaryResponse update(Long memberId, Long materialId, MaterialUpdateRequest request) {
+        StudyMaterial material = getOwnedMaterial(memberId, materialId);
+
+        if (request.title() != null) {
+            material.updateTitle(request.title());
+        }
+        if (request.status() != null) {
+            material.updateStatus(request.status());
+        }
+
+        StudyUnitRepository.UnitCountProjection counts = studyUnitRepository
+                .countByMaterialIds(List.of(material.getId())).stream()
+                .findFirst()
+                .orElse(null);
+        long total = counts == null ? 0L : counts.getTotalUnits();
+        long completed = counts == null ? 0L : counts.getCompletedUnits();
+        return MaterialSummaryResponse.of(material, total, completed);
+    }
+
+    @Transactional
+    public void delete(Long memberId, Long materialId) {
+        StudyMaterial material = getOwnedMaterial(memberId, materialId);
+        studyUnitRepository.deleteAllByMaterialId(material.getId());
+        studyMaterialRepository.delete(material);
+    }
+
+    private StudyMaterial getOwnedMaterial(Long memberId, Long materialId) {
+        return studyMaterialRepository.findByIdAndMemberId(materialId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyMaterialControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyMaterialControllerTest.java
@@ -1,0 +1,322 @@
+package ds.project.orino.planner.material.controller;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialStatus;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import ds.project.orino.domain.planner.unit.entity.UnitStatus;
+import ds.project.orino.domain.planner.unit.repository.StudyUnitRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.StudyMaterialFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class StudyMaterialControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Autowired
+    private StudyUnitRepository studyUnitRepository;
+
+    private Member member;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        studyUnitRepository.deleteAll();
+        studyMaterialRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        member = memberRepository.save(MemberFixture.create());
+        accessToken = AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials - 자료를 생성하고 201을 반환한다")
+    void create_success() throws Exception {
+        mockMvc.perform(post("/api/planner/materials")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "이펙티브 자바", "type": "BOOK"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.id").isNumber())
+                .andExpect(jsonPath("$.data.title").value("이펙티브 자바"))
+                .andExpect(jsonPath("$.data.type").value("BOOK"))
+                .andExpect(jsonPath("$.data.status").value("ACTIVE"))
+                .andExpect(jsonPath("$.data.totalUnits").value(0))
+                .andExpect(jsonPath("$.data.completedUnits").value(0));
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials - 제목이 비어있으면 400을 반환한다")
+    void create_blankTitle() throws Exception {
+        mockMvc.perform(post("/api/planner/materials")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "", "type": "BOOK"}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials - 제목이 200자를 초과하면 400을 반환한다")
+    void create_tooLongTitle() throws Exception {
+        String longTitle = "a".repeat(201);
+        mockMvc.perform(post("/api/planner/materials")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "%s", "type": "BOOK"}
+                                """.formatted(longTitle)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials - 유효하지 않은 type이면 400을 반환한다")
+    void create_invalidType() throws Exception {
+        mockMvc.perform(post("/api/planner/materials")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "이펙티브 자바", "type": "UNKNOWN"}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials - 인증 없으면 403을 반환한다")
+    void create_noAuth() throws Exception {
+        mockMvc.perform(post("/api/planner/materials")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "이펙티브 자바", "type": "BOOK"}
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("GET /api/planner/materials - 본인의 자료 목록만 반환한다")
+    void list_onlyOwnMaterials() throws Exception {
+        Member another = memberRepository.save(MemberFixture.create("other", "password"));
+        studyMaterialRepository.save(StudyMaterialFixture.create(member.getId(), "내 자료", MaterialType.BOOK));
+        studyMaterialRepository.save(StudyMaterialFixture.create(another.getId(), "타인 자료", MaterialType.LECTURE));
+
+        mockMvc.perform(get("/api/planner/materials")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.materials.length()").value(1))
+                .andExpect(jsonPath("$.data.materials[0].title").value("내 자료"));
+    }
+
+    @Test
+    @DisplayName("GET /api/planner/materials?status=ACTIVE - 상태로 필터링한다")
+    void list_filterByStatus() throws Exception {
+        studyMaterialRepository.save(StudyMaterialFixture.create(member.getId(), "활성 자료", MaterialType.BOOK));
+        StudyMaterial completed = studyMaterialRepository.save(
+                StudyMaterialFixture.create(member.getId(), "완료된 자료", MaterialType.LECTURE));
+        completed.updateStatus(MaterialStatus.COMPLETED);
+        studyMaterialRepository.save(completed);
+
+        mockMvc.perform(get("/api/planner/materials?status=COMPLETED")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.materials.length()").value(1))
+                .andExpect(jsonPath("$.data.materials[0].title").value("완료된 자료"));
+    }
+
+    @Test
+    @DisplayName("GET /api/planner/materials - 진행률(totalUnits/completedUnits)을 계산해 반환한다")
+    void list_includesProgress() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                StudyMaterialFixture.create(member.getId()));
+        StudyUnit unit1 = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(member.getId(), material.getId(), 1));
+        studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(member.getId(), material.getId(), 2));
+        studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(member.getId(), material.getId(), 3));
+        markCompleted(unit1);
+
+        mockMvc.perform(get("/api/planner/materials")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.materials[0].totalUnits").value(3))
+                .andExpect(jsonPath("$.data.materials[0].completedUnits").value(1));
+    }
+
+    @Test
+    @DisplayName("GET /api/planner/materials/{id} - 자료 상세와 단위 목록을 반환한다")
+    void detail_success() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                StudyMaterialFixture.create(member.getId()));
+        studyUnitRepository.save(StudyMaterialFixture.createUnit(member.getId(), material.getId(), 1));
+        studyUnitRepository.save(StudyMaterialFixture.createUnit(member.getId(), material.getId(), 2));
+
+        mockMvc.perform(get("/api/planner/materials/{id}", material.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(material.getId()))
+                .andExpect(jsonPath("$.data.totalUnits").value(2))
+                .andExpect(jsonPath("$.data.completedUnits").value(0))
+                .andExpect(jsonPath("$.data.units.length()").value(2))
+                .andExpect(jsonPath("$.data.units[0].sortOrder").value(1))
+                .andExpect(jsonPath("$.data.units[1].sortOrder").value(2));
+    }
+
+    @Test
+    @DisplayName("GET /api/planner/materials/{id} - 다른 멤버의 자료 조회 시 404를 반환한다")
+    void detail_otherMembers_returns404() throws Exception {
+        Member another = memberRepository.save(MemberFixture.create("other", "password"));
+        StudyMaterial othersMaterial = studyMaterialRepository.save(
+                StudyMaterialFixture.create(another.getId()));
+
+        mockMvc.perform(get("/api/planner/materials/{id}", othersMaterial.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+    }
+
+    @Test
+    @DisplayName("GET /api/planner/materials/{id} - 존재하지 않는 자료는 404를 반환한다")
+    void detail_notFound() throws Exception {
+        mockMvc.perform(get("/api/planner/materials/{id}", 99999L)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/planner/materials/{id} - title만 부분 업데이트한다")
+    void update_partialTitle() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                StudyMaterialFixture.create(member.getId()));
+
+        mockMvc.perform(patch("/api/planner/materials/{id}", material.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "수정된 제목"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("수정된 제목"))
+                .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/planner/materials/{id} - status만 부분 업데이트한다")
+    void update_partialStatus() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                StudyMaterialFixture.create(member.getId()));
+        String originalTitle = material.getTitle();
+
+        mockMvc.perform(patch("/api/planner/materials/{id}", material.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"status": "COMPLETED"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.data.title").value(originalTitle));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/planner/materials/{id} - 다른 멤버 자료 수정 시 404를 반환한다")
+    void update_otherMembers_returns404() throws Exception {
+        Member another = memberRepository.save(MemberFixture.create("other", "password"));
+        StudyMaterial othersMaterial = studyMaterialRepository.save(
+                StudyMaterialFixture.create(another.getId()));
+
+        mockMvc.perform(patch("/api/planner/materials/{id}", othersMaterial.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "해킹"}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/planner/materials/{id} - 자료를 삭제하고 204를 반환한다")
+    void delete_success() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                StudyMaterialFixture.create(member.getId()));
+
+        mockMvc.perform(delete("/api/planner/materials/{id}", material.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        assertThat(studyMaterialRepository.findById(material.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("DELETE /api/planner/materials/{id} - 단위가 있으면 cascade로 함께 삭제된다")
+    void delete_cascadesUnits() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                StudyMaterialFixture.create(member.getId()));
+        StudyUnit unit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(member.getId(), material.getId(), 1));
+
+        mockMvc.perform(delete("/api/planner/materials/{id}", material.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        assertThat(studyUnitRepository.findById(unit.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("DELETE /api/planner/materials/{id} - 다른 멤버 자료 삭제 시 404를 반환한다")
+    void delete_otherMembers_returns404() throws Exception {
+        Member another = memberRepository.save(MemberFixture.create("other", "password"));
+        StudyMaterial othersMaterial = studyMaterialRepository.save(
+                StudyMaterialFixture.create(another.getId()));
+
+        mockMvc.perform(delete("/api/planner/materials/{id}", othersMaterial.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+
+        assertThat(studyMaterialRepository.findById(othersMaterial.getId())).isPresent();
+    }
+
+    private void markCompleted(StudyUnit unit) {
+        try {
+            Field statusField = StudyUnit.class.getDeclaredField("status");
+            statusField.setAccessible(true);
+            statusField.set(unit, UnitStatus.COMPLETED);
+            Field completedAtField = StudyUnit.class.getDeclaredField("completedAt");
+            completedAtField.setAccessible(true);
+            completedAtField.set(unit, LocalDateTime.now());
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        studyUnitRepository.save(unit);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/service/StudyMaterialServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/service/StudyMaterialServiceTest.java
@@ -1,0 +1,135 @@
+package ds.project.orino.planner.material.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.material.entity.MaterialStatus;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.unit.repository.StudyUnitRepository;
+import ds.project.orino.planner.material.dto.MaterialCreateRequest;
+import ds.project.orino.planner.material.dto.MaterialSummaryResponse;
+import ds.project.orino.planner.material.dto.MaterialUpdateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class StudyMaterialServiceTest {
+
+    @Mock
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Mock
+    private StudyUnitRepository studyUnitRepository;
+
+    @InjectMocks
+    private StudyMaterialService studyMaterialService;
+
+    @Test
+    @DisplayName("create - 새 자료의 status는 ACTIVE이며 진행률은 0/0이다")
+    void create_defaultStatusActive() {
+        Long memberId = 1L;
+        given(studyMaterialRepository.save(any(StudyMaterial.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+
+        MaterialSummaryResponse response = studyMaterialService.create(
+                memberId, new MaterialCreateRequest("이펙티브 자바", MaterialType.BOOK));
+
+        assertThat(response.title()).isEqualTo("이펙티브 자바");
+        assertThat(response.type()).isEqualTo(MaterialType.BOOK);
+        assertThat(response.status()).isEqualTo(MaterialStatus.ACTIVE);
+        assertThat(response.totalUnits()).isZero();
+        assertThat(response.completedUnits()).isZero();
+    }
+
+    @Test
+    @DisplayName("findOne - 본인 자료가 아니면 RESOURCE_NOT_FOUND를 던진다")
+    void findOne_notOwned_throws() {
+        given(studyMaterialRepository.findByIdAndMemberId(1L, 1L))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> studyMaterialService.findOne(1L, 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("update - title만 제공되면 status는 변경하지 않는다")
+    void update_partialTitleOnly() {
+        Long memberId = 1L;
+        Long materialId = 10L;
+        StudyMaterial material = new StudyMaterial(memberId, "원본", MaterialType.BOOK);
+        setId(material, materialId);
+        given(studyMaterialRepository.findByIdAndMemberId(materialId, memberId))
+                .willReturn(Optional.of(material));
+        given(studyUnitRepository.countByMaterialIds(anyCollection()))
+                .willReturn(List.of());
+
+        MaterialSummaryResponse response = studyMaterialService.update(
+                memberId, materialId, new MaterialUpdateRequest("새 제목", null));
+
+        assertThat(response.title()).isEqualTo("새 제목");
+        assertThat(response.status()).isEqualTo(MaterialStatus.ACTIVE);
+        assertThat(material.getTitle()).isEqualTo("새 제목");
+    }
+
+    @Test
+    @DisplayName("update - status만 제공되면 title은 변경하지 않는다")
+    void update_partialStatusOnly() {
+        Long memberId = 1L;
+        Long materialId = 10L;
+        StudyMaterial material = new StudyMaterial(memberId, "원본", MaterialType.BOOK);
+        setId(material, materialId);
+        given(studyMaterialRepository.findByIdAndMemberId(materialId, memberId))
+                .willReturn(Optional.of(material));
+        given(studyUnitRepository.countByMaterialIds(anyCollection()))
+                .willReturn(List.of());
+
+        MaterialSummaryResponse response = studyMaterialService.update(
+                memberId, materialId, new MaterialUpdateRequest(null, MaterialStatus.COMPLETED));
+
+        assertThat(response.title()).isEqualTo("원본");
+        assertThat(response.status()).isEqualTo(MaterialStatus.COMPLETED);
+        assertThat(material.getStatus()).isEqualTo(MaterialStatus.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("delete - 본인 자료가 아니면 삭제하지 않고 예외를 던진다")
+    void delete_notOwned_doesNotDelete() {
+        given(studyMaterialRepository.findByIdAndMemberId(10L, 1L))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> studyMaterialService.delete(1L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+
+        verify(studyMaterialRepository, never()).delete(any());
+    }
+
+    private static void setId(StudyMaterial material, Long id) {
+        try {
+            java.lang.reflect.Field field = StudyMaterial.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(material, id);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/AuthFixture.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/AuthFixture.java
@@ -1,0 +1,30 @@
+package ds.project.orino.support;
+
+import com.jayway.jsonpath.JsonPath;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+public final class AuthFixture {
+
+    private AuthFixture() {
+    }
+
+    public static String loginAndGetAccessToken(MockMvc mockMvc, String loginId, String rawPassword)
+            throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"loginId": "%s", "password": "%s"}
+                                """.formatted(loginId, rawPassword)))
+                .andReturn();
+        String body = result.getResponse().getContentAsString();
+        return JsonPath.read(body, "$.data.accessToken");
+    }
+
+    public static String loginAndGetAccessToken(MockMvc mockMvc) throws Exception {
+        return loginAndGetAccessToken(mockMvc, MemberFixture.DEFAULT_LOGIN_ID, MemberFixture.DEFAULT_PASSWORD);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/StudyMaterialFixture.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/StudyMaterialFixture.java
@@ -1,0 +1,23 @@
+package ds.project.orino.support;
+
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+
+public final class StudyMaterialFixture {
+
+    private StudyMaterialFixture() {
+    }
+
+    public static StudyMaterial create(Long memberId) {
+        return new StudyMaterial(memberId, "이펙티브 자바", MaterialType.BOOK);
+    }
+
+    public static StudyMaterial create(Long memberId, String title, MaterialType type) {
+        return new StudyMaterial(memberId, title, type);
+    }
+
+    public static StudyUnit createUnit(Long memberId, Long materialId, int sortOrder) {
+        return new StudyUnit(memberId, materialId, "아이템 " + sortOrder, sortOrder);
+    }
+}

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -9,7 +9,10 @@ public enum ErrorCode {
 
     // AUTH
     INVALID_CREDENTIALS("AUTH-ERR-001", "아이디 또는 비밀번호가 올바르지 않습니다.", 401),
-    INVALID_TOKEN("AUTH-ERR-002", "유효하지 않은 토큰입니다.", 401);
+    INVALID_TOKEN("AUTH-ERR-002", "유효하지 않은 토큰입니다.", 401),
+
+    // STUDY PLANNER
+    RESOURCE_NOT_FOUND("SP-ERR-001", "존재하지 않는 리소스입니다.", 404);
 
     private final String code;
     private final String message;

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/entity/MaterialStatus.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/entity/MaterialStatus.java
@@ -1,0 +1,6 @@
+package ds.project.orino.domain.planner.material.entity;
+
+public enum MaterialStatus {
+    ACTIVE,
+    COMPLETED
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/entity/MaterialType.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/entity/MaterialType.java
@@ -1,0 +1,8 @@
+package ds.project.orino.domain.planner.material.entity;
+
+public enum MaterialType {
+    BOOK,
+    LECTURE,
+    WORKBOOK,
+    MOOC
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/entity/StudyMaterial.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/entity/StudyMaterial.java
@@ -1,0 +1,92 @@
+package ds.project.orino.domain.planner.material.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class StudyMaterial {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private MaterialType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private MaterialStatus status;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected StudyMaterial() {
+    }
+
+    public StudyMaterial(Long memberId, String title, MaterialType type) {
+        this.memberId = memberId;
+        this.title = title;
+        this.type = type;
+        this.status = MaterialStatus.ACTIVE;
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateStatus(MaterialStatus status) {
+        this.status = status;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public MaterialType getType() {
+        return type;
+    }
+
+    public MaterialStatus getStatus() {
+        return status;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepository.java
@@ -1,0 +1,17 @@
+package ds.project.orino.domain.planner.material.repository;
+
+import ds.project.orino.domain.planner.material.entity.MaterialStatus;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StudyMaterialRepository extends JpaRepository<StudyMaterial, Long> {
+
+    List<StudyMaterial> findAllByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+    List<StudyMaterial> findAllByMemberIdAndStatusOrderByCreatedAtDesc(Long memberId, MaterialStatus status);
+
+    Optional<StudyMaterial> findByIdAndMemberId(Long id, Long memberId);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/entity/StudyUnit.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/entity/StudyUnit.java
@@ -1,0 +1,98 @@
+package ds.project.orino.domain.planner.unit.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class StudyUnit {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "material_id", nullable = false)
+    private Long materialId;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private UnitStatus status;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected StudyUnit() {
+    }
+
+    public StudyUnit(Long memberId, Long materialId, String title, Integer sortOrder) {
+        this.memberId = memberId;
+        this.materialId = materialId;
+        this.title = title;
+        this.sortOrder = sortOrder;
+        this.status = UnitStatus.PENDING;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Long getMaterialId() {
+        return materialId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Integer getSortOrder() {
+        return sortOrder;
+    }
+
+    public UnitStatus getStatus() {
+        return status;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/entity/UnitStatus.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/entity/UnitStatus.java
@@ -1,0 +1,6 @@
+package ds.project.orino.domain.planner.unit.entity;
+
+public enum UnitStatus {
+    PENDING,
+    COMPLETED
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/repository/StudyUnitRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/repository/StudyUnitRepository.java
@@ -1,0 +1,33 @@
+package ds.project.orino.domain.planner.unit.repository;
+
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface StudyUnitRepository extends JpaRepository<StudyUnit, Long> {
+
+    List<StudyUnit> findAllByMaterialIdOrderBySortOrderAsc(Long materialId);
+
+    void deleteAllByMaterialId(Long materialId);
+
+    @Query("""
+            SELECT u.materialId AS materialId,
+                   COUNT(u) AS totalUnits,
+                   SUM(CASE WHEN u.status = ds.project.orino.domain.planner.unit.entity.UnitStatus.COMPLETED
+                            THEN 1 ELSE 0 END) AS completedUnits
+            FROM StudyUnit u
+            WHERE u.materialId IN :materialIds
+            GROUP BY u.materialId
+            """)
+    List<UnitCountProjection> countByMaterialIds(@Param("materialIds") Collection<Long> materialIds);
+
+    interface UnitCountProjection {
+        Long getMaterialId();
+        Long getTotalUnits();
+        Long getCompletedUnits();
+    }
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepositoryTest.java
@@ -1,0 +1,85 @@
+package ds.project.orino.domain.planner.material.repository;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialStatus;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.support.RepositoryTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RepositoryTest
+@Transactional
+class StudyMaterialRepositoryTest {
+
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("멤버별로 자료 목록을 조회한다")
+    void findAllByMemberId() {
+        Member m1 = memberRepository.save(new Member("user1", "pw"));
+        Member m2 = memberRepository.save(new Member("user2", "pw"));
+        studyMaterialRepository.save(new StudyMaterial(m1.getId(), "내 자료", MaterialType.BOOK));
+        studyMaterialRepository.save(new StudyMaterial(m2.getId(), "타인 자료", MaterialType.LECTURE));
+
+        List<StudyMaterial> result = studyMaterialRepository.findAllByMemberIdOrderByCreatedAtDesc(m1.getId());
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getTitle()).isEqualTo("내 자료");
+    }
+
+    @Test
+    @DisplayName("멤버 + 상태로 자료 목록을 필터링한다")
+    void findAllByMemberIdAndStatus() {
+        Member member = memberRepository.save(new Member("user1", "pw"));
+        studyMaterialRepository.save(new StudyMaterial(member.getId(), "활성", MaterialType.BOOK));
+        StudyMaterial completed = new StudyMaterial(member.getId(), "완료", MaterialType.LECTURE);
+        completed.updateStatus(MaterialStatus.COMPLETED);
+        studyMaterialRepository.save(completed);
+
+        List<StudyMaterial> active = studyMaterialRepository
+                .findAllByMemberIdAndStatusOrderByCreatedAtDesc(member.getId(), MaterialStatus.ACTIVE);
+
+        assertThat(active).hasSize(1);
+        assertThat(active.get(0).getTitle()).isEqualTo("활성");
+    }
+
+    @Test
+    @DisplayName("id + memberId로 자료 한 건을 조회한다")
+    void findByIdAndMemberId() {
+        Member member = memberRepository.save(new Member("user1", "pw"));
+        StudyMaterial saved = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "자료", MaterialType.BOOK));
+
+        Optional<StudyMaterial> found = studyMaterialRepository
+                .findByIdAndMemberId(saved.getId(), member.getId());
+
+        assertThat(found).isPresent();
+    }
+
+    @Test
+    @DisplayName("id + 다른 memberId로 조회 시 빈 Optional을 반환한다")
+    void findByIdAndMemberId_notOwned() {
+        Member m1 = memberRepository.save(new Member("user1", "pw"));
+        Member m2 = memberRepository.save(new Member("user2", "pw"));
+        StudyMaterial m1Material = studyMaterialRepository.save(
+                new StudyMaterial(m1.getId(), "자료", MaterialType.BOOK));
+
+        Optional<StudyMaterial> found = studyMaterialRepository
+                .findByIdAndMemberId(m1Material.getId(), m2.getId());
+
+        assertThat(found).isEmpty();
+    }
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/unit/repository/StudyUnitRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/unit/repository/StudyUnitRepositoryTest.java
@@ -1,0 +1,86 @@
+package ds.project.orino.domain.planner.unit.repository;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import ds.project.orino.domain.planner.unit.entity.UnitStatus;
+import ds.project.orino.domain.support.RepositoryTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RepositoryTest
+@Transactional
+class StudyUnitRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Autowired
+    private StudyUnitRepository studyUnitRepository;
+
+    @Test
+    @DisplayName("자료별 단위 목록을 sort_order ASC로 조회한다")
+    void findAllByMaterialId_orderedBySortOrder() {
+        Member member = memberRepository.save(new Member("user1", "pw"));
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "자료", MaterialType.BOOK));
+        studyUnitRepository.save(new StudyUnit(member.getId(), material.getId(), "두번째", 2));
+        studyUnitRepository.save(new StudyUnit(member.getId(), material.getId(), "첫번째", 1));
+        studyUnitRepository.save(new StudyUnit(member.getId(), material.getId(), "세번째", 3));
+
+        List<StudyUnit> result = studyUnitRepository.findAllByMaterialIdOrderBySortOrderAsc(material.getId());
+
+        assertThat(result).extracting(StudyUnit::getSortOrder).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("materialId 목록으로 진행률을 집계한다")
+    void countByMaterialIds_aggregates() throws Exception {
+        Member member = memberRepository.save(new Member("user1", "pw"));
+        StudyMaterial m1 = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "자료1", MaterialType.BOOK));
+        StudyMaterial m2 = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "자료2", MaterialType.LECTURE));
+
+        StudyUnit u1 = new StudyUnit(member.getId(), m1.getId(), "u1", 1);
+        StudyUnit u2 = new StudyUnit(member.getId(), m1.getId(), "u2", 2);
+        StudyUnit u3 = new StudyUnit(member.getId(), m2.getId(), "u3", 1);
+        markCompleted(u1);
+        studyUnitRepository.save(u1);
+        studyUnitRepository.save(u2);
+        studyUnitRepository.save(u3);
+
+        Map<Long, StudyUnitRepository.UnitCountProjection> map = studyUnitRepository
+                .countByMaterialIds(List.of(m1.getId(), m2.getId())).stream()
+                .collect(Collectors.toMap(
+                        StudyUnitRepository.UnitCountProjection::getMaterialId,
+                        Function.identity()));
+
+        assertThat(map.get(m1.getId()).getTotalUnits()).isEqualTo(2L);
+        assertThat(map.get(m1.getId()).getCompletedUnits()).isEqualTo(1L);
+        assertThat(map.get(m2.getId()).getTotalUnits()).isEqualTo(1L);
+        assertThat(map.get(m2.getId()).getCompletedUnits()).isZero();
+    }
+
+    private void markCompleted(StudyUnit unit) throws Exception {
+        Field status = StudyUnit.class.getDeclaredField("status");
+        status.setAccessible(true);
+        status.set(unit, UnitStatus.COMPLETED);
+    }
+}


### PR DESCRIPTION
## 이슈
closes #324

## 작업 내용

### 도메인 (`orino-domain-rdb`)
- `StudyMaterial` 엔티티 + `StudyMaterialRepository`
  - `findAllByMemberIdOrderByCreatedAtDesc`, `findAllByMemberIdAndStatusOrderByCreatedAtDesc`
  - `findByIdAndMemberId` — 권한 검증용
- `StudyUnit` 엔티티 + `StudyUnitRepository`
  - 진행률 집계 쿼리 (`countByMaterialIds` — `GROUP BY` 1쿼리로 N개 자료의 total/completed 한 번에)
  - `deleteAllByMaterialId` — 자료 삭제 시 단위 cascade

### API (`orino-app-api`)
- `StudyMaterialController` (`/api/planner/materials`)
- `StudyMaterialService`
- DTO: `MaterialCreateRequest`, `MaterialUpdateRequest`, `MaterialSummaryResponse`, `MaterialDetailResponse`, `UnitSummaryResponse`, `MaterialListResponse`

| Method | Path | Response |
|--------|------|----------|
| POST | `/api/planner/materials` | 201 Created |
| GET | `/api/planner/materials?status=ACTIVE` | 200 (목록 + 진행률) |
| GET | `/api/planner/materials/{id}` | 200 (상세 + 단위 목록 + 진행률) |
| PATCH | `/api/planner/materials/{id}` | 200 (부분 업데이트: title/status) |
| DELETE | `/api/planner/materials/{id}` | 204 (단위 cascade 삭제) |

### 에러 처리
- `SP-ERR-001` (404, `RESOURCE_NOT_FOUND`) 추가 — 존재하지 않거나 본인 소유가 아닐 때
- 검증 실패는 기존 `GlobalExceptionHandler`가 400 (GLB-ERR-001)으로 처리

### 검증
- `./gradlew clean build` 통과 (체크스타일 + 전체 테스트)
- 통합 테스트 (MockMvc + TestContainers MySQL 8.4.4): **17건**
  - CRUD 정상 / 검증 실패 / 권한 (다른 멤버 자료 접근 시 404) / cascade 삭제 / 부분 업데이트
- 서비스 단위 테스트 (Mockito): **5건** — 권한 / 부분 업데이트 / 기본값
- 리포지토리 테스트: 6건 (Material 4 + Unit 2)
- **로컬 bootRun + curl 직접 검증** — 5개 엔드포인트 모두 정상 동작:
  - POST 201, GET list 200, GET detail 200 (units 포함), PATCH 200 (부분), DELETE 204
  - 404 (없는 ID), 400 (빈 title), 403 (인증 없음)

### 참고
- 설계: [Study-Planner-API-Spec (Wiki)](https://github.com/wcorn/orino/wiki/Study-Planner-API-Spec)
- 다음 #325 (unit CRUD)에서 `POST /api/planner/materials/{id}/units` 등을 추가하며 StudyUnit 쓰기 측을 확장