### PR TITLE
feat : 복습 캘린더 화면 (투두메이트 스타일 월간 달력)

### DIFF
--- a/fe/src/app/layout/Sidebar.tsx
+++ b/fe/src/app/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, CheckSquare, Home } from "lucide-react";
+import { BookOpen, Calendar, CheckSquare, Home } from "lucide-react";
 import { NavLink } from "react-router-dom";
 
 import { useTodayReviews } from "@/features/review/hooks/useTodayReviews";
@@ -14,6 +14,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/home", label: "홈", icon: Home },
   { to: "/planner/materials", label: "학습 자료", icon: BookOpen },
   { to: "/planner/reviews/today", label: "오늘 복습", icon: CheckSquare },
+  { to: "/planner/calendar", label: "복습 캘린더", icon: Calendar },
 ];
 
 interface SidebarProps {

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -7,6 +7,7 @@ import { LandingPage } from "../pages/LandingPage";
 import { LoginPage } from "../pages/LoginPage";
 import { MaterialDetailPage } from "../pages/planner/MaterialDetailPage";
 import { MaterialListPage } from "../pages/planner/MaterialListPage";
+import { ReviewCalendarPage } from "../pages/planner/ReviewCalendarPage";
 import { TodayReviewsPage } from "../pages/planner/TodayReviewsPage";
 import { AppLayout } from "./layout/AppLayout";
 
@@ -26,6 +27,7 @@ export function AppRouter() {
             element={<MaterialDetailPage />}
           />
           <Route path="/planner/reviews/today" element={<TodayReviewsPage />} />
+          <Route path="/planner/calendar" element={<ReviewCalendarPage />} />
         </Route>
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/fe/src/features/review/api/calendar.ts
+++ b/fe/src/features/review/api/calendar.ts
@@ -1,0 +1,42 @@
+import { client } from "@/shared/api";
+
+import type { Rating, TodayReviewMaterial } from "./reviews";
+
+export type ReviewStatus = "PENDING" | "COMPLETED";
+
+export interface CalendarReviewFlashcard {
+  id: number;
+  front: string;
+  material: TodayReviewMaterial;
+}
+
+export interface CalendarReview {
+  id: number;
+  scheduledDate: string;
+  status: ReviewStatus;
+  rating: Rating | null;
+  sequence: number;
+  flashcard: CalendarReviewFlashcard;
+}
+
+export interface CalendarReviewsResponse {
+  from: string;
+  to: string;
+  reviews: CalendarReview[];
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export async function fetchCalendarReviews(
+  from: string,
+  to: string,
+): Promise<CalendarReviewsResponse> {
+  const { data } = await client.get<ApiEnvelope<CalendarReviewsResponse>>(
+    "/planner/reviews/calendar",
+    { params: { from, to } },
+  );
+  return data.data;
+}

--- a/fe/src/features/review/calendar.test.ts
+++ b/fe/src/features/review/calendar.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import type { CalendarReview } from "./api/calendar";
+import {
+  addMonths,
+  classifyReview,
+  countBuckets,
+  groupByDate,
+  monthGridDays,
+  toIsoDate,
+} from "./calendar";
+
+function review(
+  scheduledDate: string,
+  status: "PENDING" | "COMPLETED",
+): CalendarReview {
+  return {
+    id: Math.floor(Math.random() * 1e6),
+    scheduledDate,
+    status,
+    rating: status === "COMPLETED" ? "GOOD" : null,
+    sequence: 1,
+    flashcard: {
+      id: 1,
+      front: "Q",
+      material: { id: 1, title: "M", type: "BOOK" },
+    },
+  };
+}
+
+describe("monthGridDays", () => {
+  it("2026-05 (목요일 시작 달)은 6주 42칸, 일요일부터 시작한다", () => {
+    const days = monthGridDays(2026, 4); // 0-based: 4 = May
+    expect(days).toHaveLength(42);
+    expect(days[0].getDay()).toBe(0); // 일요일
+    // 5/1은 금요일 → 그리드 첫날은 4/26(일)
+    expect(toIsoDate(days[0])).toBe("2026-04-26");
+    expect(toIsoDate(days[41])).toBe("2026-06-06");
+  });
+});
+
+describe("addMonths", () => {
+  it("월 이동은 해당 월 1일을 반환한다", () => {
+    expect(toIsoDate(addMonths(new Date(2026, 4, 18), 1))).toBe("2026-06-01");
+    expect(toIsoDate(addMonths(new Date(2026, 0, 15), -1))).toBe("2025-12-01");
+  });
+});
+
+describe("classifyReview", () => {
+  const today = new Date(2026, 4, 18);
+
+  it("COMPLETED → completed", () => {
+    expect(classifyReview(review("2026-05-10", "COMPLETED"), today)).toBe(
+      "completed",
+    );
+  });
+
+  it("PENDING + 과거 → overdue", () => {
+    expect(classifyReview(review("2026-05-15", "PENDING"), today)).toBe(
+      "overdue",
+    );
+  });
+
+  it("PENDING + 오늘 → today", () => {
+    expect(classifyReview(review("2026-05-18", "PENDING"), today)).toBe(
+      "today",
+    );
+  });
+
+  it("PENDING + 미래 → upcoming", () => {
+    expect(classifyReview(review("2026-05-20", "PENDING"), today)).toBe(
+      "upcoming",
+    );
+  });
+});
+
+describe("groupByDate / countBuckets", () => {
+  it("날짜별로 그룹핑하고 버킷 카운트를 센다", () => {
+    const today = new Date(2026, 4, 18);
+    const reviews = [
+      review("2026-05-18", "PENDING"), // today
+      review("2026-05-18", "COMPLETED"), // completed
+      review("2026-05-15", "PENDING"), // overdue
+    ];
+    const grouped = groupByDate(reviews);
+    expect(grouped.get("2026-05-18")).toHaveLength(2);
+    expect(grouped.get("2026-05-15")).toHaveLength(1);
+
+    const counts = countBuckets(grouped.get("2026-05-18")!, today);
+    expect(counts.today).toBe(1);
+    expect(counts.completed).toBe(1);
+    expect(counts.overdue).toBe(0);
+  });
+});

--- a/fe/src/features/review/calendar.ts
+++ b/fe/src/features/review/calendar.ts
@@ -1,0 +1,97 @@
+import type { CalendarReview } from "./api/calendar";
+
+export type ReviewBucket = "completed" | "overdue" | "today" | "upcoming";
+
+/** YYYY-MM-DD 로컬 포맷 (UTC 변환 없이) */
+export function toIsoDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export function parseIsoDate(iso: string): Date {
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+export function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+export function addMonths(date: Date, months: number): Date {
+  return new Date(date.getFullYear(), date.getMonth() + months, 1);
+}
+
+/**
+ * 해당 월을 포함하는 6주(42일) 그리드. 일요일 시작.
+ * 첫째 날 = 해당 월 1일이 속한 주의 일요일.
+ */
+export function monthGridDays(year: number, month0: number): Date[] {
+  const first = new Date(year, month0, 1);
+  const start = addDays(first, -first.getDay());
+  return Array.from({ length: 42 }, (_, i) => addDays(start, i));
+}
+
+export function classifyReview(
+  review: CalendarReview,
+  today: Date,
+): ReviewBucket {
+  if (review.status === "COMPLETED") {
+    return "completed";
+  }
+  const scheduled = parseIsoDate(review.scheduledDate).getTime();
+  const todayMid = startOfDay(today).getTime();
+  if (scheduled < todayMid) {
+    return "overdue";
+  }
+  if (scheduled === todayMid) {
+    return "today";
+  }
+  return "upcoming";
+}
+
+export interface DayBucketCounts {
+  completed: number;
+  overdue: number;
+  today: number;
+  upcoming: number;
+}
+
+/** ISO 날짜 → 그날 복습 목록 */
+export function groupByDate(
+  reviews: CalendarReview[],
+): Map<string, CalendarReview[]> {
+  const map = new Map<string, CalendarReview[]>();
+  for (const r of reviews) {
+    const list = map.get(r.scheduledDate);
+    if (list) {
+      list.push(r);
+    } else {
+      map.set(r.scheduledDate, [r]);
+    }
+  }
+  return map;
+}
+
+export function countBuckets(
+  reviews: CalendarReview[],
+  today: Date,
+): DayBucketCounts {
+  const counts: DayBucketCounts = {
+    completed: 0,
+    overdue: 0,
+    today: 0,
+    upcoming: 0,
+  };
+  for (const r of reviews) {
+    counts[classifyReview(r, today)] += 1;
+  }
+  return counts;
+}

--- a/fe/src/features/review/components/calendar/CalendarCell.tsx
+++ b/fe/src/features/review/components/calendar/CalendarCell.tsx
@@ -1,0 +1,75 @@
+import { cn } from "@/lib/utils";
+
+import type { CalendarReview } from "../../api/calendar";
+import { countBuckets } from "../../calendar";
+import { BUCKET_DOT, BUCKET_ORDER } from "./bucketStyles";
+
+interface Props {
+  date: Date;
+  isoDate: string;
+  inMonth: boolean;
+  isToday: boolean;
+  isSelected: boolean;
+  reviews: CalendarReview[];
+  today: Date;
+  onSelect: (isoDate: string) => void;
+}
+
+const MAX_DOTS = 4;
+
+export function CalendarCell({
+  date,
+  isoDate,
+  inMonth,
+  isToday,
+  isSelected,
+  reviews,
+  today,
+  onSelect,
+}: Props) {
+  const counts = countBuckets(reviews, today);
+  const dots = BUCKET_ORDER.flatMap((bucket) =>
+    Array.from({ length: counts[bucket] }, () => bucket),
+  );
+  const shown = dots.slice(0, MAX_DOTS);
+  const overflow = dots.length - shown.length;
+
+  return (
+    <button
+      type="button"
+      aria-label={`${isoDate}${reviews.length > 0 ? ` 복습 ${reviews.length}건` : ""}`}
+      aria-pressed={isSelected}
+      onClick={() => onSelect(isoDate)}
+      className={cn(
+        "flex min-h-16 flex-col gap-1 rounded-md border p-1.5 text-left transition-colors",
+        inMonth ? "bg-card" : "bg-muted/30 text-muted-foreground",
+        isToday ? "border-primary" : "border-border",
+        isSelected && "ring-primary ring-2",
+      )}
+    >
+      <span
+        className={cn(
+          "text-xs font-medium",
+          isToday && "text-primary font-semibold",
+        )}
+      >
+        {date.getDate()}
+      </span>
+      {shown.length > 0 && (
+        <span className="flex flex-wrap items-center gap-0.5">
+          {shown.map((bucket, i) => (
+            <span
+              key={i}
+              className={cn("size-1.5 rounded-full", BUCKET_DOT[bucket])}
+            />
+          ))}
+          {overflow > 0 && (
+            <span className="text-muted-foreground text-[10px]">
+              +{overflow}
+            </span>
+          )}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/fe/src/features/review/components/calendar/CalendarLegend.tsx
+++ b/fe/src/features/review/components/calendar/CalendarLegend.tsx
@@ -1,0 +1,17 @@
+import { cn } from "@/lib/utils";
+
+import type { ReviewBucket } from "../../calendar";
+import { BUCKET_DOT, BUCKET_LABEL, BUCKET_ORDER } from "./bucketStyles";
+
+export function CalendarLegend() {
+  return (
+    <ul className="text-muted-foreground flex flex-wrap gap-x-3 gap-y-1 text-xs">
+      {BUCKET_ORDER.map((bucket: ReviewBucket) => (
+        <li key={bucket} className="flex items-center gap-1.5">
+          <span className={cn("size-2 rounded-full", BUCKET_DOT[bucket])} />
+          {BUCKET_LABEL[bucket]}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/fe/src/features/review/components/calendar/DayDetailPanel.tsx
+++ b/fe/src/features/review/components/calendar/DayDetailPanel.tsx
@@ -1,0 +1,91 @@
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import { MATERIAL_TYPE_ICONS } from "@/features/material/utils";
+
+import type { CalendarReview } from "../../api/calendar";
+import {
+  classifyReview,
+  parseIsoDate,
+  type ReviewBucket,
+} from "../../calendar";
+import { BUCKET_ICON, BUCKET_LABEL, BUCKET_ORDER } from "./bucketStyles";
+
+interface Props {
+  isoDate: string;
+  reviews: CalendarReview[];
+  today: Date;
+}
+
+function formatHeading(isoDate: string): string {
+  const d = parseIsoDate(isoDate);
+  return `${d.getMonth() + 1}월 ${d.getDate()}일`;
+}
+
+export function DayDetailPanel({ isoDate, reviews, today }: Props) {
+  const byBucket = new Map<ReviewBucket, CalendarReview[]>();
+  for (const r of reviews) {
+    const bucket = classifyReview(r, today);
+    const list = byBucket.get(bucket);
+    if (list) {
+      list.push(r);
+    } else {
+      byBucket.set(bucket, [r]);
+    }
+  }
+
+  const hasActionable =
+    (byBucket.get("overdue")?.length ?? 0) > 0 ||
+    (byBucket.get("today")?.length ?? 0) > 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-base font-medium">{formatHeading(isoDate)}</h2>
+        {hasActionable && (
+          <Link to="/planner/reviews/today">
+            <Button size="sm">오늘 복습 하러가기</Button>
+          </Link>
+        )}
+      </div>
+
+      {reviews.length === 0 ? (
+        <p className="text-muted-foreground text-sm">복습 일정이 없어요.</p>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {BUCKET_ORDER.filter((b) => (byBucket.get(b)?.length ?? 0) > 0).map(
+            (bucket) => (
+              <section key={bucket} className="flex flex-col gap-2">
+                <h3 className="text-muted-foreground text-xs font-medium">
+                  {BUCKET_ICON[bucket]} {BUCKET_LABEL[bucket]} (
+                  {byBucket.get(bucket)!.length})
+                </h3>
+                <ul className="flex flex-col gap-1.5">
+                  {byBucket.get(bucket)!.map((r) => (
+                    <li
+                      key={r.id}
+                      className="border-border bg-card flex items-start gap-2 rounded-md border p-2 text-sm"
+                    >
+                      <span aria-hidden>
+                        {MATERIAL_TYPE_ICONS[r.flashcard.material.type]}
+                      </span>
+                      <div className="flex min-w-0 flex-1 flex-col">
+                        <span className="text-muted-foreground truncate text-xs">
+                          {r.flashcard.material.title} · {r.sequence}회차
+                          {r.status === "COMPLETED" && r.rating
+                            ? ` · ${r.rating}`
+                            : ""}
+                        </span>
+                        <span className="truncate">{r.flashcard.front}</span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ),
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/fe/src/features/review/components/calendar/bucketStyles.ts
+++ b/fe/src/features/review/components/calendar/bucketStyles.ts
@@ -1,0 +1,30 @@
+import type { ReviewBucket } from "../../calendar";
+
+export const BUCKET_DOT: Record<ReviewBucket, string> = {
+  overdue: "bg-red-500",
+  today: "bg-primary",
+  upcoming: "bg-muted-foreground/40",
+  completed: "bg-foreground/30",
+};
+
+export const BUCKET_LABEL: Record<ReviewBucket, string> = {
+  overdue: "밀림",
+  today: "오늘",
+  upcoming: "예정",
+  completed: "완료",
+};
+
+export const BUCKET_ICON: Record<ReviewBucket, string> = {
+  overdue: "🔴",
+  today: "🟣",
+  upcoming: "⚪",
+  completed: "✅",
+};
+
+// 셀에서 점을 표시하는 순서 (중요도 높은 순)
+export const BUCKET_ORDER: ReviewBucket[] = [
+  "overdue",
+  "today",
+  "upcoming",
+  "completed",
+];

--- a/fe/src/features/review/hooks/useCalendarReviews.ts
+++ b/fe/src/features/review/hooks/useCalendarReviews.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchCalendarReviews } from "../api/calendar";
+import { reviewKeys } from "../queryKeys";
+
+export function useCalendarReviews(from: string, to: string) {
+  return useQuery({
+    queryKey: reviewKeys.calendar(from, to),
+    queryFn: () => fetchCalendarReviews(from, to),
+    staleTime: 60 * 1000,
+  });
+}

--- a/fe/src/features/review/queryKeys.ts
+++ b/fe/src/features/review/queryKeys.ts
@@ -1,4 +1,6 @@
 export const reviewKeys = {
   all: ["reviews"] as const,
   today: ["reviews", "today"] as const,
+  calendar: (from: string, to: string) =>
+    ["reviews", "calendar", from, to] as const,
 };

--- a/fe/src/pages/planner/ReviewCalendarPage.test.tsx
+++ b/fe/src/pages/planner/ReviewCalendarPage.test.tsx
@@ -1,0 +1,209 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { ReviewCalendarPage } from "./ReviewCalendarPage";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function renderPage() {
+  return renderWithRouter(
+    <Providers>
+      <Routes>
+        <Route path="/planner/calendar" element={<ReviewCalendarPage />} />
+        <Route
+          path="/planner/reviews/today"
+          element={<div>오늘 복습 페이지</div>}
+        />
+      </Routes>
+    </Providers>,
+    { initialEntries: ["/planner/calendar"] },
+  );
+}
+
+interface CalReview {
+  id: number;
+  scheduledDate: string;
+  status: "PENDING" | "COMPLETED";
+  rating?: string | null;
+}
+
+function mockCalendar(reviewsByCall: CalReview[]) {
+  server.use(
+    http.get(`${API_BASE}/planner/reviews/calendar`, ({ request }) => {
+      const url = new URL(request.url);
+      const from = url.searchParams.get("from")!;
+      const to = url.searchParams.get("to")!;
+      const filtered = reviewsByCall.filter(
+        (r) => r.scheduledDate >= from && r.scheduledDate <= to,
+      );
+      return HttpResponse.json({
+        code: "OK",
+        data: {
+          from,
+          to,
+          reviews: filtered.map((r) => ({
+            id: r.id,
+            scheduledDate: r.scheduledDate,
+            status: r.status,
+            rating: r.rating ?? null,
+            sequence: 1,
+            flashcard: {
+              id: r.id,
+              front: `질문 ${r.id}`,
+              material: { id: 1, title: "이펙티브 자바", type: "BOOK" },
+            },
+          })),
+        },
+      });
+    }),
+  );
+}
+
+describe("ReviewCalendarPage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+    // 오늘을 2026-05-18로 고정. Date만 fake하여 react-query/userEvent의
+    // 실제 setTimeout과 충돌하지 않게 한다.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(2026, 4, 18, 9, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("현재 월(2026년 5월) 헤더와 요일 헤더를 렌더링한다", async () => {
+    mockCalendar([]);
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "2026년 5월" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("일")).toBeInTheDocument();
+    expect(screen.getByText("토")).toBeInTheDocument();
+  });
+
+  it("복습이 없으면 빈 안내를 표시한다", async () => {
+    mockCalendar([]);
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("이 달에는 복습 일정이 없어요."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("날짜 셀에 복습 건수가 aria-label로 노출된다", async () => {
+    mockCalendar([
+      { id: 1, scheduledDate: "2026-05-18", status: "PENDING" },
+      {
+        id: 2,
+        scheduledDate: "2026-05-18",
+        status: "COMPLETED",
+        rating: "GOOD",
+      },
+    ]);
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /2026-05-18 복습 2건/ }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("날짜 클릭 시 상세 패널에 그날 복습이 상태별로 표시된다", async () => {
+    mockCalendar([
+      { id: 1, scheduledDate: "2026-05-15", status: "PENDING" }, // 밀림
+      {
+        id: 2,
+        scheduledDate: "2026-05-15",
+        status: "COMPLETED",
+        rating: "EASY",
+      },
+    ]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /2026-05-15 복습 2건/ }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /2026-05-15 복습 2건/ }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("5월 15일")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/밀림 \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText(/완료 \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText("질문 1")).toBeInTheDocument();
+  });
+
+  it("밀림/오늘 복습이 있으면 [오늘 복습 하러가기] 노출 + 이동", async () => {
+    mockCalendar([{ id: 9, scheduledDate: "2026-05-18", status: "PENDING" }]);
+    const user = userEvent.setup();
+    renderPage();
+
+    // 초기 선택은 오늘(2026-05-18)
+    await waitFor(() => {
+      expect(screen.getByText("5월 18일")).toBeInTheDocument();
+    });
+
+    const link = await screen.findByRole("link", {
+      name: "오늘 복습 하러가기",
+    });
+    await user.click(link);
+
+    await waitFor(() => {
+      expect(screen.getByText("오늘 복습 페이지")).toBeInTheDocument();
+    });
+  });
+
+  it("다음 달 버튼 클릭 시 헤더가 6월로 바뀐다", async () => {
+    mockCalendar([]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "2026년 5월" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "다음 달" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "2026년 6월" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("범례를 표시한다", async () => {
+    mockCalendar([]);
+    renderPage();
+
+    await waitFor(() => {
+      const legend = screen.getByRole("list");
+      expect(within(legend).getByText("밀림")).toBeInTheDocument();
+      expect(within(legend).getByText("오늘")).toBeInTheDocument();
+      expect(within(legend).getByText("예정")).toBeInTheDocument();
+      expect(within(legend).getByText("완료")).toBeInTheDocument();
+    });
+  });
+});

--- a/fe/src/pages/planner/ReviewCalendarPage.tsx
+++ b/fe/src/pages/planner/ReviewCalendarPage.tsx
@@ -1,0 +1,137 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  addMonths,
+  groupByDate,
+  monthGridDays,
+  startOfDay,
+  toIsoDate,
+} from "@/features/review/calendar";
+import { CalendarCell } from "@/features/review/components/calendar/CalendarCell";
+import { CalendarLegend } from "@/features/review/components/calendar/CalendarLegend";
+import { DayDetailPanel } from "@/features/review/components/calendar/DayDetailPanel";
+import { useCalendarReviews } from "@/features/review/hooks/useCalendarReviews";
+
+const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
+
+export function ReviewCalendarPage() {
+  const today = useMemo(() => startOfDay(new Date()), []);
+  const todayIso = toIsoDate(today);
+
+  const [cursor, setCursor] = useState(
+    () => new Date(today.getFullYear(), today.getMonth(), 1),
+  );
+  const [selected, setSelected] = useState<string>(todayIso);
+
+  const gridDays = useMemo(
+    () => monthGridDays(cursor.getFullYear(), cursor.getMonth()),
+    [cursor],
+  );
+  const from = toIsoDate(gridDays[0]);
+  const to = toIsoDate(gridDays[gridDays.length - 1]);
+
+  const { data, isLoading } = useCalendarReviews(from, to);
+
+  const byDate = useMemo(() => groupByDate(data?.reviews ?? []), [data]);
+
+  const selectedReviews = byDate.get(selected) ?? [];
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="이전 달"
+            onClick={() => setCursor((c) => addMonths(c, -1))}
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <h1 className="text-xl font-semibold">
+            {cursor.getFullYear()}년 {cursor.getMonth() + 1}월
+          </h1>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="다음 달"
+            onClick={() => setCursor((c) => addMonths(c, 1))}
+          >
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            setCursor(new Date(today.getFullYear(), today.getMonth(), 1));
+            setSelected(todayIso);
+          }}
+        >
+          오늘
+        </Button>
+      </div>
+
+      <CalendarLegend />
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_20rem]">
+        <Card>
+          <CardContent className="flex flex-col gap-2">
+            <div className="grid grid-cols-7 gap-1">
+              {WEEKDAYS.map((w, i) => (
+                <div
+                  key={w}
+                  className={
+                    "text-muted-foreground py-1 text-center text-xs font-medium" +
+                    (i === 0 ? " text-red-500" : "")
+                  }
+                >
+                  {w}
+                </div>
+              ))}
+            </div>
+            <div className="grid grid-cols-7 gap-1">
+              {gridDays.map((date) => {
+                const iso = toIsoDate(date);
+                return (
+                  <CalendarCell
+                    key={iso}
+                    date={date}
+                    isoDate={iso}
+                    inMonth={date.getMonth() === cursor.getMonth()}
+                    isToday={iso === todayIso}
+                    isSelected={iso === selected}
+                    reviews={byDate.get(iso) ?? []}
+                    today={today}
+                    onSelect={setSelected}
+                  />
+                );
+              })}
+            </div>
+            {isLoading && (
+              <p className="text-muted-foreground text-xs">불러오는 중...</p>
+            )}
+            {!isLoading && (data?.reviews.length ?? 0) === 0 && (
+              <p className="text-muted-foreground text-sm">
+                이 달에는 복습 일정이 없어요.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent>
+            <DayDetailPanel
+              isoDate={selected}
+              reviews={selectedReviews}
+              today={today}
+            />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 이슈
closes #402

## 작업 내용

### 화면 (`/planner/calendar`)
- 라우트 추가 + 사이드바 **📅 복습 캘린더** 메뉴
- 헤더: `[◀] 연·월 [▶]` + `[오늘]`
- **6주 × 7일 그리드 직접 렌더** (일요일 시작, 앞뒤 달 흐리게, 오늘 칸 테두리 강조, 선택 칸 ring)
- 각 날짜 칸: 상태별 색 점 (최대 4개 + `+N`)
- 범례: 🔴밀림 / 🟣오늘 / ⚪예정 / ✅완료

### 상태 분류 (FE 계산, `scheduledDate vs today`)
| 조건 | 버킷 | 색 |
|---|---|---|
| COMPLETED | 완료 | 회색 |
| PENDING + 과거 | 밀림 | red-500 |
| PENDING + 오늘 | 오늘 | primary `#8b00ff` |
| PENDING + 미래 | 예정 | muted |

### 날짜 상세 패널
- 그날 복습을 상태 그룹별로: 자료 제목 · front · 회차 · (완료면 rating)
- 밀림/오늘 있으면 `[오늘 복습 하러가기]` → `/planner/reviews/today`

### 데이터
- 월 이동 시 `GET /reviews/calendar?from=<그리드 첫날>&to=<마지막날>`
- React Query 월별 캐시 (`reviewKeys.calendar(from, to)`)
- 빈 상태: "이 달에는 복습 일정이 없어요"

### 유틸 (date-fns 미사용, 직접 구현)
- `monthGridDays` / `addMonths` / `classifyReview` / `groupByDate` / `countBuckets` — 이슈 노트대로 무거운 캘린더 라이브러리 없이 직접 렌더

## 검증
- [x] `npm test` 94건 통과 (calendar 유틸 7건 + ReviewCalendarPage 7건 신규)
  - 페이지 테스트는 `vi.useFakeTimers({ toFake: ["Date"] })`로 **Date만** 고정해 오늘을 2026-05-18로 픽스 (react-query/userEvent의 실제 setTimeout과 충돌 회피)
- [x] `npm run lint` / `format:check` / `tsc -b --noEmit` / `build` 통과
- [x] **로컬 dev + Playwright**:
  - 5월 그리드 — 완료(회색)·밀림(빨강) 점, 날짜별 건수, 5/31 오늘 테두리
  - 5/24 클릭 → 상세 패널 "5월 24일" + 🔴밀림(3) + [오늘 복습 하러가기]
  - 6월 이동 → "이 달에는 복습 일정이 없어요" 빈 상태

## 후속
- #404 노트 탭 Notion 인라인 하위 페이지 (#398 머지 완료, FE 전용)