### PR TITLE
fix : FE 배포 후 MIME 에러로 접속 불가 (nginx 캐시 헤더)

### DIFF
--- a/fe/nginx.conf
+++ b/fe/nginx.conf
@@ -3,7 +3,22 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # 해시 파일명 asset(JS/CSS/이미지 등): 내용이 바뀌면 파일명도 바뀌므로 불변·장기 캐시.
+    # 없는 파일은 index.html로 폴백하지 않고 404 → 옛 해시 요청 시 text/html(MIME 에러) 방지.
+    location /assets/ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
+    # SPA 라우팅: 그 외 경로는 index.html로
     location / {
         try_files $uri $uri/ /index.html;
+    }
+
+    # index.html은 절대 캐시하지 않는다.
+    # (배포마다 새 asset 해시를 가리켜야 하는데, 캐시되면 옛 해시를 요청해 깨진다)
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        expires off;
     }
 }


### PR DESCRIPTION
## 이슈
closes #423

## 증상
새 배포 후 `Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html"` 로 화면이 안 뜸.

## 원인
`fe/nginx.conf`이 `try_files $uri $uri/ /index.html` 하나뿐이라:
1. **index.html에 cache-control이 없음** → 브라우저가 휴리스틱 캐싱 → 배포 후 이전 index.html이 사라진 옛 asset 해시를 요청
2. **없는 `/assets/*.js`가 404가 아니라 index.html(text/html, 200)로 폴백** → JS 자리에서 HTML 수신 → MIME 에러

운영 확인: `GET /assets/index-DOESNOTEXIST.js → 200 text/html`, index.html 응답에 `cache-control` 없음.

## 수정
```nginx
location /assets/ {
    try_files $uri =404;                                    # 없는 해시 → 404 (HTML 폴백 차단)
    add_header Cache-Control "public, max-age=31536000, immutable" always;
}
location / { try_files $uri $uri/ /index.html; }            # SPA 라우팅
location = /index.html {
    add_header Cache-Control "no-cache, no-store, must-revalidate" always;  # 절대 캐시 금지
    expires off;
}
```

## 검증 (nginx:alpine 컨테이너 + 더미 dist)
- `nginx -t` 통과
- `/index.html`, SPA 라우트, `/` → `no-cache, no-store, must-revalidate`
- 실제 asset → `public, max-age=31536000, immutable`, `application/javascript`
- 없는 asset → **404** (text/html 폴백 아님)

## 배포 후
이미 깨진 사용자는 하드 리프레시(Cmd/Ctrl+Shift+R) 1회로 새 index.html을 받으면 복구되고, 이후 배포부터는 재발하지 않음.