### PR TITLE
style : 본문 하위 페이지 블록을 박스 없이 아이콘+제목만 표시

### DIFF
--- a/fe/src/features/note/editor/ChildPageView.tsx
+++ b/fe/src/features/note/editor/ChildPageView.tsx
@@ -20,7 +20,7 @@ function findTitle(
 }
 
 /**
- * 본문 안에 박히는 하위 페이지 블록.
+ * 본문 안의 하위 페이지 줄. 한 줄을 차지하되 박스 없이 아이콘 + 제목만 보인다.
  * 클릭 시 ChildPage 노드 옵션의 onOpen(noteId) 호출 → 자식 노트로 라우팅.
  * 제목은 트리(라이브)에서 조회하고, 없으면 attrs.title(삽입 시점 캐시)로 폴백한다.
  */
@@ -42,17 +42,17 @@ export function ChildPageView({ node, extension }: NodeViewProps) {
     <NodeViewWrapper
       as="div"
       data-child-page={noteId ?? ""}
-      className="my-1"
+      className="my-0.5"
       contentEditable={false}
     >
       <button
         type="button"
         onClick={handleOpen}
         aria-label={`하위 페이지 ${title} 열기`}
-        className="hover:bg-muted flex w-full items-center gap-2 rounded-md border px-3 py-2 text-left text-sm transition-colors"
+        className="group/childpage flex w-full items-center gap-1.5 py-0.5 text-left text-sm"
       >
         <FileText className="text-muted-foreground size-4 shrink-0" />
-        <span className="truncate underline-offset-2 hover:underline">
+        <span className="truncate underline-offset-2 group-hover/childpage:underline">
           {title}
         </span>
       </button>


### PR DESCRIPTION
## 이슈
closes #419

## 작업 내용
- 노트 본문의 하위 페이지(childPage) 블록에서 테두리·배경·박스 패딩 제거
- 아이콘(FileText) + 제목만 노출, hover 시 제목에 밑줄로 링크임을 표시
- 한 줄 차지 및 클릭 시 하위 노트 이동 동작은 그대로 유지

## 검증
- `npm test` 통과 (childPage·NoteTab·MaterialDetailPage 17개) / `lint` · `format` · `build` clean
- Playwright 로컬 확인: 하위 페이지 블록이 박스 없이 아이콘 + 제목만으로 렌더링됨 (클릭 시 하위 노트로 이동 정상)