### PR TITLE
feat : note 테이블 트리화 마이그레이션 (parent_id/title/sort_order)

### DIFF
--- a/be/orino-app-api/src/main/resources/db/changelog/changes/021-alter-note-tree.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/021-alter-note-tree.yaml
@@ -1,0 +1,57 @@
+databaseChangeLog:
+  - changeSet:
+      id: 021-alter-note-tree
+      author: wcorn
+      comment: |
+        노트를 Notion 스타일 트리(nested)로 확장 (#397).
+        자료당 1노트(1:1) → 자료당 N노트 + 무제한 중첩.
+        무손실 ALTER: 기존 노트는 parent_id=NULL(루트), title='제목 없음', sort_order=0으로 유지.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: note
+                columnName: parent_id
+      changes:
+        # 1) 컬럼 추가 (parent_id self-ref FK 포함)
+        - addColumn:
+            tableName: note
+            columns:
+              - column:
+                  name: parent_id
+                  type: BIGINT
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk_note_parent
+                    references: note(id)
+                    deleteCascade: true
+              - column:
+                  name: title
+                  type: VARCHAR(200)
+                  defaultValue: 제목 없음
+                  constraints:
+                    nullable: false
+              - column:
+                  name: sort_order
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+
+        # 2) 트리 조회용 인덱스 (material_id prefix → fk_note_material이 이 인덱스를 사용)
+        - createIndex:
+            tableName: note
+            indexName: idx_note_material_parent_sort
+            columns:
+              - column:
+                  name: material_id
+              - column:
+                  name: parent_id
+              - column:
+                  name: sort_order
+
+        # 3) material_id UNIQUE 제약 제거 (1자료=1노트 해제)
+        #    위 인덱스가 material_id를 커버하므로 fk_note_material을 깨지 않고 drop 가능
+        - dropUniqueConstraint:
+            tableName: note
+            constraintName: uk_note_material

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -39,3 +39,5 @@ databaseChangeLog:
       file: db/changelog/changes/019-rollback-v1-planner-tables.yaml
   - include:
       file: db/changelog/changes/020-create-v2-planner-tables.yaml
+  - include:
+      file: db/changelog/changes/021-alter-note-tree.yaml

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/note/entity/Note.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/note/entity/Note.java
@@ -7,7 +7,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -16,10 +15,11 @@ import java.time.LocalDateTime;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "note", uniqueConstraints = @UniqueConstraint(name = "uk_note_material", columnNames = "material_id"))
+@Table(name = "note")
 public class Note {
 
     public static final String DEFAULT_CONTENT = "{\"type\":\"doc\",\"content\":[]}";
+    public static final String DEFAULT_TITLE = "제목 없음";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,6 +30,15 @@ public class Note {
 
     @Column(name = "material_id", nullable = false)
     private Long materialId;
+
+    @Column(name = "parent_id")
+    private Long parentId;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
 
     @Column(nullable = false, columnDefinition = "JSON")
     private String content;
@@ -45,18 +54,41 @@ public class Note {
     protected Note() {
     }
 
+    /**
+     * 자료의 루트 노트(빈 doc)를 만든다. parentId=null, 기본 제목, sortOrder=0.
+     */
     public Note(Long memberId, Long materialId) {
-        this(memberId, materialId, DEFAULT_CONTENT);
+        this(memberId, materialId, null, DEFAULT_TITLE, 0, DEFAULT_CONTENT);
     }
 
-    public Note(Long memberId, Long materialId, String content) {
+    public Note(Long memberId, Long materialId, Long parentId, String title, int sortOrder) {
+        this(memberId, materialId, parentId, title, sortOrder, DEFAULT_CONTENT);
+    }
+
+    public Note(Long memberId, Long materialId, Long parentId, String title,
+                int sortOrder, String content) {
         this.memberId = memberId;
         this.materialId = materialId;
+        this.parentId = parentId;
+        this.title = (title == null || title.isBlank()) ? DEFAULT_TITLE : title;
+        this.sortOrder = sortOrder;
         this.content = content;
     }
 
     public void updateContent(String content) {
         this.content = content;
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateParent(Long parentId) {
+        this.parentId = parentId;
+    }
+
+    public void updateSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
     }
 
     public Long getId() {
@@ -69,6 +101,18 @@ public class Note {
 
     public Long getMaterialId() {
         return materialId;
+    }
+
+    public Long getParentId() {
+        return parentId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Integer getSortOrder() {
+        return sortOrder;
     }
 
     public String getContent() {


### PR DESCRIPTION
## 이슈
closes #397

## 작업 내용

노트를 Notion 스타일 트리(nested)로 확장하기 위한 **무손실 ALTER**. 자료당 1노트(1:1) → 자료당 N노트 + 무제한 중첩.

### Liquibase (`021-alter-note-tree.yaml`)
- `parent_id BIGINT NULL` + self-ref FK `fk_note_parent` ON DELETE CASCADE
- `title VARCHAR(200) NOT NULL DEFAULT '제목 없음'`
- `sort_order INT NOT NULL DEFAULT 0`
- 인덱스 `(material_id, parent_id, sort_order)`
- `material_id` UNIQUE(`uk_note_material`) 제거 → 1자료=1노트 해제

**drop 순서 주의**: `fk_note_material`이 `material_id` 인덱스를 필요로 하므로, UNIQUE를 먼저 drop하면 `Cannot drop index 'uk_note_material': needed in a foreign key constraint` 에러가 난다. 그래서 컬럼 추가 → 트리 인덱스 생성(`material_id` prefix 제공) → UNIQUE drop 순서로 배치해 FK를 깨지 않고 제거.

### Note 엔티티
- `parentId` / `title` / `sortOrder` 필드 + `updateTitle`/`updateParent`/`updateSortOrder`
- 2-arg 생성자 `new Note(memberId, materialId)`는 루트 노트(parentId=null, 기본 제목, sortOrder=0)로 **하위 호환 유지**
  - 자료 생성 시 빈 노트 자동 생성 로직은 다음 이슈(#398)에서 제거 예정이라, 본 PR은 깨지 않고 컴파일/테스트 유지

### 검증
- [x] `./gradlew build` (checkstyle 포함) 통과
- [x] `SchemaValidationTest` 통과 — 엔티티 ↔ Liquibase ALTER 결과 일치 (Hibernate validate)
- [x] **로컬 bootRun (실제 무손실 검증)**: 이전 세션 DB가 마침 020 상태(노트 5건 존재)로 남아 있어, 021 적용 후:
  - `material_id` UNI → MUL (UNIQUE 제거, FK는 유지)
  - 기존 5건 노트: `parent_id=NULL`(루트), `title='제목 없음'`(HEX `ECA09C...` UTF-8 확인), `sort_order=0` 으로 무손실 유지
  - `idx_note_material_parent_sort` + `fk_note_parent` self-ref FK 생성 확인

## 후속
- #398 노트 트리 CRUD API (단건 GET/PUT 제거, 자료 자동 노트 생성 제거, 사이클 방지)
- #399 FE 노트 탭 트리화 (2-pane)