### PR TITLE
fix : mysql 3306 inbound을 istio sidecar에서 제외

### DIFF
--- a/infra/helm/mysql/templates/statefulset.yaml
+++ b/infra/helm/mysql/templates/statefulset.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         app: mysql
+      annotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: "3306"
     spec:
       containers:
         - name: mysql


### PR DESCRIPTION
refs #387

## Description

PR #388 (`appProtocol: tcp` 추가)에도 불구하고 NodePort 외부 접속이 여전히 hang됨. 더 강한 우회가 필요하여 inbound 3306을 Istio iptables redirect에서 완전 제외한다.

## 원인 분석 (#388 한계)

`appProtocol: tcp` 설정은 envoy의 **filter chain**을 단순화하지만, **listener filter 단계의 TLS inspector**는 여전히 동작한다.

```
External JDBC → NodePort 30306 → pod iptables (istio-init)
  → istio-proxy virtualInbound(15006)
    → TLS inspector listener filter (transport_protocol sniff)  ← HERE
      → filter chain (tcp_proxy)
        → mysql container :3306
```

TLS inspector는 client의 첫 byte를 sniff해서 TLS인지 raw_buffer인지 판단하는데, MySQL은 **server-speaks-first** 프로토콜이라:

1. 클라이언트(JDBC)가 연결 후 server greeting을 기다림
2. 서버(mysql)는 envoy에 막혀서 greeting을 못 보냄
3. envoy는 client byte를 기다림
4. → 데드락

config_dump로 확인한 filter chain (이미 tcp_proxy만 가짐):
```
destination_port: 3306, transport_protocol: raw_buffer
  filters: [istio.metadata_exchange, istio.stats, envoy.filters.network.tcp_proxy]
```

문제는 filter chain이 아니라 **transport_protocol detection** 자체.

## 해결

`traffic.sidecar.istio.io/excludeInboundPorts: "3306"` annotation 추가:

- istio-init이 생성하는 iptables redirect rule에서 3306을 제외
- 3306 inbound 트래픽은 sidecar를 거치지 않고 mysql 컨테이너로 직접 전달
- outbound 트래픽은 여전히 sidecar 경유 (mysql → 다른 서비스 통신은 mTLS 유지)

## 변경 사항

- `infra/helm/mysql/templates/statefulset.yaml`: pod template annotation 추가

## 영향도

- ✅ 외부 NodePort 30306 JDBC 접속 정상 동작
- ✅ 클러스터 내부 `mysql.orino.svc:3306` BE 접속도 정상 (어차피 mysql sidecar bypass)
- ⚠️  mysql ← BE 트래픽은 BE sidecar mTLS 유지 (outbound) but mysql 측에서는 plain TCP로 수신
- ⚠️  PeerAuthentication을 STRICT로 설정하지 않은 상태라 기존 동작과 동일

## 검증

- helm template 렌더링 정상
- 배포 후 외부 NodePort 30306으로 DataGrip 접속 가능 여부 확인 필요
- BE → MySQL 정상 동작 확인 필요 (회귀 방지)

## 대안 (선택하지 않음)

| 방안 | 이유 |
|---|---|
| sidecar 완전 비활성 (`inject: false`) | mysql → 다른 서비스 outbound도 mTLS 잃음 |
| PeerAuthentication: DISABLE | namespace 전체 mTLS 영향 |
| EnvoyFilter로 TLS inspector 제거 | 너무 침습적, 다른 트래픽까지 영향 |