### PR TITLE
feat : 복습 평가 API + SM-2 다음 복습 자동 생성

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
@@ -1,0 +1,32 @@
+package ds.project.orino.planner.review.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.review.dto.ReviewCompletionRequest;
+import ds.project.orino.planner.review.dto.ReviewCompletionResponse;
+import ds.project.orino.planner.review.service.ReviewCompletionService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/planner/reviews")
+public class ReviewController {
+
+    private final ReviewCompletionService reviewCompletionService;
+
+    public ReviewController(ReviewCompletionService reviewCompletionService) {
+        this.reviewCompletionService = reviewCompletionService;
+    }
+
+    @PostMapping("/{id}/complete")
+    public ApiResponse<ReviewCompletionResponse> complete(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @Valid @RequestBody ReviewCompletionRequest request) {
+        return ApiResponse.success(reviewCompletionService.complete(memberId, id, request));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CompletedReviewView.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CompletedReviewView.java
@@ -1,0 +1,21 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.review.entity.Rating;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+
+import java.time.LocalDateTime;
+
+public record CompletedReviewView(
+        Long id,
+        ReviewStatus status,
+        Rating rating,
+        Integer elapsedDays,
+        LocalDateTime completedAt
+) {
+    public static CompletedReviewView of(ReviewSchedule r) {
+        return new CompletedReviewView(
+                r.getId(), r.getStatus(), r.getRating(),
+                r.getElapsedDays(), r.getCompletedAt());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewCompletionRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewCompletionRequest.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.review.entity.Rating;
+import jakarta.validation.constraints.NotNull;
+
+public record ReviewCompletionRequest(
+        @NotNull(message = "rating은 필수입니다.")
+        Rating rating
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewCompletionResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewCompletionResponse.java
@@ -1,0 +1,7 @@
+package ds.project.orino.planner.review.dto;
+
+public record ReviewCompletionResponse(
+        CompletedReviewView completed,
+        ReviewScheduleView nextReview
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCompletionService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCompletionService.java
@@ -1,0 +1,58 @@
+package ds.project.orino.planner.review.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.planner.review.dto.CompletedReviewView;
+import ds.project.orino.planner.review.dto.ReviewCompletionRequest;
+import ds.project.orino.planner.review.dto.ReviewCompletionResponse;
+import ds.project.orino.planner.review.dto.ReviewScheduleView;
+import ds.project.orino.planner.review.sm2.Sm2Calculator;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+public class ReviewCompletionService {
+
+    private final ReviewScheduleRepository reviewScheduleRepository;
+    private final Clock clock;
+
+    public ReviewCompletionService(ReviewScheduleRepository reviewScheduleRepository, Clock clock) {
+        this.reviewScheduleRepository = reviewScheduleRepository;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public ReviewCompletionResponse complete(Long memberId, Long reviewId, ReviewCompletionRequest request) {
+        ReviewSchedule current = reviewScheduleRepository.findByIdAndMemberId(reviewId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (current.getStatus() != ReviewStatus.PENDING) {
+            throw new CustomException(ErrorCode.INVALID_STATE);
+        }
+
+        LocalDate today = LocalDate.now(clock);
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        int newSequence = current.getSequence() + 1;
+        Sm2Calculator.Result computed = Sm2Calculator.next(
+                newSequence, current.getIntervalDays(), current.getEaseFactor(), request.rating());
+
+        current.complete(request.rating(), today, now);
+
+        ReviewSchedule next = reviewScheduleRepository.save(new ReviewSchedule(
+                memberId, current.getFlashcardId(), newSequence,
+                today.plusDays(computed.intervalDays()), computed.intervalDays(),
+                computed.easeFactor()));
+
+        return new ReviewCompletionResponse(
+                CompletedReviewView.of(current),
+                ReviewScheduleView.firstReview(next));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/sm2/Sm2Calculator.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/sm2/Sm2Calculator.java
@@ -1,0 +1,55 @@
+package ds.project.orino.planner.review.sm2;
+
+import ds.project.orino.domain.planner.review.entity.Rating;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public final class Sm2Calculator {
+
+    public static final BigDecimal MIN_EASE = new BigDecimal("1.30");
+
+    private Sm2Calculator() {
+    }
+
+    public record Result(int intervalDays, BigDecimal easeFactor) {
+    }
+
+    public static Result next(int newSequence, int prevIntervalDays, BigDecimal prevEase, Rating rating) {
+        int q = qScore(rating);
+
+        if (q < 3) {
+            BigDecimal newEase = clampEase(prevEase.subtract(new BigDecimal("0.20")));
+            return new Result(1, newEase);
+        }
+
+        int intervalDays;
+        if (newSequence == 1) {
+            intervalDays = 1;
+        } else if (newSequence == 2) {
+            intervalDays = 6;
+        } else {
+            intervalDays = (int) Math.round(prevIntervalDays * prevEase.doubleValue());
+        }
+
+        double diff = 5 - q;
+        double delta = 0.1 - diff * (0.08 + diff * 0.02);
+        BigDecimal newEase = clampEase(
+                prevEase.add(BigDecimal.valueOf(delta).setScale(2, RoundingMode.HALF_UP)));
+
+        return new Result(intervalDays, newEase);
+    }
+
+    private static int qScore(Rating rating) {
+        return switch (rating) {
+            case AGAIN -> 0;
+            case HARD -> 3;
+            case GOOD -> 4;
+            case EASY -> 5;
+        };
+    }
+
+    private static BigDecimal clampEase(BigDecimal value) {
+        return value.compareTo(MIN_EASE) < 0 ? MIN_EASE : value.setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
@@ -1,0 +1,254 @@
+package ds.project.orino.planner.review.controller;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ReviewControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Autowired
+    private FlashcardRepository flashcardRepository;
+
+    @Autowired
+    private ReviewScheduleRepository reviewScheduleRepository;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    @Autowired
+    private Clock clock;
+
+    private Member member;
+    private Member otherMember;
+    private Flashcard card;
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        member = memberRepository.save(MemberFixture.create());
+        otherMember = memberRepository.save(MemberFixture.create("other", "password"));
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "자료", MaterialType.BOOK));
+        card = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    @Test
+    @DisplayName("POST complete - GOOD 평가 시 현재 review COMPLETED + 다음 review 생성")
+    void complete_good_creates_next_review() throws Exception {
+        LocalDate today = LocalDate.now(clock);
+        ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 1, today.minusDays(1), 1,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating":"GOOD"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.completed.id").value(current.getId()))
+                .andExpect(jsonPath("$.data.completed.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.data.completed.rating").value("GOOD"))
+                .andExpect(jsonPath("$.data.completed.elapsedDays").value(1))
+                .andExpect(jsonPath("$.data.completed.completedAt").exists())
+                .andExpect(jsonPath("$.data.nextReview.flashcardId").value(card.getId()))
+                .andExpect(jsonPath("$.data.nextReview.sequence").value(2))
+                .andExpect(jsonPath("$.data.nextReview.scheduledDate").value(today.plusDays(6).toString()))
+                .andExpect(jsonPath("$.data.nextReview.intervalDays").value(6))
+                .andExpect(jsonPath("$.data.nextReview.easeFactor").value(2.50))
+                .andExpect(jsonPath("$.data.nextReview.status").value("PENDING"));
+
+        List<ReviewSchedule> all = reviewScheduleRepository.findAll();
+        assertThat(all).hasSize(2);
+        ReviewSchedule completed = all.stream()
+                .filter(r -> r.getId().equals(current.getId()))
+                .findFirst().orElseThrow();
+        assertThat(completed.getStatus()).isEqualTo(ReviewStatus.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("POST complete - AGAIN 평가 시 interval=1, ease -0.20")
+    void complete_again() throws Exception {
+        LocalDate today = LocalDate.now(clock);
+        ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 2, today, 6,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating":"AGAIN"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nextReview.intervalDays").value(1))
+                .andExpect(jsonPath("$.data.nextReview.scheduledDate").value(today.plusDays(1).toString()))
+                .andExpect(jsonPath("$.data.nextReview.easeFactor").value(2.30));
+    }
+
+    @Test
+    @DisplayName("POST complete - EASY 평가 시 ease +0.10")
+    void complete_easy() throws Exception {
+        LocalDate today = LocalDate.now(clock);
+        ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 2, today, 6,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating":"EASY"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nextReview.easeFactor").value(2.60));
+    }
+
+    @Test
+    @DisplayName("POST complete - 이미 COMPLETED 인 경우 409 SP-ERR-003")
+    void complete_already_completed_returns_409() throws Exception {
+        LocalDate today = LocalDate.now(clock);
+        ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 1, today.minusDays(1), 1,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating":"GOOD"}
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating":"GOOD"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("SP-ERR-003"));
+    }
+
+    @Test
+    @DisplayName("POST complete - 타인 review 평가 시 404")
+    void complete_other_member_returns_404() throws Exception {
+        StudyMaterial otherMaterial = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+        Flashcard otherCard = flashcardRepository.save(
+                new Flashcard(otherMember.getId(), otherMaterial.getId(), "Q", "A"));
+        LocalDate today = LocalDate.now(clock);
+        ReviewSchedule otherReview = reviewScheduleRepository.save(new ReviewSchedule(
+                otherMember.getId(), otherCard.getId(), 1, today, 1,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", otherReview.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating":"GOOD"}
+                                """))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("POST complete - rating 누락 시 400")
+    void complete_missing_rating_returns_400() throws Exception {
+        LocalDate today = LocalDate.now(clock);
+        ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 1, today, 1,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST complete - elapsedDays는 (today - scheduledDate)로 음수 가능")
+    void complete_elapsed_days_can_be_negative_for_early_review() throws Exception {
+        LocalDate today = LocalDate.now(clock);
+        ReviewSchedule earlyReview = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 1, today.plusDays(2), 1,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", earlyReview.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating":"GOOD"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.completed.elapsedDays").value(-2));
+    }
+
+    @Test
+    @DisplayName("4번 연속 GOOD 평가 - sequence 1→2→3→4→5, scheduledDate가 모두 today+interval로 산정")
+    void complete_four_consecutive_good_evaluations() throws Exception {
+        LocalDate today = LocalDate.now(clock);
+        ReviewSchedule firstReview = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 1, today, 1,
+                new BigDecimal("2.50")));
+
+        Long currentId = firstReview.getId();
+        int[] expectedIntervals = {6, 15, 38, 95};
+
+        for (int i = 0; i < 4; i++) {
+            int expectedInterval = expectedIntervals[i];
+            int expectedSequence = i + 2;
+
+            String body = mockMvc.perform(post("/api/planner/reviews/{id}/complete", currentId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"rating":"GOOD"}
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.nextReview.sequence").value(expectedSequence))
+                    .andExpect(jsonPath("$.data.nextReview.intervalDays").value(expectedInterval))
+                    .andExpect(jsonPath("$.data.nextReview.scheduledDate")
+                            .value(today.plusDays(expectedInterval).toString()))
+                    .andReturn().getResponse().getContentAsString();
+            Number nextId = com.jayway.jsonpath.JsonPath.read(body, "$.data.nextReview.id");
+            currentId = nextId.longValue();
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/sm2/Sm2CalculatorTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/sm2/Sm2CalculatorTest.java
@@ -1,0 +1,102 @@
+package ds.project.orino.planner.review.sm2;
+
+import ds.project.orino.domain.planner.review.entity.Rating;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Sm2CalculatorTest {
+
+    private static final BigDecimal INITIAL_EASE = new BigDecimal("2.50");
+
+    @Nested
+    @DisplayName("AGAIN 평가")
+    class Again {
+
+        @Test
+        @DisplayName("interval=1, ease는 -0.20")
+        void interval_and_ease() {
+            Sm2Calculator.Result r = Sm2Calculator.next(2, 1, INITIAL_EASE, Rating.AGAIN);
+
+            assertThat(r.intervalDays()).isEqualTo(1);
+            assertThat(r.easeFactor()).isEqualByComparingTo("2.30");
+        }
+
+        @Test
+        @DisplayName("ease는 1.30 미만으로 떨어지지 않는다 (클램프)")
+        void ease_clamps_at_min() {
+            Sm2Calculator.Result r = Sm2Calculator.next(5, 30,
+                    new BigDecimal("1.40"), Rating.AGAIN);
+
+            assertThat(r.easeFactor()).isEqualByComparingTo("1.30");
+        }
+    }
+
+    @Nested
+    @DisplayName("HARD 평가")
+    class Hard {
+
+        @Test
+        @DisplayName("sequence 2 → interval=6, ease는 약간 감소 (-0.14)")
+        void seq2() {
+            Sm2Calculator.Result r = Sm2Calculator.next(2, 1, INITIAL_EASE, Rating.HARD);
+
+            assertThat(r.intervalDays()).isEqualTo(6);
+            assertThat(r.easeFactor()).isEqualByComparingTo("2.36");
+        }
+
+        @Test
+        @DisplayName("sequence 3+ → round(prevInterval * prevEase)")
+        void seq3_plus() {
+            Sm2Calculator.Result r = Sm2Calculator.next(3, 6, INITIAL_EASE, Rating.HARD);
+
+            assertThat(r.intervalDays()).isEqualTo(15);
+        }
+    }
+
+    @Nested
+    @DisplayName("GOOD 평가")
+    class Good {
+
+        @Test
+        @DisplayName("ease 유지")
+        void ease_unchanged() {
+            Sm2Calculator.Result r = Sm2Calculator.next(3, 6, INITIAL_EASE, Rating.GOOD);
+
+            assertThat(r.easeFactor()).isEqualByComparingTo("2.50");
+        }
+
+        @ParameterizedTest(name = "sequence={0}, prevInterval={1} → interval={2}")
+        @CsvSource({
+                "1, 0, 1",
+                "2, 1, 6",
+                "3, 6, 15",
+                "4, 15, 38"
+        })
+        @DisplayName("sequence별 다음 interval")
+        void intervals(int newSeq, int prevInterval, int expected) {
+            Sm2Calculator.Result r = Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.GOOD);
+
+            assertThat(r.intervalDays()).isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("EASY 평가")
+    class Easy {
+
+        @Test
+        @DisplayName("ease는 +0.10")
+        void ease_increases() {
+            Sm2Calculator.Result r = Sm2Calculator.next(3, 6, INITIAL_EASE, Rating.EASY);
+
+            assertThat(r.easeFactor()).isEqualByComparingTo("2.60");
+        }
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewSchedule.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewSchedule.java
@@ -87,6 +87,13 @@ public class ReviewSchedule {
                 today.plusDays(1), 1, INITIAL_EASE_FACTOR);
     }
 
+    public void complete(Rating rating, LocalDate today, LocalDateTime now) {
+        this.status = ReviewStatus.COMPLETED;
+        this.rating = rating;
+        this.elapsedDays = (int) java.time.temporal.ChronoUnit.DAYS.between(this.scheduledDate, today);
+        this.completedAt = now;
+    }
+
     public Long getId() {
         return id;
     }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, Long> {
 
     List<ReviewSchedule> findAllByFlashcardIdInAndStatusOrderByScheduledDateAscIdAsc(
             Collection<Long> flashcardIds, ReviewStatus status);
+
+    Optional<ReviewSchedule> findByIdAndMemberId(Long id, Long memberId);
 }


### PR DESCRIPTION
## 이슈
closes #368

## 작업 내용

### SM-2 도메인 (pure logic)
`Sm2Calculator.next(newSequence, prevInterval, prevEase, rating) → Result(intervalDays, easeFactor)`

| Rating | q | 동작 |
|---|---|---|
| AGAIN | 0 | interval=1, ease -= 0.20 (1.30 클램프) |
| HARD  | 3 | sequence별 interval, ease -= 0.14 |
| GOOD  | 4 | sequence별 interval, ease 유지 |
| EASY  | 5 | sequence별 interval, ease += 0.10 |

Sequence별 interval (q≥3):
- `newSeq == 1` → 1 (사용되지 않음 — 첫 복습은 카드 생성 시 고정)
- `newSeq == 2` → 6
- `newSeq >= 3` → `round(prevInterval * prevEase)`

유닛 테스트 9건 — sequence별 분기, ease 증감, 클램프.

### API
| 메서드 | 경로 |
|---|---|
| POST | `/api/planner/reviews/{id}/complete` |

요청:
```json
{ "rating": "AGAIN" | "HARD" | "GOOD" | "EASY" }
```

응답:
```json
{
  "completed": { "id", "status": "COMPLETED", "rating", "elapsedDays", "completedAt" },
  "nextReview": { "id", "flashcardId", "sequence", "scheduledDate", "intervalDays", "easeFactor", "status": "PENDING" }
}
```

### 핵심 규칙
- `nextReview.scheduledDate = today + intervalDays` (※ `prevScheduled + interval` 아님)
  - 늦게 복습해도 다음 일정이 따라잡힘
- `elapsedDays = today - scheduledDate` — 조기 복습 시 음수 가능
- 이미 COMPLETED 인 review를 다시 평가 → `409 SP-ERR-003 (INVALID_STATE)`
- 타인 review → `404 SP-ERR-001`
- 단일 `@Transactional` — 현재 review 업데이트 + 다음 review 생성을 원자적으로

### 엔티티 변경
- `ReviewSchedule.complete(rating, today, now)` — status/rating/elapsedDays/completedAt를 한 번에 갱신
- `ReviewScheduleRepository.findByIdAndMemberId` — ownership 조회

## 검증
- [x] `./gradlew build` (checkstyle 포함) 통과
- [x] SM-2 유닛 테스트 9건 (Nested AGAIN/HARD/GOOD/EASY + parameterized sequence)
- [x] 통합 테스트 8건 — GOOD/AGAIN/EASY 평가 결과, 멱등성 (409), 음수 elapsedDays, 4번 연속 GOOD (sequence 1→2→3→4→5, interval 1→6→15→38→95), 타인 권한 404, rating 누락 400
- [x] **로컬 bootRun + curl**:
  - 첫 GOOD 평가 → sequence=2, intervalDays=6, scheduledDate=today+6, easeFactor=2.50, status=PENDING ✓
  - 같은 review 재평가 → `409 SP-ERR-003` ✓
  - 잘못된 rating(WRONG) → `400` ✓

## 후속
- #369 오늘 복습 조회 (preview 4지선다 포함)
- FE #370~#374