### PR TITLE
feat : 오늘 복습 화면 (앞면 → Space → 답 공개 → 1/2/3/4 평가)

### DIFF
--- a/fe/src/app/router.test.tsx
+++ b/fe/src/app/router.test.tsx
@@ -154,7 +154,7 @@ describe("AppRouter", () => {
     });
   });
 
-  it("/planner/reviews/today 경로에서 오늘 복습 stub을 렌더링한다", async () => {
+  it("/planner/reviews/today 경로에서 빈 상태를 렌더링한다", async () => {
     mockEmptyTodayReviews();
     useAuthStore.setState({ accessToken: "valid-token" });
 
@@ -162,7 +162,7 @@ describe("AppRouter", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: "오늘 복습" }),
+        screen.getByText("오늘은 복습할 카드가 없어요! 🌱"),
       ).toBeInTheDocument();
     });
   });

--- a/fe/src/features/review/api/reviews.ts
+++ b/fe/src/features/review/api/reviews.ts
@@ -49,3 +49,37 @@ export async function fetchTodayReviews(): Promise<TodayReviewsResponse> {
   );
   return data.data;
 }
+
+export interface CompletedReview {
+  id: number;
+  status: "COMPLETED";
+  rating: Rating;
+  elapsedDays: number;
+  completedAt: string;
+}
+
+export interface NextReview {
+  id: number;
+  flashcardId: number;
+  sequence: number;
+  scheduledDate: string;
+  intervalDays: number;
+  easeFactor: number;
+  status: "PENDING";
+}
+
+export interface CompleteReviewResponse {
+  completed: CompletedReview;
+  nextReview: NextReview;
+}
+
+export async function completeReview(
+  reviewId: number,
+  rating: Rating,
+): Promise<CompleteReviewResponse> {
+  const { data } = await client.post<ApiEnvelope<CompleteReviewResponse>>(
+    `/planner/reviews/${reviewId}/complete`,
+    { rating },
+  );
+  return data.data;
+}

--- a/fe/src/features/review/components/CompletionState.tsx
+++ b/fe/src/features/review/components/CompletionState.tsx
@@ -1,0 +1,26 @@
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  count: number;
+}
+
+export function CompletionState({ count }: Props) {
+  return (
+    <div className="flex min-h-[40svh] flex-col items-center justify-center gap-4 text-center">
+      <p className="text-foreground text-2xl font-medium">
+        🎉 오늘 복습 {count}개 모두 완료!
+      </p>
+      <p className="text-muted-foreground text-sm">오늘도 수고하셨어요.</p>
+      <div className="flex gap-2">
+        <Link to="/home">
+          <Button variant="outline">홈으로</Button>
+        </Link>
+        <Link to="/planner/materials">
+          <Button>학습 자료 보기</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/review/components/EmptyTodayState.tsx
+++ b/fe/src/features/review/components/EmptyTodayState.tsx
@@ -1,0 +1,14 @@
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+
+export function EmptyTodayState() {
+  return (
+    <div className="flex min-h-[40svh] flex-col items-center justify-center gap-4 text-center">
+      <p className="text-foreground text-lg">오늘은 복습할 카드가 없어요! 🌱</p>
+      <Link to="/home">
+        <Button variant="outline">홈으로</Button>
+      </Link>
+    </div>
+  );
+}

--- a/fe/src/features/review/components/ReviewCard.tsx
+++ b/fe/src/features/review/components/ReviewCard.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { MATERIAL_TYPE_ICONS } from "@/features/material/utils";
+import { cn } from "@/lib/utils";
+
+import type { Rating, TodayReview } from "../api/reviews";
+
+interface Props {
+  review: TodayReview;
+  pending: boolean;
+  onRate: (rating: Rating) => void;
+}
+
+interface RatingButton {
+  rating: Rating;
+  label: string;
+  key: string;
+  preview: (r: TodayReview) => number;
+  textClass: string;
+}
+
+const RATING_BUTTONS: RatingButton[] = [
+  {
+    rating: "AGAIN",
+    label: "Again",
+    key: "1",
+    preview: (r) => r.preview.again,
+    textClass: "text-red-500",
+  },
+  {
+    rating: "HARD",
+    label: "Hard",
+    key: "2",
+    preview: (r) => r.preview.hard,
+    textClass: "text-orange-500",
+  },
+  {
+    rating: "GOOD",
+    label: "Good",
+    key: "3",
+    preview: (r) => r.preview.good,
+    textClass: "text-primary",
+  },
+  {
+    rating: "EASY",
+    label: "Easy",
+    key: "4",
+    preview: (r) => r.preview.easy,
+    textClass: "text-green-500",
+  },
+];
+
+export function ReviewCard({ review, pending, onRate }: Props) {
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    setRevealed(false);
+  }, [review.id]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (isTypingTarget(event.target)) return;
+      if (!revealed) {
+        if (event.code === "Space" || event.key === "Enter") {
+          event.preventDefault();
+          setRevealed(true);
+        }
+        return;
+      }
+      if (pending) return;
+      const match = RATING_BUTTONS.find((b) => b.key === event.key);
+      if (match) {
+        event.preventDefault();
+        onRate(match.rating);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [revealed, pending, onRate]);
+
+  return (
+    <Card className="mx-auto w-full max-w-2xl">
+      <CardContent className="flex flex-col gap-6 py-6">
+        <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+          <span className="text-base">
+            {MATERIAL_TYPE_ICONS[review.flashcard.material.type]}
+          </span>
+          <span className="font-medium">{review.flashcard.material.title}</span>
+          <span>{review.sequence}회차</span>
+          {review.delayDays > 0 && (
+            <span className="text-destructive">
+              {review.delayDays}일 밀린 복습
+            </span>
+          )}
+        </div>
+
+        <div className="bg-muted/30 rounded-lg px-4 py-10 text-center">
+          <p
+            className={cn(
+              "text-foreground text-2xl font-medium whitespace-pre-wrap",
+            )}
+          >
+            {review.flashcard.front}
+          </p>
+        </div>
+
+        {!revealed ? (
+          <div className="flex justify-center">
+            <Button size="lg" onClick={() => setRevealed(true)}>
+              답 보기 (Space)
+            </Button>
+          </div>
+        ) : (
+          <>
+            <div className="bg-card border-border rounded-lg border px-4 py-6 text-center">
+              <p className="text-foreground text-lg whitespace-pre-wrap">
+                {review.flashcard.back}
+              </p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              {RATING_BUTTONS.map((btn) => {
+                const days = btn.preview(review);
+                return (
+                  <Button
+                    key={btn.rating}
+                    variant="outline"
+                    size="lg"
+                    disabled={pending}
+                    onClick={() => onRate(btn.rating)}
+                    aria-label={`${btn.label} (${btn.key})`}
+                    className="flex h-auto flex-col gap-1 py-3"
+                  >
+                    <span className="text-muted-foreground text-xs">
+                      {days}d
+                    </span>
+                    <span className={cn("text-sm font-medium", btn.textClass)}>
+                      {btn.label}
+                    </span>
+                    <span className="text-muted-foreground text-[10px]">
+                      [{btn.key}]
+                    </span>
+                  </Button>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable;
+}

--- a/fe/src/features/review/hooks/useCompleteReview.ts
+++ b/fe/src/features/review/hooks/useCompleteReview.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { materialKeys } from "@/features/material/queryKeys";
+
+import {
+  completeReview,
+  type CompleteReviewResponse,
+  type Rating,
+} from "../api/reviews";
+import { reviewKeys } from "../queryKeys";
+
+interface Variables {
+  reviewId: number;
+  rating: Rating;
+}
+
+export function useCompleteReview() {
+  const queryClient = useQueryClient();
+  return useMutation<CompleteReviewResponse, Error, Variables>({
+    mutationFn: ({ reviewId, rating }) => completeReview(reviewId, rating),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: reviewKeys.today });
+      queryClient.invalidateQueries({ queryKey: materialKeys.all });
+    },
+  });
+}

--- a/fe/src/pages/planner/TodayReviewsPage.test.tsx
+++ b/fe/src/pages/planner/TodayReviewsPage.test.tsx
@@ -1,0 +1,207 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { Toaster } from "@/components/Toaster";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { useToastStore } from "@/shared/lib/toast";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { TodayReviewsPage } from "./TodayReviewsPage";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function renderPage() {
+  return renderWithRouter(
+    <Providers>
+      <Routes>
+        <Route
+          path="/planner/reviews/today"
+          element={
+            <>
+              <TodayReviewsPage />
+              <Toaster />
+            </>
+          }
+        />
+        <Route path="/home" element={<div>홈 페이지</div>} />
+        <Route path="/planner/materials" element={<div>목록 페이지</div>} />
+      </Routes>
+    </Providers>,
+    { initialEntries: ["/planner/reviews/today"] },
+  );
+}
+
+function mockToday(reviewIds: number[], opts?: { delayDays?: number }) {
+  server.use(
+    http.get(`${API_BASE}/planner/reviews/today`, () => {
+      return HttpResponse.json({
+        code: "OK",
+        data: {
+          today: "2026-05-18",
+          reviews: reviewIds.map((id) => ({
+            id,
+            scheduledDate: "2026-05-18",
+            delayDays: opts?.delayDays ?? 0,
+            sequence: 2,
+            intervalDays: 6,
+            easeFactor: 2.5,
+            flashcard: {
+              id: id * 10,
+              front: `질문 ${id}`,
+              back: `답 ${id}`,
+              material: { id: 1, title: "테스트 자료", type: "BOOK" },
+            },
+            preview: { again: 1, hard: 6, good: 6, easy: 15 },
+          })),
+        },
+      });
+    }),
+  );
+}
+
+function mockComplete(captureRatings: Array<{ id: number; rating: string }>) {
+  server.use(
+    http.post(
+      `${API_BASE}/planner/reviews/:id/complete`,
+      async ({ params, request }) => {
+        const body = (await request.json()) as { rating: string };
+        captureRatings.push({ id: Number(params.id), rating: body.rating });
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            completed: {
+              id: Number(params.id),
+              status: "COMPLETED",
+              rating: body.rating,
+              elapsedDays: 0,
+              completedAt: "2026-05-18T10:00:00",
+            },
+            nextReview: {
+              id: 999,
+              flashcardId: 1,
+              sequence: 3,
+              scheduledDate: "2026-05-24",
+              intervalDays: 6,
+              easeFactor: 2.5,
+              status: "PENDING",
+            },
+          },
+        });
+      },
+    ),
+  );
+}
+
+describe("TodayReviewsPage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+    useToastStore.setState({ toasts: [] });
+  });
+
+  it("0건이면 빈 상태와 [홈으로] 버튼을 표시한다", async () => {
+    mockToday([]);
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("오늘은 복습할 카드가 없어요! 🌱"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "홈으로" })).toBeInTheDocument();
+  });
+
+  it("진입 시 첫 카드 앞면 + [답 보기] 버튼만 보인다", async () => {
+    mockToday([1, 2]);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("질문 1")).toBeInTheDocument();
+    });
+    expect(screen.getByText("1 / 2")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /답 보기/ })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Again/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("답 1")).not.toBeInTheDocument();
+  });
+
+  it("Space로 답이 공개되고 1/2/3/4 키로 평가가 전송된다", async () => {
+    mockToday([1]);
+    const ratings: Array<{ id: number; rating: string }> = [];
+    mockComplete(ratings);
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("질문 1")).toBeInTheDocument();
+    });
+
+    await user.keyboard(" ");
+    expect(await screen.findByText("답 1")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Good/ })).toBeInTheDocument();
+
+    await user.keyboard("3");
+
+    await waitFor(() => {
+      expect(ratings).toEqual([{ id: 1, rating: "GOOD" }]);
+    });
+  });
+
+  it("평가 후 다음 카드로 넘어가고, 마지막 후 완료 화면이 보인다", async () => {
+    mockToday([1, 2]);
+    mockComplete([]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("질문 1")).toBeInTheDocument();
+    });
+
+    await user.keyboard(" ");
+    await user.click(await screen.findByRole("button", { name: /Good/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("질문 2")).toBeInTheDocument();
+    });
+    expect(screen.getByText("2 / 2")).toBeInTheDocument();
+
+    await user.keyboard(" ");
+    await user.click(await screen.findByRole("button", { name: /Good/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/모두 완료/)).toBeInTheDocument();
+    });
+  });
+
+  it("평가 성공 시 다음 복습 토스트가 표시된다", async () => {
+    mockToday([1]);
+    mockComplete([]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("질문 1")).toBeInTheDocument();
+    });
+
+    await user.keyboard(" ");
+    await user.click(await screen.findByRole("button", { name: /Good/ }));
+
+    expect(
+      await screen.findByText(/다음 복습은 .* \(5\/24\)/),
+    ).toBeInTheDocument();
+  });
+
+  it("delayDays > 0이면 헤더에 밀린 일수가 표시된다", async () => {
+    mockToday([1], { delayDays: 3 });
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("3일 밀린 복습")).toBeInTheDocument();
+    });
+  });
+});

--- a/fe/src/pages/planner/TodayReviewsPage.tsx
+++ b/fe/src/pages/planner/TodayReviewsPage.tsx
@@ -1,8 +1,95 @@
+import { useEffect, useState } from "react";
+
+import { type TodayReview } from "@/features/review/api/reviews";
+import { CompletionState } from "@/features/review/components/CompletionState";
+import { EmptyTodayState } from "@/features/review/components/EmptyTodayState";
+import { ReviewCard } from "@/features/review/components/ReviewCard";
+import { useCompleteReview } from "@/features/review/hooks/useCompleteReview";
+import { useTodayReviews } from "@/features/review/hooks/useTodayReviews";
+import { toast } from "@/shared/lib/toast";
+
 export function TodayReviewsPage() {
+  const { data, isLoading, isError } = useTodayReviews();
+  const completeMutation = useCompleteReview();
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [queue, setQueue] = useState<TodayReview[] | null>(null);
+
+  useEffect(() => {
+    if (data && queue === null) {
+      setQueue(data.reviews);
+    }
+  }, [data, queue]);
+
+  if (isLoading || (data && queue === null)) {
+    return <p className="text-muted-foreground text-sm">불러오는 중...</p>;
+  }
+  if (isError || !data || !queue) {
+    return (
+      <p className="text-destructive text-sm">복습을 불러오지 못했어요.</p>
+    );
+  }
+
+  const reviews = queue;
+  const total = reviews.length;
+
+  if (total === 0) {
+    return <EmptyTodayState />;
+  }
+  if (currentIndex >= total) {
+    return <CompletionState count={total} />;
+  }
+
+  const current = reviews[currentIndex];
+
+  const handleRate = (rating: "AGAIN" | "HARD" | "GOOD" | "EASY") => {
+    if (completeMutation.isPending) return;
+    completeMutation.mutate(
+      { reviewId: current.id, rating },
+      {
+        onSuccess: (res) => {
+          toast(
+            formatNextReviewMessage(res.nextReview.scheduledDate),
+            "success",
+          );
+          setCurrentIndex((i) => i + 1);
+        },
+      },
+    );
+  };
+
   return (
     <div className="flex flex-col gap-4">
-      <h1 className="text-xl font-semibold">오늘 복습</h1>
-      <p className="text-muted-foreground text-sm">곧 만나요.</p>
+      <div className="text-muted-foreground text-center text-sm">
+        {currentIndex + 1} / {total}
+      </div>
+      <ReviewCard
+        review={current}
+        pending={completeMutation.isPending}
+        onRate={handleRate}
+      />
     </div>
   );
+}
+
+function formatNextReviewMessage(scheduledDate: string): string {
+  const today = new Date();
+  const todayMid = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate(),
+  );
+  const next = parseDate(scheduledDate);
+  const days = Math.round(
+    (next.getTime() - todayMid.getTime()) / (1000 * 60 * 60 * 24),
+  );
+  const md = `${next.getMonth() + 1}/${next.getDate()}`;
+  if (days <= 0) {
+    return `다음 복습은 오늘 (${md})`;
+  }
+  return `다음 복습은 ${days}일 후 (${md})`;
+}
+
+function parseDate(isoDate: string): Date {
+  const [y, m, d] = isoDate.split("-").map(Number);
+  return new Date(y, m - 1, d);
 }


### PR DESCRIPTION
## 이슈
closes #374

## 작업 내용

### 화면 (`/planner/reviews/today`)
- 진입: `GET /api/planner/reviews/today` → **초기 큐를 로컬 snapshot으로 고정**
  - 평가 후 invalidate가 발생해도 큐 길이가 변하지 않아 카드 N개를 끝까지 처리
- 상단 진행 카운터 `N / Total`
- 카드 헤더: 유형 아이콘 + 자료 제목 + 회차 + (지연 시 "N일 밀린 복습")
- 앞면: 큰 폰트, `whitespace-pre-wrap`, 중앙 정렬
- [답 보기 (Space)] → 답 공개 + 4지선다 노출

### 4지선다 (반응형 `grid-cols-2 sm:grid-cols-4`)
| Rating | 색상 | 키 |
|---|---|---|
| Again | 🔴 빨강 | 1 |
| Hard | 🟠 주황 | 2 |
| Good | 🟣 primary | 3 |
| Easy | 🟢 초록 | 4 |

각 버튼 위에 다음 간격 미리보기 (`Nd`) + 단축키 라벨 `[1~4]`

### 키보드 단축키
- **Space/Enter**: 답 공개 (앞 단계만)
- **1/2/3/4**: AGAIN/HARD/GOOD/EASY (답 공개 후만)
- INPUT/TEXTAREA/contenteditable 포커스 시 무시 (입력 안전)

### 흐름
- 평가 → `POST /api/planner/reviews/:id/complete`
- 성공 시 토스트 "다음 복습은 N일 후 (M/D)" + 다음 카드로 진행
- 마지막 후: **CompletionState** "🎉 오늘 복습 N개 모두 완료!" + [홈으로]/[학습 자료 보기]
- 진입 시 0건: **EmptyTodayState** "오늘은 복습할 카드가 없어요! 🌱" + [홈으로]
- `useCompleteReview`는 `reviews.today` + `material` 키 invalidate
  → 사이드바 뱃지 + 자료 목록 dueReviewCount 자동 갱신

### `features/review/` 확장
- api: `completeReview` + 응답 타입
- hooks: `useCompleteReview` (mutation + invalidate)
- components: `ReviewCard`, `EmptyTodayState`, `CompletionState`

## 검증
- [x] `npm test` 80건 통과 (`TodayReviewsPage` 6건 신규)
- [x] `npm run lint` / `format:check` / `tsc -b --noEmit` / `build` 통과
- [x] **로컬 dev + Playwright**:
  - 백데이트된 review로 진입 → "1 / 2" 카운터 + "3일 밀린 복습" 표시
  - Space → 답 + 4지선다 (preview "1d / 6d / 6d / 6d") 노출
  - 키보드 `3` → GOOD 평가 → 다음 카드 → 마지막 후 "🎉 오늘 복습 N개 모두 완료!" + 사이드바 뱃지 자동 사라짐 확인

### 구현 노트
- 처음엔 `data.reviews`를 직접 사용했으나 평가 후 `invalidateQueries(reviews.today)`가 즉시 refetch → 큐 길이가 감소 → currentIndex가 새 total을 초과해 완료 화면으로 점프하는 버그가 있어, 초기 데이터를 로컬 state(`queue`)에 snapshot으로 고정하는 형태로 수정

## 후속
- **B안 v2 완료** — BE 7건 + FE 5건 모두 종료