### PR TITLE
feat : 학습 자료 상세 화면 구현 (단위 CRUD + 완료 + 자료 편집/삭제)

### DIFF
--- a/fe/src/app/layout/AppLayout.tsx
+++ b/fe/src/app/layout/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { LogOut, Moon, Sun } from "lucide-react";
 import { Outlet, useNavigate } from "react-router-dom";
 
+import { Toaster } from "@/components/Toaster";
 import { Button } from "@/components/ui/button";
 import { logout } from "@/features/auth/api/auth";
 import { useThemeStore } from "@/shared/lib/theme";
@@ -50,6 +51,7 @@ export function AppLayout() {
           <Outlet />
         </main>
       </div>
+      <Toaster />
     </div>
   );
 }

--- a/fe/src/app/router.test.tsx
+++ b/fe/src/app/router.test.tsx
@@ -93,12 +93,30 @@ describe("AppRouter", () => {
 
   it("/planner/materials/:id 경로에서 자료 상세 페이지를 렌더링한다", async () => {
     useAuthStore.setState({ accessToken: "valid-token" });
+    server.use(
+      http.get(`${API_BASE}/planner/materials/42`, () => {
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 42,
+            title: "테스트 자료",
+            type: "BOOK",
+            status: "ACTIVE",
+            totalUnits: 0,
+            completedUnits: 0,
+            createdAt: "2026-05-01T10:00:00",
+            updatedAt: "2026-05-01T10:00:00",
+            units: [],
+          },
+        });
+      }),
+    );
 
     renderApp(["/planner/materials/42"]);
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: /학습 자료 #42/ }),
+        screen.getByRole("heading", { name: "테스트 자료" }),
       ).toBeInTheDocument();
     });
   });

--- a/fe/src/components/ConfirmDialog.tsx
+++ b/fe/src/components/ConfirmDialog.tsx
@@ -1,0 +1,63 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { type ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  onConfirm: () => void;
+  pending?: boolean;
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "확인",
+  cancelLabel = "취소",
+  destructive = false,
+  onConfirm,
+  pending = false,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
+        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+          <Dialog.Title className="text-base font-semibold">
+            {title}
+          </Dialog.Title>
+          {description && (
+            <Dialog.Description className="text-muted-foreground mt-2 text-sm">
+              {description}
+            </Dialog.Description>
+          )}
+          <div className="mt-5 flex justify-end gap-2">
+            <Dialog.Close
+              render={
+                <Button variant="ghost" type="button" disabled={pending}>
+                  {cancelLabel}
+                </Button>
+              }
+            />
+            <Button
+              type="button"
+              variant={destructive ? "destructive" : "default"}
+              onClick={onConfirm}
+              disabled={pending}
+            >
+              {pending ? "처리 중..." : confirmLabel}
+            </Button>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/fe/src/components/Toaster.tsx
+++ b/fe/src/components/Toaster.tsx
@@ -1,0 +1,45 @@
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useToastStore } from "@/shared/lib/toast";
+
+const VARIANT_STYLES: Record<string, string> = {
+  info: "bg-background border-border text-foreground",
+  success: "bg-primary text-primary-foreground border-primary",
+  error: "bg-destructive text-destructive-foreground border-destructive",
+};
+
+export function Toaster() {
+  const toasts = useToastStore((state) => state.toasts);
+  const dismiss = useToastStore((state) => state.dismiss);
+
+  return (
+    <div
+      role="region"
+      aria-label="알림"
+      className="pointer-events-none fixed right-4 bottom-4 z-[60] flex flex-col gap-2"
+    >
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          role="status"
+          aria-live="polite"
+          className={cn(
+            "pointer-events-auto flex w-72 items-start justify-between gap-2 rounded-lg border px-3 py-2 text-sm shadow-md",
+            VARIANT_STYLES[toast.variant],
+          )}
+        >
+          <span className="flex-1">{toast.message}</span>
+          <button
+            type="button"
+            onClick={() => dismiss(toast.id)}
+            aria-label="알림 닫기"
+            className="opacity-70 hover:opacity-100"
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/fe/src/features/material/api/materials.ts
+++ b/fe/src/features/material/api/materials.ts
@@ -2,6 +2,15 @@ import client from "../../../shared/api/client";
 
 export type MaterialType = "BOOK" | "LECTURE" | "WORKBOOK" | "MOOC";
 export type MaterialStatus = "ACTIVE" | "COMPLETED";
+export type UnitStatus = "PENDING" | "COMPLETED";
+
+export interface UnitSummary {
+  id: number;
+  title: string;
+  sortOrder: number;
+  status: UnitStatus;
+  completedAt: string | null;
+}
 
 export interface MaterialSummary {
   id: number;
@@ -12,6 +21,10 @@ export interface MaterialSummary {
   completedUnits: number;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface MaterialDetail extends MaterialSummary {
+  units: UnitSummary[];
 }
 
 interface ApiResponse<T> {
@@ -46,4 +59,31 @@ export async function createMaterial(
     request,
   );
   return data.data;
+}
+
+export async function fetchMaterial(id: number): Promise<MaterialDetail> {
+  const { data } = await client.get<ApiResponse<MaterialDetail>>(
+    `/planner/materials/${id}`,
+  );
+  return data.data;
+}
+
+export interface UpdateMaterialRequest {
+  title?: string;
+  status?: MaterialStatus;
+}
+
+export async function updateMaterial(
+  id: number,
+  request: UpdateMaterialRequest,
+): Promise<MaterialSummary> {
+  const { data } = await client.patch<ApiResponse<MaterialSummary>>(
+    `/planner/materials/${id}`,
+    request,
+  );
+  return data.data;
+}
+
+export async function deleteMaterial(id: number): Promise<void> {
+  await client.delete(`/planner/materials/${id}`);
 }

--- a/fe/src/features/material/api/units.ts
+++ b/fe/src/features/material/api/units.ts
@@ -1,0 +1,83 @@
+import client from "../../../shared/api/client";
+import type { UnitStatus } from "./materials";
+
+interface ApiResponse<T> {
+  code: string;
+  data: T;
+}
+
+export interface UnitDetail {
+  id: number;
+  materialId: number;
+  title: string;
+  sortOrder: number;
+  status: UnitStatus;
+  completedAt: string | null;
+}
+
+interface UnitListResponse {
+  units: UnitDetail[];
+}
+
+export interface UnitItemInput {
+  title: string;
+}
+
+export async function createUnits(
+  materialId: number,
+  units: UnitItemInput[],
+): Promise<UnitDetail[]> {
+  const { data } = await client.post<ApiResponse<UnitListResponse>>(
+    `/planner/materials/${materialId}/units`,
+    { units },
+  );
+  return data.data.units;
+}
+
+export interface UpdateUnitRequest {
+  title?: string;
+  sortOrder?: number;
+}
+
+export async function updateUnit(
+  unitId: number,
+  request: UpdateUnitRequest,
+): Promise<UnitDetail> {
+  const { data } = await client.patch<ApiResponse<UnitDetail>>(
+    `/planner/units/${unitId}`,
+    request,
+  );
+  return data.data;
+}
+
+export async function deleteUnit(unitId: number): Promise<void> {
+  await client.delete(`/planner/units/${unitId}`);
+}
+
+export interface UnitCompletionResult {
+  unit: {
+    id: number;
+    title: string;
+    status: UnitStatus;
+    completedAt: string;
+  };
+  firstReview: {
+    id: number;
+    studyUnitId: number;
+    sequence: number;
+    scheduledDate: string;
+    intervalDays: number;
+    easeFactor: number;
+    status: "PENDING" | "COMPLETED";
+    completedAt: string | null;
+  };
+}
+
+export async function completeUnit(
+  unitId: number,
+): Promise<UnitCompletionResult> {
+  const { data } = await client.post<ApiResponse<UnitCompletionResult>>(
+    `/planner/units/${unitId}/complete`,
+  );
+  return data.data;
+}

--- a/fe/src/features/material/components/AddUnitsDialog.tsx
+++ b/fe/src/features/material/components/AddUnitsDialog.tsx
@@ -1,0 +1,104 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { X } from "lucide-react";
+import { type FormEvent, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { toast } from "@/shared/lib/toast";
+
+import { useCreateUnits } from "../hooks/useUnits";
+
+interface AddUnitsDialogProps {
+  materialId: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function parseLines(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+export function AddUnitsDialog({
+  materialId,
+  open,
+  onOpenChange,
+}: AddUnitsDialogProps) {
+  const [text, setText] = useState("");
+  const { mutateAsync, isPending } = useCreateUnits(materialId);
+
+  const titles = parseLines(text);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (titles.length === 0 || isPending) return;
+    await mutateAsync(titles.map((title) => ({ title })));
+    toast(`${titles.length}개의 단위가 추가되었어요.`, "success");
+    setText("");
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) setText("");
+        onOpenChange(isOpen);
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
+        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+          <div className="flex items-start justify-between gap-4">
+            <Dialog.Title className="text-base font-semibold">
+              학습 단위 추가
+            </Dialog.Title>
+            <Dialog.Close
+              render={
+                <Button variant="ghost" size="icon-sm" aria-label="닫기">
+                  <X className="size-4" />
+                </Button>
+              }
+            />
+          </div>
+          <form
+            onSubmit={handleSubmit}
+            className="mt-4 flex flex-col gap-4"
+            aria-label="학습 단위 추가 폼"
+          >
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="unit-titles">한 줄에 하나씩 입력</Label>
+              <textarea
+                id="unit-titles"
+                value={text}
+                onChange={(event) => setText(event.target.value)}
+                placeholder={"예:\n아이템 1\n아이템 2\n아이템 3"}
+                rows={8}
+                className="border-border bg-background placeholder:text-muted-foreground focus-visible:ring-ring/50 min-h-32 w-full resize-y rounded-md border px-3 py-2 text-sm focus-visible:ring-3 focus-visible:outline-none"
+                autoFocus
+                required
+              />
+              <p className="text-muted-foreground text-xs">
+                {titles.length}개 단위가 추가됩니다.
+              </p>
+            </div>
+            <div className="mt-2 flex justify-end gap-2">
+              <Dialog.Close
+                render={
+                  <Button variant="ghost" type="button">
+                    취소
+                  </Button>
+                }
+              />
+              <Button type="submit" disabled={titles.length === 0 || isPending}>
+                {isPending ? "추가 중..." : "추가"}
+              </Button>
+            </div>
+          </form>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/fe/src/features/material/components/EditMaterialDialog.tsx
+++ b/fe/src/features/material/components/EditMaterialDialog.tsx
@@ -1,0 +1,150 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { Select } from "@base-ui/react/select";
+import { Check, ChevronDown, X } from "lucide-react";
+import { type FormEvent, useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { toast } from "@/shared/lib/toast";
+
+import type { MaterialDetail, MaterialStatus } from "../api/materials";
+import { useUpdateMaterial } from "../hooks/useMaterials";
+
+const STATUS_OPTIONS: { value: MaterialStatus; label: string }[] = [
+  { value: "ACTIVE", label: "진행 중" },
+  { value: "COMPLETED", label: "완료" },
+];
+
+interface EditMaterialDialogProps {
+  material: MaterialDetail;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRequestDelete: () => void;
+}
+
+export function EditMaterialDialog({
+  material,
+  open,
+  onOpenChange,
+  onRequestDelete,
+}: EditMaterialDialogProps) {
+  const [title, setTitle] = useState(material.title);
+  const [status, setStatus] = useState<MaterialStatus>(material.status);
+  const { mutateAsync, isPending } = useUpdateMaterial(material.id);
+
+  useEffect(() => {
+    if (open) {
+      setTitle(material.title);
+      setStatus(material.status);
+    }
+  }, [open, material.title, material.status]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!title.trim() || isPending) return;
+    await mutateAsync({ title: title.trim(), status });
+    toast("자료가 수정되었어요.", "success");
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
+        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+          <div className="flex items-start justify-between gap-4">
+            <Dialog.Title className="text-base font-semibold">
+              자료 편집
+            </Dialog.Title>
+            <Dialog.Close
+              render={
+                <Button variant="ghost" size="icon-sm" aria-label="닫기">
+                  <X className="size-4" />
+                </Button>
+              }
+            />
+          </div>
+          <form
+            onSubmit={handleSubmit}
+            className="mt-4 flex flex-col gap-4"
+            aria-label="자료 편집 폼"
+          >
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="edit-material-title">제목</Label>
+              <Input
+                id="edit-material-title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                maxLength={200}
+                autoFocus
+                required
+              />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="edit-material-status">상태</Label>
+              <Select.Root
+                value={status}
+                onValueChange={(value) => setStatus(value as MaterialStatus)}
+              >
+                <Select.Trigger
+                  id="edit-material-status"
+                  className="border-border bg-background hover:bg-muted/50 focus-visible:ring-ring/50 flex h-9 w-full items-center justify-between rounded-md border px-3 text-sm focus-visible:ring-3 focus-visible:outline-none"
+                >
+                  <Select.Value />
+                  <Select.Icon>
+                    <ChevronDown className="text-muted-foreground size-4" />
+                  </Select.Icon>
+                </Select.Trigger>
+                <Select.Portal>
+                  <Select.Positioner sideOffset={4} className="z-50">
+                    <Select.Popup className="bg-popover text-popover-foreground min-w-[var(--anchor-width)] overflow-hidden rounded-md border p-1 shadow-md">
+                      {STATUS_OPTIONS.map((option) => (
+                        <Select.Item
+                          key={option.value}
+                          value={option.value}
+                          className="hover:bg-muted data-[highlighted]:bg-muted relative flex h-8 cursor-pointer items-center justify-between rounded px-2 text-sm select-none"
+                        >
+                          <Select.ItemText>{option.label}</Select.ItemText>
+                          <Select.ItemIndicator>
+                            <Check className="text-primary size-4" />
+                          </Select.ItemIndicator>
+                        </Select.Item>
+                      ))}
+                    </Select.Popup>
+                  </Select.Positioner>
+                </Select.Portal>
+              </Select.Root>
+            </div>
+
+            <div className="mt-2 flex items-center justify-between gap-2">
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={() => {
+                  onOpenChange(false);
+                  onRequestDelete();
+                }}
+              >
+                자료 삭제
+              </Button>
+              <div className="flex gap-2">
+                <Dialog.Close
+                  render={
+                    <Button variant="ghost" type="button">
+                      취소
+                    </Button>
+                  }
+                />
+                <Button type="submit" disabled={!title.trim() || isPending}>
+                  {isPending ? "저장 중..." : "저장"}
+                </Button>
+              </div>
+            </div>
+          </form>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/fe/src/features/material/components/EditUnitDialog.tsx
+++ b/fe/src/features/material/components/EditUnitDialog.tsx
@@ -1,0 +1,110 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { X } from "lucide-react";
+import { type FormEvent, useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { toast } from "@/shared/lib/toast";
+
+import type { UnitSummary } from "../api/materials";
+import { useUpdateUnit } from "../hooks/useUnits";
+
+interface EditUnitDialogProps {
+  materialId: number;
+  unit: UnitSummary | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function EditUnitDialog({
+  materialId,
+  unit,
+  open,
+  onOpenChange,
+}: EditUnitDialogProps) {
+  const [title, setTitle] = useState("");
+  const [sortOrder, setSortOrder] = useState<number>(1);
+  const { mutateAsync, isPending } = useUpdateUnit(materialId);
+
+  useEffect(() => {
+    if (unit) {
+      setTitle(unit.title);
+      setSortOrder(unit.sortOrder);
+    }
+  }, [unit]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!unit || !title.trim() || isPending) return;
+    await mutateAsync({
+      unitId: unit.id,
+      request: { title: title.trim(), sortOrder },
+    });
+    toast("단위가 수정되었어요.", "success");
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
+        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+          <div className="flex items-start justify-between gap-4">
+            <Dialog.Title className="text-base font-semibold">
+              단위 수정
+            </Dialog.Title>
+            <Dialog.Close
+              render={
+                <Button variant="ghost" size="icon-sm" aria-label="닫기">
+                  <X className="size-4" />
+                </Button>
+              }
+            />
+          </div>
+          <form
+            onSubmit={handleSubmit}
+            className="mt-4 flex flex-col gap-4"
+            aria-label="단위 수정 폼"
+          >
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="edit-unit-title">제목</Label>
+              <Input
+                id="edit-unit-title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                maxLength={200}
+                autoFocus
+                required
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="edit-unit-order">순서</Label>
+              <Input
+                id="edit-unit-order"
+                type="number"
+                min={1}
+                value={sortOrder}
+                onChange={(event) =>
+                  setSortOrder(Math.max(1, Number(event.target.value) || 1))
+                }
+              />
+            </div>
+            <div className="mt-2 flex justify-end gap-2">
+              <Dialog.Close
+                render={
+                  <Button variant="ghost" type="button">
+                    취소
+                  </Button>
+                }
+              />
+              <Button type="submit" disabled={!title.trim() || isPending}>
+                {isPending ? "저장 중..." : "저장"}
+              </Button>
+            </div>
+          </form>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/fe/src/features/material/components/UnitItem.tsx
+++ b/fe/src/features/material/components/UnitItem.tsx
@@ -1,0 +1,77 @@
+import { Check, Pencil, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import type { UnitSummary } from "../api/materials";
+
+interface UnitItemProps {
+  unit: UnitSummary;
+  onComplete: (unit: UnitSummary) => void;
+  onEdit: (unit: UnitSummary) => void;
+  onDelete: (unit: UnitSummary) => void;
+  completing?: boolean;
+}
+
+export function UnitItem({
+  unit,
+  onComplete,
+  onEdit,
+  onDelete,
+  completing = false,
+}: UnitItemProps) {
+  const isCompleted = unit.status === "COMPLETED";
+
+  return (
+    <li
+      className={cn(
+        "border-border flex items-center gap-3 rounded-lg border px-3 py-2 text-sm",
+        isCompleted && "text-muted-foreground",
+      )}
+    >
+      <span
+        className={cn(
+          "flex size-5 shrink-0 items-center justify-center rounded-full border",
+          isCompleted
+            ? "border-primary bg-primary text-primary-foreground"
+            : "border-border",
+        )}
+        aria-hidden
+      >
+        {isCompleted && <Check className="size-3" />}
+      </span>
+      <span className="text-muted-foreground w-6 shrink-0 text-xs">
+        {unit.sortOrder}.
+      </span>
+      <span className={cn("flex-1 truncate", isCompleted && "line-through")}>
+        {unit.title}
+      </span>
+      {!isCompleted && (
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => onComplete(unit)}
+          disabled={completing}
+        >
+          {completing ? "처리 중..." : "완료"}
+        </Button>
+      )}
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        aria-label="단위 수정"
+        onClick={() => onEdit(unit)}
+      >
+        <Pencil className="size-3.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        aria-label="단위 삭제"
+        onClick={() => onDelete(unit)}
+      >
+        <Trash2 className="size-3.5" />
+      </Button>
+    </li>
+  );
+}

--- a/fe/src/features/material/hooks/useMaterials.ts
+++ b/fe/src/features/material/hooks/useMaterials.ts
@@ -3,13 +3,21 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   createMaterial,
   type CreateMaterialRequest,
+  deleteMaterial,
+  fetchMaterial,
   fetchMaterials,
+  type MaterialDetail,
   type MaterialStatus,
   type MaterialSummary,
+  updateMaterial,
+  type UpdateMaterialRequest,
 } from "../api/materials";
 
 export const materialsQueryKey = (status?: MaterialStatus) =>
   ["planner", "materials", status ?? "ALL"] as const;
+
+export const materialDetailQueryKey = (id: number) =>
+  ["planner", "material", id] as const;
 
 export function useMaterials(status?: MaterialStatus) {
   return useQuery<MaterialSummary[]>({
@@ -18,11 +26,40 @@ export function useMaterials(status?: MaterialStatus) {
   });
 }
 
+export function useMaterial(id: number) {
+  return useQuery<MaterialDetail>({
+    queryKey: materialDetailQueryKey(id),
+    queryFn: () => fetchMaterial(id),
+  });
+}
+
 export function useCreateMaterial() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (request: CreateMaterialRequest) => createMaterial(request),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["planner", "materials"] });
+    },
+  });
+}
+
+export function useUpdateMaterial(id: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (request: UpdateMaterialRequest) => updateMaterial(id, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["planner", "material", id] });
+      queryClient.invalidateQueries({ queryKey: ["planner", "materials"] });
+    },
+  });
+}
+
+export function useDeleteMaterial() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => deleteMaterial(id),
+    onSuccess: (_, id) => {
+      queryClient.removeQueries({ queryKey: ["planner", "material", id] });
       queryClient.invalidateQueries({ queryKey: ["planner", "materials"] });
     },
   });

--- a/fe/src/features/material/hooks/useUnits.ts
+++ b/fe/src/features/material/hooks/useUnits.ts
@@ -1,0 +1,59 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  completeUnit,
+  createUnits,
+  deleteUnit,
+  type UnitItemInput,
+  updateUnit,
+  type UpdateUnitRequest,
+} from "../api/units";
+
+function invalidateMaterial(
+  queryClient: ReturnType<typeof useQueryClient>,
+  materialId: number,
+) {
+  queryClient.invalidateQueries({
+    queryKey: ["planner", "material", materialId],
+  });
+  queryClient.invalidateQueries({ queryKey: ["planner", "materials"] });
+  queryClient.invalidateQueries({ queryKey: ["planner", "reviews", "today"] });
+}
+
+export function useCreateUnits(materialId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (units: UnitItemInput[]) => createUnits(materialId, units),
+    onSuccess: () => invalidateMaterial(queryClient, materialId),
+  });
+}
+
+export function useUpdateUnit(materialId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      unitId,
+      request,
+    }: {
+      unitId: number;
+      request: UpdateUnitRequest;
+    }) => updateUnit(unitId, request),
+    onSuccess: () => invalidateMaterial(queryClient, materialId),
+  });
+}
+
+export function useDeleteUnit(materialId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (unitId: number) => deleteUnit(unitId),
+    onSuccess: () => invalidateMaterial(queryClient, materialId),
+  });
+}
+
+export function useCompleteUnit(materialId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (unitId: number) => completeUnit(unitId),
+    onSuccess: () => invalidateMaterial(queryClient, materialId),
+  });
+}

--- a/fe/src/pages/planner/MaterialDetailPage.test.tsx
+++ b/fe/src/pages/planner/MaterialDetailPage.test.tsx
@@ -1,0 +1,273 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { Toaster } from "@/components/Toaster";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { MaterialDetailPage } from "./MaterialDetailPage";
+
+const API_BASE = "https://api.orino.dev/api";
+
+interface UnitState {
+  id: number;
+  title: string;
+  sortOrder: number;
+  status: "PENDING" | "COMPLETED";
+  completedAt: string | null;
+}
+
+function setupMaterialApis(initialUnits: UnitState[] = []) {
+  let units: UnitState[] = [...initialUnits];
+  let nextUnitId = 100;
+  let deletedMaterial = false;
+  let materialTitle = "이펙티브 자바";
+
+  server.use(
+    http.get(`${API_BASE}/planner/materials/1`, () => {
+      if (deletedMaterial) {
+        return HttpResponse.json(
+          { code: "SP-ERR-001", message: "Not found" },
+          { status: 404 },
+        );
+      }
+      return HttpResponse.json({
+        code: "OK",
+        data: {
+          id: 1,
+          title: materialTitle,
+          type: "BOOK",
+          status: "ACTIVE",
+          totalUnits: units.length,
+          completedUnits: units.filter((u) => u.status === "COMPLETED").length,
+          createdAt: "2026-05-01T10:00:00",
+          updatedAt: "2026-05-01T10:00:00",
+          units,
+        },
+      });
+    }),
+    http.post(`${API_BASE}/planner/materials/1/units`, async ({ request }) => {
+      const body = (await request.json()) as {
+        units: { title: string }[];
+      };
+      const created = body.units.map((u, idx) => ({
+        id: nextUnitId++,
+        materialId: 1,
+        title: u.title,
+        sortOrder: units.length + idx + 1,
+        status: "PENDING" as const,
+        completedAt: null,
+      }));
+      units = [...units, ...created];
+      return HttpResponse.json(
+        { code: "OK", data: { units: created } },
+        { status: 201 },
+      );
+    }),
+    http.post(`${API_BASE}/planner/units/:id/complete`, ({ params }) => {
+      const id = Number(params.id);
+      const idx = units.findIndex((u) => u.id === id);
+      if (idx >= 0) {
+        units[idx] = {
+          ...units[idx],
+          status: "COMPLETED",
+          completedAt: "2026-05-12T10:00:00",
+        };
+      }
+      return HttpResponse.json({
+        code: "OK",
+        data: {
+          unit: {
+            id,
+            title: units[idx]?.title ?? "",
+            status: "COMPLETED",
+            completedAt: "2026-05-12T10:00:00",
+          },
+          firstReview: {
+            id: 200,
+            studyUnitId: id,
+            sequence: 1,
+            scheduledDate: "2026-05-13",
+            intervalDays: 1,
+            easeFactor: 2.5,
+            status: "PENDING",
+            completedAt: null,
+          },
+        },
+      });
+    }),
+    http.delete(`${API_BASE}/planner/units/:id`, ({ params }) => {
+      const id = Number(params.id);
+      units = units.filter((u) => u.id !== id);
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.delete(`${API_BASE}/planner/materials/1`, () => {
+      deletedMaterial = true;
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.patch(`${API_BASE}/planner/materials/1`, async ({ request }) => {
+      const body = (await request.json()) as { title?: string };
+      if (body.title) materialTitle = body.title;
+      return HttpResponse.json({
+        code: "OK",
+        data: {
+          id: 1,
+          title: materialTitle,
+          type: "BOOK",
+          status: "ACTIVE",
+          totalUnits: units.length,
+          completedUnits: units.filter((u) => u.status === "COMPLETED").length,
+          createdAt: "2026-05-01T10:00:00",
+          updatedAt: "2026-05-01T10:00:00",
+        },
+      });
+    }),
+  );
+}
+
+function renderPage() {
+  return renderWithRouter(
+    <Providers>
+      <Routes>
+        <Route path="/planner/materials/:id" element={<MaterialDetailPage />} />
+        <Route path="/planner/materials" element={<div>목록 페이지</div>} />
+      </Routes>
+      <Toaster />
+    </Providers>,
+    { initialEntries: ["/planner/materials/1"] },
+  );
+}
+
+describe("MaterialDetailPage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+  });
+
+  it("자료 메타와 단위가 없을 때 빈 메시지를 표시한다", async () => {
+    setupMaterialApis([]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("이펙티브 자바")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/등록된 단위가 없습니다/)).toBeInTheDocument();
+  });
+
+  it("단위 추가 다이얼로그에서 여러 줄 입력 시 배열로 POST된다", async () => {
+    setupMaterialApis([]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("이펙티브 자바")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /단위 추가/ }));
+
+    const dialog = await screen.findByRole("dialog", {
+      name: /학습 단위 추가/,
+    });
+    await user.type(
+      within(dialog).getByLabelText(/한 줄에 하나씩/),
+      "아이템 1\n아이템 2\n아이템 3",
+    );
+    await user.click(within(dialog).getByRole("button", { name: "추가" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("아이템 1")).toBeInTheDocument();
+    });
+    expect(screen.getByText("아이템 2")).toBeInTheDocument();
+    expect(screen.getByText("아이템 3")).toBeInTheDocument();
+  });
+
+  it("완료 버튼 클릭 시 단위가 COMPLETED 상태로 표시되고 토스트가 뜬다", async () => {
+    setupMaterialApis([
+      {
+        id: 10,
+        title: "아이템 1",
+        sortOrder: 1,
+        status: "PENDING",
+        completedAt: null,
+      },
+    ]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("아이템 1")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "완료" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/2026-05-13에 첫 복습이 예정되었어요/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("단위 삭제 확인 후 목록에서 사라진다", async () => {
+    setupMaterialApis([
+      {
+        id: 10,
+        title: "삭제할 단위",
+        sortOrder: 1,
+        status: "PENDING",
+        completedAt: null,
+      },
+    ]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("삭제할 단위")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "단위 삭제" }));
+
+    const confirm = await screen.findByRole("dialog", {
+      name: /단위를 삭제할까요/,
+    });
+    await user.click(within(confirm).getByRole("button", { name: "삭제" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("삭제할 단위")).not.toBeInTheDocument();
+    });
+  });
+
+  it("자료 삭제 후 목록 페이지로 이동한다", async () => {
+    setupMaterialApis([]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("이펙티브 자바")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /편집/ }));
+
+    const editDialog = await screen.findByRole("dialog", {
+      name: /자료 편집/,
+    });
+    await user.click(
+      within(editDialog).getByRole("button", { name: "자료 삭제" }),
+    );
+
+    const confirmDialog = await screen.findByRole("dialog", {
+      name: /자료를 삭제할까요/,
+    });
+    await user.click(
+      within(confirmDialog).getByRole("button", { name: "삭제" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("목록 페이지")).toBeInTheDocument();
+    });
+  });
+});

--- a/fe/src/pages/planner/MaterialDetailPage.tsx
+++ b/fe/src/pages/planner/MaterialDetailPage.tsx
@@ -1,20 +1,200 @@
-import { Link, useParams } from "react-router-dom";
+import { ChevronLeft, Plus, Settings2 } from "lucide-react";
+import { useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { Button } from "@/components/ui/button";
+import type { UnitSummary } from "@/features/material/api/materials";
+import { AddUnitsDialog } from "@/features/material/components/AddUnitsDialog";
+import { EditMaterialDialog } from "@/features/material/components/EditMaterialDialog";
+import { EditUnitDialog } from "@/features/material/components/EditUnitDialog";
+import { MaterialProgress } from "@/features/material/components/MaterialProgress";
+import { UnitItem } from "@/features/material/components/UnitItem";
+import {
+  useDeleteMaterial,
+  useMaterial,
+} from "@/features/material/hooks/useMaterials";
+import {
+  useCompleteUnit,
+  useDeleteUnit,
+} from "@/features/material/hooks/useUnits";
+import { toast } from "@/shared/lib/toast";
+
+const TYPE_LABELS: Record<string, string> = {
+  BOOK: "책",
+  LECTURE: "강의",
+  WORKBOOK: "문제집",
+  MOOC: "MOOC",
+};
 
 export function MaterialDetailPage() {
+  const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
+  const materialId = Number(id);
+
+  const { data: material, isLoading, isError } = useMaterial(materialId);
+  const completeUnit = useCompleteUnit(materialId);
+  const deleteUnitMutation = useDeleteUnit(materialId);
+  const deleteMaterialMutation = useDeleteMaterial();
+
+  const [addUnitsOpen, setAddUnitsOpen] = useState(false);
+  const [editingUnit, setEditingUnit] = useState<UnitSummary | null>(null);
+  const [deletingUnit, setDeletingUnit] = useState<UnitSummary | null>(null);
+  const [editMaterialOpen, setEditMaterialOpen] = useState(false);
+  const [deleteMaterialOpen, setDeleteMaterialOpen] = useState(false);
+  const [completingUnitId, setCompletingUnitId] = useState<number | null>(null);
+
+  const handleComplete = async (unit: UnitSummary) => {
+    setCompletingUnitId(unit.id);
+    try {
+      const result = await completeUnit.mutateAsync(unit.id);
+      toast(
+        `${result.firstReview.scheduledDate}에 첫 복습이 예정되었어요.`,
+        "success",
+      );
+    } finally {
+      setCompletingUnitId(null);
+    }
+  };
+
+  const handleDeleteUnit = async () => {
+    if (!deletingUnit) return;
+    await deleteUnitMutation.mutateAsync(deletingUnit.id);
+    toast("단위가 삭제되었어요.", "success");
+    setDeletingUnit(null);
+  };
+
+  const handleDeleteMaterial = async () => {
+    await deleteMaterialMutation.mutateAsync(materialId);
+    toast("자료가 삭제되었어요.", "success");
+    navigate("/planner/materials", { replace: true });
+  };
+
+  if (isLoading) {
+    return <p className="text-muted-foreground text-sm">불러오는 중...</p>;
+  }
+
+  if (isError || !material) {
+    return (
+      <div className="flex flex-col gap-4">
+        <Link
+          to="/planner/materials"
+          className="text-muted-foreground hover:text-foreground inline-flex w-fit items-center gap-1 text-sm"
+        >
+          <ChevronLeft className="size-4" /> 뒤로
+        </Link>
+        <p className="text-destructive text-sm">
+          학습 자료를 불러오지 못했어요.
+        </p>
+      </div>
+    );
+  }
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-6">
       <Link
         to="/planner/materials"
-        className="text-muted-foreground hover:text-foreground w-fit text-sm"
+        className="text-muted-foreground hover:text-foreground inline-flex w-fit items-center gap-1 text-sm"
       >
-        ← 뒤로
+        <ChevronLeft className="size-4" /> 뒤로
       </Link>
-      <h1 className="text-xl font-semibold">학습 자료 #{id}</h1>
-      <p className="text-muted-foreground text-sm">
-        곧 단위 목록이 표시됩니다.
-      </p>
+
+      <header className="flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <h1 className="text-xl font-semibold">{material.title}</h1>
+            <p className="text-muted-foreground text-xs">
+              {TYPE_LABELS[material.type] ?? material.type}
+              {material.status === "COMPLETED" && " · 완료"}
+            </p>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setEditMaterialOpen(true)}
+          >
+            <Settings2 className="size-3.5" /> 편집
+          </Button>
+        </div>
+        <MaterialProgress
+          completed={material.completedUnits}
+          total={material.totalUnits}
+        />
+      </header>
+
+      <section className="flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-medium">학습 단위</h2>
+          <Button size="sm" onClick={() => setAddUnitsOpen(true)}>
+            <Plus className="size-3.5" /> 단위 추가
+          </Button>
+        </div>
+
+        {material.units.length === 0 ? (
+          <p className="text-muted-foreground py-8 text-center text-sm">
+            등록된 단위가 없습니다. 위 [단위 추가]로 시작해보세요.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {material.units.map((unit) => (
+              <UnitItem
+                key={unit.id}
+                unit={unit}
+                onComplete={handleComplete}
+                onEdit={setEditingUnit}
+                onDelete={setDeletingUnit}
+                completing={completingUnitId === unit.id}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <AddUnitsDialog
+        materialId={materialId}
+        open={addUnitsOpen}
+        onOpenChange={setAddUnitsOpen}
+      />
+
+      <EditUnitDialog
+        materialId={materialId}
+        unit={editingUnit}
+        open={editingUnit !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditingUnit(null);
+        }}
+      />
+
+      <ConfirmDialog
+        open={deletingUnit !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeletingUnit(null);
+        }}
+        title="단위를 삭제할까요?"
+        description={`"${deletingUnit?.title}" 단위가 삭제됩니다. 연결된 복습 일정도 함께 사라져요.`}
+        confirmLabel="삭제"
+        destructive
+        onConfirm={handleDeleteUnit}
+        pending={deleteUnitMutation.isPending}
+      />
+
+      <EditMaterialDialog
+        material={material}
+        open={editMaterialOpen}
+        onOpenChange={setEditMaterialOpen}
+        onRequestDelete={() => setDeleteMaterialOpen(true)}
+      />
+
+      <ConfirmDialog
+        open={deleteMaterialOpen}
+        onOpenChange={setDeleteMaterialOpen}
+        title="자료를 삭제할까요?"
+        description="자료와 함께 모든 단위 및 복습 일정이 삭제됩니다. 되돌릴 수 없어요."
+        confirmLabel="삭제"
+        destructive
+        onConfirm={handleDeleteMaterial}
+        pending={deleteMaterialMutation.isPending}
+      />
     </div>
   );
 }

--- a/fe/src/shared/lib/toast.ts
+++ b/fe/src/shared/lib/toast.ts
@@ -1,0 +1,34 @@
+import { create } from "zustand";
+
+export type ToastVariant = "info" | "success" | "error";
+
+export interface ToastItem {
+  id: string;
+  message: string;
+  variant: ToastVariant;
+}
+
+interface ToastState {
+  toasts: ToastItem[];
+  show: (message: string, variant?: ToastVariant) => void;
+  dismiss: (id: string) => void;
+}
+
+const AUTO_DISMISS_MS = 3500;
+
+let counter = 0;
+
+export const useToastStore = create<ToastState>((set, get) => ({
+  toasts: [],
+  show: (message, variant = "info") => {
+    const id = `t-${Date.now()}-${++counter}`;
+    set((state) => ({ toasts: [...state.toasts, { id, message, variant }] }));
+    setTimeout(() => get().dismiss(id), AUTO_DISMISS_MS);
+  },
+  dismiss: (id) =>
+    set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) })),
+}));
+
+export function toast(message: string, variant: ToastVariant = "info") {
+  useToastStore.getState().show(message, variant);
+}


### PR DESCRIPTION
## 이슈
closes #330

## 작업 내용

### 페이지
- `MaterialDetailPage`: 헤더(제목 + 타입 + 진행률 + [편집]) + 학습 단위 리스트 + [+ 단위 추가]
- 단위 0건: 빈 메시지 표시
- 자료 삭제 후 자동으로 `/planner/materials`로 이동

### 컴포넌트
- `UnitItem`: 완료 버튼, 수정/삭제 아이콘. COMPLETED 시 회색 + 체크 + 취소선
- `AddUnitsDialog`: 멀티라인 `textarea` → 줄바꿈 split → 배열 POST (입력 개수 미리보기)
- `EditUnitDialog`: 제목 + `sortOrder` 부분 업데이트
- `EditMaterialDialog`: 제목 + 상태(진행/완료) `Select`, 좌하단 빨간 [자료 삭제] (확인 다이얼로그 분리)
- `ConfirmDialog` (재사용): destructive variant, 처리 중 상태
- `Toaster` + `shared/lib/toast.ts`: zustand 전역 store, 3.5초 auto-dismiss, AppLayout에 마운트

### API / hooks
- `features/material/api/materials.ts`: `fetchMaterial`, `updateMaterial`, `deleteMaterial` 추가
- `features/material/api/units.ts` 신규: `createUnits`, `updateUnit`, `deleteUnit`, `completeUnit`
- `features/material/hooks/useMaterials.ts`: `useMaterial`, `useUpdateMaterial`, `useDeleteMaterial` 추가
- `features/material/hooks/useUnits.ts` 신규: `useCreateUnits`, `useUpdateUnit`, `useDeleteUnit`, `useCompleteUnit`
- 모든 mutation은 `material`, `materials`, `reviews.today` 쿼리를 무효화

### UX 피드백
| 액션 | 토스트 |
|------|--------|
| 단위 추가 | "N개의 단위가 추가되었어요." |
| 단위 완료 | "YYYY-MM-DD에 첫 복습이 예정되었어요." (응답의 `firstReview.scheduledDate`) |
| 단위 수정 | "단위가 수정되었어요." |
| 단위 삭제 | "단위가 삭제되었어요." |
| 자료 수정 | "자료가 수정되었어요." |
| 자료 삭제 | "자료가 삭제되었어요." + /planner/materials 이동 |

삭제는 모두 `ConfirmDialog` 확인.

### 검증
- `npm test`: **15 파일 / 66 케이스 통과** (MaterialDetailPage 5건, router 테스트 1건 보강)
- `npm run lint` / `format:check` / `npm run build` 통과
- **로컬 dev 직접 검증** (BE + FE + Playwright):
  - 자료 생성 → 상세 진입
  - 단위 멀티라인 추가 → 3개 표시 (sort_order 1/2/3, 진행률 0/3)
  - "아이템 1" 완료 → 체크 표시 + 진행률 1/3 (33%) + 토스트
  - "아이템 2" 삭제 → 확인 다이얼로그 → 사라짐 (2개 잔여)
  - [편집] → [자료 삭제] → 확인 → /planner/materials로 이동 (빈 상태)

### 한계
- 단위 정렬은 `sortOrder` 입력 수정으로만 가능 (drag-drop 미구현). 단순한 number input. 향후 v2에서 드래그앤드롭 도입 시 별도 이슈.

### 참고
- 설계: [Study-Planner-UI-Design §3.3 (Wiki)](https://github.com/wcorn/orino/wiki/Study-Planner-UI-Design)
- 다음 #331 (오늘 복습 화면) — 4지선다 평가 + preview UI