### PR TITLE
feat : 복습 캘린더 조회 API (기간 복습 일정)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
@@ -1,19 +1,24 @@
 package ds.project.orino.planner.review.controller;
 
 import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.review.dto.CalendarReviewsResponse;
 import ds.project.orino.planner.review.dto.ReviewCompletionRequest;
 import ds.project.orino.planner.review.dto.ReviewCompletionResponse;
 import ds.project.orino.planner.review.dto.TodayReviewsResponse;
 import ds.project.orino.planner.review.service.ReviewCompletionService;
 import ds.project.orino.planner.review.service.ReviewQueryService;
 import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/planner/reviews")
@@ -31,6 +36,14 @@ public class ReviewController {
     @GetMapping("/today")
     public ApiResponse<TodayReviewsResponse> today(@AuthenticationPrincipal Long memberId) {
         return ApiResponse.success(reviewQueryService.findToday(memberId));
+    }
+
+    @GetMapping("/calendar")
+    public ApiResponse<CalendarReviewsResponse> calendar(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return ApiResponse.success(reviewQueryService.findCalendar(memberId, from, to));
     }
 
     @PostMapping("/{id}/complete")

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CalendarReviewFlashcard.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CalendarReviewFlashcard.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+
+public record CalendarReviewFlashcard(
+        Long id,
+        String front,
+        CalendarReviewMaterial material
+) {
+    public static CalendarReviewFlashcard of(Flashcard f, CalendarReviewMaterial material) {
+        return new CalendarReviewFlashcard(f.getId(), f.getFront(), material);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CalendarReviewItem.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CalendarReviewItem.java
@@ -1,0 +1,16 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.review.entity.Rating;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+
+import java.time.LocalDate;
+
+public record CalendarReviewItem(
+        Long id,
+        LocalDate scheduledDate,
+        ReviewStatus status,
+        Rating rating,
+        int sequence,
+        CalendarReviewFlashcard flashcard
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CalendarReviewMaterial.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CalendarReviewMaterial.java
@@ -1,0 +1,14 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+
+public record CalendarReviewMaterial(
+        Long id,
+        String title,
+        MaterialType type
+) {
+    public static CalendarReviewMaterial of(StudyMaterial m) {
+        return new CalendarReviewMaterial(m.getId(), m.getTitle(), m.getType());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CalendarReviewsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CalendarReviewsResponse.java
@@ -1,0 +1,11 @@
+package ds.project.orino.planner.review.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CalendarReviewsResponse(
+        LocalDate from,
+        LocalDate to,
+        List<CalendarReviewItem> reviews
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
@@ -8,6 +8,12 @@ import ds.project.orino.domain.planner.review.entity.Rating;
 import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
 import ds.project.orino.domain.planner.review.entity.ReviewStatus;
 import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.review.dto.CalendarReviewFlashcard;
+import ds.project.orino.planner.review.dto.CalendarReviewItem;
+import ds.project.orino.planner.review.dto.CalendarReviewMaterial;
+import ds.project.orino.planner.review.dto.CalendarReviewsResponse;
 import ds.project.orino.planner.review.dto.PreviewView;
 import ds.project.orino.planner.review.dto.TodayReviewFlashcard;
 import ds.project.orino.planner.review.dto.TodayReviewItem;
@@ -69,6 +75,52 @@ public class ReviewQueryService {
                 .toList();
 
         return new TodayReviewsResponse(today, items);
+    }
+
+    static final int MAX_RANGE_DAYS = 100;
+
+    public CalendarReviewsResponse findCalendar(Long memberId, LocalDate from, LocalDate to) {
+        if (from == null || to == null || to.isBefore(from)
+                || ChronoUnit.DAYS.between(from, to) > MAX_RANGE_DAYS) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        List<ReviewSchedule> reviews = reviewScheduleRepository
+                .findAllByMemberIdAndScheduledDateBetweenOrderByScheduledDateAscIdAsc(memberId, from, to);
+
+        if (reviews.isEmpty()) {
+            return new CalendarReviewsResponse(from, to, List.of());
+        }
+
+        Map<Long, Flashcard> cardById = loadCards(reviews);
+        Map<Long, StudyMaterial> materialById = loadMaterials(cardById);
+
+        List<CalendarReviewItem> items = reviews.stream()
+                .map(r -> {
+                    Flashcard card = cardById.get(r.getFlashcardId());
+                    StudyMaterial material = materialById.get(card.getMaterialId());
+                    CalendarReviewFlashcard flashcardDto = CalendarReviewFlashcard.of(
+                            card, CalendarReviewMaterial.of(material));
+                    return new CalendarReviewItem(
+                            r.getId(), r.getScheduledDate(), r.getStatus(),
+                            r.getRating(), r.getSequence(), flashcardDto);
+                })
+                .toList();
+
+        return new CalendarReviewsResponse(from, to, items);
+    }
+
+    private Map<Long, Flashcard> loadCards(List<ReviewSchedule> reviews) {
+        List<Long> flashcardIds = reviews.stream().map(ReviewSchedule::getFlashcardId).distinct().toList();
+        return flashcardRepository.findAllByIdIn(flashcardIds).stream()
+                .collect(Collectors.toMap(Flashcard::getId, Function.identity()));
+    }
+
+    private Map<Long, StudyMaterial> loadMaterials(Map<Long, Flashcard> cardById) {
+        List<Long> materialIds = cardById.values().stream()
+                .map(Flashcard::getMaterialId).distinct().toList();
+        return studyMaterialRepository.findAllByIdIn(materialIds).stream()
+                .collect(Collectors.toMap(StudyMaterial::getId, Function.identity()));
     }
 
     private TodayReviewItem toItem(ReviewSchedule r,

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewCalendarControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewCalendarControllerTest.java
@@ -1,0 +1,199 @@
+package ds.project.orino.planner.review.controller;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.Rating;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ReviewCalendarControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Autowired
+    private FlashcardRepository flashcardRepository;
+
+    @Autowired
+    private ReviewScheduleRepository reviewScheduleRepository;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private Member member;
+    private Member otherMember;
+    private Flashcard card;
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        member = memberRepository.save(MemberFixture.create());
+        otherMember = memberRepository.save(MemberFixture.create("other", "password"));
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "이펙티브 자바", MaterialType.BOOK));
+        card = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    private ReviewSchedule pending(LocalDate date, int sequence) {
+        return reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), sequence, date, 6, new BigDecimal("2.50")));
+    }
+
+    private ReviewSchedule completed(LocalDate date, int sequence, Rating rating) {
+        ReviewSchedule r = new ReviewSchedule(
+                member.getId(), card.getId(), sequence, date, 6, new BigDecimal("2.50"));
+        r.complete(rating, date, java.time.LocalDateTime.of(date, java.time.LocalTime.NOON));
+        return reviewScheduleRepository.save(r);
+    }
+
+    @Test
+    @DisplayName("GET calendar - 기간 내 복습이 없으면 빈 배열, from/to는 채워짐")
+    void empty() throws Exception {
+        mockMvc.perform(get("/api/planner/reviews/calendar")
+                        .queryParam("from", "2026-05-01")
+                        .queryParam("to", "2026-05-31")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.from").value("2026-05-01"))
+                .andExpect(jsonPath("$.data.to").value("2026-05-31"))
+                .andExpect(jsonPath("$.data.reviews", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("GET calendar - PENDING + COMPLETED 모두 포함, scheduledDate asc 정렬")
+    void includes_pending_and_completed_sorted() throws Exception {
+        completed(LocalDate.parse("2026-05-10"), 1, Rating.GOOD);
+        pending(LocalDate.parse("2026-05-20"), 2);
+
+        mockMvc.perform(get("/api/planner/reviews/calendar")
+                        .queryParam("from", "2026-05-01")
+                        .queryParam("to", "2026-05-31")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews", hasSize(2)))
+                .andExpect(jsonPath("$.data.reviews[0].scheduledDate").value("2026-05-10"))
+                .andExpect(jsonPath("$.data.reviews[0].status").value("COMPLETED"))
+                .andExpect(jsonPath("$.data.reviews[0].rating").value("GOOD"))
+                .andExpect(jsonPath("$.data.reviews[1].scheduledDate").value("2026-05-20"))
+                .andExpect(jsonPath("$.data.reviews[1].status").value("PENDING"))
+                .andExpect(jsonPath("$.data.reviews[1].rating").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET calendar - 범위 밖 항목은 제외 (경계 inclusive)")
+    void range_boundary_inclusive() throws Exception {
+        pending(LocalDate.parse("2026-04-30"), 1); // 범위 밖
+        pending(LocalDate.parse("2026-05-01"), 1); // from 경계 포함
+        pending(LocalDate.parse("2026-05-31"), 1); // to 경계 포함
+        pending(LocalDate.parse("2026-06-01"), 1); // 범위 밖
+
+        mockMvc.perform(get("/api/planner/reviews/calendar")
+                        .queryParam("from", "2026-05-01")
+                        .queryParam("to", "2026-05-31")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews", hasSize(2)))
+                .andExpect(jsonPath("$.data.reviews[0].scheduledDate").value("2026-05-01"))
+                .andExpect(jsonPath("$.data.reviews[1].scheduledDate").value("2026-05-31"));
+    }
+
+    @Test
+    @DisplayName("GET calendar - flashcard + material 동봉, back은 제외")
+    void embeds_flashcard_material_without_back() throws Exception {
+        pending(LocalDate.parse("2026-05-15"), 2);
+
+        mockMvc.perform(get("/api/planner/reviews/calendar")
+                        .queryParam("from", "2026-05-01")
+                        .queryParam("to", "2026-05-31")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.id").value(card.getId()))
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.front").value("Q"))
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.back").doesNotExist())
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.material.title").value("이펙티브 자바"))
+                .andExpect(jsonPath("$.data.reviews[0].sequence").value(2));
+    }
+
+    @Test
+    @DisplayName("GET calendar - 타인 review는 제외")
+    void excludes_other_members() throws Exception {
+        StudyMaterial otherMaterial = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+        Flashcard otherCard = flashcardRepository.save(
+                new Flashcard(otherMember.getId(), otherMaterial.getId(), "Q2", "A2"));
+        reviewScheduleRepository.save(new ReviewSchedule(
+                otherMember.getId(), otherCard.getId(), 1, LocalDate.parse("2026-05-15"), 6,
+                new BigDecimal("2.50")));
+        pending(LocalDate.parse("2026-05-16"), 1);
+
+        mockMvc.perform(get("/api/planner/reviews/calendar")
+                        .queryParam("from", "2026-05-01")
+                        .queryParam("to", "2026-05-31")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews", hasSize(1)))
+                .andExpect(jsonPath("$.data.reviews[0].scheduledDate").value("2026-05-16"));
+    }
+
+    @Test
+    @DisplayName("GET calendar - to < from 이면 400")
+    void reversed_range_400() throws Exception {
+        mockMvc.perform(get("/api/planner/reviews/calendar")
+                        .queryParam("from", "2026-05-31")
+                        .queryParam("to", "2026-05-01")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("GET calendar - 범위가 100일 초과면 400")
+    void too_wide_range_400() throws Exception {
+        mockMvc.perform(get("/api/planner/reviews/calendar")
+                        .queryParam("from", "2026-01-01")
+                        .queryParam("to", "2026-12-31")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("GET calendar - from 누락 시 400")
+    void missing_from_400() throws Exception {
+        mockMvc.perform(get("/api/planner/reviews/calendar")
+                        .queryParam("to", "2026-05-31")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/be/orino-core-web/src/main/java/ds/project/orino/core/web/GlobalExceptionHandler.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/web/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -57,6 +58,14 @@ public class GlobalExceptionHandler {
         log.error("handleTypeMismatch: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(ErrorCode.BAD_REQUEST, e));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingParameter(
+            MissingServletRequestParameterException e) {
+        log.error("handleMissingParameter: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(ErrorCode.BAD_REQUEST, e.getParameterName() + " 파라미터가 필요합니다."));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
@@ -18,4 +18,7 @@ public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, 
 
     List<ReviewSchedule> findAllByMemberIdAndStatusAndScheduledDateLessThanEqualOrderByScheduledDateAscIdAsc(
             Long memberId, ReviewStatus status, LocalDate scheduledDate);
+
+    List<ReviewSchedule> findAllByMemberIdAndScheduledDateBetweenOrderByScheduledDateAscIdAsc(
+            Long memberId, LocalDate from, LocalDate to);
 }


### PR DESCRIPTION
## 이슈
closes #401

## 작업 내용

투두메이트 스타일 월간 달력용 **기간 복습 조회** API.

### API
`GET /api/planner/reviews/calendar?from=2026-05-01&to=2026-05-31`

- 조건: `member=me AND scheduledDate BETWEEN from AND to` (경계 inclusive)
- **status 무관** (PENDING + COMPLETED 모두)
- 정렬: `scheduledDate ASC, id ASC`

응답:
```json
{
  "from": "2026-05-01", "to": "2026-05-31",
  "reviews": [{
    "id": 95, "scheduledDate": "2026-05-16",
    "status": "PENDING", "rating": null, "sequence": 2,
    "flashcard": { "id": 11, "front": "...",
                   "material": { "id": 1, "title": "...", "type": "BOOK" } }
  }]
}
```

### 설계
- `back` 제외 (캘린더는 front 일부만 표시) → 페이로드 절감
- 상태 분류(밀림/오늘/예정)는 **FE가** `scheduledDate vs today`로 계산 (서버는 raw status/rating만)
- review → flashcard → material 3-쿼리 batch 로딩 (N+1 회피, `findToday`와 동일 패턴)
- **DB 변경 없음** (기존 `review_schedule` 사용)

### 범위 가드 (`MAX_RANGE_DAYS = 100`)
- `to < from` / `from`·`to` null / `(to - from) > 100일` → `400 SP-ERR-002`
- 필수 쿼리 파라미터 누락 → `400` — `GlobalExceptionHandler`에 `MissingServletRequestParameterException` 핸들러 추가 (기존엔 없어서 500으로 떨어졌음, 전역적으로 유용)

## 검증
- [x] `./gradlew build` (checkstyle 포함) 통과
- [x] `ReviewCalendarControllerTest` 8건 — 빈 결과 / PENDING+COMPLETED 혼합 정렬 / 경계 inclusive / back 제외 임베드 / 타인 제외 / 역순·과대범위·파라미터 누락 가드
- [x] **로컬 bootRun + curl**: 혼합 데이터(PENDING/COMPLETED) 조회 시 scheduledDate 오름차순 + front만 동봉(back 없음) 확인, `to<from` / `100일 초과` / `from 누락` 모두 400

## 후속
- #402 복습 캘린더 화면 (투두메이트 스타일 월간 달력) — FE