### PR TITLE
feat : datetime UTC 저장 + 사용자 시간대 기반 반환 (하이브리드)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/config/ClockConfig.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/config/ClockConfig.java
@@ -4,13 +4,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.time.Clock;
-import java.time.ZoneId;
 
 @Configuration
 public class ClockConfig {
 
     @Bean
     public Clock clock() {
-        return Clock.system(ZoneId.of("Asia/Seoul"));
+        // 저장/비교는 UTC Instant 기준. 사용자 로컬 기준 계산은 요청 시간대(UserTimeZone)로 변환한다.
+        return Clock.systemUTC();
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
 import ds.project.orino.planner.review.dto.ReviewScheduleView;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record FlashcardResponse(
@@ -13,7 +13,7 @@ public record FlashcardResponse(
         String front,
         String back,
         ReviewScheduleView nextReview,
-        LocalDateTime createdAt
+        Instant createdAt
 ) {
     public static FlashcardResponse of(Flashcard f, ReviewScheduleView nextReview) {
         return new FlashcardResponse(

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/service/FlashcardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/service/FlashcardService.java
@@ -13,11 +13,13 @@ import ds.project.orino.planner.flashcard.dto.FlashcardCreateResponse;
 import ds.project.orino.planner.flashcard.dto.FlashcardResponse;
 import ds.project.orino.planner.flashcard.dto.FlashcardUpdateRequest;
 import ds.project.orino.planner.review.dto.ReviewScheduleView;
+import ds.project.orino.core.time.UserTimeZone;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,9 +66,10 @@ public class FlashcardService {
 
         Flashcard saved = flashcardRepository.save(
                 new Flashcard(memberId, materialId, request.front(), request.back()));
-        LocalDate today = LocalDate.now(clock);
+        ZoneId zone = UserTimeZone.get();
+        LocalDate today = clock.instant().atZone(zone).toLocalDate();
         ReviewSchedule firstReview = reviewScheduleRepository.save(
-                ReviewSchedule.firstReview(memberId, saved.getId(), today));
+                ReviewSchedule.firstReview(memberId, saved.getId(), today, zone));
 
         return new FlashcardCreateResponse(
                 FlashcardResponse.withoutReview(saved),

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/dto/MaterialResponse.java
@@ -4,7 +4,7 @@ import ds.project.orino.domain.planner.material.entity.MaterialStatus;
 import ds.project.orino.domain.planner.material.entity.MaterialType;
 import ds.project.orino.domain.planner.material.entity.StudyMaterial;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record MaterialResponse(
         Long id,
@@ -13,8 +13,8 @@ public record MaterialResponse(
         MaterialStatus status,
         long flashcardCount,
         long dueReviewCount,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        Instant createdAt,
+        Instant updatedAt
 ) {
     public static MaterialResponse of(StudyMaterial m, long flashcardCount, long dueReviewCount) {
         return new MaterialResponse(

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyMaterialService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyMaterialService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -85,7 +84,7 @@ public class StudyMaterialService {
         Map<Long, Long> flashcardCounts = toCountMap(
                 studyMaterialRepository.countFlashcardsByMaterialIds(ids));
         Map<Long, Long> dueReviewCounts = toCountMap(
-                studyMaterialRepository.countDueReviewsByMaterialIds(ids, LocalDateTime.now(clock)));
+                studyMaterialRepository.countDueReviewsByMaterialIds(ids, clock.instant()));
         return materials.stream()
                 .map(m -> MaterialResponse.of(m,
                         flashcardCounts.getOrDefault(m.getId(), 0L),

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteDetailResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteDetailResponse.java
@@ -7,7 +7,7 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record NoteDetailResponse(
         Long id,
@@ -16,7 +16,7 @@ public record NoteDetailResponse(
         String title,
         int sortOrder,
         JsonNode content,
-        LocalDateTime updatedAt
+        Instant updatedAt
 ) {
     private static final JsonMapper MAPPER = JsonMapper.builder().build();
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteUpdateResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/note/dto/NoteUpdateResponse.java
@@ -2,7 +2,7 @@ package ds.project.orino.planner.note.dto;
 
 import ds.project.orino.domain.planner.note.entity.Note;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record NoteUpdateResponse(
         Long id,
@@ -10,7 +10,7 @@ public record NoteUpdateResponse(
         Long parentId,
         String title,
         int sortOrder,
-        LocalDateTime updatedAt
+        Instant updatedAt
 ) {
     public static NoteUpdateResponse of(Note note) {
         return new NoteUpdateResponse(

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CalendarReviewItem.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CalendarReviewItem.java
@@ -3,11 +3,11 @@ package ds.project.orino.planner.review.dto;
 import ds.project.orino.domain.planner.review.entity.Rating;
 import ds.project.orino.domain.planner.review.entity.ReviewStatus;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record CalendarReviewItem(
         Long id,
-        LocalDateTime scheduledAt,
+        Instant scheduledAt,
         ReviewStatus status,
         Rating rating,
         int sequence,

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CompletedReviewView.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CompletedReviewView.java
@@ -4,14 +4,14 @@ import ds.project.orino.domain.planner.review.entity.Rating;
 import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
 import ds.project.orino.domain.planner.review.entity.ReviewStatus;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record CompletedReviewView(
         Long id,
         ReviewStatus status,
         Rating rating,
         Integer elapsedDays,
-        LocalDateTime completedAt
+        Instant completedAt
 ) {
     public static CompletedReviewView of(ReviewSchedule r) {
         return new CompletedReviewView(

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewScheduleView.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewScheduleView.java
@@ -5,14 +5,14 @@ import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
 import ds.project.orino.domain.planner.review.entity.ReviewStatus;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ReviewScheduleView(
         Long id,
         Long flashcardId,
         Integer sequence,
-        LocalDateTime scheduledAt,
+        Instant scheduledAt,
         Integer intervalDays,
         BigDecimal easeFactor,
         ReviewStatus status

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewItem.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewItem.java
@@ -1,11 +1,11 @@
 package ds.project.orino.planner.review.dto;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record TodayReviewItem(
         Long id,
-        LocalDateTime scheduledAt,
+        Instant scheduledAt,
         int delayDays,
         int sequence,
         int intervalDays,

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCompletionService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCompletionService.java
@@ -9,12 +9,14 @@ import ds.project.orino.planner.review.dto.CompletedReviewView;
 import ds.project.orino.planner.review.dto.ReviewCompletionRequest;
 import ds.project.orino.planner.review.dto.ReviewCompletionResponse;
 import ds.project.orino.planner.review.dto.ReviewScheduleView;
+import ds.project.orino.core.time.UserTimeZone;
 import ds.project.orino.planner.review.sm2.Sm2Calculator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.ZoneId;
 
 @Service
 public class ReviewCompletionService {
@@ -36,16 +38,17 @@ public class ReviewCompletionService {
             throw new CustomException(ErrorCode.INVALID_STATE);
         }
 
-        LocalDateTime now = LocalDateTime.now(clock);
+        Instant now = clock.instant();
+        ZoneId zone = UserTimeZone.get();
 
         int newSequence = current.getSequence() + 1;
         Sm2Calculator.Result computed = Sm2Calculator.next(
                 newSequence, current.getIntervalDays(), current.getEaseFactor(), request.rating());
 
-        current.complete(request.rating(), now);
+        current.complete(request.rating(), now, zone);
 
-        LocalDateTime scheduledAt = ReviewSchedule.computeScheduledAt(
-                request.rating(), computed.intervalDays(), now);
+        Instant scheduledAt = ReviewSchedule.computeScheduledAt(
+                request.rating(), computed.intervalDays(), now, zone);
         ReviewSchedule next = reviewScheduleRepository.save(new ReviewSchedule(
                 memberId, current.getFlashcardId(), newSequence,
                 scheduledAt, computed.intervalDays(), computed.easeFactor()));

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
@@ -23,10 +23,13 @@ import ds.project.orino.planner.review.sm2.Sm2Calculator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import ds.project.orino.core.time.UserTimeZone;
+
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
@@ -53,8 +56,9 @@ public class ReviewQueryService {
     }
 
     public TodayReviewsResponse findToday(Long memberId) {
-        LocalDate today = LocalDate.now(clock);
-        LocalDateTime now = LocalDateTime.now(clock);
+        ZoneId zone = UserTimeZone.get();
+        Instant now = clock.instant();
+        LocalDate today = now.atZone(zone).toLocalDate();
 
         List<ReviewSchedule> reviews = reviewScheduleRepository
                 .findAllByMemberIdAndStatusAndScheduledAtLessThanEqualOrderByScheduledAtAscIdAsc(
@@ -74,7 +78,7 @@ public class ReviewQueryService {
                 .collect(Collectors.toMap(StudyMaterial::getId, Function.identity()));
 
         List<TodayReviewItem> items = reviews.stream()
-                .map(r -> toItem(r, cardById, materialById, today))
+                .map(r -> toItem(r, cardById, materialById, today, zone))
                 .toList();
 
         return new TodayReviewsResponse(today, items);
@@ -88,9 +92,13 @@ public class ReviewQueryService {
             throw new CustomException(ErrorCode.INVALID_REQUEST);
         }
 
+        ZoneId zone = UserTimeZone.get();
+        Instant fromInstant = from.atStartOfDay(zone).toInstant();
+        Instant toInstant = to.atTime(LocalTime.MAX).atZone(zone).toInstant();
+
         List<ReviewSchedule> reviews = reviewScheduleRepository
                 .findAllByMemberIdAndScheduledAtBetweenOrderByScheduledAtAscIdAsc(
-                        memberId, from.atStartOfDay(), to.atTime(LocalTime.MAX));
+                        memberId, fromInstant, toInstant);
 
         if (reviews.isEmpty()) {
             return new CalendarReviewsResponse(from, to, List.of());
@@ -130,12 +138,13 @@ public class ReviewQueryService {
     private TodayReviewItem toItem(ReviewSchedule r,
                                    Map<Long, Flashcard> cardById,
                                    Map<Long, StudyMaterial> materialById,
-                                   LocalDate today) {
+                                   LocalDate today,
+                                   ZoneId zone) {
         Flashcard card = cardById.get(r.getFlashcardId());
         StudyMaterial material = materialById.get(card.getMaterialId());
         TodayReviewFlashcard flashcardDto = TodayReviewFlashcard.of(card, TodayReviewMaterial.of(material));
         PreviewView preview = preview(r);
-        int delayDays = (int) ChronoUnit.DAYS.between(r.getScheduledAt().toLocalDate(), today);
+        int delayDays = (int) ChronoUnit.DAYS.between(r.getScheduledAt().atZone(zone).toLocalDate(), today);
         return new TodayReviewItem(
                 r.getId(), r.getScheduledAt(), delayDays,
                 r.getSequence(), r.getIntervalDays(), r.getEaseFactor(),

--- a/be/orino-app-api/src/main/resources/application-mysql.yml
+++ b/be/orino-app-api/src/main/resources/application-mysql.yml
@@ -10,6 +10,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
 ---
@@ -30,6 +34,8 @@ spring:
         format_sql: true
         highlight_sql: true
         generate_statistics: true
+        jdbc:
+          time_zone: UTC
   liquibase:
     enabled: true
     change-log: classpath:db/changelog/db.changelog-master.yaml
@@ -52,6 +58,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
   liquibase:
     enabled: true
     change-log: classpath:db/changelog/db.changelog-master.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/flashcard/controller/FlashcardControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/flashcard/controller/FlashcardControllerTest.java
@@ -75,7 +75,7 @@ class FlashcardControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("POST - 카드 생성 + 첫 복습(sequence=1, today+1, 1일, 2.50) 자동 생성")
     void create_with_first_review() throws Exception {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
 
         mockMvc.perform(post("/api/planner/materials/{id}/flashcards", material.getId())
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
@@ -138,12 +138,12 @@ class FlashcardControllerTest extends ApiTestSupport {
     void list_returns_cards_in_creation_order_with_next_review() throws Exception {
         Flashcard card1 = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q1", "A1"));
         Flashcard card2 = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q2", "A2"));
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         reviewScheduleRepository.save(
-                new ReviewSchedule(member.getId(), card1.getId(), 1, today.plusDays(1).atTime(4, 0), 1,
+                new ReviewSchedule(member.getId(), card1.getId(), 1, atTestZone(today.plusDays(1).atTime(4, 0)), 1,
                         new BigDecimal("2.50")));
         reviewScheduleRepository.save(
-                new ReviewSchedule(member.getId(), card2.getId(), 1, today.plusDays(3).atTime(4, 0), 1,
+                new ReviewSchedule(member.getId(), card2.getId(), 1, atTestZone(today.plusDays(3).atTime(4, 0)), 1,
                         new BigDecimal("2.50")));
 
         mockMvc.perform(get("/api/planner/materials/{id}/flashcards", material.getId())
@@ -163,7 +163,7 @@ class FlashcardControllerTest extends ApiTestSupport {
     @DisplayName("GET - 가장 가까운 PENDING이 nextReview로 선택된다 (COMPLETED 무시)")
     void list_next_review_picks_earliest_pending() throws Exception {
         Flashcard card = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         jdbcTemplate.update("""
                 INSERT INTO review_schedule
                   (member_id, flashcard_id, sequence, scheduled_at, interval_days,
@@ -171,10 +171,10 @@ class FlashcardControllerTest extends ApiTestSupport {
                 VALUES (?, ?, 1, ?, 1, 2.50, 'COMPLETED', NOW(6), NOW(6), NOW(6))
                 """, member.getId(), card.getId(), today.minusDays(5).atStartOfDay());
         reviewScheduleRepository.save(
-                new ReviewSchedule(member.getId(), card.getId(), 3, today.plusDays(10).atTime(4, 0), 10,
+                new ReviewSchedule(member.getId(), card.getId(), 3, atTestZone(today.plusDays(10).atTime(4, 0)), 10,
                         new BigDecimal("2.50")));
         reviewScheduleRepository.save(
-                new ReviewSchedule(member.getId(), card.getId(), 2, today.plusDays(2).atTime(4, 0), 2,
+                new ReviewSchedule(member.getId(), card.getId(), 2, atTestZone(today.plusDays(2).atTime(4, 0)), 2,
                         new BigDecimal("2.50")));
 
         mockMvc.perform(get("/api/planner/materials/{id}/flashcards", material.getId())
@@ -211,9 +211,9 @@ class FlashcardControllerTest extends ApiTestSupport {
     @DisplayName("PATCH - front/back 부분 수정, 복습 일정에 영향 없음")
     void update_does_not_affect_reviews() throws Exception {
         Flashcard card = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         ReviewSchedule review = reviewScheduleRepository.save(
-                new ReviewSchedule(member.getId(), card.getId(), 1, today.plusDays(1).atTime(4, 0), 1,
+                new ReviewSchedule(member.getId(), card.getId(), 1, atTestZone(today.plusDays(1).atTime(4, 0)), 1,
                         new BigDecimal("2.50")));
 
         mockMvc.perform(patch("/api/planner/flashcards/{id}", card.getId())
@@ -228,7 +228,7 @@ class FlashcardControllerTest extends ApiTestSupport {
 
         ReviewSchedule unchanged = reviewScheduleRepository.findById(review.getId()).orElseThrow();
         org.assertj.core.api.Assertions.assertThat(unchanged.getScheduledAt())
-                .isEqualTo(today.plusDays(1).atTime(4, 0));
+                .isEqualTo(atTestZone(today.plusDays(1).atTime(4, 0)));
         org.assertj.core.api.Assertions.assertThat(unchanged.getSequence()).isEqualTo(1);
     }
 
@@ -265,12 +265,12 @@ class FlashcardControllerTest extends ApiTestSupport {
     @DisplayName("DELETE - 카드 삭제 시 관련 review_schedule이 cascade 삭제된다")
     void delete_cascades_reviews() throws Exception {
         Flashcard card = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         reviewScheduleRepository.save(
-                new ReviewSchedule(member.getId(), card.getId(), 1, today.plusDays(1).atTime(4, 0), 1,
+                new ReviewSchedule(member.getId(), card.getId(), 1, atTestZone(today.plusDays(1).atTime(4, 0)), 1,
                         new BigDecimal("2.50")));
         reviewScheduleRepository.save(
-                new ReviewSchedule(member.getId(), card.getId(), 2, today.plusDays(7).atTime(4, 0), 7,
+                new ReviewSchedule(member.getId(), card.getId(), 2, atTestZone(today.plusDays(7).atTime(4, 0)), 7,
                         new BigDecimal("2.50")));
 
         mockMvc.perform(delete("/api/planner/flashcards/{id}", card.getId())

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewCalendarControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewCalendarControllerTest.java
@@ -68,13 +68,13 @@ class ReviewCalendarControllerTest extends ApiTestSupport {
 
     private ReviewSchedule pending(LocalDate date, int sequence) {
         return reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), sequence, date.atTime(4, 0), 6, new BigDecimal("2.50")));
+                member.getId(), card.getId(), sequence, atTestZone(date.atTime(4, 0)), 6, new BigDecimal("2.50")));
     }
 
     private ReviewSchedule completed(LocalDate date, int sequence, Rating rating) {
         ReviewSchedule r = new ReviewSchedule(
-                member.getId(), card.getId(), sequence, date.atTime(4, 0), 6, new BigDecimal("2.50"));
-        r.complete(rating, java.time.LocalDateTime.of(date, java.time.LocalTime.NOON));
+                member.getId(), card.getId(), sequence, atTestZone(date.atTime(4, 0)), 6, new BigDecimal("2.50"));
+        r.complete(rating, atTestZone(java.time.LocalDateTime.of(date, java.time.LocalTime.NOON)), TEST_ZONE);
         return reviewScheduleRepository.save(r);
     }
 
@@ -154,7 +154,7 @@ class ReviewCalendarControllerTest extends ApiTestSupport {
         Flashcard otherCard = flashcardRepository.save(
                 new Flashcard(otherMember.getId(), otherMaterial.getId(), "Q2", "A2"));
         reviewScheduleRepository.save(new ReviewSchedule(
-                otherMember.getId(), otherCard.getId(), 1, LocalDate.parse("2026-05-15").atTime(4, 0), 6,
+                otherMember.getId(), otherCard.getId(), 1, atTestZone(LocalDate.parse("2026-05-15").atTime(4, 0)), 6,
                 new BigDecimal("2.50")));
         pending(LocalDate.parse("2026-05-16"), 1);
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
@@ -71,9 +71,9 @@ class ReviewControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("POST complete - GOOD 평가 시 현재 review COMPLETED + 다음 review 생성")
     void complete_good_creates_next_review() throws Exception {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 1, today.minusDays(1).atTime(4, 0), 1,
+                member.getId(), card.getId(), 1, atTestZone(today.minusDays(1).atTime(4, 0)), 1,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
@@ -107,9 +107,9 @@ class ReviewControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("POST complete - AGAIN 평가 시 interval=1, ease -0.20")
     void complete_again() throws Exception {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 2, today.atTime(4, 0), 6,
+                member.getId(), card.getId(), 2, atTestZone(today.atTime(4, 0)), 6,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
@@ -129,9 +129,9 @@ class ReviewControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("POST complete - EASY 평가 시 ease +0.10")
     void complete_easy() throws Exception {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 2, today.atTime(4, 0), 6,
+                member.getId(), card.getId(), 2, atTestZone(today.atTime(4, 0)), 6,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
@@ -147,9 +147,9 @@ class ReviewControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("POST complete - 이미 COMPLETED 인 경우 409 SP-ERR-003")
     void complete_already_completed_returns_409() throws Exception {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 1, today.minusDays(1).atTime(4, 0), 1,
+                member.getId(), card.getId(), 1, atTestZone(today.minusDays(1).atTime(4, 0)), 1,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
@@ -177,9 +177,9 @@ class ReviewControllerTest extends ApiTestSupport {
                 new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
         Flashcard otherCard = flashcardRepository.save(
                 new Flashcard(otherMember.getId(), otherMaterial.getId(), "Q", "A"));
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         ReviewSchedule otherReview = reviewScheduleRepository.save(new ReviewSchedule(
-                otherMember.getId(), otherCard.getId(), 1, today.atTime(4, 0), 1,
+                otherMember.getId(), otherCard.getId(), 1, atTestZone(today.atTime(4, 0)), 1,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", otherReview.getId())
@@ -194,9 +194,9 @@ class ReviewControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("POST complete - rating 누락 시 400")
     void complete_missing_rating_returns_400() throws Exception {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 1, today.atTime(4, 0), 1,
+                member.getId(), card.getId(), 1, atTestZone(today.atTime(4, 0)), 1,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
@@ -209,9 +209,9 @@ class ReviewControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("POST complete - elapsedDays는 (today - scheduledDate)로 음수 가능")
     void complete_elapsed_days_can_be_negative_for_early_review() throws Exception {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         ReviewSchedule earlyReview = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 1, today.plusDays(2).atTime(4, 0), 1,
+                member.getId(), card.getId(), 1, atTestZone(today.plusDays(2).atTime(4, 0)), 1,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", earlyReview.getId())
@@ -227,9 +227,9 @@ class ReviewControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("4번 연속 GOOD 평가 - sequence 1→2→3→4→5, scheduledDate가 모두 today+interval로 산정")
     void complete_four_consecutive_good_evaluations() throws Exception {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         ReviewSchedule firstReview = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 1, today.atTime(4, 0), 1,
+                member.getId(), card.getId(), 1, atTestZone(today.atTime(4, 0)), 1,
                 new BigDecimal("2.50")));
 
         Long currentId = firstReview.getId();

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsControllerTest.java
@@ -68,7 +68,7 @@ class TodayReviewsControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("GET today - PENDING이 없으면 빈 배열, today 필드는 채워짐")
     void empty_returns_today_and_empty_list() throws Exception {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
 
         mockMvc.perform(get("/api/planner/reviews/today")
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
@@ -80,15 +80,15 @@ class TodayReviewsControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("GET today - scheduledDate <= today AND status=PENDING 만 반환, 정렬 ASC")
     void returns_pending_due_today_or_overdue_sorted() throws Exception {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         ReviewSchedule overdue = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 2, today.minusDays(2).atTime(4, 0), 6,
+                member.getId(), card.getId(), 2, atTestZone(today.minusDays(2).atTime(4, 0)), 6,
                 new BigDecimal("2.50")));
         ReviewSchedule dueToday = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 3, today.atStartOfDay(), 15,
+                member.getId(), card.getId(), 3, atTestZone(today.atStartOfDay()), 15,
                 new BigDecimal("2.50")));
         reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 4, today.plusDays(3).atTime(4, 0), 3,
+                member.getId(), card.getId(), 4, atTestZone(today.plusDays(3).atTime(4, 0)), 3,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(get("/api/planner/reviews/today")
@@ -104,9 +104,9 @@ class TodayReviewsControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("GET today - flashcard + material을 한 응답에 동봉")
     void embeds_flashcard_and_material() throws Exception {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 1, today.atStartOfDay(), 1,
+                member.getId(), card.getId(), 1, atTestZone(today.atStartOfDay()), 1,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(get("/api/planner/reviews/today")
@@ -123,9 +123,9 @@ class TodayReviewsControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("GET today - preview 4지가 SM-2와 일치 (sequence=2 기준)")
     void preview_matches_sm2() throws Exception {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 2, today.atStartOfDay(), 6,
+                member.getId(), card.getId(), 2, atTestZone(today.atStartOfDay()), 6,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(get("/api/planner/reviews/today")
@@ -140,16 +140,16 @@ class TodayReviewsControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("GET today - 타인 review는 제외된다")
     void excludes_other_members_reviews() throws Exception {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         StudyMaterial otherMaterial = studyMaterialRepository.save(
                 new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
         Flashcard otherCard = flashcardRepository.save(
                 new Flashcard(otherMember.getId(), otherMaterial.getId(), "Q2", "A2"));
         reviewScheduleRepository.save(new ReviewSchedule(
-                otherMember.getId(), otherCard.getId(), 1, today.atStartOfDay(), 1,
+                otherMember.getId(), otherCard.getId(), 1, atTestZone(today.atStartOfDay()), 1,
                 new BigDecimal("2.50")));
         reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 1, today.atStartOfDay(), 1,
+                member.getId(), card.getId(), 1, atTestZone(today.atStartOfDay()), 1,
                 new BigDecimal("2.50")));
 
         mockMvc.perform(get("/api/planner/reviews/today")
@@ -162,15 +162,14 @@ class TodayReviewsControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("GET today - COMPLETED 는 제외된다")
     void excludes_completed_reviews() throws Exception {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = testToday(clock);
         ReviewSchedule pending = reviewScheduleRepository.save(new ReviewSchedule(
-                member.getId(), card.getId(), 2, today.atStartOfDay(), 6,
+                member.getId(), card.getId(), 2, atTestZone(today.atStartOfDay()), 6,
                 new BigDecimal("2.50")));
         ReviewSchedule completed = new ReviewSchedule(
-                member.getId(), card.getId(), 1, today.minusDays(5).atTime(4, 0), 1,
+                member.getId(), card.getId(), 1, atTestZone(today.minusDays(5).atTime(4, 0)), 1,
                 new BigDecimal("2.50"));
-        completed.complete(ds.project.orino.domain.planner.review.entity.Rating.GOOD,
-                java.time.LocalDateTime.now(clock));
+        completed.complete(ds.project.orino.domain.planner.review.entity.Rating.GOOD, clock.instant(), TEST_ZONE);
         reviewScheduleRepository.save(completed);
 
         mockMvc.perform(get("/api/planner/reviews/today")

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/sm2/ReviewSchedulingTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/sm2/ReviewSchedulingTest.java
@@ -5,43 +5,63 @@ import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisplayName("ReviewSchedule.computeScheduledAt - datetime 하이브리드 스케줄링")
+@DisplayName("ReviewSchedule.computeScheduledAt - datetime 하이브리드 스케줄링 (UTC 저장 + 사용자 TZ 기준 계산)")
 class ReviewSchedulingTest {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+    /** 사용자 TZ 로컬 시각을 UTC Instant로 변환하는 헬퍼. */
+    private static Instant atSeoul(int year, int month, int day, int hour, int minute) {
+        return LocalDateTime.of(year, month, day, hour, minute).atZone(SEOUL).toInstant();
+    }
 
     @Test
     @DisplayName("AGAIN은 당일 10분 뒤(분 단위)로 잡힌다")
     void again_reschedules_in_ten_minutes() {
-        LocalDateTime now = LocalDateTime.of(2026, 6, 1, 13, 0);
+        Instant now = atSeoul(2026, 6, 1, 13, 0);
 
-        LocalDateTime result = ReviewSchedule.computeScheduledAt(Rating.AGAIN, 1, now);
+        Instant result = ReviewSchedule.computeScheduledAt(Rating.AGAIN, 1, now, SEOUL);
 
-        assertThat(result).isEqualTo(now.plusMinutes(10));
+        assertThat(result).isEqualTo(now.plusSeconds(600));
     }
 
     @Test
-    @DisplayName("GOOD 등 다중일 복습은 (오늘+간격) 날짜의 04:00(롤오버)로 잡힌다")
+    @DisplayName("GOOD 등 다중일 복습은 사용자 TZ 기준 (오늘+간격) 날짜의 04:00(롤오버)로 잡힌다")
     void good_reschedules_at_rollover_hour() {
-        LocalDateTime now = LocalDateTime.of(2026, 6, 1, 13, 0);
+        Instant now = atSeoul(2026, 6, 1, 13, 0);
 
-        LocalDateTime result = ReviewSchedule.computeScheduledAt(Rating.GOOD, 6, now);
+        Instant result = ReviewSchedule.computeScheduledAt(Rating.GOOD, 6, now, SEOUL);
 
-        assertThat(result).isEqualTo(LocalDateTime.of(2026, 6, 7, 4, 0));
+        assertThat(result).isEqualTo(atSeoul(2026, 6, 7, 4, 0));
     }
 
     @Test
-    @DisplayName("다중일 due 시각은 복습한 시각과 무관하게 항상 04:00이다")
+    @DisplayName("다중일 due 시각은 복습한 시각과 무관하게 항상 사용자 TZ 04:00이다")
     void rollover_is_independent_of_time_of_day() {
-        LocalDateTime morning = LocalDateTime.of(2026, 6, 1, 1, 30);
-        LocalDateTime evening = LocalDateTime.of(2026, 6, 1, 23, 45);
+        Instant morning = atSeoul(2026, 6, 1, 1, 30);
+        Instant evening = atSeoul(2026, 6, 1, 23, 45);
 
-        LocalDateTime fromMorning = ReviewSchedule.computeScheduledAt(Rating.EASY, 4, morning);
-        LocalDateTime fromEvening = ReviewSchedule.computeScheduledAt(Rating.EASY, 4, evening);
+        Instant fromMorning = ReviewSchedule.computeScheduledAt(Rating.EASY, 4, morning, SEOUL);
+        Instant fromEvening = ReviewSchedule.computeScheduledAt(Rating.EASY, 4, evening, SEOUL);
 
-        assertThat(fromMorning).isEqualTo(LocalDateTime.of(2026, 6, 5, 4, 0));
-        assertThat(fromEvening).isEqualTo(LocalDateTime.of(2026, 6, 5, 4, 0));
+        assertThat(fromMorning).isEqualTo(atSeoul(2026, 6, 5, 4, 0));
+        assertThat(fromEvening).isEqualTo(atSeoul(2026, 6, 5, 4, 0));
+    }
+
+    @Test
+    @DisplayName("롤오버 04:00은 사용자 시간대 기준이라 UTC로는 전날 19:00이다")
+    void rollover_is_user_timezone_based() {
+        Instant now = atSeoul(2026, 6, 1, 13, 0);
+
+        Instant result = ReviewSchedule.computeScheduledAt(Rating.GOOD, 1, now, SEOUL);
+
+        // 사용자 TZ 6/2 04:00 = UTC 6/1 19:00
+        assertThat(result).isEqualTo(Instant.parse("2026-06-01T19:00:00Z"));
     }
 }

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/ApiTestSupport.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/ApiTestSupport.java
@@ -6,10 +6,20 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
 @IntegrationTest
 public abstract class ApiTestSupport {
+
+    /** 테스트 기본 사용자 시간대. 모든 요청에 X-Timezone 헤더로 주입한다. */
+    protected static final ZoneId TEST_ZONE = ZoneId.of("Asia/Seoul");
 
     protected MockMvc mockMvc;
 
@@ -20,6 +30,17 @@ public abstract class ApiTestSupport {
     void setUpMockMvc() {
         mockMvc = MockMvcBuilders.webAppContextSetup(context)
                 .apply(springSecurity())
+                .defaultRequest(get("/").header("X-Timezone", TEST_ZONE.getId()))
                 .build();
+    }
+
+    /** 사용자 시간대(Asia/Seoul) 로컬 시각을 UTC Instant로 변환한다. */
+    protected static Instant atTestZone(LocalDateTime localDateTime) {
+        return localDateTime.atZone(TEST_ZONE).toInstant();
+    }
+
+    /** 사용자 시간대(Asia/Seoul) 기준 오늘 날짜. */
+    protected static LocalDate testToday(Clock clock) {
+        return clock.instant().atZone(TEST_ZONE).toLocalDate();
     }
 }

--- a/be/orino-core-web/src/main/java/ds/project/orino/core/time/InstantToUserZoneSerializer.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/time/InstantToUserZoneSerializer.java
@@ -1,0 +1,30 @@
+package ds.project.orino.core.time;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * UTC로 저장된 {@link Instant}를 요청 사용자 시간대 기준의 offset 포함 ISO-8601로 직렬화한다.
+ * <p>
+ * 예: UTC {@code 2026-06-06T19:00:00Z} → 사용자 TZ가 {@code Asia/Seoul}이면
+ * {@code "2026-06-07T04:00:00+09:00"}.
+ * <p>
+ * Spring Boot 4 / Jackson 3({@code tools.jackson}) 기반.
+ */
+public class InstantToUserZoneSerializer extends StdSerializer<Instant> {
+
+    public InstantToUserZoneSerializer() {
+        super(Instant.class);
+    }
+
+    @Override
+    public void serialize(Instant value, JsonGenerator gen, SerializationContext ctxt) {
+        OffsetDateTime offset = value.atZone(UserTimeZone.get()).toOffsetDateTime();
+        gen.writeString(offset.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+    }
+}

--- a/be/orino-core-web/src/main/java/ds/project/orino/core/time/UserTimeZone.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/time/UserTimeZone.java
@@ -1,0 +1,34 @@
+package ds.project.orino.core.time;
+
+import java.time.ZoneId;
+
+/**
+ * 요청 단위 사용자 시간대를 보관하는 ThreadLocal 컨텍스트.
+ * <p>
+ * 저장은 UTC(Instant)로 하되, 복습 스케줄의 "새벽 4시 롤오버" 같은 사용자 로컬
+ * 기준 계산과 응답 직렬화(offset 포함)를 위해 요청의 시간대를 전파한다.
+ * {@link UserTimeZoneInterceptor}가 {@code X-Timezone} 헤더로부터 설정한다.
+ */
+public final class UserTimeZone {
+
+    /** 헤더가 없거나 유효하지 않을 때 사용할 기본 시간대. */
+    public static final ZoneId DEFAULT = ZoneId.of("Asia/Seoul");
+
+    private static final ThreadLocal<ZoneId> HOLDER = new ThreadLocal<>();
+
+    private UserTimeZone() {
+    }
+
+    public static void set(ZoneId zoneId) {
+        HOLDER.set(zoneId);
+    }
+
+    public static ZoneId get() {
+        ZoneId zoneId = HOLDER.get();
+        return zoneId != null ? zoneId : DEFAULT;
+    }
+
+    public static void clear() {
+        HOLDER.remove();
+    }
+}

--- a/be/orino-core-web/src/main/java/ds/project/orino/core/time/UserTimeZoneInterceptor.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/time/UserTimeZoneInterceptor.java
@@ -1,0 +1,43 @@
+package ds.project.orino.core.time;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+
+/**
+ * {@code X-Timezone} 헤더(IANA 시간대, 예: {@code Asia/Seoul})를 읽어
+ * 요청 단위로 {@link UserTimeZone}에 설정한다. 헤더가 없거나 유효하지 않으면
+ * 기본값({@link UserTimeZone#DEFAULT})을 사용한다.
+ */
+@Component
+public class UserTimeZoneInterceptor implements HandlerInterceptor {
+
+    public static final String HEADER = "X-Timezone";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        UserTimeZone.set(resolve(request.getHeader(HEADER)));
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+                                Object handler, Exception ex) {
+        UserTimeZone.clear();
+    }
+
+    private ZoneId resolve(String header) {
+        if (header == null || header.isBlank()) {
+            return UserTimeZone.DEFAULT;
+        }
+        try {
+            return ZoneId.of(header.trim());
+        } catch (DateTimeException e) {
+            return UserTimeZone.DEFAULT;
+        }
+    }
+}

--- a/be/orino-core-web/src/main/java/ds/project/orino/core/time/UserTimeZoneWebConfig.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/time/UserTimeZoneWebConfig.java
@@ -1,0 +1,42 @@
+package ds.project.orino.core.time;
+
+import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import tools.jackson.databind.module.SimpleModule;
+
+import java.time.Instant;
+
+/**
+ * 사용자 시간대 처리를 위한 웹 설정.
+ * <ul>
+ *   <li>{@link UserTimeZoneInterceptor}를 모든 요청에 등록한다.</li>
+ *   <li>{@link Instant} 직렬화를 사용자 시간대 offset 포함 ISO로 커스터마이즈한다.</li>
+ * </ul>
+ * Spring Boot 4 / Jackson 3 기반. {@link JsonMapperBuilderCustomizer}로 기본 JsonMapper에
+ * Instant 직렬화 모듈을 추가해 표준 Instant 직렬화({@code ...Z})를 덮어쓴다.
+ */
+@Configuration
+public class UserTimeZoneWebConfig implements WebMvcConfigurer {
+
+    private final UserTimeZoneInterceptor userTimeZoneInterceptor;
+
+    public UserTimeZoneWebConfig(UserTimeZoneInterceptor userTimeZoneInterceptor) {
+        this.userTimeZoneInterceptor = userTimeZoneInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(userTimeZoneInterceptor);
+    }
+
+    @Bean
+    public JsonMapperBuilderCustomizer instantToUserZoneCustomizer() {
+        SimpleModule module = new SimpleModule("InstantToUserZoneModule");
+        module.addSerializer(Instant.class, new InstantToUserZoneSerializer());
+        return builder -> builder.addModule(module);
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/config/JpaAuditingConfig.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/config/JpaAuditingConfig.java
@@ -1,9 +1,23 @@
 package ds.project.orino.domain.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
+import java.time.Instant;
+import java.util.Optional;
+
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
 @Configuration
 public class JpaAuditingConfig {
+
+    /**
+     * 감사 시각을 UTC {@link Instant}로 제공한다.
+     * 기본 CurrentDateTimeProvider는 LocalDateTime을 반환해 Instant 필드와 맞지 않으므로 명시한다.
+     */
+    @Bean
+    public DateTimeProvider auditingDateTimeProvider() {
+        return () -> Optional.of(Instant.now());
+    }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/member/entity/Member.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/member/entity/Member.java
@@ -10,7 +10,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
@@ -28,11 +28,11 @@ public class Member {
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     protected Member() {
     }
@@ -54,11 +54,11 @@ public class Member {
         return password;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public Instant getCreatedAt() {
         return createdAt;
     }
 
-    public LocalDateTime getUpdatedAt() {
+    public Instant getUpdatedAt() {
         return updatedAt;
     }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/entity/Flashcard.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/entity/Flashcard.java
@@ -11,7 +11,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
@@ -36,11 +36,11 @@ public class Flashcard {
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     protected Flashcard() {
     }
@@ -80,11 +80,11 @@ public class Flashcard {
         return back;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public Instant getCreatedAt() {
         return createdAt;
     }
 
-    public LocalDateTime getUpdatedAt() {
+    public Instant getUpdatedAt() {
         return updatedAt;
     }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/entity/StudyMaterial.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/entity/StudyMaterial.java
@@ -12,7 +12,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
@@ -38,11 +38,11 @@ public class StudyMaterial {
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     protected StudyMaterial() {
     }
@@ -82,11 +82,11 @@ public class StudyMaterial {
         return status;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public Instant getCreatedAt() {
         return createdAt;
     }
 
-    public LocalDateTime getUpdatedAt() {
+    public Instant getUpdatedAt() {
         return updatedAt;
     }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -45,5 +45,5 @@ public interface StudyMaterialRepository extends JpaRepository<StudyMaterial, Lo
             """, nativeQuery = true)
     List<MaterialCountRow> countDueReviewsByMaterialIds(
             @Param("materialIds") Collection<Long> materialIds,
-            @Param("now") LocalDateTime now);
+            @Param("now") Instant now);
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/note/entity/Note.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/note/entity/Note.java
@@ -11,7 +11,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
@@ -45,11 +45,11 @@ public class Note {
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     protected Note() {
     }
@@ -119,11 +119,11 @@ public class Note {
         return content;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public Instant getCreatedAt() {
         return createdAt;
     }
 
-    public LocalDateTime getUpdatedAt() {
+    public Instant getUpdatedAt() {
         return updatedAt;
     }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewSchedule.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewSchedule.java
@@ -14,8 +14,9 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 @Entity
@@ -45,7 +46,7 @@ public class ReviewSchedule {
     private Integer sequence;
 
     @Column(name = "scheduled_at", nullable = false)
-    private LocalDateTime scheduledAt;
+    private Instant scheduledAt;
 
     @Column(name = "interval_days", nullable = false)
     private Integer intervalDays;
@@ -65,21 +66,21 @@ public class ReviewSchedule {
     private Integer elapsedDays;
 
     @Column(name = "completed_at")
-    private LocalDateTime completedAt;
+    private Instant completedAt;
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     protected ReviewSchedule() {
     }
 
     public ReviewSchedule(Long memberId, Long flashcardId, int sequence,
-                          LocalDateTime scheduledAt, int intervalDays, BigDecimal easeFactor) {
+                          Instant scheduledAt, int intervalDays, BigDecimal easeFactor) {
         this.memberId = memberId;
         this.flashcardId = flashcardId;
         this.sequence = sequence;
@@ -89,26 +90,35 @@ public class ReviewSchedule {
         this.status = ReviewStatus.PENDING;
     }
 
-    public static ReviewSchedule firstReview(Long memberId, Long flashcardId, LocalDate today) {
-        return new ReviewSchedule(memberId, flashcardId, 1,
-                today.plusDays(1).atTime(ROLLOVER_HOUR, 0), 1, INITIAL_EASE_FACTOR);
+    /**
+     * 첫 복습 일정을 생성한다. due 시각은 사용자 시간대 기준 익일 04:00(롤오버)을 UTC로 환산한 값이다.
+     */
+    public static ReviewSchedule firstReview(Long memberId, Long flashcardId, LocalDate today, ZoneId zone) {
+        Instant scheduledAt = today.plusDays(1).atTime(ROLLOVER_HOUR, 0).atZone(zone).toInstant();
+        return new ReviewSchedule(memberId, flashcardId, 1, scheduledAt, 1, INITIAL_EASE_FACTOR);
     }
 
     /**
-     * 다음 복습 due 시각을 계산한다.
-     * AGAIN(틀림)은 당일 {@value #RELEARN_MINUTES}분 뒤(분 단위), 그 외는 일 간격 뒤 날짜의 04:00(롤오버).
+     * 다음 복습 due 시각을 계산한다. 저장은 UTC({@link Instant})지만 "당일/익일 04:00 롤오버"는
+     * 사용자 시간대({@code zone}) 기준으로 계산한다.
+     * AGAIN(틀림)은 {@value #RELEARN_MINUTES}분 뒤(분 단위), 그 외는 사용자 로컬 날짜 기준 일 간격 뒤 04:00.
      */
-    public static LocalDateTime computeScheduledAt(Rating rating, int intervalDays, LocalDateTime now) {
+    public static Instant computeScheduledAt(Rating rating, int intervalDays, Instant now, ZoneId zone) {
         if (rating == Rating.AGAIN) {
-            return now.plusMinutes(RELEARN_MINUTES);
+            return now.plusSeconds(RELEARN_MINUTES * 60L);
         }
-        return now.toLocalDate().plusDays(intervalDays).atTime(ROLLOVER_HOUR, 0);
+        LocalDate dueDate = now.atZone(zone).toLocalDate().plusDays(intervalDays);
+        return dueDate.atTime(ROLLOVER_HOUR, 0).atZone(zone).toInstant();
     }
 
-    public void complete(Rating rating, LocalDateTime now) {
+    /**
+     * 복습을 완료 처리한다. 경과일(elapsedDays)은 사용자 시간대 기준 날짜 차이로 계산한다.
+     */
+    public void complete(Rating rating, Instant now, ZoneId zone) {
         this.status = ReviewStatus.COMPLETED;
         this.rating = rating;
-        this.elapsedDays = (int) ChronoUnit.DAYS.between(this.scheduledAt.toLocalDate(), now.toLocalDate());
+        this.elapsedDays = (int) ChronoUnit.DAYS.between(
+                this.scheduledAt.atZone(zone).toLocalDate(), now.atZone(zone).toLocalDate());
         this.completedAt = now;
     }
 
@@ -128,7 +138,7 @@ public class ReviewSchedule {
         return sequence;
     }
 
-    public LocalDateTime getScheduledAt() {
+    public Instant getScheduledAt() {
         return scheduledAt;
     }
 
@@ -152,15 +162,15 @@ public class ReviewSchedule {
         return elapsedDays;
     }
 
-    public LocalDateTime getCompletedAt() {
+    public Instant getCompletedAt() {
         return completedAt;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public Instant getCreatedAt() {
         return createdAt;
     }
 
-    public LocalDateTime getUpdatedAt() {
+    public Instant getUpdatedAt() {
         return updatedAt;
     }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
@@ -4,7 +4,7 @@ import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
 import ds.project.orino.domain.planner.review.entity.ReviewStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -17,8 +17,8 @@ public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, 
     Optional<ReviewSchedule> findByIdAndMemberId(Long id, Long memberId);
 
     List<ReviewSchedule> findAllByMemberIdAndStatusAndScheduledAtLessThanEqualOrderByScheduledAtAscIdAsc(
-            Long memberId, ReviewStatus status, LocalDateTime scheduledAt);
+            Long memberId, ReviewStatus status, Instant scheduledAt);
 
     List<ReviewSchedule> findAllByMemberIdAndScheduledAtBetweenOrderByScheduledAtAscIdAsc(
-            Long memberId, LocalDateTime from, LocalDateTime to);
+            Long memberId, Instant from, Instant to);
 }

--- a/fe/src/shared/api/client.ts
+++ b/fe/src/shared/api/client.ts
@@ -13,10 +13,17 @@ const client = axios.create({
   withCredentials: true,
 });
 
+// 사용자 브라우저의 IANA 시간대. 서버는 이 값으로 저장된 UTC 시각을
+// 사용자 로컬 기준(응답 변환 + 복습 4시 롤오버 계산)으로 처리한다.
+const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 client.interceptors.request.use((config) => {
   const token = getAccessToken();
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
+  }
+  if (userTimeZone) {
+    config.headers["X-Timezone"] = userTimeZone;
   }
   return config;
 });


### PR DESCRIPTION
closes #432

## Description

시간을 UTC로 저장하고, 응답·복습 스케줄 계산은 사용자 시간대 기준으로 처리하는 **하이브리드** 전략으로 전환한다. 사용자 시간대는 요청 `X-Timezone` 헤더(IANA)로 전달한다.

운영 DB에 시간 데이터가 거의 없어(`review_schedule` 0건 등) **데이터 마이그레이션 불필요**.

## 배경 (기존 문제)

- 엔티티가 `LocalDateTime`(타임존 정보 없음) 사용
- Jackson이 `"2026-06-07T04:00:00"`(타임존 없음)으로 직렬화
- FE `new Date()`가 브라우저 로컬로 해석 → 위치마다 다른 시점 → "한국 기준 아님"

## 전략

| 레이어 | 처리 |
|---|---|
| 저장/비교 | UTC `Instant` (`hibernate.jdbc.time_zone=UTC`) |
| 사용자 로컬 계산 | 요청 `X-Timezone` 기준 (복습 4시 롤오버, 날짜 경과) |
| 응답 | 사용자 TZ offset 포함 ISO (`2026-06-07T04:00:00+09:00`) |

## 변경 사항

### BE — 사용자 시간대 인프라 (core-web)
- `UserTimeZone`: 요청 단위 ThreadLocal 시간대 (기본 `Asia/Seoul`)
- `UserTimeZoneInterceptor`: `X-Timezone` 헤더 → 컨텍스트
- `InstantToUserZoneSerializer`: `Instant` → 사용자 TZ offset ISO (**Spring Boot 4 / Jackson 3 `tools.jackson` 기반**)
- `UserTimeZoneWebConfig`: 인터셉터 + `JsonMapperBuilderCustomizer` 등록

### BE — 저장 (UTC)
- 엔티티 5종(`Member`/`Flashcard`/`StudyMaterial`/`Note`/`ReviewSchedule`) `LocalDateTime` → `Instant`
- `JpaAuditingConfig`: `Instant` 기반 `DateTimeProvider`
- `ClockConfig`: `Clock.systemUTC()`
- `application-mysql.yml`: `hibernate.jdbc.time_zone=UTC` (prod/local/test)

### BE — 복습 스케줄 계산 (사용자 TZ)
- `computeScheduledAt`/`firstReview`/`complete`: `Instant` + `ZoneId`로 4시 롤오버·경과일 계산
- `ReviewQueryService`: today/캘린더 범위를 사용자 TZ 기준 `Instant`로 변환

### FE
- `client.ts`: 모든 요청에 `X-Timezone`(브라우저 IANA) 헤더 추가
- 응답이 offset ISO라 기존 표시 로직(`new Date()`, `slice(0,10)`)은 그대로 정확히 동작

## 검증

- BE `./gradlew build` 전체 통과 (TestContainers MySQL + checkstyle)
  - `ReviewSchedulingTest`: 롤오버가 사용자 TZ 04:00 = UTC 전날 19:00임을 명시 검증
  - 컨트롤러 통합 테스트: `X-Timezone: Asia/Seoul` 기본 헤더 + `atTestZone` 헬퍼로 일관 검증
- FE `npm test`(108) + lint + format:check 통과

## 회귀/운영 영향

- 응답 시간 형식이 **offset 포함 ISO**로 변경됨 (FE는 정확히 파싱, 외부 소비자 없음)
- 헤더 미전송 클라이언트는 기본 `Asia/Seoul`로 동작 (안전)
- DB 컬럼(DATETIME)은 유지, hibernate가 UTC로 읽고 씀 → 데이터 마이그레이션 불필요

## 향후

- 다른 사용자/디바이스가 추가되면 각자 브라우저 TZ로 자동 동작