### PR TITLE
feat : 노트 API (Tiptap JSON GET/PUT idempotent)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/controller/NoteController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/controller/NoteController.java
@@ -1,0 +1,41 @@
+package ds.project.orino.planner.note.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.note.dto.NoteResponse;
+import ds.project.orino.planner.note.dto.NoteUpdateRequest;
+import ds.project.orino.planner.note.dto.NoteUpdateResponse;
+import ds.project.orino.planner.note.service.NoteService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/planner/materials/{materialId}/note")
+public class NoteController {
+
+    private final NoteService noteService;
+
+    public NoteController(NoteService noteService) {
+        this.noteService = noteService;
+    }
+
+    @GetMapping
+    public ApiResponse<NoteResponse> get(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long materialId) {
+        return ApiResponse.success(noteService.findByMaterialId(memberId, materialId));
+    }
+
+    @PutMapping
+    public ApiResponse<NoteUpdateResponse> put(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long materialId,
+            @Valid @RequestBody NoteUpdateRequest request) {
+        return ApiResponse.success(noteService.update(memberId, materialId, request.content()));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteUpdateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteUpdateRequest.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.note.dto;
+
+import jakarta.validation.constraints.NotNull;
+import tools.jackson.databind.JsonNode;
+
+public record NoteUpdateRequest(
+        @NotNull(message = "content는 필수입니다.")
+        JsonNode content
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteUpdateResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteUpdateResponse.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.note.dto;
+
+import ds.project.orino.domain.planner.note.entity.Note;
+
+import java.time.LocalDateTime;
+
+public record NoteUpdateResponse(
+        Long id,
+        Long materialId,
+        LocalDateTime updatedAt
+) {
+    public static NoteUpdateResponse of(Note note) {
+        return new NoteUpdateResponse(note.getId(), note.getMaterialId(), note.getUpdatedAt());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/service/NoteService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/service/NoteService.java
@@ -1,0 +1,61 @@
+package ds.project.orino.planner.note.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.note.entity.Note;
+import ds.project.orino.domain.planner.note.repository.NoteRepository;
+import ds.project.orino.planner.note.dto.NoteResponse;
+import ds.project.orino.planner.note.dto.NoteUpdateResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.nio.charset.StandardCharsets;
+
+@Service
+@Transactional(readOnly = true)
+public class NoteService {
+
+    static final int MAX_CONTENT_BYTES = 1024 * 1024;
+    private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+    private final NoteRepository noteRepository;
+
+    public NoteService(NoteRepository noteRepository) {
+        this.noteRepository = noteRepository;
+    }
+
+    public NoteResponse findByMaterialId(Long memberId, Long materialId) {
+        return NoteResponse.of(getOwnedNote(memberId, materialId));
+    }
+
+    @Transactional
+    public NoteUpdateResponse update(Long memberId, Long materialId, JsonNode content) {
+        String serialized = serialize(content);
+        if (serialized.getBytes(StandardCharsets.UTF_8).length > MAX_CONTENT_BYTES) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        Note note = getOwnedNote(memberId, materialId);
+        note.updateContent(serialized);
+        return NoteUpdateResponse.of(note);
+    }
+
+    private Note getOwnedNote(Long memberId, Long materialId) {
+        Note note = noteRepository.findByMaterialId(materialId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        if (!note.getMemberId().equals(memberId)) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+        return note;
+    }
+
+    private static String serialize(JsonNode content) {
+        try {
+            return MAPPER.writeValueAsString(content);
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST, e);
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyMaterialControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyMaterialControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+import java.time.Clock;
 import java.time.LocalDate;
 
 import static org.hamcrest.Matchers.hasSize;
@@ -46,6 +47,9 @@ class StudyMaterialControllerTest extends ApiTestSupport {
 
     @Autowired
     private DbCleaner dbCleaner;
+
+    @Autowired
+    private Clock clock;
 
     private Member member;
     private Member otherMember;
@@ -149,10 +153,11 @@ class StudyMaterialControllerTest extends ApiTestSupport {
         Long fc2 = insertFlashcard(material.getId());
         Long fc3 = insertFlashcard(material.getId());
 
-        insertReview(fc1, LocalDate.now().minusDays(1), "PENDING");
-        insertReview(fc2, LocalDate.now(), "PENDING");
-        insertReview(fc3, LocalDate.now().plusDays(1), "PENDING");
-        insertReview(fc1, LocalDate.now().minusDays(2), "COMPLETED");
+        LocalDate today = LocalDate.now(clock);
+        insertReview(fc1, today.minusDays(1), "PENDING");
+        insertReview(fc2, today, "PENDING");
+        insertReview(fc3, today.plusDays(1), "PENDING");
+        insertReview(fc1, today.minusDays(2), "COMPLETED");
 
         mockMvc.perform(get("/api/planner/materials")
                         .header(HttpHeaders.AUTHORIZATION, authHeader))

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/note/controller/NoteControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/note/controller/NoteControllerTest.java
@@ -1,0 +1,174 @@
+package ds.project.orino.planner.note.controller;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.note.entity.Note;
+import ds.project.orino.domain.planner.note.repository.NoteRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class NoteControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Autowired
+    private NoteRepository noteRepository;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Member member;
+    private Member otherMember;
+    private StudyMaterial material;
+    private Note note;
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        member = memberRepository.save(MemberFixture.create());
+        otherMember = memberRepository.save(MemberFixture.create("other", "password"));
+        material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "이펙티브 자바", MaterialType.BOOK));
+        note = noteRepository.save(new Note(member.getId(), material.getId()));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    @Test
+    @DisplayName("GET - 빈 노트 조회 시 기본 doc 구조를 반환한다")
+    void get_returns_default_empty_doc() throws Exception {
+        mockMvc.perform(get("/api/planner/materials/{id}/note", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(note.getId()))
+                .andExpect(jsonPath("$.data.materialId").value(material.getId()))
+                .andExpect(jsonPath("$.data.content.type").value("doc"))
+                .andExpect(jsonPath("$.data.content.content").isArray());
+    }
+
+    private static final String HELLO_BODY = """
+            {"content":{"type":"doc","content":[
+              {"type":"paragraph","content":[{"type":"text","text":"hello"}]}
+            ]}}
+            """;
+
+    private static final String HELLO_KOR_BODY = """
+            {"content":{"type":"doc","content":[
+              {"type":"paragraph","content":[{"type":"text","text":"안녕"}]}
+            ]}}
+            """;
+
+    @Test
+    @DisplayName("PUT - 응답은 id/materialId/updatedAt 메타데이터만 반환한다")
+    void put_returns_metadata_only() throws Exception {
+        mockMvc.perform(put("/api/planner/materials/{id}/note", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(HELLO_BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(note.getId()))
+                .andExpect(jsonPath("$.data.materialId").value(material.getId()))
+                .andExpect(jsonPath("$.data.updatedAt").exists())
+                .andExpect(jsonPath("$.data.content").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("PUT 후 GET - 저장된 content가 반환된다")
+    void put_then_get_returns_updated_content() throws Exception {
+        mockMvc.perform(put("/api/planner/materials/{id}/note", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(HELLO_KOR_BODY))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/planner/materials/{id}/note", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.type").value("doc"))
+                .andExpect(jsonPath("$.data.content.content[0].type").value("paragraph"))
+                .andExpect(jsonPath("$.data.content.content[0].content[0].text").value("안녕"));
+    }
+
+    @Test
+    @DisplayName("PUT 멱등성 - 동일 content 두 번 저장해도 결과는 동일하다")
+    void put_idempotent() throws Exception {
+        String body = """
+                {"content":{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"x"}]}]}}
+                """;
+        mockMvc.perform(put("/api/planner/materials/{id}/note", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(put("/api/planner/materials/{id}/note", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/planner/materials/{id}/note", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.content.content[0].content[0].text").value("x"));
+    }
+
+    @Test
+    @DisplayName("PUT - 직렬화 1MB 초과 시 400 SP-ERR-002")
+    void put_oversize_returns_400() throws Exception {
+        String huge = "a".repeat(1024 * 1024 + 100);
+        String body = "{\"content\":{\"type\":\"doc\",\"content\":[{\"type\":\"text\",\"text\":\""
+                + huge + "\"}]}}";
+
+        mockMvc.perform(put("/api/planner/materials/{id}/note", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("GET - 타인 자료의 노트 조회 시 404")
+    void get_other_member_note_returns_404() throws Exception {
+        StudyMaterial otherMaterial = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+        noteRepository.save(new Note(otherMember.getId(), otherMaterial.getId()));
+
+        mockMvc.perform(get("/api/planner/materials/{id}/note", otherMaterial.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+    }
+
+    @Test
+    @DisplayName("PUT - 존재하지 않는 자료 ID는 404")
+    void put_nonexistent_material_returns_404() throws Exception {
+        mockMvc.perform(put("/api/planner/materials/{id}/note", 99999L)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"content":{"type":"doc","content":[]}}
+                                """))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
 
     // STUDY PLANNER
     RESOURCE_NOT_FOUND("SP-ERR-001", "존재하지 않는 리소스입니다.", 404),
+    INVALID_REQUEST("SP-ERR-002", "유효하지 않은 요청입니다.", 400),
     INVALID_STATE("SP-ERR-003", "현재 상태에서 수행할 수 없는 작업입니다.", 409);
 
     private final String code;


### PR DESCRIPTION
## 이슈
closes #366

## 작업 내용

### API
| 메서드 | 경로 | 응답 |
|---|---|---|
| GET | `/api/planner/materials/{materialId}/note` | 전체 NoteResponse (content 포함) |
| PUT | `/api/planner/materials/{materialId}/note` | 메타데이터만 (id, materialId, updatedAt) |

PUT 응답이 메타데이터만인 이유: FE가 2초 debounce로 빈번히 호출하므로 큰 Tiptap content를 매번 왕복시키지 않기 위함. 화면에 표시되는 건 클라이언트가 이미 가진 값.

### 구현
- `NoteService`
  - `findByMaterialId(memberId, materialId)` — note의 memberId 검증 (FK 우회 가능성)
  - `update(memberId, materialId, content)` — JsonNode 받아 JsonMapper로 직렬화 후 entity에 저장
- 자료 생성 시(#365) 이미 빈 노트가 만들어졌으므로 PUT은 항상 update 경로
- 멱등성: 동일 content를 N번 PUT해도 결과 동일

### 검증
- `content` 직렬화 후 UTF-8 byte 길이 > 1MB → `400 SP-ERR-002`
- 자료/노트 미존재 또는 타인 소유 → `404 SP-ERR-001`

### ErrorCode 추가
- `INVALID_REQUEST("SP-ERR-002", 400)` 신규
- 기존엔 GLB-ERR-001(BAD_REQUEST)만 있었음. Wiki API Spec의 Study Planner 에러코드 체계에 맞춰 SP-ERR-002를 분리

### Jackson 3
- `tools.jackson.databind.JsonNode` (Spring Boot 4 = Jackson 3)
- `JsonMapper.builder().build()` static 인스턴스 (#365와 동일 패턴)

## 검증
- [x] `./gradlew build` (checkstyle 포함, 통합 테스트 7건 추가) 통과
- [x] **로컬 bootRun + curl** 전체 라이프사이클:
  - GET 빈 노트 → `{"type":"doc","content":[]}`
  - PUT content → 메타데이터만 반환
  - GET → 저장된 content 반환
  - PUT 동일 content → 멱등 (응답 동일)
  - PUT 1MB+ payload → `400 SP-ERR-002`

## 후속
- #367 플래시카드 CRUD + 첫 복습 자동 생성
- #368 복습 평가 (SM-2)
- #369 오늘 복습 조회