### PR TITLE
fix : 미인증/만료 토큰 요청에 403 대신 401 반환

### DIFF
--- a/be/orino-app-api/src/test/java/ds/project/orino/security/SecurityConfigTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/security/SecurityConfigTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class SecurityConfigTest extends ApiTestSupport {
@@ -56,10 +57,20 @@ class SecurityConfigTest extends ApiTestSupport {
     }
 
     @Test
-    @DisplayName("보호된 경로는 인증 없이 접근하면 403을 반환한다")
+    @DisplayName("보호된 경로는 인증 없이 접근하면 401을 반환한다")
     void protectedEndpoint_requiresAuth() throws Exception {
         mockMvc.perform(get("/api/protected"))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("만료/유효하지 않은 토큰으로 접근하면 401을 반환한다")
+    void protectedEndpoint_withInvalidToken_returnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/protected")
+                        .header("Authorization", "Bearer invalid.jwt.token"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH-ERR-002"));
     }
 
     @Test

--- a/be/orino-core-web/src/main/java/ds/project/orino/core/security/JwtAuthenticationEntryPoint.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package ds.project.orino.core.security;
+
+import ds.project.orino.common.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 인증되지 않은(또는 토큰이 만료된) 요청에 대해 401과 ErrorResponse JSON을 반환한다.
+ * <p>
+ * 기본 Spring Security는 미인증 요청에 403을 반환하는데, FE 인터셉터는 401에만
+ * 토큰 자동 재발급을 수행한다. 인증 실패를 401로 통일해 access token 만료 시
+ * 런타임에서도 자동 재발급이 동작하도록 한다.
+ * <p>
+ * core-web 모듈에는 ObjectMapper 빈이 없으므로(웹 MVC 자동설정 미적용 라이브러리 모듈),
+ * 의존성을 추가하지 않고 ErrorResponse와 동일한 형태의 JSON을 직접 작성한다.
+ */
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        ErrorCode errorCode = ErrorCode.INVALID_TOKEN;
+        response.setStatus(errorCode.getHttpStatus());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(
+                "{\"code\":\"" + errorCode.getCode() + "\",\"message\":\"" + errorCode.getMessage() + "\"}");
+    }
+}

--- a/be/orino-core-web/src/main/java/ds/project/orino/core/security/SecurityConfig.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/security/SecurityConfig.java
@@ -15,9 +15,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
-    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
+                          JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
     }
 
     @Bean
@@ -43,6 +46,8 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
+                // 미인증/만료 토큰 요청에 403 대신 401을 반환한다 (FE 자동 재발급 트리거)
+                .exceptionHandling(handler -> handler.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();


### PR DESCRIPTION
closes #429

## Description

오랜만에 접속하면 403이 뜨고 새로고침해야 복구되던 문제를 해결한다.

## 원인

- Access token TTL(30분) 만료 후 보호된 API 요청 시, Spring Security 기본 동작상 미인증 요청에 **403(Forbidden)** 반환
- FE axios 인터셉터(`fe/src/shared/api/client.ts`)는 **401일 때만** `/api/auth/reissue` 자동 호출 → 403은 그대로 throw
- 새로고침 시에는 `AuthProvider`가 앱 로드 시 `reissue()`를 호출하므로 복구됨 → "새로고침하면 됨"

즉 런타임 만료 시 자동 재발급이 403 케이스에서 동작하지 않았다.

## 해결

HTTP 시맨틱상 "미인증"은 401이 맞다. 인증 실패를 **401로 통일**하여 FE의 기존 401 자동 재발급 로직이 런타임에서도 동작하게 한다.

- `JwtAuthenticationEntryPoint` 추가 → 미인증/만료 토큰 요청에 401 + `ErrorResponse` JSON(`AUTH-ERR-002`) 반환
- `SecurityConfig`에 `authenticationEntryPoint` 연결
- FE 변경 불필요 (기존 401 처리 그대로 자동 재발급)

> core-web은 웹 MVC 자동설정이 없는 라이브러리 모듈이라 `ObjectMapper` 빈이 없다. 의존성 추가 없이 `ErrorResponse`와 동일 형태의 JSON을 직접 작성했다.

## 변경 사항

- `JwtAuthenticationEntryPoint.java` (신규)
- `SecurityConfig.java`: exceptionHandling + entryPoint 연결
- `SecurityConfigTest.java`: 미인증 403 기대 → **401** 수정, 만료/유효하지 않은 토큰 케이스 추가

## 검증

- `./gradlew build` 전체 통과 (checkstyle + 전 모듈 테스트)
- `SecurityConfigTest`:
  - 미인증 요청 → 401 + `AUTH-ERR-002`
  - 유효하지 않은 토큰 → 401 + `AUTH-ERR-002`
  - permitAll 경로(`/api/auth/**`, swagger, api-docs) 정상
  - 유효 JWT → 401/403 아님
- 로컬 재현 검증 권장: access TTL 짧게 설정 후 만료 → 401 → 자동 reissue → 원요청 재시도 성공

## 회귀 영향

- 관리(actuator) 필터 체인(@Order 0)은 별도라 영향 없음 (ActuatorSecurityTest 통과)
- 진짜 권한 부족(향후 역할 도입 시)은 여전히 403으로 구분 가능 (이번 변경은 인증=401만 처리)