### PR TITLE
docs : FE README에 환경변수·스크립트·Faro 섹션 추가

### DIFF
--- a/fe/README.md
+++ b/fe/README.md
@@ -1,6 +1,6 @@
 # fe
 
-React 프론트엔드 — MinIO 정적 웹 호스팅
+React 프론트엔드.
 
 ## 버전
 
@@ -17,33 +17,71 @@ React 프론트엔드 — MinIO 정적 웹 호스팅
 cp .env.example .env.development   # 최초 1회
 npm install
 npm run dev      # 개발 서버 (port 3000, /api → localhost:8080 프록시)
-npm run build    # 프로덕션 빌드 (dist/)
 ```
+
+`npm run dev`는 BE를 `http://localhost:8080`으로 프록시한다. BE는
+`be/`에서 `docker compose up -d mysql redis` + `./gradlew bootRun`으로 띄운다.
+
+## 스크립트
+
+| 명령                   | 설명                                                   |
+| ---------------------- | ------------------------------------------------------ |
+| `npm run dev`          | Vite 개발 서버 (HMR)                                   |
+| `npm run build`        | 프로덕션 빌드 (`tsc -b && vite build`, 산출물 `dist/`) |
+| `npm run preview`      | 빌드 결과물을 로컬에서 미리보기                        |
+| `npm test`             | Vitest 단위·통합 테스트                                |
+| `npm run test:watch`   | Vitest watch 모드                                      |
+| `npm run test:e2e`     | Playwright E2E (`e2e/`)                                |
+| `npm run test:e2e:ui`  | Playwright UI 모드                                     |
+| `npm run lint`         | ESLint                                                 |
+| `npm run format`       | Prettier 자동 수정                                     |
+| `npm run format:check` | Prettier 검사 (CI)                                     |
 
 ## 환경변수
 
-| 변수           | 설명                                           |
-| -------------- | ---------------------------------------------- |
-| `VITE_API_URL` | 백엔드 API 주소 (dev: `http://localhost:8080`) |
+| 변수            | 용도                      | dev 기본값 | prod                                            |
+| --------------- | ------------------------- | ---------- | ----------------------------------------------- |
+| `VITE_API_URL`  | BE API base URL           | `/api`     | `https://api.orino.dev/api` (하드코딩 fallback) |
+| `VITE_FARO_URL` | Grafana Faro receiver URL | 없음       | `https://telemetry.orino.dev/collect`           |
+| `VITE_FARO_KEY` | Faro API key              | 없음       | SealedSecret으로 주입                           |
 
-## MinIO 배포
+- dev에서 `VITE_API_URL=/api`로 두면 `vite.config.ts`의 proxy가
+  `/api/*` 요청을 `http://localhost:8080`으로 포워딩한다.
+- `VITE_FARO_URL` / `VITE_FARO_KEY` 둘 중 하나라도 비어있으면 Faro
+  초기화를 생략한다. 앱 동작에는 영향 없음.
 
-빌드 시 `VITE_API_URL`을 주입하고, `dist/`를 MinIO 버킷에 업로드합니다.
+## Grafana Faro (관측성)
 
-```bash
-docker build \
-  --build-arg VITE_API_URL=https://api.orino.example.com \
-  --build-arg MINIO_ALIAS=minio \
-  --build-arg MINIO_BUCKET=orino-fe \
-  .
+자동 수집:
+
+- 에러 (`window.error`, `unhandledrejection`, React `ErrorBoundary`)
+- console (`captureConsole: true`)
+- Web Vitals (LCP, FID, CLS, INP, TTFB)
+- 라우트 변경 (page view 이벤트)
+- fetch/XHR 트레이스 + `API_BASE_URL`에 W3C `traceparent` 헤더 전파
+
+수동 API:
+
+```ts
+import { faro } from "@grafana/faro-react";
+
+faro?.api?.pushLog(["사용자 행동"], { level: "info" });
+faro?.api?.pushError(error, { context: { extra: "..." } });
 ```
 
-### MinIO 버킷 설정 (최초 1회)
+초기화 코드: `src/shared/faro/init.ts`. env 미설정 또는 SDK 오류 시
+`console.warn`만 출력하고 앱은 정상 동작한다.
 
-SPA 라우팅을 위해 error document를 `index.html`로 설정해야 합니다.
+## Docker 빌드
 
 ```bash
-mc mb minio/orino-fe
-mc website set minio/orino-fe --index index.html --error index.html
-mc anonymous set download minio/orino-fe
+docker build -t orino-fe .
 ```
+
+`fe/Dockerfile`은 multi-stage (Node alpine builder → nginx alpine 런타임).
+런타임 nginx는 SPA fallback을 위해 `nginx.conf`에서 `try_files $uri /index.html`을
+적용한다.
+
+prod 환경 변수는 빌드 시점에 vite가 인라인하므로, 환경별로 다른 이미지를
+빌드하거나 빌드 시 `--build-arg`로 주입하는 패턴이 필요하다 (현재는 기본값으로
+빌드).


### PR DESCRIPTION
## 이슈
closes #357

## 작업 내용

### 환경변수 표 확장
| 변수 | 용도 | dev 기본값 | prod |
|------|------|------------|------|
| `VITE_API_URL` | BE API base URL | `/api` (proxy → localhost:8080) | `https://api.orino.dev/api` |
| `VITE_FARO_URL` | Grafana Faro receiver URL | 없음 | `https://telemetry.orino.dev/collect` |
| `VITE_FARO_KEY` | Faro API key | 없음 | SealedSecret으로 주입 |

- `VITE_API_URL=/api`일 때 vite proxy 동작 명시
- Faro env 미설정 시 noop 동작 명시

### 스크립트 표
build / test / test:watch / test:e2e / test:e2e:ui / lint / format / format:check / preview / dev 정리

### Grafana Faro (관측성) 섹션 신설
- 자동 수집 항목 (에러·console·Web Vitals·라우트·트레이스)
- 수동 API 예시 (`faro.api.pushLog`, `faro.api.pushError`)
- 초기화 위치 (`src/shared/faro/init.ts`)
- env 미설정/SDK 오류 시 앱 정상 동작 명시

### Docker 섹션 정정
- 기존 MinIO 빌드 가이드는 실제 Dockerfile(nginx multi-stage)과 달라 정정
- prod env는 vite가 빌드 시점에 인라인하는 동작 명시

### 참고
- 선행: #297 (Faro 도입), #354 (Faro PR)