### PR TITLE
feat : 오늘 복습 조회 API (preview 포함)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
@@ -3,11 +3,14 @@ package ds.project.orino.planner.review.controller;
 import ds.project.orino.common.response.ApiResponse;
 import ds.project.orino.planner.review.dto.ReviewCompletionRequest;
 import ds.project.orino.planner.review.dto.ReviewCompletionResponse;
+import ds.project.orino.planner.review.dto.TodayReviewsResponse;
 import ds.project.orino.planner.review.dto.UnitCompletionResponse;
 import ds.project.orino.planner.review.service.ReviewCompletionService;
+import ds.project.orino.planner.review.service.ReviewQueryService;
 import ds.project.orino.planner.review.service.UnitCompletionService;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,11 +23,19 @@ public class ReviewController {
 
     private final UnitCompletionService unitCompletionService;
     private final ReviewCompletionService reviewCompletionService;
+    private final ReviewQueryService reviewQueryService;
 
     public ReviewController(UnitCompletionService unitCompletionService,
-                            ReviewCompletionService reviewCompletionService) {
+                            ReviewCompletionService reviewCompletionService,
+                            ReviewQueryService reviewQueryService) {
         this.unitCompletionService = unitCompletionService;
         this.reviewCompletionService = reviewCompletionService;
+        this.reviewQueryService = reviewQueryService;
+    }
+
+    @GetMapping("/reviews/today")
+    public ApiResponse<TodayReviewsResponse> todayReviews(@AuthenticationPrincipal Long memberId) {
+        return ApiResponse.success(reviewQueryService.getTodayReviews(memberId));
     }
 
     @PostMapping("/units/{id}/complete")

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/PreviewResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/PreviewResponse.java
@@ -1,0 +1,9 @@
+package ds.project.orino.planner.review.dto;
+
+public record PreviewResponse(
+        int again,
+        int hard,
+        int good,
+        int easy
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewMaterialResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewMaterialResponse.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+
+public record ReviewMaterialResponse(
+        Long id,
+        String title,
+        MaterialType type
+) {
+
+    public static ReviewMaterialResponse from(StudyMaterial material) {
+        return new ReviewMaterialResponse(material.getId(), material.getTitle(), material.getType());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewUnitResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewUnitResponse.java
@@ -1,0 +1,14 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+
+public record ReviewUnitResponse(
+        Long id,
+        String title,
+        ReviewMaterialResponse material
+) {
+
+    public static ReviewUnitResponse of(StudyUnit unit, ReviewMaterialResponse material) {
+        return new ReviewUnitResponse(unit.getId(), unit.getTitle(), material);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewResponse.java
@@ -1,0 +1,16 @@
+package ds.project.orino.planner.review.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record TodayReviewResponse(
+        Long id,
+        LocalDate scheduledDate,
+        int delayDays,
+        int sequence,
+        int intervalDays,
+        BigDecimal easeFactor,
+        ReviewUnitResponse unit,
+        PreviewResponse preview
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewsResponse.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.review.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record TodayReviewsResponse(
+        LocalDate today,
+        List<TodayReviewResponse> reviews
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
@@ -1,0 +1,101 @@
+package ds.project.orino.planner.review.service;
+
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.Rating;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import ds.project.orino.domain.planner.unit.repository.StudyUnitRepository;
+import ds.project.orino.planner.review.dto.PreviewResponse;
+import ds.project.orino.planner.review.dto.ReviewMaterialResponse;
+import ds.project.orino.planner.review.dto.ReviewUnitResponse;
+import ds.project.orino.planner.review.dto.TodayReviewResponse;
+import ds.project.orino.planner.review.dto.TodayReviewsResponse;
+import ds.project.orino.planner.review.sm2.Sm2Calculator;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class ReviewQueryService {
+
+    private final ReviewScheduleRepository reviewScheduleRepository;
+    private final StudyUnitRepository studyUnitRepository;
+    private final StudyMaterialRepository studyMaterialRepository;
+    private final Clock clock;
+
+    public ReviewQueryService(ReviewScheduleRepository reviewScheduleRepository,
+                              StudyUnitRepository studyUnitRepository,
+                              StudyMaterialRepository studyMaterialRepository,
+                              Clock clock) {
+        this.reviewScheduleRepository = reviewScheduleRepository;
+        this.studyUnitRepository = studyUnitRepository;
+        this.studyMaterialRepository = studyMaterialRepository;
+        this.clock = clock;
+    }
+
+    public TodayReviewsResponse getTodayReviews(Long memberId) {
+        LocalDate today = LocalDate.now(clock);
+
+        List<ReviewSchedule> reviews = reviewScheduleRepository
+                .findAllByMemberIdAndScheduledDateLessThanEqualAndStatusOrderByScheduledDateAscIdAsc(
+                        memberId, today, ReviewStatus.PENDING);
+
+        if (reviews.isEmpty()) {
+            return new TodayReviewsResponse(today, List.of());
+        }
+
+        List<Long> unitIds = reviews.stream().map(ReviewSchedule::getStudyUnitId).distinct().toList();
+        Map<Long, StudyUnit> unitsById = studyUnitRepository.findAllByIdIn(unitIds).stream()
+                .collect(Collectors.toMap(StudyUnit::getId, Function.identity()));
+
+        List<Long> materialIds = unitsById.values().stream()
+                .map(StudyUnit::getMaterialId).distinct().toList();
+        Map<Long, StudyMaterial> materialsById = studyMaterialRepository.findAllByIdIn(materialIds).stream()
+                .collect(Collectors.toMap(StudyMaterial::getId, Function.identity()));
+
+        List<TodayReviewResponse> items = reviews.stream()
+                .map(r -> toResponse(r, today, unitsById, materialsById))
+                .toList();
+
+        return new TodayReviewsResponse(today, items);
+    }
+
+    private TodayReviewResponse toResponse(ReviewSchedule review, LocalDate today,
+                                            Map<Long, StudyUnit> unitsById,
+                                            Map<Long, StudyMaterial> materialsById) {
+        StudyUnit unit = unitsById.get(review.getStudyUnitId());
+        StudyMaterial material = materialsById.get(unit.getMaterialId());
+        return new TodayReviewResponse(
+                review.getId(),
+                review.getScheduledDate(),
+                Math.max(0, (int) (today.toEpochDay() - review.getScheduledDate().toEpochDay())),
+                review.getSequence(),
+                review.getIntervalDays(),
+                review.getEaseFactor(),
+                ReviewUnitResponse.of(unit, ReviewMaterialResponse.from(material)),
+                buildPreview(review)
+        );
+    }
+
+    private PreviewResponse buildPreview(ReviewSchedule review) {
+        int seq = review.getSequence();
+        int interval = review.getIntervalDays();
+        var ease = review.getEaseFactor();
+        return new PreviewResponse(
+                Sm2Calculator.next(seq, interval, ease, Rating.AGAIN).intervalDays(),
+                Sm2Calculator.next(seq, interval, ease, Rating.HARD).intervalDays(),
+                Sm2Calculator.next(seq, interval, ease, Rating.GOOD).intervalDays(),
+                Sm2Calculator.next(seq, interval, ease, Rating.EASY).intervalDays()
+        );
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsControllerTest.java
@@ -1,0 +1,220 @@
+package ds.project.orino.planner.review.controller;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.domain.planner.unit.entity.StudyUnit;
+import ds.project.orino.domain.planner.unit.repository.StudyUnitRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.StudyMaterialFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class TodayReviewsControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Autowired
+    private StudyUnitRepository studyUnitRepository;
+
+    @Autowired
+    private ReviewScheduleRepository reviewScheduleRepository;
+
+    private Member member;
+    private String accessToken;
+    private StudyMaterial material;
+    private StudyUnit unit;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        reviewScheduleRepository.deleteAll();
+        studyUnitRepository.deleteAll();
+        studyMaterialRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        member = memberRepository.save(MemberFixture.create());
+        accessToken = AuthFixture.loginAndGetAccessToken(mockMvc);
+        material = studyMaterialRepository.save(StudyMaterialFixture.create(member.getId()));
+        unit = studyUnitRepository.save(StudyMaterialFixture.createUnit(member.getId(), material.getId(), 1));
+    }
+
+    @Test
+    @DisplayName("GET /api/planner/reviews/today - 복습이 없으면 빈 배열 + today 반환")
+    void today_empty() throws Exception {
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.today").value(LocalDate.now().toString()))
+                .andExpect(jsonPath("$.data.reviews.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("미래 예정 복습은 응답에 포함되지 않는다")
+    void today_excludesFutureReviews() throws Exception {
+        reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), unit.getId(), 2,
+                LocalDate.now().plusDays(5), 6, new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("오늘 예정 복습은 delayDays=0으로 응답에 포함된다")
+    void today_includesToday() throws Exception {
+        reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), unit.getId(), 2,
+                LocalDate.now(), 6, new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews.length()").value(1))
+                .andExpect(jsonPath("$.data.reviews[0].delayDays").value(0))
+                .andExpect(jsonPath("$.data.reviews[0].sequence").value(2))
+                .andExpect(jsonPath("$.data.reviews[0].unit.id").value(unit.getId()))
+                .andExpect(jsonPath("$.data.reviews[0].unit.title").value(unit.getTitle()))
+                .andExpect(jsonPath("$.data.reviews[0].unit.material.id").value(material.getId()))
+                .andExpect(jsonPath("$.data.reviews[0].unit.material.title").value(material.getTitle()))
+                .andExpect(jsonPath("$.data.reviews[0].unit.material.type").value(material.getType().name()));
+    }
+
+    @Test
+    @DisplayName("밀린 복습(scheduled_date < today)도 포함, delayDays는 (today - scheduled_date)")
+    void today_includesOverdueWithDelay() throws Exception {
+        reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), unit.getId(), 2,
+                LocalDate.now().minusDays(3), 6, new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews[0].delayDays").value(3));
+    }
+
+    @Test
+    @DisplayName("COMPLETED 상태 복습은 응답에 포함되지 않는다")
+    void today_excludesCompleted() throws Exception {
+        ReviewSchedule done = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), unit.getId(), 1,
+                LocalDate.now(), 1, new BigDecimal("2.50")));
+        markCompleted(done);
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("정렬: scheduled_date ASC, id ASC")
+    void today_orderedByDateThenId() throws Exception {
+        ReviewSchedule r1 = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), unit.getId(), 1,
+                LocalDate.now(), 1, new BigDecimal("2.50")));
+        ReviewSchedule r2 = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), unit.getId(), 2,
+                LocalDate.now().minusDays(2), 6, new BigDecimal("2.50")));
+        ReviewSchedule r3 = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), unit.getId(), 3,
+                LocalDate.now(), 1, new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews[0].id").value(r2.getId()))
+                .andExpect(jsonPath("$.data.reviews[1].id").value(r1.getId()))
+                .andExpect(jsonPath("$.data.reviews[2].id").value(r3.getId()));
+    }
+
+    @Test
+    @DisplayName("preview는 SM-2 4가지 평가의 next_interval을 담는다")
+    void today_previewMatchesSm2() throws Exception {
+        // sequence=2, interval=6, ease=2.50 → seq=3 계산:
+        // AGAIN: 1, HARD/GOOD/EASY: round(6 × 2.50) = 15
+        reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), unit.getId(), 2,
+                LocalDate.now(), 6, new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews[0].preview.again").value(1))
+                .andExpect(jsonPath("$.data.reviews[0].preview.hard").value(15))
+                .andExpect(jsonPath("$.data.reviews[0].preview.good").value(15))
+                .andExpect(jsonPath("$.data.reviews[0].preview.easy").value(15));
+    }
+
+    @Test
+    @DisplayName("preview는 sequence=1일 때 next interval=6 (HARD/GOOD/EASY) / 1 (AGAIN)")
+    void today_previewForFirstReview() throws Exception {
+        reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), unit.getId(), 1,
+                LocalDate.now(), 1, new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews[0].preview.again").value(1))
+                .andExpect(jsonPath("$.data.reviews[0].preview.hard").value(6))
+                .andExpect(jsonPath("$.data.reviews[0].preview.good").value(6))
+                .andExpect(jsonPath("$.data.reviews[0].preview.easy").value(6));
+    }
+
+    @Test
+    @DisplayName("다른 멤버의 복습은 응답에 포함되지 않는다")
+    void today_otherMembersExcluded() throws Exception {
+        Member another = memberRepository.save(MemberFixture.create("other", "password"));
+        StudyMaterial othersMaterial = studyMaterialRepository.save(StudyMaterialFixture.create(another.getId()));
+        StudyUnit othersUnit = studyUnitRepository.save(
+                StudyMaterialFixture.createUnit(another.getId(), othersMaterial.getId(), 1));
+        reviewScheduleRepository.save(new ReviewSchedule(
+                another.getId(), othersUnit.getId(), 1,
+                LocalDate.now(), 1, new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("인증 없이 호출하면 403")
+    void today_noAuth() throws Exception {
+        mockMvc.perform(get("/api/planner/reviews/today"))
+                .andExpect(status().isForbidden());
+    }
+
+    private void markCompleted(ReviewSchedule review) {
+        try {
+            Field f = ReviewSchedule.class.getDeclaredField("status");
+            f.setAccessible(true);
+            f.set(review, ReviewStatus.COMPLETED);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        reviewScheduleRepository.save(review);
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepository.java
@@ -14,4 +14,6 @@ public interface StudyMaterialRepository extends JpaRepository<StudyMaterial, Lo
     List<StudyMaterial> findAllByMemberIdAndStatusOrderByCreatedAtDesc(Long memberId, MaterialStatus status);
 
     Optional<StudyMaterial> findByIdAndMemberId(Long id, Long memberId);
+
+    List<StudyMaterial> findAllByIdIn(java.util.Collection<Long> ids);
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
@@ -1,9 +1,12 @@
 package ds.project.orino.domain.planner.review.repository;
 
 import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, Long> {
@@ -13,4 +16,7 @@ public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, 
     void deleteAllByStudyUnitId(Long studyUnitId);
 
     void deleteAllByStudyUnitIdIn(Collection<Long> studyUnitIds);
+
+    List<ReviewSchedule> findAllByMemberIdAndScheduledDateLessThanEqualAndStatusOrderByScheduledDateAscIdAsc(
+            Long memberId, LocalDate scheduledDate, ReviewStatus status);
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/repository/StudyUnitRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/unit/repository/StudyUnitRepository.java
@@ -23,6 +23,8 @@ public interface StudyUnitRepository extends JpaRepository<StudyUnit, Long> {
     @Query("SELECT u.id FROM StudyUnit u WHERE u.materialId = :materialId")
     List<Long> findIdsByMaterialId(@Param("materialId") Long materialId);
 
+    List<StudyUnit> findAllByIdIn(Collection<Long> ids);
+
     @Query("""
             SELECT u.materialId AS materialId,
                    COUNT(u) AS totalUnits,


### PR DESCRIPTION
## 이슈
closes #327

## 작업 내용

### API
- `GET /api/planner/reviews/today` — 인증 필요
- 응답: `{today: LocalDate, reviews: [...]}`

| 필드 | 설명 |
|------|------|
| `id` | review_schedule.id |
| `scheduledDate` | 예정일 |
| `delayDays` | `max(0, today − scheduled_date)` — 음수 안 나옴 |
| `sequence`, `intervalDays`, `easeFactor` | 현재 복습 상태 |
| `unit` | `{id, title, material: {id, title, type}}` |
| `preview` | `{again, hard, good, easy}` — 각 평가 시 다음 복습까지 일수 |

### 조회 조건
- `member_id = :memberId AND scheduled_date <= :today AND status = PENDING`
- 정렬: `scheduled_date ASC, id ASC`

### preview 계산
`Sm2Calculator.next(seq, interval, ease, rating)` 4번 호출.
- AGAIN: 항상 1
- HARD/GOOD/EASY: SM-2 공식 (seq=2면 6, 이외는 round(prev_interval × prev_ease))

### N+1 방지
- review N건 → 단위 ID 모아서 `findAllByIdIn` 1쿼리 → 자료 ID 모아서 `findAllByIdIn` 1쿼리. **총 3쿼리**.
- 단위/자료에 JPA @ManyToOne 관계 없이 ID 기반으로 조립

### 검증
- `./gradlew clean build` 통과
- 통합 테스트 **10건** (TestContainers MySQL 8.4.4):
  - 빈 상태 / 미래 예정 제외 / 오늘 포함 / 밀린 복습 + delayDays / COMPLETED 제외 / 정렬(date+id) / preview seq=1·seq=2 / 사용자 격리 / 인증 없음 403
- **로컬 bootRun + curl**: 미래만 있을 때 빈 응답, 오늘로 변경 시 delayDays=0, 밀린 복습(2일 전) → delayDays=2 / sequence=2 / preview {again:1, hard:15, good:15, easy:15} = `round(6 × 2.50)` 모두 SM-2와 일치

### 참고
- 설계: [Study-Planner-API-Spec §6.1 (Wiki)](https://github.com/wcorn/orino/wiki/Study-Planner-API-Spec)
- BE 작업 시퀀스 #323~#327 모두 완료. 이후 FE 작업(#328~#332)으로 이어짐