### PR TITLE
feat : 플래시카드 CRUD + 카드 생성 시 첫 복습 자동 생성

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/controller/FlashcardController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/controller/FlashcardController.java
@@ -1,0 +1,65 @@
+package ds.project.orino.planner.flashcard.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.flashcard.dto.FlashcardCreateRequest;
+import ds.project.orino.planner.flashcard.dto.FlashcardCreateResponse;
+import ds.project.orino.planner.flashcard.dto.FlashcardListResponse;
+import ds.project.orino.planner.flashcard.dto.FlashcardResponse;
+import ds.project.orino.planner.flashcard.dto.FlashcardUpdateRequest;
+import ds.project.orino.planner.flashcard.service.FlashcardService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/planner")
+public class FlashcardController {
+
+    private final FlashcardService flashcardService;
+
+    public FlashcardController(FlashcardService flashcardService) {
+        this.flashcardService = flashcardService;
+    }
+
+    @GetMapping("/materials/{materialId}/flashcards")
+    public ApiResponse<FlashcardListResponse> list(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long materialId) {
+        return ApiResponse.success(new FlashcardListResponse(
+                flashcardService.findAllByMaterialId(memberId, materialId)));
+    }
+
+    @PostMapping("/materials/{materialId}/flashcards")
+    public ResponseEntity<ApiResponse<FlashcardCreateResponse>> create(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long materialId,
+            @Valid @RequestBody FlashcardCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(flashcardService.create(memberId, materialId, request)));
+    }
+
+    @PatchMapping("/flashcards/{id}")
+    public ApiResponse<FlashcardResponse> update(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @Valid @RequestBody FlashcardUpdateRequest request) {
+        return ApiResponse.success(flashcardService.update(memberId, id, request));
+    }
+
+    @DeleteMapping("/flashcards/{id}")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id) {
+        flashcardService.delete(memberId, id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardCreateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardCreateRequest.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.flashcard.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record FlashcardCreateRequest(
+        @NotBlank(message = "front는 비어 있을 수 없습니다.")
+        @Size(min = 1, max = 1000, message = "front는 1~1000자여야 합니다.")
+        String front,
+
+        @NotBlank(message = "back은 비어 있을 수 없습니다.")
+        @Size(min = 1, max = 1000, message = "back은 1~1000자여야 합니다.")
+        String back
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardCreateResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardCreateResponse.java
@@ -1,0 +1,9 @@
+package ds.project.orino.planner.flashcard.dto;
+
+import ds.project.orino.planner.review.dto.ReviewScheduleView;
+
+public record FlashcardCreateResponse(
+        FlashcardResponse flashcard,
+        ReviewScheduleView firstReview
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardListResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardListResponse.java
@@ -1,0 +1,6 @@
+package ds.project.orino.planner.flashcard.dto;
+
+import java.util.List;
+
+public record FlashcardListResponse(List<FlashcardResponse> flashcards) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardResponse.java
@@ -1,0 +1,29 @@
+package ds.project.orino.planner.flashcard.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.planner.review.dto.ReviewScheduleView;
+
+import java.time.LocalDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record FlashcardResponse(
+        Long id,
+        Long materialId,
+        String front,
+        String back,
+        ReviewScheduleView nextReview,
+        LocalDateTime createdAt
+) {
+    public static FlashcardResponse of(Flashcard f, ReviewScheduleView nextReview) {
+        return new FlashcardResponse(
+                f.getId(), f.getMaterialId(), f.getFront(), f.getBack(),
+                nextReview, f.getCreatedAt());
+    }
+
+    public static FlashcardResponse withoutReview(Flashcard f) {
+        return new FlashcardResponse(
+                f.getId(), f.getMaterialId(), f.getFront(), f.getBack(),
+                null, f.getCreatedAt());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardUpdateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardUpdateRequest.java
@@ -1,0 +1,12 @@
+package ds.project.orino.planner.flashcard.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record FlashcardUpdateRequest(
+        @Size(min = 1, max = 1000, message = "front는 1~1000자여야 합니다.")
+        String front,
+
+        @Size(min = 1, max = 1000, message = "back은 1~1000자여야 합니다.")
+        String back
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/service/FlashcardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/service/FlashcardService.java
@@ -1,0 +1,117 @@
+package ds.project.orino.planner.flashcard.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.planner.flashcard.dto.FlashcardCreateRequest;
+import ds.project.orino.planner.flashcard.dto.FlashcardCreateResponse;
+import ds.project.orino.planner.flashcard.dto.FlashcardResponse;
+import ds.project.orino.planner.flashcard.dto.FlashcardUpdateRequest;
+import ds.project.orino.planner.review.dto.ReviewScheduleView;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Transactional(readOnly = true)
+public class FlashcardService {
+
+    private final FlashcardRepository flashcardRepository;
+    private final ReviewScheduleRepository reviewScheduleRepository;
+    private final StudyMaterialRepository studyMaterialRepository;
+    private final Clock clock;
+
+    public FlashcardService(FlashcardRepository flashcardRepository,
+                            ReviewScheduleRepository reviewScheduleRepository,
+                            StudyMaterialRepository studyMaterialRepository,
+                            Clock clock) {
+        this.flashcardRepository = flashcardRepository;
+        this.reviewScheduleRepository = reviewScheduleRepository;
+        this.studyMaterialRepository = studyMaterialRepository;
+        this.clock = clock;
+    }
+
+    public List<FlashcardResponse> findAllByMaterialId(Long memberId, Long materialId) {
+        requireOwnedMaterial(memberId, materialId);
+
+        List<Flashcard> cards = flashcardRepository.findAllByMaterialIdOrderByCreatedAtAscIdAsc(materialId);
+        if (cards.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, ReviewSchedule> nextReviewByCard = loadNextReviewByCard(cards);
+        return cards.stream()
+                .map(c -> {
+                    ReviewSchedule next = nextReviewByCard.get(c.getId());
+                    return FlashcardResponse.of(c, next == null ? null : ReviewScheduleView.nextReview(next));
+                })
+                .toList();
+    }
+
+    @Transactional
+    public FlashcardCreateResponse create(Long memberId, Long materialId, FlashcardCreateRequest request) {
+        requireOwnedMaterial(memberId, materialId);
+
+        Flashcard saved = flashcardRepository.save(
+                new Flashcard(memberId, materialId, request.front(), request.back()));
+        LocalDate today = LocalDate.now(clock);
+        ReviewSchedule firstReview = reviewScheduleRepository.save(
+                ReviewSchedule.firstReview(memberId, saved.getId(), today));
+
+        return new FlashcardCreateResponse(
+                FlashcardResponse.withoutReview(saved),
+                ReviewScheduleView.firstReview(firstReview));
+    }
+
+    @Transactional
+    public FlashcardResponse update(Long memberId, Long flashcardId, FlashcardUpdateRequest request) {
+        if (request.front() == null && request.back() == null) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+        Flashcard card = getOwnedFlashcard(memberId, flashcardId);
+        if (request.front() != null) {
+            card.updateFront(request.front());
+        }
+        if (request.back() != null) {
+            card.updateBack(request.back());
+        }
+        return FlashcardResponse.withoutReview(card);
+    }
+
+    @Transactional
+    public void delete(Long memberId, Long flashcardId) {
+        Flashcard card = getOwnedFlashcard(memberId, flashcardId);
+        flashcardRepository.delete(card);
+    }
+
+    private void requireOwnedMaterial(Long memberId, Long materialId) {
+        studyMaterialRepository.findByIdAndMemberId(materialId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    private Flashcard getOwnedFlashcard(Long memberId, Long flashcardId) {
+        return flashcardRepository.findByIdAndMemberId(flashcardId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    private Map<Long, ReviewSchedule> loadNextReviewByCard(List<Flashcard> cards) {
+        List<Long> ids = cards.stream().map(Flashcard::getId).toList();
+        List<ReviewSchedule> reviews = reviewScheduleRepository
+                .findAllByFlashcardIdInAndStatusOrderByScheduledDateAscIdAsc(ids, ReviewStatus.PENDING);
+        Map<Long, ReviewSchedule> firstByCard = new HashMap<>();
+        for (ReviewSchedule r : reviews) {
+            firstByCard.putIfAbsent(r.getFlashcardId(), r);
+        }
+        return firstByCard;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewScheduleView.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewScheduleView.java
@@ -1,0 +1,33 @@
+package ds.project.orino.planner.review.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ReviewScheduleView(
+        Long id,
+        Long flashcardId,
+        Integer sequence,
+        LocalDate scheduledDate,
+        Integer intervalDays,
+        BigDecimal easeFactor,
+        ReviewStatus status
+) {
+    public static ReviewScheduleView nextReview(ReviewSchedule r) {
+        return new ReviewScheduleView(
+                r.getId(), null, r.getSequence(),
+                r.getScheduledDate(), r.getIntervalDays(), r.getEaseFactor(),
+                null);
+    }
+
+    public static ReviewScheduleView firstReview(ReviewSchedule r) {
+        return new ReviewScheduleView(
+                r.getId(), r.getFlashcardId(), r.getSequence(),
+                r.getScheduledDate(), r.getIntervalDays(), r.getEaseFactor(),
+                r.getStatus());
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/flashcard/controller/FlashcardControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/flashcard/controller/FlashcardControllerTest.java
@@ -1,0 +1,298 @@
+package ds.project.orino.planner.flashcard.controller;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDate;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class FlashcardControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Autowired
+    private FlashcardRepository flashcardRepository;
+
+    @Autowired
+    private ReviewScheduleRepository reviewScheduleRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    @Autowired
+    private Clock clock;
+
+    private Member member;
+    private Member otherMember;
+    private StudyMaterial material;
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        member = memberRepository.save(MemberFixture.create());
+        otherMember = memberRepository.save(MemberFixture.create("other", "password"));
+        material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "자료", MaterialType.BOOK));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    @Test
+    @DisplayName("POST - 카드 생성 + 첫 복습(sequence=1, today+1, 1일, 2.50) 자동 생성")
+    void create_with_first_review() throws Exception {
+        LocalDate today = LocalDate.now(clock);
+
+        mockMvc.perform(post("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"front":"Q","back":"A"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.flashcard.front").value("Q"))
+                .andExpect(jsonPath("$.data.flashcard.back").value("A"))
+                .andExpect(jsonPath("$.data.flashcard.materialId").value(material.getId()))
+                .andExpect(jsonPath("$.data.firstReview.sequence").value(1))
+                .andExpect(jsonPath("$.data.firstReview.intervalDays").value(1))
+                .andExpect(jsonPath("$.data.firstReview.easeFactor").value(2.50))
+                .andExpect(jsonPath("$.data.firstReview.status").value("PENDING"))
+                .andExpect(jsonPath("$.data.firstReview.scheduledDate").value(today.plusDays(1).toString()));
+    }
+
+    @Test
+    @DisplayName("POST - front 빈 문자열이면 400")
+    void create_blank_front() throws Exception {
+        mockMvc.perform(post("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"front":"","back":"A"}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST - front 1001자면 400")
+    void create_too_long_front() throws Exception {
+        String tooLong = "a".repeat(1001);
+        mockMvc.perform(post("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"front\":\"" + tooLong + "\",\"back\":\"A\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST - 타인 자료에 카드 생성 시 404")
+    void create_on_other_material_returns_404() throws Exception {
+        StudyMaterial otherMaterial = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+
+        mockMvc.perform(post("/api/planner/materials/{id}/flashcards", otherMaterial.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"front":"Q","back":"A"}
+                                """))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET - 카드 목록은 생성순으로 정렬되고 nextReview 포함")
+    void list_returns_cards_in_creation_order_with_next_review() throws Exception {
+        Flashcard card1 = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q1", "A1"));
+        Flashcard card2 = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q2", "A2"));
+        LocalDate today = LocalDate.now(clock);
+        reviewScheduleRepository.save(
+                new ReviewSchedule(member.getId(), card1.getId(), 1, today.plusDays(1), 1,
+                        new BigDecimal("2.50")));
+        reviewScheduleRepository.save(
+                new ReviewSchedule(member.getId(), card2.getId(), 1, today.plusDays(3), 1,
+                        new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.flashcards", hasSize(2)))
+                .andExpect(jsonPath("$.data.flashcards[0].id").value(card1.getId()))
+                .andExpect(jsonPath("$.data.flashcards[0].nextReview.sequence").value(1))
+                .andExpect(jsonPath("$.data.flashcards[0].nextReview.scheduledDate")
+                        .value(today.plusDays(1).toString()))
+                .andExpect(jsonPath("$.data.flashcards[1].id").value(card2.getId()))
+                .andExpect(jsonPath("$.data.flashcards[1].nextReview.scheduledDate")
+                        .value(today.plusDays(3).toString()));
+    }
+
+    @Test
+    @DisplayName("GET - 가장 가까운 PENDING이 nextReview로 선택된다 (COMPLETED 무시)")
+    void list_next_review_picks_earliest_pending() throws Exception {
+        Flashcard card = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
+        LocalDate today = LocalDate.now(clock);
+        jdbcTemplate.update("""
+                INSERT INTO review_schedule
+                  (member_id, flashcard_id, sequence, scheduled_date, interval_days,
+                   ease_factor, status, completed_at, created_at, updated_at)
+                VALUES (?, ?, 1, ?, 1, 2.50, 'COMPLETED', NOW(6), NOW(6), NOW(6))
+                """, member.getId(), card.getId(), today.minusDays(5));
+        reviewScheduleRepository.save(
+                new ReviewSchedule(member.getId(), card.getId(), 3, today.plusDays(10), 10,
+                        new BigDecimal("2.50")));
+        reviewScheduleRepository.save(
+                new ReviewSchedule(member.getId(), card.getId(), 2, today.plusDays(2), 2,
+                        new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.flashcards[0].nextReview.sequence").value(2))
+                .andExpect(jsonPath("$.data.flashcards[0].nextReview.scheduledDate")
+                        .value(today.plusDays(2).toString()));
+    }
+
+    @Test
+    @DisplayName("GET - PENDING 복습이 없는 카드는 nextReview가 null/omit")
+    void list_card_without_pending_review() throws Exception {
+        flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
+
+        mockMvc.perform(get("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.flashcards[0].nextReview").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET - 타인 자료 카드 목록 조회 시 404")
+    void list_other_material_returns_404() throws Exception {
+        StudyMaterial otherMaterial = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+
+        mockMvc.perform(get("/api/planner/materials/{id}/flashcards", otherMaterial.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("PATCH - front/back 부분 수정, 복습 일정에 영향 없음")
+    void update_does_not_affect_reviews() throws Exception {
+        Flashcard card = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
+        LocalDate today = LocalDate.now(clock);
+        ReviewSchedule review = reviewScheduleRepository.save(
+                new ReviewSchedule(member.getId(), card.getId(), 1, today.plusDays(1), 1,
+                        new BigDecimal("2.50")));
+
+        mockMvc.perform(patch("/api/planner/flashcards/{id}", card.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"front":"Q2"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.front").value("Q2"))
+                .andExpect(jsonPath("$.data.back").value("A"));
+
+        ReviewSchedule unchanged = reviewScheduleRepository.findById(review.getId()).orElseThrow();
+        org.assertj.core.api.Assertions.assertThat(unchanged.getScheduledDate()).isEqualTo(today.plusDays(1));
+        org.assertj.core.api.Assertions.assertThat(unchanged.getSequence()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("PATCH - 본문이 모두 null이면 400")
+    void update_empty_body_returns_400() throws Exception {
+        Flashcard card = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
+
+        mockMvc.perform(patch("/api/planner/flashcards/{id}", card.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PATCH - 타인 카드 수정 시 404")
+    void update_other_card_returns_404() throws Exception {
+        StudyMaterial otherMaterial = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+        Flashcard otherCard = flashcardRepository.save(
+                new Flashcard(otherMember.getId(), otherMaterial.getId(), "Q", "A"));
+
+        mockMvc.perform(patch("/api/planner/flashcards/{id}", otherCard.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"front":"X"}
+                                """))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("DELETE - 카드 삭제 시 관련 review_schedule이 cascade 삭제된다")
+    void delete_cascades_reviews() throws Exception {
+        Flashcard card = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
+        LocalDate today = LocalDate.now(clock);
+        reviewScheduleRepository.save(
+                new ReviewSchedule(member.getId(), card.getId(), 1, today.plusDays(1), 1,
+                        new BigDecimal("2.50")));
+        reviewScheduleRepository.save(
+                new ReviewSchedule(member.getId(), card.getId(), 2, today.plusDays(7), 7,
+                        new BigDecimal("2.50")));
+
+        mockMvc.perform(delete("/api/planner/flashcards/{id}", card.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNoContent());
+
+        Integer cardCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM flashcard WHERE id = ?", Integer.class, card.getId());
+        Integer reviewCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM review_schedule WHERE flashcard_id = ?", Integer.class, card.getId());
+
+        org.assertj.core.api.Assertions.assertThat(cardCount).isZero();
+        org.assertj.core.api.Assertions.assertThat(reviewCount).isZero();
+    }
+
+    @Test
+    @DisplayName("DELETE - 타인 카드 삭제 시 404")
+    void delete_other_card_returns_404() throws Exception {
+        StudyMaterial otherMaterial = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+        Flashcard otherCard = flashcardRepository.save(
+                new Flashcard(otherMember.getId(), otherMaterial.getId(), "Q", "A"));
+
+        mockMvc.perform(delete("/api/planner/flashcards/{id}", otherCard.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/entity/Flashcard.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/entity/Flashcard.java
@@ -1,0 +1,90 @@
+package ds.project.orino.domain.planner.flashcard.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "flashcard")
+public class Flashcard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "material_id", nullable = false)
+    private Long materialId;
+
+    @Column(nullable = false, length = 1000)
+    private String front;
+
+    @Column(nullable = false, length = 1000)
+    private String back;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected Flashcard() {
+    }
+
+    public Flashcard(Long memberId, Long materialId, String front, String back) {
+        this.memberId = memberId;
+        this.materialId = materialId;
+        this.front = front;
+        this.back = back;
+    }
+
+    public void updateFront(String front) {
+        this.front = front;
+    }
+
+    public void updateBack(String back) {
+        this.back = back;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Long getMaterialId() {
+        return materialId;
+    }
+
+    public String getFront() {
+        return front;
+    }
+
+    public String getBack() {
+        return back;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/repository/FlashcardRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/repository/FlashcardRepository.java
@@ -1,0 +1,14 @@
+package ds.project.orino.domain.planner.flashcard.repository;
+
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FlashcardRepository extends JpaRepository<Flashcard, Long> {
+
+    List<Flashcard> findAllByMaterialIdOrderByCreatedAtAscIdAsc(Long materialId);
+
+    Optional<Flashcard> findByIdAndMemberId(Long id, Long memberId);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/Rating.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/Rating.java
@@ -1,0 +1,8 @@
+package ds.project.orino.domain.planner.review.entity;
+
+public enum Rating {
+    AGAIN,
+    HARD,
+    GOOD,
+    EASY
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewSchedule.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewSchedule.java
@@ -1,0 +1,141 @@
+package ds.project.orino.domain.planner.review.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "review_schedule")
+public class ReviewSchedule {
+
+    public static final BigDecimal INITIAL_EASE_FACTOR = new BigDecimal("2.50");
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "flashcard_id", nullable = false)
+    private Long flashcardId;
+
+    @Column(nullable = false)
+    private Integer sequence;
+
+    @Column(name = "scheduled_date", nullable = false)
+    private LocalDate scheduledDate;
+
+    @Column(name = "interval_days", nullable = false)
+    private Integer intervalDays;
+
+    @Column(name = "ease_factor", nullable = false, precision = 4, scale = 2)
+    private BigDecimal easeFactor;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private ReviewStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10)
+    private Rating rating;
+
+    @Column(name = "elapsed_days")
+    private Integer elapsedDays;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected ReviewSchedule() {
+    }
+
+    public ReviewSchedule(Long memberId, Long flashcardId, int sequence,
+                          LocalDate scheduledDate, int intervalDays, BigDecimal easeFactor) {
+        this.memberId = memberId;
+        this.flashcardId = flashcardId;
+        this.sequence = sequence;
+        this.scheduledDate = scheduledDate;
+        this.intervalDays = intervalDays;
+        this.easeFactor = easeFactor;
+        this.status = ReviewStatus.PENDING;
+    }
+
+    public static ReviewSchedule firstReview(Long memberId, Long flashcardId, LocalDate today) {
+        return new ReviewSchedule(memberId, flashcardId, 1,
+                today.plusDays(1), 1, INITIAL_EASE_FACTOR);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Long getFlashcardId() {
+        return flashcardId;
+    }
+
+    public Integer getSequence() {
+        return sequence;
+    }
+
+    public LocalDate getScheduledDate() {
+        return scheduledDate;
+    }
+
+    public Integer getIntervalDays() {
+        return intervalDays;
+    }
+
+    public BigDecimal getEaseFactor() {
+        return easeFactor;
+    }
+
+    public ReviewStatus getStatus() {
+        return status;
+    }
+
+    public Rating getRating() {
+        return rating;
+    }
+
+    public Integer getElapsedDays() {
+        return elapsedDays;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewStatus.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewStatus.java
@@ -1,0 +1,6 @@
+package ds.project.orino.domain.planner.review.entity;
+
+public enum ReviewStatus {
+    PENDING,
+    COMPLETED
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
@@ -1,0 +1,14 @@
+package ds.project.orino.domain.planner.review.repository;
+
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, Long> {
+
+    List<ReviewSchedule> findAllByFlashcardIdInAndStatusOrderByScheduledDateAscIdAsc(
+            Collection<Long> flashcardIds, ReviewStatus status);
+}


### PR DESCRIPTION
## 이슈
closes #367

## 작업 내용

### Domain
- `Flashcard` 엔티티 — front/back VARCHAR(1000), materialId, memberId
- `ReviewSchedule` (v2) 엔티티 — flashcard_id 기반, sequence/scheduledDate/intervalDays/easeFactor/status/rating
- `ReviewStatus`(PENDING/COMPLETED), `Rating`(AGAIN/HARD/GOOD/EASY) enum — #363 롤백 시 제거된 것 v2 스펙으로 재도입
- `FlashcardRepository`, `ReviewScheduleRepository`

### API
| 메서드 | 경로 | 비고 |
|---|---|---|
| GET    | `/api/planner/materials/{materialId}/flashcards` | 생성순 + 카드별 `nextReview` 포함 |
| POST   | `/api/planner/materials/{materialId}/flashcards` | 카드 + 첫 복습 자동 생성, 응답에 `{flashcard, firstReview}` 동봉 |
| PATCH  | `/api/planner/flashcards/{id}` | front/back 부분 수정 (복습 영향 없음) |
| DELETE | `/api/planner/flashcards/{id}` | DB cascade로 review_schedule도 삭제 |

### 첫 복습 정책
`sequence=1, scheduledDate=today+1, intervalDays=1, easeFactor=2.50, status=PENDING`. today는 `Clock(Asia/Seoul)`.

### nextReview 일괄 조회
```java
findAllByFlashcardIdInAndStatusOrderByScheduledDateAscIdAsc(ids, PENDING)
```
한 번의 IN 쿼리로 모든 카드의 PENDING 복습을 가져온 뒤, 카드별로 첫 항목만 취해 N+1을 회피.

### 응답 DTO 형식
`ReviewScheduleView`는 `@JsonInclude(NON_NULL)`로 nextReview/firstReview를 한 record로 처리:
- **nextReview**: `{id, sequence, scheduledDate, intervalDays, easeFactor}` (flashcardId/status 생략)
- **firstReview**: `{id, flashcardId, sequence, scheduledDate, intervalDays, easeFactor, status}` (전체)

Wiki API Spec과 일치.

### 검증
- front/back 각각 `@NotBlank @Size(1,1000)`
- 타인 자료에 카드 생성 / 타인 카드 조회·수정·삭제 → `404 SP-ERR-001`
- PATCH 본문이 모두 null이면 `400`

## 검증
- [x] `./gradlew build` (checkstyle 포함, 14개 통합 테스트 신규) 통과
- [x] SchemaValidationTest로 엔티티 ↔ Liquibase 스키마 일치 확인
- [x] **로컬 bootRun + curl** 전 라이프사이클:
  - POST → `{flashcard, firstReview}` 응답, firstReview.scheduledDate = 내일 ✓
  - GET 목록 → `nextReview.id/sequence/scheduledDate/intervalDays/easeFactor`만 포함 (flashcardId/status 생략 확인) ✓
  - PATCH → front 갱신, 복습 일정 변화 없음 ✓
  - DELETE → 204, DB에서 flashcard + 모든 review_schedule cascade 삭제 확인 ✓

## 후속
- #368 복습 평가 (SM-2 다음 복습 자동 생성)
- #369 오늘 복습 조회 (preview 4지선다 포함)