### PR TITLE
feat : 복습 스케줄링 datetime 하이브리드 (AGAIN 10분 재복습 + 다중일 새벽4시 롤오버)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/service/FlashcardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/service/FlashcardService.java
@@ -107,7 +107,7 @@ public class FlashcardService {
     private Map<Long, ReviewSchedule> loadNextReviewByCard(List<Flashcard> cards) {
         List<Long> ids = cards.stream().map(Flashcard::getId).toList();
         List<ReviewSchedule> reviews = reviewScheduleRepository
-                .findAllByFlashcardIdInAndStatusOrderByScheduledDateAscIdAsc(ids, ReviewStatus.PENDING);
+                .findAllByFlashcardIdInAndStatusOrderByScheduledAtAscIdAsc(ids, ReviewStatus.PENDING);
         Map<Long, ReviewSchedule> firstByCard = new HashMap<>();
         for (ReviewSchedule r : reviews) {
             firstByCard.putIfAbsent(r.getFlashcardId(), r);

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyMaterialService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyMaterialService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -85,7 +85,7 @@ public class StudyMaterialService {
         Map<Long, Long> flashcardCounts = toCountMap(
                 studyMaterialRepository.countFlashcardsByMaterialIds(ids));
         Map<Long, Long> dueReviewCounts = toCountMap(
-                studyMaterialRepository.countDueReviewsByMaterialIds(ids, LocalDate.now(clock)));
+                studyMaterialRepository.countDueReviewsByMaterialIds(ids, LocalDateTime.now(clock)));
         return materials.stream()
                 .map(m -> MaterialResponse.of(m,
                         flashcardCounts.getOrDefault(m.getId(), 0L),

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CalendarReviewItem.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CalendarReviewItem.java
@@ -3,11 +3,11 @@ package ds.project.orino.planner.review.dto;
 import ds.project.orino.domain.planner.review.entity.Rating;
 import ds.project.orino.domain.planner.review.entity.ReviewStatus;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record CalendarReviewItem(
         Long id,
-        LocalDate scheduledDate,
+        LocalDateTime scheduledAt,
         ReviewStatus status,
         Rating rating,
         int sequence,

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewScheduleView.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewScheduleView.java
@@ -5,14 +5,14 @@ import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
 import ds.project.orino.domain.planner.review.entity.ReviewStatus;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ReviewScheduleView(
         Long id,
         Long flashcardId,
         Integer sequence,
-        LocalDate scheduledDate,
+        LocalDateTime scheduledAt,
         Integer intervalDays,
         BigDecimal easeFactor,
         ReviewStatus status
@@ -20,14 +20,14 @@ public record ReviewScheduleView(
     public static ReviewScheduleView nextReview(ReviewSchedule r) {
         return new ReviewScheduleView(
                 r.getId(), null, r.getSequence(),
-                r.getScheduledDate(), r.getIntervalDays(), r.getEaseFactor(),
+                r.getScheduledAt(), r.getIntervalDays(), r.getEaseFactor(),
                 null);
     }
 
     public static ReviewScheduleView firstReview(ReviewSchedule r) {
         return new ReviewScheduleView(
                 r.getId(), r.getFlashcardId(), r.getSequence(),
-                r.getScheduledDate(), r.getIntervalDays(), r.getEaseFactor(),
+                r.getScheduledAt(), r.getIntervalDays(), r.getEaseFactor(),
                 r.getStatus());
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewItem.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewItem.java
@@ -1,11 +1,11 @@
 package ds.project.orino.planner.review.dto;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record TodayReviewItem(
         Long id,
-        LocalDate scheduledDate,
+        LocalDateTime scheduledAt,
         int delayDays,
         int sequence,
         int intervalDays,

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCompletionService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCompletionService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Service
@@ -37,19 +36,19 @@ public class ReviewCompletionService {
             throw new CustomException(ErrorCode.INVALID_STATE);
         }
 
-        LocalDate today = LocalDate.now(clock);
         LocalDateTime now = LocalDateTime.now(clock);
 
         int newSequence = current.getSequence() + 1;
         Sm2Calculator.Result computed = Sm2Calculator.next(
                 newSequence, current.getIntervalDays(), current.getEaseFactor(), request.rating());
 
-        current.complete(request.rating(), today, now);
+        current.complete(request.rating(), now);
 
+        LocalDateTime scheduledAt = ReviewSchedule.computeScheduledAt(
+                request.rating(), computed.intervalDays(), now);
         ReviewSchedule next = reviewScheduleRepository.save(new ReviewSchedule(
                 memberId, current.getFlashcardId(), newSequence,
-                today.plusDays(computed.intervalDays()), computed.intervalDays(),
-                computed.easeFactor()));
+                scheduledAt, computed.intervalDays(), computed.easeFactor()));
 
         return new ReviewCompletionResponse(
                 CompletedReviewView.of(current),

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
@@ -25,6 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
@@ -52,10 +54,11 @@ public class ReviewQueryService {
 
     public TodayReviewsResponse findToday(Long memberId) {
         LocalDate today = LocalDate.now(clock);
+        LocalDateTime now = LocalDateTime.now(clock);
 
         List<ReviewSchedule> reviews = reviewScheduleRepository
-                .findAllByMemberIdAndStatusAndScheduledDateLessThanEqualOrderByScheduledDateAscIdAsc(
-                        memberId, ReviewStatus.PENDING, today);
+                .findAllByMemberIdAndStatusAndScheduledAtLessThanEqualOrderByScheduledAtAscIdAsc(
+                        memberId, ReviewStatus.PENDING, now);
 
         if (reviews.isEmpty()) {
             return new TodayReviewsResponse(today, List.of());
@@ -86,7 +89,8 @@ public class ReviewQueryService {
         }
 
         List<ReviewSchedule> reviews = reviewScheduleRepository
-                .findAllByMemberIdAndScheduledDateBetweenOrderByScheduledDateAscIdAsc(memberId, from, to);
+                .findAllByMemberIdAndScheduledAtBetweenOrderByScheduledAtAscIdAsc(
+                        memberId, from.atStartOfDay(), to.atTime(LocalTime.MAX));
 
         if (reviews.isEmpty()) {
             return new CalendarReviewsResponse(from, to, List.of());
@@ -102,7 +106,7 @@ public class ReviewQueryService {
                     CalendarReviewFlashcard flashcardDto = CalendarReviewFlashcard.of(
                             card, CalendarReviewMaterial.of(material));
                     return new CalendarReviewItem(
-                            r.getId(), r.getScheduledDate(), r.getStatus(),
+                            r.getId(), r.getScheduledAt(), r.getStatus(),
                             r.getRating(), r.getSequence(), flashcardDto);
                 })
                 .toList();
@@ -131,9 +135,9 @@ public class ReviewQueryService {
         StudyMaterial material = materialById.get(card.getMaterialId());
         TodayReviewFlashcard flashcardDto = TodayReviewFlashcard.of(card, TodayReviewMaterial.of(material));
         PreviewView preview = preview(r);
-        int delayDays = (int) ChronoUnit.DAYS.between(r.getScheduledDate(), today);
+        int delayDays = (int) ChronoUnit.DAYS.between(r.getScheduledAt().toLocalDate(), today);
         return new TodayReviewItem(
-                r.getId(), r.getScheduledDate(), delayDays,
+                r.getId(), r.getScheduledAt(), delayDays,
                 r.getSequence(), r.getIntervalDays(), r.getEaseFactor(),
                 flashcardDto, preview);
     }

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/022-review-schedule-datetime.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/022-review-schedule-datetime.yaml
@@ -1,0 +1,52 @@
+databaseChangeLog:
+  - changeSet:
+      id: 022-review-schedule-scheduled-at
+      author: wcorn
+      comment: >-
+        복습 due를 하루 단위(scheduled_date DATE)에서 datetime(scheduled_at)로 전환한다.
+        기존 데이터는 해당 날짜 04:00(롤오버)으로 백필한다.
+      preConditions:
+        - onFail: MARK_RAN
+        - and:
+            - columnExists:
+                tableName: review_schedule
+                columnName: scheduled_date
+            - not:
+                - columnExists:
+                    tableName: review_schedule
+                    columnName: scheduled_at
+      changes:
+        - addColumn:
+            tableName: review_schedule
+            columns:
+              - column:
+                  name: scheduled_at
+                  type: DATETIME(6)
+        - update:
+            tableName: review_schedule
+            columns:
+              - column:
+                  name: scheduled_at
+                  valueComputed: "TIMESTAMP(scheduled_date, '04:00:00')"
+        - addNotNullConstraint:
+            tableName: review_schedule
+            columnName: scheduled_at
+            columnDataType: DATETIME(6)
+        # 새 인덱스를 먼저 생성한다. member_id가 leftmost라 member FK를 지탱하므로,
+        # 그 다음 옛 인덱스를 안전하게 드롭할 수 있다(FK용 인덱스 부재 에러 방지).
+        - createIndex:
+            tableName: review_schedule
+            indexName: idx_review_schedule_member_at_status
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: scheduled_at
+              - column:
+                  name: status
+        - dropIndex:
+            tableName: review_schedule
+            indexName: idx_review_schedule_member_date_status
+        - dropColumn:
+            tableName: review_schedule
+            columnName: scheduled_date

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -41,3 +41,5 @@ databaseChangeLog:
       file: db/changelog/changes/020-create-v2-planner-tables.yaml
   - include:
       file: db/changelog/changes/021-alter-note-tree.yaml
+  - include:
+      file: db/changelog/changes/022-review-schedule-datetime.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/flashcard/controller/FlashcardControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/flashcard/controller/FlashcardControllerTest.java
@@ -26,6 +26,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -90,7 +91,8 @@ class FlashcardControllerTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.firstReview.intervalDays").value(1))
                 .andExpect(jsonPath("$.data.firstReview.easeFactor").value(2.50))
                 .andExpect(jsonPath("$.data.firstReview.status").value("PENDING"))
-                .andExpect(jsonPath("$.data.firstReview.scheduledDate").value(today.plusDays(1).toString()));
+                .andExpect(jsonPath("$.data.firstReview.scheduledAt",
+                        startsWith(today.plusDays(1) + "T04:00")));
     }
 
     @Test
@@ -138,10 +140,10 @@ class FlashcardControllerTest extends ApiTestSupport {
         Flashcard card2 = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q2", "A2"));
         LocalDate today = LocalDate.now(clock);
         reviewScheduleRepository.save(
-                new ReviewSchedule(member.getId(), card1.getId(), 1, today.plusDays(1), 1,
+                new ReviewSchedule(member.getId(), card1.getId(), 1, today.plusDays(1).atTime(4, 0), 1,
                         new BigDecimal("2.50")));
         reviewScheduleRepository.save(
-                new ReviewSchedule(member.getId(), card2.getId(), 1, today.plusDays(3), 1,
+                new ReviewSchedule(member.getId(), card2.getId(), 1, today.plusDays(3).atTime(4, 0), 1,
                         new BigDecimal("2.50")));
 
         mockMvc.perform(get("/api/planner/materials/{id}/flashcards", material.getId())
@@ -150,11 +152,11 @@ class FlashcardControllerTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.flashcards", hasSize(2)))
                 .andExpect(jsonPath("$.data.flashcards[0].id").value(card1.getId()))
                 .andExpect(jsonPath("$.data.flashcards[0].nextReview.sequence").value(1))
-                .andExpect(jsonPath("$.data.flashcards[0].nextReview.scheduledDate")
-                        .value(today.plusDays(1).toString()))
+                .andExpect(jsonPath("$.data.flashcards[0].nextReview.scheduledAt",
+                        startsWith(today.plusDays(1) + "T04:00")))
                 .andExpect(jsonPath("$.data.flashcards[1].id").value(card2.getId()))
-                .andExpect(jsonPath("$.data.flashcards[1].nextReview.scheduledDate")
-                        .value(today.plusDays(3).toString()));
+                .andExpect(jsonPath("$.data.flashcards[1].nextReview.scheduledAt",
+                        startsWith(today.plusDays(3) + "T04:00")));
     }
 
     @Test
@@ -164,23 +166,23 @@ class FlashcardControllerTest extends ApiTestSupport {
         LocalDate today = LocalDate.now(clock);
         jdbcTemplate.update("""
                 INSERT INTO review_schedule
-                  (member_id, flashcard_id, sequence, scheduled_date, interval_days,
+                  (member_id, flashcard_id, sequence, scheduled_at, interval_days,
                    ease_factor, status, completed_at, created_at, updated_at)
                 VALUES (?, ?, 1, ?, 1, 2.50, 'COMPLETED', NOW(6), NOW(6), NOW(6))
-                """, member.getId(), card.getId(), today.minusDays(5));
+                """, member.getId(), card.getId(), today.minusDays(5).atStartOfDay());
         reviewScheduleRepository.save(
-                new ReviewSchedule(member.getId(), card.getId(), 3, today.plusDays(10), 10,
+                new ReviewSchedule(member.getId(), card.getId(), 3, today.plusDays(10).atTime(4, 0), 10,
                         new BigDecimal("2.50")));
         reviewScheduleRepository.save(
-                new ReviewSchedule(member.getId(), card.getId(), 2, today.plusDays(2), 2,
+                new ReviewSchedule(member.getId(), card.getId(), 2, today.plusDays(2).atTime(4, 0), 2,
                         new BigDecimal("2.50")));
 
         mockMvc.perform(get("/api/planner/materials/{id}/flashcards", material.getId())
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.flashcards[0].nextReview.sequence").value(2))
-                .andExpect(jsonPath("$.data.flashcards[0].nextReview.scheduledDate")
-                        .value(today.plusDays(2).toString()));
+                .andExpect(jsonPath("$.data.flashcards[0].nextReview.scheduledAt",
+                        startsWith(today.plusDays(2) + "T04:00")));
     }
 
     @Test
@@ -211,7 +213,7 @@ class FlashcardControllerTest extends ApiTestSupport {
         Flashcard card = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
         LocalDate today = LocalDate.now(clock);
         ReviewSchedule review = reviewScheduleRepository.save(
-                new ReviewSchedule(member.getId(), card.getId(), 1, today.plusDays(1), 1,
+                new ReviewSchedule(member.getId(), card.getId(), 1, today.plusDays(1).atTime(4, 0), 1,
                         new BigDecimal("2.50")));
 
         mockMvc.perform(patch("/api/planner/flashcards/{id}", card.getId())
@@ -225,7 +227,7 @@ class FlashcardControllerTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.back").value("A"));
 
         ReviewSchedule unchanged = reviewScheduleRepository.findById(review.getId()).orElseThrow();
-        org.assertj.core.api.Assertions.assertThat(unchanged.getScheduledDate()).isEqualTo(today.plusDays(1));
+        org.assertj.core.api.Assertions.assertThat(unchanged.getScheduledAt()).isEqualTo(today.plusDays(1).atTime(4, 0));
         org.assertj.core.api.Assertions.assertThat(unchanged.getSequence()).isEqualTo(1);
     }
 
@@ -264,10 +266,10 @@ class FlashcardControllerTest extends ApiTestSupport {
         Flashcard card = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
         LocalDate today = LocalDate.now(clock);
         reviewScheduleRepository.save(
-                new ReviewSchedule(member.getId(), card.getId(), 1, today.plusDays(1), 1,
+                new ReviewSchedule(member.getId(), card.getId(), 1, today.plusDays(1).atTime(4, 0), 1,
                         new BigDecimal("2.50")));
         reviewScheduleRepository.save(
-                new ReviewSchedule(member.getId(), card.getId(), 2, today.plusDays(7), 7,
+                new ReviewSchedule(member.getId(), card.getId(), 2, today.plusDays(7).atTime(4, 0), 7,
                         new BigDecimal("2.50")));
 
         mockMvc.perform(delete("/api/planner/flashcards/{id}", card.getId())

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/flashcard/controller/FlashcardControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/flashcard/controller/FlashcardControllerTest.java
@@ -227,7 +227,8 @@ class FlashcardControllerTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.back").value("A"));
 
         ReviewSchedule unchanged = reviewScheduleRepository.findById(review.getId()).orElseThrow();
-        org.assertj.core.api.Assertions.assertThat(unchanged.getScheduledAt()).isEqualTo(today.plusDays(1).atTime(4, 0));
+        org.assertj.core.api.Assertions.assertThat(unchanged.getScheduledAt())
+                .isEqualTo(today.plusDays(1).atTime(4, 0));
         org.assertj.core.api.Assertions.assertThat(unchanged.getSequence()).isEqualTo(1);
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyMaterialControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/material/controller/StudyMaterialControllerTest.java
@@ -270,10 +270,10 @@ class StudyMaterialControllerTest extends ApiTestSupport {
     private void insertReview(Long flashcardId, LocalDate scheduledDate, String status) {
         jdbcTemplate.update("""
                 INSERT INTO review_schedule
-                  (member_id, flashcard_id, sequence, scheduled_date, interval_days,
+                  (member_id, flashcard_id, sequence, scheduled_at, interval_days,
                    ease_factor, status, created_at, updated_at)
                 VALUES (?, ?, 1, ?, 1, 2.50, ?, NOW(6), NOW(6))
-                """, member.getId(), flashcardId, scheduledDate, status);
+                """, member.getId(), flashcardId, scheduledDate.atStartOfDay(), status);
     }
 
     private static void assertCountZero(Integer count, String tableName) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewCalendarControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewCalendarControllerTest.java
@@ -25,6 +25,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -67,13 +68,13 @@ class ReviewCalendarControllerTest extends ApiTestSupport {
 
     private ReviewSchedule pending(LocalDate date, int sequence) {
         return reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), sequence, date, 6, new BigDecimal("2.50")));
+                member.getId(), card.getId(), sequence, date.atTime(4, 0), 6, new BigDecimal("2.50")));
     }
 
     private ReviewSchedule completed(LocalDate date, int sequence, Rating rating) {
         ReviewSchedule r = new ReviewSchedule(
-                member.getId(), card.getId(), sequence, date, 6, new BigDecimal("2.50"));
-        r.complete(rating, date, java.time.LocalDateTime.of(date, java.time.LocalTime.NOON));
+                member.getId(), card.getId(), sequence, date.atTime(4, 0), 6, new BigDecimal("2.50"));
+        r.complete(rating, java.time.LocalDateTime.of(date, java.time.LocalTime.NOON));
         return reviewScheduleRepository.save(r);
     }
 
@@ -102,10 +103,10 @@ class ReviewCalendarControllerTest extends ApiTestSupport {
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.reviews", hasSize(2)))
-                .andExpect(jsonPath("$.data.reviews[0].scheduledDate").value("2026-05-10"))
+                .andExpect(jsonPath("$.data.reviews[0].scheduledAt", startsWith("2026-05-10T")))
                 .andExpect(jsonPath("$.data.reviews[0].status").value("COMPLETED"))
                 .andExpect(jsonPath("$.data.reviews[0].rating").value("GOOD"))
-                .andExpect(jsonPath("$.data.reviews[1].scheduledDate").value("2026-05-20"))
+                .andExpect(jsonPath("$.data.reviews[1].scheduledAt", startsWith("2026-05-20T")))
                 .andExpect(jsonPath("$.data.reviews[1].status").value("PENDING"))
                 .andExpect(jsonPath("$.data.reviews[1].rating").doesNotExist());
     }
@@ -124,8 +125,8 @@ class ReviewCalendarControllerTest extends ApiTestSupport {
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.reviews", hasSize(2)))
-                .andExpect(jsonPath("$.data.reviews[0].scheduledDate").value("2026-05-01"))
-                .andExpect(jsonPath("$.data.reviews[1].scheduledDate").value("2026-05-31"));
+                .andExpect(jsonPath("$.data.reviews[0].scheduledAt", startsWith("2026-05-01T")))
+                .andExpect(jsonPath("$.data.reviews[1].scheduledAt", startsWith("2026-05-31T")));
     }
 
     @Test
@@ -153,7 +154,7 @@ class ReviewCalendarControllerTest extends ApiTestSupport {
         Flashcard otherCard = flashcardRepository.save(
                 new Flashcard(otherMember.getId(), otherMaterial.getId(), "Q2", "A2"));
         reviewScheduleRepository.save(new ReviewSchedule(
-                otherMember.getId(), otherCard.getId(), 1, LocalDate.parse("2026-05-15"), 6,
+                otherMember.getId(), otherCard.getId(), 1, LocalDate.parse("2026-05-15").atTime(4, 0), 6,
                 new BigDecimal("2.50")));
         pending(LocalDate.parse("2026-05-16"), 1);
 
@@ -163,7 +164,7 @@ class ReviewCalendarControllerTest extends ApiTestSupport {
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.reviews", hasSize(1)))
-                .andExpect(jsonPath("$.data.reviews[0].scheduledDate").value("2026-05-16"));
+                .andExpect(jsonPath("$.data.reviews[0].scheduledAt", startsWith("2026-05-16T")));
     }
 
     @Test

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
@@ -27,6 +27,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -72,7 +73,7 @@ class ReviewControllerTest extends ApiTestSupport {
     void complete_good_creates_next_review() throws Exception {
         LocalDate today = LocalDate.now(clock);
         ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 1, today.minusDays(1), 1,
+                member.getId(), card.getId(), 1, today.minusDays(1).atTime(4, 0), 1,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
@@ -89,7 +90,8 @@ class ReviewControllerTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.completed.completedAt").exists())
                 .andExpect(jsonPath("$.data.nextReview.flashcardId").value(card.getId()))
                 .andExpect(jsonPath("$.data.nextReview.sequence").value(2))
-                .andExpect(jsonPath("$.data.nextReview.scheduledDate").value(today.plusDays(6).toString()))
+                .andExpect(jsonPath("$.data.nextReview.scheduledAt",
+                        startsWith(today.plusDays(6) + "T04:00")))
                 .andExpect(jsonPath("$.data.nextReview.intervalDays").value(6))
                 .andExpect(jsonPath("$.data.nextReview.easeFactor").value(2.50))
                 .andExpect(jsonPath("$.data.nextReview.status").value("PENDING"));
@@ -107,7 +109,7 @@ class ReviewControllerTest extends ApiTestSupport {
     void complete_again() throws Exception {
         LocalDate today = LocalDate.now(clock);
         ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 2, today, 6,
+                member.getId(), card.getId(), 2, today.atTime(4, 0), 6,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
@@ -118,7 +120,9 @@ class ReviewControllerTest extends ApiTestSupport {
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.nextReview.intervalDays").value(1))
-                .andExpect(jsonPath("$.data.nextReview.scheduledDate").value(today.plusDays(1).toString()))
+                // AGAIN은 당일 10분 뒤(분 단위) 재복습 → 오늘 날짜의 datetime
+                .andExpect(jsonPath("$.data.nextReview.scheduledAt",
+                        startsWith(today.toString() + "T")))
                 .andExpect(jsonPath("$.data.nextReview.easeFactor").value(2.30));
     }
 
@@ -127,7 +131,7 @@ class ReviewControllerTest extends ApiTestSupport {
     void complete_easy() throws Exception {
         LocalDate today = LocalDate.now(clock);
         ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 2, today, 6,
+                member.getId(), card.getId(), 2, today.atTime(4, 0), 6,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
@@ -145,7 +149,7 @@ class ReviewControllerTest extends ApiTestSupport {
     void complete_already_completed_returns_409() throws Exception {
         LocalDate today = LocalDate.now(clock);
         ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 1, today.minusDays(1), 1,
+                member.getId(), card.getId(), 1, today.minusDays(1).atTime(4, 0), 1,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
@@ -175,7 +179,7 @@ class ReviewControllerTest extends ApiTestSupport {
                 new Flashcard(otherMember.getId(), otherMaterial.getId(), "Q", "A"));
         LocalDate today = LocalDate.now(clock);
         ReviewSchedule otherReview = reviewScheduleRepository.save(new ReviewSchedule(
-                otherMember.getId(), otherCard.getId(), 1, today, 1,
+                otherMember.getId(), otherCard.getId(), 1, today.atTime(4, 0), 1,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", otherReview.getId())
@@ -192,7 +196,7 @@ class ReviewControllerTest extends ApiTestSupport {
     void complete_missing_rating_returns_400() throws Exception {
         LocalDate today = LocalDate.now(clock);
         ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 1, today, 1,
+                member.getId(), card.getId(), 1, today.atTime(4, 0), 1,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
@@ -207,7 +211,7 @@ class ReviewControllerTest extends ApiTestSupport {
     void complete_elapsed_days_can_be_negative_for_early_review() throws Exception {
         LocalDate today = LocalDate.now(clock);
         ReviewSchedule earlyReview = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 1, today.plusDays(2), 1,
+                member.getId(), card.getId(), 1, today.plusDays(2).atTime(4, 0), 1,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", earlyReview.getId())
@@ -225,7 +229,7 @@ class ReviewControllerTest extends ApiTestSupport {
     void complete_four_consecutive_good_evaluations() throws Exception {
         LocalDate today = LocalDate.now(clock);
         ReviewSchedule firstReview = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 1, today, 1,
+                member.getId(), card.getId(), 1, today.atTime(4, 0), 1,
                 new BigDecimal("2.50")));
 
         Long currentId = firstReview.getId();
@@ -244,8 +248,8 @@ class ReviewControllerTest extends ApiTestSupport {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.nextReview.sequence").value(expectedSequence))
                     .andExpect(jsonPath("$.data.nextReview.intervalDays").value(expectedInterval))
-                    .andExpect(jsonPath("$.data.nextReview.scheduledDate")
-                            .value(today.plusDays(expectedInterval).toString()))
+                    .andExpect(jsonPath("$.data.nextReview.scheduledAt",
+                            startsWith(today.plusDays(expectedInterval) + "T04:00")))
                     .andReturn().getResponse().getContentAsString();
             Number nextId = com.jayway.jsonpath.JsonPath.read(body, "$.data.nextReview.id");
             currentId = nextId.longValue();

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsControllerTest.java
@@ -82,13 +82,13 @@ class TodayReviewsControllerTest extends ApiTestSupport {
     void returns_pending_due_today_or_overdue_sorted() throws Exception {
         LocalDate today = LocalDate.now(clock);
         ReviewSchedule overdue = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 2, today.minusDays(2), 6,
+                member.getId(), card.getId(), 2, today.minusDays(2).atTime(4, 0), 6,
                 new BigDecimal("2.50")));
         ReviewSchedule dueToday = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 3, today, 15,
+                member.getId(), card.getId(), 3, today.atStartOfDay(), 15,
                 new BigDecimal("2.50")));
         reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 4, today.plusDays(3), 3,
+                member.getId(), card.getId(), 4, today.plusDays(3).atTime(4, 0), 3,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(get("/api/planner/reviews/today")
@@ -106,7 +106,7 @@ class TodayReviewsControllerTest extends ApiTestSupport {
     void embeds_flashcard_and_material() throws Exception {
         LocalDate today = LocalDate.now(clock);
         reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 1, today, 1,
+                member.getId(), card.getId(), 1, today.atStartOfDay(), 1,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(get("/api/planner/reviews/today")
@@ -125,7 +125,7 @@ class TodayReviewsControllerTest extends ApiTestSupport {
     void preview_matches_sm2() throws Exception {
         LocalDate today = LocalDate.now(clock);
         reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 2, today, 6,
+                member.getId(), card.getId(), 2, today.atStartOfDay(), 6,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(get("/api/planner/reviews/today")
@@ -146,10 +146,10 @@ class TodayReviewsControllerTest extends ApiTestSupport {
         Flashcard otherCard = flashcardRepository.save(
                 new Flashcard(otherMember.getId(), otherMaterial.getId(), "Q2", "A2"));
         reviewScheduleRepository.save(new ReviewSchedule(
-                otherMember.getId(), otherCard.getId(), 1, today, 1,
+                otherMember.getId(), otherCard.getId(), 1, today.atStartOfDay(), 1,
                 new BigDecimal("2.50")));
         reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 1, today, 1,
+                member.getId(), card.getId(), 1, today.atStartOfDay(), 1,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(get("/api/planner/reviews/today")
@@ -164,13 +164,13 @@ class TodayReviewsControllerTest extends ApiTestSupport {
     void excludes_completed_reviews() throws Exception {
         LocalDate today = LocalDate.now(clock);
         ReviewSchedule pending = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 2, today, 6,
+                member.getId(), card.getId(), 2, today.atStartOfDay(), 6,
                 new BigDecimal("2.50")));
         ReviewSchedule completed = new ReviewSchedule(
-                member.getId(), card.getId(), 1, today.minusDays(5), 1,
+                member.getId(), card.getId(), 1, today.minusDays(5).atTime(4, 0), 1,
                 new BigDecimal("2.50"));
         completed.complete(ds.project.orino.domain.planner.review.entity.Rating.GOOD,
-                today, java.time.LocalDateTime.now(clock));
+                java.time.LocalDateTime.now(clock));
         reviewScheduleRepository.save(completed);
 
         mockMvc.perform(get("/api/planner/reviews/today")

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/sm2/ReviewSchedulingTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/sm2/ReviewSchedulingTest.java
@@ -1,0 +1,47 @@
+package ds.project.orino.planner.review.sm2;
+
+import ds.project.orino.domain.planner.review.entity.Rating;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ReviewSchedule.computeScheduledAt - datetime 하이브리드 스케줄링")
+class ReviewSchedulingTest {
+
+    @Test
+    @DisplayName("AGAIN은 당일 10분 뒤(분 단위)로 잡힌다")
+    void again_reschedules_in_ten_minutes() {
+        LocalDateTime now = LocalDateTime.of(2026, 6, 1, 13, 0);
+
+        LocalDateTime result = ReviewSchedule.computeScheduledAt(Rating.AGAIN, 1, now);
+
+        assertThat(result).isEqualTo(now.plusMinutes(10));
+    }
+
+    @Test
+    @DisplayName("GOOD 등 다중일 복습은 (오늘+간격) 날짜의 04:00(롤오버)로 잡힌다")
+    void good_reschedules_at_rollover_hour() {
+        LocalDateTime now = LocalDateTime.of(2026, 6, 1, 13, 0);
+
+        LocalDateTime result = ReviewSchedule.computeScheduledAt(Rating.GOOD, 6, now);
+
+        assertThat(result).isEqualTo(LocalDateTime.of(2026, 6, 7, 4, 0));
+    }
+
+    @Test
+    @DisplayName("다중일 due 시각은 복습한 시각과 무관하게 항상 04:00이다")
+    void rollover_is_independent_of_time_of_day() {
+        LocalDateTime morning = LocalDateTime.of(2026, 6, 1, 1, 30);
+        LocalDateTime evening = LocalDateTime.of(2026, 6, 1, 23, 45);
+
+        LocalDateTime fromMorning = ReviewSchedule.computeScheduledAt(Rating.EASY, 4, morning);
+        LocalDateTime fromEvening = ReviewSchedule.computeScheduledAt(Rating.EASY, 4, evening);
+
+        assertThat(fromMorning).isEqualTo(LocalDateTime.of(2026, 6, 5, 4, 0));
+        assertThat(fromEvening).isEqualTo(LocalDateTime.of(2026, 6, 5, 4, 0));
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -40,10 +40,10 @@ public interface StudyMaterialRepository extends JpaRepository<StudyMaterial, Lo
             JOIN flashcard f ON f.id = r.flashcard_id
             WHERE f.material_id IN (:materialIds)
               AND r.status = 'PENDING'
-              AND r.scheduled_date <= :today
+              AND r.scheduled_at <= :now
             GROUP BY f.material_id
             """, nativeQuery = true)
     List<MaterialCountRow> countDueReviewsByMaterialIds(
             @Param("materialIds") Collection<Long> materialIds,
-            @Param("today") LocalDate today);
+            @Param("now") LocalDateTime now);
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewSchedule.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewSchedule.java
@@ -16,6 +16,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
@@ -23,6 +24,12 @@ import java.time.LocalDateTime;
 public class ReviewSchedule {
 
     public static final BigDecimal INITIAL_EASE_FACTOR = new BigDecimal("2.50");
+
+    /** 다중일 복습 due 시각(롤오버). 해당 날짜 04:00부터 due가 되어 그 날 하루 종일 복습 가능. */
+    public static final int ROLLOVER_HOUR = 4;
+
+    /** AGAIN(틀림) 시 당일 재복습까지의 분. */
+    public static final int RELEARN_MINUTES = 10;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,8 +44,8 @@ public class ReviewSchedule {
     @Column(nullable = false)
     private Integer sequence;
 
-    @Column(name = "scheduled_date", nullable = false)
-    private LocalDate scheduledDate;
+    @Column(name = "scheduled_at", nullable = false)
+    private LocalDateTime scheduledAt;
 
     @Column(name = "interval_days", nullable = false)
     private Integer intervalDays;
@@ -72,11 +79,11 @@ public class ReviewSchedule {
     }
 
     public ReviewSchedule(Long memberId, Long flashcardId, int sequence,
-                          LocalDate scheduledDate, int intervalDays, BigDecimal easeFactor) {
+                          LocalDateTime scheduledAt, int intervalDays, BigDecimal easeFactor) {
         this.memberId = memberId;
         this.flashcardId = flashcardId;
         this.sequence = sequence;
-        this.scheduledDate = scheduledDate;
+        this.scheduledAt = scheduledAt;
         this.intervalDays = intervalDays;
         this.easeFactor = easeFactor;
         this.status = ReviewStatus.PENDING;
@@ -84,13 +91,24 @@ public class ReviewSchedule {
 
     public static ReviewSchedule firstReview(Long memberId, Long flashcardId, LocalDate today) {
         return new ReviewSchedule(memberId, flashcardId, 1,
-                today.plusDays(1), 1, INITIAL_EASE_FACTOR);
+                today.plusDays(1).atTime(ROLLOVER_HOUR, 0), 1, INITIAL_EASE_FACTOR);
     }
 
-    public void complete(Rating rating, LocalDate today, LocalDateTime now) {
+    /**
+     * 다음 복습 due 시각을 계산한다.
+     * AGAIN(틀림)은 당일 {@value #RELEARN_MINUTES}분 뒤(분 단위), 그 외는 일 간격 뒤 날짜의 04:00(롤오버).
+     */
+    public static LocalDateTime computeScheduledAt(Rating rating, int intervalDays, LocalDateTime now) {
+        if (rating == Rating.AGAIN) {
+            return now.plusMinutes(RELEARN_MINUTES);
+        }
+        return now.toLocalDate().plusDays(intervalDays).atTime(ROLLOVER_HOUR, 0);
+    }
+
+    public void complete(Rating rating, LocalDateTime now) {
         this.status = ReviewStatus.COMPLETED;
         this.rating = rating;
-        this.elapsedDays = (int) java.time.temporal.ChronoUnit.DAYS.between(this.scheduledDate, today);
+        this.elapsedDays = (int) ChronoUnit.DAYS.between(this.scheduledAt.toLocalDate(), now.toLocalDate());
         this.completedAt = now;
     }
 
@@ -110,8 +128,8 @@ public class ReviewSchedule {
         return sequence;
     }
 
-    public LocalDate getScheduledDate() {
-        return scheduledDate;
+    public LocalDateTime getScheduledAt() {
+        return scheduledAt;
     }
 
     public Integer getIntervalDays() {

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
@@ -4,21 +4,21 @@ import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
 import ds.project.orino.domain.planner.review.entity.ReviewStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, Long> {
 
-    List<ReviewSchedule> findAllByFlashcardIdInAndStatusOrderByScheduledDateAscIdAsc(
+    List<ReviewSchedule> findAllByFlashcardIdInAndStatusOrderByScheduledAtAscIdAsc(
             Collection<Long> flashcardIds, ReviewStatus status);
 
     Optional<ReviewSchedule> findByIdAndMemberId(Long id, Long memberId);
 
-    List<ReviewSchedule> findAllByMemberIdAndStatusAndScheduledDateLessThanEqualOrderByScheduledDateAscIdAsc(
-            Long memberId, ReviewStatus status, LocalDate scheduledDate);
+    List<ReviewSchedule> findAllByMemberIdAndStatusAndScheduledAtLessThanEqualOrderByScheduledAtAscIdAsc(
+            Long memberId, ReviewStatus status, LocalDateTime scheduledAt);
 
-    List<ReviewSchedule> findAllByMemberIdAndScheduledDateBetweenOrderByScheduledDateAscIdAsc(
-            Long memberId, LocalDate from, LocalDate to);
+    List<ReviewSchedule> findAllByMemberIdAndScheduledAtBetweenOrderByScheduledAtAscIdAsc(
+            Long memberId, LocalDateTime from, LocalDateTime to);
 }

--- a/fe/src/app/layout/AppLayout.test.tsx
+++ b/fe/src/app/layout/AppLayout.test.tsx
@@ -44,7 +44,7 @@ function mockTodayReviews(count: number) {
           today: "2026-05-18",
           reviews: Array.from({ length: count }, (_, i) => ({
             id: i + 1,
-            scheduledDate: "2026-05-18",
+            scheduledAt: "2026-05-18T04:00:00",
             delayDays: 0,
             sequence: 1,
             intervalDays: 1,

--- a/fe/src/features/flashcard/api/flashcards.ts
+++ b/fe/src/features/flashcard/api/flashcards.ts
@@ -3,7 +3,7 @@ import { client } from "@/shared/api";
 export interface NextReview {
   id: number;
   sequence: number;
-  scheduledDate: string;
+  scheduledAt: string;
   intervalDays: number;
   easeFactor: number;
 }

--- a/fe/src/features/flashcard/components/FlashcardListTab.test.tsx
+++ b/fe/src/features/flashcard/components/FlashcardListTab.test.tsx
@@ -37,7 +37,7 @@ function mockListWith(
     id: number;
     front: string;
     back: string;
-    nextReview?: { sequence: number; scheduledDate: string } | null;
+    nextReview?: { sequence: number; scheduledAt: string } | null;
   }>,
 ) {
   server.use(
@@ -56,7 +56,8 @@ function mockListWith(
                 : {
                     id: 100,
                     sequence: f.nextReview?.sequence ?? 1,
-                    scheduledDate: f.nextReview?.scheduledDate ?? "2026-05-20",
+                    scheduledAt:
+                      f.nextReview?.scheduledAt ?? "2026-05-20T04:00:00",
                     intervalDays: 1,
                     easeFactor: 2.5,
                   },
@@ -91,7 +92,7 @@ describe("FlashcardListTab", () => {
         id: 1,
         front: "Q1",
         back: "A1",
-        nextReview: { sequence: 2, scheduledDate: "2026-05-24" },
+        nextReview: { sequence: 2, scheduledAt: "2026-05-24T04:00:00" },
       },
       { id: 2, front: "Q2", back: "A2", nextReview: null },
     ]);
@@ -130,7 +131,7 @@ describe("FlashcardListTab", () => {
                   id: 100,
                   flashcardId: 10,
                   sequence: 1,
-                  scheduledDate: "2026-05-19",
+                  scheduledAt: "2026-05-19T04:00:00",
                   intervalDays: 1,
                   easeFactor: 2.5,
                   status: "PENDING",
@@ -167,7 +168,7 @@ describe("FlashcardListTab", () => {
         id: 7,
         front: "Q",
         back: "A",
-        nextReview: { sequence: 1, scheduledDate: "2026-05-20" },
+        nextReview: { sequence: 1, scheduledAt: "2026-05-20T04:00:00" },
       },
     ]);
     let deleted = false;

--- a/fe/src/features/flashcard/hooks/useCreateFlashcard.test.tsx
+++ b/fe/src/features/flashcard/hooks/useCreateFlashcard.test.tsx
@@ -41,7 +41,7 @@ describe("useCreateFlashcard", () => {
                 id: 1,
                 flashcardId: 99,
                 sequence: 1,
-                scheduledDate: "2026-06-01",
+                scheduledAt: "2026-06-01T04:00:00",
                 intervalDays: 1,
                 easeFactor: 2.5,
                 status: "PENDING",

--- a/fe/src/features/flashcard/utils.test.ts
+++ b/fe/src/features/flashcard/utils.test.ts
@@ -11,7 +11,7 @@ describe("formatNextReview", () => {
         {
           id: 1,
           sequence: 1,
-          scheduledDate: "2026-05-18",
+          scheduledAt: "2026-05-18T04:00:00",
           intervalDays: 1,
           easeFactor: 2.5,
         },
@@ -26,7 +26,7 @@ describe("formatNextReview", () => {
         {
           id: 1,
           sequence: 2,
-          scheduledDate: "2026-05-24",
+          scheduledAt: "2026-05-24T04:00:00",
           intervalDays: 6,
           easeFactor: 2.5,
         },
@@ -41,7 +41,7 @@ describe("formatNextReview", () => {
         {
           id: 1,
           sequence: 3,
-          scheduledDate: "2026-05-15",
+          scheduledAt: "2026-05-15T04:00:00",
           intervalDays: 1,
           easeFactor: 2.5,
         },

--- a/fe/src/features/flashcard/utils.ts
+++ b/fe/src/features/flashcard/utils.ts
@@ -4,7 +4,7 @@ export function formatNextReview(
   next: NextReview,
   today: Date = new Date(),
 ): string {
-  const d = parseDate(next.scheduledDate);
+  const d = parseDate(next.scheduledAt.slice(0, 10));
   const todayMid = new Date(
     today.getFullYear(),
     today.getMonth(),

--- a/fe/src/features/review/api/calendar.ts
+++ b/fe/src/features/review/api/calendar.ts
@@ -12,7 +12,8 @@ export interface CalendarReviewFlashcard {
 
 export interface CalendarReview {
   id: number;
-  scheduledDate: string;
+  /** ISO datetime. 캘린더 그룹/분류는 날짜 부분(slice 0..10)으로 한다. */
+  scheduledAt: string;
   status: ReviewStatus;
   rating: Rating | null;
   sequence: number;

--- a/fe/src/features/review/api/reviews.ts
+++ b/fe/src/features/review/api/reviews.ts
@@ -24,7 +24,8 @@ export interface PreviewView {
 
 export interface TodayReview {
   id: number;
-  scheduledDate: string;
+  /** ISO datetime (예: "2026-06-07T04:00:00"). due = scheduledAt <= now */
+  scheduledAt: string;
   delayDays: number;
   sequence: number;
   intervalDays: number;
@@ -62,7 +63,7 @@ export interface NextReview {
   id: number;
   flashcardId: number;
   sequence: number;
-  scheduledDate: string;
+  scheduledAt: string;
   intervalDays: number;
   easeFactor: number;
   status: "PENDING";

--- a/fe/src/features/review/calendar.test.ts
+++ b/fe/src/features/review/calendar.test.ts
@@ -10,13 +10,10 @@ import {
   toIsoDate,
 } from "./calendar";
 
-function review(
-  scheduledDate: string,
-  status: "PENDING" | "COMPLETED",
-): CalendarReview {
+function review(date: string, status: "PENDING" | "COMPLETED"): CalendarReview {
   return {
     id: Math.floor(Math.random() * 1e6),
-    scheduledDate,
+    scheduledAt: `${date}T04:00:00`,
     status,
     rating: status === "COMPLETED" ? "GOOD" : null,
     sequence: 1,

--- a/fe/src/features/review/calendar.ts
+++ b/fe/src/features/review/calendar.ts
@@ -2,6 +2,11 @@ import type { CalendarReview } from "./api/calendar";
 
 export type ReviewBucket = "completed" | "overdue" | "today" | "upcoming";
 
+/** scheduledAt(datetime)에서 로컬 날짜 부분(YYYY-MM-DD)만 추출. 캘린더는 날짜 단위로 그룹/분류한다. */
+export function reviewDate(review: CalendarReview): string {
+  return review.scheduledAt.slice(0, 10);
+}
+
 /** YYYY-MM-DD 로컬 포맷 (UTC 변환 없이) */
 export function toIsoDate(date: Date): string {
   const y = date.getFullYear();
@@ -46,7 +51,7 @@ export function classifyReview(
   if (review.status === "COMPLETED") {
     return "completed";
   }
-  const scheduled = parseIsoDate(review.scheduledDate).getTime();
+  const scheduled = parseIsoDate(reviewDate(review)).getTime();
   const todayMid = startOfDay(today).getTime();
   if (scheduled < todayMid) {
     return "overdue";
@@ -70,11 +75,12 @@ export function groupByDate(
 ): Map<string, CalendarReview[]> {
   const map = new Map<string, CalendarReview[]>();
   for (const r of reviews) {
-    const list = map.get(r.scheduledDate);
+    const key = reviewDate(r);
+    const list = map.get(key);
     if (list) {
       list.push(r);
     } else {
-      map.set(r.scheduledDate, [r]);
+      map.set(key, [r]);
     }
   }
   return map;

--- a/fe/src/features/review/components/ReviewCard.tsx
+++ b/fe/src/features/review/components/ReviewCard.tsx
@@ -17,7 +17,7 @@ interface RatingButton {
   rating: Rating;
   label: string;
   key: string;
-  preview: (r: TodayReview) => number;
+  previewLabel: (r: TodayReview) => string;
   textClass: string;
 }
 
@@ -26,28 +26,29 @@ const RATING_BUTTONS: RatingButton[] = [
     rating: "AGAIN",
     label: "Again",
     key: "1",
-    preview: (r) => r.preview.again,
+    // AGAIN은 당일 10분 뒤 재복습 (일 단위 아님)
+    previewLabel: () => "10분",
     textClass: "text-red-500",
   },
   {
     rating: "HARD",
     label: "Hard",
     key: "2",
-    preview: (r) => r.preview.hard,
+    previewLabel: (r) => `${r.preview.hard}d`,
     textClass: "text-orange-500",
   },
   {
     rating: "GOOD",
     label: "Good",
     key: "3",
-    preview: (r) => r.preview.good,
+    previewLabel: (r) => `${r.preview.good}d`,
     textClass: "text-primary",
   },
   {
     rating: "EASY",
     label: "Easy",
     key: "4",
-    preview: (r) => r.preview.easy,
+    previewLabel: (r) => `${r.preview.easy}d`,
     textClass: "text-green-500",
   },
 ];
@@ -122,7 +123,7 @@ export function ReviewCard({ review, pending, onRate }: Props) {
 
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
               {RATING_BUTTONS.map((btn) => {
-                const days = btn.preview(review);
+                const previewLabel = btn.previewLabel(review);
                 return (
                   <Button
                     key={btn.rating}
@@ -134,7 +135,7 @@ export function ReviewCard({ review, pending, onRate }: Props) {
                     className="flex h-auto flex-col gap-1 py-3"
                   >
                     <span className="text-muted-foreground text-xs">
-                      {days}d
+                      {previewLabel}
                     </span>
                     <span className={cn("text-sm font-medium", btn.textClass)}>
                       {btn.label}

--- a/fe/src/pages/planner/ReviewCalendarPage.test.tsx
+++ b/fe/src/pages/planner/ReviewCalendarPage.test.tsx
@@ -51,7 +51,7 @@ function mockCalendar(reviewsByCall: CalReview[]) {
           to,
           reviews: filtered.map((r) => ({
             id: r.id,
-            scheduledDate: r.scheduledDate,
+            scheduledAt: `${r.scheduledDate}T04:00:00`,
             status: r.status,
             rating: r.rating ?? null,
             sequence: 1,

--- a/fe/src/pages/planner/TodayReviewsPage.test.tsx
+++ b/fe/src/pages/planner/TodayReviewsPage.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { Route, Routes } from "react-router-dom";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Providers } from "@/app/providers";
 import { Toaster } from "@/components/Toaster";
@@ -45,7 +45,7 @@ function mockToday(reviewIds: number[], opts?: { delayDays?: number }) {
           today: "2026-05-18",
           reviews: reviewIds.map((id) => ({
             id,
-            scheduledDate: "2026-05-18",
+            scheduledAt: "2026-05-18T04:00:00",
             delayDays: opts?.delayDays ?? 0,
             sequence: 2,
             intervalDays: 6,
@@ -85,7 +85,7 @@ function mockComplete(captureRatings: Array<{ id: number; rating: string }>) {
               id: 999,
               flashcardId: 1,
               sequence: 3,
-              scheduledDate: "2026-05-24",
+              scheduledAt: "2026-05-24T04:00:00",
               intervalDays: 6,
               easeFactor: 2.5,
               status: "PENDING",
@@ -101,6 +101,14 @@ describe("TodayReviewsPage", () => {
   beforeEach(() => {
     useAuthStore.setState({ accessToken: "mock-token" });
     useToastStore.setState({ toasts: [] });
+    // 오늘을 2026-05-18로 고정 (다음 복습 토스트 메시지가 now 기준이므로).
+    // Date만 fake하여 react-query/userEvent의 실제 setTimeout과 충돌하지 않게 한다.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(2026, 4, 18, 9, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("0건이면 빈 상태와 [홈으로] 버튼을 표시한다", async () => {

--- a/fe/src/pages/planner/TodayReviewsPage.tsx
+++ b/fe/src/pages/planner/TodayReviewsPage.tsx
@@ -47,10 +47,7 @@ export function TodayReviewsPage() {
       { reviewId: current.id, rating },
       {
         onSuccess: (res) => {
-          toast(
-            formatNextReviewMessage(res.nextReview.scheduledDate),
-            "success",
-          );
+          toast(formatNextReviewMessage(res.nextReview.scheduledAt), "success");
           setCurrentIndex((i) => i + 1);
         },
       },
@@ -71,25 +68,27 @@ export function TodayReviewsPage() {
   );
 }
 
-function formatNextReviewMessage(scheduledDate: string): string {
-  const today = new Date();
-  const todayMid = new Date(
-    today.getFullYear(),
-    today.getMonth(),
-    today.getDate(),
-  );
-  const next = parseDate(scheduledDate);
+function formatNextReviewMessage(scheduledAt: string): string {
+  const now = new Date();
+  const next = new Date(scheduledAt);
+
+  // 당일 짧은 재복습(AGAIN 등)은 분/시간 단위로 안내
+  const diffMin = Math.round((next.getTime() - now.getTime()) / 60000);
+  if (diffMin <= 0) {
+    return "다음 복습이 곧 다시 표시됩니다";
+  }
+  if (diffMin < 60) {
+    return `다음 복습은 약 ${diffMin}분 후`;
+  }
+
+  const todayMid = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const nextMid = new Date(next.getFullYear(), next.getMonth(), next.getDate());
   const days = Math.round(
-    (next.getTime() - todayMid.getTime()) / (1000 * 60 * 60 * 24),
+    (nextMid.getTime() - todayMid.getTime()) / (1000 * 60 * 60 * 24),
   );
   const md = `${next.getMonth() + 1}/${next.getDate()}`;
   if (days <= 0) {
     return `다음 복습은 오늘 (${md})`;
   }
   return `다음 복습은 ${days}일 후 (${md})`;
-}
-
-function parseDate(isoDate: string): Date {
-  const [y, m, d] = isoDate.split("-").map(Number);
-  return new Date(y, m - 1, d);
 }


### PR DESCRIPTION
## 이슈
closes #427

## 배경
복습을 "시간 단위로 더 정확하게" 하자는 요청 → Anki 방식을 정확히 조사한 뒤 **하이브리드**로 합의:
- 여러 날 간격 복습 = 하루 단위(due 시각은 해당 날짜 **새벽 4시 롤오버**, 그 날 하루 종일 due)
- 틀렸을 때(AGAIN) = **당일 10분 뒤** 분 단위 재복습 (Anki learning step)

> "오후 1시에 했으면 6일 후 오후 1시"는 Anki도 안 하는 방식(날 경계로 끌어당김). 시각 정밀도가 의미 있는 곳은 당일 짧은 재복습뿐.

## 변경

### BE
- **마이그레이션(022)**: `review_schedule.scheduled_date`(DATE) → `scheduled_at`(DATETIME(6)). 기존 데이터 `TIMESTAMP(scheduled_date,'04:00:00')`로 백필 + 인덱스 교체(`member_id, scheduled_at, status`). FK 충돌 방지 위해 새 인덱스 생성 후 옛 인덱스 드롭 순서.
- **스케줄링**: `ReviewSchedule.computeScheduledAt(rating, interval, now)`
  - AGAIN → `now + 10분`, 그 외 → `(today+interval) 04:00`
  - SM-2 간격/ease 계산은 그대로(`Sm2Calculator`)
- **due 판정**: `scheduled_at <= now`. 오늘 목록·dueReviewCount·캘린더 범위 쿼리 모두 datetime 기준
- DTO `scheduledDate` → `scheduledAt`(LocalDateTime)
- 새 단위 테스트 `ReviewSchedulingTest` + 기존 통합 테스트 전면 갱신

### FE
- 타입 `scheduledDate` → `scheduledAt`(ISO datetime). 캘린더 분류·그룹은 `DATE(scheduledAt)`(날짜부 slice)로 유지
- 오늘 복습 토스트: 분/시간 단위 안내(`약 10분 후`) + 일 단위(`N일 후 (M/D)`)
- `ReviewCard` AGAIN 미리보기 `10분` 표시

### Wiki
- Study-Planner Data-Model / API-Spec / Architecture 의 `scheduled_at` + 하이브리드 스케줄링 반영

## 검증
- **BE**: `./gradlew test` 100개 통과. TestContainers(실제 MySQL 8.4.4)가 **022 마이그레이션 포함 전체 changelog**를 적용 → 마이그레이션·백필·인덱스 교체 검증됨. 컨트롤러 통합 테스트가 실제 HTTP+DB로 새 스케줄링 동작 단언
- **FE**: `npm test` 108개 통과 / `lint` · `format` · `build` clean
- ⚠️ 로컬 bootRun 실시간 확인은 이 환경에서 gradle bootRun이 배너 후 즉시 종료되어(코드 무관, 데몬 이슈) 미완. 로컬 DB 데이터는 미변경(손상 없음). API/DB 동작은 TestContainers 통합 테스트로 동등 검증됨

## 배포 주의
운영 DB에 `scheduled_date`→`scheduled_at` 마이그레이션이 적용됩니다(기존 일정은 04:00으로 백필). 무중단 점검 후 배포 권장.