### PR TITLE
feat : Cloudflare Tunnel로 mysql operator access 구축

### DIFF
--- a/infra/helm/cloudflared/values.yaml
+++ b/infra/helm/cloudflared/values.yaml
@@ -22,6 +22,10 @@ cloudflared:
       service: http://istio-gateway.istio-ingress.svc.cluster.local:80
     - hostname: telemetry.orino.dev
       service: http://istio-gateway.istio-ingress.svc.cluster.local:80
+    # MySQL operator access via Cloudflare Access (TCP)
+    # 로컬: cloudflared access tcp --hostname mysql.orino.dev --url localhost:3306
+    - hostname: mysql.orino.dev
+      service: tcp://mysql.orino.svc.cluster.local:3306
     - service: http_status:404
 
   resources:

--- a/infra/helm/mysql/templates/service.yaml
+++ b/infra/helm/mysql/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: mysql
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: mysql
   ports:
@@ -11,4 +11,3 @@ spec:
       appProtocol: tcp
       port: 3306
       targetPort: 3306
-      nodePort: 30306

--- a/infra/helm/mysql/templates/statefulset.yaml
+++ b/infra/helm/mysql/templates/statefulset.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         app: mysql
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: mysql


### PR DESCRIPTION
closes #387
closes #390

## Description

MySQL 외부 접근을 **Cloudflare Zero Trust (Tunnel + Access)** 기반 Identity-Aware Proxy 패턴으로 구축한다.

## 배경

PR #388, #389에서 NodePort + Istio sidecar bypass로 외부 접속을 열려 시도했으나, 다음 안티패턴 문제 발견:

- NodePort DB 노출은 보안 anti-pattern
- Istio sidecar bypass는 mTLS/authz/telemetry 손실
- 사람 계정으로 DB 직접 접속은 audit/JIT/MFA 부재

리서치 결과 표준 best practice는 **Identity-Aware Proxy(IAP)**. 이미 운영 중인 Cloudflare Tunnel을 활용하면 **추가 인프라/비용 0원**으로 구현 가능.

## 아키텍처

\`\`\`
DataGrip (laptop)
    │ localhost:3306
    ▼
cloudflared access tcp (laptop)
    │ HTTPS/QUIC outbound
    ▼
Cloudflare Edge (Access SSO + MFA 검증)
    │
    ▼
Cloudflare Tunnel
    │
    ▼
cloudflared (cluster pod, 기존 재사용)
    │
    ▼
mysql.orino.svc.cluster.local:3306 (ClusterIP, no sidecar)
\`\`\`

## 변경 사항

### \`infra/helm/cloudflared/values.yaml\`
- \`mysql.orino.dev\` → \`tcp://mysql.orino.svc:3306\` 라우팅 추가

### \`infra/helm/mysql/templates/statefulset.yaml\`
- \`sidecar.istio.io/inject: \"false\"\` annotation 추가
- Istio 공식 권장: stateful DB는 mesh에서 제외 (Salesforce/eBay IstioCon 2023 사례)

### \`infra/helm/mysql/templates/service.yaml\`
- NodePort 제거 → ClusterIP
- 외부 노출 0, 모든 외부 접근은 Cloudflare Access를 통과해야만 가능

## 보안 모델

- **인증**: Cloudflare Access SSO (Google/GitHub) + MFA 강제
- **권한**: Access Policy로 본인 이메일만 허용
- **세션**: 1시간 만료
- **감사**: Cloudflare 대시보드 audit log
- **네트워크**: origin port 노출 0 (outbound tunnel만 사용)

## 사용자 작업 (배포 후)

### 1. Cloudflare 대시보드
Zero Trust → Access → Applications → Add Application:
- Type: **Self-hosted**
- Application: \`mysql\`
- Domain: \`mysql.orino.dev\`
- (TCP application이므로 Service Auth/TCP 옵션 선택)
- Policy: Allow if \`email = wcorn@gmail.com\` (본인 이메일)
- Session duration: 1h
- (옵션) Country = KR

### 2. 로컬
\`\`\`bash
brew install cloudflared
cloudflared access tcp --hostname mysql.orino.dev --url localhost:3306
\`\`\`

### 3. DataGrip
- Host: \`localhost\`
- Port: \`3306\`
- Database: \`orino\`
- User: \`orino_app\` / Password: (mysql-secret 값)

## 검증

- \`helm template\` 렌더링 정상 (cloudflared config, mysql Service/StatefulSet)
- 배포 후:
  - [ ] mysql pod에 sidecar 없는지 확인 (\`kubectl get pod -n orino mysql-0 -o jsonpath='{.spec.containers[*].name}'\`)
  - [ ] BE → mysql 정상 동작 (회귀)
  - [ ] mysql-backup CronJob 정상 동작 (회귀)
  - [ ] \`cloudflared access tcp\` 로컬 실행 + DataGrip 접속 성공
  - [ ] Cloudflare Access 미인증 시 차단 확인

## 추가 비용

**0원** — Cloudflare Zero Trust free tier(50명) 한도 내

## 참고

- Cloudflare MySQL Tunnel tutorial
- Istio + DB workload (IstioCon 2023, Salesforce)
- CNCF Cloud Native Security Whitepaper v2 (사람 계정 ≠ DB 사용자)