### PR TITLE
fix : Spring Boot/Security/Netty/베이스 이미지 CVE 수정

### DIFF
--- a/be/Dockerfile
+++ b/be/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . .
 RUN ./gradlew :orino-app-api:build -x test --no-daemon
 
-FROM eclipse-temurin:25-jre
+FROM eclipse-temurin:25-jre-alpine
 WORKDIR /app
 COPY --from=builder /app/orino-app-api/build/libs/*.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.3' apply false
+    id 'org.springframework.boot' version '4.0.6' apply false
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -19,9 +19,10 @@ subprojects {
         }
     }
 
-    ext['jackson-2-bom.version'] = '2.21.1'
-    ext['jackson-bom.version'] = '3.1.1'
-    ext['spring-security.version'] = '7.0.4'
+    ext['jackson-2-bom.version'] = '2.21.2'
+    ext['jackson-bom.version'] = '3.1.2'
+    ext['netty.version'] = '4.2.13.Final'
+    ext['spring-security.version'] = '7.0.5'
     ext['tomcat.version'] = '11.0.21'
 
     repositories {
@@ -30,7 +31,7 @@ subprojects {
 
     dependencyManagement {
         imports {
-            mavenBom "org.springframework.boot:spring-boot-dependencies:4.0.3"
+            mavenBom "org.springframework.boot:spring-boot-dependencies:4.0.6"
         }
     }
 


### PR DESCRIPTION
## 이슈
closes #343

## 작업 내용
- Spring Boot 플러그인 4.0.3 → 4.0.6, BOM도 4.0.6로 동기화
- `spring-security.version` 7.0.4 → 7.0.5 override
- `netty.version` 4.2.13.Final override 추가 (Spring Boot 4.0.6 BOM 기본 4.2.12는 여전히 취약)
- jackson 2.21.2 / 3.1.2 로 BOM 동기화
- Dockerfile 베이스 이미지 `eclipse-temurin:25-jre` → `eclipse-temurin:25-jre-alpine`
  Ubuntu 26.04 베이스의 `/usr/bin/pebble` (Go stdlib 1.26.2) CVE 5건 제거

## CVE 수정 내역

| CVE | Severity | Package | Installed → Fixed |
| --- | --- | --- | --- |
| CVE-2026-40976 | CRITICAL | spring-boot | 4.0.3 → 4.0.6 |
| CVE-2026-40973 | HIGH | spring-boot | 4.0.3 → 4.0.6 |
| CVE-2026-22753 | HIGH | spring-security-config | 7.0.4 → 7.0.5 |
| CVE-2026-22754 | HIGH | spring-security-config | 7.0.4 → 7.0.5 |
| CVE-2026-42579 | HIGH | netty-codec-dns | 4.2.10 → 4.2.13.Final |
| CVE-2026-42499 | HIGH | stdlib (pebble) | 베이스 변경으로 제거 |
| CVE-2026-39836 | HIGH | stdlib (pebble) | 베이스 변경으로 제거 |
| CVE-2026-39820 | HIGH | stdlib (pebble) | 베이스 변경으로 제거 |
| CVE-2026-33814 | HIGH | stdlib (pebble) | 베이스 변경으로 제거 |
| CVE-2026-33811 | HIGH | stdlib (pebble) | 베이스 변경으로 제거 |

## 검증
- `./gradlew clean build` 성공 (모든 모듈 테스트 통과)
- `:orino-app-api:dependencies --configuration runtimeClasspath` 로 신규 버전 반영 확인
  - `spring-boot:4.0.6`, `spring-security-config:7.0.5`, `netty-codec-dns:4.2.13.Final`
  - `jackson-core:3.1.2`, `jackson-core:2.21.2`