### PR TITLE
feat : SM-2 알고리즘 + 단위 완료/복습 평가 API

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/config/ClockConfig.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/config/ClockConfig.java
@@ -1,0 +1,16 @@
+package ds.project.orino.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyMaterialService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyMaterialService.java
@@ -5,6 +5,7 @@ import ds.project.orino.common.exception.ErrorCode;
 import ds.project.orino.domain.planner.material.entity.MaterialStatus;
 import ds.project.orino.domain.planner.material.entity.StudyMaterial;
 import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
 import ds.project.orino.domain.planner.unit.entity.StudyUnit;
 import ds.project.orino.domain.planner.unit.repository.StudyUnitRepository;
 import ds.project.orino.planner.material.dto.MaterialCreateRequest;
@@ -25,11 +26,14 @@ public class StudyMaterialService {
 
     private final StudyMaterialRepository studyMaterialRepository;
     private final StudyUnitRepository studyUnitRepository;
+    private final ReviewScheduleRepository reviewScheduleRepository;
 
     public StudyMaterialService(StudyMaterialRepository studyMaterialRepository,
-                                StudyUnitRepository studyUnitRepository) {
+                                StudyUnitRepository studyUnitRepository,
+                                ReviewScheduleRepository reviewScheduleRepository) {
         this.studyMaterialRepository = studyMaterialRepository;
         this.studyUnitRepository = studyUnitRepository;
+        this.reviewScheduleRepository = reviewScheduleRepository;
     }
 
     public List<MaterialSummaryResponse> findAll(Long memberId, MaterialStatus status) {
@@ -94,6 +98,10 @@ public class StudyMaterialService {
     @Transactional
     public void delete(Long memberId, Long materialId) {
         StudyMaterial material = getOwnedMaterial(memberId, materialId);
+        List<Long> unitIds = studyUnitRepository.findIdsByMaterialId(material.getId());
+        if (!unitIds.isEmpty()) {
+            reviewScheduleRepository.deleteAllByStudyUnitIdIn(unitIds);
+        }
         studyUnitRepository.deleteAllByMaterialId(material.getId());
         studyMaterialRepository.delete(material);
     }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyUnitService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyUnitService.java
@@ -4,6 +4,7 @@ import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
 import ds.project.orino.domain.planner.material.entity.StudyMaterial;
 import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
 import ds.project.orino.domain.planner.unit.entity.StudyUnit;
 import ds.project.orino.domain.planner.unit.repository.StudyUnitRepository;
 import ds.project.orino.planner.material.dto.UnitCreateRequest;
@@ -21,11 +22,14 @@ public class StudyUnitService {
 
     private final StudyMaterialRepository studyMaterialRepository;
     private final StudyUnitRepository studyUnitRepository;
+    private final ReviewScheduleRepository reviewScheduleRepository;
 
     public StudyUnitService(StudyMaterialRepository studyMaterialRepository,
-                            StudyUnitRepository studyUnitRepository) {
+                            StudyUnitRepository studyUnitRepository,
+                            ReviewScheduleRepository reviewScheduleRepository) {
         this.studyMaterialRepository = studyMaterialRepository;
         this.studyUnitRepository = studyUnitRepository;
+        this.reviewScheduleRepository = reviewScheduleRepository;
     }
 
     @Transactional
@@ -61,6 +65,7 @@ public class StudyUnitService {
     public void delete(Long memberId, Long unitId) {
         StudyUnit unit = studyUnitRepository.findByIdAndMemberId(unitId, memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        reviewScheduleRepository.deleteAllByStudyUnitId(unit.getId());
         studyUnitRepository.delete(unit);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
@@ -1,0 +1,44 @@
+package ds.project.orino.planner.review.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.review.dto.ReviewCompletionRequest;
+import ds.project.orino.planner.review.dto.ReviewCompletionResponse;
+import ds.project.orino.planner.review.dto.UnitCompletionResponse;
+import ds.project.orino.planner.review.service.ReviewCompletionService;
+import ds.project.orino.planner.review.service.UnitCompletionService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/planner")
+public class ReviewController {
+
+    private final UnitCompletionService unitCompletionService;
+    private final ReviewCompletionService reviewCompletionService;
+
+    public ReviewController(UnitCompletionService unitCompletionService,
+                            ReviewCompletionService reviewCompletionService) {
+        this.unitCompletionService = unitCompletionService;
+        this.reviewCompletionService = reviewCompletionService;
+    }
+
+    @PostMapping("/units/{id}/complete")
+    public ApiResponse<UnitCompletionResponse> completeUnit(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id) {
+        return ApiResponse.success(unitCompletionService.complete(memberId, id));
+    }
+
+    @PostMapping("/reviews/{id}/complete")
+    public ApiResponse<ReviewCompletionResponse> completeReview(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @Valid @RequestBody ReviewCompletionRequest request) {
+        return ApiResponse.success(reviewCompletionService.complete(memberId, id, request));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CompletedUnitResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CompletedUnitResponse.java
@@ -1,0 +1,23 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import ds.project.orino.domain.planner.unit.entity.UnitStatus;
+
+import java.time.LocalDateTime;
+
+public record CompletedUnitResponse(
+        Long id,
+        String title,
+        UnitStatus status,
+        LocalDateTime completedAt
+) {
+
+    public static CompletedUnitResponse from(StudyUnit unit) {
+        return new CompletedUnitResponse(
+                unit.getId(),
+                unit.getTitle(),
+                unit.getStatus(),
+                unit.getCompletedAt()
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewCompletionRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewCompletionRequest.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.review.entity.Rating;
+import jakarta.validation.constraints.NotNull;
+
+public record ReviewCompletionRequest(
+        @NotNull(message = "평가를 입력해주세요.")
+        Rating rating
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewCompletionResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewCompletionResponse.java
@@ -1,0 +1,7 @@
+package ds.project.orino.planner.review.dto;
+
+public record ReviewCompletionResponse(
+        ReviewResponse completed,
+        ReviewResponse nextReview
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewResponse.java
@@ -1,0 +1,33 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record ReviewResponse(
+        Long id,
+        Long studyUnitId,
+        Integer sequence,
+        LocalDate scheduledDate,
+        Integer intervalDays,
+        BigDecimal easeFactor,
+        ReviewStatus status,
+        LocalDateTime completedAt
+) {
+
+    public static ReviewResponse from(ReviewSchedule review) {
+        return new ReviewResponse(
+                review.getId(),
+                review.getStudyUnitId(),
+                review.getSequence(),
+                review.getScheduledDate(),
+                review.getIntervalDays(),
+                review.getEaseFactor(),
+                review.getStatus(),
+                review.getCompletedAt()
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/UnitCompletionResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/UnitCompletionResponse.java
@@ -1,0 +1,7 @@
+package ds.project.orino.planner.review.dto;
+
+public record UnitCompletionResponse(
+        CompletedUnitResponse unit,
+        ReviewResponse firstReview
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCompletionService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCompletionService.java
@@ -1,0 +1,64 @@
+package ds.project.orino.planner.review.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.planner.review.dto.ReviewCompletionRequest;
+import ds.project.orino.planner.review.dto.ReviewCompletionResponse;
+import ds.project.orino.planner.review.dto.ReviewResponse;
+import ds.project.orino.planner.review.sm2.Sm2Calculator;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+public class ReviewCompletionService {
+
+    private final ReviewScheduleRepository reviewScheduleRepository;
+    private final Clock clock;
+
+    public ReviewCompletionService(ReviewScheduleRepository reviewScheduleRepository, Clock clock) {
+        this.reviewScheduleRepository = reviewScheduleRepository;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public ReviewCompletionResponse complete(Long memberId, Long reviewId, ReviewCompletionRequest request) {
+        ReviewSchedule current = reviewScheduleRepository.findByIdAndMemberId(reviewId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (current.getStatus() == ReviewStatus.COMPLETED) {
+            throw new CustomException(ErrorCode.INVALID_STATE);
+        }
+
+        LocalDate today = LocalDate.now(clock);
+        LocalDateTime now = LocalDateTime.now(clock);
+        current.complete(request.rating(), today, now);
+
+        Sm2Calculator.Result next = Sm2Calculator.next(
+                current.getSequence(),
+                current.getIntervalDays(),
+                current.getEaseFactor(),
+                request.rating()
+        );
+
+        ReviewSchedule nextReview = reviewScheduleRepository.save(new ReviewSchedule(
+                memberId,
+                current.getStudyUnitId(),
+                current.getSequence() + 1,
+                today.plusDays(next.intervalDays()),
+                next.intervalDays(),
+                next.easeFactor()
+        ));
+
+        return new ReviewCompletionResponse(
+                ReviewResponse.from(current),
+                ReviewResponse.from(nextReview)
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/UnitCompletionService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/UnitCompletionService.java
@@ -1,0 +1,64 @@
+package ds.project.orino.planner.review.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import ds.project.orino.domain.planner.unit.repository.StudyUnitRepository;
+import ds.project.orino.planner.review.dto.CompletedUnitResponse;
+import ds.project.orino.planner.review.dto.ReviewResponse;
+import ds.project.orino.planner.review.dto.UnitCompletionResponse;
+import ds.project.orino.planner.review.sm2.Sm2Calculator;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+public class UnitCompletionService {
+
+    private static final int FIRST_INTERVAL_DAYS = 1;
+
+    private final StudyUnitRepository studyUnitRepository;
+    private final ReviewScheduleRepository reviewScheduleRepository;
+    private final Clock clock;
+
+    public UnitCompletionService(StudyUnitRepository studyUnitRepository,
+                                 ReviewScheduleRepository reviewScheduleRepository,
+                                 Clock clock) {
+        this.studyUnitRepository = studyUnitRepository;
+        this.reviewScheduleRepository = reviewScheduleRepository;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public UnitCompletionResponse complete(Long memberId, Long unitId) {
+        StudyUnit unit = studyUnitRepository.findByIdAndMemberId(unitId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (unit.isCompleted()) {
+            throw new CustomException(ErrorCode.INVALID_STATE);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDate today = LocalDate.now(clock);
+        unit.markCompleted(now);
+
+        ReviewSchedule firstReview = reviewScheduleRepository.save(new ReviewSchedule(
+                memberId,
+                unit.getId(),
+                1,
+                today.plusDays(FIRST_INTERVAL_DAYS),
+                FIRST_INTERVAL_DAYS,
+                Sm2Calculator.INITIAL_EASE
+        ));
+
+        return new UnitCompletionResponse(
+                CompletedUnitResponse.from(unit),
+                ReviewResponse.from(firstReview)
+        );
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/sm2/Sm2Calculator.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/sm2/Sm2Calculator.java
@@ -1,0 +1,53 @@
+package ds.project.orino.planner.review.sm2;
+
+import ds.project.orino.domain.planner.review.entity.Rating;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * SM-2 (SuperMemo-2) 알고리즘으로 다음 복습 간격과 ease factor를 계산한다.
+ * 모든 입력은 직전 복습(currentSequence)의 상태이며 다음 복습(newSequence = currentSequence + 1)의
+ * 파라미터를 반환한다. 순수 함수로, side-effect가 없고 단일 호출당 동일한 입력은 동일한 출력을 낸다.
+ */
+public final class Sm2Calculator {
+
+    public static final BigDecimal INITIAL_EASE = new BigDecimal("2.50");
+    public static final BigDecimal MIN_EASE = new BigDecimal("1.30");
+
+    private static final BigDecimal AGAIN_PENALTY = new BigDecimal("0.20");
+
+    private Sm2Calculator() {
+    }
+
+    public record Result(int intervalDays, BigDecimal easeFactor) {
+    }
+
+    public static Result next(int currentSequence, int prevInterval, BigDecimal prevEase, Rating rating) {
+        if (rating == Rating.AGAIN) {
+            BigDecimal newEase = prevEase.subtract(AGAIN_PENALTY).max(MIN_EASE)
+                    .setScale(2, RoundingMode.HALF_UP);
+            return new Result(1, newEase);
+        }
+
+        int newSequence = currentSequence + 1;
+        int newInterval = computeInterval(newSequence, prevInterval, prevEase);
+        BigDecimal newEase = computeEase(prevEase, rating);
+        return new Result(newInterval, newEase);
+    }
+
+    private static int computeInterval(int newSequence, int prevInterval, BigDecimal prevEase) {
+        if (newSequence == 2) {
+            return 6;
+        }
+        return (int) Math.round(prevInterval * prevEase.doubleValue());
+    }
+
+    private static BigDecimal computeEase(BigDecimal prevEase, Rating rating) {
+        int q = rating.getQScore();
+        double delta = 0.1 - (5 - q) * (0.08 + (5 - q) * 0.02);
+        BigDecimal newEase = prevEase.add(BigDecimal.valueOf(delta))
+                .setScale(2, RoundingMode.HALF_UP);
+        return newEase.max(MIN_EASE);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyMaterialControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyMaterialControllerTest.java
@@ -41,11 +41,15 @@ class StudyMaterialControllerTest extends ApiTestSupport {
     @Autowired
     private StudyUnitRepository studyUnitRepository;
 
+    @Autowired
+    private ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository reviewScheduleRepository;
+
     private Member member;
     private String accessToken;
 
     @BeforeEach
     void setUp() throws Exception {
+        reviewScheduleRepository.deleteAll();
         studyUnitRepository.deleteAll();
         studyMaterialRepository.deleteAll();
         memberRepository.deleteAll();

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyUnitControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyUnitControllerTest.java
@@ -34,12 +34,16 @@ class StudyUnitControllerTest extends ApiTestSupport {
     @Autowired
     private StudyUnitRepository studyUnitRepository;
 
+    @Autowired
+    private ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository reviewScheduleRepository;
+
     private Member member;
     private String accessToken;
     private StudyMaterial material;
 
     @BeforeEach
     void setUp() throws Exception {
+        reviewScheduleRepository.deleteAll();
         studyUnitRepository.deleteAll();
         studyMaterialRepository.deleteAll();
         memberRepository.deleteAll();

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/service/StudyMaterialServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/service/StudyMaterialServiceTest.java
@@ -37,6 +37,9 @@ class StudyMaterialServiceTest {
     @Mock
     private StudyUnitRepository studyUnitRepository;
 
+    @Mock
+    private ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository reviewScheduleRepository;
+
     @InjectMocks
     private StudyMaterialService studyMaterialService;
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/service/StudyUnitServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/service/StudyUnitServiceTest.java
@@ -37,6 +37,9 @@ class StudyUnitServiceTest {
     @Mock
     private StudyUnitRepository studyUnitRepository;
 
+    @Mock
+    private ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository reviewScheduleRepository;
+
     @InjectMocks
     private StudyUnitService studyUnitService;
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
@@ -1,0 +1,274 @@
+package ds.project.orino.planner.review.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import ds.project.orino.domain.planner.unit.entity.UnitStatus;
+import ds.project.orino.domain.planner.unit.repository.StudyUnitRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.StudyMaterialFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ReviewControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Autowired
+    private StudyUnitRepository studyUnitRepository;
+
+    @Autowired
+    private ReviewScheduleRepository reviewScheduleRepository;
+
+    private Member member;
+    private String accessToken;
+    private StudyMaterial material;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        reviewScheduleRepository.deleteAll();
+        studyUnitRepository.deleteAll();
+        studyMaterialRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        member = memberRepository.save(MemberFixture.create());
+        accessToken = AuthFixture.loginAndGetAccessToken(mockMvc);
+        material = studyMaterialRepository.save(StudyMaterialFixture.create(member.getId()));
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/units/{id}/complete - 단위 완료 + 첫 복습 생성")
+    void completeUnit_createsFirstReview() throws Exception {
+        StudyUnit unit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(member.getId(), material.getId(), 1));
+
+        MvcResult result = mockMvc.perform(post("/api/planner/units/{id}/complete", unit.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.unit.id").value(unit.getId()))
+                .andExpect(jsonPath("$.data.unit.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.data.unit.completedAt").isNotEmpty())
+                .andExpect(jsonPath("$.data.firstReview.sequence").value(1))
+                .andExpect(jsonPath("$.data.firstReview.intervalDays").value(1))
+                .andExpect(jsonPath("$.data.firstReview.easeFactor").value(2.50))
+                .andExpect(jsonPath("$.data.firstReview.status").value("PENDING"))
+                .andExpect(jsonPath("$.data.firstReview.scheduledDate")
+                        .value(LocalDate.now().plusDays(1).toString()))
+                .andReturn();
+
+        Long reviewId = ((Number) JsonPath.read(result.getResponse().getContentAsString(),
+                "$.data.firstReview.id")).longValue();
+        assertThat(reviewScheduleRepository.findById(reviewId)).isPresent();
+
+        StudyUnit refreshed = studyUnitRepository.findById(unit.getId()).orElseThrow();
+        assertThat(refreshed.getStatus()).isEqualTo(UnitStatus.COMPLETED);
+        assertThat(refreshed.getCompletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/units/{id}/complete - 이미 COMPLETED 단위는 409")
+    void completeUnit_alreadyCompleted_returns409() throws Exception {
+        StudyUnit unit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(member.getId(), material.getId(), 1));
+        markUnitCompleted(unit);
+
+        mockMvc.perform(post("/api/planner/units/{id}/complete", unit.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("SP-ERR-003"));
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/units/{id}/complete - 다른 멤버 단위는 404")
+    void completeUnit_otherMembers_returns404() throws Exception {
+        Member another = memberRepository.save(MemberFixture.create("other", "password"));
+        StudyMaterial othersMaterial = studyMaterialRepository.save(
+                StudyMaterialFixture.create(another.getId()));
+        StudyUnit othersUnit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(another.getId(), othersMaterial.getId(), 1));
+
+        mockMvc.perform(post("/api/planner/units/{id}/complete", othersUnit.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/reviews/{id}/complete - GOOD 평가 → seq=2, interval=6")
+    void completeReview_goodCreatesSecondReview() throws Exception {
+        StudyUnit unit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(member.getId(), material.getId(), 1));
+        ReviewSchedule firstReview = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), unit.getId(), 1,
+                LocalDate.now().plusDays(1), 1, new BigDecimal("2.50")));
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", firstReview.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating": "GOOD"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.completed.id").value(firstReview.getId()))
+                .andExpect(jsonPath("$.data.completed.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.data.completed.completedAt").isNotEmpty())
+                .andExpect(jsonPath("$.data.nextReview.sequence").value(2))
+                .andExpect(jsonPath("$.data.nextReview.intervalDays").value(6))
+                .andExpect(jsonPath("$.data.nextReview.easeFactor").value(2.50))
+                .andExpect(jsonPath("$.data.nextReview.scheduledDate")
+                        .value(LocalDate.now().plusDays(6).toString()))
+                .andExpect(jsonPath("$.data.nextReview.status").value("PENDING"));
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/reviews/{id}/complete - AGAIN 평가 → interval=1, ease -= 0.20")
+    void completeReview_again_resetsInterval() throws Exception {
+        StudyUnit unit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(member.getId(), material.getId(), 1));
+        ReviewSchedule second = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), unit.getId(), 2,
+                LocalDate.now(), 6, new BigDecimal("2.50")));
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", second.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating": "AGAIN"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nextReview.intervalDays").value(1))
+                .andExpect(jsonPath("$.data.nextReview.easeFactor").value(2.30));
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/reviews/{id}/complete - 이미 COMPLETED 복습은 409")
+    void completeReview_alreadyCompleted_returns409() throws Exception {
+        StudyUnit unit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(member.getId(), material.getId(), 1));
+        ReviewSchedule review = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), unit.getId(), 1,
+                LocalDate.now(), 1, new BigDecimal("2.50")));
+        markReviewCompleted(review);
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", review.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating": "GOOD"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("SP-ERR-003"));
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/reviews/{id}/complete - 다른 멤버 복습은 404")
+    void completeReview_otherMembers_returns404() throws Exception {
+        Member another = memberRepository.save(MemberFixture.create("other", "password"));
+        StudyMaterial othersMaterial = studyMaterialRepository.save(
+                StudyMaterialFixture.create(another.getId()));
+        StudyUnit othersUnit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(another.getId(), othersMaterial.getId(), 1));
+        ReviewSchedule othersReview = reviewScheduleRepository.save(new ReviewSchedule(
+                another.getId(), othersUnit.getId(), 1,
+                LocalDate.now(), 1, new BigDecimal("2.50")));
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", othersReview.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating": "GOOD"}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/reviews/{id}/complete - rating 누락 시 400")
+    void completeReview_missingRating_returns400() throws Exception {
+        StudyUnit unit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(member.getId(), material.getId(), 1));
+        ReviewSchedule review = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), unit.getId(), 1,
+                LocalDate.now(), 1, new BigDecimal("2.50")));
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", review.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("전체 흐름: 단위 완료 → 첫 복습 → GOOD 평가 → 두번째 복습 (sequence=2, interval=6)")
+    void fullFlow() throws Exception {
+        StudyUnit unit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(member.getId(), material.getId(), 1));
+
+        MvcResult completeResult = mockMvc.perform(post("/api/planner/units/{id}/complete", unit.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Long firstReviewId = ((Number) JsonPath.read(completeResult.getResponse().getContentAsString(),
+                "$.data.firstReview.id")).longValue();
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", firstReviewId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating": "GOOD"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nextReview.sequence").value(2))
+                .andExpect(jsonPath("$.data.nextReview.intervalDays").value(6));
+    }
+
+    private void markUnitCompleted(StudyUnit unit) {
+        try {
+            Field statusField = StudyUnit.class.getDeclaredField("status");
+            statusField.setAccessible(true);
+            statusField.set(unit, UnitStatus.COMPLETED);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        studyUnitRepository.save(unit);
+    }
+
+    private void markReviewCompleted(ReviewSchedule review) {
+        try {
+            Field statusField = ReviewSchedule.class.getDeclaredField("status");
+            statusField.setAccessible(true);
+            statusField.set(review, ReviewStatus.COMPLETED);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        reviewScheduleRepository.save(review);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/sm2/Sm2CalculatorTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/sm2/Sm2CalculatorTest.java
@@ -1,0 +1,127 @@
+package ds.project.orino.planner.review.sm2;
+
+import ds.project.orino.domain.planner.review.entity.Rating;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Sm2CalculatorTest {
+
+    private static final BigDecimal INITIAL_EASE = new BigDecimal("2.50");
+
+    @Nested
+    @DisplayName("AGAIN 평가 (q=0)")
+    class Again {
+
+        @Test
+        @DisplayName("interval은 항상 1")
+        void interval_alwaysOne() {
+            Sm2Calculator.Result r1 = Sm2Calculator.next(1, 1, INITIAL_EASE, Rating.AGAIN);
+            Sm2Calculator.Result r3 = Sm2Calculator.next(3, 15, new BigDecimal("2.50"), Rating.AGAIN);
+
+            assertThat(r1.intervalDays()).isEqualTo(1);
+            assertThat(r3.intervalDays()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("ease는 prev_ease - 0.20")
+        void ease_minus020() {
+            Sm2Calculator.Result r = Sm2Calculator.next(1, 1, new BigDecimal("2.50"), Rating.AGAIN);
+
+            assertThat(r.easeFactor()).isEqualByComparingTo(new BigDecimal("2.30"));
+        }
+
+        @Test
+        @DisplayName("ease는 1.30 미만으로 떨어지지 않는다")
+        void ease_clampedAt130() {
+            Sm2Calculator.Result r = Sm2Calculator.next(5, 1, new BigDecimal("1.30"), Rating.AGAIN);
+
+            assertThat(r.easeFactor()).isEqualByComparingTo(new BigDecimal("1.30"));
+        }
+
+        @Test
+        @DisplayName("ease가 1.40에서 AGAIN 시 1.30으로 클램프")
+        void ease_clampedFromLowEase() {
+            Sm2Calculator.Result r = Sm2Calculator.next(2, 6, new BigDecimal("1.40"), Rating.AGAIN);
+
+            assertThat(r.easeFactor()).isEqualByComparingTo(new BigDecimal("1.30"));
+        }
+    }
+
+    @Nested
+    @DisplayName("성공 평가 (HARD/GOOD/EASY)")
+    class Success {
+
+        @Test
+        @DisplayName("첫 번째 복습 평가(seq=1) → 다음 복습(seq=2) interval = 6")
+        void firstReview_nextIs6() {
+            Sm2Calculator.Result good = Sm2Calculator.next(1, 1, INITIAL_EASE, Rating.GOOD);
+            Sm2Calculator.Result hard = Sm2Calculator.next(1, 1, INITIAL_EASE, Rating.HARD);
+            Sm2Calculator.Result easy = Sm2Calculator.next(1, 1, INITIAL_EASE, Rating.EASY);
+
+            assertThat(good.intervalDays()).isEqualTo(6);
+            assertThat(hard.intervalDays()).isEqualTo(6);
+            assertThat(easy.intervalDays()).isEqualTo(6);
+        }
+
+        @Test
+        @DisplayName("두 번째 복습 이후 → round(prev_interval × ease)")
+        void laterReview_intervalIsMultiplied() {
+            Sm2Calculator.Result r = Sm2Calculator.next(2, 6, new BigDecimal("2.50"), Rating.GOOD);
+
+            assertThat(r.intervalDays()).isEqualTo(15);
+        }
+
+        @Test
+        @DisplayName("HARD(q=3) → ease -= 0.14 (= 0.1 - 2*(0.08+2*0.02))")
+        void hard_easeDecreases() {
+            Sm2Calculator.Result r = Sm2Calculator.next(2, 6, new BigDecimal("2.50"), Rating.HARD);
+
+            assertThat(r.easeFactor()).isEqualByComparingTo(new BigDecimal("2.36"));
+        }
+
+        @Test
+        @DisplayName("GOOD(q=4) → ease 변화 없음 (= 0.1 - 1*(0.08+1*0.02) = 0)")
+        void good_easeUnchanged() {
+            Sm2Calculator.Result r = Sm2Calculator.next(2, 6, new BigDecimal("2.50"), Rating.GOOD);
+
+            assertThat(r.easeFactor()).isEqualByComparingTo(new BigDecimal("2.50"));
+        }
+
+        @Test
+        @DisplayName("EASY(q=5) → ease += 0.10")
+        void easy_easeIncreases() {
+            Sm2Calculator.Result r = Sm2Calculator.next(2, 6, new BigDecimal("2.50"), Rating.EASY);
+
+            assertThat(r.easeFactor()).isEqualByComparingTo(new BigDecimal("2.60"));
+        }
+
+        @Test
+        @DisplayName("ease 상한은 없다 (반복적 EASY로 증가 가능)")
+        void easy_noUpperLimit() {
+            Sm2Calculator.Result r = Sm2Calculator.next(2, 6, new BigDecimal("3.50"), Rating.EASY);
+
+            assertThat(r.easeFactor()).isEqualByComparingTo(new BigDecimal("3.60"));
+        }
+
+        @Test
+        @DisplayName("HARD 반복 시 ease는 1.30으로 클램프")
+        void hard_easeClampedAt130() {
+            Sm2Calculator.Result r = Sm2Calculator.next(2, 6, new BigDecimal("1.30"), Rating.HARD);
+
+            assertThat(r.easeFactor()).isEqualByComparingTo(new BigDecimal("1.30"));
+        }
+
+        @Test
+        @DisplayName("3차 복습 이후의 interval 계산 (round)")
+        void thirdReview_rounded() {
+            Sm2Calculator.Result r = Sm2Calculator.next(3, 15, new BigDecimal("2.50"), Rating.GOOD);
+
+            assertThat(r.intervalDays()).isEqualTo(38);
+        }
+    }
+}

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     INVALID_TOKEN("AUTH-ERR-002", "유효하지 않은 토큰입니다.", 401),
 
     // STUDY PLANNER
-    RESOURCE_NOT_FOUND("SP-ERR-001", "존재하지 않는 리소스입니다.", 404);
+    RESOURCE_NOT_FOUND("SP-ERR-001", "존재하지 않는 리소스입니다.", 404),
+    INVALID_STATE("SP-ERR-003", "현재 상태에서 수행할 수 없는 작업입니다.", 409);
 
     private final String code;
     private final String message;

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/Rating.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/Rating.java
@@ -1,0 +1,18 @@
+package ds.project.orino.domain.planner.review.entity;
+
+public enum Rating {
+    AGAIN(0),
+    HARD(3),
+    GOOD(4),
+    EASY(5);
+
+    private final int qScore;
+
+    Rating(int qScore) {
+        this.qScore = qScore;
+    }
+
+    public int getQScore() {
+        return qScore;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewSchedule.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewSchedule.java
@@ -1,0 +1,141 @@
+package ds.project.orino.domain.planner.review.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "review_schedule")
+@EntityListeners(AuditingEntityListener.class)
+public class ReviewSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "study_unit_id", nullable = false)
+    private Long studyUnitId;
+
+    @Column(nullable = false)
+    private Integer sequence;
+
+    @Column(name = "scheduled_date", nullable = false)
+    private LocalDate scheduledDate;
+
+    @Column(name = "interval_days", nullable = false)
+    private Integer intervalDays;
+
+    @Column(name = "ease_factor", nullable = false, precision = 4, scale = 2)
+    private BigDecimal easeFactor;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private ReviewStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10)
+    private Rating rating;
+
+    @Column(name = "elapsed_days")
+    private Integer elapsedDays;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected ReviewSchedule() {
+    }
+
+    public ReviewSchedule(Long memberId, Long studyUnitId, int sequence,
+                          LocalDate scheduledDate, int intervalDays, BigDecimal easeFactor) {
+        this.memberId = memberId;
+        this.studyUnitId = studyUnitId;
+        this.sequence = sequence;
+        this.scheduledDate = scheduledDate;
+        this.intervalDays = intervalDays;
+        this.easeFactor = easeFactor;
+        this.status = ReviewStatus.PENDING;
+    }
+
+    public void complete(Rating rating, LocalDate today, LocalDateTime now) {
+        this.status = ReviewStatus.COMPLETED;
+        this.rating = rating;
+        this.completedAt = now;
+        this.elapsedDays = (int) (today.toEpochDay() - scheduledDate.toEpochDay());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Long getStudyUnitId() {
+        return studyUnitId;
+    }
+
+    public Integer getSequence() {
+        return sequence;
+    }
+
+    public LocalDate getScheduledDate() {
+        return scheduledDate;
+    }
+
+    public Integer getIntervalDays() {
+        return intervalDays;
+    }
+
+    public BigDecimal getEaseFactor() {
+        return easeFactor;
+    }
+
+    public ReviewStatus getStatus() {
+        return status;
+    }
+
+    public Rating getRating() {
+        return rating;
+    }
+
+    public Integer getElapsedDays() {
+        return elapsedDays;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewStatus.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewStatus.java
@@ -1,0 +1,6 @@
+package ds.project.orino.domain.planner.review.entity;
+
+public enum ReviewStatus {
+    PENDING,
+    COMPLETED
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
@@ -1,0 +1,16 @@
+package ds.project.orino.domain.planner.review.repository;
+
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.Optional;
+
+public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, Long> {
+
+    Optional<ReviewSchedule> findByIdAndMemberId(Long id, Long memberId);
+
+    void deleteAllByStudyUnitId(Long studyUnitId);
+
+    void deleteAllByStudyUnitIdIn(Collection<Long> studyUnitIds);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/entity/StudyUnit.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/entity/StudyUnit.java
@@ -68,6 +68,15 @@ public class StudyUnit {
         this.sortOrder = sortOrder;
     }
 
+    public boolean isCompleted() {
+        return status == UnitStatus.COMPLETED;
+    }
+
+    public void markCompleted(LocalDateTime completedAt) {
+        this.status = UnitStatus.COMPLETED;
+        this.completedAt = completedAt;
+    }
+
     public Long getId() {
         return id;
     }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/repository/StudyUnitRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/repository/StudyUnitRepository.java
@@ -20,6 +20,9 @@ public interface StudyUnitRepository extends JpaRepository<StudyUnit, Long> {
 
     void deleteAllByMaterialId(Long materialId);
 
+    @Query("SELECT u.id FROM StudyUnit u WHERE u.materialId = :materialId")
+    List<Long> findIdsByMaterialId(@Param("materialId") Long materialId);
+
     @Query("""
             SELECT u.materialId AS materialId,
                    COUNT(u) AS totalUnits,


### PR DESCRIPTION
## 이슈
closes #326

## 작업 내용

### 도메인 (`orino-domain-rdb`)
- `ReviewSchedule` 엔티티 + `ReviewScheduleRepository`
  - `findByIdAndMemberId` (권한), `deleteAllByStudyUnitId`, `deleteAllByStudyUnitIdIn`
- `Rating` enum (AGAIN/HARD/GOOD/EASY) — `getQScore()`로 SM-2 q-score 매핑
- `ReviewStatus` enum (PENDING/COMPLETED)
- `StudyUnit.markCompleted(now)`, `isCompleted()` 추가

### SM-2 알고리즘 (`planner/review/sm2/Sm2Calculator`)
순수 함수로 분리해 단위 테스트가 가능하게 함.

| 조건 | next_interval | new_ease |
|------|---------------|----------|
| AGAIN (q=0) | 1 | `max(prev - 0.20, 1.30)` |
| 2회차, q≥3 | 6 | `prev + (0.1 − (5−q)·(0.08 + (5−q)·0.02))` |
| 3회차 이상, q≥3 | `round(prev_interval × prev_ease)` | 동일 공식 |

ease는 항상 `max(_, 1.30)` 클램프. 상한 없음.

### API (`orino-app-api`)
- `ReviewController` (`/api/planner`)
- `UnitCompletionService` — 단위 완료 + 첫 복습 생성 (`sequence=1, interval=1, ease=2.50`)
- `ReviewCompletionService` — `current.complete()` + SM-2로 다음 복습 생성
- `ClockConfig` — `Clock.system(Asia/Seoul)` 빈 (시간 의존성 주입 용도)

| Method | Path | Response |
|--------|------|----------|
| POST | `/api/planner/units/{id}/complete` | 200 `{unit, firstReview}` |
| POST | `/api/planner/reviews/{id}/complete` | 200 `{completed, nextReview}` |

### 멱등성 + 에러 처리
- 이미 COMPLETED 단위/복습에 호출 시 → `SP-ERR-003` (409, `INVALID_STATE`)
- 본인 소유 아닐 때 → `SP-ERR-001` (404)

### Cascade 삭제 보강
- `StudyUnitService.delete` → `reviewScheduleRepository.deleteAllByStudyUnitId` 선행
- `StudyMaterialService.delete` → `findIdsByMaterialId` + `deleteAllByStudyUnitIdIn` 선행
- 프로덕션은 DB FK CASCADE가 안전망 역할, 테스트(ddl-auto)에서도 동작

### 검증
- `./gradlew clean build` 통과 (체크스타일 + 전체 테스트)
- **Sm2Calculator 단위 테스트 13건** — AGAIN/HARD/GOOD/EASY × 경계값 (ease 클램프, 상한 없음, interval 곱셈 등)
- **통합 테스트 9건** (MockMvc + TestContainers): 단위 완료 → 첫 복습 → GOOD 평가 → seq=2 흐름 전체, AGAIN 시 interval=1·ease=2.30, 멱등성 409, 권한 404, rating 누락 400
- **로컬 bootRun + curl 직접 검증** — 1단위 → 첫 복습 → GOOD → 두번째 복습 → AGAIN → 세번째 복습 일련 흐름 (`ease`/`interval` 값 모두 SM-2 기대와 일치)

### 참고
- 설계: [Study-Planner-Architecture §3 (Wiki)](https://github.com/wcorn/orino/wiki/Study-Planner-Architecture)
- 다음 #327에서 `GET /api/planner/reviews/today`(오늘 복습 + preview) 추가