### PR TITLE
feat : v2 마이그레이션 - note/flashcard/review_schedule 신규

### DIFF
--- a/be/orino-app-api/src/main/resources/db/changelog/changes/020-create-v2-planner-tables.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/020-create-v2-planner-tables.yaml
@@ -1,0 +1,214 @@
+databaseChangeLog:
+  - changeSet:
+      id: 020-create-note
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: note
+      changes:
+        - createTable:
+            tableName: note
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_note_member
+                    references: member(id)
+              - column:
+                  name: material_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uk_note_material
+                    foreignKeyName: fk_note_material
+                    references: study_material(id)
+                    deleteCascade: true
+              - column:
+                  name: content
+                  type: JSON
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 020-create-flashcard
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: flashcard
+      changes:
+        - createTable:
+            tableName: flashcard
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_flashcard_member
+                    references: member(id)
+              - column:
+                  name: material_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_flashcard_material
+                    references: study_material(id)
+                    deleteCascade: true
+              - column:
+                  name: front
+                  type: VARCHAR(1000)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: back
+                  type: VARCHAR(1000)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: flashcard
+            indexName: idx_flashcard_material_id
+            columns:
+              - column:
+                  name: material_id
+              - column:
+                  name: id
+
+  - changeSet:
+      id: 020-create-review-schedule-v2
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: review_schedule
+      changes:
+        - createTable:
+            tableName: review_schedule
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_review_schedule_member
+                    references: member(id)
+              - column:
+                  name: flashcard_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_review_schedule_flashcard
+                    references: flashcard(id)
+                    deleteCascade: true
+              - column:
+                  name: sequence
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: scheduled_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: interval_days
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: ease_factor
+                  type: DECIMAL(4,2)
+                  defaultValueNumeric: 2.50
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(10)
+                  defaultValue: PENDING
+                  constraints:
+                    nullable: false
+              - column:
+                  name: rating
+                  type: VARCHAR(10)
+              - column:
+                  name: elapsed_days
+                  type: INT
+              - column:
+                  name: completed_at
+                  type: DATETIME(6)
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: review_schedule
+            indexName: idx_review_schedule_member_date_status
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: scheduled_date
+              - column:
+                  name: status
+        - createIndex:
+            tableName: review_schedule
+            indexName: idx_review_schedule_flashcard_sequence
+            columns:
+              - column:
+                  name: flashcard_id
+              - column:
+                  name: sequence

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -37,3 +37,5 @@ databaseChangeLog:
       file: db/changelog/changes/018-create-review-schedule.yaml
   - include:
       file: db/changelog/changes/019-rollback-v1-planner-tables.yaml
+  - include:
+      file: db/changelog/changes/020-create-v2-planner-tables.yaml


### PR DESCRIPTION
## 이슈
closes #364

## 작업 내용

신규 changeset `020-create-v2-planner-tables.yaml` 추가. 3개 테이블을 별도 changeSet로 분리해 부분 실패/롤백을 격리.

### `note`
- `material_id` UNIQUE (자료 1:1 매핑) + FK `study_material` ON DELETE CASCADE
- `content` JSON NOT NULL (Tiptap 문서)

### `flashcard`
- `front`, `back` VARCHAR(1000) NOT NULL
- FK `study_material` ON DELETE CASCADE
- 인덱스 `(material_id, id)` — 자료 상세에서 카드 목록 페이징 조회

### `review_schedule` (v2)
- v1 drop 후 신규 생성 — FK가 `study_unit_id` → `flashcard_id`로 변경
- `ease_factor DECIMAL(4,2) DEFAULT 2.50`, `status DEFAULT 'PENDING'`
- 인덱스 2개:
  - `(member_id, scheduled_date, status)` — 오늘 복습 조회
  - `(flashcard_id, sequence)` — 카드별 시퀀스 추적

## 검증
- [x] `./gradlew build` (checkstyle 포함) 통과
- [x] `SchemaValidationTest` 통과 — Liquibase 적용 후 Hibernate validate (테이블 생성 검증)
- 엔티티는 후속 이슈(#365~#368)에서 추가 예정 — 현재는 DDL만 검증

## 후속
- #365 자료 CRUD + 빈 노트 자동 생성
- #366 노트 API
- #367 플래시카드 CRUD + 첫 복습 자동 생성
- #368 복습 평가 (SM-2)
- #369 오늘 복습 조회