### PR TITLE
chore : CI/CD 속도 최적화 (concurrency + Docker gha 캐시 + BE 레이어 분리)

### DIFF
--- a/.github/workflows/be-cd.yml
+++ b/.github/workflows/be-cd.yml
@@ -10,6 +10,11 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/be
 
+# 배포는 취소하지 않고 직렬화한다 (이전 배포가 끝난 뒤 다음 배포 실행)
+concurrency:
+  group: be-cd
+  cancel-in-progress: false
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -20,6 +25,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -45,6 +53,8 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=be
+          cache-to: type=gha,mode=max,scope=be
 
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@v0.35.0
@@ -62,6 +72,7 @@ jobs:
         with:
           sarif_file: trivy-results.sarif
 
+      # 위 Build image와 동일 레이어 → gha 캐시 전체 히트로 즉시 push
       - name: Push image
         uses: docker/build-push-action@v6
         with:
@@ -69,3 +80,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=be

--- a/.github/workflows/be-ci.yml
+++ b/.github/workflows/be-ci.yml
@@ -10,6 +10,11 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/be
 
+# 같은 PR에 새 커밋이 푸시되면 진행 중인 이전 실행을 취소한다 (러너 시간 절약)
+concurrency:
+  group: be-ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -30,8 +35,13 @@ jobs:
         working-directory: be
         run: ./gradlew build
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       # CD와 동일한 이미지 취약점 게이트를 PR 단계에서도 검사한다.
       # CD에만 두면 머지 후에야 push가 막혀 배포가 조용히 실패한다.
+      # gha 캐시로 Docker 빌더 stage의 Gradle 의존성/컴파일 레이어를 재사용한다.
+      # scope=be로 BE CI/CD가 캐시를 공유한다.
       - name: Build image for scan
         uses: docker/build-push-action@v6
         with:
@@ -39,6 +49,8 @@ jobs:
           push: false
           load: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-scan
+          cache-from: type=gha,scope=be
+          cache-to: type=gha,mode=max,scope=be
 
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@v0.35.0

--- a/.github/workflows/fe-cd.yml
+++ b/.github/workflows/fe-cd.yml
@@ -10,6 +10,11 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/fe
 
+# 배포는 취소하지 않고 직렬화한다
+concurrency:
+  group: fe-cd
+  cancel-in-progress: false
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -20,6 +25,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -45,6 +53,8 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=fe
+          cache-to: type=gha,mode=max,scope=fe
 
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@v0.35.0
@@ -61,6 +71,7 @@ jobs:
         with:
           sarif_file: trivy-results.sarif
 
+      # 위 Build image와 동일 레이어 → gha 캐시 전체 히트로 즉시 push
       - name: Push image
         uses: docker/build-push-action@v6
         with:
@@ -68,3 +79,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=fe

--- a/.github/workflows/fe-ci.yml
+++ b/.github/workflows/fe-ci.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'fe/**'
 
+# 같은 PR에 새 커밋이 푸시되면 진행 중인 이전 실행을 취소한다
+concurrency:
+  group: fe-ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'infra/**'
 
+# 같은 PR에 새 커밋이 푸시되면 진행 중인 이전 실행을 취소한다
+concurrency:
+  group: infra-ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   yaml-lint:
     runs-on: ubuntu-latest

--- a/be/Dockerfile
+++ b/be/Dockerfile
@@ -1,5 +1,21 @@
+# syntax=docker/dockerfile:1
 FROM eclipse-temurin:25-jdk AS builder
 WORKDIR /app
+
+# 1) 빌드 스크립트/래퍼만 먼저 복사 → 의존성 해석 레이어를 캐시한다.
+#    소스 코드만 바뀌면 이 레이어(의존성 다운로드)는 gha 캐시에서 재사용되어
+#    매 빌드마다 전체 의존성을 다시 받지 않는다.
+COPY gradlew settings.gradle build.gradle ./
+COPY gradle ./gradle
+COPY gradle.properties ./
+COPY orino-common/build.gradle ./orino-common/
+COPY orino-domain-rdb/build.gradle ./orino-domain-rdb/
+COPY orino-domain-redis/build.gradle ./orino-domain-redis/
+COPY orino-core-web/build.gradle ./orino-core-web/
+COPY orino-app-api/build.gradle ./orino-app-api/
+RUN ./gradlew :orino-app-api:dependencies --no-daemon --quiet || true
+
+# 2) 소스 복사 후 빌드 (소스만 변경 시 위 의존성 레이어는 캐시 히트)
 COPY . .
 RUN ./gradlew :orino-app-api:build -x test --no-daemon
 

--- a/be/Dockerfile
+++ b/be/Dockerfile
@@ -7,7 +7,6 @@ WORKDIR /app
 #    매 빌드마다 전체 의존성을 다시 받지 않는다.
 COPY gradlew settings.gradle build.gradle ./
 COPY gradle ./gradle
-COPY gradle.properties ./
 COPY orino-common/build.gradle ./orino-common/
 COPY orino-domain-rdb/build.gradle ./orino-domain-rdb/
 COPY orino-domain-redis/build.gradle ./orino-domain-redis/


### PR DESCRIPTION
closes #425

## Description

be/fe/infra 5개 워크플로우의 빌드 속도를 최적화한다.

## 변경 사항

### 1. concurrency 취소/직렬화 (5개 전부)
- **CI** (be-ci, fe-ci, infra-ci): `cancel-in-progress: true` — 같은 PR에 새 커밋 푸시 시 진행 중 실행 즉시 취소
- **CD** (be-cd, fe-cd): `cancel-in-progress: false` — 배포는 취소하지 않고 직렬화

### 2. Docker gha 레이어 캐시 + buildx
- `be-ci`(scan), `be-cd`(build+push), `fe-cd`(build+push)에 `cache-from/to: type=gha`
- `docker/setup-buildx-action` 추가 (gha 캐시 export 지원 빌더)
- `scope=be`/`scope=fe`로 CI↔CD 캐시 공유
- CD의 `Build image`→`Push image` 2회 빌드가 캐시 전체 히트로 사실상 1회化

### 3. BE Dockerfile 레이어 분리
- 빌드 스크립트(gradlew/settings.gradle/build.gradle/모듈별 build.gradle/gradle.properties)만 먼저 COPY → `:orino-app-api:dependencies`로 의존성 레이어 생성
- 이후 소스 COPY → 빌드
- **소스만 바뀌면 의존성 레이어는 gha 캐시 재사용** → 매 빌드 의존성 재다운로드 제거
- `# syntax=docker/dockerfile:1` 추가

## 기대 효과

| 항목 | Before | After |
|---|---|---|
| 연속 푸시 | 이전 실행 계속 진행 | 즉시 취소 (CI) |
| BE/FE Docker 빌드 | 매번 전체 재빌드 | gha 캐시 히트 |
| BE 의존성 | 소스 변경마다 재다운로드 | 레이어 캐시 재사용 |
| BE CD build→push | 2회 전체 빌드 | 2번째는 캐시 히트 |

## 검증

- 5개 워크플로우 YAML 문법 검증 통과
- BE Dockerfile: 모듈 5개 build.gradle + gradle.properties 존재 확인, `./gradlew`(100755 실행가능) 유지 → 산출물(JAR) 동일
- 머지 후 실제 실행 시간/캐시 히트 확인 필요 (사용자)

## 회귀 영향

- 워크플로우 스텝 추가만, 검증 로직/결과물 변화 없음
- BE Dockerfile 최종 JAR 동일, COPY 순서만 변경

## 후속 (별도)

- infra-ci helm 의존성 캐시(actions/cache)로 helm repo/dependency 재다운로드 제거 (#425 Todo)