### PR TITLE
feat : 노트 트리 CRUD API (Notion 스타일 중첩)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/controller/StudyMaterialController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/controller/StudyMaterialController.java
@@ -3,7 +3,6 @@ package ds.project.orino.planner.material.controller;
 import ds.project.orino.common.response.ApiResponse;
 import ds.project.orino.domain.planner.material.entity.MaterialStatus;
 import ds.project.orino.planner.material.dto.MaterialCreateRequest;
-import ds.project.orino.planner.material.dto.MaterialCreateResponse;
 import ds.project.orino.planner.material.dto.MaterialListResponse;
 import ds.project.orino.planner.material.dto.MaterialResponse;
 import ds.project.orino.planner.material.dto.MaterialUpdateRequest;
@@ -41,7 +40,7 @@ public class StudyMaterialController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<MaterialCreateResponse>> create(
+    public ResponseEntity<ApiResponse<MaterialResponse>> create(
             @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody MaterialCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialCreateResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialCreateResponse.java
@@ -1,6 +1,0 @@
-package ds.project.orino.planner.material.dto;
-
-import ds.project.orino.planner.note.dto.NoteResponse;
-
-public record MaterialCreateResponse(MaterialResponse material, NoteResponse note) {
-}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyMaterialService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyMaterialService.java
@@ -6,13 +6,9 @@ import ds.project.orino.domain.planner.material.entity.MaterialStatus;
 import ds.project.orino.domain.planner.material.entity.StudyMaterial;
 import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
 import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository.MaterialCountRow;
-import ds.project.orino.domain.planner.note.entity.Note;
-import ds.project.orino.domain.planner.note.repository.NoteRepository;
 import ds.project.orino.planner.material.dto.MaterialCreateRequest;
-import ds.project.orino.planner.material.dto.MaterialCreateResponse;
 import ds.project.orino.planner.material.dto.MaterialResponse;
 import ds.project.orino.planner.material.dto.MaterialUpdateRequest;
-import ds.project.orino.planner.note.dto.NoteResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,14 +23,11 @@ import java.util.stream.Collectors;
 public class StudyMaterialService {
 
     private final StudyMaterialRepository studyMaterialRepository;
-    private final NoteRepository noteRepository;
     private final Clock clock;
 
     public StudyMaterialService(StudyMaterialRepository studyMaterialRepository,
-                                NoteRepository noteRepository,
                                 Clock clock) {
         this.studyMaterialRepository = studyMaterialRepository;
-        this.noteRepository = noteRepository;
         this.clock = clock;
     }
 
@@ -55,12 +48,10 @@ public class StudyMaterialService {
     }
 
     @Transactional
-    public MaterialCreateResponse create(Long memberId, MaterialCreateRequest request) {
+    public MaterialResponse create(Long memberId, MaterialCreateRequest request) {
         StudyMaterial saved = studyMaterialRepository.save(
                 new StudyMaterial(memberId, request.title(), request.type()));
-        Note note = noteRepository.save(new Note(memberId, saved.getId()));
-        MaterialResponse materialResponse = MaterialResponse.of(saved, 0L, 0L);
-        return new MaterialCreateResponse(materialResponse, NoteResponse.of(note));
+        return MaterialResponse.of(saved, 0L, 0L);
     }
 
     @Transactional

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/controller/NoteController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/controller/NoteController.java
@@ -1,21 +1,27 @@
 package ds.project.orino.planner.note.controller;
 
 import ds.project.orino.common.response.ApiResponse;
-import ds.project.orino.planner.note.dto.NoteResponse;
+import ds.project.orino.planner.note.dto.NoteCreateRequest;
+import ds.project.orino.planner.note.dto.NoteDetailResponse;
+import ds.project.orino.planner.note.dto.NoteTreeResponse;
 import ds.project.orino.planner.note.dto.NoteUpdateRequest;
 import ds.project.orino.planner.note.dto.NoteUpdateResponse;
 import ds.project.orino.planner.note.service.NoteService;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/planner/materials/{materialId}/note")
+@RequestMapping("/api/planner")
 public class NoteController {
 
     private final NoteService noteService;
@@ -24,18 +30,42 @@ public class NoteController {
         this.noteService = noteService;
     }
 
-    @GetMapping
-    public ApiResponse<NoteResponse> get(
+    @GetMapping("/materials/{materialId}/notes")
+    public ApiResponse<NoteTreeResponse> tree(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long materialId) {
-        return ApiResponse.success(noteService.findByMaterialId(memberId, materialId));
+        return ApiResponse.success(noteService.findTree(memberId, materialId));
     }
 
-    @PutMapping
-    public ApiResponse<NoteUpdateResponse> put(
+    @PostMapping("/materials/{materialId}/notes")
+    public ResponseEntity<ApiResponse<NoteDetailResponse>> create(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long materialId,
+            @Valid @RequestBody NoteCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(noteService.create(memberId, materialId, request)));
+    }
+
+    @GetMapping("/notes/{noteId}")
+    public ApiResponse<NoteDetailResponse> detail(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long noteId) {
+        return ApiResponse.success(noteService.findOne(memberId, noteId));
+    }
+
+    @PatchMapping("/notes/{noteId}")
+    public ApiResponse<NoteUpdateResponse> update(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long noteId,
             @Valid @RequestBody NoteUpdateRequest request) {
-        return ApiResponse.success(noteService.update(memberId, materialId, request.content()));
+        return ApiResponse.success(noteService.update(memberId, noteId, request));
+    }
+
+    @DeleteMapping("/notes/{noteId}")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long noteId) {
+        noteService.delete(memberId, noteId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteCreateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteCreateRequest.java
@@ -1,0 +1,11 @@
+package ds.project.orino.planner.note.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record NoteCreateRequest(
+        Long parentId,
+
+        @Size(min = 1, max = 200, message = "title은 1~200자여야 합니다.")
+        String title
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteDetailResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteDetailResponse.java
@@ -9,21 +9,26 @@ import tools.jackson.databind.json.JsonMapper;
 
 import java.time.LocalDateTime;
 
-public record NoteResponse(
+public record NoteDetailResponse(
         Long id,
         Long materialId,
+        Long parentId,
+        String title,
+        int sortOrder,
         JsonNode content,
         LocalDateTime updatedAt
 ) {
     private static final JsonMapper MAPPER = JsonMapper.builder().build();
 
-    public static NoteResponse of(Note note) {
+    public static NoteDetailResponse of(Note note) {
         JsonNode parsed;
         try {
             parsed = MAPPER.readTree(note.getContent());
         } catch (JacksonException e) {
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, e);
         }
-        return new NoteResponse(note.getId(), note.getMaterialId(), parsed, note.getUpdatedAt());
+        return new NoteDetailResponse(
+                note.getId(), note.getMaterialId(), note.getParentId(),
+                note.getTitle(), note.getSortOrder(), parsed, note.getUpdatedAt());
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteTreeNode.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteTreeNode.java
@@ -1,0 +1,12 @@
+package ds.project.orino.planner.note.dto;
+
+import java.util.List;
+
+public record NoteTreeNode(
+        Long id,
+        String title,
+        Long parentId,
+        int sortOrder,
+        List<NoteTreeNode> children
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteTreeResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteTreeResponse.java
@@ -1,0 +1,6 @@
+package ds.project.orino.planner.note.dto;
+
+import java.util.List;
+
+public record NoteTreeResponse(List<NoteTreeNode> notes) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteUpdateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteUpdateRequest.java
@@ -1,10 +1,16 @@
 package ds.project.orino.planner.note.dto;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import tools.jackson.databind.JsonNode;
 
 public record NoteUpdateRequest(
-        @NotNull(message = "content는 필수입니다.")
-        JsonNode content
+        @Size(min = 1, max = 200, message = "title은 1~200자여야 합니다.")
+        String title,
+
+        JsonNode content,
+
+        Long parentId,
+
+        Integer sortOrder
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteUpdateResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteUpdateResponse.java
@@ -7,9 +7,14 @@ import java.time.LocalDateTime;
 public record NoteUpdateResponse(
         Long id,
         Long materialId,
+        Long parentId,
+        String title,
+        int sortOrder,
         LocalDateTime updatedAt
 ) {
     public static NoteUpdateResponse of(Note note) {
-        return new NoteUpdateResponse(note.getId(), note.getMaterialId(), note.getUpdatedAt());
+        return new NoteUpdateResponse(
+                note.getId(), note.getMaterialId(), note.getParentId(),
+                note.getTitle(), note.getSortOrder(), note.getUpdatedAt());
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/service/NoteService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/service/NoteService.java
@@ -2,9 +2,14 @@ package ds.project.orino.planner.note.service;
 
 import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
 import ds.project.orino.domain.planner.note.entity.Note;
 import ds.project.orino.domain.planner.note.repository.NoteRepository;
-import ds.project.orino.planner.note.dto.NoteResponse;
+import ds.project.orino.planner.note.dto.NoteCreateRequest;
+import ds.project.orino.planner.note.dto.NoteDetailResponse;
+import ds.project.orino.planner.note.dto.NoteTreeNode;
+import ds.project.orino.planner.note.dto.NoteTreeResponse;
+import ds.project.orino.planner.note.dto.NoteUpdateRequest;
 import ds.project.orino.planner.note.dto.NoteUpdateResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +18,12 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Service
 @Transactional(readOnly = true)
@@ -22,33 +33,148 @@ public class NoteService {
     private static final JsonMapper MAPPER = JsonMapper.builder().build();
 
     private final NoteRepository noteRepository;
+    private final StudyMaterialRepository studyMaterialRepository;
 
-    public NoteService(NoteRepository noteRepository) {
+    public NoteService(NoteRepository noteRepository,
+                       StudyMaterialRepository studyMaterialRepository) {
         this.noteRepository = noteRepository;
+        this.studyMaterialRepository = studyMaterialRepository;
     }
 
-    public NoteResponse findByMaterialId(Long memberId, Long materialId) {
-        return NoteResponse.of(getOwnedNote(memberId, materialId));
+    public NoteTreeResponse findTree(Long memberId, Long materialId) {
+        requireOwnedMaterial(memberId, materialId);
+        List<Note> notes = noteRepository.findAllByMaterialIdOrderBySortOrderAscIdAsc(materialId);
+        return new NoteTreeResponse(buildTree(notes));
+    }
+
+    public NoteDetailResponse findOne(Long memberId, Long noteId) {
+        return NoteDetailResponse.of(getOwnedNote(memberId, noteId));
     }
 
     @Transactional
-    public NoteUpdateResponse update(Long memberId, Long materialId, JsonNode content) {
-        String serialized = serialize(content);
-        if (serialized.getBytes(StandardCharsets.UTF_8).length > MAX_CONTENT_BYTES) {
-            throw new CustomException(ErrorCode.INVALID_REQUEST);
+    public NoteDetailResponse create(Long memberId, Long materialId, NoteCreateRequest request) {
+        requireOwnedMaterial(memberId, materialId);
+
+        Long parentId = request.parentId();
+        if (parentId != null) {
+            Note parent = getOwnedNote(memberId, parentId);
+            if (!parent.getMaterialId().equals(materialId)) {
+                throw new CustomException(ErrorCode.INVALID_REQUEST);
+            }
         }
-        Note note = getOwnedNote(memberId, materialId);
-        note.updateContent(serialized);
+
+        int sortOrder = noteRepository.findMaxSortOrder(materialId, parentId) + 1;
+        Note saved = noteRepository.save(
+                new Note(memberId, materialId, parentId, request.title(), sortOrder));
+        return NoteDetailResponse.of(saved);
+    }
+
+    @Transactional
+    public NoteUpdateResponse update(Long memberId, Long noteId, NoteUpdateRequest request) {
+        if (request.title() == null && request.content() == null
+                && request.parentId() == null && request.sortOrder() == null) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+
+        Note note = getOwnedNote(memberId, noteId);
+
+        if (request.content() != null) {
+            String serialized = serialize(request.content());
+            if (serialized.getBytes(StandardCharsets.UTF_8).length > MAX_CONTENT_BYTES) {
+                throw new CustomException(ErrorCode.INVALID_REQUEST);
+            }
+            note.updateContent(serialized);
+        }
+        if (request.title() != null) {
+            note.updateTitle(request.title());
+        }
+        if (request.parentId() != null) {
+            moveTo(memberId, note, request.parentId());
+        }
+        if (request.sortOrder() != null) {
+            note.updateSortOrder(request.sortOrder());
+        }
+
         return NoteUpdateResponse.of(note);
     }
 
-    private Note getOwnedNote(Long memberId, Long materialId) {
-        Note note = noteRepository.findByMaterialId(materialId)
-                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
-        if (!note.getMemberId().equals(memberId)) {
-            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+    @Transactional
+    public void delete(Long memberId, Long noteId) {
+        Note note = getOwnedNote(memberId, noteId);
+        noteRepository.delete(note);
+    }
+
+    private void moveTo(Long memberId, Note note, Long newParentId) {
+        if (newParentId.equals(note.getId())) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
         }
-        return note;
+        Note newParent = getOwnedNote(memberId, newParentId);
+        if (!newParent.getMaterialId().equals(note.getMaterialId())) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        if (isDescendant(note.getMaterialId(), note.getId(), newParentId)) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        note.updateParent(newParentId);
+    }
+
+    /**
+     * candidateId가 rootId의 서브트리(자손) 안에 있으면 true.
+     */
+    private boolean isDescendant(Long materialId, Long rootId, Long candidateId) {
+        List<Note> all = noteRepository.findAllByMaterialIdOrderBySortOrderAscIdAsc(materialId);
+        Map<Long, List<Long>> childrenByParent = new HashMap<>();
+        for (Note n : all) {
+            childrenByParent
+                    .computeIfAbsent(n.getParentId(), k -> new ArrayList<>())
+                    .add(n.getId());
+        }
+        Set<Long> visited = new HashSet<>();
+        List<Long> stack = new ArrayList<>(childrenByParent.getOrDefault(rootId, List.of()));
+        while (!stack.isEmpty()) {
+            Long cur = stack.remove(stack.size() - 1);
+            if (!visited.add(cur)) {
+                continue;
+            }
+            if (cur.equals(candidateId)) {
+                return true;
+            }
+            stack.addAll(childrenByParent.getOrDefault(cur, List.of()));
+        }
+        return false;
+    }
+
+    private List<NoteTreeNode> buildTree(List<Note> notes) {
+        Map<Long, List<Note>> childrenByParent = new HashMap<>();
+        for (Note n : notes) {
+            childrenByParent
+                    .computeIfAbsent(n.getParentId(), k -> new ArrayList<>())
+                    .add(n);
+        }
+        return toNodes(childrenByParent.get(null), childrenByParent);
+    }
+
+    private List<NoteTreeNode> toNodes(List<Note> level, Map<Long, List<Note>> childrenByParent) {
+        if (level == null) {
+            return List.of();
+        }
+        List<NoteTreeNode> nodes = new ArrayList<>(level.size());
+        for (Note n : level) {
+            nodes.add(new NoteTreeNode(
+                    n.getId(), n.getTitle(), n.getParentId(), n.getSortOrder(),
+                    toNodes(childrenByParent.get(n.getId()), childrenByParent)));
+        }
+        return nodes;
+    }
+
+    private void requireOwnedMaterial(Long memberId, Long materialId) {
+        studyMaterialRepository.findByIdAndMemberId(materialId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    private Note getOwnedNote(Long memberId, Long noteId) {
+        return noteRepository.findByIdAndMemberId(noteId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
     }
 
     private static String serialize(JsonNode content) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyMaterialControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyMaterialControllerTest.java
@@ -66,8 +66,8 @@ class StudyMaterialControllerTest extends ApiTestSupport {
     }
 
     @Test
-    @DisplayName("POST /api/planner/materials - 자료 생성 시 빈 노트가 함께 생성된다")
-    void create_material_with_empty_note() throws Exception {
+    @DisplayName("POST /api/planner/materials - 자료를 생성한다 (노트는 동봉하지 않는다)")
+    void create_material() throws Exception {
         mockMvc.perform(post("/api/planner/materials")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -75,14 +75,12 @@ class StudyMaterialControllerTest extends ApiTestSupport {
                                 {"title": "이펙티브 자바", "type": "BOOK"}
                                 """))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.data.material.title").value("이펙티브 자바"))
-                .andExpect(jsonPath("$.data.material.type").value("BOOK"))
-                .andExpect(jsonPath("$.data.material.status").value("ACTIVE"))
-                .andExpect(jsonPath("$.data.material.flashcardCount").value(0))
-                .andExpect(jsonPath("$.data.material.dueReviewCount").value(0))
-                .andExpect(jsonPath("$.data.note.content.type").value("doc"))
-                .andExpect(jsonPath("$.data.note.content.content").isArray())
-                .andExpect(jsonPath("$.data.note.materialId").exists());
+                .andExpect(jsonPath("$.data.title").value("이펙티브 자바"))
+                .andExpect(jsonPath("$.data.type").value("BOOK"))
+                .andExpect(jsonPath("$.data.status").value("ACTIVE"))
+                .andExpect(jsonPath("$.data.flashcardCount").value(0))
+                .andExpect(jsonPath("$.data.dueReviewCount").value(0))
+                .andExpect(jsonPath("$.data.note").doesNotExist());
     }
 
     @Test

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/note/controller/NoteControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/note/controller/NoteControllerTest.java
@@ -17,9 +17,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -37,10 +42,12 @@ class NoteControllerTest extends ApiTestSupport {
     @Autowired
     private DbCleaner dbCleaner;
 
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
     private Member member;
     private Member otherMember;
     private StudyMaterial material;
-    private Note note;
     private String authHeader;
 
     @BeforeEach
@@ -50,125 +57,256 @@ class NoteControllerTest extends ApiTestSupport {
         otherMember = memberRepository.save(MemberFixture.create("other", "password"));
         material = studyMaterialRepository.save(
                 new StudyMaterial(member.getId(), "이펙티브 자바", MaterialType.BOOK));
-        note = noteRepository.save(new Note(member.getId(), material.getId()));
         authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
     }
 
+    private Note root(String title, int sortOrder) {
+        return noteRepository.save(new Note(member.getId(), material.getId(), null, title, sortOrder));
+    }
+
+    private Note child(Long parentId, String title, int sortOrder) {
+        return noteRepository.save(new Note(member.getId(), material.getId(), parentId, title, sortOrder));
+    }
+
     @Test
-    @DisplayName("GET - 빈 노트 조회 시 기본 doc 구조를 반환한다")
-    void get_returns_default_empty_doc() throws Exception {
-        mockMvc.perform(get("/api/planner/materials/{id}/note", material.getId())
+    @DisplayName("GET notes - 노트가 없으면 빈 트리")
+    void tree_empty() throws Exception {
+        mockMvc.perform(get("/api/planner/materials/{id}/notes", material.getId())
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").value(note.getId()))
-                .andExpect(jsonPath("$.data.materialId").value(material.getId()))
+                .andExpect(jsonPath("$.data.notes", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("GET notes - 중첩 트리를 sortOrder 순으로 조립한다 (content 제외)")
+    void tree_nested() throws Exception {
+        Note r1 = root("1장", 0);
+        Note r2 = root("2장", 1);
+        Note c1 = child(r1.getId(), "1-1 절", 0);
+        child(c1.getId(), "1-1-1 항", 0);
+
+        mockMvc.perform(get("/api/planner/materials/{id}/notes", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.notes", hasSize(2)))
+                .andExpect(jsonPath("$.data.notes[0].id").value(r1.getId()))
+                .andExpect(jsonPath("$.data.notes[0].title").value("1장"))
+                .andExpect(jsonPath("$.data.notes[0].children", hasSize(1)))
+                .andExpect(jsonPath("$.data.notes[0].children[0].id").value(c1.getId()))
+                .andExpect(jsonPath("$.data.notes[0].children[0].children", hasSize(1)))
+                .andExpect(jsonPath("$.data.notes[0].children[0].children[0].title").value("1-1-1 항"))
+                .andExpect(jsonPath("$.data.notes[1].id").value(r2.getId()))
+                .andExpect(jsonPath("$.data.notes[0].content").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET notes - 타인 자료의 트리 조회 시 404")
+    void tree_other_material_404() throws Exception {
+        StudyMaterial otherMaterial = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+
+        mockMvc.perform(get("/api/planner/materials/{id}/notes", otherMaterial.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("POST notes - 루트 노트 생성 (parentId null, sortOrder=같은 부모 max+1)")
+    void create_root() throws Exception {
+        root("기존 루트", 0);
+
+        mockMvc.perform(post("/api/planner/materials/{id}/notes", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "새 루트"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.title").value("새 루트"))
+                .andExpect(jsonPath("$.data.parentId").doesNotExist())
+                .andExpect(jsonPath("$.data.sortOrder").value(1))
                 .andExpect(jsonPath("$.data.content.type").value("doc"))
                 .andExpect(jsonPath("$.data.content.content").isArray());
     }
 
-    private static final String HELLO_BODY = """
-            {"content":{"type":"doc","content":[
-              {"type":"paragraph","content":[{"type":"text","text":"hello"}]}
-            ]}}
-            """;
-
-    private static final String HELLO_KOR_BODY = """
-            {"content":{"type":"doc","content":[
-              {"type":"paragraph","content":[{"type":"text","text":"안녕"}]}
-            ]}}
-            """;
-
     @Test
-    @DisplayName("PUT - 응답은 id/materialId/updatedAt 메타데이터만 반환한다")
-    void put_returns_metadata_only() throws Exception {
-        mockMvc.perform(put("/api/planner/materials/{id}/note", material.getId())
+    @DisplayName("POST notes - title 생략 시 기본 제목, 하위 노트 생성")
+    void create_child_default_title() throws Exception {
+        Note parent = root("부모", 0);
+
+        mockMvc.perform(post("/api/planner/materials/{id}/notes", material.getId())
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(HELLO_BODY))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").value(note.getId()))
-                .andExpect(jsonPath("$.data.materialId").value(material.getId()))
-                .andExpect(jsonPath("$.data.updatedAt").exists())
-                .andExpect(jsonPath("$.data.content").doesNotExist());
+                        .content("""
+                                {"parentId": %d}
+                                """.formatted(parent.getId())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.parentId").value(parent.getId()))
+                .andExpect(jsonPath("$.data.title").value("제목 없음"))
+                .andExpect(jsonPath("$.data.sortOrder").value(0));
     }
 
     @Test
-    @DisplayName("PUT 후 GET - 저장된 content가 반환된다")
-    void put_then_get_returns_updated_content() throws Exception {
-        mockMvc.perform(put("/api/planner/materials/{id}/note", material.getId())
+    @DisplayName("POST notes - 다른 자료의 노트를 부모로 지정하면 400")
+    void create_with_cross_material_parent_400() throws Exception {
+        StudyMaterial otherMaterial = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "다른 자료", MaterialType.BOOK));
+        Note otherNote = noteRepository.save(
+                new Note(member.getId(), otherMaterial.getId(), null, "다른 자료 노트", 0));
+
+        mockMvc.perform(post("/api/planner/materials/{id}/notes", material.getId())
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(HELLO_KOR_BODY))
-                .andExpect(status().isOk());
-
-        mockMvc.perform(get("/api/planner/materials/{id}/note", material.getId())
-                        .header(HttpHeaders.AUTHORIZATION, authHeader))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content.type").value("doc"))
-                .andExpect(jsonPath("$.data.content.content[0].type").value("paragraph"))
-                .andExpect(jsonPath("$.data.content.content[0].content[0].text").value("안녕"));
-    }
-
-    @Test
-    @DisplayName("PUT 멱등성 - 동일 content 두 번 저장해도 결과는 동일하다")
-    void put_idempotent() throws Exception {
-        String body = """
-                {"content":{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"x"}]}]}}
-                """;
-        mockMvc.perform(put("/api/planner/materials/{id}/note", material.getId())
-                        .header(HttpHeaders.AUTHORIZATION, authHeader)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
-                .andExpect(status().isOk());
-
-        mockMvc.perform(put("/api/planner/materials/{id}/note", material.getId())
-                        .header(HttpHeaders.AUTHORIZATION, authHeader)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
-                .andExpect(status().isOk());
-
-        mockMvc.perform(get("/api/planner/materials/{id}/note", material.getId())
-                        .header(HttpHeaders.AUTHORIZATION, authHeader))
-                .andExpect(jsonPath("$.data.content.content[0].content[0].text").value("x"));
-    }
-
-    @Test
-    @DisplayName("PUT - 직렬화 1MB 초과 시 400 SP-ERR-002")
-    void put_oversize_returns_400() throws Exception {
-        String huge = "a".repeat(1024 * 1024 + 100);
-        String body = "{\"content\":{\"type\":\"doc\",\"content\":[{\"type\":\"text\",\"text\":\""
-                + huge + "\"}]}}";
-
-        mockMvc.perform(put("/api/planner/materials/{id}/note", material.getId())
-                        .header(HttpHeaders.AUTHORIZATION, authHeader)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                        .content("""
+                                {"parentId": %d}
+                                """.formatted(otherNote.getId())))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("SP-ERR-002"));
     }
 
     @Test
-    @DisplayName("GET - 타인 자료의 노트 조회 시 404")
-    void get_other_member_note_returns_404() throws Exception {
+    @DisplayName("GET note/{id} - 단건 content 포함 조회")
+    void detail_with_content() throws Exception {
+        Note note = root("노트", 0);
+
+        mockMvc.perform(get("/api/planner/notes/{id}", note.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(note.getId()))
+                .andExpect(jsonPath("$.data.materialId").value(material.getId()))
+                .andExpect(jsonPath("$.data.title").value("노트"))
+                .andExpect(jsonPath("$.data.content.type").value("doc"));
+    }
+
+    @Test
+    @DisplayName("GET note/{id} - 타인 노트 조회 시 404")
+    void detail_other_member_404() throws Exception {
         StudyMaterial otherMaterial = studyMaterialRepository.save(
                 new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
-        noteRepository.save(new Note(otherMember.getId(), otherMaterial.getId()));
+        Note otherNote = noteRepository.save(
+                new Note(otherMember.getId(), otherMaterial.getId(), null, "남의 노트", 0));
 
-        mockMvc.perform(get("/api/planner/materials/{id}/note", otherMaterial.getId())
+        mockMvc.perform(get("/api/planner/notes/{id}", otherNote.getId())
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("SP-ERR-001"));
     }
 
     @Test
-    @DisplayName("PUT - 존재하지 않는 자료 ID는 404")
-    void put_nonexistent_material_returns_404() throws Exception {
-        mockMvc.perform(put("/api/planner/materials/{id}/note", 99999L)
+    @DisplayName("PATCH note - title/content 부분 수정")
+    void update_title_content() throws Exception {
+        Note note = root("원래 제목", 0);
+
+        mockMvc.perform(patch("/api/planner/notes/{id}", note.getId())
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"content":{"type":"doc","content":[]}}
+                                {"title": "바뀐 제목",
+                                 "content": {"type":"doc","content":[
+                                   {"type":"paragraph","content":[{"type":"text","text":"내용"}]}]}}
                                 """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("바뀐 제목"));
+
+        mockMvc.perform(get("/api/planner/notes/{id}", note.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.content.content[0].content[0].text").value("내용"));
+    }
+
+    @Test
+    @DisplayName("PATCH note - 본문이 모두 null이면 400")
+    void update_empty_400() throws Exception {
+        Note note = root("노트", 0);
+
+        mockMvc.perform(patch("/api/planner/notes/{id}", note.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PATCH note - parentId 이동 (정상)")
+    void update_move_parent() throws Exception {
+        Note a = root("A", 0);
+        Note b = root("B", 1);
+
+        mockMvc.perform(patch("/api/planner/notes/{id}", b.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"parentId": %d}
+                                """.formatted(a.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.parentId").value(a.getId()));
+    }
+
+    @Test
+    @DisplayName("PATCH note - 자기 자신을 부모로 지정하면 400")
+    void update_self_parent_400() throws Exception {
+        Note note = root("노트", 0);
+
+        mockMvc.perform(patch("/api/planner/notes/{id}", note.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"parentId": %d}
+                                """.formatted(note.getId())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("PATCH note - 자손을 부모로 지정하면 사이클이라 400")
+    void update_descendant_parent_cycle_400() throws Exception {
+        Note a = root("A", 0);
+        Note b = child(a.getId(), "B", 0);
+        Note c = child(b.getId(), "C", 0);
+
+        // A를 C(자손)의 자식으로 이동 → 사이클
+        mockMvc.perform(patch("/api/planner/notes/{id}", a.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"parentId": %d}
+                                """.formatted(c.getId())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("DELETE note - 서브트리가 cascade 삭제된다")
+    void delete_subtree_cascade() throws Exception {
+        Note a = root("A", 0);
+        Note b = child(a.getId(), "B", 0);
+        Note c = child(b.getId(), "C", 0);
+        Note sibling = root("형제", 1);
+
+        mockMvc.perform(delete("/api/planner/notes/{id}", a.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNoContent());
+
+        assertThat(noteCount(a.getId())).isZero();
+        assertThat(noteCount(b.getId())).isZero();
+        assertThat(noteCount(c.getId())).isZero();
+        assertThat(noteCount(sibling.getId())).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("DELETE note - 타인 노트 삭제 시 404")
+    void delete_other_member_404() throws Exception {
+        StudyMaterial otherMaterial = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+        Note otherNote = noteRepository.save(
+                new Note(otherMember.getId(), otherMaterial.getId(), null, "남의 노트", 0));
+
+        mockMvc.perform(delete("/api/planner/notes/{id}", otherNote.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
                 .andExpect(status().isNotFound());
+    }
+
+    private Integer noteCount(Long id) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM note WHERE id = ?", Integer.class, id);
     }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/note/repository/NoteRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/note/repository/NoteRepository.java
@@ -2,10 +2,24 @@ package ds.project.orino.domain.planner.note.repository;
 
 import ds.project.orino.domain.planner.note.entity.Note;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface NoteRepository extends JpaRepository<Note, Long> {
 
-    Optional<Note> findByMaterialId(Long materialId);
+    List<Note> findAllByMaterialIdOrderBySortOrderAscIdAsc(Long materialId);
+
+    Optional<Note> findByIdAndMemberId(Long id, Long memberId);
+
+    @Query("""
+            SELECT COALESCE(MAX(n.sortOrder), -1)
+            FROM Note n
+            WHERE n.materialId = :materialId
+              AND (:parentId IS NULL AND n.parentId IS NULL
+                   OR n.parentId = :parentId)
+            """)
+    int findMaxSortOrder(@Param("materialId") Long materialId, @Param("parentId") Long parentId);
 }


### PR DESCRIPTION
## 이슈
closes #398

## 작업 내용

단건 노트 API를 트리 CRUD로 확장. Notion 스타일 무제한 중첩.

### 신규 API (`NoteController` → `/api/planner`)
| 메서드 | 경로 | 설명 |
|---|---|---|
| GET | `/materials/{materialId}/notes` | 트리 조회 (제목/계층만, content 제외) |
| GET | `/notes/{noteId}` | 단건 (content 포함) |
| POST | `/materials/{materialId}/notes` | 생성 (parentId null=루트, title 선택, sortOrder=max+1) |
| PATCH | `/notes/{noteId}` | 부분 수정 (title/content/parentId/sortOrder) |
| DELETE | `/notes/{noteId}` | 서브트리 cascade 삭제 |

트리 조립: flat 조회(`sortOrder asc, id asc`) 후 서버 메모리에서 `children` 중첩 배열 구성 (단일 사용자, 노트 수 적음).

### 검증 / 비즈니스 규칙
- `content` 직렬화 1MB 초과 → `400 SP-ERR-002`
- `title` 1~200자
- `parentId` 이동: **자기 자신/자손 지정 불가** (사이클 방지) → `400 SP-ERR-002`
  - 사이클 검증: 이동 노트의 서브트리에 새 parentId가 포함되는지 DFS로 확인
- 다른 자료의 노트를 부모로 지정 불가 → `400 SP-ERR-002`
- 미존재/타인 노트 → `404 SP-ERR-001`

### 제거
- 기존 단건 `GET/PUT /materials/{id}/note` + `NoteResponse`
- **자료 생성 시 빈 노트 자동 생성** (`StudyMaterialService`) → 자료는 빈 트리로 시작
- `MaterialCreateResponse`(자료+노트 동봉) → 자료 생성은 `MaterialResponse`만 반환

### DTO / Repository
- `NoteTreeNode`/`NoteTreeResponse` (children 중첩), `NoteDetailResponse`, `NoteCreateRequest`, `NoteUpdateRequest`
- `NoteRepository`: `findAllByMaterialIdOrderBySortOrderAscIdAsc`, `findByIdAndMemberId`, `findMaxSortOrder(materialId, parentId)`

## 검증
- [x] `./gradlew build` (checkstyle 포함) 통과
- [x] `NoteControllerTest` 14건 — 빈/중첩 트리, 루트/하위 생성, cross-material 부모 거부, 단건, 사이클(자기/자손) 거부, 서브트리 cascade 삭제, 권한
- [x] `StudyMaterialControllerTest` — 자료 생성 응답에 note 미동봉으로 갱신
- [x] **로컬 bootRun + curl** 전 흐름:
  - 자료 생성 → 응답에 note 없음 ✓
  - 빈 트리 → 루트 생성(sortOrder 0) → 하위 생성(parentId 연결) → 트리 조회(children 중첩) ✓
  - 사이클(루트를 자손의 자식으로 / 자기 자신) → `400 SP-ERR-002` ✓
  - 단건 content 조회 ✓
  - 루트 DELETE → 204 → 서브트리(루트+자손) DB 0건 cascade 확인 ✓

## 후속
- #399 FE 노트 탭 트리화 (2-pane: 트리 사이드바 + 에디터)