### PR TITLE
feat : 자료 상세 - 카드 탭 (목록/생성/편집/삭제)

### DIFF
--- a/fe/src/features/flashcard/api/flashcards.ts
+++ b/fe/src/features/flashcard/api/flashcards.ts
@@ -1,0 +1,82 @@
+import { client } from "@/shared/api";
+
+export interface NextReview {
+  id: number;
+  sequence: number;
+  scheduledDate: string;
+  intervalDays: number;
+  easeFactor: number;
+}
+
+export interface FirstReview extends NextReview {
+  flashcardId: number;
+  status: "PENDING" | "COMPLETED";
+}
+
+export interface Flashcard {
+  id: number;
+  materialId: number;
+  front: string;
+  back: string;
+  nextReview: NextReview | null;
+  createdAt: string;
+}
+
+export interface FlashcardListResponse {
+  flashcards: Flashcard[];
+}
+
+export interface FlashcardCreateRequest {
+  front: string;
+  back: string;
+}
+
+export interface FlashcardCreateResponse {
+  flashcard: Flashcard;
+  firstReview: FirstReview;
+}
+
+export interface FlashcardUpdateRequest {
+  front?: string;
+  back?: string;
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export async function fetchFlashcards(
+  materialId: number,
+): Promise<Flashcard[]> {
+  const { data } = await client.get<ApiEnvelope<FlashcardListResponse>>(
+    `/planner/materials/${materialId}/flashcards`,
+  );
+  return data.data.flashcards;
+}
+
+export async function createFlashcard(
+  materialId: number,
+  request: FlashcardCreateRequest,
+): Promise<FlashcardCreateResponse> {
+  const { data } = await client.post<ApiEnvelope<FlashcardCreateResponse>>(
+    `/planner/materials/${materialId}/flashcards`,
+    request,
+  );
+  return data.data;
+}
+
+export async function updateFlashcard(
+  flashcardId: number,
+  request: FlashcardUpdateRequest,
+): Promise<Flashcard> {
+  const { data } = await client.patch<ApiEnvelope<Flashcard>>(
+    `/planner/flashcards/${flashcardId}`,
+    request,
+  );
+  return data.data;
+}
+
+export async function deleteFlashcard(flashcardId: number): Promise<void> {
+  await client.delete(`/planner/flashcards/${flashcardId}`);
+}

--- a/fe/src/features/flashcard/components/EmptyFlashcardState.tsx
+++ b/fe/src/features/flashcard/components/EmptyFlashcardState.tsx
@@ -1,0 +1,18 @@
+import { Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  onAdd: () => void;
+}
+
+export function EmptyFlashcardState({ onAdd }: Props) {
+  return (
+    <div className="flex min-h-[30svh] flex-col items-center justify-center gap-4 text-center">
+      <p className="text-muted-foreground text-sm">아직 카드가 없습니다.</p>
+      <Button onClick={onAdd}>
+        <Plus className="size-4" /> 첫 카드 추가
+      </Button>
+    </div>
+  );
+}

--- a/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
+++ b/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
@@ -1,0 +1,170 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { useEffect, useId, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const MAX_LEN = 1000;
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "create" | "edit";
+  initialFront?: string;
+  initialBack?: string;
+  pending?: boolean;
+  errorMessage?: string;
+  onSubmit: (values: { front: string; back: string }) => void;
+  onDelete?: () => void;
+}
+
+export function FlashcardFormDialog({
+  open,
+  onOpenChange,
+  mode,
+  initialFront = "",
+  initialBack = "",
+  pending = false,
+  errorMessage,
+  onSubmit,
+  onDelete,
+}: Props) {
+  const frontId = useId();
+  const backId = useId();
+  const [front, setFront] = useState(initialFront);
+  const [back, setBack] = useState(initialBack);
+
+  useEffect(() => {
+    if (open) {
+      setFront(initialFront);
+      setBack(initialBack);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const frontTrim = front.trim();
+  const backTrim = back.trim();
+  const valid =
+    frontTrim.length >= 1 &&
+    frontTrim.length <= MAX_LEN &&
+    backTrim.length >= 1 &&
+    backTrim.length <= MAX_LEN;
+  const dirty =
+    mode === "create" || front !== initialFront || back !== initialBack;
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!valid || !dirty || pending) return;
+    onSubmit({ front: frontTrim, back: backTrim });
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
+        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+          <Dialog.Title className="text-base font-semibold">
+            {mode === "create" ? "카드 추가" : "카드 편집"}
+          </Dialog.Title>
+
+          <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-4">
+            <CharField
+              id={frontId}
+              label="앞면 (질문)"
+              rows={3}
+              value={front}
+              onChange={setFront}
+              max={MAX_LEN}
+              autoFocus
+            />
+            <CharField
+              id={backId}
+              label="뒷면 (답)"
+              rows={4}
+              value={back}
+              onChange={setBack}
+              max={MAX_LEN}
+            />
+
+            {errorMessage && (
+              <p className="text-destructive text-sm">{errorMessage}</p>
+            )}
+
+            <div className="mt-1 flex items-center justify-between gap-2">
+              {mode === "edit" && onDelete ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="text-destructive"
+                  disabled={pending}
+                  onClick={onDelete}
+                >
+                  삭제
+                </Button>
+              ) : (
+                <span />
+              )}
+              <div className="flex gap-2">
+                <Dialog.Close
+                  render={
+                    <Button variant="ghost" type="button" disabled={pending}>
+                      취소
+                    </Button>
+                  }
+                />
+                <Button type="submit" disabled={!valid || !dirty || pending}>
+                  {pending ? "저장 중..." : "저장"}
+                </Button>
+              </div>
+            </div>
+          </form>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+interface CharFieldProps {
+  id: string;
+  label: string;
+  rows: number;
+  value: string;
+  onChange: (next: string) => void;
+  max: number;
+  autoFocus?: boolean;
+}
+
+function CharField({
+  id,
+  label,
+  rows,
+  value,
+  onChange,
+  max,
+  autoFocus,
+}: CharFieldProps) {
+  const over = value.length > max;
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor={id} className="text-sm font-medium">
+        {label}
+      </label>
+      <textarea
+        id={id}
+        rows={rows}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        autoFocus={autoFocus}
+        className="border-input bg-background focus-visible:ring-ring/30 min-h-[3rem] resize-y rounded-md border p-2 text-sm shadow-xs focus-visible:ring-2 focus-visible:outline-none"
+      />
+      <span
+        className={cn(
+          "text-muted-foreground self-end text-xs",
+          over && "text-destructive",
+        )}
+      >
+        {value.length} / {max}
+      </span>
+    </div>
+  );
+}

--- a/fe/src/features/flashcard/components/FlashcardItem.tsx
+++ b/fe/src/features/flashcard/components/FlashcardItem.tsx
@@ -1,0 +1,48 @@
+import { Pencil } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+import type { Flashcard } from "../api/flashcards";
+import { formatNextReview } from "../utils";
+
+interface Props {
+  index: number;
+  flashcard: Flashcard;
+  onEdit: () => void;
+}
+
+export function FlashcardItem({ index, flashcard, onEdit }: Props) {
+  return (
+    <Card>
+      <CardContent className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground text-xs font-medium">
+              📇 #{index + 1}
+            </span>
+            {flashcard.nextReview && (
+              <span className="text-muted-foreground text-xs">
+                다음 복습: {formatNextReview(flashcard.nextReview)}
+              </span>
+            )}
+          </div>
+          <p className="text-sm font-medium whitespace-pre-line">
+            {flashcard.front}
+          </p>
+          <p className="text-muted-foreground text-xs whitespace-pre-line">
+            뒤: {flashcard.back}
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label={`카드 ${index + 1} 편집`}
+          onClick={onEdit}
+        >
+          <Pencil className="size-4" />
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/fe/src/features/flashcard/components/FlashcardListTab.test.tsx
+++ b/fe/src/features/flashcard/components/FlashcardListTab.test.tsx
@@ -1,0 +1,213 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { Toaster } from "@/components/Toaster";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { FlashcardListTab } from "./FlashcardListTab";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function renderTab() {
+  return renderWithRouter(
+    <Providers>
+      <>
+        <FlashcardListTab materialId={1} />
+        <Toaster />
+      </>
+    </Providers>,
+  );
+}
+
+function mockListEmpty() {
+  server.use(
+    http.get(`${API_BASE}/planner/materials/1/flashcards`, () => {
+      return HttpResponse.json({ code: "OK", data: { flashcards: [] } });
+    }),
+  );
+}
+
+function mockListWith(
+  flashcards: Array<{
+    id: number;
+    front: string;
+    back: string;
+    nextReview?: { sequence: number; scheduledDate: string } | null;
+  }>,
+) {
+  server.use(
+    http.get(`${API_BASE}/planner/materials/1/flashcards`, () => {
+      return HttpResponse.json({
+        code: "OK",
+        data: {
+          flashcards: flashcards.map((f) => ({
+            id: f.id,
+            materialId: 1,
+            front: f.front,
+            back: f.back,
+            nextReview:
+              f.nextReview === null
+                ? null
+                : {
+                    id: 100,
+                    sequence: f.nextReview?.sequence ?? 1,
+                    scheduledDate: f.nextReview?.scheduledDate ?? "2026-05-20",
+                    intervalDays: 1,
+                    easeFactor: 2.5,
+                  },
+            createdAt: "2026-05-18T00:00:00",
+          })),
+        },
+      });
+    }),
+  );
+}
+
+describe("FlashcardListTab", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+  });
+
+  it("빈 목록이면 빈 상태와 [첫 카드 추가] 버튼을 표시한다", async () => {
+    mockListEmpty();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 카드가 없습니다.")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: /첫 카드 추가/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("카드 목록과 다음 복습 텍스트를 표시한다", async () => {
+    mockListWith([
+      {
+        id: 1,
+        front: "Q1",
+        back: "A1",
+        nextReview: { sequence: 2, scheduledDate: "2026-05-24" },
+      },
+      { id: 2, front: "Q2", back: "A2", nextReview: null },
+    ]);
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Q1")).toBeInTheDocument();
+    });
+    expect(screen.getByText("뒤: A1")).toBeInTheDocument();
+    expect(screen.getByText(/다음 복습: 5\/24/)).toBeInTheDocument();
+    expect(screen.getByText("Q2")).toBeInTheDocument();
+    expect(screen.getByText("총 2장")).toBeInTheDocument();
+  });
+
+  it("[카드 추가] 다이얼로그를 열어 카드 생성 후 토스트가 표시된다", async () => {
+    mockListEmpty();
+    let posted: { front: string; back: string } | null = null;
+    server.use(
+      http.post(
+        `${API_BASE}/planner/materials/1/flashcards`,
+        async ({ request }) => {
+          posted = (await request.json()) as { front: string; back: string };
+          return HttpResponse.json(
+            {
+              code: "OK",
+              data: {
+                flashcard: {
+                  id: 10,
+                  materialId: 1,
+                  front: posted.front,
+                  back: posted.back,
+                  nextReview: null,
+                  createdAt: "2026-05-18T00:00:00",
+                },
+                firstReview: {
+                  id: 100,
+                  flashcardId: 10,
+                  sequence: 1,
+                  scheduledDate: "2026-05-19",
+                  intervalDays: 1,
+                  easeFactor: 2.5,
+                  status: "PENDING",
+                },
+              },
+            },
+            { status: 201 },
+          );
+        },
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 카드가 없습니다.")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /첫 카드 추가/ }));
+
+    await user.type(await screen.findByLabelText("앞면 (질문)"), "front-text");
+    await user.type(screen.getByLabelText("뒷면 (답)"), "back-text");
+    await user.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() => {
+      expect(posted).toEqual({ front: "front-text", back: "back-text" });
+    });
+    expect(await screen.findByText(/카드가 추가되었어요/)).toBeInTheDocument();
+  });
+
+  it("[편집] 후 [삭제] 클릭 시 확인 → DELETE 호출", async () => {
+    mockListWith([
+      {
+        id: 7,
+        front: "Q",
+        back: "A",
+        nextReview: { sequence: 1, scheduledDate: "2026-05-20" },
+      },
+    ]);
+    let deleted = false;
+    server.use(
+      http.delete(`${API_BASE}/planner/flashcards/7`, () => {
+        deleted = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Q")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /카드 1 편집/ }));
+    await user.click(await screen.findByRole("button", { name: "삭제" }));
+    await user.click(await screen.findByRole("button", { name: "삭제" }));
+
+    await waitFor(() => expect(deleted).toBe(true));
+  });
+
+  it("앞면 또는 뒷면이 비어 있으면 [저장] 비활성", async () => {
+    mockListEmpty();
+    const user = userEvent.setup();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 카드가 없습니다.")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /첫 카드 추가/ }));
+
+    expect(await screen.findByRole("button", { name: "저장" })).toBeDisabled();
+
+    await user.type(await screen.findByLabelText("앞면 (질문)"), "Q");
+    expect(screen.getByRole("button", { name: "저장" })).toBeDisabled();
+
+    await user.type(screen.getByLabelText("뒷면 (답)"), "A");
+    expect(screen.getByRole("button", { name: "저장" })).toBeEnabled();
+  });
+});

--- a/fe/src/features/flashcard/components/FlashcardListTab.tsx
+++ b/fe/src/features/flashcard/components/FlashcardListTab.tsx
@@ -1,0 +1,144 @@
+import { Plus } from "lucide-react";
+import { useState } from "react";
+
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/shared/lib/toast";
+
+import type { Flashcard } from "../api/flashcards";
+import { useCreateFlashcard } from "../hooks/useCreateFlashcard";
+import { useDeleteFlashcard } from "../hooks/useDeleteFlashcard";
+import { useFlashcards } from "../hooks/useFlashcards";
+import { useUpdateFlashcard } from "../hooks/useUpdateFlashcard";
+import { EmptyFlashcardState } from "./EmptyFlashcardState";
+import { FlashcardFormDialog } from "./FlashcardFormDialog";
+import { FlashcardItem } from "./FlashcardItem";
+
+interface Props {
+  materialId: number;
+}
+
+export function FlashcardListTab({ materialId }: Props) {
+  const flashcardsQuery = useFlashcards(materialId);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editing, setEditing] = useState<Flashcard | null>(null);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+
+  const createMutation = useCreateFlashcard(materialId);
+  const updateMutation = useUpdateFlashcard(materialId, editing?.id ?? 0);
+  const deleteMutation = useDeleteFlashcard(materialId);
+
+  const handleCreate = (values: { front: string; back: string }) => {
+    createMutation.mutate(values, {
+      onSuccess: () => {
+        setCreateOpen(false);
+        toast("카드가 추가되었어요. 첫 복습은 내일.", "success");
+      },
+    });
+  };
+
+  const handleUpdate = (values: { front: string; back: string }) => {
+    if (!editing) return;
+    updateMutation.mutate(values, {
+      onSuccess: () => setEditing(null),
+    });
+  };
+
+  const handleConfirmDelete = () => {
+    if (!editing) return;
+    deleteMutation.mutate(editing.id, {
+      onSuccess: () => {
+        setDeleteConfirmOpen(false);
+        setEditing(null);
+      },
+    });
+  };
+
+  if (flashcardsQuery.isLoading) {
+    return <p className="text-muted-foreground text-sm">불러오는 중...</p>;
+  }
+  if (flashcardsQuery.isError || !flashcardsQuery.data) {
+    return (
+      <p className="text-destructive text-sm">카드를 불러오지 못했어요.</p>
+    );
+  }
+
+  const flashcards = flashcardsQuery.data;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <p className="text-muted-foreground text-sm">
+          총 {flashcards.length}장
+        </p>
+        <Button size="sm" onClick={() => setCreateOpen(true)}>
+          <Plus className="size-4" /> 카드 추가
+        </Button>
+      </div>
+
+      {flashcards.length === 0 ? (
+        <EmptyFlashcardState onAdd={() => setCreateOpen(true)} />
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {flashcards.map((card, idx) => (
+            <li key={card.id}>
+              <FlashcardItem
+                index={idx}
+                flashcard={card}
+                onEdit={() => setEditing(card)}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <FlashcardFormDialog
+        mode="create"
+        open={createOpen}
+        onOpenChange={(o) => {
+          setCreateOpen(o);
+          if (!o) createMutation.reset();
+        }}
+        pending={createMutation.isPending}
+        errorMessage={
+          createMutation.isError
+            ? "카드 추가에 실패했어요. 잠시 후 다시 시도해주세요."
+            : undefined
+        }
+        onSubmit={handleCreate}
+      />
+
+      <FlashcardFormDialog
+        mode="edit"
+        open={editing !== null}
+        onOpenChange={(o) => {
+          if (!o) {
+            setEditing(null);
+            updateMutation.reset();
+          }
+        }}
+        initialFront={editing?.front}
+        initialBack={editing?.back}
+        pending={updateMutation.isPending}
+        errorMessage={
+          updateMutation.isError
+            ? "저장에 실패했어요. 잠시 후 다시 시도해주세요."
+            : undefined
+        }
+        onSubmit={handleUpdate}
+        onDelete={() => setDeleteConfirmOpen(true)}
+      />
+
+      <ConfirmDialog
+        open={deleteConfirmOpen}
+        onOpenChange={setDeleteConfirmOpen}
+        title="카드를 삭제할까요?"
+        description="이 카드의 복습 일정도 함께 삭제됩니다. 되돌릴 수 없어요."
+        confirmLabel="삭제"
+        destructive
+        onConfirm={handleConfirmDelete}
+        pending={deleteMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/fe/src/features/flashcard/hooks/useCreateFlashcard.ts
+++ b/fe/src/features/flashcard/hooks/useCreateFlashcard.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { materialKeys } from "@/features/material/queryKeys";
+import { reviewKeys } from "@/features/review/queryKeys";
+
+import {
+  createFlashcard,
+  type FlashcardCreateRequest,
+  type FlashcardCreateResponse,
+} from "../api/flashcards";
+import { flashcardKeys } from "../queryKeys";
+
+export function useCreateFlashcard(materialId: number) {
+  const queryClient = useQueryClient();
+  return useMutation<FlashcardCreateResponse, Error, FlashcardCreateRequest>({
+    mutationFn: (request) => createFlashcard(materialId, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: flashcardKeys.byMaterial(materialId),
+      });
+      queryClient.invalidateQueries({ queryKey: materialKeys.all });
+      queryClient.invalidateQueries({ queryKey: reviewKeys.today });
+    },
+  });
+}

--- a/fe/src/features/flashcard/hooks/useDeleteFlashcard.ts
+++ b/fe/src/features/flashcard/hooks/useDeleteFlashcard.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { materialKeys } from "@/features/material/queryKeys";
+import { reviewKeys } from "@/features/review/queryKeys";
+
+import { deleteFlashcard } from "../api/flashcards";
+import { flashcardKeys } from "../queryKeys";
+
+export function useDeleteFlashcard(materialId: number) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, number>({
+    mutationFn: deleteFlashcard,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: flashcardKeys.byMaterial(materialId),
+      });
+      queryClient.invalidateQueries({ queryKey: materialKeys.all });
+      queryClient.invalidateQueries({ queryKey: reviewKeys.today });
+    },
+  });
+}

--- a/fe/src/features/flashcard/hooks/useFlashcards.ts
+++ b/fe/src/features/flashcard/hooks/useFlashcards.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchFlashcards } from "../api/flashcards";
+import { flashcardKeys } from "../queryKeys";
+
+export function useFlashcards(materialId: number) {
+  return useQuery({
+    queryKey: flashcardKeys.byMaterial(materialId),
+    queryFn: () => fetchFlashcards(materialId),
+  });
+}

--- a/fe/src/features/flashcard/hooks/useUpdateFlashcard.ts
+++ b/fe/src/features/flashcard/hooks/useUpdateFlashcard.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  type Flashcard,
+  type FlashcardUpdateRequest,
+  updateFlashcard,
+} from "../api/flashcards";
+import { flashcardKeys } from "../queryKeys";
+
+export function useUpdateFlashcard(materialId: number, flashcardId: number) {
+  const queryClient = useQueryClient();
+  return useMutation<Flashcard, Error, FlashcardUpdateRequest>({
+    mutationFn: (request) => updateFlashcard(flashcardId, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: flashcardKeys.byMaterial(materialId),
+      });
+    },
+  });
+}

--- a/fe/src/features/flashcard/queryKeys.ts
+++ b/fe/src/features/flashcard/queryKeys.ts
@@ -1,0 +1,5 @@
+export const flashcardKeys = {
+  all: ["flashcards"] as const,
+  byMaterial: (materialId: number) =>
+    ["flashcards", "material", materialId] as const,
+};

--- a/fe/src/features/flashcard/utils.test.ts
+++ b/fe/src/features/flashcard/utils.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { formatNextReview } from "./utils";
+
+describe("formatNextReview", () => {
+  const today = new Date(2026, 4, 18);
+
+  it("같은 날이면 오늘", () => {
+    expect(
+      formatNextReview(
+        {
+          id: 1,
+          sequence: 1,
+          scheduledDate: "2026-05-18",
+          intervalDays: 1,
+          easeFactor: 2.5,
+        },
+        today,
+      ),
+    ).toBe("5/18 (오늘) · 1회차");
+  });
+
+  it("미래 날짜는 N일 후", () => {
+    expect(
+      formatNextReview(
+        {
+          id: 1,
+          sequence: 2,
+          scheduledDate: "2026-05-24",
+          intervalDays: 6,
+          easeFactor: 2.5,
+        },
+        today,
+      ),
+    ).toBe("5/24 (6일 후) · 2회차");
+  });
+
+  it("지난 날짜는 N일 지남", () => {
+    expect(
+      formatNextReview(
+        {
+          id: 1,
+          sequence: 3,
+          scheduledDate: "2026-05-15",
+          intervalDays: 1,
+          easeFactor: 2.5,
+        },
+        today,
+      ),
+    ).toBe("5/15 (3일 지남) · 3회차");
+  });
+});

--- a/fe/src/features/flashcard/utils.ts
+++ b/fe/src/features/flashcard/utils.ts
@@ -1,0 +1,30 @@
+import type { NextReview } from "./api/flashcards";
+
+export function formatNextReview(
+  next: NextReview,
+  today: Date = new Date(),
+): string {
+  const d = parseDate(next.scheduledDate);
+  const todayMid = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate(),
+  );
+  const daysDiff = Math.round(
+    (d.getTime() - todayMid.getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  const md = `${d.getMonth() + 1}/${d.getDate()}`;
+  const relative =
+    daysDiff === 0
+      ? "오늘"
+      : daysDiff > 0
+        ? `${daysDiff}일 후`
+        : `${-daysDiff}일 지남`;
+  return `${md} (${relative}) · ${next.sequence}회차`;
+}
+
+function parseDate(isoDate: string): Date {
+  const [y, m, d] = isoDate.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}

--- a/fe/src/pages/planner/MaterialDetailPage.test.tsx
+++ b/fe/src/pages/planner/MaterialDetailPage.test.tsx
@@ -82,8 +82,13 @@ describe("MaterialDetailPage", () => {
     expect(screen.getByRole("tab", { name: /카드 12/ })).toBeInTheDocument();
   });
 
-  it("카드 탭 클릭 시 ?tab=cards로 변경되고 stub이 보인다", async () => {
+  it("카드 탭 클릭 시 카드 목록이 보인다", async () => {
     mockMaterial();
+    server.use(
+      http.get(`${API_BASE}/planner/materials/1/flashcards`, () => {
+        return HttpResponse.json({ code: "OK", data: { flashcards: [] } });
+      }),
+    );
     const user = userEvent.setup();
     renderPage();
 
@@ -96,7 +101,7 @@ describe("MaterialDetailPage", () => {
     await user.click(screen.getByRole("tab", { name: /카드/ }));
 
     await waitFor(() => {
-      expect(screen.getByText(/카드 탭은 곧 만나요/)).toBeInTheDocument();
+      expect(screen.getByText("아직 카드가 없습니다.")).toBeInTheDocument();
     });
   });
 

--- a/fe/src/pages/planner/MaterialDetailPage.tsx
+++ b/fe/src/pages/planner/MaterialDetailPage.tsx
@@ -1,6 +1,7 @@
 import { Tabs } from "@base-ui/react/tabs";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
+import { FlashcardListTab } from "@/features/flashcard/components/FlashcardListTab";
 import { MaterialHeader } from "@/features/material/components/MaterialHeader";
 import { useMaterial } from "@/features/material/hooks/useMaterial";
 import { NoteEditor } from "@/features/note/components/NoteEditor";
@@ -72,9 +73,7 @@ export function MaterialDetailPage() {
           />
         </Tabs.Panel>
         <Tabs.Panel value="cards" className="pt-4">
-          <p className="text-muted-foreground text-sm">
-            카드 탭은 곧 만나요. (#373)
-          </p>
+          <FlashcardListTab materialId={materialId} />
         </Tabs.Panel>
       </Tabs.Root>
     </div>


### PR DESCRIPTION
## 이슈
closes #373

## 작업 내용

### 화면 (`?tab=cards`)
- 카드 리스트 (생성순, 1열)
  - `📇 #N` 번호 + 앞면(질문) + `뒤: 답` + 다음 복습 표시
  - **다음 복습 형식**: `M/D (N일 후|오늘|N일 지남) · X회차`
  - PENDING 복습 없으면 표시 생략
  - 우측 [편집] 아이콘
- 우상단 [+ 카드 추가] 버튼
- **빈 상태**: "아직 카드가 없습니다" + 큰 [+ 첫 카드 추가] 버튼

### 카드 추가/편집 다이얼로그
- textarea: 앞면 `rows=3`, 뒷면 `rows=4`, 각 1~1000자
- 글자수 카운터 `n / 1000` (초과 시 destructive)
- 편집 모드에 [삭제] 버튼 → `ConfirmDialog` ("이 카드의 복습 일정도 함께 삭제됩니다")
- 추가 성공 시 토스트: **"카드가 추가되었어요. 첫 복습은 내일."**

### `features/flashcard/`
- `api/flashcards.ts` — types + `fetchFlashcards`/`createFlashcard`/`updateFlashcard`/`deleteFlashcard`
- hooks: `useFlashcards`, `useCreateFlashcard`, `useUpdateFlashcard`, `useDeleteFlashcard`
  - 성공 시 flashcard / material / today review 키 invalidate (사이드바 뱃지 + 헤더 카운트 동기화)
- components: `FlashcardItem`, `FlashcardFormDialog`, `EmptyFlashcardState`, `FlashcardListTab`
- `utils.ts` — `formatNextReview(next, today)`

### MaterialDetailPage
- 카드 탭 stub 자리에 `FlashcardListTab` 연결

## 검증
- [x] `npm test` 74건 통과 (`formatNextReview` 3건 + `FlashcardListTab` 5건 신규)
- [x] `npm run lint` / `format:check` / `tsc -b --noEmit` / `build` 통과
- [x] **로컬 dev + Playwright**: 로그인 → `/planner/materials/6?tab=cards` → 빈 상태 → [첫 카드 추가] → 다이얼로그 → 앞/뒤 입력 → 저장 → 카드 표시 ("다음 복습: 5/19 (1일 후) · 1회차") + 헤더의 "카드 N장" 및 탭 라벨 "📇 카드 1" 자동 갱신 확인

## 후속
- #374 오늘 복습 화면 (앞면 → Space → 답 공개 → 1/2/3/4 평가) — B안 v2 FE 마지막