### PR TITLE
feat : FE 빌드 sourcemap 활성화 + Alloy faro.receiver download 모드

### DIFF
--- a/fe/vite.config.ts
+++ b/fe/vite.config.ts
@@ -27,7 +27,11 @@ export default defineConfig(() => {
     build: {
       outDir: "dist",
       assetsDir: "assets",
-      sourcemap: false,
+      // sourcemap: true → .map 파일 생성 + JS 끝에 //# sourceMappingURL 코멘트 추가.
+      // Alloy faro.receiver의 sourcemaps { download = true } 가 이 URL로 .map을 받아와
+      // Grafana 에러 화면에서 unminified stack을 보여준다.
+      // 소스는 이미 공개 저장소이므로 .map 공개 노출 무관.
+      sourcemap: true,
     },
     server: {
       host: "0.0.0.0",

--- a/infra/helm/alloy/values.yaml
+++ b/infra/helm/alloy/values.yaml
@@ -42,6 +42,13 @@ alloy:
             }
           }
 
+          // FE 빌드(vite sourcemap: true)가 dist/assets/*.js.map을 함께 배포한다.
+          // 브라우저 스택 트레이스의 minified URL을 보고 동일 origin의 .map을 받아와
+          // unminified stack을 Grafana 에러 화면에 표시.
+          sourcemaps {
+            download = true
+          }
+
           output {
             logs   = [loki.process.faro.receiver]
             traces = [otelcol.exporter.otlp.tempo.input]


### PR DESCRIPTION
## 이슈
closes #356

## 작업 내용

FE 빌드가 `.map`을 함께 배포하고, Alloy `faro.receiver`가 동일 origin에서 `.map`을 받아 unminified stack을 Grafana에 표시한다.

### 변경 사항

| 파일 | 변경 |
|------|------|
| `fe/vite.config.ts` | `build.sourcemap` `false` → `true` (`.map` 파일 + `//# sourceMappingURL` 코멘트 생성) |
| `infra/helm/alloy/values.yaml` | `faro.receiver`에 `sourcemaps { download = true }` 블록 추가 |

### 동작 흐름

1. `vite build` → `dist/assets/index-<hash>.js` + `index-<hash>.js.map` 함께 산출
2. nginx가 두 파일 모두 정적 서빙 (기본 `try_files` 동작)
3. 브라우저 에러 발생 → Faro SDK가 minified stack URL을 Alloy로 전송
4. Alloy `faro.receiver`가 `https://orino.dev/assets/index-<hash>.js.map`을 fetch
5. Grafana 에러 화면에서 unminified 파일/라인 표시

### 채택한 모델

이슈 본문은 **업로드 모델**(@grafana/faro-rollup-plugin 또는 -cli)을 제시했지만, 본 PR은 더 간단한 **download 모델**을 채택:
- 업로드용 별도 API key/엔드포인트 불필요
- 소스가 이미 공개 저장소이므로 `.map` 공개 노출이 보안 이슈가 아님
- 빌드 파이프라인 변경 최소화 (vite 옵션 1개 + Alloy 3줄)

### 검증

- `npm run build` → `dist/assets/index-<hash>.js.map` (2.8MB) 생성 확인
- `npm test` 17 파일 / 72 케이스 통과 / lint 통과
- `helm template infra/helm/alloy` 렌더링에서 `sourcemaps { download = true }` 블록 정상 출력 확인

### 미반영 (별도 이슈 권장)

- Alloy `sourcemaps` 블록에는 `download_origins`(허용 도메인 제한), `download_from_host`(고정 호스트) 등 보안 옵션이 있다. 현재 origin 제한 없이 download 활성화 — 운영에서 외부 자원 fetch 차단이 필요하면 후속 PR에서 강화 권장.
- `dist/assets/*.js.map` 파일 크기가 2.8MB 수준. CDN 캐싱·gzip 적용 검토 가능.

### 참고
- 선행: #297 (Faro SDK 도입, 완료), #354 PR
- 인프라: #296 (Alloy faro.receiver 베이스, 완료)