### PR TITLE
fix : 노트가 있는 자료에서 카드 탭 전환이 안 되던 버그

### DIFF
--- a/fe/src/features/note/components/NoteTab.tsx
+++ b/fe/src/features/note/components/NoteTab.tsx
@@ -31,6 +31,10 @@ export function NoteTab({ materialId }: Props) {
   const [searchParams, setSearchParams] = useSearchParams();
   const noteParam = searchParams.get("note");
   const activeNoteId = noteParam ? Number(noteParam) : null;
+  // 노트 탭이 활성일 때만 자동선택을 수행한다. base-ui Tabs는 패널이 숨겨진
+  // 직후에도 한 렌더 동안 마운트를 유지하는데, 그 사이 자동선택이 tab=note로
+  // URL을 되돌려 카드 탭 전환을 막던 버그가 있었다.
+  const isNoteTab = (searchParams.get("tab") ?? "note") === "note";
 
   const treeQuery = useNoteTree(materialId);
   const detailQuery = useNoteDetail(activeNoteId);
@@ -56,13 +60,13 @@ export function NoteTab({ materialId }: Props) {
 
   const tree = treeQuery.data ?? [];
 
-  // 노트가 있는데 아무것도 선택 안 됐으면 첫 루트 자동 선택
+  // 노트가 있는데 아무것도 선택 안 됐으면 첫 루트 자동 선택 (노트 탭 한정)
   useEffect(() => {
-    if (activeNoteId == null && tree.length > 0) {
+    if (isNoteTab && activeNoteId == null && tree.length > 0) {
       setActiveNote(tree[0].id);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeNoteId, tree]);
+  }, [isNoteTab, activeNoteId, tree]);
 
   const handleAddRoot = () => {
     if (createNote.isPending) return;

--- a/fe/src/pages/planner/MaterialDetailPage.test.tsx
+++ b/fe/src/pages/planner/MaterialDetailPage.test.tsx
@@ -112,6 +112,61 @@ describe("MaterialDetailPage", () => {
     });
   });
 
+  it("노트가 있어도 카드 탭으로 전환되고 유지된다 (자동선택이 탭을 되돌리지 않음)", async () => {
+    mockMaterial({ flashcardCount: 1 });
+    server.use(
+      // 노트가 존재 → 노트 탭에서 첫 노트가 자동선택됨
+      http.get(`${API_BASE}/planner/materials/1/notes`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            notes: [
+              {
+                id: 7,
+                title: "노트1",
+                parentId: null,
+                sortOrder: 0,
+                children: [],
+              },
+            ],
+          },
+        }),
+      ),
+      http.get(`${API_BASE}/planner/notes/7`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 7,
+            materialId: 1,
+            parentId: null,
+            title: "노트1",
+            sortOrder: 0,
+            content: { type: "doc", content: [] },
+            updatedAt: "2026-05-31T10:00:00",
+          },
+        }),
+      ),
+      http.get(`${API_BASE}/planner/materials/1/flashcards`, () =>
+        HttpResponse.json({ code: "OK", data: { flashcards: [] } }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderPage();
+
+    // 노트 탭: 자동선택으로 노트1 에디터가 열린다
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("노트1");
+    });
+
+    await user.click(screen.getByRole("tab", { name: /카드/ }));
+
+    // 카드 탭이 유지되고 (노트 에디터가 사라지고) 카드 목록이 보인다
+    await waitFor(() => {
+      expect(screen.getByText("아직 카드가 없습니다.")).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("노트 제목")).not.toBeInTheDocument();
+  });
+
   it("자료 메뉴 → 삭제 → 확인 시 DELETE 호출 후 목록으로 이동한다", async () => {
     mockMaterial();
     let deleted = false;


### PR DESCRIPTION
## 이슈
closes #415

## 작업 내용
- 노트가 1개 이상 있는 자료에서 카드 탭을 눌러도 노트 탭으로 되돌아가던 버그 수정
- 원인: `NoteTab`의 첫 노트 자동선택 effect가 `setActiveNote`로 URL에 항상 `tab=note`를 씀
  - 카드 탭 클릭 → `note` 파라미터 삭제 → base-ui Tabs 패널이 숨겨진 직후 한 렌더 동안 마운트를 유지하는 사이 `activeNoteId`가 null이 되어 자동선택 발화 → `tab=note`로 복귀
- 자동선택을 **노트 탭이 활성일 때(`isNoteTab`)만** 수행하도록 가드
- `MaterialDetailPage` 회귀 테스트 추가 (노트가 있는 상태에서 카드 탭 전환·유지 검증)
  - 수정 전 이 테스트는 실패 / 수정 후 통과로 버그 재현·검증 확인

## 검증
- `npm test` 106개 통과 / `lint` · `format` · `build` clean
- Playwright 로컬 확인: 노트 있는 자료(노트 자동선택됨)에서 `카드` 탭 클릭 → `?tab=cards`로 전환·유지, 카드 목록 정상 표시 (기존엔 `?tab=note`로 즉시 복귀)