### PR TITLE
fix : 하위 페이지 블록이 자식 노트 최신 제목을 표시하도록 수정

### DIFF
--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -57,7 +57,7 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
         Placeholder.configure({
           placeholder: "내용을 입력하거나 페이지를 추가하세요...",
         }),
-        ChildPage.configure({ onOpen: onOpenNote }),
+        ChildPage.configure({ onOpen: onOpenNote, materialId }),
       ],
       content: note.content as JSONContent,
       editorProps: {

--- a/fe/src/features/note/components/NoteTab.test.tsx
+++ b/fe/src/features/note/components/NoteTab.test.tsx
@@ -228,6 +228,45 @@ describe("NoteTab", () => {
     });
   });
 
+  it("childPage 블록은 attrs 캐시가 아니라 트리의 최신 제목을 표시한다", async () => {
+    // 부모 본문의 childPage는 삽입 시점 캐시("제목 없음")를 갖지만,
+    // 트리에서 자식 제목이 "test"로 바뀐 상태 → 블록도 "test"로 보여야 한다.
+    mockTree([
+      {
+        id: 1,
+        title: "부모",
+        parentId: null,
+        sortOrder: 0,
+        children: [
+          { id: 2, title: "test", parentId: 1, sortOrder: 0, children: [] },
+        ],
+      },
+    ]);
+    mockNoteDetail(
+      1,
+      {
+        type: "doc",
+        content: [
+          { type: "childPage", attrs: { noteId: 2, title: "제목 없음" } },
+        ],
+      },
+      "부모",
+    );
+
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("부모");
+    });
+
+    expect(
+      await screen.findByRole("button", { name: "하위 페이지 test 열기" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /하위 페이지 제목 없음 열기/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it("트리 [⋯] → 삭제 → 확인 시 DELETE 호출 (루트 노트)", async () => {
     mockTree([
       {

--- a/fe/src/features/note/editor/ChildPageView.tsx
+++ b/fe/src/features/note/editor/ChildPageView.tsx
@@ -1,16 +1,37 @@
 import { type NodeViewProps, NodeViewWrapper } from "@tiptap/react";
 import { FileText } from "lucide-react";
 
+import type { NoteTreeNode } from "../api/notes";
+import { useNoteTree } from "../hooks/useNoteTree";
 import type { ChildPageOptions } from "./childPage";
+
+/** 트리에서 noteId에 해당하는 노드의 현재 제목을 찾는다. */
+function findTitle(
+  nodes: NoteTreeNode[] | undefined,
+  id: number,
+): string | undefined {
+  if (!nodes) return undefined;
+  for (const node of nodes) {
+    if (node.id === id) return node.title;
+    const found = findTitle(node.children, id);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
 
 /**
  * 본문 안에 박히는 하위 페이지 블록.
  * 클릭 시 ChildPage 노드 옵션의 onOpen(noteId) 호출 → 자식 노트로 라우팅.
+ * 제목은 트리(라이브)에서 조회하고, 없으면 attrs.title(삽입 시점 캐시)로 폴백한다.
  */
 export function ChildPageView({ node, extension }: NodeViewProps) {
   const noteId = node.attrs.noteId as number | null;
-  const title = (node.attrs.title as string) || "제목 없음";
+  const cachedTitle = (node.attrs.title as string) || "제목 없음";
   const options = extension.options as ChildPageOptions;
+
+  const { data: tree } = useNoteTree(options.materialId);
+  const liveTitle = noteId != null ? findTitle(tree, noteId) : undefined;
+  const title = liveTitle ?? cachedTitle;
 
   const handleOpen = () => {
     if (noteId == null) return;

--- a/fe/src/features/note/editor/childPage.ts
+++ b/fe/src/features/note/editor/childPage.ts
@@ -12,6 +12,8 @@ export interface ChildPageAttrs {
 
 export interface ChildPageOptions {
   onOpen: (noteId: number) => void;
+  /** 라이브 제목 조회용. attrs.title은 삽입 시점 캐시라 stale할 수 있어 트리에서 보강한다. */
+  materialId: number;
 }
 
 declare module "@tiptap/core" {
@@ -36,6 +38,7 @@ export const ChildPage = Node.create<ChildPageOptions>({
   addOptions() {
     return {
       onOpen: () => {},
+      materialId: 0,
     };
   },
 


### PR DESCRIPTION
## 이슈
closes #413

## 작업 내용
- 상위 노트 본문의 하위 페이지(childPage) 블록이 자식 제목 변경을 반영하지 못하던 버그 수정
  - `attrs.title`은 삽입 시점 캐시 → 자식 제목을 `test`로 바꿔도 본문 블록은 `제목 없음` 유지
- `ChildPageView`가 노트 트리(라이브 캐시)에서 현재 제목을 조회하도록 변경, 없으면 `attrs.title`로 폴백
  - 제목 변경 시 이미 트리를 invalidate하므로 반응형으로 갱신됨
- `ChildPage` 옵션에 `materialId` 추가 (트리 조회 키), `NoteEditor`에서 주입
- `NoteTab` 회귀 테스트 추가 (stale attrs여도 트리 최신 제목 표시)

## 검증
- `npm test` 106개 통과 / `lint` · `format` · `build` clean
- Playwright 로컬 확인: 하위 페이지 제목 `test` 변경 → 상위 본문 블록도 `test`로 표시 (기존 `제목 없음` → 수정 후 `test`)