### PR TITLE
feat : 오늘 복습 조회 API + preview 4지 미리보기

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
@@ -3,9 +3,12 @@ package ds.project.orino.planner.review.controller;
 import ds.project.orino.common.response.ApiResponse;
 import ds.project.orino.planner.review.dto.ReviewCompletionRequest;
 import ds.project.orino.planner.review.dto.ReviewCompletionResponse;
+import ds.project.orino.planner.review.dto.TodayReviewsResponse;
 import ds.project.orino.planner.review.service.ReviewCompletionService;
+import ds.project.orino.planner.review.service.ReviewQueryService;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,9 +20,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReviewController {
 
     private final ReviewCompletionService reviewCompletionService;
+    private final ReviewQueryService reviewQueryService;
 
-    public ReviewController(ReviewCompletionService reviewCompletionService) {
+    public ReviewController(ReviewCompletionService reviewCompletionService,
+                            ReviewQueryService reviewQueryService) {
         this.reviewCompletionService = reviewCompletionService;
+        this.reviewQueryService = reviewQueryService;
+    }
+
+    @GetMapping("/today")
+    public ApiResponse<TodayReviewsResponse> today(@AuthenticationPrincipal Long memberId) {
+        return ApiResponse.success(reviewQueryService.findToday(memberId));
     }
 
     @PostMapping("/{id}/complete")

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/PreviewView.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/PreviewView.java
@@ -1,0 +1,9 @@
+package ds.project.orino.planner.review.dto;
+
+public record PreviewView(
+        int again,
+        int hard,
+        int good,
+        int easy
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewFlashcard.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewFlashcard.java
@@ -1,0 +1,14 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+
+public record TodayReviewFlashcard(
+        Long id,
+        String front,
+        String back,
+        TodayReviewMaterial material
+) {
+    public static TodayReviewFlashcard of(Flashcard f, TodayReviewMaterial material) {
+        return new TodayReviewFlashcard(f.getId(), f.getFront(), f.getBack(), material);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewItem.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewItem.java
@@ -1,0 +1,16 @@
+package ds.project.orino.planner.review.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record TodayReviewItem(
+        Long id,
+        LocalDate scheduledDate,
+        int delayDays,
+        int sequence,
+        int intervalDays,
+        BigDecimal easeFactor,
+        TodayReviewFlashcard flashcard,
+        PreviewView preview
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewMaterial.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewMaterial.java
@@ -1,0 +1,14 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+
+public record TodayReviewMaterial(
+        Long id,
+        String title,
+        MaterialType type
+) {
+    public static TodayReviewMaterial of(StudyMaterial m) {
+        return new TodayReviewMaterial(m.getId(), m.getTitle(), m.getType());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewsResponse.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.review.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record TodayReviewsResponse(
+        LocalDate today,
+        List<TodayReviewItem> reviews
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
@@ -1,0 +1,97 @@
+package ds.project.orino.planner.review.service;
+
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.Rating;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.planner.review.dto.PreviewView;
+import ds.project.orino.planner.review.dto.TodayReviewFlashcard;
+import ds.project.orino.planner.review.dto.TodayReviewItem;
+import ds.project.orino.planner.review.dto.TodayReviewMaterial;
+import ds.project.orino.planner.review.dto.TodayReviewsResponse;
+import ds.project.orino.planner.review.sm2.Sm2Calculator;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class ReviewQueryService {
+
+    private final ReviewScheduleRepository reviewScheduleRepository;
+    private final FlashcardRepository flashcardRepository;
+    private final StudyMaterialRepository studyMaterialRepository;
+    private final Clock clock;
+
+    public ReviewQueryService(ReviewScheduleRepository reviewScheduleRepository,
+                              FlashcardRepository flashcardRepository,
+                              StudyMaterialRepository studyMaterialRepository,
+                              Clock clock) {
+        this.reviewScheduleRepository = reviewScheduleRepository;
+        this.flashcardRepository = flashcardRepository;
+        this.studyMaterialRepository = studyMaterialRepository;
+        this.clock = clock;
+    }
+
+    public TodayReviewsResponse findToday(Long memberId) {
+        LocalDate today = LocalDate.now(clock);
+
+        List<ReviewSchedule> reviews = reviewScheduleRepository
+                .findAllByMemberIdAndStatusAndScheduledDateLessThanEqualOrderByScheduledDateAscIdAsc(
+                        memberId, ReviewStatus.PENDING, today);
+
+        if (reviews.isEmpty()) {
+            return new TodayReviewsResponse(today, List.of());
+        }
+
+        List<Long> flashcardIds = reviews.stream().map(ReviewSchedule::getFlashcardId).distinct().toList();
+        Map<Long, Flashcard> cardById = flashcardRepository.findAllByIdIn(flashcardIds).stream()
+                .collect(Collectors.toMap(Flashcard::getId, Function.identity()));
+
+        List<Long> materialIds = cardById.values().stream()
+                .map(Flashcard::getMaterialId).distinct().toList();
+        Map<Long, StudyMaterial> materialById = studyMaterialRepository.findAllByIdIn(materialIds).stream()
+                .collect(Collectors.toMap(StudyMaterial::getId, Function.identity()));
+
+        List<TodayReviewItem> items = reviews.stream()
+                .map(r -> toItem(r, cardById, materialById, today))
+                .toList();
+
+        return new TodayReviewsResponse(today, items);
+    }
+
+    private TodayReviewItem toItem(ReviewSchedule r,
+                                   Map<Long, Flashcard> cardById,
+                                   Map<Long, StudyMaterial> materialById,
+                                   LocalDate today) {
+        Flashcard card = cardById.get(r.getFlashcardId());
+        StudyMaterial material = materialById.get(card.getMaterialId());
+        TodayReviewFlashcard flashcardDto = TodayReviewFlashcard.of(card, TodayReviewMaterial.of(material));
+        PreviewView preview = preview(r);
+        int delayDays = (int) ChronoUnit.DAYS.between(r.getScheduledDate(), today);
+        return new TodayReviewItem(
+                r.getId(), r.getScheduledDate(), delayDays,
+                r.getSequence(), r.getIntervalDays(), r.getEaseFactor(),
+                flashcardDto, preview);
+    }
+
+    private PreviewView preview(ReviewSchedule r) {
+        int newSeq = r.getSequence() + 1;
+        return new PreviewView(
+                Sm2Calculator.next(newSeq, r.getIntervalDays(), r.getEaseFactor(), Rating.AGAIN).intervalDays(),
+                Sm2Calculator.next(newSeq, r.getIntervalDays(), r.getEaseFactor(), Rating.HARD).intervalDays(),
+                Sm2Calculator.next(newSeq, r.getIntervalDays(), r.getEaseFactor(), Rating.GOOD).intervalDays(),
+                Sm2Calculator.next(newSeq, r.getIntervalDays(), r.getEaseFactor(), Rating.EASY).intervalDays());
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsControllerTest.java
@@ -1,0 +1,182 @@
+package ds.project.orino.planner.review.controller;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDate;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class TodayReviewsControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Autowired
+    private FlashcardRepository flashcardRepository;
+
+    @Autowired
+    private ReviewScheduleRepository reviewScheduleRepository;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    @Autowired
+    private Clock clock;
+
+    private Member member;
+    private Member otherMember;
+    private StudyMaterial material;
+    private Flashcard card;
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        member = memberRepository.save(MemberFixture.create());
+        otherMember = memberRepository.save(MemberFixture.create("other", "password"));
+        material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "이펙티브 자바", MaterialType.BOOK));
+        card = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    @Test
+    @DisplayName("GET today - PENDING이 없으면 빈 배열, today 필드는 채워짐")
+    void empty_returns_today_and_empty_list() throws Exception {
+        LocalDate today = LocalDate.now(clock);
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.today").value(today.toString()))
+                .andExpect(jsonPath("$.data.reviews", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("GET today - scheduledDate <= today AND status=PENDING 만 반환, 정렬 ASC")
+    void returns_pending_due_today_or_overdue_sorted() throws Exception {
+        LocalDate today = LocalDate.now(clock);
+        ReviewSchedule overdue = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 2, today.minusDays(2), 6,
+                new BigDecimal("2.50")));
+        ReviewSchedule dueToday = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 3, today, 15,
+                new BigDecimal("2.50")));
+        reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 4, today.plusDays(3), 3,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews", hasSize(2)))
+                .andExpect(jsonPath("$.data.reviews[0].id").value(overdue.getId()))
+                .andExpect(jsonPath("$.data.reviews[0].delayDays").value(2))
+                .andExpect(jsonPath("$.data.reviews[1].id").value(dueToday.getId()))
+                .andExpect(jsonPath("$.data.reviews[1].delayDays").value(0));
+    }
+
+    @Test
+    @DisplayName("GET today - flashcard + material을 한 응답에 동봉")
+    void embeds_flashcard_and_material() throws Exception {
+        LocalDate today = LocalDate.now(clock);
+        reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 1, today, 1,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.id").value(card.getId()))
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.front").value("Q"))
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.back").value("A"))
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.material.id").value(material.getId()))
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.material.title").value("이펙티브 자바"))
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.material.type").value("BOOK"));
+    }
+
+    @Test
+    @DisplayName("GET today - preview 4지가 SM-2와 일치 (sequence=2 기준)")
+    void preview_matches_sm2() throws Exception {
+        LocalDate today = LocalDate.now(clock);
+        reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 2, today, 6,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews[0].preview.again").value(1))
+                .andExpect(jsonPath("$.data.reviews[0].preview.hard").value(15))
+                .andExpect(jsonPath("$.data.reviews[0].preview.good").value(15))
+                .andExpect(jsonPath("$.data.reviews[0].preview.easy").value(15));
+    }
+
+    @Test
+    @DisplayName("GET today - 타인 review는 제외된다")
+    void excludes_other_members_reviews() throws Exception {
+        LocalDate today = LocalDate.now(clock);
+        StudyMaterial otherMaterial = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+        Flashcard otherCard = flashcardRepository.save(
+                new Flashcard(otherMember.getId(), otherMaterial.getId(), "Q2", "A2"));
+        reviewScheduleRepository.save(new ReviewSchedule(
+                otherMember.getId(), otherCard.getId(), 1, today, 1,
+                new BigDecimal("2.50")));
+        reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 1, today, 1,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews", hasSize(1)))
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.front").value("Q"));
+    }
+
+    @Test
+    @DisplayName("GET today - COMPLETED 는 제외된다")
+    void excludes_completed_reviews() throws Exception {
+        LocalDate today = LocalDate.now(clock);
+        ReviewSchedule pending = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 2, today, 6,
+                new BigDecimal("2.50")));
+        ReviewSchedule completed = new ReviewSchedule(
+                member.getId(), card.getId(), 1, today.minusDays(5), 1,
+                new BigDecimal("2.50"));
+        completed.complete(ds.project.orino.domain.planner.review.entity.Rating.GOOD,
+                today, java.time.LocalDateTime.now(clock));
+        reviewScheduleRepository.save(completed);
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews", hasSize(1)))
+                .andExpect(jsonPath("$.data.reviews[0].id").value(pending.getId()));
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/repository/FlashcardRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/repository/FlashcardRepository.java
@@ -3,6 +3,7 @@ package ds.project.orino.domain.planner.flashcard.repository;
 import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,4 +12,6 @@ public interface FlashcardRepository extends JpaRepository<Flashcard, Long> {
     List<Flashcard> findAllByMaterialIdOrderByCreatedAtAscIdAsc(Long materialId);
 
     Optional<Flashcard> findByIdAndMemberId(Long id, Long memberId);
+
+    List<Flashcard> findAllByIdIn(Collection<Long> ids);
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepository.java
@@ -19,6 +19,8 @@ public interface StudyMaterialRepository extends JpaRepository<StudyMaterial, Lo
 
     Optional<StudyMaterial> findByIdAndMemberId(Long id, Long memberId);
 
+    List<StudyMaterial> findAllByIdIn(Collection<Long> ids);
+
     interface MaterialCountRow {
         Long getMaterialId();
         Long getCount();

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
@@ -4,6 +4,7 @@ import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
 import ds.project.orino.domain.planner.review.entity.ReviewStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -14,4 +15,7 @@ public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, 
             Collection<Long> flashcardIds, ReviewStatus status);
 
     Optional<ReviewSchedule> findByIdAndMemberId(Long id, Long memberId);
+
+    List<ReviewSchedule> findAllByMemberIdAndStatusAndScheduledDateLessThanEqualOrderByScheduledDateAscIdAsc(
+            Long memberId, ReviewStatus status, LocalDate scheduledDate);
 }


### PR DESCRIPTION
## 이슈
closes #369

## 작업 내용

### API
`GET /api/planner/reviews/today`

응답:
```json
{
  "today": "2026-05-18",
  "reviews": [{
    "id": 95, "scheduledDate": "2026-05-15", "delayDays": 3,
    "sequence": 2, "intervalDays": 6, "easeFactor": 2.50,
    "flashcard": { "id": 11, "front": "...", "back": "...",
                   "material": { "id": 1, "title": "...", "type": "BOOK" } },
    "preview": { "again": 1, "hard": 4, "good": 6, "easy": 8 }
  }]
}
```

### 핵심 동작
- 조건: `member=me AND scheduled_date <= today AND status=PENDING`
- 정렬: `scheduled_date ASC, id ASC`
- `delayDays = today - scheduledDate` (0=정시, >0=밀린 일수)
- `flashcard.back` 동봉 — 화면에서 답 공개 시 추가 API 호출 없이 즉시 표시
- `preview`: `Sm2Calculator.next(seq+1, prevInterval, prevEase, rating)` 4회 호출하여 각 평가별 다음 interval 일수 미리보기 제공 → FE가 평가 버튼 위에 표시

### N+1 회피
1. PENDING reviews 한 번에 조회
2. 거기서 추출한 flashcardIds로 `findAllByIdIn`
3. 추출한 materialIds로 `findAllByIdIn`

총 3쿼리. 일일 ~20건 미만이라 페이지네이션 없음.

### 테스트
- 6건 통합 테스트
  - 빈 결과
  - 오늘+밀린 혼합 정렬 (`delayDays` 정확)
  - flashcard + material 임베드
  - preview 4지가 Sm2Calculator와 일치 (sequence=2, ease=2.50 케이스)
  - 타인 review 제외
  - COMPLETED 제외

### Repo 확장
- `ReviewScheduleRepository.findAllByMemberIdAndStatusAndScheduledDateLessThanEqualOrderByScheduledDateAscIdAsc`
- `FlashcardRepository.findAllByIdIn`
- `StudyMaterialRepository.findAllByIdIn`

## 검증
- [x] `./gradlew build` (checkstyle 포함) 통과
- [x] **로컬 bootRun + curl**
  - 빈 상태 → `{today, reviews: []}` ✓
  - 3일 지연 review 1건 → delayDays=3, preview {again:1, hard:6, good:6, easy:6} (sequence=1 → newSeq=2 → 6일 고정) ✓

## 후속 (B안 BE 완료)
- #370~#374 FE 5건