### PR TITLE
feat : 학습 자료 목록 화면 구현

### DIFF
--- a/fe/.env.development
+++ b/fe/.env.development
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:8080
+VITE_API_URL=/api

--- a/fe/.env.example
+++ b/fe/.env.example
@@ -1,1 +1,3 @@
-VITE_API_URL=http://localhost:8080
+# dev에서는 /api로 두면 vite proxy(localhost:8080)를 거친다.
+# prod 빌드 시에만 절대 URL을 지정 (예: https://api.orino.dev/api).
+VITE_API_URL=/api

--- a/fe/src/app/providers.tsx
+++ b/fe/src/app/providers.tsx
@@ -59,7 +59,12 @@ function AuthProvider({ children }: { children: ReactNode }) {
 }
 
 export function Providers({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      }),
+  );
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>{children}</AuthProvider>

--- a/fe/src/features/material/api/materials.ts
+++ b/fe/src/features/material/api/materials.ts
@@ -1,0 +1,49 @@
+import client from "../../../shared/api/client";
+
+export type MaterialType = "BOOK" | "LECTURE" | "WORKBOOK" | "MOOC";
+export type MaterialStatus = "ACTIVE" | "COMPLETED";
+
+export interface MaterialSummary {
+  id: number;
+  title: string;
+  type: MaterialType;
+  status: MaterialStatus;
+  totalUnits: number;
+  completedUnits: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ApiResponse<T> {
+  code: string;
+  data: T;
+}
+
+interface MaterialListResponse {
+  materials: MaterialSummary[];
+}
+
+export async function fetchMaterials(
+  status?: MaterialStatus,
+): Promise<MaterialSummary[]> {
+  const { data } = await client.get<ApiResponse<MaterialListResponse>>(
+    "/planner/materials",
+    { params: status ? { status } : undefined },
+  );
+  return data.data.materials;
+}
+
+export interface CreateMaterialRequest {
+  title: string;
+  type: MaterialType;
+}
+
+export async function createMaterial(
+  request: CreateMaterialRequest,
+): Promise<MaterialSummary> {
+  const { data } = await client.post<ApiResponse<MaterialSummary>>(
+    "/planner/materials",
+    request,
+  );
+  return data.data;
+}

--- a/fe/src/features/material/components/AddMaterialDialog.tsx
+++ b/fe/src/features/material/components/AddMaterialDialog.tsx
@@ -1,0 +1,140 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { Select } from "@base-ui/react/select";
+import { Check, ChevronDown, X } from "lucide-react";
+import { type FormEvent, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import type { MaterialType } from "../api/materials";
+import { useCreateMaterial } from "../hooks/useMaterials";
+
+const TYPE_OPTIONS: { value: MaterialType; label: string }[] = [
+  { value: "BOOK", label: "책" },
+  { value: "LECTURE", label: "강의" },
+  { value: "WORKBOOK", label: "문제집" },
+  { value: "MOOC", label: "MOOC" },
+];
+
+interface AddMaterialDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function AddMaterialDialog({
+  open,
+  onOpenChange,
+}: AddMaterialDialogProps) {
+  const [title, setTitle] = useState("");
+  const [type, setType] = useState<MaterialType>("BOOK");
+  const { mutateAsync, isPending } = useCreateMaterial();
+
+  const reset = () => {
+    setTitle("");
+    setType("BOOK");
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!title.trim() || isPending) return;
+    await mutateAsync({ title: title.trim(), type });
+    reset();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) reset();
+        onOpenChange(isOpen);
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
+        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+          <div className="flex items-start justify-between gap-4">
+            <Dialog.Title className="text-base font-semibold">
+              학습 자료 추가
+            </Dialog.Title>
+            <Dialog.Close
+              render={
+                <Button variant="ghost" size="icon-sm" aria-label="닫기">
+                  <X className="size-4" />
+                </Button>
+              }
+            />
+          </div>
+          <form
+            onSubmit={handleSubmit}
+            className="mt-4 flex flex-col gap-4"
+            aria-label="학습 자료 추가 폼"
+          >
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="material-title">제목</Label>
+              <Input
+                id="material-title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="예: 이펙티브 자바"
+                maxLength={200}
+                autoFocus
+                required
+              />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="material-type">유형</Label>
+              <Select.Root
+                value={type}
+                onValueChange={(value) => setType(value as MaterialType)}
+              >
+                <Select.Trigger
+                  id="material-type"
+                  className="border-border bg-background hover:bg-muted/50 focus-visible:ring-ring/50 flex h-9 w-full items-center justify-between rounded-md border px-3 text-sm focus-visible:ring-3 focus-visible:outline-none"
+                >
+                  <Select.Value />
+                  <Select.Icon>
+                    <ChevronDown className="text-muted-foreground size-4" />
+                  </Select.Icon>
+                </Select.Trigger>
+                <Select.Portal>
+                  <Select.Positioner sideOffset={4} className="z-50">
+                    <Select.Popup className="bg-popover text-popover-foreground min-w-[var(--anchor-width)] overflow-hidden rounded-md border p-1 shadow-md">
+                      {TYPE_OPTIONS.map((option) => (
+                        <Select.Item
+                          key={option.value}
+                          value={option.value}
+                          className="hover:bg-muted data-[highlighted]:bg-muted relative flex h-8 cursor-pointer items-center justify-between rounded px-2 text-sm select-none"
+                        >
+                          <Select.ItemText>{option.label}</Select.ItemText>
+                          <Select.ItemIndicator>
+                            <Check className="text-primary size-4" />
+                          </Select.ItemIndicator>
+                        </Select.Item>
+                      ))}
+                    </Select.Popup>
+                  </Select.Positioner>
+                </Select.Portal>
+              </Select.Root>
+            </div>
+
+            <div className="mt-2 flex justify-end gap-2">
+              <Dialog.Close
+                render={
+                  <Button variant="ghost" type="button">
+                    취소
+                  </Button>
+                }
+              />
+              <Button type="submit" disabled={!title.trim() || isPending}>
+                {isPending ? "추가 중..." : "추가"}
+              </Button>
+            </div>
+          </form>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/fe/src/features/material/components/EmptyMaterialState.tsx
+++ b/fe/src/features/material/components/EmptyMaterialState.tsx
@@ -1,0 +1,20 @@
+import { Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface EmptyMaterialStateProps {
+  onAdd: () => void;
+}
+
+export function EmptyMaterialState({ onAdd }: EmptyMaterialStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20">
+      <p className="text-muted-foreground text-sm">
+        아직 등록된 학습 자료가 없습니다.
+      </p>
+      <Button onClick={onAdd}>
+        <Plus className="size-4" />첫 자료 추가
+      </Button>
+    </div>
+  );
+}

--- a/fe/src/features/material/components/MaterialCard.tsx
+++ b/fe/src/features/material/components/MaterialCard.tsx
@@ -1,0 +1,58 @@
+import { BookOpen, GraduationCap, NotebookPen, Video } from "lucide-react";
+import { Link } from "react-router-dom";
+
+import { Card, CardContent } from "@/components/ui/card";
+
+import type { MaterialSummary, MaterialType } from "../api/materials";
+import { MaterialProgress } from "./MaterialProgress";
+
+const TYPE_META: Record<
+  MaterialType,
+  { icon: typeof BookOpen; label: string }
+> = {
+  BOOK: { icon: BookOpen, label: "책" },
+  LECTURE: { icon: Video, label: "강의" },
+  WORKBOOK: { icon: NotebookPen, label: "문제집" },
+  MOOC: { icon: GraduationCap, label: "MOOC" },
+};
+
+interface MaterialCardProps {
+  material: MaterialSummary;
+}
+
+export function MaterialCard({ material }: MaterialCardProps) {
+  const meta = TYPE_META[material.type];
+  const Icon = meta.icon;
+
+  return (
+    <Card
+      size="sm"
+      className="hover:ring-primary/40 cursor-pointer transition-shadow"
+    >
+      <CardContent>
+        <Link
+          to={`/planner/materials/${material.id}`}
+          className="flex flex-col gap-2.5"
+          aria-label={`${material.title} 상세 보기`}
+        >
+          <div className="flex items-center gap-2">
+            <Icon className="text-primary size-4" />
+            <span className="font-medium">{material.title}</span>
+            <span className="text-muted-foreground text-xs">
+              · {meta.label}
+            </span>
+            {material.status === "COMPLETED" && (
+              <span className="bg-muted text-muted-foreground ml-auto rounded-full px-2 py-0.5 text-xs">
+                완료
+              </span>
+            )}
+          </div>
+          <MaterialProgress
+            completed={material.completedUnits}
+            total={material.totalUnits}
+          />
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/fe/src/features/material/components/MaterialProgress.tsx
+++ b/fe/src/features/material/components/MaterialProgress.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+
+interface MaterialProgressProps {
+  completed: number;
+  total: number;
+  className?: string;
+}
+
+export function MaterialProgress({
+  completed,
+  total,
+  className,
+}: MaterialProgressProps) {
+  const percent = total === 0 ? 0 : Math.round((completed / total) * 100);
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      <div
+        role="progressbar"
+        aria-valuenow={percent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`진행률 ${percent}%`}
+        className="bg-muted h-1.5 w-full overflow-hidden rounded-full"
+      >
+        <div
+          className="bg-primary h-full transition-all"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      <p className="text-muted-foreground text-xs">
+        {completed} / {total} ({percent}%)
+      </p>
+    </div>
+  );
+}

--- a/fe/src/features/material/hooks/useMaterials.ts
+++ b/fe/src/features/material/hooks/useMaterials.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  createMaterial,
+  type CreateMaterialRequest,
+  fetchMaterials,
+  type MaterialStatus,
+  type MaterialSummary,
+} from "../api/materials";
+
+export const materialsQueryKey = (status?: MaterialStatus) =>
+  ["planner", "materials", status ?? "ALL"] as const;
+
+export function useMaterials(status?: MaterialStatus) {
+  return useQuery<MaterialSummary[]>({
+    queryKey: materialsQueryKey(status),
+    queryFn: () => fetchMaterials(status),
+  });
+}
+
+export function useCreateMaterial() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (request: CreateMaterialRequest) => createMaterial(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["planner", "materials"] });
+    },
+  });
+}

--- a/fe/src/pages/planner/MaterialListPage.test.tsx
+++ b/fe/src/pages/planner/MaterialListPage.test.tsx
@@ -1,0 +1,197 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { MaterialListPage } from "./MaterialListPage";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function renderPage() {
+  return renderWithRouter(
+    <Providers>
+      <Routes>
+        <Route path="/planner/materials" element={<MaterialListPage />} />
+        <Route path="/planner/materials/:id" element={<div>상세 페이지</div>} />
+      </Routes>
+    </Providers>,
+    { initialEntries: ["/planner/materials"] },
+  );
+}
+
+describe("MaterialListPage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+  });
+
+  it("자료 목록이 있으면 카드 리스트를 렌더링한다", async () => {
+    server.use(
+      http.get(`${API_BASE}/planner/materials`, () => {
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            materials: [
+              {
+                id: 1,
+                title: "이펙티브 자바",
+                type: "BOOK",
+                status: "ACTIVE",
+                totalUnits: 90,
+                completedUnits: 12,
+                createdAt: "2026-05-01T10:00:00",
+                updatedAt: "2026-05-01T10:00:00",
+              },
+              {
+                id: 2,
+                title: "토비의 스프링",
+                type: "BOOK",
+                status: "ACTIVE",
+                totalUnits: 0,
+                completedUnits: 0,
+                createdAt: "2026-05-02T10:00:00",
+                updatedAt: "2026-05-02T10:00:00",
+              },
+            ],
+          },
+        });
+      }),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("이펙티브 자바")).toBeInTheDocument();
+    });
+    expect(screen.getByText("토비의 스프링")).toBeInTheDocument();
+    expect(screen.getByText("12 / 90 (13%)")).toBeInTheDocument();
+    expect(screen.getByText("0 / 0 (0%)")).toBeInTheDocument();
+  });
+
+  it("자료가 0건이면 빈 상태와 첫 자료 추가 버튼이 보인다", async () => {
+    server.use(
+      http.get(`${API_BASE}/planner/materials`, () => {
+        return HttpResponse.json({
+          code: "OK",
+          data: { materials: [] },
+        });
+      }),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("아직 등록된 학습 자료가 없습니다."),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: /첫 자료 추가/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("자료 추가 버튼 클릭 시 다이얼로그가 열린다", async () => {
+    server.use(
+      http.get(`${API_BASE}/planner/materials`, () => {
+        return HttpResponse.json({
+          code: "OK",
+          data: { materials: [] },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /자료 추가/ }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByRole("button", { name: /자료 추가/ })[0]);
+
+    expect(
+      await screen.findByRole("dialog", { name: /학습 자료 추가/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("제목")).toBeInTheDocument();
+  });
+
+  it("다이얼로그에서 자료를 추가하면 목록이 갱신된다", async () => {
+    let materials: unknown[] = [];
+    server.use(
+      http.get(`${API_BASE}/planner/materials`, () => {
+        return HttpResponse.json({
+          code: "OK",
+          data: { materials },
+        });
+      }),
+      http.post(`${API_BASE}/planner/materials`, async ({ request }) => {
+        const body = (await request.json()) as {
+          title: string;
+          type: string;
+        };
+        const created = {
+          id: 1,
+          title: body.title,
+          type: body.type,
+          status: "ACTIVE",
+          totalUnits: 0,
+          completedUnits: 0,
+          createdAt: "2026-05-12T00:00:00",
+          updatedAt: "2026-05-12T00:00:00",
+        };
+        materials = [created];
+        return HttpResponse.json(
+          { code: "OK", data: created },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("아직 등록된 학습 자료가 없습니다."),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /첫 자료 추가/ }));
+
+    const dialog = await screen.findByRole("dialog", {
+      name: /학습 자료 추가/,
+    });
+    await user.type(within(dialog).getByLabelText("제목"), "이펙티브 자바");
+    await user.click(within(dialog).getByRole("button", { name: "추가" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("이펙티브 자바")).toBeInTheDocument();
+    });
+  });
+
+  it("API 에러 시 에러 메시지를 표시한다", async () => {
+    server.use(
+      http.get(`${API_BASE}/planner/materials`, () => {
+        return HttpResponse.json(
+          { code: "GLB-ERR-003", message: "서버 오류" },
+          { status: 500 },
+        );
+      }),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/학습 자료를 불러오지 못했어요/),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/fe/src/pages/planner/MaterialListPage.tsx
+++ b/fe/src/pages/planner/MaterialListPage.tsx
@@ -1,10 +1,51 @@
+import { Plus } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { AddMaterialDialog } from "@/features/material/components/AddMaterialDialog";
+import { EmptyMaterialState } from "@/features/material/components/EmptyMaterialState";
+import { MaterialCard } from "@/features/material/components/MaterialCard";
+import { useMaterials } from "@/features/material/hooks/useMaterials";
+
 export function MaterialListPage() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const { data: materials, isLoading, isError } = useMaterials();
+
   return (
-    <div>
-      <h1 className="text-xl font-semibold">학습 자료</h1>
-      <p className="text-muted-foreground mt-2 text-sm">
-        곧 자료 목록이 표시됩니다.
-      </p>
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">학습 자료</h1>
+        <Button onClick={() => setDialogOpen(true)}>
+          <Plus className="size-4" />
+          자료 추가
+        </Button>
+      </div>
+
+      {isLoading && (
+        <p className="text-muted-foreground text-sm">불러오는 중...</p>
+      )}
+
+      {isError && (
+        <p className="text-destructive text-sm">
+          학습 자료를 불러오지 못했어요. 잠시 후 다시 시도해주세요.
+        </p>
+      )}
+
+      {!isLoading && !isError && materials && materials.length === 0 && (
+        <EmptyMaterialState onAdd={() => setDialogOpen(true)} />
+      )}
+
+      {!isLoading && !isError && materials && materials.length > 0 && (
+        <ul className="flex flex-col gap-3">
+          {materials.map((material) => (
+            <li key={material.id}>
+              <MaterialCard material={material} />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <AddMaterialDialog open={dialogOpen} onOpenChange={setDialogOpen} />
     </div>
   );
 }

--- a/fe/src/shared/api/client.ts
+++ b/fe/src/shared/api/client.ts
@@ -6,8 +6,11 @@ import {
 } from "../../features/auth/store/authStore";
 import { logApiError } from "../error/error-logger";
 
+export const API_BASE_URL =
+  import.meta.env.VITE_API_URL ?? "https://api.orino.dev/api";
+
 const client = axios.create({
-  baseURL: "https://api.orino.dev/api",
+  baseURL: API_BASE_URL,
   withCredentials: true,
 });
 
@@ -42,11 +45,9 @@ client.interceptors.response.use(
     isRefreshing = true;
 
     try {
-      const { data } = await axios.post(
-        "https://api.orino.dev/api/auth/reissue",
-        null,
-        { withCredentials: true },
-      );
+      const { data } = await axios.post(`${API_BASE_URL}/auth/reissue`, null, {
+        withCredentials: true,
+      });
       setAccessToken(data.data.accessToken);
       pendingRequests.forEach((cb) => cb());
       return client(originalRequest);

--- a/fe/vite.config.ts
+++ b/fe/vite.config.ts
@@ -1,11 +1,9 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), "");
-
+export default defineConfig(() => {
   return {
     plugins: [react(), tailwindcss()],
     resolve: {
@@ -34,10 +32,7 @@ export default defineConfig(({ mode }) => {
       },
       proxy: {
         "/api": {
-          target:
-            process.env.API_TARGET ??
-            env.VITE_API_URL ??
-            "http://localhost:8080",
+          target: process.env.API_TARGET ?? "http://localhost:8080",
           changeOrigin: true,
         },
       },


### PR DESCRIPTION
## 이슈
closes #329

## 작업 내용

### features/material/
- `api/materials.ts` — `fetchMaterials`, `createMaterial` + 타입
- `hooks/useMaterials.ts` — `useMaterials`(GET), `useCreateMaterial`(POST + invalidate)
- `components/MaterialCard.tsx` — 타입별 아이콘(책/강의/문제집/MOOC), 제목, 진행률, 상세 페이지 링크
- `components/MaterialProgress.tsx` — 재사용 가능, ARIA `progressbar` 라벨링
- `components/AddMaterialDialog.tsx` — base-ui `Dialog` + `Select`, 제목 1~200자
- `components/EmptyMaterialState.tsx` — 중앙 메시지 + 큰 CTA

### MaterialListPage
- 우상단 `[+ 자료 추가]` 버튼
- 자료 있으면: 카드 리스트
- 자료 0건: `EmptyMaterialState` 표시
- 로딩 / 에러 상태도 텍스트로 표시

### 인프라 수정 (#329 검증을 위해 필수)
- `client.ts`: 하드코딩 baseURL → `import.meta.env.VITE_API_URL ?? prod URL`
- `.env.development` / `.env.example`: `VITE_API_URL=/api`로 통일 (vite proxy 사용)
- `vite.config.ts`: 프록시 `target`에서 잘못된 `env.VITE_API_URL` 폴백 제거 (target은 항상 BE URL이어야 함)
- `providers`: `QueryClient`에 `retry: false` 적용 → 에러 즉시 피드백 + 테스트 단순화

### 검증
- `npm test`: **14 파일 / 61 케이스 통과** (MaterialListPage 5건 추가)
- `npm run lint` / `format:check` / `npm run build` 모두 통과
- **로컬 dev 직접 검증** (BE + FE + Playwright):
  - 로그인 → /home → 사이드바 "학습 자료" 클릭 → 빈 상태 표시
  - [첫 자료 추가] 클릭 → 다이얼로그 열림
  - "이펙티브 자바" 입력 후 [추가] → 카드 즉시 표시 (id=5, 0/0)
  - 카드 클릭 → `/planner/materials/5` 상세 페이지 이동 확인

### 참고
- 설계: [Study-Planner-UI-Design §3.2 (Wiki)](https://github.com/wcorn/orino/wiki/Study-Planner-UI-Design)
- 다음 #330 (자료 상세 화면) — 본 PR의 카드 클릭으로 진입하는 페이지를 실제 UI로 구현