### PR TITLE
fix : CORS allowHeaders에 X-Timezone 추가

### DIFF
--- a/infra/helm/istio-gateway/templates/virtualservice-be.yaml
+++ b/infra/helm/istio-gateway/templates/virtualservice-be.yaml
@@ -23,6 +23,7 @@ spec:
         allowHeaders:
           - Authorization
           - Content-Type
+          - X-Timezone
         allowCredentials: true
         maxAge: "86400s"
       timeout: 10s


### PR DESCRIPTION
refs #432

## Description

#435 배포 후 `api.orino.dev`의 모든 요청(로그인 포함)이 CORS 에러로 실패하는 문제를 긴급 수정한다.

## 증상

```
Access to XMLHttpRequest at 'https://api.orino.dev/api/auth/login' from origin
'https://orino.dev' has been blocked by CORS policy: Request header field
x-timezone is not allowed by Access-Control-Allow-Headers in preflight response
```

## 원인

- #435에서 FE가 모든 요청에 `X-Timezone` 헤더를 추가
- istio VirtualService(`virtualservice-be.yaml`)의 `corsPolicy.allowHeaders`에 `Authorization`, `Content-Type`만 등록되어 있어 preflight(OPTIONS)에서 `X-Timezone`이 거부됨
- 결과적으로 본 요청 자체가 차단

## 변경 사항

- `corsPolicy.allowHeaders`에 `X-Timezone` 추가

## 검증

- `helm template` 렌더링에 `X-Timezone` 포함 확인
- 배포 후 `api.orino.dev` 로그인/조회 정상 동작 확인 필요 (사용자)

## 영향

- istio VirtualService 변경만, ArgoCD sync 시 즉시 반영