### PR TITLE
feat : 학습 단위(unit) CRUD API 구현

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/controller/StudyUnitController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/controller/StudyUnitController.java
@@ -1,0 +1,56 @@
+package ds.project.orino.planner.material.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.material.dto.UnitCreateRequest;
+import ds.project.orino.planner.material.dto.UnitListResponse;
+import ds.project.orino.planner.material.dto.UnitResponse;
+import ds.project.orino.planner.material.dto.UnitUpdateRequest;
+import ds.project.orino.planner.material.service.StudyUnitService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/planner")
+public class StudyUnitController {
+
+    private final StudyUnitService studyUnitService;
+
+    public StudyUnitController(StudyUnitService studyUnitService) {
+        this.studyUnitService = studyUnitService;
+    }
+
+    @PostMapping("/materials/{materialId}/units")
+    public ResponseEntity<ApiResponse<UnitListResponse>> create(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long materialId,
+            @Valid @RequestBody UnitCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(new UnitListResponse(
+                        studyUnitService.create(memberId, materialId, request))));
+    }
+
+    @PatchMapping("/units/{id}")
+    public ApiResponse<UnitResponse> update(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @Valid @RequestBody UnitUpdateRequest request) {
+        return ApiResponse.success(studyUnitService.update(memberId, id, request));
+    }
+
+    @DeleteMapping("/units/{id}")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id) {
+        studyUnitService.delete(memberId, id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/UnitCreateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/UnitCreateRequest.java
@@ -1,0 +1,21 @@
+package ds.project.orino.planner.material.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record UnitCreateRequest(
+        @NotEmpty(message = "단위를 1개 이상 입력해주세요.")
+        @Valid
+        List<Item> units
+) {
+    public record Item(
+            @NotBlank(message = "단위 제목을 입력해주세요.")
+            @Size(min = 1, max = 200, message = "제목은 1~200자여야 합니다.")
+            String title
+    ) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/UnitListResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/UnitListResponse.java
@@ -1,0 +1,6 @@
+package ds.project.orino.planner.material.dto;
+
+import java.util.List;
+
+public record UnitListResponse(List<UnitResponse> units) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/UnitResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/UnitResponse.java
@@ -1,0 +1,27 @@
+package ds.project.orino.planner.material.dto;
+
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import ds.project.orino.domain.planner.unit.entity.UnitStatus;
+
+import java.time.LocalDateTime;
+
+public record UnitResponse(
+        Long id,
+        Long materialId,
+        String title,
+        Integer sortOrder,
+        UnitStatus status,
+        LocalDateTime completedAt
+) {
+
+    public static UnitResponse from(StudyUnit unit) {
+        return new UnitResponse(
+                unit.getId(),
+                unit.getMaterialId(),
+                unit.getTitle(),
+                unit.getSortOrder(),
+                unit.getStatus(),
+                unit.getCompletedAt()
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/UnitUpdateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/UnitUpdateRequest.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.material.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+public record UnitUpdateRequest(
+        @Size(min = 1, max = 200, message = "제목은 1~200자여야 합니다.")
+        String title,
+
+        @Min(value = 1, message = "sortOrder는 1 이상이어야 합니다.")
+        Integer sortOrder
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyUnitService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyUnitService.java
@@ -1,0 +1,66 @@
+package ds.project.orino.planner.material.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import ds.project.orino.domain.planner.unit.repository.StudyUnitRepository;
+import ds.project.orino.planner.material.dto.UnitCreateRequest;
+import ds.project.orino.planner.material.dto.UnitResponse;
+import ds.project.orino.planner.material.dto.UnitUpdateRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class StudyUnitService {
+
+    private final StudyMaterialRepository studyMaterialRepository;
+    private final StudyUnitRepository studyUnitRepository;
+
+    public StudyUnitService(StudyMaterialRepository studyMaterialRepository,
+                            StudyUnitRepository studyUnitRepository) {
+        this.studyMaterialRepository = studyMaterialRepository;
+        this.studyUnitRepository = studyUnitRepository;
+    }
+
+    @Transactional
+    public List<UnitResponse> create(Long memberId, Long materialId, UnitCreateRequest request) {
+        StudyMaterial material = studyMaterialRepository.findByIdAndMemberId(materialId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        int nextOrder = studyUnitRepository.findMaxSortOrderByMaterialId(material.getId()) + 1;
+
+        List<StudyUnit> saved = new ArrayList<>(request.units().size());
+        for (UnitCreateRequest.Item item : request.units()) {
+            saved.add(studyUnitRepository.save(
+                    new StudyUnit(memberId, material.getId(), item.title(), nextOrder++)));
+        }
+        return saved.stream().map(UnitResponse::from).toList();
+    }
+
+    @Transactional
+    public UnitResponse update(Long memberId, Long unitId, UnitUpdateRequest request) {
+        StudyUnit unit = studyUnitRepository.findByIdAndMemberId(unitId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (request.title() != null) {
+            unit.updateTitle(request.title());
+        }
+        if (request.sortOrder() != null) {
+            unit.updateSortOrder(request.sortOrder());
+        }
+        return UnitResponse.from(unit);
+    }
+
+    @Transactional
+    public void delete(Long memberId, Long unitId) {
+        StudyUnit unit = studyUnitRepository.findByIdAndMemberId(unitId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        studyUnitRepository.delete(unit);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyUnitControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyUnitControllerTest.java
@@ -1,0 +1,238 @@
+package ds.project.orino.planner.material.controller;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import ds.project.orino.domain.planner.unit.repository.StudyUnitRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.StudyMaterialFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class StudyUnitControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Autowired
+    private StudyUnitRepository studyUnitRepository;
+
+    private Member member;
+    private String accessToken;
+    private StudyMaterial material;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        studyUnitRepository.deleteAll();
+        studyMaterialRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        member = memberRepository.save(MemberFixture.create());
+        accessToken = AuthFixture.loginAndGetAccessToken(mockMvc);
+        material = studyMaterialRepository.save(StudyMaterialFixture.create(member.getId()));
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials/{materialId}/units - 단건 추가, sort_order=1로 시작한다")
+    void create_single() throws Exception {
+        mockMvc.perform(post("/api/planner/materials/{materialId}/units", material.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"units": [{"title": "아이템 1"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.units.length()").value(1))
+                .andExpect(jsonPath("$.data.units[0].title").value("아이템 1"))
+                .andExpect(jsonPath("$.data.units[0].materialId").value(material.getId()))
+                .andExpect(jsonPath("$.data.units[0].sortOrder").value(1))
+                .andExpect(jsonPath("$.data.units[0].status").value("PENDING"));
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials/{materialId}/units - 배열 추가, sort_order가 순차 부여된다")
+    void create_batch_sortOrderSequential() throws Exception {
+        mockMvc.perform(post("/api/planner/materials/{materialId}/units", material.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"units": [
+                                    {"title": "아이템 1"},
+                                    {"title": "아이템 2"},
+                                    {"title": "아이템 3"}
+                                ]}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.units.length()").value(3))
+                .andExpect(jsonPath("$.data.units[0].sortOrder").value(1))
+                .andExpect(jsonPath("$.data.units[1].sortOrder").value(2))
+                .andExpect(jsonPath("$.data.units[2].sortOrder").value(3));
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials/{materialId}/units - 기존 단위가 있으면 max+1부터 부여된다")
+    void create_continuesFromMaxSortOrder() throws Exception {
+        studyUnitRepository.save(StudyMaterialFixture.createUnit(member.getId(), material.getId(), 5));
+
+        mockMvc.perform(post("/api/planner/materials/{materialId}/units", material.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"units": [{"title": "신규 1"}, {"title": "신규 2"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.units[0].sortOrder").value(6))
+                .andExpect(jsonPath("$.data.units[1].sortOrder").value(7));
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials/{materialId}/units - 빈 배열은 400을 반환한다")
+    void create_emptyArray_returns400() throws Exception {
+        mockMvc.perform(post("/api/planner/materials/{materialId}/units", material.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"units": []}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials/{materialId}/units - 단위 제목이 빈 문자열이면 400을 반환한다")
+    void create_blankTitle_returns400() throws Exception {
+        mockMvc.perform(post("/api/planner/materials/{materialId}/units", material.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"units": [{"title": ""}]}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials/{materialId}/units - 다른 멤버 자료에 추가 시 404를 반환한다")
+    void create_otherMembersMaterial_returns404() throws Exception {
+        Member another = memberRepository.save(MemberFixture.create("other", "password"));
+        StudyMaterial othersMaterial = studyMaterialRepository.save(
+                StudyMaterialFixture.create(another.getId()));
+
+        mockMvc.perform(post("/api/planner/materials/{materialId}/units", othersMaterial.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"units": [{"title": "해킹"}]}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/planner/units/{id} - title만 부분 업데이트")
+    void update_title() throws Exception {
+        StudyUnit unit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(member.getId(), material.getId(), 1));
+
+        mockMvc.perform(patch("/api/planner/units/{id}", unit.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "수정된 단위"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("수정된 단위"))
+                .andExpect(jsonPath("$.data.sortOrder").value(1));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/planner/units/{id} - sortOrder만 부분 업데이트")
+    void update_sortOrder() throws Exception {
+        StudyUnit unit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(member.getId(), material.getId(), 1));
+
+        mockMvc.perform(patch("/api/planner/units/{id}", unit.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"sortOrder": 5}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sortOrder").value(5));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/planner/units/{id} - 다른 멤버 단위 수정 시 404")
+    void update_otherMembers_returns404() throws Exception {
+        Member another = memberRepository.save(MemberFixture.create("other", "password"));
+        StudyMaterial othersMaterial = studyMaterialRepository.save(
+                StudyMaterialFixture.create(another.getId()));
+        StudyUnit othersUnit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(another.getId(), othersMaterial.getId(), 1));
+
+        mockMvc.perform(patch("/api/planner/units/{id}", othersUnit.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "해킹"}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/planner/units/{id} - 단위를 삭제하고 204를 반환한다")
+    void delete_success() throws Exception {
+        StudyUnit unit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(member.getId(), material.getId(), 1));
+
+        mockMvc.perform(delete("/api/planner/units/{id}", unit.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        assertThat(studyUnitRepository.findById(unit.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("DELETE /api/planner/units/{id} - 다른 멤버 단위 삭제 시 404")
+    void delete_otherMembers_returns404() throws Exception {
+        Member another = memberRepository.save(MemberFixture.create("other", "password"));
+        StudyMaterial othersMaterial = studyMaterialRepository.save(
+                StudyMaterialFixture.create(another.getId()));
+        StudyUnit othersUnit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(another.getId(), othersMaterial.getId(), 1));
+
+        mockMvc.perform(delete("/api/planner/units/{id}", othersUnit.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+
+        assertThat(studyUnitRepository.findById(othersUnit.getId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials/{materialId}/units - 인증 없으면 403")
+    void create_noAuth() throws Exception {
+        mockMvc.perform(post("/api/planner/materials/{materialId}/units", material.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"units": [{"title": "아이템"}]}
+                                """))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/service/StudyUnitServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/service/StudyUnitServiceTest.java
@@ -1,0 +1,147 @@
+package ds.project.orino.planner.material.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import ds.project.orino.domain.planner.unit.entity.UnitStatus;
+import ds.project.orino.domain.planner.unit.repository.StudyUnitRepository;
+import ds.project.orino.planner.material.dto.UnitCreateRequest;
+import ds.project.orino.planner.material.dto.UnitResponse;
+import ds.project.orino.planner.material.dto.UnitUpdateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class StudyUnitServiceTest {
+
+    @Mock
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Mock
+    private StudyUnitRepository studyUnitRepository;
+
+    @InjectMocks
+    private StudyUnitService studyUnitService;
+
+    @Test
+    @DisplayName("create - 기존 단위가 없으면 sort_order는 1부터 시작한다")
+    void create_firstUnit_sortOrderStartsAt1() {
+        Long memberId = 1L;
+        Long materialId = 10L;
+        StudyMaterial material = new StudyMaterial(memberId, "자료", MaterialType.BOOK);
+        setId(material, materialId);
+        given(studyMaterialRepository.findByIdAndMemberId(materialId, memberId))
+                .willReturn(Optional.of(material));
+        given(studyUnitRepository.findMaxSortOrderByMaterialId(materialId)).willReturn(0);
+        given(studyUnitRepository.save(any(StudyUnit.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+
+        List<UnitResponse> result = studyUnitService.create(memberId, materialId,
+                new UnitCreateRequest(List.of(new UnitCreateRequest.Item("u1"))));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).sortOrder()).isEqualTo(1);
+        assertThat(result.get(0).status()).isEqualTo(UnitStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("create - 기존 단위가 있으면 max+1부터 순차 부여한다")
+    void create_continuesFromMax() {
+        Long memberId = 1L;
+        Long materialId = 10L;
+        StudyMaterial material = new StudyMaterial(memberId, "자료", MaterialType.BOOK);
+        setId(material, materialId);
+        given(studyMaterialRepository.findByIdAndMemberId(materialId, memberId))
+                .willReturn(Optional.of(material));
+        given(studyUnitRepository.findMaxSortOrderByMaterialId(materialId)).willReturn(5);
+        given(studyUnitRepository.save(any(StudyUnit.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+
+        List<UnitResponse> result = studyUnitService.create(memberId, materialId,
+                new UnitCreateRequest(List.of(
+                        new UnitCreateRequest.Item("u1"),
+                        new UnitCreateRequest.Item("u2"))));
+
+        assertThat(result).extracting(UnitResponse::sortOrder).containsExactly(6, 7);
+    }
+
+    @Test
+    @DisplayName("create - 다른 멤버 자료면 RESOURCE_NOT_FOUND")
+    void create_notOwnedMaterial_throws() {
+        given(studyMaterialRepository.findByIdAndMemberId(10L, 1L))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> studyUnitService.create(1L, 10L,
+                new UnitCreateRequest(List.of(new UnitCreateRequest.Item("u")))))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+
+        verify(studyUnitRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("update - 본인 단위가 아니면 RESOURCE_NOT_FOUND")
+    void update_notOwned_throws() {
+        given(studyUnitRepository.findByIdAndMemberId(10L, 1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> studyUnitService.update(1L, 10L,
+                new UnitUpdateRequest("새 제목", null)))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("update - title만 제공하면 sortOrder는 그대로")
+    void update_titleOnly() {
+        StudyUnit unit = new StudyUnit(1L, 10L, "원본", 3);
+        given(studyUnitRepository.findByIdAndMemberId(100L, 1L)).willReturn(Optional.of(unit));
+
+        UnitResponse response = studyUnitService.update(1L, 100L,
+                new UnitUpdateRequest("새 제목", null));
+
+        assertThat(response.title()).isEqualTo("새 제목");
+        assertThat(response.sortOrder()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("delete - 본인 단위가 아니면 RESOURCE_NOT_FOUND")
+    void delete_notOwned_throws() {
+        given(studyUnitRepository.findByIdAndMemberId(10L, 1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> studyUnitService.delete(1L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+
+        verify(studyUnitRepository, never()).delete(any());
+    }
+
+    private static void setId(StudyMaterial material, Long id) {
+        try {
+            java.lang.reflect.Field field = StudyMaterial.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(material, id);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/entity/StudyUnit.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/entity/StudyUnit.java
@@ -60,6 +60,14 @@ public class StudyUnit {
         this.status = UnitStatus.PENDING;
     }
 
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
     public Long getId() {
         return id;
     }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/repository/StudyUnitRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/repository/StudyUnitRepository.java
@@ -7,10 +7,16 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface StudyUnitRepository extends JpaRepository<StudyUnit, Long> {
 
     List<StudyUnit> findAllByMaterialIdOrderBySortOrderAsc(Long materialId);
+
+    Optional<StudyUnit> findByIdAndMemberId(Long id, Long memberId);
+
+    @Query("SELECT COALESCE(MAX(u.sortOrder), 0) FROM StudyUnit u WHERE u.materialId = :materialId")
+    int findMaxSortOrderByMaterialId(@Param("materialId") Long materialId);
 
     void deleteAllByMaterialId(Long materialId);
 

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/unit/repository/StudyUnitRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/unit/repository/StudyUnitRepositoryTest.java
@@ -78,6 +78,60 @@ class StudyUnitRepositoryTest {
         assertThat(map.get(m2.getId()).getCompletedUnits()).isZero();
     }
 
+    @Test
+    @DisplayName("findMaxSortOrderByMaterialId - 단위가 없으면 0을 반환한다")
+    void findMaxSortOrder_empty_returnsZero() {
+        Member member = memberRepository.save(new Member("user1", "pw"));
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "자료", MaterialType.BOOK));
+
+        int max = studyUnitRepository.findMaxSortOrderByMaterialId(material.getId());
+
+        assertThat(max).isZero();
+    }
+
+    @Test
+    @DisplayName("findMaxSortOrderByMaterialId - 가장 큰 sort_order를 반환한다")
+    void findMaxSortOrder_returnsMax() {
+        Member member = memberRepository.save(new Member("user1", "pw"));
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "자료", MaterialType.BOOK));
+        studyUnitRepository.save(new StudyUnit(member.getId(), material.getId(), "u1", 2));
+        studyUnitRepository.save(new StudyUnit(member.getId(), material.getId(), "u2", 7));
+        studyUnitRepository.save(new StudyUnit(member.getId(), material.getId(), "u3", 5));
+
+        int max = studyUnitRepository.findMaxSortOrderByMaterialId(material.getId());
+
+        assertThat(max).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("findByIdAndMemberId - 본인 단위면 Optional에 담아 반환한다")
+    void findByIdAndMemberId_owned() {
+        Member member = memberRepository.save(new Member("user1", "pw"));
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "자료", MaterialType.BOOK));
+        StudyUnit unit = studyUnitRepository.save(
+                new StudyUnit(member.getId(), material.getId(), "u1", 1));
+
+        assertThat(studyUnitRepository.findByIdAndMemberId(unit.getId(), member.getId()))
+                .isPresent();
+    }
+
+    @Test
+    @DisplayName("findByIdAndMemberId - 다른 멤버 단위면 빈 Optional")
+    void findByIdAndMemberId_notOwned_empty() {
+        Member m1 = memberRepository.save(new Member("user1", "pw"));
+        Member m2 = memberRepository.save(new Member("user2", "pw"));
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(m1.getId(), "자료", MaterialType.BOOK));
+        StudyUnit unit = studyUnitRepository.save(
+                new StudyUnit(m1.getId(), material.getId(), "u1", 1));
+
+        assertThat(studyUnitRepository.findByIdAndMemberId(unit.getId(), m2.getId()))
+                .isEmpty();
+    }
+
     private void markCompleted(StudyUnit unit) throws Exception {
         Field status = StudyUnit.class.getDeclaredField("status");
         status.setAccessible(true);


### PR DESCRIPTION
## 이슈
closes #325

## 작업 내용

### API (`orino-app-api`)
- `StudyUnitController` (`/api/planner`)
- `StudyUnitService`
- DTO: `UnitCreateRequest`, `UnitUpdateRequest`, `UnitResponse`, `UnitListResponse`

| Method | Path | 설명 |
|--------|------|------|
| POST | `/api/planner/materials/{materialId}/units` | 단위 추가 (단건/배열 모두 같은 엔드포인트, sort_order 자동) |
| PATCH | `/api/planner/units/{id}` | 단위 수정 (title / sortOrder 부분 업데이트) |
| DELETE | `/api/planner/units/{id}` | 단위 삭제 |

### sort_order 자동 부여
- `StudyUnitRepository.findMaxSortOrderByMaterialId` — `COALESCE(MAX(sort_order), 0)` 쿼리로 max 조회
- 서비스에서 `max + 1`부터 순차 부여 (배열 입력 시에도 연속)

### 도메인 확장 (`orino-domain-rdb`)
- `StudyUnit`: `updateTitle`, `updateSortOrder` 메서드 추가
- `StudyUnitRepository`: `findByIdAndMemberId` (소유자 검증), `findMaxSortOrderByMaterialId` 추가

### 권한 검증
- 자료 추가: 자료의 소유자가 본인이 아니면 404 (`SP-ERR-001`)
- 단위 수정/삭제: 단위의 소유자가 본인이 아니면 404 (StudyUnit이 비정규화 `member_id`를 보유)

### 검증
- `./gradlew clean build` 통과 (체크스타일 + 전체 테스트)
- 통합 테스트 (MockMvc + TestContainers MySQL 8.4.4): **12건**
  - 단건/배열 추가, sort_order 연속성, 빈 배열 400, 빈 title 400, 인증 없음 403
  - 다른 멤버 자료/단위 접근 시 404 (3건)
  - title/sortOrder 부분 업데이트, 단순 삭제
- 서비스 단위 테스트 (Mockito): **6건**
- 리포지토리 테스트: 4건 (max sort_order 2건, ownership 2건)
- **로컬 bootRun + curl 직접 검증** — 단건/배열/PATCH/DELETE 모두 정상:
  - 1건 → sort_order 1
  - 2건 추가 → sort_order 2, 3 (연속 부여)
  - PATCH title + sortOrder, DELETE 후 detail 확인

### 참고
- 설계: [Study-Planner-API-Spec (Wiki)](https://github.com/wcorn/orino/wiki/Study-Planner-API-Spec)
- 다음 #326 (SM-2 알고리즘)에서 `POST /api/planner/units/{id}/complete` 추가 시 ReviewSchedule cascade 처리 보강 예정