### PR TITLE
feat : Planner v2 라우팅 + 사이드바 (오늘 복습 뱃지 + 모바일 햄버거)

### DIFF
--- a/fe/src/app/layout/AppLayout.test.tsx
+++ b/fe/src/app/layout/AppLayout.test.tsx
@@ -1,13 +1,17 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
 import { Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { Providers } from "@/app/providers";
 import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
 import { renderWithRouter } from "@/test/render";
 
 import { AppLayout } from "./AppLayout";
+
+const API_BASE = "https://api.orino.dev/api";
 
 function renderLayout(initialEntries: string[] = ["/home"]) {
   return renderWithRouter(
@@ -15,11 +19,47 @@ function renderLayout(initialEntries: string[] = ["/home"]) {
       <Routes>
         <Route element={<AppLayout />}>
           <Route path="/home" element={<div>홈 컨텐츠</div>} />
+          <Route
+            path="/planner/materials"
+            element={<div>자료 목록 컨텐츠</div>}
+          />
+          <Route
+            path="/planner/reviews/today"
+            element={<div>오늘 복습 컨텐츠</div>}
+          />
         </Route>
         <Route path="/" element={<div>랜딩 페이지</div>} />
       </Routes>
     </Providers>,
     { initialEntries },
+  );
+}
+
+function mockTodayReviews(count: number) {
+  server.use(
+    http.get(`${API_BASE}/planner/reviews/today`, () => {
+      return HttpResponse.json({
+        code: "OK",
+        data: {
+          today: "2026-05-18",
+          reviews: Array.from({ length: count }, (_, i) => ({
+            id: i + 1,
+            scheduledDate: "2026-05-18",
+            delayDays: 0,
+            sequence: 1,
+            intervalDays: 1,
+            easeFactor: 2.5,
+            flashcard: {
+              id: 1,
+              front: "Q",
+              back: "A",
+              material: { id: 1, title: "M", type: "BOOK" },
+            },
+            preview: { again: 1, hard: 6, good: 6, easy: 6 },
+          })),
+        },
+      });
+    }),
   );
 }
 
@@ -29,6 +69,7 @@ describe("AppLayout", () => {
   });
 
   it("헤더에 로고와 로그아웃 버튼이 렌더링된다", async () => {
+    mockTodayReviews(0);
     renderLayout();
     await waitFor(() => {
       expect(screen.getByText("orino")).toBeInTheDocument();
@@ -38,14 +79,64 @@ describe("AppLayout", () => {
     ).toBeInTheDocument();
   });
 
-  it("사이드바에 홈 메뉴가 있다", async () => {
+  it("사이드바에 홈/학습 자료/오늘 복습 메뉴가 있다", async () => {
+    mockTodayReviews(0);
     renderLayout();
     await waitFor(() => {
       expect(screen.getByRole("link", { name: /홈/ })).toBeInTheDocument();
     });
+    expect(screen.getByRole("link", { name: /학습 자료/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /오늘 복습/ })).toBeInTheDocument();
+  });
+
+  it("자료 목록 메뉴 클릭 시 /planner/materials로 이동한다", async () => {
+    mockTodayReviews(0);
+    const user = userEvent.setup();
+    renderLayout();
+    await waitFor(() => {
+      expect(screen.getByText("홈 컨텐츠")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("link", { name: /학습 자료/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("자료 목록 컨텐츠")).toBeInTheDocument();
+    });
+  });
+
+  it("미완료 복습이 3건이면 사이드바에 뱃지를 표시한다", async () => {
+    mockTodayReviews(3);
+    renderLayout();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("미완료 3건")).toBeInTheDocument();
+    });
+  });
+
+  it("미완료 복습이 0건이면 뱃지를 표시하지 않는다", async () => {
+    mockTodayReviews(0);
+    renderLayout();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /오늘 복습/ }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText(/미완료 \d+건/)).not.toBeInTheDocument();
+  });
+
+  it("모바일 햄버거 버튼이 헤더에 존재한다", async () => {
+    mockTodayReviews(0);
+    renderLayout();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /메뉴 열기/ }),
+      ).toBeInTheDocument();
+    });
   });
 
   it("로그아웃 클릭 시 토큰이 제거되고 /로 이동한다", async () => {
+    mockTodayReviews(0);
     const user = userEvent.setup();
     renderLayout();
 

--- a/fe/src/app/layout/AppLayout.tsx
+++ b/fe/src/app/layout/AppLayout.tsx
@@ -1,5 +1,6 @@
-import { LogOut, Moon, Sun } from "lucide-react";
-import { Outlet, useNavigate } from "react-router-dom";
+import { LogOut, Menu, Moon, Sun } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
 
 import { Toaster } from "@/components/Toaster";
 import { Button } from "@/components/ui/button";
@@ -13,6 +14,12 @@ export function AppLayout() {
   const navigate = useNavigate();
   const { refresh } = useAuth();
   const { theme, setTheme } = useThemeStore();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    setMobileMenuOpen(false);
+  }, [pathname]);
 
   const handleLogout = async () => {
     await logout();
@@ -33,7 +40,18 @@ export function AppLayout() {
   return (
     <div className="flex min-h-svh flex-col">
       <header className="flex items-center justify-between border-b px-6 py-3">
-        <span className="text-base font-semibold">orino</span>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="md:hidden"
+            aria-label="메뉴 열기"
+            onClick={() => setMobileMenuOpen(true)}
+          >
+            <Menu className="size-4" />
+          </Button>
+          <span className="text-base font-semibold">orino</span>
+        </div>
         <div className="flex items-center gap-1">
           <Button variant="ghost" size="icon-sm" onClick={toggleTheme}>
             <Sun className="size-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
@@ -46,7 +64,10 @@ export function AppLayout() {
         </div>
       </header>
       <div className="flex flex-1">
-        <Sidebar />
+        <Sidebar
+          open={mobileMenuOpen}
+          onClose={() => setMobileMenuOpen(false)}
+        />
         <main className="flex-1 p-6">
           <Outlet />
         </main>

--- a/fe/src/app/layout/Sidebar.tsx
+++ b/fe/src/app/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
-import { Home } from "lucide-react";
+import { BookOpen, CheckSquare, Home } from "lucide-react";
 import { NavLink } from "react-router-dom";
 
+import { useTodayReviews } from "@/features/review/hooks/useTodayReviews";
 import { cn } from "@/lib/utils";
 
 interface NavItem {
@@ -9,40 +10,76 @@ interface NavItem {
   icon: typeof Home;
 }
 
-const NAV_ITEMS: NavItem[] = [{ to: "/home", label: "홈", icon: Home }];
+const NAV_ITEMS: NavItem[] = [
+  { to: "/home", label: "홈", icon: Home },
+  { to: "/planner/materials", label: "학습 자료", icon: BookOpen },
+  { to: "/planner/reviews/today", label: "오늘 복습", icon: CheckSquare },
+];
 
-export function Sidebar() {
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function Sidebar({ open, onClose }: SidebarProps) {
+  const { data } = useTodayReviews();
+  const reviewCount = data?.reviews.length ?? 0;
+
   return (
-    <nav
-      aria-label="주 메뉴"
-      className="border-border bg-background w-56 shrink-0 border-r"
-    >
-      <ul className="flex flex-col gap-0.5 p-2">
-        {NAV_ITEMS.map((item) => {
-          const Icon = item.icon;
-          return (
-            <li key={item.to}>
-              <NavLink
-                to={item.to}
-                end={item.to === "/home"}
-                className={({ isActive }) =>
-                  cn(
-                    "flex h-9 items-center justify-between rounded-md px-3 text-sm font-medium transition-colors",
-                    isActive
-                      ? "bg-primary/10 text-primary"
-                      : "text-foreground/70 hover:bg-muted hover:text-foreground",
-                  )
-                }
-              >
-                <span className="flex items-center gap-2">
-                  <Icon className="size-4" />
-                  {item.label}
-                </span>
-              </NavLink>
-            </li>
-          );
-        })}
-      </ul>
-    </nav>
+    <>
+      {open && (
+        <button
+          type="button"
+          aria-label="사이드바 닫기"
+          className="bg-foreground/40 fixed inset-0 z-40 md:hidden"
+          onClick={onClose}
+        />
+      )}
+      <nav
+        aria-label="주 메뉴"
+        className={cn(
+          "border-border bg-background w-56 shrink-0 border-r",
+          "fixed inset-y-0 left-0 z-50 transition-transform",
+          "md:static md:translate-x-0",
+          open ? "translate-x-0" : "-translate-x-full md:translate-x-0",
+        )}
+      >
+        <ul className="flex flex-col gap-0.5 p-2">
+          {NAV_ITEMS.map((item) => {
+            const Icon = item.icon;
+            const isReviewItem = item.to === "/planner/reviews/today";
+            return (
+              <li key={item.to}>
+                <NavLink
+                  to={item.to}
+                  end={item.to === "/home"}
+                  className={({ isActive }) =>
+                    cn(
+                      "flex h-9 items-center justify-between rounded-md px-3 text-sm font-medium transition-colors",
+                      isActive
+                        ? "bg-primary/10 text-primary"
+                        : "text-foreground/70 hover:bg-muted hover:text-foreground",
+                    )
+                  }
+                >
+                  <span className="flex items-center gap-2">
+                    <Icon className="size-4" />
+                    {item.label}
+                  </span>
+                  {isReviewItem && reviewCount > 0 && (
+                    <span
+                      aria-label={`미완료 ${reviewCount}건`}
+                      className="bg-primary text-primary-foreground inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-xs font-semibold"
+                    >
+                      {reviewCount}
+                    </span>
+                  )}
+                </NavLink>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </>
   );
 }

--- a/fe/src/app/router.test.tsx
+++ b/fe/src/app/router.test.tsx
@@ -10,6 +10,17 @@ import { AppRouter } from "./router";
 
 const API_BASE = "https://api.orino.dev/api";
 
+function mockEmptyTodayReviews() {
+  server.use(
+    http.get(`${API_BASE}/planner/reviews/today`, () => {
+      return HttpResponse.json({
+        code: "OK",
+        data: { today: "2026-05-18", reviews: [] },
+      });
+    }),
+  );
+}
+
 function renderApp(initialEntries: string[]) {
   return renderWithRouter(
     <Providers>
@@ -41,6 +52,7 @@ describe("AppRouter", () => {
   });
 
   it("/login 경로에서 인증 시 /home으로 리다이렉트한다", async () => {
+    mockEmptyTodayReviews();
     useAuthStore.setState({ accessToken: "valid-token" });
 
     renderApp(["/login"]);
@@ -67,6 +79,7 @@ describe("AppRouter", () => {
   });
 
   it("/home 경로에서 인증 시 홈 페이지를 렌더링한다", async () => {
+    mockEmptyTodayReviews();
     useAuthStore.setState({ accessToken: "valid-token" });
 
     renderApp(["/home"]);
@@ -77,6 +90,45 @@ describe("AppRouter", () => {
       ).toBeInTheDocument();
     });
     expect(screen.getByText("안녕하세요 👋")).toBeInTheDocument();
+  });
+
+  it("/planner/materials 경로에서 자료 목록 stub을 렌더링한다", async () => {
+    mockEmptyTodayReviews();
+    useAuthStore.setState({ accessToken: "valid-token" });
+
+    renderApp(["/planner/materials"]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "학습 자료" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("/planner/materials/:id 경로에서 자료 상세 stub을 렌더링한다", async () => {
+    mockEmptyTodayReviews();
+    useAuthStore.setState({ accessToken: "valid-token" });
+
+    renderApp(["/planner/materials/42"]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "자료 상세" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("/planner/reviews/today 경로에서 오늘 복습 stub을 렌더링한다", async () => {
+    mockEmptyTodayReviews();
+    useAuthStore.setState({ accessToken: "valid-token" });
+
+    renderApp(["/planner/reviews/today"]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "오늘 복습" }),
+      ).toBeInTheDocument();
+    });
   });
 
   it("정의되지 않은 경로는 /로 리다이렉트된다", async () => {

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -5,6 +5,9 @@ import { PublicRoute } from "../features/auth/components/PublicRoute";
 import { HomePage } from "../pages/HomePage";
 import { LandingPage } from "../pages/LandingPage";
 import { LoginPage } from "../pages/LoginPage";
+import { MaterialDetailPage } from "../pages/planner/MaterialDetailPage";
+import { MaterialListPage } from "../pages/planner/MaterialListPage";
+import { TodayReviewsPage } from "../pages/planner/TodayReviewsPage";
 import { AppLayout } from "./layout/AppLayout";
 
 export function AppRouter() {
@@ -17,6 +20,12 @@ export function AppRouter() {
       <Route element={<PrivateRoute />}>
         <Route element={<AppLayout />}>
           <Route path="/home" element={<HomePage />} />
+          <Route path="/planner/materials" element={<MaterialListPage />} />
+          <Route
+            path="/planner/materials/:id"
+            element={<MaterialDetailPage />}
+          />
+          <Route path="/planner/reviews/today" element={<TodayReviewsPage />} />
         </Route>
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/fe/src/features/review/api/reviews.ts
+++ b/fe/src/features/review/api/reviews.ts
@@ -1,0 +1,51 @@
+import { client } from "@/shared/api";
+
+export type Rating = "AGAIN" | "HARD" | "GOOD" | "EASY";
+
+export interface TodayReviewMaterial {
+  id: number;
+  title: string;
+  type: "BOOK" | "LECTURE" | "WORKBOOK" | "MOOC";
+}
+
+export interface TodayReviewFlashcard {
+  id: number;
+  front: string;
+  back: string;
+  material: TodayReviewMaterial;
+}
+
+export interface PreviewView {
+  again: number;
+  hard: number;
+  good: number;
+  easy: number;
+}
+
+export interface TodayReview {
+  id: number;
+  scheduledDate: string;
+  delayDays: number;
+  sequence: number;
+  intervalDays: number;
+  easeFactor: number;
+  flashcard: TodayReviewFlashcard;
+  preview: PreviewView;
+}
+
+export interface TodayReviewsResponse {
+  today: string;
+  reviews: TodayReview[];
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export async function fetchTodayReviews(): Promise<TodayReviewsResponse> {
+  const { data } = await client.get<ApiEnvelope<TodayReviewsResponse>>(
+    "/planner/reviews/today",
+  );
+  return data.data;
+}

--- a/fe/src/features/review/hooks/useTodayReviews.ts
+++ b/fe/src/features/review/hooks/useTodayReviews.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchTodayReviews } from "../api/reviews";
+import { reviewKeys } from "../queryKeys";
+
+export function useTodayReviews() {
+  return useQuery({
+    queryKey: reviewKeys.today,
+    queryFn: fetchTodayReviews,
+    staleTime: 60 * 1000,
+  });
+}

--- a/fe/src/features/review/queryKeys.ts
+++ b/fe/src/features/review/queryKeys.ts
@@ -1,0 +1,4 @@
+export const reviewKeys = {
+  all: ["reviews"] as const,
+  today: ["reviews", "today"] as const,
+};

--- a/fe/src/pages/planner/MaterialDetailPage.tsx
+++ b/fe/src/pages/planner/MaterialDetailPage.tsx
@@ -1,0 +1,8 @@
+export function MaterialDetailPage() {
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-xl font-semibold">자료 상세</h1>
+      <p className="text-muted-foreground text-sm">곧 만나요.</p>
+    </div>
+  );
+}

--- a/fe/src/pages/planner/MaterialListPage.tsx
+++ b/fe/src/pages/planner/MaterialListPage.tsx
@@ -1,0 +1,8 @@
+export function MaterialListPage() {
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-xl font-semibold">학습 자료</h1>
+      <p className="text-muted-foreground text-sm">곧 만나요.</p>
+    </div>
+  );
+}

--- a/fe/src/pages/planner/TodayReviewsPage.tsx
+++ b/fe/src/pages/planner/TodayReviewsPage.tsx
@@ -1,0 +1,8 @@
+export function TodayReviewsPage() {
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-xl font-semibold">오늘 복습</h1>
+      <p className="text-muted-foreground text-sm">곧 만나요.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## 이슈
closes #370

## 작업 내용

### 라우트 (`/planner/*`)
| 경로 | 페이지 |
|---|---|
| `/planner/materials` | MaterialListPage (stub) |
| `/planner/materials/:id` | MaterialDetailPage (stub) |
| `/planner/reviews/today` | TodayReviewsPage (stub) |

실제 화면은 후속 이슈(#371~#374)에서 구현. 본 이슈는 라우팅 + 사이드바 + 뱃지 기반만 깔아둠.

### 사이드바
- 메뉴: 🏠 홈 / 📚 학습 자료 / 📝 오늘 복습
- **뱃지**: `GET /api/planner/reviews/today` 결과 길이, 0이면 미표시
- React Query (`queryKey: ["reviews", "today"]`, `staleTime: 60s`)
- 후속 이슈에서 복습 평가 시 동일 키로 invalidate 가능

### 모바일 (md 미만)
- 헤더에 햄버거 버튼 (`md:hidden`)
- 사이드바는 `fixed inset-y-0 left-0` 슬라이드인 + backdrop 오버레이
- 라우트 이동 시 자동 닫기 (AppLayout `useEffect` watch `pathname`)
- 데스크탑(md+)에서는 `md:static` 항상 표시

### `features/review/`
- `api/reviews.ts` — 타입 + `fetchTodayReviews`
- `hooks/useTodayReviews` — React Query 훅
- `queryKeys` — 공용 키 (invalidate 용)

## 검증
- [x] `npx tsc -b --noEmit` / `npm run lint` / `npm run format:check` / `npm run build` 통과
- [x] `npm test` 54개 통과 (AppLayout 7건, AppRouter 9건 등)
- [x] **로컬 dev 서버 + Playwright**
  - 데스크탑: 3개 메뉴 정상 표시, 오늘 복습 뱃지 "1" 표시 (BE에 PENDING review 1건 있을 때)
  - 메뉴 클릭 → 해당 stub 페이지 렌더 확인
  - 모바일 (375x667): 햄버거 표시 → 클릭 → 사이드바 슬라이드인 + backdrop 표시 → 메뉴 클릭 → 사이드바 자동 닫기

### 구현 노트
- 사이드바 자동 닫기 로직을 처음엔 Sidebar 내부 `useEffect`에 두었으나 `onClose` 인라인 함수가 매 렌더마다 새 ref → 즉시 close되는 버그가 있어, AppLayout에서 `pathname` 변화를 직접 감시하는 형태로 정리

## 후속
- #371 학습 자료 목록 화면
- #372 자료 상세 - 노트 탭
- #373 자료 상세 - 카드 탭
- #374 오늘 복습 화면