### PR TITLE
feat : 노트 트리 사이드바에서 노트 삭제 (루트 포함)

### DIFF
--- a/fe/src/features/note/components/NoteTab.test.tsx
+++ b/fe/src/features/note/components/NoteTab.test.tsx
@@ -132,7 +132,7 @@ describe("NoteTab", () => {
       expect(screen.getByLabelText("노트 제목")).toHaveValue("1장");
     });
 
-    await user.click(screen.getByRole("button", { name: /2장/ }));
+    await user.click(screen.getByRole("button", { name: "2장" }));
 
     await waitFor(() => {
       expect(screen.getByLabelText("노트 제목")).toHaveValue("2장");
@@ -226,5 +226,75 @@ describe("NoteTab", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("노트 제목")).toHaveValue("자식");
     });
+  });
+
+  it("트리 [⋯] → 삭제 → 확인 시 DELETE 호출 (루트 노트)", async () => {
+    mockTree([
+      {
+        id: 1,
+        title: "삭제할 루트",
+        parentId: null,
+        sortOrder: 0,
+        children: [],
+      },
+    ]);
+    mockNoteDetail(1, { type: "doc", content: [] }, "삭제할 루트");
+    let deletedId: number | null = null;
+    server.use(
+      http.delete(`${API_BASE}/planner/notes/1`, () => {
+        deletedId = 1;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("삭제할 루트");
+    });
+
+    await user.click(screen.getByRole("button", { name: /삭제할 루트 메뉴/ }));
+    await user.click(await screen.findByRole("menuitem", { name: /삭제/ }));
+    await user.click(await screen.findByRole("button", { name: "삭제" }));
+
+    await waitFor(() => expect(deletedId).toBe(1));
+  });
+
+  it("자손이 있는 노트 삭제 시 확인 문구에 하위 개수를 표시한다", async () => {
+    mockTree([
+      {
+        id: 1,
+        title: "부모",
+        parentId: null,
+        sortOrder: 0,
+        children: [
+          {
+            id: 2,
+            title: "자식",
+            parentId: 1,
+            sortOrder: 0,
+            children: [
+              { id: 3, title: "손자", parentId: 2, sortOrder: 0, children: [] },
+            ],
+          },
+        ],
+      },
+    ]);
+    mockNoteDetail(1, { type: "doc", content: [] }, "부모");
+
+    const user = userEvent.setup();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("부모");
+    });
+
+    await user.click(screen.getByRole("button", { name: /부모 메뉴/ }));
+    await user.click(await screen.findByRole("menuitem", { name: /삭제/ }));
+
+    expect(
+      await screen.findByText(/하위 노트 2개도 함께 삭제됩니다/),
+    ).toBeInTheDocument();
   });
 });

--- a/fe/src/features/note/components/NoteTab.tsx
+++ b/fe/src/features/note/components/NoteTab.tsx
@@ -1,17 +1,30 @@
 import { ArrowLeft, Plus } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 
+import type { NoteTreeNode } from "../api/notes";
 import { useNoteDetail } from "../hooks/useNoteDetail";
-import { useCreateNote } from "../hooks/useNoteMutations";
+import { useCreateNote, useDeleteNote } from "../hooks/useNoteMutations";
 import { useNoteTree } from "../hooks/useNoteTree";
 import { NoteEditor } from "./NoteEditor";
 import { NoteTreeSidebar } from "./NoteTreeSidebar";
 
 interface Props {
   materialId: number;
+}
+
+function collectSubtreeIds(node: NoteTreeNode): number[] {
+  return [node.id, ...node.children.flatMap(collectSubtreeIds)];
+}
+
+function countDescendants(node: NoteTreeNode): number {
+  return node.children.reduce(
+    (sum, child) => sum + 1 + countDescendants(child),
+    0,
+  );
 }
 
 export function NoteTab({ materialId }: Props) {
@@ -22,6 +35,8 @@ export function NoteTab({ materialId }: Props) {
   const treeQuery = useNoteTree(materialId);
   const detailQuery = useNoteDetail(activeNoteId);
   const createNote = useCreateNote(materialId);
+  const deleteNote = useDeleteNote(materialId);
+  const [pendingDelete, setPendingDelete] = useState<NoteTreeNode | null>(null);
 
   const setActiveNote = (noteId: number | null) => {
     setSearchParams(
@@ -57,6 +72,22 @@ export function NoteTab({ materialId }: Props) {
     );
   };
 
+  const handleConfirmDelete = () => {
+    if (!pendingDelete || deleteNote.isPending) return;
+    const removedIds = new Set(collectSubtreeIds(pendingDelete));
+    deleteNote.mutate(pendingDelete.id, {
+      onSuccess: () => {
+        // 삭제된 서브트리에 활성 노트가 포함됐으면 선택 해제
+        // (남은 루트가 있으면 useEffect가 자동 선택)
+        if (activeNoteId != null && removedIds.has(activeNoteId)) {
+          setActiveNote(null);
+        }
+        setPendingDelete(null);
+      },
+      onError: () => setPendingDelete(null),
+    });
+  };
+
   if (treeQuery.isLoading) {
     return <p className="text-muted-foreground text-sm">불러오는 중...</p>;
   }
@@ -89,6 +120,7 @@ export function NoteTab({ materialId }: Props) {
           activeNoteId={activeNoteId}
           onSelect={setActiveNote}
           onAddRoot={handleAddRoot}
+          onRequestDelete={setPendingDelete}
           addRootPending={createNote.isPending}
         />
       </div>
@@ -124,6 +156,23 @@ export function NoteTab({ materialId }: Props) {
           />
         )}
       </div>
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+        title="노트를 삭제할까요?"
+        description={
+          pendingDelete && countDescendants(pendingDelete) > 0
+            ? `하위 노트 ${countDescendants(pendingDelete)}개도 함께 삭제됩니다. 되돌릴 수 없어요.`
+            : "이 노트가 삭제됩니다. 되돌릴 수 없어요."
+        }
+        confirmLabel="삭제"
+        destructive
+        onConfirm={handleConfirmDelete}
+        pending={deleteNote.isPending}
+      />
     </div>
   );
 }

--- a/fe/src/features/note/components/NoteTreeSidebar.tsx
+++ b/fe/src/features/note/components/NoteTreeSidebar.tsx
@@ -1,4 +1,12 @@
-import { ChevronDown, ChevronRight, FileText, Plus } from "lucide-react";
+import { Menu } from "@base-ui/react/menu";
+import {
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  MoreHorizontal,
+  Plus,
+  Trash2,
+} from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -11,6 +19,7 @@ interface Props {
   activeNoteId: number | null;
   onSelect: (noteId: number) => void;
   onAddRoot: () => void;
+  onRequestDelete: (node: NoteTreeNode) => void;
   addRootPending?: boolean;
 }
 
@@ -19,6 +28,7 @@ export function NoteTreeSidebar({
   activeNoteId,
   onSelect,
   onAddRoot,
+  onRequestDelete,
   addRootPending,
 }: Props) {
   return (
@@ -51,6 +61,7 @@ export function NoteTreeSidebar({
               depth={0}
               activeNoteId={activeNoteId}
               onSelect={onSelect}
+              onRequestDelete={onRequestDelete}
             />
           ))}
         </ul>
@@ -64,9 +75,16 @@ interface ItemProps {
   depth: number;
   activeNoteId: number | null;
   onSelect: (noteId: number) => void;
+  onRequestDelete: (node: NoteTreeNode) => void;
 }
 
-function NoteTreeItem({ node, depth, activeNoteId, onSelect }: ItemProps) {
+function NoteTreeItem({
+  node,
+  depth,
+  activeNoteId,
+  onSelect,
+  onRequestDelete,
+}: ItemProps) {
   const [expanded, setExpanded] = useState(true);
   const hasChildren = node.children.length > 0;
   const isActive = node.id === activeNoteId;
@@ -75,7 +93,7 @@ function NoteTreeItem({ node, depth, activeNoteId, onSelect }: ItemProps) {
     <li>
       <div
         className={cn(
-          "flex items-center gap-0.5 rounded-md pr-1 text-sm",
+          "group/note flex items-center gap-0.5 rounded-md pr-1 text-sm",
           isActive
             ? "bg-primary/10 text-primary"
             : "text-foreground/80 hover:bg-muted",
@@ -106,6 +124,33 @@ function NoteTreeItem({ node, depth, activeNoteId, onSelect }: ItemProps) {
           <FileText className="size-3.5 shrink-0 opacity-60" />
           <span className="truncate">{node.title}</span>
         </button>
+
+        <Menu.Root>
+          <Menu.Trigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label={`${node.title} 메뉴`}
+                className="size-6 shrink-0 opacity-0 group-hover/note:opacity-100 data-[popup-open]:opacity-100"
+              >
+                <MoreHorizontal className="size-3.5" />
+              </Button>
+            }
+          />
+          <Menu.Portal>
+            <Menu.Positioner sideOffset={4} align="end" className="z-50">
+              <Menu.Popup className="bg-popover text-popover-foreground min-w-28 rounded-md border p-1 shadow-md">
+                <Menu.Item
+                  onClick={() => onRequestDelete(node)}
+                  className="text-destructive data-[highlighted]:bg-destructive/10 flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none"
+                >
+                  <Trash2 className="size-3.5" /> 삭제
+                </Menu.Item>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>
       </div>
       {hasChildren && expanded && (
         <ul className="flex flex-col gap-0.5">
@@ -116,6 +161,7 @@ function NoteTreeItem({ node, depth, activeNoteId, onSelect }: ItemProps) {
               depth={depth + 1}
               activeNoteId={activeNoteId}
               onSelect={onSelect}
+              onRequestDelete={onRequestDelete}
             />
           ))}
         </ul>


### PR DESCRIPTION
## 이슈
closes #409

## 작업 내용
- 노트 트리 사이드바 각 행에 `[⋯]` 메뉴 추가 (호버 시 노출, 팝업 열림 시 유지)
- 메뉴의 **삭제** 항목으로 루트·하위 노트 모두 삭제 가능
  - 기존엔 본문 childPage 블록 제거로만 삭제 가능 → 루트 노트는 삭제 수단이 없었음
- 자손이 있는 노트 삭제 시 확인 다이얼로그에 `하위 노트 N개도 함께 삭제됩니다` 표시
- 삭제된 서브트리에 활성 노트가 포함되면 선택 해제 (남은 루트는 기존 로직이 자동 선택)
- `NoteTab` 삭제 시나리오 RTL 테스트 추가 (루트 삭제 DELETE 호출 / 자손 개수 문구)

## 검증
- `npm test` 105개 통과 / `lint` · `format` · `build` clean
- Playwright 로컬 확인: `[⋯] → 삭제 → 확인 다이얼로그(하위 1개 문구) → 삭제` 후 트리·에디터 비워지고 URL `note` 파라미터 제거, DB cascade 삭제 확인