### PR TITLE
fix : FE nghttp2-libs CVE 수정

### DIFF
--- a/fe/Dockerfile
+++ b/fe/Dockerfile
@@ -6,6 +6,7 @@ COPY . .
 RUN npm run build
 
 FROM nginx:alpine
+RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80


### PR DESCRIPTION
## 이슈
closes #350

## 작업 내용
- `fe/Dockerfile` 런타임 stage(`nginx:alpine`)에 `apk update && apk upgrade --no-cache` 추가
- Alpine 저장소의 패치 버전을 가져와 HIGH 취약점 해결
- 빌드 stage(`node:22-alpine`)는 산출물만 사용되므로 변경하지 않음

## CVE 요약

| CVE | 패키지 | 설치 버전 | 수정 버전 | 심각도 |
|---|---|---|---|---|
| CVE-2026-27135 | nghttp2-libs | 1.68.0-r0 | 1.69.0-r0 | HIGH |

## 검증

로컬에서 빌드 후 Trivy 스캔 결과:

```
Report Summary
┌───────────────────────────────┬────────┬─────────────────┬─────────┐
│            Target             │  Type  │ Vulnerabilities │ Secrets │
├───────────────────────────────┼────────┼─────────────────┼─────────┤
│ orino-fe:test (alpine 3.23.4) │ alpine │        0        │    -    │
└───────────────────────────────┴────────┴─────────────────┴─────────┘
```

- `docker build -t orino-fe:test fe/` 성공
- `trivy image --severity HIGH,CRITICAL --ignore-unfixed orino-fe:test` HIGH/CRITICAL 0건