### PR TITLE
fix : mysql service에 appProtocol=tcp 명시 (Istio sniff 우회)

### DIFF
--- a/infra/helm/mysql/templates/service.yaml
+++ b/infra/helm/mysql/templates/service.yaml
@@ -7,6 +7,8 @@ spec:
   selector:
     app: mysql
   ports:
-    - port: 3306
+    - name: tcp-mysql
+      appProtocol: tcp
+      port: 3306
       targetPort: 3306
       nodePort: 30306


### PR DESCRIPTION
closes #387

## Description

MySQL Service 포트에 `portName=tcp-mysql` + `appProtocol=tcp`를 명시하여 Istio envoy의 프로토콜 sniff를 우회한다.

## 배경

mysql pod에는 Istio sidecar(`istio-proxy`)가 주입되어 있다. Service 포트에 protocol 힌트가 없으면 Istio가 자동으로 protocol sniff를 시도하는데, MySQL은 **server-speaks-first** 프로토콜이라 envoy가 client greeting을 무한 대기하며 hang된다.

### 증상

- 외부에서 `nc -zv 192.168.0.18 30306` → 연결 성공
- DataGrip 등 JDBC 클라이언트 → "Incorrect driver and/or database URL specified" 또는 timeout
- pod 내부 socket 접속(`mysql -u orino_app`)은 정상

### 해결 원리

Istio는 다음 우선순위로 프로토콜을 결정:
1. Service port의 `appProtocol` 필드
2. portName prefix (`tcp-`, `mysql-` 등)
3. (없으면) 자동 sniff

`appProtocol: tcp`로 명시하면 sniff 없이 plain TCP 패스스루.

## 변경 사항

- `infra/helm/mysql/templates/service.yaml`: port에 `name: tcp-mysql` + `appProtocol: tcp` 추가

## 검증

- helm template 렌더링 정상
- 배포 후 외부 NodePort(`30306`)로 DataGrip 접속 가능 여부 확인 필요 (사용자)
- 클러스터 내부 접속(`mysql.orino.svc.cluster.local:3306`)에서 BE 정상 동작 확인 필요 (회귀 방지)
- `mysql-backup` CronJob도 동일 namespace 내부 접속이라 영향 없음 예상

## 참고

- [Istio Protocol Selection](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/)