### PR TITLE
fix : 노트 본문 자동저장이 빈 doc으로 덮어써지는 버그

### DIFF
--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -28,7 +28,12 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
   const queryClient = useQueryClient();
   const { status, savedAt, schedule, flush, retry } = useAutoSaveNote(note.id, {
     onSaved: (patch) => {
-      // 제목 저장 시 사이드바 트리 라벨 갱신
+      // 저장된 값을 detail 캐시에 반영해 노트 재진입 시 최신 내용이 보이게 한다.
+      // (자동저장 응답엔 content가 없으므로 보낸 patch를 직접 머지)
+      queryClient.setQueryData<NoteDetail>(noteKeys.detail(note.id), (old) =>
+        old ? { ...old, ...patch } : old,
+      );
+      // 제목 저장 시 사이드바 트리 라벨도 갱신
       if (patch.title !== undefined) {
         queryClient.invalidateQueries({ queryKey: noteKeys.tree(materialId) });
       }
@@ -39,8 +44,9 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
 
   const [title, setTitle] = useState(note.title);
   const [pendingDelete, setPendingDelete] = useState<number | null>(null);
-  // 본문에 현재 박혀 있는 childPage noteId 집합 (삭제 diff 기준)
-  const childIdsRef = useRef<Set<number>>(new Set());
+  // 본문에 현재 박혀 있는 childPage noteId 집합 (삭제 diff 기준).
+  // NoteTab이 key={note.id}로 리마운트하므로 마운트 시점 content 기준으로 1회 초기화한다.
+  const childIdsRef = useRef<Set<number>>(collectChildPageIds(note.content));
 
   const editor = useEditor(
     {
@@ -70,13 +76,10 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
     [note.id],
   );
 
-  // 노트 전환 시 제목/본문/childPage 기준 초기화
-  useEffect(() => {
-    setTitle(note.title);
-    childIdsRef.current = collectChildPageIds(note.content);
-    editor?.commands.setContent(note.content as JSONContent);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [note.id, editor]);
+  // 노트 전환은 NoteTab의 key={note.id} 리마운트로 처리되므로
+  // setContent를 수동 호출하지 않는다. (editor 재생성마다 setContent가
+  // 캐시의 옛 content로 onUpdate를 발화해 방금 쓴 내용을 빈 doc으로
+  // 덮어쓰던 버그를 제거)
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## 이슈
closes #410

## 증상
노트(특히 하위 페이지)에 글을 쓰면 한 번 저장된 뒤 **빈 doc으로 다시 덮어써져** 화면/BE 모두에서 글이 사라지고 트리 노드만 남는다.

## 원인
`NoteEditor`의 useEffect:
```js
useEffect(() => {
  ...
  editor?.commands.setContent(note.content);
}, [note.id, editor]);
```
- `editor` 인스턴스가 마운트 과정/리렌더에서 바뀌면 effect 재실행
- `note.content`는 react-query 캐시의 첫 GET값(빈 doc) — 자동저장은 캐시를 갱신하지 않음
- `setContent`가 Tiptap `onUpdate`를 발화 → `schedule({content: 빈doc})` → **빈 doc 자동저장**으로 방금 쓴 글을 덮어씀
- `NoteTab`이 이미 `key={note.id}`로 리마운트하므로 이 setContent는 애초에 불필요

## 수정
- **setContent useEffect 제거** (노트 전환은 key 리마운트로 처리)
- `childIdsRef`를 마운트 시 content 기준 1회 초기화
- 자동저장 성공(`onSaved`) 시 detail 캐시를 `setQueryData`로 갱신 → 재진입 시 최신 내용 표시

## 검증
- [x] `npm test` 103건 통과 (회귀 없음), `lint`/`format`/`build` 통과
- [x] **로컬 dev + Playwright 3중 확인**:
  - 자식 본문 입력 → 화면에 즉시 보임 → **2초 debounce 후에도 유지**(수정 전엔 빈 doc으로 사라짐)
  - 부모 노트 갔다가 자식 재진입 → 글 그대로 보임 (캐시 갱신)
  - BE `GET /notes/10` content에 글 저장 확인
  - 부모 본문의 childPage 블록도 보존됨

## 비고
- 이 버그는 editor 인스턴스 재생성 타이밍에 의존해 jsdom/RTL로 안정적 재현이 어려워 Playwright 통합 검증으로 확인. 기존 NoteTab/useAutoSaveNote 테스트(노트 전환·자동저장)는 전부 통과