### PR TITLE
fix : 노트 본문 heading이 일반 텍스트로 보이는 문제 (prose 스타일 누락)

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -38,6 +38,7 @@
       "devDependencies": {
         "@eslint/js": "^9.0.0",
         "@playwright/test": "^1.59.1",
+        "@tailwindcss/typography": "^0.5.19",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -2931,6 +2932,33 @@
       ],
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@tailwindcss/vite": {

--- a/fe/package.json
+++ b/fe/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "@playwright/test": "^1.59.1",
+    "@tailwindcss/typography": "^0.5.19",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -3,6 +3,9 @@
 @import "shadcn/tailwind.css";
 @import "pretendard/dist/web/variable/pretendardvariable.css";
 
+/* 노트 본문(.prose) heading/list/blockquote 스타일. 없으면 #430처럼 전부 일반 텍스트로 보인다. */
+@plugin "@tailwindcss/typography";
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {


### PR DESCRIPTION
closes #430

## Description

노트 본문에서 `## 제목`, 목록, 인용 등이 전부 일반 텍스트로만 보이던 문제를 해결한다.

## 진단 (핵심)

처음엔 "마크다운 입력이 변환 안 된다"로 의심했으나, Tiptap input rule을 실제 타이핑(`handleTextInput`)으로 재현 테스트한 결과 **`## ` → `<h2>` 변환은 정상 동작**했다.

진짜 원인은 **스타일 누락**이었다:
- NoteEditor는 `class="prose prose-sm dark:prose-invert ..."`로 본문을 스타일링
- 그러나 **`@tailwindcss/typography` 플러그인이 설치/등록되어 있지 않았음**
- 빌드된 CSS에 `.prose` 규칙이 **0개** → `prose` 클래스가 전부 무력화
- 결과적으로 `<h2>`가 `<p>`와 동일하게 렌더 → "텍스트로만 보임"

빌드 CSS 검증:
- before: `grep -c '\.prose' dist/assets/*.css` → `0`
- after: prose heading 규칙 생성 (`font-size:2.14286em` 등 + `--tw-prose-*` 토큰 + `prose-invert` 다크)

## 변경 사항

- `@tailwindcss/typography@0.5.19` devDependency 추가
- `index.css`에 `@plugin "@tailwindcss/typography"` 등록 (Tailwind v4 방식)

## 검증

- `npm run build` 후 `.prose`/heading/`prose-invert` 규칙 CSS 생성 확인
- `npm test`(108) + lint + format:check 통과
- 배포 후 노트 본문에서 heading/목록/인용 스타일 표시 확인 필요 (사용자)

## 참고

- 마크다운 자동 변환(input rule)은 원래 정상이었으므로 별도 코드 변경 불필요
- 슬래시 명령/추가 heading 레벨 등 에디터 UX 확장은 후속 과제로 분리 가능