### PR TITLE
feat : 노트 본문 블록 드래그로 순서 이동 (노션 스타일)

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -13,6 +13,8 @@
         "@grafana/faro-web-tracing": "^2.6.3",
         "@tailwindcss/vite": "^4.2.2",
         "@tanstack/react-query": "^5.96.1",
+        "@tiptap/extension-drag-handle": "3.23.4",
+        "@tiptap/extension-drag-handle-react": "3.23.4",
         "@tiptap/extension-placeholder": "^3.23.4",
         "@tiptap/extension-task-item": "^3.23.4",
         "@tiptap/extension-task-list": "^3.23.4",
@@ -3158,6 +3160,23 @@
         "@tiptap/pm": "3.23.4"
       }
     },
+    "node_modules/@tiptap/extension-collaboration": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.23.4.tgz",
+      "integrity": "sha512-28TJFayxCk7J9TmHBG4+8lVAz6YgyjN0RqzZueVeimWxSEgnTDGlkfHx6Ho5tOuyLwDa6SMBhN/6Q0iUMdnwMQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4",
+        "@tiptap/y-tiptap": "^3.0.2",
+        "yjs": "^13"
+      }
+    },
     "node_modules/@tiptap/extension-document": {
       "version": "3.23.4",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.23.4.tgz",
@@ -3169,6 +3188,43 @@
       },
       "peerDependencies": {
         "@tiptap/core": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-drag-handle": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-3.23.4.tgz",
+      "integrity": "sha512-ia027RBIdZIA9YBzt7Yuc4fGFAgdbxbVhrPqiDDJIN41IVsbb1PSQHDp8NVit50BNH1XVeAEB/E6WA/QLBoOgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.13"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4",
+        "@tiptap/extension-collaboration": "3.23.4",
+        "@tiptap/extension-node-range": "3.23.4",
+        "@tiptap/pm": "3.23.4",
+        "@tiptap/y-tiptap": "^3.0.2"
+      }
+    },
+    "node_modules/@tiptap/extension-drag-handle-react": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-react/-/extension-drag-handle-react-3.23.4.tgz",
+      "integrity": "sha512-/enO9HmUgkXACRa0FxETkQeBrnv2WDoAHAXQ0LL25yIV7YW5tWIwXgDBpPd8G7YEk9R05XhFq1tN6NmU0JYIAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-drag-handle": "3.23.4",
+        "@tiptap/pm": "3.23.4",
+        "@tiptap/react": "3.23.4",
+        "react": "^16.8 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@tiptap/extension-dropcursor": {
@@ -3321,6 +3377,21 @@
       },
       "peerDependencies": {
         "@tiptap/extension-list": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-node-range": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.23.4.tgz",
+      "integrity": "sha512-wmJrIT2Ng4TP4HniA0+WCNtqL09ZBZYd9bSnyDfZiz5phEcnqfCTBGpPXiA+jTjxZp/ZrJPFTjgQPevNQIAa9g==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-ordered-list": {
@@ -3526,6 +3597,27 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/y-tiptap": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/y-tiptap/-/y-tiptap-3.0.4.tgz",
+      "integrity": "sha512-I7NnntIPR9PgCuBEjZ0hco+eeLvTpMDnXxsyhwn8z7Se0/Ac6RIq903wn6KoMn7FRVXpTtXAfZphFtpErjabVw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.100"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.5.38"
       }
     },
     "node_modules/@ts-morph/common": {
@@ -6607,6 +6699,17 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -6794,6 +6897,28 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lightningcss": {
@@ -9924,6 +10049,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y-protocols": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -10005,6 +10151,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.31",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
+      "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yocto-queue": {

--- a/fe/package.json
+++ b/fe/package.json
@@ -21,6 +21,8 @@
     "@grafana/faro-web-tracing": "^2.6.3",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-query": "^5.96.1",
+    "@tiptap/extension-drag-handle": "3.23.4",
+    "@tiptap/extension-drag-handle-react": "3.23.4",
     "@tiptap/extension-placeholder": "^3.23.4",
     "@tiptap/extension-task-item": "^3.23.4",
     "@tiptap/extension-task-list": "^3.23.4",

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -1,9 +1,11 @@
 import { useQueryClient } from "@tanstack/react-query";
+import { DragHandle } from "@tiptap/extension-drag-handle-react";
 import Placeholder from "@tiptap/extension-placeholder";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
 import { EditorContent, type JSONContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
+import { GripVertical } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -63,7 +65,7 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
       editorProps: {
         attributes: {
           class:
-            "prose prose-sm dark:prose-invert max-w-none min-h-[40svh] focus:outline-none p-4",
+            "prose prose-sm dark:prose-invert max-w-none min-h-[40svh] focus:outline-none py-4 pr-4 pl-10",
           "aria-label": "노트 본문",
         },
       },
@@ -155,7 +157,18 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
           onInsertPage={handleInsertPage}
           insertPagePending={createNote.isPending}
         />
-        <EditorContent editor={editor} />
+        {editor && (
+          <DragHandle editor={editor} className="z-10">
+            <button
+              type="button"
+              aria-label="블록 이동"
+              className="text-muted-foreground hover:bg-muted flex size-6 cursor-grab items-center justify-center rounded transition-colors active:cursor-grabbing"
+            >
+              <GripVertical className="size-4" />
+            </button>
+          </DragHandle>
+        )}
+        <EditorContent editor={editor} className="relative" />
       </div>
 
       <ConfirmDialog


### PR DESCRIPTION
## 이슈
closes #421

## 작업 내용
- 노션처럼 노트 본문 블록을 드래그 핸들로 잡아 순서를 바꿀 수 있게 함
- Tiptap 공식 드래그 핸들 확장 도입: `@tiptap/extension-drag-handle-react` / `@tiptap/extension-drag-handle`
  - peer 정합성을 위해 현재 Tiptap 버전(`3.23.4`)에 정확히 핀
- `NoteEditor`에 `<DragHandle>` 추가 — 블록 hover 시 좌측 거터에 핸들(⠿) 노출
- 핸들 공간 확보를 위해 본문 좌측 패딩 `pl-10`, `EditorContent`에 `relative`(핸들 positioning context)
- 재배치는 기존 자동저장 파이프라인으로 영속화됨 (추가 작업 불필요)

## 검증
- `npm test` 108개 통과 / `lint` · `format` · `build` clean (DragHandle 렌더가 기존 에디터 테스트 17개에서 정상)
- Playwright 로컬 확인:
  - 블록 hover 시 좌측 거터에 드래그 핸들 노출 (클리핑 없음)
  - `첫·두·세` → 세번째 줄을 맨 위로 드래그 → `세·첫·두`로 재정렬
  - 자동저장 후 **새로고침해도 순서 유지**