### PR TITLE
fix : 카드 변경·복습 완료 후 복습 캘린더 캐시 무효화 누락 수정

### DIFF
--- a/fe/src/features/flashcard/hooks/useCreateFlashcard.test.tsx
+++ b/fe/src/features/flashcard/hooks/useCreateFlashcard.test.tsx
@@ -1,0 +1,67 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { server } from "@/test/mocks/server";
+
+import { useCreateFlashcard } from "./useCreateFlashcard";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const spy = vi.spyOn(queryClient, "invalidateQueries");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper, spy };
+}
+
+describe("useCreateFlashcard", () => {
+  it("카드 생성 성공 시 복습(today·캘린더 포함) 쿼리를 무효화한다", async () => {
+    server.use(
+      http.post(`${API_BASE}/planner/materials/1/flashcards`, () =>
+        HttpResponse.json(
+          {
+            code: "OK",
+            data: {
+              flashcard: {
+                id: 99,
+                materialId: 1,
+                front: "test",
+                back: "test",
+                nextReview: null,
+                createdAt: "2026-05-31T10:00:00",
+              },
+              firstReview: {
+                id: 1,
+                flashcardId: 99,
+                sequence: 1,
+                scheduledDate: "2026-06-01",
+                intervalDays: 1,
+                easeFactor: 2.5,
+                status: "PENDING",
+              },
+            },
+          },
+          { status: 201 },
+        ),
+      ),
+    );
+
+    const { wrapper, spy } = makeWrapper();
+    const { result } = renderHook(() => useCreateFlashcard(1), { wrapper });
+
+    result.current.mutate({ front: "test", back: "test" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // 캘린더 쿼리(["reviews","calendar",...])까지 포함하도록 ["reviews"] 프리픽스를 무효화해야 한다.
+    const invalidatedKeys = spy.mock.calls.map((call) => call[0]?.queryKey);
+    expect(invalidatedKeys).toContainEqual(["reviews"]);
+  });
+});

--- a/fe/src/features/flashcard/hooks/useCreateFlashcard.ts
+++ b/fe/src/features/flashcard/hooks/useCreateFlashcard.ts
@@ -19,7 +19,8 @@ export function useCreateFlashcard(materialId: number) {
         queryKey: flashcardKeys.byMaterial(materialId),
       });
       queryClient.invalidateQueries({ queryKey: materialKeys.all });
-      queryClient.invalidateQueries({ queryKey: reviewKeys.today });
+      // 카드 생성 시 복습 일정이 함께 생성되므로 today뿐 아니라 캘린더도 갱신
+      queryClient.invalidateQueries({ queryKey: reviewKeys.all });
     },
   });
 }

--- a/fe/src/features/flashcard/hooks/useDeleteFlashcard.ts
+++ b/fe/src/features/flashcard/hooks/useDeleteFlashcard.ts
@@ -15,7 +15,8 @@ export function useDeleteFlashcard(materialId: number) {
         queryKey: flashcardKeys.byMaterial(materialId),
       });
       queryClient.invalidateQueries({ queryKey: materialKeys.all });
-      queryClient.invalidateQueries({ queryKey: reviewKeys.today });
+      // 카드 삭제 시 복습 일정도 사라지므로 today뿐 아니라 캘린더도 갱신
+      queryClient.invalidateQueries({ queryKey: reviewKeys.all });
     },
   });
 }

--- a/fe/src/features/flashcard/hooks/useUpdateFlashcard.ts
+++ b/fe/src/features/flashcard/hooks/useUpdateFlashcard.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { reviewKeys } from "@/features/review/queryKeys";
+
 import {
   type Flashcard,
   type FlashcardUpdateRequest,
@@ -15,6 +17,8 @@ export function useUpdateFlashcard(materialId: number, flashcardId: number) {
       queryClient.invalidateQueries({
         queryKey: flashcardKeys.byMaterial(materialId),
       });
+      // 카드 앞면 텍스트는 today·캘린더에도 노출되므로 함께 갱신
+      queryClient.invalidateQueries({ queryKey: reviewKeys.all });
     },
   });
 }

--- a/fe/src/features/review/hooks/useCompleteReview.ts
+++ b/fe/src/features/review/hooks/useCompleteReview.ts
@@ -19,7 +19,8 @@ export function useCompleteReview() {
   return useMutation<CompleteReviewResponse, Error, Variables>({
     mutationFn: ({ reviewId, rating }) => completeReview(reviewId, rating),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: reviewKeys.today });
+      // 복습 완료는 상태 변경 + 다음 일정 생성이라 today·캘린더 모두 갱신
+      queryClient.invalidateQueries({ queryKey: reviewKeys.all });
       queryClient.invalidateQueries({ queryKey: materialKeys.all });
     },
   });


### PR DESCRIPTION
## 이슈
closes #417

## 작업 내용
- 카드를 추가하면 복습 일정이 함께 생성되지만, 복습 캘린더가 새로고침 전까지 갱신되지 않던 버그 수정
- 원인: `useCreateFlashcard`가 `reviewKeys.today`만 무효화하고 `reviewKeys.calendar(from, to)`는 무효화하지 않음
- `reviewKeys.today` → `reviewKeys.all`(`["reviews"]` 프리픽스 = today + calendar 모두 커버)로 변경
- 같은 문제가 있던 훅도 함께 수정
  - `useDeleteFlashcard` (삭제 시 복습 일정도 사라짐)
  - `useCompleteReview` (상태 변경 + 다음 일정 생성)
  - `useUpdateFlashcard` (앞면 텍스트가 캘린더·today에 노출 → reviews 무효화 추가)
- `useCreateFlashcard` 무효화 회귀 테스트 추가 (수정 전 실패 / 수정 후 통과로 확인)

## 검증
- `npm test` 106개 통과 / `lint` · `format` · `build` clean
- Playwright 로컬 확인:
  1. 복습 캘린더 진입(캐시) → 6/1 칸 복습 없음
  2. 자료 카드 탭에서 카드 추가
  3. **새로고침 없이** 캘린더로 이동 → 6/1 칸에 `복습 1건` 표시됨 (수정 전엔 stale로 안 보임)