### PR TITLE
fix : tomcat CVE 6건 해결 + BE CI에 Trivy 게이트 추가

### DIFF
--- a/.github/workflows/be-ci.yml
+++ b/.github/workflows/be-ci.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'be/**'
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/be
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -25,3 +29,22 @@ jobs:
       - name: Build and Test
         working-directory: be
         run: ./gradlew build
+
+      # CD와 동일한 이미지 취약점 게이트를 PR 단계에서도 검사한다.
+      # CD에만 두면 머지 후에야 push가 막혀 배포가 조용히 실패한다.
+      - name: Build image for scan
+        uses: docker/build-push-action@v6
+        with:
+          context: be
+          push: false
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-scan
+
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@v0.35.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-scan
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: false
+          exit-code: '1'

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -23,7 +23,7 @@ subprojects {
     ext['jackson-bom.version'] = '3.1.2'
     ext['netty.version'] = '4.2.13.Final'
     ext['spring-security.version'] = '7.0.5'
-    ext['tomcat.version'] = '11.0.21'
+    ext['tomcat.version'] = '11.0.22'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## 이슈
운영 노트 트리 API 500 장애 (별도 이슈 없이 핫픽스)

## 배경 (장애 원인 체인)

운영에서 `GET /api/planner/materials/1/notes` 500. 진단 결과:

```
BE CD 워크플로: Build → Trivy 스캔(CRITICAL/HIGH, exit-code 1) → Push
                                  ↑ 여기서 실패해 Push 미실행
→ ghcr be:latest 미갱신 (5/17 이미지 그대로)
→ ArgoCD Image Updater가 be digest 변화 없어 미동작 (fe만 갱신)
→ 운영 BE = 5/17 구버전 + DB = 020 (021 미적용)
→ 새 FE의 노트 트리 요청 → 500
```

즉 #400(마이그레이션)·#403(노트 트리 API)·#405(캘린더 API) BE 변경분이 운영에 **하나도 반영되지 않았고**, FE만 앞서 나가 깨졌다.

## 변경 내용

### 1. tomcat 취약점 수정 (장애 원인)
- `ext['tomcat.version']` **11.0.21 → 11.0.22**
- tomcat-embed-core 11.0.21에 **CRITICAL 3 + HIGH 3**:
  - CVE-2026-41293 / 43512 / 43515 (CRITICAL)
  - CVE-2026-41284 / 42498 / 43513 (HIGH)
  - 모두 11.0.22에서 fixed
- 로컬 Trivy(0.69.3, CI와 동일) 재스캔 → **0건** 확인

### 2. BE CI에 Trivy 게이트 추가 (재발 방지)
- 기존엔 Trivy가 **BE CD(머지 후 main push)에만** 있어 PR에선 통과하고 **머지된 뒤에야** push가 조용히 실패 → 아무도 못 알아챔
- BE CI(`pull_request`)에도 동일 게이트(이미지 빌드 + Trivy CRITICAL/HIGH, `exit-code: 1`)를 추가해 **머지 전에 차단**

## 검증
- [x] `./gradlew build` (전 모듈 테스트 + checkstyle) 통과
- [x] jar 내 `tomcat-embed-core-11.0.22.jar` 확인
- [x] `trivy rootfs` 재스캔 CRITICAL/HIGH **0건** (수정 전 6건)
- [x] 이 PR의 BE CI에서 새 Trivy 단계가 통과하는지로 게이트 자체도 셀프 검증됨

## 머지 후 (운영 복구 절차)
1. 이 PR 머지 → BE CD가 Trivy 통과 → be:latest ghcr push
2. ArgoCD Image Updater가 be 새 digest 감지 → 롤아웃
3. 새 BE 기동 시 Liquibase가 **021 마이그레이션 적용** (note 트리 컬럼 생성)
4. 노트 트리/캘린더 API 정상화

> 추가 개선거리(별도): `be:latest` 단일 태그라 BE/FE 배포가 어긋날 수 있음 — sha 태그 기반 추적 등 검토