### PR TITLE
feat : 학습 자료 CRUD API + 자료 생성 시 빈 노트 자동 생성

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/controller/StudyMaterialController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/controller/StudyMaterialController.java
@@ -1,0 +1,73 @@
+package ds.project.orino.planner.material.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.domain.planner.material.entity.MaterialStatus;
+import ds.project.orino.planner.material.dto.MaterialCreateRequest;
+import ds.project.orino.planner.material.dto.MaterialCreateResponse;
+import ds.project.orino.planner.material.dto.MaterialListResponse;
+import ds.project.orino.planner.material.dto.MaterialResponse;
+import ds.project.orino.planner.material.dto.MaterialUpdateRequest;
+import ds.project.orino.planner.material.service.StudyMaterialService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/planner/materials")
+public class StudyMaterialController {
+
+    private final StudyMaterialService studyMaterialService;
+
+    public StudyMaterialController(StudyMaterialService studyMaterialService) {
+        this.studyMaterialService = studyMaterialService;
+    }
+
+    @GetMapping
+    public ApiResponse<MaterialListResponse> list(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam(required = false) MaterialStatus status) {
+        return ApiResponse.success(new MaterialListResponse(
+                studyMaterialService.findAll(memberId, status)));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<MaterialCreateResponse>> create(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody MaterialCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(studyMaterialService.create(memberId, request)));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<MaterialResponse> detail(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id) {
+        return ApiResponse.success(studyMaterialService.findOne(memberId, id));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponse<MaterialResponse> update(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @Valid @RequestBody MaterialUpdateRequest request) {
+        return ApiResponse.success(studyMaterialService.update(memberId, id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id) {
+        studyMaterialService.delete(memberId, id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialCreateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialCreateRequest.java
@@ -1,0 +1,16 @@
+package ds.project.orino.planner.material.dto;
+
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record MaterialCreateRequest(
+        @NotBlank(message = "title은 비어 있을 수 없습니다.")
+        @Size(min = 1, max = 200, message = "title은 1~200자여야 합니다.")
+        String title,
+
+        @NotNull(message = "type은 필수입니다.")
+        MaterialType type
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialCreateResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialCreateResponse.java
@@ -1,0 +1,6 @@
+package ds.project.orino.planner.material.dto;
+
+import ds.project.orino.planner.note.dto.NoteResponse;
+
+public record MaterialCreateResponse(MaterialResponse material, NoteResponse note) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialListResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialListResponse.java
@@ -1,0 +1,6 @@
+package ds.project.orino.planner.material.dto;
+
+import java.util.List;
+
+public record MaterialListResponse(List<MaterialResponse> materials) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialResponse.java
@@ -1,0 +1,30 @@
+package ds.project.orino.planner.material.dto;
+
+import ds.project.orino.domain.planner.material.entity.MaterialStatus;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+
+import java.time.LocalDateTime;
+
+public record MaterialResponse(
+        Long id,
+        String title,
+        MaterialType type,
+        MaterialStatus status,
+        long flashcardCount,
+        long dueReviewCount,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static MaterialResponse of(StudyMaterial m, long flashcardCount, long dueReviewCount) {
+        return new MaterialResponse(
+                m.getId(),
+                m.getTitle(),
+                m.getType(),
+                m.getStatus(),
+                flashcardCount,
+                dueReviewCount,
+                m.getCreatedAt(),
+                m.getUpdatedAt());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialUpdateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialUpdateRequest.java
@@ -1,0 +1,12 @@
+package ds.project.orino.planner.material.dto;
+
+import ds.project.orino.domain.planner.material.entity.MaterialStatus;
+import jakarta.validation.constraints.Size;
+
+public record MaterialUpdateRequest(
+        @Size(min = 1, max = 200, message = "title은 1~200자여야 합니다.")
+        String title,
+
+        MaterialStatus status
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyMaterialService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyMaterialService.java
@@ -1,0 +1,111 @@
+package ds.project.orino.planner.material.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.material.entity.MaterialStatus;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository.MaterialCountRow;
+import ds.project.orino.domain.planner.note.entity.Note;
+import ds.project.orino.domain.planner.note.repository.NoteRepository;
+import ds.project.orino.planner.material.dto.MaterialCreateRequest;
+import ds.project.orino.planner.material.dto.MaterialCreateResponse;
+import ds.project.orino.planner.material.dto.MaterialResponse;
+import ds.project.orino.planner.material.dto.MaterialUpdateRequest;
+import ds.project.orino.planner.note.dto.NoteResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class StudyMaterialService {
+
+    private final StudyMaterialRepository studyMaterialRepository;
+    private final NoteRepository noteRepository;
+    private final Clock clock;
+
+    public StudyMaterialService(StudyMaterialRepository studyMaterialRepository,
+                                NoteRepository noteRepository,
+                                Clock clock) {
+        this.studyMaterialRepository = studyMaterialRepository;
+        this.noteRepository = noteRepository;
+        this.clock = clock;
+    }
+
+    public List<MaterialResponse> findAll(Long memberId, MaterialStatus status) {
+        List<StudyMaterial> materials = (status == null)
+                ? studyMaterialRepository.findAllByMemberIdOrderByCreatedAtDesc(memberId)
+                : studyMaterialRepository.findAllByMemberIdAndStatusOrderByCreatedAtDesc(memberId, status);
+
+        if (materials.isEmpty()) {
+            return List.of();
+        }
+        return mapWithCounts(materials);
+    }
+
+    public MaterialResponse findOne(Long memberId, Long materialId) {
+        StudyMaterial material = getOwnedMaterial(memberId, materialId);
+        return mapWithCounts(List.of(material)).get(0);
+    }
+
+    @Transactional
+    public MaterialCreateResponse create(Long memberId, MaterialCreateRequest request) {
+        StudyMaterial saved = studyMaterialRepository.save(
+                new StudyMaterial(memberId, request.title(), request.type()));
+        Note note = noteRepository.save(new Note(memberId, saved.getId()));
+        MaterialResponse materialResponse = MaterialResponse.of(saved, 0L, 0L);
+        return new MaterialCreateResponse(materialResponse, NoteResponse.of(note));
+    }
+
+    @Transactional
+    public MaterialResponse update(Long memberId, Long materialId, MaterialUpdateRequest request) {
+        if (request.title() == null && request.status() == null) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+        StudyMaterial material = getOwnedMaterial(memberId, materialId);
+        if (request.title() != null) {
+            material.updateTitle(request.title());
+        }
+        if (request.status() != null) {
+            material.updateStatus(request.status());
+        }
+        return mapWithCounts(List.of(material)).get(0);
+    }
+
+    @Transactional
+    public void delete(Long memberId, Long materialId) {
+        StudyMaterial material = getOwnedMaterial(memberId, materialId);
+        studyMaterialRepository.delete(material);
+    }
+
+    private StudyMaterial getOwnedMaterial(Long memberId, Long materialId) {
+        return studyMaterialRepository.findByIdAndMemberId(materialId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    private List<MaterialResponse> mapWithCounts(List<StudyMaterial> materials) {
+        List<Long> ids = materials.stream().map(StudyMaterial::getId).toList();
+        Map<Long, Long> flashcardCounts = toCountMap(
+                studyMaterialRepository.countFlashcardsByMaterialIds(ids));
+        Map<Long, Long> dueReviewCounts = toCountMap(
+                studyMaterialRepository.countDueReviewsByMaterialIds(ids, LocalDate.now(clock)));
+        return materials.stream()
+                .map(m -> MaterialResponse.of(m,
+                        flashcardCounts.getOrDefault(m.getId(), 0L),
+                        dueReviewCounts.getOrDefault(m.getId(), 0L)))
+                .toList();
+    }
+
+    private static Map<Long, Long> toCountMap(List<MaterialCountRow> rows) {
+        return rows.stream().collect(Collectors.toMap(
+                MaterialCountRow::getMaterialId,
+                MaterialCountRow::getCount,
+                (a, b) -> a));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteResponse.java
@@ -1,0 +1,29 @@
+package ds.project.orino.planner.note.dto;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.note.entity.Note;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.time.LocalDateTime;
+
+public record NoteResponse(
+        Long id,
+        Long materialId,
+        JsonNode content,
+        LocalDateTime updatedAt
+) {
+    private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+    public static NoteResponse of(Note note) {
+        JsonNode parsed;
+        try {
+            parsed = MAPPER.readTree(note.getContent());
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, e);
+        }
+        return new NoteResponse(note.getId(), note.getMaterialId(), parsed, note.getUpdatedAt());
+    }
+}

--- a/be/orino-app-api/src/main/resources/application-mysql.yml
+++ b/be/orino-app-api/src/main/resources/application-mysql.yml
@@ -24,14 +24,15 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true
         highlight_sql: true
         generate_statistics: true
   liquibase:
-    enabled: false
+    enabled: true
+    change-log: classpath:db/changelog/db.changelog-master.yaml
 
 logging:
   level:
@@ -50,9 +51,10 @@ spring:
     password: test
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
   liquibase:
-    enabled: false
+    enabled: true
+    change-log: classpath:db/changelog/db.changelog-master.yaml
 
 management:
   tracing:

--- a/be/orino-app-api/src/test/java/ds/project/orino/auth/controller/AuthControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/auth/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package ds.project.orino.auth.controller;
 
 import ds.project.orino.domain.member.repository.MemberRepository;
 import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.MemberFixture;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,9 +21,12 @@ class AuthControllerTest extends ApiTestSupport {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private DbCleaner dbCleaner;
+
     @BeforeEach
     void setUp() {
-        memberRepository.deleteAll();
+        dbCleaner.clean();
         memberRepository.save(MemberFixture.create());
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyMaterialControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyMaterialControllerTest.java
@@ -1,0 +1,281 @@
+package ds.project.orino.planner.material.controller;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialStatus;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.note.entity.Note;
+import ds.project.orino.domain.planner.note.repository.NoteRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.LocalDate;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class StudyMaterialControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Autowired
+    private NoteRepository noteRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Member member;
+    private Member otherMember;
+    private String accessToken;
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        member = memberRepository.save(MemberFixture.create());
+        otherMember = memberRepository.save(MemberFixture.create("other", "password"));
+        accessToken = AuthFixture.loginAndGetAccessToken(mockMvc);
+        authHeader = "Bearer " + accessToken;
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials - 자료 생성 시 빈 노트가 함께 생성된다")
+    void create_material_with_empty_note() throws Exception {
+        mockMvc.perform(post("/api/planner/materials")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "이펙티브 자바", "type": "BOOK"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.material.title").value("이펙티브 자바"))
+                .andExpect(jsonPath("$.data.material.type").value("BOOK"))
+                .andExpect(jsonPath("$.data.material.status").value("ACTIVE"))
+                .andExpect(jsonPath("$.data.material.flashcardCount").value(0))
+                .andExpect(jsonPath("$.data.material.dueReviewCount").value(0))
+                .andExpect(jsonPath("$.data.note.content.type").value("doc"))
+                .andExpect(jsonPath("$.data.note.content.content").isArray())
+                .andExpect(jsonPath("$.data.note.materialId").exists());
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials - title이 빈 문자열이면 400")
+    void create_blank_title() throws Exception {
+        mockMvc.perform(post("/api/planner/materials")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "", "type": "BOOK"}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /api/planner/materials - type이 enum 외 값이면 400")
+    void create_invalid_type() throws Exception {
+        mockMvc.perform(post("/api/planner/materials")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "x", "type": "UNKNOWN"}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET /api/planner/materials - 본인 자료만 createdAt desc 순으로 반환한다")
+    void list_returns_own_materials_desc() throws Exception {
+        StudyMaterial first = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "첫째", MaterialType.BOOK));
+        StudyMaterial second = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "둘째", MaterialType.LECTURE));
+        studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+
+        mockMvc.perform(get("/api/planner/materials")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.materials", hasSize(2)))
+                .andExpect(jsonPath("$.data.materials[0].id").value(second.getId()))
+                .andExpect(jsonPath("$.data.materials[1].id").value(first.getId()));
+    }
+
+    @Test
+    @DisplayName("GET /api/planner/materials?status=ACTIVE - 상태 필터가 동작한다")
+    void list_filters_by_status() throws Exception {
+        studyMaterialRepository.save(new StudyMaterial(member.getId(), "활성", MaterialType.BOOK));
+        StudyMaterial done = new StudyMaterial(member.getId(), "완료", MaterialType.LECTURE);
+        done.updateStatus(MaterialStatus.COMPLETED);
+        studyMaterialRepository.save(done);
+
+        mockMvc.perform(get("/api/planner/materials")
+                        .queryParam("status", "COMPLETED")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.materials", hasSize(1)))
+                .andExpect(jsonPath("$.data.materials[0].title").value("완료"));
+    }
+
+    @Test
+    @DisplayName("GET /api/planner/materials - flashcardCount, dueReviewCount가 집계된다")
+    void list_aggregates_counts() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "자료", MaterialType.BOOK));
+
+        Long fc1 = insertFlashcard(material.getId());
+        Long fc2 = insertFlashcard(material.getId());
+        Long fc3 = insertFlashcard(material.getId());
+
+        insertReview(fc1, LocalDate.now().minusDays(1), "PENDING");
+        insertReview(fc2, LocalDate.now(), "PENDING");
+        insertReview(fc3, LocalDate.now().plusDays(1), "PENDING");
+        insertReview(fc1, LocalDate.now().minusDays(2), "COMPLETED");
+
+        mockMvc.perform(get("/api/planner/materials")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.materials[0].flashcardCount").value(3))
+                .andExpect(jsonPath("$.data.materials[0].dueReviewCount").value(2));
+    }
+
+    @Test
+    @DisplayName("GET /api/planner/materials/{id} - 본인 자료 상세를 반환한다")
+    void detail_returns_own_material() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "자료", MaterialType.BOOK));
+
+        mockMvc.perform(get("/api/planner/materials/{id}", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("자료"))
+                .andExpect(jsonPath("$.data.flashcardCount").value(0))
+                .andExpect(jsonPath("$.data.dueReviewCount").value(0));
+    }
+
+    @Test
+    @DisplayName("GET /api/planner/materials/{id} - 타인 자료 조회 시 404")
+    void detail_not_owned_returns_404() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+
+        mockMvc.perform(get("/api/planner/materials/{id}", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/planner/materials/{id} - title, status 부분 수정")
+    void update_partial() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "기존", MaterialType.BOOK));
+
+        mockMvc.perform(patch("/api/planner/materials/{id}", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "수정", "status": "COMPLETED"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("수정"))
+                .andExpect(jsonPath("$.data.status").value("COMPLETED"));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/planner/materials/{id} - body가 모두 null이면 400")
+    void update_empty_request() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "기존", MaterialType.BOOK));
+
+        mockMvc.perform(patch("/api/planner/materials/{id}", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/planner/materials/{id} - 자료/노트/플래시카드/복습이 모두 cascade 삭제된다")
+    void delete_cascades_to_children() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "삭제 대상", MaterialType.BOOK));
+        Note note = noteRepository.save(new Note(member.getId(), material.getId()));
+        Long flashcardId = insertFlashcard(material.getId());
+        insertReview(flashcardId, LocalDate.now(), "PENDING");
+
+        mockMvc.perform(delete("/api/planner/materials/{id}", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNoContent());
+
+        Integer materialCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM study_material WHERE id = ?", Integer.class, material.getId());
+        Integer noteCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM note WHERE id = ?", Integer.class, note.getId());
+        Integer flashcardCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM flashcard WHERE id = ?", Integer.class, flashcardId);
+        Integer reviewCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM review_schedule WHERE flashcard_id = ?", Integer.class, flashcardId);
+
+        assertCountZero(materialCount, "study_material");
+        assertCountZero(noteCount, "note");
+        assertCountZero(flashcardCount, "flashcard");
+        assertCountZero(reviewCount, "review_schedule");
+    }
+
+    @Test
+    @DisplayName("DELETE /api/planner/materials/{id} - 타인 자료 삭제 시도는 404")
+    void delete_not_owned_returns_404() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+
+        mockMvc.perform(delete("/api/planner/materials/{id}", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNotFound());
+    }
+
+    private Long insertFlashcard(Long materialId) {
+        jdbcTemplate.update("""
+                INSERT INTO flashcard (member_id, material_id, front, back, created_at, updated_at)
+                VALUES (?, ?, 'q', 'a', NOW(6), NOW(6))
+                """, member.getId(), materialId);
+        return jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+    }
+
+    private void insertReview(Long flashcardId, LocalDate scheduledDate, String status) {
+        jdbcTemplate.update("""
+                INSERT INTO review_schedule
+                  (member_id, flashcard_id, sequence, scheduled_date, interval_days,
+                   ease_factor, status, created_at, updated_at)
+                VALUES (?, ?, 1, ?, 1, 2.50, ?, NOW(6), NOW(6))
+                """, member.getId(), flashcardId, scheduledDate, status);
+    }
+
+    private static void assertCountZero(Integer count, String tableName) {
+        if (count == null || count != 0) {
+            throw new AssertionError(tableName + " row count should be 0 but was " + count);
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/schema/SchemaValidationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/schema/SchemaValidationTest.java
@@ -3,20 +3,14 @@ package ds.project.orino.schema;
 import ds.project.orino.support.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.context.TestPropertySource;
 
 /**
  * Liquibase changelog과 JPA 엔티티의 일치 여부를 검증한다.
  *
- * Liquibase가 changelog를 적용한 뒤, Hibernate validate가
+ * 테스트 프로파일이 Liquibase를 적용한 뒤 Hibernate validate가
  * 엔티티와 DB 스키마를 비교한다. 불일치 시 컨텍스트 로딩 실패 → 테스트 실패.
  */
 @IntegrationTest
-@TestPropertySource(properties = {
-        "spring.jpa.hibernate.ddl-auto=validate",
-        "spring.liquibase.enabled=true",
-        "spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml"
-})
 class SchemaValidationTest {
 
     @Test

--- a/be/orino-app-api/src/test/java/ds/project/orino/security/SecurityConfigTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/security/SecurityConfigTest.java
@@ -2,6 +2,7 @@ package ds.project.orino.security;
 
 import ds.project.orino.domain.member.repository.MemberRepository;
 import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.MemberFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,9 +21,12 @@ class SecurityConfigTest extends ApiTestSupport {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private DbCleaner dbCleaner;
+
     @BeforeEach
     void setUp() {
-        memberRepository.deleteAll();
+        dbCleaner.clean();
         memberRepository.save(MemberFixture.create());
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
@@ -1,0 +1,33 @@
+package ds.project.orino.support;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DbCleaner {
+
+    private static final String[] TABLES_IN_FK_ORDER = {
+            "review_schedule",
+            "flashcard",
+            "note",
+            "study_material",
+            "member"
+    };
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public DbCleaner(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public void clean() {
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+        try {
+            for (String table : TABLES_IN_FK_ORDER) {
+                jdbcTemplate.execute("DELETE FROM " + table);
+            }
+        } finally {
+            jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+        }
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepository.java
@@ -3,7 +3,11 @@ package ds.project.orino.domain.planner.material.repository;
 import ds.project.orino.domain.planner.material.entity.MaterialStatus;
 import ds.project.orino.domain.planner.material.entity.StudyMaterial;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,4 +18,30 @@ public interface StudyMaterialRepository extends JpaRepository<StudyMaterial, Lo
     List<StudyMaterial> findAllByMemberIdAndStatusOrderByCreatedAtDesc(Long memberId, MaterialStatus status);
 
     Optional<StudyMaterial> findByIdAndMemberId(Long id, Long memberId);
+
+    interface MaterialCountRow {
+        Long getMaterialId();
+        Long getCount();
+    }
+
+    @Query(value = """
+            SELECT material_id AS materialId, COUNT(*) AS count
+            FROM flashcard
+            WHERE material_id IN (:materialIds)
+            GROUP BY material_id
+            """, nativeQuery = true)
+    List<MaterialCountRow> countFlashcardsByMaterialIds(@Param("materialIds") Collection<Long> materialIds);
+
+    @Query(value = """
+            SELECT f.material_id AS materialId, COUNT(r.id) AS count
+            FROM review_schedule r
+            JOIN flashcard f ON f.id = r.flashcard_id
+            WHERE f.material_id IN (:materialIds)
+              AND r.status = 'PENDING'
+              AND r.scheduled_date <= :today
+            GROUP BY f.material_id
+            """, nativeQuery = true)
+    List<MaterialCountRow> countDueReviewsByMaterialIds(
+            @Param("materialIds") Collection<Long> materialIds,
+            @Param("today") LocalDate today);
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/note/entity/Note.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/note/entity/Note.java
@@ -1,0 +1,85 @@
+package ds.project.orino.domain.planner.note.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "note", uniqueConstraints = @UniqueConstraint(name = "uk_note_material", columnNames = "material_id"))
+public class Note {
+
+    public static final String DEFAULT_CONTENT = "{\"type\":\"doc\",\"content\":[]}";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "material_id", nullable = false)
+    private Long materialId;
+
+    @Column(nullable = false, columnDefinition = "JSON")
+    private String content;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected Note() {
+    }
+
+    public Note(Long memberId, Long materialId) {
+        this(memberId, materialId, DEFAULT_CONTENT);
+    }
+
+    public Note(Long memberId, Long materialId, String content) {
+        this.memberId = memberId;
+        this.materialId = materialId;
+        this.content = content;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Long getMaterialId() {
+        return materialId;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/note/repository/NoteRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/note/repository/NoteRepository.java
@@ -1,0 +1,11 @@
+package ds.project.orino.domain.planner.note.repository;
+
+import ds.project.orino.domain.planner.note.entity.Note;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NoteRepository extends JpaRepository<Note, Long> {
+
+    Optional<Note> findByMaterialId(Long materialId);
+}


### PR DESCRIPTION
## 이슈
closes #365

## 작업 내용

### Domain
- `Note` 엔티티 + `NoteRepository`
  - `material_id` UNIQUE (1:1), `content` JSON, 기본값 `{"type":"doc","content":[]}`
- `StudyMaterialRepository`에 네이티브 카운트 쿼리 추가
  - `countFlashcardsByMaterialIds(ids)` — flashcard 테이블 GROUP BY
  - `countDueReviewsByMaterialIds(ids, today)` — flashcard JOIN review_schedule, PENDING + scheduled_date<=today
  - 한 번에 N개 자료 카운트 → N+1 회피

### API
| 메서드 | 경로 | 설명 |
|---|---|---|
| GET    | `/api/planner/materials?status=ACTIVE` | 목록 (옵션: status 필터) |
| POST   | `/api/planner/materials` | 생성 + 빈 노트 자동 생성 (단일 트랜잭션) |
| GET    | `/api/planner/materials/{id}` | 상세 |
| PATCH  | `/api/planner/materials/{id}` | title / status 부분 수정 |
| DELETE | `/api/planner/materials/{id}` | cascade 삭제 (note/flashcard/review_schedule) |

POST 응답에 `{ material, note }` 동봉. 응답 JSON 형식은 Wiki API Spec과 동일.

검증:
- title 1~200자 (`@Size`), type 필수 `@NotNull` enum
- PATCH 본문이 모두 null이면 400 (BAD_REQUEST)
- 타인 자료 조회/수정/삭제 시 404 (SP-ERR-001)

### 카운트 동작
- v2 flashcard/review_schedule 엔티티는 #367/#368에서 추가됨
- 본 PR 시점엔 양쪽 다 0 (데이터 없음). 단, 네이티브 카운트 SQL이 미리 들어가 있어 후속 이슈가 데이터 producer 추가만 하면 즉시 실값 집계 가능
- 통합 테스트는 JdbcTemplate으로 raw insert 후 실값 검증

### 테스트 인프라 변경
- **테스트 프로파일**: `ddl-auto: create-drop`/`liquibase: false` → `validate`/`true`
  - 이유: v2부터 flashcard/review_schedule이 엔티티 없이 Liquibase로만 관리됨. 테스트도 prod와 동일한 Liquibase 스키마 사용
- **DbCleaner**: TestContainers 컨테이너 재사용으로 인한 데이터 잔존을 해결. FK 안전한 순서로 DELETE
- 기존 `AuthControllerTest`, `SecurityConfigTest` setUp을 `DbCleaner` 사용으로 갱신

### 로컬 프로파일 변경
- `ddl-auto: update` → `validate`, `liquibase: enabled: true`
- prod와 동일한 마이그레이션 기반 스키마 관리. 로컬에서도 새 Liquibase changeset이 즉시 반영됨

### Spring Boot 4 / Jackson 3 호환
- Spring Boot 4가 Jackson 3 (`tools.jackson.*`) 채택. `com.fasterxml.jackson.databind.JsonNode`로는 직렬화 시 POJO로 풀려 `{"array":false,...}` 형태로 나옴
- `tools.jackson.databind.JsonNode` + `JsonMapper` 사용
- Spring 4가 등록하는 `JsonMapper` 빈을 주입받지 못하는 이슈가 별도로 있어 (조건부 빈 정의 매칭 단계에서 누락) `NoteResponse` record에 `private static final JsonMapper MAPPER` 보유

## 검증
- [x] `./gradlew build` (checkstyle 포함, 26개 통합 테스트) 통과
- [x] 통합 테스트 12개 — 생성/조회/필터/카운트 집계/cascade 삭제/검증
- [x] **로컬 bootRun + curl** — POST/GET/PATCH/DELETE 전 라이프사이클 정상, 노트도 cascade 삭제 검증

```
$ curl POST /api/planner/materials
{"data":{"material":{...},"note":{"id":1,"materialId":1,"content":{"type":"doc","content":[]}}}}
$ curl DELETE /api/planner/materials/1 → 204
$ SELECT * FROM note;   → 0 rows
```

## 후속
- #366 노트 API (GET/PUT content)
- #367 플래시카드 CRUD + 첫 복습 자동 생성
- #368 복습 평가 (SM-2)
- #369 오늘 복습 조회