### PR TITLE
feat : 학습 자료 목록 화면 + 자료 추가 다이얼로그

### DIFF
--- a/fe/src/features/material/api/materials.ts
+++ b/fe/src/features/material/api/materials.ts
@@ -1,0 +1,68 @@
+import { client } from "@/shared/api";
+
+export type MaterialType = "BOOK" | "LECTURE" | "WORKBOOK" | "MOOC";
+export type MaterialStatus = "ACTIVE" | "COMPLETED";
+
+export interface Material {
+  id: number;
+  title: string;
+  type: MaterialType;
+  status: MaterialStatus;
+  flashcardCount: number;
+  dueReviewCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MaterialListResponse {
+  materials: Material[];
+}
+
+export interface NoteContent {
+  type: string;
+  content: unknown[];
+}
+
+export interface Note {
+  id: number;
+  materialId: number;
+  content: NoteContent;
+  updatedAt: string;
+}
+
+export interface MaterialCreateResponse {
+  material: Material;
+  note: Note;
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export async function fetchMaterials(
+  status?: MaterialStatus,
+): Promise<Material[]> {
+  const { data } = await client.get<ApiEnvelope<MaterialListResponse>>(
+    "/planner/materials",
+    {
+      params: status ? { status } : undefined,
+    },
+  );
+  return data.data.materials;
+}
+
+export interface MaterialCreateRequest {
+  title: string;
+  type: MaterialType;
+}
+
+export async function createMaterial(
+  request: MaterialCreateRequest,
+): Promise<MaterialCreateResponse> {
+  const { data } = await client.post<ApiEnvelope<MaterialCreateResponse>>(
+    "/planner/materials",
+    request,
+  );
+  return data.data;
+}

--- a/fe/src/features/material/components/AddMaterialDialog.tsx
+++ b/fe/src/features/material/components/AddMaterialDialog.tsx
@@ -1,0 +1,160 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { Select } from "@base-ui/react/select";
+import { Check, ChevronDown } from "lucide-react";
+import { useEffect, useId, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+import type { MaterialType } from "../api/materials";
+import { useCreateMaterial } from "../hooks/useCreateMaterial";
+import { MATERIAL_TYPE_ICONS, MATERIAL_TYPE_LABELS } from "../utils";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated?: (materialId: number) => void;
+}
+
+const TYPE_OPTIONS: MaterialType[] = ["BOOK", "LECTURE", "WORKBOOK", "MOOC"];
+
+export function AddMaterialDialog({ open, onOpenChange, onCreated }: Props) {
+  const titleId = useId();
+  const typeLabelId = useId();
+  const [title, setTitle] = useState("");
+  const [type, setType] = useState<MaterialType>("BOOK");
+  const mutation = useCreateMaterial();
+
+  useEffect(() => {
+    if (open) {
+      setTitle("");
+      setType("BOOK");
+      mutation.reset();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const trimmedTitle = title.trim();
+  const titleValid = trimmedTitle.length >= 1 && trimmedTitle.length <= 200;
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!titleValid || mutation.isPending) return;
+    mutation.mutate(
+      { title: trimmedTitle, type },
+      {
+        onSuccess: (data) => {
+          onOpenChange(false);
+          onCreated?.(data.material.id);
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
+        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+          <Dialog.Title className="text-base font-semibold">
+            학습 자료 추가
+          </Dialog.Title>
+
+          <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-4">
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor={titleId} className="text-sm font-medium">
+                제목
+              </label>
+              <Input
+                id={titleId}
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="예: 이펙티브 자바"
+                maxLength={200}
+                autoFocus
+              />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <span id={typeLabelId} className="text-sm font-medium">
+                유형
+              </span>
+              <Select.Root
+                value={type}
+                onValueChange={(value) => setType(value as MaterialType)}
+              >
+                <Select.Trigger
+                  aria-labelledby={typeLabelId}
+                  className="border-input bg-background focus-visible:ring-ring/30 flex h-9 items-center justify-between gap-2 rounded-md border px-3 text-sm shadow-xs focus-visible:ring-2 focus-visible:outline-none"
+                >
+                  <Select.Value>
+                    {(value) => {
+                      const t = value as MaterialType;
+                      return (
+                        <span>
+                          {MATERIAL_TYPE_ICONS[t]} {MATERIAL_TYPE_LABELS[t]}
+                        </span>
+                      );
+                    }}
+                  </Select.Value>
+                  <Select.Icon>
+                    <ChevronDown className="size-4 opacity-60" />
+                  </Select.Icon>
+                </Select.Trigger>
+                <Select.Portal>
+                  <Select.Positioner sideOffset={4} className="z-50">
+                    <Select.Popup className="bg-popover text-popover-foreground min-w-(--anchor-width) overflow-hidden rounded-md border p-1 shadow-md">
+                      {TYPE_OPTIONS.map((value) => (
+                        <Select.Item
+                          key={value}
+                          value={value}
+                          className="data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground flex cursor-pointer items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm outline-none"
+                        >
+                          <Select.ItemText>
+                            <span>
+                              {MATERIAL_TYPE_ICONS[value]}{" "}
+                              {MATERIAL_TYPE_LABELS[value]}
+                            </span>
+                          </Select.ItemText>
+                          <Select.ItemIndicator>
+                            <Check className="size-3.5" />
+                          </Select.ItemIndicator>
+                        </Select.Item>
+                      ))}
+                    </Select.Popup>
+                  </Select.Positioner>
+                </Select.Portal>
+              </Select.Root>
+            </div>
+
+            {mutation.isError && (
+              <p className="text-destructive text-sm">
+                자료를 추가하지 못했어요. 잠시 후 다시 시도해주세요.
+              </p>
+            )}
+
+            <div className="mt-1 flex justify-end gap-2">
+              <Dialog.Close
+                render={
+                  <Button
+                    variant="ghost"
+                    type="button"
+                    disabled={mutation.isPending}
+                  >
+                    취소
+                  </Button>
+                }
+              />
+              <Button
+                type="submit"
+                disabled={!titleValid || mutation.isPending}
+              >
+                {mutation.isPending ? "추가 중..." : "추가"}
+              </Button>
+            </div>
+          </form>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/fe/src/features/material/components/EmptyMaterialState.tsx
+++ b/fe/src/features/material/components/EmptyMaterialState.tsx
@@ -1,0 +1,20 @@
+import { Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  onAdd: () => void;
+}
+
+export function EmptyMaterialState({ onAdd }: Props) {
+  return (
+    <div className="flex min-h-[40svh] flex-col items-center justify-center gap-4 text-center">
+      <p className="text-muted-foreground text-sm">
+        아직 등록된 학습 자료가 없습니다.
+      </p>
+      <Button onClick={onAdd}>
+        <Plus className="size-4" /> 첫 자료 추가
+      </Button>
+    </div>
+  );
+}

--- a/fe/src/features/material/components/MaterialCard.tsx
+++ b/fe/src/features/material/components/MaterialCard.tsx
@@ -1,0 +1,51 @@
+import { Link } from "react-router-dom";
+
+import { Card, CardContent } from "@/components/ui/card";
+
+import type { Material } from "../api/materials";
+import { MATERIAL_TYPE_ICONS, MATERIAL_TYPE_LABELS } from "../utils";
+
+interface Props {
+  material: Material;
+}
+
+export function MaterialCard({ material }: Props) {
+  return (
+    <Link
+      to={`/planner/materials/${material.id}?tab=note`}
+      className="block focus:outline-none"
+      aria-label={`${material.title} 상세 열기`}
+    >
+      <Card className="hover:bg-muted/40 transition-colors">
+        <CardContent className="flex items-center gap-4">
+          <span
+            aria-hidden
+            className="text-3xl leading-none"
+            title={MATERIAL_TYPE_LABELS[material.type]}
+          >
+            {MATERIAL_TYPE_ICONS[material.type]}
+          </span>
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <h2 className="truncate text-base font-medium">{material.title}</h2>
+            <div className="text-muted-foreground flex flex-wrap gap-x-3 text-xs">
+              <span>{MATERIAL_TYPE_LABELS[material.type]}</span>
+              <span>카드 {material.flashcardCount}장</span>
+              <span>
+                오늘 복습{" "}
+                <span
+                  className={
+                    material.dueReviewCount > 0
+                      ? "text-primary font-medium"
+                      : undefined
+                  }
+                >
+                  {material.dueReviewCount}건
+                </span>
+              </span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/fe/src/features/material/hooks/useCreateMaterial.ts
+++ b/fe/src/features/material/hooks/useCreateMaterial.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  createMaterial,
+  type MaterialCreateRequest,
+  type MaterialCreateResponse,
+} from "../api/materials";
+import { materialKeys } from "../queryKeys";
+
+export function useCreateMaterial() {
+  const queryClient = useQueryClient();
+  return useMutation<MaterialCreateResponse, Error, MaterialCreateRequest>({
+    mutationFn: createMaterial,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: materialKeys.all });
+    },
+  });
+}

--- a/fe/src/features/material/hooks/useMaterials.ts
+++ b/fe/src/features/material/hooks/useMaterials.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchMaterials, type MaterialStatus } from "../api/materials";
+import { materialKeys } from "../queryKeys";
+
+export function useMaterials(status?: MaterialStatus) {
+  return useQuery({
+    queryKey: materialKeys.list(status),
+    queryFn: () => fetchMaterials(status),
+  });
+}

--- a/fe/src/features/material/queryKeys.ts
+++ b/fe/src/features/material/queryKeys.ts
@@ -1,0 +1,8 @@
+export const materialKeys = {
+  all: ["materials"] as const,
+  list: (status?: string) =>
+    status
+      ? (["materials", "list", status] as const)
+      : (["materials", "list"] as const),
+  detail: (id: number) => ["materials", "detail", id] as const,
+};

--- a/fe/src/features/material/utils.ts
+++ b/fe/src/features/material/utils.ts
@@ -1,0 +1,15 @@
+import type { MaterialType } from "./api/materials";
+
+export const MATERIAL_TYPE_ICONS: Record<MaterialType, string> = {
+  BOOK: "📕",
+  LECTURE: "🎬",
+  WORKBOOK: "📘",
+  MOOC: "🎓",
+};
+
+export const MATERIAL_TYPE_LABELS: Record<MaterialType, string> = {
+  BOOK: "책",
+  LECTURE: "강의",
+  WORKBOOK: "문제집",
+  MOOC: "MOOC",
+};

--- a/fe/src/pages/planner/MaterialListPage.test.tsx
+++ b/fe/src/pages/planner/MaterialListPage.test.tsx
@@ -1,0 +1,205 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { MaterialListPage } from "./MaterialListPage";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function renderPage(initialEntries: string[] = ["/planner/materials"]) {
+  return renderWithRouter(
+    <Providers>
+      <Routes>
+        <Route path="/planner/materials" element={<MaterialListPage />} />
+        <Route
+          path="/planner/materials/:id"
+          element={<div>자료 상세 페이지</div>}
+        />
+      </Routes>
+    </Providers>,
+    { initialEntries },
+  );
+}
+
+function mockListEmpty() {
+  server.use(
+    http.get(`${API_BASE}/planner/materials`, () => {
+      return HttpResponse.json({
+        code: "OK",
+        data: { materials: [] },
+      });
+    }),
+  );
+}
+
+function mockListWith(
+  ...materials: Array<{
+    id: number;
+    title: string;
+    type?: string;
+    flashcardCount?: number;
+    dueReviewCount?: number;
+  }>
+) {
+  server.use(
+    http.get(`${API_BASE}/planner/materials`, () => {
+      return HttpResponse.json({
+        code: "OK",
+        data: {
+          materials: materials.map((m) => ({
+            id: m.id,
+            title: m.title,
+            type: m.type ?? "BOOK",
+            status: "ACTIVE",
+            flashcardCount: m.flashcardCount ?? 0,
+            dueReviewCount: m.dueReviewCount ?? 0,
+            createdAt: "2026-05-18T00:00:00",
+            updatedAt: "2026-05-18T00:00:00",
+          })),
+        },
+      });
+    }),
+  );
+}
+
+describe("MaterialListPage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+  });
+
+  it("빈 목록일 때 빈 상태 메시지와 [첫 자료 추가] 버튼을 표시한다", async () => {
+    mockListEmpty();
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("아직 등록된 학습 자료가 없습니다."),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: /첫 자료 추가/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("자료가 있으면 카드 목록을 표시하고 카드 수/오늘 복습 수를 보여준다", async () => {
+    mockListWith(
+      { id: 1, title: "이펙티브 자바", flashcardCount: 24, dueReviewCount: 3 },
+      {
+        id: 2,
+        title: "스프링 강의",
+        type: "LECTURE",
+        flashcardCount: 0,
+        dueReviewCount: 0,
+      },
+    );
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("이펙티브 자바")).toBeInTheDocument();
+    });
+    expect(screen.getByText("스프링 강의")).toBeInTheDocument();
+    expect(screen.getByText("카드 24장")).toBeInTheDocument();
+    expect(screen.getByText("3건")).toBeInTheDocument();
+  });
+
+  it("자료 카드 클릭 시 /planner/materials/:id?tab=note로 이동한다", async () => {
+    mockListWith({ id: 42, title: "테스트 자료" });
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("테스트 자료")).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("link", { name: /테스트 자료 상세 열기/ }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("자료 상세 페이지")).toBeInTheDocument();
+    });
+  });
+
+  it("[자료 추가] 다이얼로그를 열어 자료 생성 후 상세로 이동한다", async () => {
+    mockListEmpty();
+    server.use(
+      http.post(`${API_BASE}/planner/materials`, async ({ request }) => {
+        const body = (await request.json()) as { title: string; type: string };
+        expect(body.title).toBe("새 자료");
+        expect(body.type).toBe("BOOK");
+        return HttpResponse.json(
+          {
+            code: "OK",
+            data: {
+              material: {
+                id: 99,
+                title: body.title,
+                type: body.type,
+                status: "ACTIVE",
+                flashcardCount: 0,
+                dueReviewCount: 0,
+                createdAt: "2026-05-18T00:00:00",
+                updatedAt: "2026-05-18T00:00:00",
+              },
+              note: {
+                id: 99,
+                materialId: 99,
+                content: { type: "doc", content: [] },
+                updatedAt: "2026-05-18T00:00:00",
+              },
+            },
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("아직 등록된 학습 자료가 없습니다."),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /첫 자료 추가/ }));
+    expect(
+      await screen.findByRole("dialog", { name: /학습 자료 추가/ }),
+    ).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("제목"), "새 자료");
+    await user.click(screen.getByRole("button", { name: "추가" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("자료 상세 페이지")).toBeInTheDocument();
+    });
+  });
+
+  it("제목이 비어 있으면 추가 버튼이 비활성화된다", async () => {
+    mockListEmpty();
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /첫 자료 추가/ }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /첫 자료 추가/ }));
+    expect(
+      await screen.findByRole("dialog", { name: /학습 자료 추가/ }),
+    ).toBeInTheDocument();
+
+    const submit = screen.getByRole("button", { name: "추가" });
+    expect(submit).toBeDisabled();
+  });
+});

--- a/fe/src/pages/planner/MaterialListPage.tsx
+++ b/fe/src/pages/planner/MaterialListPage.tsx
@@ -1,8 +1,50 @@
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import { AddMaterialDialog } from "@/features/material/components/AddMaterialDialog";
+import { EmptyMaterialState } from "@/features/material/components/EmptyMaterialState";
+import { MaterialCard } from "@/features/material/components/MaterialCard";
+import { useMaterials } from "@/features/material/hooks/useMaterials";
+
 export function MaterialListPage() {
+  const navigate = useNavigate();
+  const { data: materials, isLoading } = useMaterials("ACTIVE");
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const handleCreated = (materialId: number) => {
+    navigate(`/planner/materials/${materialId}?tab=note`);
+  };
+
   return (
-    <div className="flex flex-col gap-4">
-      <h1 className="text-xl font-semibold">학습 자료</h1>
-      <p className="text-muted-foreground text-sm">곧 만나요.</p>
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold">학습 자료</h1>
+        <Button onClick={() => setDialogOpen(true)}>
+          <Plus className="size-4" /> 자료 추가
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <p className="text-muted-foreground text-sm">불러오는 중...</p>
+      ) : !materials || materials.length === 0 ? (
+        <EmptyMaterialState onAdd={() => setDialogOpen(true)} />
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {materials.map((material) => (
+            <li key={material.id}>
+              <MaterialCard material={material} />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <AddMaterialDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onCreated={handleCreated}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 이슈
closes #371

## 작업 내용

### 화면 (`/planner/materials`)
- 자료 카드 리스트 (1열 세로)
  - 유형 아이콘 (📕 BOOK / 🎬 LECTURE / 📘 WORKBOOK / 🎓 MOOC)
  - 제목, 유형 라벨, 카드 수, 오늘 복습 수
  - 오늘 복습 1건 이상이면 primary 색으로 강조
  - 카드 클릭 → `/planner/materials/:id?tab=note`
- 우상단 [+ 자료 추가] 버튼
- **빈 상태**: 중앙에 "아직 등록된 학습 자료가 없습니다" + 큰 [+ 첫 자료 추가] 버튼

### 자료 추가 다이얼로그 (base-ui `Dialog` + `Select`)
- 제목: 1~200자 (`maxLength=200`, 빈 문자열 시 [추가] 비활성)
- 유형: 4지 (📕 책 / 🎬 강의 / 📘 문제집 / 🎓 MOOC)
- 성공 → 다이얼로그 닫기 → 새 자료의 `?tab=note` 상세로 자동 이동
- 실패 → 다이얼로그 내 에러 텍스트 표시 (다이얼로그 유지)

### `features/material/`
- `api/materials.ts` — 타입 + `fetchMaterials`, `createMaterial`
- `hooks/useMaterials(status)` — react-query
- `hooks/useCreateMaterial` — mutation + 성공 시 `invalidateQueries(materialKeys.all)`
- `queryKeys` — `list`, `detail` 공유
- `components/` — `MaterialCard`, `AddMaterialDialog`, `EmptyMaterialState`
- `utils.ts` — `MATERIAL_TYPE_ICONS`, `MATERIAL_TYPE_LABELS`

### 검증
- [x] `npm test` 59건 통과 (MaterialListPage 5건 신규)
- [x] `npx tsc -b --noEmit` / `npm run lint` / `npm run format:check` / `npm run build` 통과
- [x] **로컬 dev + Playwright**: 로그인 → 목록 표시(기존 4건) → [자료 추가] 클릭 → 다이얼로그 열림 → 제목 입력 + 유형(강의) 선택 → [추가] → `/planner/materials/6?tab=note` 자동 이동 확인

## 후속
- #372 자료 상세 - 노트 탭 (Tiptap 에디터)
- #373 자료 상세 - 카드 탭
- #374 오늘 복습 화면