### PR TITLE
feat : 메인 홈 카드 추가 (오늘 복습 / 학습 자료)

### DIFF
--- a/fe/src/features/review/components/ReviewCard.tsx
+++ b/fe/src/features/review/components/ReviewCard.tsx
@@ -1,4 +1,10 @@
-import { AlertTriangle, BookOpen, GraduationCap, NotebookPen, Video } from "lucide-react";
+import {
+  AlertTriangle,
+  BookOpen,
+  GraduationCap,
+  NotebookPen,
+  Video,
+} from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -104,9 +110,10 @@ export function ReviewCard({
 
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
         {RATINGS.map((meta) => {
-          const previewDays = review.preview[
-            meta.rating.toLowerCase() as keyof typeof review.preview
-          ];
+          const previewDays =
+            review.preview[
+              meta.rating.toLowerCase() as keyof typeof review.preview
+            ];
           const isPending = pendingRating === meta.rating;
           return (
             <button

--- a/fe/src/pages/HomePage.test.tsx
+++ b/fe/src/pages/HomePage.test.tsx
@@ -90,13 +90,9 @@ describe("HomePage", () => {
     renderPage();
 
     await waitFor(() => {
-      expect(
-        screen.getByText("0건 — 모두 완료했어요!"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("0건 — 모두 완료했어요!")).toBeInTheDocument();
     });
-    expect(
-      screen.getByText("아직 등록된 자료가 없어요."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("아직 등록된 자료가 없어요.")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /첫 자료 추가/ }),
     ).toBeInTheDocument();
@@ -104,11 +100,7 @@ describe("HomePage", () => {
 
   it("복습 3건(밀린 1건) + 자료 5개일 때 카운트를 표시한다", async () => {
     setup({
-      todayReviews: [
-        { delayDays: 0 },
-        { delayDays: 0 },
-        { delayDays: 2 },
-      ],
+      todayReviews: [{ delayDays: 0 }, { delayDays: 0 }, { delayDays: 2 }],
       materials: 5,
     });
     renderPage();

--- a/fe/src/pages/HomePage.test.tsx
+++ b/fe/src/pages/HomePage.test.tsx
@@ -1,0 +1,174 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { HomePage } from "./HomePage";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function renderPage() {
+  return renderWithRouter(
+    <Providers>
+      <Routes>
+        <Route path="/home" element={<HomePage />} />
+        <Route
+          path="/planner/reviews/today"
+          element={<div>오늘 복습 페이지</div>}
+        />
+        <Route
+          path="/planner/materials"
+          element={<div>자료 목록 페이지</div>}
+        />
+      </Routes>
+    </Providers>,
+    { initialEntries: ["/home"] },
+  );
+}
+
+interface Setup {
+  todayReviews?: { delayDays: number }[];
+  materials?: number;
+}
+
+function setup({ todayReviews = [], materials = 0 }: Setup) {
+  server.use(
+    http.get(`${API_BASE}/planner/reviews/today`, () => {
+      return HttpResponse.json({
+        code: "OK",
+        data: {
+          today: "2026-05-12",
+          reviews: todayReviews.map((r, i) => ({
+            id: i + 1,
+            scheduledDate: "2026-05-12",
+            delayDays: r.delayDays,
+            sequence: 1,
+            intervalDays: 1,
+            easeFactor: 2.5,
+            unit: {
+              id: 1,
+              title: "u",
+              material: { id: 1, title: "m", type: "BOOK" },
+            },
+            preview: { again: 1, hard: 6, good: 6, easy: 6 },
+          })),
+        },
+      });
+    }),
+    http.get(`${API_BASE}/planner/materials`, () => {
+      const list = Array.from({ length: materials }, (_, i) => ({
+        id: i + 1,
+        title: `자료 ${i + 1}`,
+        type: "BOOK",
+        status: "ACTIVE",
+        totalUnits: 0,
+        completedUnits: 0,
+        createdAt: "2026-05-01T10:00:00",
+        updatedAt: "2026-05-01T10:00:00",
+      }));
+      return HttpResponse.json({
+        code: "OK",
+        data: { materials: list },
+      });
+    }),
+  );
+}
+
+describe("HomePage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+  });
+
+  it("복습 0건 / 자료 0개일 때 빈 상태 메시지를 표시한다", async () => {
+    setup({});
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("0건 — 모두 완료했어요!"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("아직 등록된 자료가 없어요."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /첫 자료 추가/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("복습 3건(밀린 1건) + 자료 5개일 때 카운트를 표시한다", async () => {
+    setup({
+      todayReviews: [
+        { delayDays: 0 },
+        { delayDays: 0 },
+        { delayDays: 2 },
+      ],
+      materials: 5,
+    });
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("3건")).toBeInTheDocument();
+    });
+    expect(screen.getByText("밀린 복습 1건 포함")).toBeInTheDocument();
+    expect(screen.getByText("5개 진행 중")).toBeInTheDocument();
+  });
+
+  it("오늘 복습 카드의 '바로가기' 클릭 시 /planner/reviews/today로 이동한다", async () => {
+    setup({ todayReviews: [{ delayDays: 0 }] });
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("1건")).toBeInTheDocument();
+    });
+
+    const links = screen.getAllByRole("link", { name: /바로가기/ });
+    await user.click(links[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText("오늘 복습 페이지")).toBeInTheDocument();
+    });
+  });
+
+  it("학습 자료 카드의 '바로가기' 클릭 시 /planner/materials로 이동한다", async () => {
+    setup({ materials: 2 });
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("2개 진행 중")).toBeInTheDocument();
+    });
+
+    const links = screen.getAllByRole("link", { name: /바로가기/ });
+    await user.click(links[1]);
+
+    await waitFor(() => {
+      expect(screen.getByText("자료 목록 페이지")).toBeInTheDocument();
+    });
+  });
+
+  it("자료 0개일 때 [첫 자료 추가] 클릭 시 다이얼로그가 열린다", async () => {
+    setup({});
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /첫 자료 추가/ }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /첫 자료 추가/ }));
+
+    expect(
+      await screen.findByRole("dialog", { name: /학습 자료 추가/ }),
+    ).toBeInTheDocument();
+  });
+});

--- a/fe/src/pages/HomePage.tsx
+++ b/fe/src/pages/HomePage.tsx
@@ -1,10 +1,118 @@
+import { BookOpen, CheckSquare, Plus } from "lucide-react";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { AddMaterialDialog } from "@/features/material/components/AddMaterialDialog";
+import { useMaterials } from "@/features/material/hooks/useMaterials";
+import { useTodayReviews } from "@/features/review/hooks/useTodayReviews";
+
+function TodayReviewCard() {
+  const { data, isLoading } = useTodayReviews();
+  const reviews = data?.reviews ?? [];
+  const total = reviews.length;
+  const overdue = reviews.filter((r) => r.delayDays > 0).length;
+
+  return (
+    <Card>
+      <CardContent>
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-2">
+            <CheckSquare className="text-primary size-4" />
+            <h2 className="text-base font-medium">오늘 복습</h2>
+          </div>
+
+          {isLoading ? (
+            <p className="text-muted-foreground text-sm">불러오는 중...</p>
+          ) : total === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              0건 — 모두 완료했어요!
+            </p>
+          ) : (
+            <div className="flex flex-col gap-1">
+              <p className="text-foreground text-2xl font-semibold">
+                {total}건
+              </p>
+              {overdue > 0 && (
+                <p className="text-destructive text-xs">
+                  밀린 복습 {overdue}건 포함
+                </p>
+              )}
+            </div>
+          )}
+
+          <Link
+            to="/planner/reviews/today"
+            className="text-primary w-fit text-sm font-medium hover:underline"
+          >
+            바로가기 →
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function MaterialsCard() {
+  const { data, isLoading } = useMaterials("ACTIVE");
+  const total = data?.length ?? 0;
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <Card>
+      <CardContent>
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-2">
+            <BookOpen className="text-primary size-4" />
+            <h2 className="text-base font-medium">학습 자료</h2>
+          </div>
+
+          {isLoading ? (
+            <p className="text-muted-foreground text-sm">불러오는 중...</p>
+          ) : total === 0 ? (
+            <div className="flex flex-col gap-2">
+              <p className="text-muted-foreground text-sm">
+                아직 등록된 자료가 없어요.
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-fit"
+                onClick={() => setDialogOpen(true)}
+              >
+                <Plus className="size-3.5" /> 첫 자료 추가
+              </Button>
+            </div>
+          ) : (
+            <p className="text-foreground text-2xl font-semibold">
+              {total}개 진행 중
+            </p>
+          )}
+
+          {total > 0 && (
+            <Link
+              to="/planner/materials"
+              className="text-primary w-fit text-sm font-medium hover:underline"
+            >
+              바로가기 →
+            </Link>
+          )}
+        </div>
+      </CardContent>
+      <AddMaterialDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+    </Card>
+  );
+}
+
 export function HomePage() {
   return (
-    <div>
+    <div className="flex flex-col gap-6">
       <h1 className="text-xl font-semibold">안녕하세요 👋</h1>
-      <p className="text-muted-foreground mt-2 text-sm">
-        오늘도 학습 잘 부탁드려요.
-      </p>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <TodayReviewCard />
+        <MaterialsCard />
+      </div>
     </div>
   );
 }

--- a/fe/src/pages/planner/TodayReviewsPage.test.tsx
+++ b/fe/src/pages/planner/TodayReviewsPage.test.tsx
@@ -14,7 +14,14 @@ import { TodayReviewsPage } from "./TodayReviewsPage";
 
 const API_BASE = "https://api.orino.dev/api";
 
-function reviewFixture(overrides: Partial<{ id: number; sequence: number; delayDays: number; unitTitle: string }> = {}) {
+function reviewFixture(
+  overrides: Partial<{
+    id: number;
+    sequence: number;
+    delayDays: number;
+    unitTitle: string;
+  }> = {},
+) {
   return {
     id: overrides.id ?? 1,
     scheduledDate: "2026-05-12",

--- a/fe/src/pages/planner/TodayReviewsPage.tsx
+++ b/fe/src/pages/planner/TodayReviewsPage.tsx
@@ -103,9 +103,7 @@ export function TodayReviewsPage() {
 
   if (isError || !data) {
     return (
-      <p className="text-destructive text-sm">
-        오늘 복습을 불러오지 못했어요.
-      </p>
+      <p className="text-destructive text-sm">오늘 복습을 불러오지 못했어요.</p>
     );
   }
 
@@ -118,8 +116,7 @@ export function TodayReviewsPage() {
         <h1 className="text-xl font-semibold">오늘 복습</h1>
         {reviews.length > 0 && (
           <p className="text-muted-foreground text-sm">
-            {reviews.length}건
-            {overdueCount > 0 && ` (밀린 ${overdueCount}건)`}
+            {reviews.length}건{overdueCount > 0 && ` (밀린 ${overdueCount}건)`}
           </p>
         )}
       </header>


### PR DESCRIPTION
## 이슈
closes #332

## 작업 내용

### `HomePage`
- "안녕하세요 👋" 헤딩 + 2개 카드 그리드 (`grid-cols-1 sm:grid-cols-2`)
- 기존 hooks 재사용 — 별도 API 추가 없음

### `TodayReviewCard`
| 상태 | 표시 |
|------|------|
| 로딩 | "불러오는 중..." |
| 0건 | "0건 — 모두 완료했어요!" |
| N건 | 큰 글씨 "N건" + (밀린 M건 있으면) "밀린 복습 M건 포함" 빨간 라벨 |
| 어느 경우든 | "바로가기 →" 링크 → `/planner/reviews/today` |

### `MaterialsCard`
| 상태 | 표시 |
|------|------|
| 로딩 | "불러오는 중..." |
| 0개 | "아직 등록된 자료가 없어요." + `[+ 첫 자료 추가]` 버튼 → `AddMaterialDialog` |
| N개 | 큰 글씨 "N개 진행 중" + "바로가기 →" → `/planner/materials` |

`useMaterials("ACTIVE")`로 ACTIVE 상태만 카운트.

### 검증
- `npm test`: **17 파일 / 76 케이스 통과** (HomePage 5건 추가)
- `lint` / `format:check` / `build` 통과
- **로컬 dev 직접 검증** (BE + FE + Playwright):
  - 빈 DB → /home: "0건 — 모두 완료했어요!" / "아직 등록된 자료가 없어요" + [첫 자료 추가] 버튼
  - 2자료 + 2복습 시드 → 새로고침: "2건 + 밀린 복습 2건 포함" / "2개 진행 중" + 사이드바 badge "2"
  - 학습 자료 카드 [바로가기] 클릭 → /planner/materials 이동 확인

### 참고
- 설계: [Study-Planner-UI-Design §3.1 (Wiki)](https://github.com/wcorn/orino/wiki/Study-Planner-UI-Design)
- B안 MVP의 마지막 작업. 머지 후 `/home` 진입 시 사용자에게 즉시 컨텍스트를 제공