### PR TITLE
feat : 노트 탭 Notion 인라인 하위 페이지 (Tiptap childPage 노드)

### DIFF
--- a/fe/src/features/note/api/notes.ts
+++ b/fe/src/features/note/api/notes.ts
@@ -6,9 +6,24 @@ export interface NoteContent {
   [key: string]: unknown;
 }
 
-export interface Note {
+export interface NoteTreeNode {
+  id: number;
+  title: string;
+  parentId: number | null;
+  sortOrder: number;
+  children: NoteTreeNode[];
+}
+
+export interface NoteTreeResponse {
+  notes: NoteTreeNode[];
+}
+
+export interface NoteDetail {
   id: number;
   materialId: number;
+  parentId: number | null;
+  title: string;
+  sortOrder: number;
   content: NoteContent;
   updatedAt: string;
 }
@@ -16,6 +31,9 @@ export interface Note {
 export interface NoteUpdateResponse {
   id: number;
   materialId: number;
+  parentId: number | null;
+  title: string;
+  sortOrder: number;
   updatedAt: string;
 }
 
@@ -24,20 +42,56 @@ interface ApiEnvelope<T> {
   data: T;
 }
 
-export async function fetchNote(materialId: number): Promise<Note> {
-  const { data } = await client.get<ApiEnvelope<Note>>(
-    `/planner/materials/${materialId}/note`,
+export async function fetchNoteTree(
+  materialId: number,
+): Promise<NoteTreeNode[]> {
+  const { data } = await client.get<ApiEnvelope<NoteTreeResponse>>(
+    `/planner/materials/${materialId}/notes`,
+  );
+  return data.data.notes;
+}
+
+export async function fetchNote(noteId: number): Promise<NoteDetail> {
+  const { data } = await client.get<ApiEnvelope<NoteDetail>>(
+    `/planner/notes/${noteId}`,
   );
   return data.data;
 }
 
-export async function putNote(
+export interface NoteCreateRequest {
+  parentId?: number | null;
+  title?: string;
+}
+
+export async function createNote(
   materialId: number,
-  content: NoteContent,
-): Promise<NoteUpdateResponse> {
-  const { data } = await client.put<ApiEnvelope<NoteUpdateResponse>>(
-    `/planner/materials/${materialId}/note`,
-    { content },
+  request: NoteCreateRequest,
+): Promise<NoteDetail> {
+  const { data } = await client.post<ApiEnvelope<NoteDetail>>(
+    `/planner/materials/${materialId}/notes`,
+    request,
   );
   return data.data;
+}
+
+export interface NoteUpdateRequest {
+  title?: string;
+  content?: NoteContent;
+  parentId?: number | null;
+  sortOrder?: number;
+}
+
+export async function updateNote(
+  noteId: number,
+  request: NoteUpdateRequest,
+): Promise<NoteUpdateResponse> {
+  const { data } = await client.patch<ApiEnvelope<NoteUpdateResponse>>(
+    `/planner/notes/${noteId}`,
+    request,
+  );
+  return data.data;
+}
+
+export async function deleteNote(noteId: number): Promise<void> {
+  await client.delete(`/planner/notes/${noteId}`);
 }

--- a/fe/src/features/note/components/EditorToolbar.tsx
+++ b/fe/src/features/note/components/EditorToolbar.tsx
@@ -3,6 +3,7 @@ import {
   Bold,
   Code,
   Code2,
+  FilePlus,
   Heading1,
   Heading2,
   Italic,
@@ -16,6 +17,8 @@ import { cn } from "@/lib/utils";
 
 interface Props {
   editor: Editor | null;
+  onInsertPage?: () => void;
+  insertPagePending?: boolean;
 }
 
 interface ToolbarButton {
@@ -25,7 +28,11 @@ interface ToolbarButton {
   onClick: () => void;
 }
 
-export function EditorToolbar({ editor }: Props) {
+export function EditorToolbar({
+  editor,
+  onInsertPage,
+  insertPagePending,
+}: Props) {
   if (!editor) return null;
 
   const buttons: ToolbarButton[] = [
@@ -108,6 +115,21 @@ export function EditorToolbar({ editor }: Props) {
           </Button>
         );
       })}
+      {onInsertPage && (
+        <>
+          <span className="bg-border mx-1 w-px self-stretch" aria-hidden />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label="하위 페이지 추가"
+            disabled={insertPagePending}
+            onClick={onInsertPage}
+          >
+            <FilePlus className="size-4" /> 페이지
+          </Button>
+        </>
+      )}
     </div>
   );
 }

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -1,45 +1,82 @@
+import { useQueryClient } from "@tanstack/react-query";
 import Placeholder from "@tiptap/extension-placeholder";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
 import { EditorContent, type JSONContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 
-import type { NoteContent } from "../api/notes";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { Input } from "@/components/ui/input";
+
+import type { NoteContent, NoteDetail } from "../api/notes";
+import { ChildPage, collectChildPageIds } from "../editor/childPage";
 import { useAutoSaveNote } from "../hooks/useAutoSaveNote";
+import { useCreateNote, useDeleteNote } from "../hooks/useNoteMutations";
+import { noteKeys } from "../queryKeys";
 import { EditorToolbar } from "./EditorToolbar";
 import { SaveStatusIndicator } from "./SaveStatusIndicator";
 
 interface Props {
   materialId: number;
-  initialContent: NoteContent;
+  note: NoteDetail;
+  /** childPage 블록 클릭 시 자식 노트로 이동 */
+  onOpenNote: (noteId: number) => void;
 }
 
-export function NoteEditor({ materialId, initialContent }: Props) {
-  const { status, savedAt, schedule, flush, retry } =
-    useAutoSaveNote(materialId);
-
-  const editor = useEditor({
-    extensions: [
-      StarterKit,
-      TaskList,
-      TaskItem.configure({ nested: true }),
-      Placeholder.configure({
-        placeholder: "학습한 내용을 정리해보세요...",
-      }),
-    ],
-    content: initialContent as JSONContent,
-    editorProps: {
-      attributes: {
-        class:
-          "prose prose-sm dark:prose-invert max-w-none min-h-[40svh] focus:outline-none p-4",
-        "aria-label": "노트 본문",
-      },
-    },
-    onUpdate: ({ editor }) => {
-      schedule(editor.getJSON() as NoteContent);
+export function NoteEditor({ materialId, note, onOpenNote }: Props) {
+  const queryClient = useQueryClient();
+  const { status, savedAt, schedule, flush, retry } = useAutoSaveNote(note.id, {
+    onSaved: (patch) => {
+      // 제목 저장 시 사이드바 트리 라벨 갱신
+      if (patch.title !== undefined) {
+        queryClient.invalidateQueries({ queryKey: noteKeys.tree(materialId) });
+      }
     },
   });
+  const createNote = useCreateNote(materialId);
+  const deleteNote = useDeleteNote(materialId);
+
+  const [title, setTitle] = useState(note.title);
+  const [pendingDelete, setPendingDelete] = useState<number | null>(null);
+  // 본문에 현재 박혀 있는 childPage noteId 집합 (삭제 diff 기준)
+  const childIdsRef = useRef<Set<number>>(new Set());
+
+  const editor = useEditor(
+    {
+      extensions: [
+        StarterKit,
+        TaskList,
+        TaskItem.configure({ nested: true }),
+        Placeholder.configure({
+          placeholder: "내용을 입력하거나 페이지를 추가하세요...",
+        }),
+        ChildPage.configure({ onOpen: onOpenNote }),
+      ],
+      content: note.content as JSONContent,
+      editorProps: {
+        attributes: {
+          class:
+            "prose prose-sm dark:prose-invert max-w-none min-h-[40svh] focus:outline-none p-4",
+          "aria-label": "노트 본문",
+        },
+      },
+      onUpdate: ({ editor }) => {
+        const json = editor.getJSON() as NoteContent;
+        schedule({ content: json });
+        detectRemovedChildPage(json);
+      },
+    },
+    [note.id],
+  );
+
+  // 노트 전환 시 제목/본문/childPage 기준 초기화
+  useEffect(() => {
+    setTitle(note.title);
+    childIdsRef.current = collectChildPageIds(note.content);
+    editor?.commands.setContent(note.content as JSONContent);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [note.id, editor]);
 
   useEffect(() => {
     return () => {
@@ -47,19 +84,89 @@ export function NoteEditor({ materialId, initialContent }: Props) {
     };
   }, [flush]);
 
+  const detectRemovedChildPage = (json: NoteContent) => {
+    const current = collectChildPageIds(json);
+    const prev = childIdsRef.current;
+    const removed = [...prev].filter((id) => !current.has(id));
+    childIdsRef.current = current;
+    if (removed.length > 0) {
+      setPendingDelete(removed[0]);
+    }
+  };
+
+  const handleTitleChange = (next: string) => {
+    setTitle(next);
+    schedule({ title: next });
+  };
+
+  const handleInsertPage = () => {
+    if (createNote.isPending) return;
+    createNote.mutate(
+      { parentId: note.id, title: "제목 없음" },
+      {
+        onSuccess: (created) => {
+          editor
+            ?.chain()
+            .focus()
+            .insertChildPage({ noteId: created.id, title: created.title })
+            .run();
+          // 새 childPage 반영
+          if (editor) {
+            childIdsRef.current = collectChildPageIds(
+              editor.getJSON() as NoteContent,
+            );
+          }
+        },
+      },
+    );
+  };
+
+  const confirmDelete = () => {
+    if (pendingDelete == null) return;
+    deleteNote.mutate(pendingDelete, {
+      onSuccess: () => setPendingDelete(null),
+      onError: () => setPendingDelete(null),
+    });
+  };
+
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center justify-end">
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-3">
+        <Input
+          value={title}
+          onChange={(e) => handleTitleChange(e.target.value)}
+          aria-label="노트 제목"
+          placeholder="제목 없음"
+          className="border-none px-0 text-lg font-semibold shadow-none focus-visible:ring-0"
+        />
         <SaveStatusIndicator
           status={status}
           savedAt={savedAt}
           onRetry={retry}
         />
       </div>
+
       <div className="border-border bg-card overflow-hidden rounded-md border">
-        <EditorToolbar editor={editor} />
+        <EditorToolbar
+          editor={editor}
+          onInsertPage={handleInsertPage}
+          insertPagePending={createNote.isPending}
+        />
         <EditorContent editor={editor} />
       </div>
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+        title="하위 페이지를 삭제할까요?"
+        description="본문에서 제거한 하위 페이지와 그 안의 모든 내용이 삭제됩니다. 되돌릴 수 없어요."
+        confirmLabel="삭제"
+        destructive
+        onConfirm={confirmDelete}
+        pending={deleteNote.isPending}
+      />
     </div>
   );
 }

--- a/fe/src/features/note/components/NoteTab.test.tsx
+++ b/fe/src/features/note/components/NoteTab.test.tsx
@@ -1,0 +1,230 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { NoteTab } from "./NoteTab";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function renderTab(initialEntries = ["/m?tab=note"]) {
+  return renderWithRouter(
+    <Providers>
+      <Routes>
+        <Route path="/m" element={<NoteTab materialId={1} />} />
+      </Routes>
+    </Providers>,
+    { initialEntries },
+  );
+}
+
+interface TreeNode {
+  id: number;
+  title: string;
+  parentId: number | null;
+  sortOrder: number;
+  children: TreeNode[];
+}
+
+function mockTree(notes: TreeNode[]) {
+  server.use(
+    http.get(`${API_BASE}/planner/materials/1/notes`, () =>
+      HttpResponse.json({ code: "OK", data: { notes } }),
+    ),
+  );
+}
+
+function mockNoteDetail(
+  id: number,
+  content: unknown = { type: "doc", content: [] },
+  title = "노트",
+) {
+  server.use(
+    http.get(`${API_BASE}/planner/notes/${id}`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          id,
+          materialId: 1,
+          parentId: null,
+          title,
+          sortOrder: 0,
+          content,
+          updatedAt: "2026-05-31T10:00:00",
+        },
+      }),
+    ),
+  );
+}
+
+describe("NoteTab", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+  });
+
+  it("노트가 없으면 빈 상태와 [첫 노트 만들기]를 표시한다", async () => {
+    mockTree([]);
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 노트가 없습니다.")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: /첫 노트 만들기/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("[첫 노트 만들기] → POST 후 새 노트가 선택되어 에디터가 열린다", async () => {
+    mockTree([]);
+    server.use(
+      http.post(`${API_BASE}/planner/materials/1/notes`, () =>
+        HttpResponse.json(
+          {
+            code: "OK",
+            data: {
+              id: 50,
+              materialId: 1,
+              parentId: null,
+              title: "제목 없음",
+              sortOrder: 0,
+              content: { type: "doc", content: [] },
+              updatedAt: "2026-05-31T10:00:00",
+            },
+          },
+          { status: 201 },
+        ),
+      ),
+    );
+    mockNoteDetail(50, { type: "doc", content: [] }, "제목 없음");
+
+    const user = userEvent.setup();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 노트가 없습니다.")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /첫 노트 만들기/ }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toBeInTheDocument();
+    });
+  });
+
+  it("트리의 노트를 클릭하면 해당 노트 에디터가 열린다", async () => {
+    mockTree([
+      { id: 1, title: "1장", parentId: null, sortOrder: 0, children: [] },
+      { id: 2, title: "2장", parentId: null, sortOrder: 1, children: [] },
+    ]);
+    mockNoteDetail(1, { type: "doc", content: [] }, "1장");
+    mockNoteDetail(2, { type: "doc", content: [] }, "2장");
+
+    const user = userEvent.setup();
+    renderTab();
+
+    // 첫 루트가 자동 선택됨
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("1장");
+    });
+
+    await user.click(screen.getByRole("button", { name: /2장/ }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("2장");
+    });
+  });
+
+  it("[+ 페이지] 클릭 시 POST로 하위 노트 생성 후 본문에 childPage 블록이 박힌다", async () => {
+    mockTree([
+      { id: 1, title: "부모", parentId: null, sortOrder: 0, children: [] },
+    ]);
+    mockNoteDetail(1, { type: "doc", content: [] }, "부모");
+    let postedParentId: number | null = null;
+    server.use(
+      http.post(
+        `${API_BASE}/planner/materials/1/notes`,
+        async ({ request }) => {
+          const body = (await request.json()) as { parentId: number | null };
+          postedParentId = body.parentId;
+          return HttpResponse.json(
+            {
+              code: "OK",
+              data: {
+                id: 99,
+                materialId: 1,
+                parentId: body.parentId,
+                title: "제목 없음",
+                sortOrder: 0,
+                content: { type: "doc", content: [] },
+                updatedAt: "2026-05-31T10:00:00",
+              },
+            },
+            { status: 201 },
+          );
+        },
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("부모");
+    });
+
+    await user.click(screen.getByRole("button", { name: "하위 페이지 추가" }));
+
+    await waitFor(() => {
+      expect(postedParentId).toBe(1);
+    });
+    // 본문에 childPage 블록 렌더
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /하위 페이지 .* 열기/ }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("본문 childPage 블록 클릭 시 그 자식 노트로 전환된다", async () => {
+    mockTree([
+      {
+        id: 1,
+        title: "부모",
+        parentId: null,
+        sortOrder: 0,
+        children: [
+          { id: 2, title: "자식", parentId: 1, sortOrder: 0, children: [] },
+        ],
+      },
+    ]);
+    mockNoteDetail(
+      1,
+      {
+        type: "doc",
+        content: [{ type: "childPage", attrs: { noteId: 2, title: "자식" } }],
+      },
+      "부모",
+    );
+    mockNoteDetail(2, { type: "doc", content: [] }, "자식");
+
+    const user = userEvent.setup();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("부모");
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: /하위 페이지 자식 열기/ }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("자식");
+    });
+  });
+});

--- a/fe/src/features/note/components/NoteTab.tsx
+++ b/fe/src/features/note/components/NoteTab.tsx
@@ -1,0 +1,129 @@
+import { ArrowLeft, Plus } from "lucide-react";
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+
+import { useNoteDetail } from "../hooks/useNoteDetail";
+import { useCreateNote } from "../hooks/useNoteMutations";
+import { useNoteTree } from "../hooks/useNoteTree";
+import { NoteEditor } from "./NoteEditor";
+import { NoteTreeSidebar } from "./NoteTreeSidebar";
+
+interface Props {
+  materialId: number;
+}
+
+export function NoteTab({ materialId }: Props) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const noteParam = searchParams.get("note");
+  const activeNoteId = noteParam ? Number(noteParam) : null;
+
+  const treeQuery = useNoteTree(materialId);
+  const detailQuery = useNoteDetail(activeNoteId);
+  const createNote = useCreateNote(materialId);
+
+  const setActiveNote = (noteId: number | null) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set("tab", "note");
+        if (noteId == null) {
+          next.delete("note");
+        } else {
+          next.set("note", String(noteId));
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  };
+
+  const tree = treeQuery.data ?? [];
+
+  // 노트가 있는데 아무것도 선택 안 됐으면 첫 루트 자동 선택
+  useEffect(() => {
+    if (activeNoteId == null && tree.length > 0) {
+      setActiveNote(tree[0].id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeNoteId, tree]);
+
+  const handleAddRoot = () => {
+    if (createNote.isPending) return;
+    createNote.mutate(
+      { parentId: null, title: "제목 없음" },
+      { onSuccess: (created) => setActiveNote(created.id) },
+    );
+  };
+
+  if (treeQuery.isLoading) {
+    return <p className="text-muted-foreground text-sm">불러오는 중...</p>;
+  }
+  if (treeQuery.isError) {
+    return (
+      <p className="text-destructive text-sm">노트를 불러오지 못했어요.</p>
+    );
+  }
+
+  // 빈 상태: 노트 0개 + 선택된 노트도 없음 (생성 직후 refetch 전이면 에디터로 진행)
+  if (tree.length === 0 && activeNoteId == null) {
+    return (
+      <div className="flex min-h-[40svh] flex-col items-center justify-center gap-4 text-center">
+        <p className="text-muted-foreground text-sm">아직 노트가 없습니다.</p>
+        <Button onClick={handleAddRoot} disabled={createNote.isPending}>
+          <Plus className="size-4" /> 첫 노트 만들기
+        </Button>
+      </div>
+    );
+  }
+
+  const showEditorOnMobile = activeNoteId != null;
+
+  return (
+    <div className="flex flex-col gap-4 md:flex-row md:items-start md:gap-6">
+      {/* 모바일: 노트 선택 시 트리 숨김(드릴다운) */}
+      <div className={showEditorOnMobile ? "hidden md:block" : "block"}>
+        <NoteTreeSidebar
+          tree={tree}
+          activeNoteId={activeNoteId}
+          onSelect={setActiveNote}
+          onAddRoot={handleAddRoot}
+          addRootPending={createNote.isPending}
+        />
+      </div>
+
+      <div
+        className={
+          "min-w-0 flex-1 " + (showEditorOnMobile ? "block" : "hidden md:block")
+        }
+      >
+        <Button
+          variant="ghost"
+          size="sm"
+          className="mb-2 md:hidden"
+          onClick={() => setActiveNote(null)}
+        >
+          <ArrowLeft className="size-4" /> 노트 목록
+        </Button>
+
+        {activeNoteId == null ? (
+          <p className="text-muted-foreground hidden text-sm md:block">
+            왼쪽에서 노트를 선택하거나 새로 만드세요.
+          </p>
+        ) : detailQuery.isLoading ? (
+          <p className="text-muted-foreground text-sm">불러오는 중...</p>
+        ) : detailQuery.isError || !detailQuery.data ? (
+          <p className="text-destructive text-sm">노트를 불러오지 못했어요.</p>
+        ) : (
+          <NoteEditor
+            key={detailQuery.data.id}
+            materialId={materialId}
+            note={detailQuery.data}
+            onOpenNote={setActiveNote}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/note/components/NoteTreeSidebar.tsx
+++ b/fe/src/features/note/components/NoteTreeSidebar.tsx
@@ -1,0 +1,125 @@
+import { ChevronDown, ChevronRight, FileText, Plus } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import type { NoteTreeNode } from "../api/notes";
+
+interface Props {
+  tree: NoteTreeNode[];
+  activeNoteId: number | null;
+  onSelect: (noteId: number) => void;
+  onAddRoot: () => void;
+  addRootPending?: boolean;
+}
+
+export function NoteTreeSidebar({
+  tree,
+  activeNoteId,
+  onSelect,
+  onAddRoot,
+  addRootPending,
+}: Props) {
+  return (
+    <nav
+      aria-label="노트 목록"
+      className="flex w-full flex-col gap-1 md:w-56 md:shrink-0"
+    >
+      <div className="flex items-center justify-between px-1">
+        <span className="text-muted-foreground text-xs font-medium">노트</span>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="새 노트"
+          disabled={addRootPending}
+          onClick={onAddRoot}
+        >
+          <Plus className="size-4" />
+        </Button>
+      </div>
+      {tree.length === 0 ? (
+        <p className="text-muted-foreground px-2 py-1 text-xs">
+          아직 노트가 없습니다
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-0.5">
+          {tree.map((node) => (
+            <NoteTreeItem
+              key={node.id}
+              node={node}
+              depth={0}
+              activeNoteId={activeNoteId}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      )}
+    </nav>
+  );
+}
+
+interface ItemProps {
+  node: NoteTreeNode;
+  depth: number;
+  activeNoteId: number | null;
+  onSelect: (noteId: number) => void;
+}
+
+function NoteTreeItem({ node, depth, activeNoteId, onSelect }: ItemProps) {
+  const [expanded, setExpanded] = useState(true);
+  const hasChildren = node.children.length > 0;
+  const isActive = node.id === activeNoteId;
+
+  return (
+    <li>
+      <div
+        className={cn(
+          "flex items-center gap-0.5 rounded-md pr-1 text-sm",
+          isActive
+            ? "bg-primary/10 text-primary"
+            : "text-foreground/80 hover:bg-muted",
+        )}
+        style={{ paddingLeft: `${depth * 0.75}rem` }}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            aria-label={expanded ? "접기" : "펼치기"}
+            onClick={() => setExpanded((v) => !v)}
+            className="hover:bg-muted-foreground/10 flex size-5 shrink-0 items-center justify-center rounded"
+          >
+            {expanded ? (
+              <ChevronDown className="size-3.5" />
+            ) : (
+              <ChevronRight className="size-3.5" />
+            )}
+          </button>
+        ) : (
+          <span className="size-5 shrink-0" />
+        )}
+        <button
+          type="button"
+          onClick={() => onSelect(node.id)}
+          className="flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left"
+        >
+          <FileText className="size-3.5 shrink-0 opacity-60" />
+          <span className="truncate">{node.title}</span>
+        </button>
+      </div>
+      {hasChildren && expanded && (
+        <ul className="flex flex-col gap-0.5">
+          {node.children.map((child) => (
+            <NoteTreeItem
+              key={child.id}
+              node={child}
+              depth={depth + 1}
+              activeNoteId={activeNoteId}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}

--- a/fe/src/features/note/editor/ChildPageView.tsx
+++ b/fe/src/features/note/editor/ChildPageView.tsx
@@ -1,0 +1,40 @@
+import { type NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+import { FileText } from "lucide-react";
+
+import type { ChildPageOptions } from "./childPage";
+
+/**
+ * 본문 안에 박히는 하위 페이지 블록.
+ * 클릭 시 ChildPage 노드 옵션의 onOpen(noteId) 호출 → 자식 노트로 라우팅.
+ */
+export function ChildPageView({ node, extension }: NodeViewProps) {
+  const noteId = node.attrs.noteId as number | null;
+  const title = (node.attrs.title as string) || "제목 없음";
+  const options = extension.options as ChildPageOptions;
+
+  const handleOpen = () => {
+    if (noteId == null) return;
+    options.onOpen(noteId);
+  };
+
+  return (
+    <NodeViewWrapper
+      as="div"
+      data-child-page={noteId ?? ""}
+      className="my-1"
+      contentEditable={false}
+    >
+      <button
+        type="button"
+        onClick={handleOpen}
+        aria-label={`하위 페이지 ${title} 열기`}
+        className="hover:bg-muted flex w-full items-center gap-2 rounded-md border px-3 py-2 text-left text-sm transition-colors"
+      >
+        <FileText className="text-muted-foreground size-4 shrink-0" />
+        <span className="truncate underline-offset-2 hover:underline">
+          {title}
+        </span>
+      </button>
+    </NodeViewWrapper>
+  );
+}

--- a/fe/src/features/note/editor/childPage.test.ts
+++ b/fe/src/features/note/editor/childPage.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { collectChildPageIds } from "./childPage";
+
+describe("collectChildPageIds", () => {
+  it("중첩 doc에서 모든 childPage noteId를 수집한다", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "hi" }] },
+        { type: "childPage", attrs: { noteId: 11, title: "A" } },
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                { type: "childPage", attrs: { noteId: 22, title: "B" } },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const ids = collectChildPageIds(doc);
+    expect([...ids].sort()).toEqual([11, 22]);
+  });
+
+  it("childPage가 없으면 빈 집합", () => {
+    const doc = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "x" }] }],
+    };
+    expect(collectChildPageIds(doc).size).toBe(0);
+  });
+
+  it("noteId가 number가 아니면 무시한다", () => {
+    const doc = {
+      type: "doc",
+      content: [{ type: "childPage", attrs: { title: "noid" } }],
+    };
+    expect(collectChildPageIds(doc).size).toBe(0);
+  });
+});

--- a/fe/src/features/note/editor/childPage.ts
+++ b/fe/src/features/note/editor/childPage.ts
@@ -1,0 +1,131 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+import { Fragment, type Node as PMNode, Slice } from "@tiptap/pm/model";
+import { Plugin } from "@tiptap/pm/state";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+
+import { ChildPageView } from "./ChildPageView";
+
+export interface ChildPageAttrs {
+  noteId: number;
+  title: string;
+}
+
+export interface ChildPageOptions {
+  onOpen: (noteId: number) => void;
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    childPage: {
+      insertChildPage: (attrs: ChildPageAttrs) => ReturnType;
+    };
+  }
+}
+
+/**
+ * Notion 스타일 인라인 하위 페이지. atom block 노드.
+ * attrs.noteId = 실제 note 레코드 id, attrs.title = 표시용 캐시.
+ */
+export const ChildPage = Node.create<ChildPageOptions>({
+  name: "childPage",
+  group: "block",
+  atom: true,
+  selectable: true,
+  draggable: false,
+
+  addOptions() {
+    return {
+      onOpen: () => {},
+    };
+  },
+
+  addAttributes() {
+    return {
+      noteId: {
+        default: null,
+        parseHTML: (el) => {
+          const v = el.getAttribute("data-note-id");
+          return v ? Number(v) : null;
+        },
+        renderHTML: (attrs) =>
+          attrs.noteId == null ? {} : { "data-note-id": String(attrs.noteId) },
+      },
+      title: {
+        default: "제목 없음",
+        parseHTML: (el) => el.getAttribute("data-title") ?? "제목 없음",
+        renderHTML: (attrs) => ({ "data-title": attrs.title }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "div[data-child-page]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["div", mergeAttributes(HTMLAttributes, { "data-child-page": "" })];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ChildPageView);
+  },
+
+  addCommands() {
+    return {
+      insertChildPage:
+        (attrs: ChildPageAttrs) =>
+        ({ commands }) =>
+          commands.insertContent({
+            type: this.name,
+            attrs,
+          }),
+    };
+  },
+
+  // 복붙/복제 차단: 붙여넣기 slice에서 childPage 노드 제거 (noteId 중복 방지)
+  addProseMirrorPlugins() {
+    const nodeType = this.name;
+    return [
+      new Plugin({
+        props: {
+          transformPasted(slice) {
+            const kept: PMNode[] = [];
+            slice.content.forEach((node) => {
+              if (node.type.name !== nodeType) {
+                kept.push(node);
+              }
+            });
+            return new Slice(
+              Fragment.fromArray(kept),
+              slice.openStart,
+              slice.openEnd,
+            );
+          },
+        },
+      }),
+    ];
+  },
+});
+
+/**
+ * Tiptap doc JSON에서 모든 childPage 노드의 noteId 집합을 수집한다.
+ */
+export function collectChildPageIds(doc: unknown): Set<number> {
+  const ids = new Set<number>();
+  const walk = (node: unknown) => {
+    if (!node || typeof node !== "object") return;
+    const n = node as {
+      type?: string;
+      attrs?: { noteId?: number };
+      content?: unknown[];
+    };
+    if (n.type === "childPage" && typeof n.attrs?.noteId === "number") {
+      ids.add(n.attrs.noteId);
+    }
+    if (Array.isArray(n.content)) {
+      n.content.forEach(walk);
+    }
+  };
+  walk(doc);
+  return ids;
+}

--- a/fe/src/features/note/hooks/useAutoSaveNote.test.ts
+++ b/fe/src/features/note/hooks/useAutoSaveNote.test.ts
@@ -17,33 +17,31 @@ describe("useAutoSaveNote", () => {
     vi.useRealTimers();
   });
 
-  it("schedule 호출 후 2초 debounce되어 PUT을 호출하고 saved 상태로 전환된다", async () => {
-    const calls: Array<{ content: unknown }> = [];
+  it("schedule 후 2초 debounce되어 PATCH를 호출하고 saved로 전환된다", async () => {
+    const calls: unknown[] = [];
     server.use(
-      http.put(
-        `${API_BASE}/planner/materials/:id/note`,
-        async ({ request }) => {
-          const body = (await request.json()) as { content: unknown };
-          calls.push(body);
-          return HttpResponse.json({
-            code: "OK",
-            data: {
-              id: 1,
-              materialId: 1,
-              updatedAt: "2026-05-18T10:30:00",
-            },
-          });
-        },
-      ),
+      http.patch(`${API_BASE}/planner/notes/:id`, async ({ request }) => {
+        calls.push(await request.json());
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            materialId: 1,
+            parentId: null,
+            title: "t",
+            sortOrder: 0,
+            updatedAt: "2026-05-31T10:30:00",
+          },
+        });
+      }),
     );
 
     const { result } = renderHook(() => useAutoSaveNote(1));
     expect(result.current.status).toBe("idle");
 
     act(() => {
-      result.current.schedule({ type: "doc", content: [] });
+      result.current.schedule({ content: { type: "doc", content: [] } });
     });
-    // 디바운스 전: idle 유지
     expect(result.current.status).toBe("idle");
 
     await act(async () => {
@@ -53,80 +51,85 @@ describe("useAutoSaveNote", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]).toEqual({ content: { type: "doc", content: [] } });
     expect(result.current.status).toBe("saved");
-    expect(result.current.savedAt).not.toBeNull();
   });
 
-  it("연속 schedule은 마지막 값만 1회 PUT으로 합쳐진다 (debounce)", async () => {
-    let putCount = 0;
+  it("같은 창의 title/content schedule은 병합되어 1회 PATCH", async () => {
+    let count = 0;
+    let lastBody: { title?: string; content?: unknown } | null = null;
     server.use(
-      http.put(
-        `${API_BASE}/planner/materials/:id/note`,
-        async ({ request }) => {
-          putCount++;
-          const body = (await request.json()) as { content: { tag?: string } };
-          return HttpResponse.json({
-            code: "OK",
-            data: {
-              id: 1,
-              materialId: 1,
-              updatedAt: "2026-05-18T10:30:00",
-              _echo: body.content.tag,
-            },
-          });
-        },
-      ),
-    );
-
-    const { result } = renderHook(() => useAutoSaveNote(1));
-    act(() => {
-      result.current.schedule({ type: "doc", tag: "a" });
-    });
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1500);
-    });
-    act(() => {
-      result.current.schedule({ type: "doc", tag: "b" });
-    });
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
-    });
-
-    expect(putCount).toBe(1);
-  });
-
-  it("실패 시 error 상태가 되고 retry로 재전송된다", async () => {
-    let firstFailed = false;
-    server.use(
-      http.put(`${API_BASE}/planner/materials/:id/note`, async () => {
-        if (!firstFailed) {
-          firstFailed = true;
-          return HttpResponse.json(
-            { code: "ERR", message: "fail" },
-            { status: 500 },
-          );
-        }
+      http.patch(`${API_BASE}/planner/notes/:id`, async ({ request }) => {
+        count++;
+        lastBody = (await request.json()) as typeof lastBody;
         return HttpResponse.json({
           code: "OK",
-          data: { id: 1, materialId: 1, updatedAt: "2026-05-18T10:30:00" },
+          data: {
+            id: 1,
+            materialId: 1,
+            parentId: null,
+            title: "t",
+            sortOrder: 0,
+            updatedAt: "2026-05-31T10:30:00",
+          },
         });
       }),
     );
 
     const { result } = renderHook(() => useAutoSaveNote(1));
     act(() => {
-      result.current.schedule({ type: "doc", content: [] });
+      result.current.schedule({ title: "새 제목" });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    act(() => {
+      result.current.schedule({ content: { type: "doc", content: [] } });
     });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2000);
     });
 
+    expect(count).toBe(1);
+    expect(lastBody).toEqual({
+      title: "새 제목",
+      content: { type: "doc", content: [] },
+    });
+  });
+
+  it("실패하면 error → retry로 재전송하여 saved", async () => {
+    let failed = false;
+    server.use(
+      http.patch(`${API_BASE}/planner/notes/:id`, async () => {
+        if (!failed) {
+          failed = true;
+          return HttpResponse.json({ code: "ERR" }, { status: 500 });
+        }
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            materialId: 1,
+            parentId: null,
+            title: "t",
+            sortOrder: 0,
+            updatedAt: "2026-05-31T10:30:00",
+          },
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useAutoSaveNote(1));
+    act(() => {
+      result.current.schedule({ title: "x" });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
     expect(result.current.status).toBe("error");
 
     await act(async () => {
       result.current.retry();
       await vi.advanceTimersByTimeAsync(0);
     });
-
     expect(result.current.status).toBe("saved");
   });
 });

--- a/fe/src/features/note/hooks/useAutoSaveNote.ts
+++ b/fe/src/features/note/hooks/useAutoSaveNote.ts
@@ -1,43 +1,59 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { type NoteContent, putNote } from "../api/notes";
+import { type NoteUpdateRequest, updateNote } from "../api/notes";
 
 export type SaveStatus = "idle" | "saving" | "saved" | "error";
+
+interface UseAutoSaveNoteOptions {
+  /** 저장 성공 시 호출. 방금 반영된 patch를 전달 (예: title 변경 시 트리 invalidate). */
+  onSaved?: (patch: NoteUpdateRequest) => void;
+}
 
 interface UseAutoSaveNoteResult {
   status: SaveStatus;
   savedAt: Date | null;
-  schedule: (content: NoteContent) => void;
+  schedule: (patch: NoteUpdateRequest) => void;
   flush: () => void;
   retry: () => void;
 }
 
 const DEBOUNCE_MS = 2000;
 
-export function useAutoSaveNote(materialId: number): UseAutoSaveNoteResult {
+/**
+ * noteId의 노트에 대해 title/content 부분 변경을 2초 debounce로 PATCH.
+ * 같은 debounce 창의 여러 schedule은 병합되어 1회 호출된다.
+ */
+export function useAutoSaveNote(
+  noteId: number | null,
+  options: UseAutoSaveNoteOptions = {},
+): UseAutoSaveNoteResult {
   const [status, setStatus] = useState<SaveStatus>("idle");
   const [savedAt, setSavedAt] = useState<Date | null>(null);
-  const pendingRef = useRef<NoteContent | null>(null);
+  const pendingRef = useRef<NoteUpdateRequest | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastFailedRef = useRef<NoteContent | null>(null);
+  const lastFailedRef = useRef<NoteUpdateRequest | null>(null);
+  const noteIdRef = useRef(noteId);
+  noteIdRef.current = noteId;
+  const onSavedRef = useRef(options.onSaved);
+  onSavedRef.current = options.onSaved;
 
-  const save = useCallback(
-    async (content: NoteContent) => {
-      setStatus("saving");
-      try {
-        const res = await putNote(materialId, content);
-        setSavedAt(new Date(res.updatedAt));
-        setStatus("saved");
-        lastFailedRef.current = null;
-      } catch {
-        lastFailedRef.current = content;
-        setStatus("error");
-      }
-    },
-    [materialId],
-  );
+  const save = useCallback(async (patch: NoteUpdateRequest) => {
+    const id = noteIdRef.current;
+    if (id == null) return;
+    setStatus("saving");
+    try {
+      const res = await updateNote(id, patch);
+      setSavedAt(new Date(res.updatedAt));
+      setStatus("saved");
+      lastFailedRef.current = null;
+      onSavedRef.current?.(patch);
+    } catch {
+      lastFailedRef.current = patch;
+      setStatus("error");
+    }
+  }, []);
 
-  const flush = useCallback(() => {
+  const fire = useCallback(() => {
     if (timerRef.current) {
       clearTimeout(timerRef.current);
       timerRef.current = null;
@@ -50,22 +66,19 @@ export function useAutoSaveNote(materialId: number): UseAutoSaveNoteResult {
   }, [save]);
 
   const schedule = useCallback(
-    (content: NoteContent) => {
-      pendingRef.current = content;
+    (patch: NoteUpdateRequest) => {
+      pendingRef.current = { ...pendingRef.current, ...patch };
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
-      timerRef.current = setTimeout(() => {
-        timerRef.current = null;
-        const pending = pendingRef.current;
-        pendingRef.current = null;
-        if (pending) {
-          void save(pending);
-        }
-      }, DEBOUNCE_MS);
+      timerRef.current = setTimeout(fire, DEBOUNCE_MS);
     },
-    [save],
+    [fire],
   );
+
+  const flush = useCallback(() => {
+    fire();
+  }, [fire]);
 
   const retry = useCallback(() => {
     const failed = lastFailedRef.current;

--- a/fe/src/features/note/hooks/useNoteDetail.ts
+++ b/fe/src/features/note/hooks/useNoteDetail.ts
@@ -3,10 +3,11 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchNote } from "../api/notes";
 import { noteKeys } from "../queryKeys";
 
-export function useNote(materialId: number) {
+export function useNoteDetail(noteId: number | null) {
   return useQuery({
-    queryKey: noteKeys.byMaterial(materialId),
-    queryFn: () => fetchNote(materialId),
+    queryKey: noteKeys.detail(noteId ?? 0),
+    queryFn: () => fetchNote(noteId as number),
+    enabled: noteId !== null,
     staleTime: Infinity,
   });
 }

--- a/fe/src/features/note/hooks/useNoteMutations.ts
+++ b/fe/src/features/note/hooks/useNoteMutations.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  createNote,
+  deleteNote,
+  type NoteCreateRequest,
+  type NoteDetail,
+} from "../api/notes";
+import { noteKeys } from "../queryKeys";
+
+export function useCreateNote(materialId: number) {
+  const queryClient = useQueryClient();
+  return useMutation<NoteDetail, Error, NoteCreateRequest>({
+    mutationFn: (request) => createNote(materialId, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: noteKeys.tree(materialId) });
+    },
+  });
+}
+
+export function useDeleteNote(materialId: number) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, number>({
+    mutationFn: deleteNote,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: noteKeys.tree(materialId) });
+    },
+  });
+}

--- a/fe/src/features/note/hooks/useNoteTree.ts
+++ b/fe/src/features/note/hooks/useNoteTree.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchNoteTree } from "../api/notes";
+import { noteKeys } from "../queryKeys";
+
+export function useNoteTree(materialId: number) {
+  return useQuery({
+    queryKey: noteKeys.tree(materialId),
+    queryFn: () => fetchNoteTree(materialId),
+  });
+}

--- a/fe/src/features/note/queryKeys.ts
+++ b/fe/src/features/note/queryKeys.ts
@@ -1,5 +1,5 @@
 export const noteKeys = {
   all: ["notes"] as const,
-  byMaterial: (materialId: number) =>
-    ["notes", "material", materialId] as const,
+  tree: (materialId: number) => ["notes", "tree", materialId] as const,
+  detail: (noteId: number) => ["notes", "detail", noteId] as const,
 };

--- a/fe/src/pages/planner/MaterialDetailPage.test.tsx
+++ b/fe/src/pages/planner/MaterialDetailPage.test.tsx
@@ -50,15 +50,10 @@ function mockMaterial(
         },
       });
     }),
-    http.get(`${API_BASE}/planner/materials/1/note`, () => {
+    http.get(`${API_BASE}/planner/materials/1/notes`, () => {
       return HttpResponse.json({
         code: "OK",
-        data: {
-          id: 10,
-          materialId: 1,
-          content: { type: "doc", content: [] },
-          updatedAt: "2026-05-18T00:00:00",
-        },
+        data: { notes: [] },
       });
     }),
   );
@@ -80,6 +75,18 @@ describe("MaterialDetailPage", () => {
     });
     expect(screen.getByRole("tab", { name: /📝 노트/ })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /카드 12/ })).toBeInTheDocument();
+  });
+
+  it("노트가 없으면 노트 탭에 빈 상태를 표시한다", async () => {
+    mockMaterial();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 노트가 없습니다.")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: /첫 노트 만들기/ }),
+    ).toBeInTheDocument();
   });
 
   it("카드 탭 클릭 시 카드 목록이 보인다", async () => {

--- a/fe/src/pages/planner/MaterialDetailPage.tsx
+++ b/fe/src/pages/planner/MaterialDetailPage.tsx
@@ -1,11 +1,10 @@
 import { Tabs } from "@base-ui/react/tabs";
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 
 import { FlashcardListTab } from "@/features/flashcard/components/FlashcardListTab";
 import { MaterialHeader } from "@/features/material/components/MaterialHeader";
 import { useMaterial } from "@/features/material/hooks/useMaterial";
-import { NoteEditor } from "@/features/note/components/NoteEditor";
-import { useNote } from "@/features/note/hooks/useNote";
+import { NoteTab } from "@/features/note/components/NoteTab";
 
 type TabValue = "note" | "cards";
 
@@ -14,8 +13,7 @@ const VALID_TABS: TabValue[] = ["note", "cards"];
 export function MaterialDetailPage() {
   const { id } = useParams<{ id: string }>();
   const materialId = Number(id);
-  const [searchParams] = useSearchParams();
-  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const tabParam = searchParams.get("tab");
   const tab: TabValue = VALID_TABS.includes(tabParam as TabValue)
@@ -23,23 +21,28 @@ export function MaterialDetailPage() {
     : "note";
 
   const handleTabChange = (next: TabValue) => {
-    navigate(`/planner/materials/${materialId}?tab=${next}`, { replace: true });
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev);
+        params.set("tab", next);
+        // 카드 탭으로 가면 활성 노트 쿼리는 정리
+        if (next !== "note") {
+          params.delete("note");
+        }
+        return params;
+      },
+      { replace: true },
+    );
   };
 
   const materialQuery = useMaterial(materialId);
-  const noteQuery = useNote(materialId);
 
-  if (materialQuery.isLoading || noteQuery.isLoading) {
+  if (materialQuery.isLoading) {
     return <p className="text-muted-foreground text-sm">불러오는 중...</p>;
   }
   if (materialQuery.isError || !materialQuery.data) {
     return (
       <p className="text-destructive text-sm">자료를 불러오지 못했어요.</p>
-    );
-  }
-  if (noteQuery.isError || !noteQuery.data) {
-    return (
-      <p className="text-destructive text-sm">노트를 불러오지 못했어요.</p>
     );
   }
 
@@ -67,10 +70,7 @@ export function MaterialDetailPage() {
         </Tabs.List>
 
         <Tabs.Panel value="note" className="pt-4">
-          <NoteEditor
-            materialId={materialId}
-            initialContent={noteQuery.data.content}
-          />
+          <NoteTab materialId={materialId} />
         </Tabs.Panel>
         <Tabs.Panel value="cards" className="pt-4">
           <FlashcardListTab materialId={materialId} />


### PR DESCRIPTION
## 이슈
closes #404 (#399 대체)

## 작업 내용

#372의 단일 에디터 노트 탭을 **트리/childPage** 방식으로 전면 재구성. BE(#397 마이그레이션, #398 트리 API)는 그대로 사용. **FE 전용**.

> 부수 효과: #398에서 단건 노트 API(`/materials/:id/note`)가 트리 API로 바뀌었는데 FE가 옛 API를 계속 호출하던 버그("노트를 불러오지 못했어요")도 함께 해소.

### Tiptap `ChildPage` 커스텀 노드
- atom block 노드, `attrs { noteId, title }` (title은 표시용 캐시, 진실은 note 레코드)
- ReactNodeView: 📄 아이콘 + 제목 라벨, 클릭 시 `onOpen(noteId)`
- `insertChildPage` command
- **복붙 차단**: `transformPasted` 플러그인으로 paste slice에서 childPage 제거 (noteId 중복 방지)
- `collectChildPageIds`: doc JSON에서 childPage noteId 수집 (삭제 diff용)

### 화면 (2-pane, `?tab=note&note=:noteId`)
- 좌: `NoteTreeSidebar` (parent_id 트리, 펼침/접힘, [+ 새 노트] 루트만)
- 우: 제목 input + Tiptap 본문 (StarterKit + TaskList + TaskItem + Placeholder + **ChildPage**)
- 빈 상태: "아직 노트가 없습니다" + [첫 노트 만들기]
- 모바일: 트리 ↔ 에디터 드릴다운 ([← 노트 목록])

### 동작
- 본문 입력 → 2초 debounce → `PATCH /notes/:id { content }`
- 제목 입력 → debounce → `PATCH { title }` → 트리 라벨 invalidate
- **[+ 페이지]** → `POST /materials/:id/notes { parentId: 현재노트 }` → `insertChildPage` → 본문 블록 삽입 + 트리 자식 추가
- childPage 블록 클릭 → `?note=childId` 전환 (`setContent`로 본문 교체)
- 본문에서 childPage 제거 감지 (이전/현재 id diff) → 확인 다이얼로그 → `DELETE /notes/:childId` (서브트리 cascade)
- 저장 상태: 저장 중 / 저장됨·HH:mm / 실패(재시도)

### API/hooks 재작성
- `api/notes.ts`: 트리 CRUD
- hooks: `useNoteTree`, `useNoteDetail`, `useCreateNote`/`useDeleteNote`, `useAutoSaveNote`(noteId 기반 + `onSaved` 콜백)
- 단건 `useNote` 제거

### 1차 제외 (차기)
- 노트 이동(부모 변경) — API는 있으나 미사용
- 슬래시 메뉴 풀세트 (1차는 툴바 `[+ 페이지]`만, 나머지는 툴바 + 마크다운 단축키)

## 검증
- [x] `npm test` 103건 통과 (childPage 3 / useAutoSaveNote 3 / NoteTab 5 신규, MaterialDetailPage 트리 API로 갱신)
- [x] `npm run lint` / `format:check` / `tsc -b --noEmit` / `build` 통과
- [x] **로컬 dev + Playwright** 전 흐름:
  - 노트 빈 상태 → 노트 생성 → 2-pane 진입
  - [+ 페이지] → 본문에 childPage 블록 + 트리에 자식 추가 + "저장됨" 반영
  - childPage 블록 클릭 → `?note=9` 자식 진입
  - 자식 제목 입력 → BE 저장 확인(`title="정적 팩토리 메서드"`) + 사이드바 트리 라벨 갱신
  - 본문에서 childPage 블록 삭제(Backspace) → "하위 페이지를 삭제할까요?" 확인 → 자식 노트 cascade 삭제 (트리에서 사라짐, `GET /notes/9` → 404)

## 후속
- 노트 이동(드래그/메뉴), 슬래시 커맨드 — 차기