### PR TITLE
feat : 노트 본문 표(table) 블록 추가 (Notion 스타일)

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -16,6 +16,7 @@
         "@tiptap/extension-drag-handle": "3.23.4",
         "@tiptap/extension-drag-handle-react": "3.23.4",
         "@tiptap/extension-placeholder": "^3.23.4",
+        "@tiptap/extension-table": "^3.23.4",
         "@tiptap/extension-task-item": "^3.23.4",
         "@tiptap/extension-task-list": "^3.23.4",
         "@tiptap/pm": "^3.23.4",
@@ -3472,6 +3473,20 @@
       },
       "peerDependencies": {
         "@tiptap/core": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-table": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.23.4.tgz",
+      "integrity": "sha512-TRh6JMTRYXCWpwavGt3aAHH2f51ZzkhurfW3XvrURG3It8MvfuuY1xB1xba1ss5c0QLWlrKx6GVaSXrUCdFLlg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-task-item": {

--- a/fe/package.json
+++ b/fe/package.json
@@ -24,6 +24,7 @@
     "@tiptap/extension-drag-handle": "3.23.4",
     "@tiptap/extension-drag-handle-react": "3.23.4",
     "@tiptap/extension-placeholder": "^3.23.4",
+    "@tiptap/extension-table": "^3.23.4",
     "@tiptap/extension-task-item": "^3.23.4",
     "@tiptap/extension-task-list": "^3.23.4",
     "@tiptap/pm": "^3.23.4",

--- a/fe/src/features/note/components/EditorToolbar.tsx
+++ b/fe/src/features/note/components/EditorToolbar.tsx
@@ -1,8 +1,9 @@
-import type { Editor } from "@tiptap/react";
+import { type Editor, useEditorState } from "@tiptap/react";
 import {
   Bold,
   Code,
   Code2,
+  Columns3,
   FilePlus,
   Heading1,
   Heading2,
@@ -10,6 +11,9 @@ import {
   List,
   ListOrdered,
   Quote,
+  Rows3,
+  Table,
+  Trash2,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -33,6 +37,12 @@ export function EditorToolbar({
   onInsertPage,
   insertPagePending,
 }: Props) {
+  // selection 변화(표 진입/이탈, 마크 토글 등)에 toolbar가 리렌더되도록 구독한다.
+  const isInTable = useEditorState({
+    editor,
+    selector: ({ editor }) => editor?.isActive("table") ?? false,
+  });
+
   if (!editor) return null;
 
   const buttons: ToolbarButton[] = [
@@ -90,6 +100,17 @@ export function EditorToolbar({
       isActive: () => editor.isActive("codeBlock"),
       onClick: () => editor.chain().focus().toggleCodeBlock().run(),
     },
+    {
+      label: "표 삽입",
+      icon: Table,
+      isActive: () => editor.isActive("table"),
+      onClick: () =>
+        editor
+          .chain()
+          .focus()
+          .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+          .run(),
+    },
   ];
 
   return (
@@ -129,6 +150,69 @@ export function EditorToolbar({
             <FilePlus className="size-4" /> 페이지
           </Button>
         </>
+      )}
+
+      {isInTable && (
+        <div
+          role="group"
+          aria-label="표 편집"
+          className="flex w-full flex-wrap items-center gap-0.5 pt-1"
+        >
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label="열 추가"
+            onClick={() => editor.chain().focus().addColumnAfter().run()}
+          >
+            <Columns3 className="size-4" /> 열+
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label="열 삭제"
+            onClick={() => editor.chain().focus().deleteColumn().run()}
+          >
+            <Columns3 className="size-4" /> 열−
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label="행 추가"
+            onClick={() => editor.chain().focus().addRowAfter().run()}
+          >
+            <Rows3 className="size-4" /> 행+
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label="행 삭제"
+            onClick={() => editor.chain().focus().deleteRow().run()}
+          >
+            <Rows3 className="size-4" /> 행−
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label="헤더 행 전환"
+            onClick={() => editor.chain().focus().toggleHeaderRow().run()}
+          >
+            <Table className="size-4" /> 헤더
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label="표 삭제"
+            onClick={() => editor.chain().focus().deleteTable().run()}
+          >
+            <Trash2 className="size-4" /> 표 삭제
+          </Button>
+        </div>
       )}
     </div>
   );

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -1,6 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { DragHandle } from "@tiptap/extension-drag-handle-react";
 import Placeholder from "@tiptap/extension-placeholder";
+import { TableKit } from "@tiptap/extension-table";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
 import { EditorContent, type JSONContent, useEditor } from "@tiptap/react";
@@ -56,6 +57,7 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
         StarterKit,
         TaskList,
         TaskItem.configure({ nested: true }),
+        TableKit.configure({ table: { resizable: true } }),
         Placeholder.configure({
           placeholder: "내용을 입력하거나 페이지를 추가하세요...",
         }),

--- a/fe/src/features/note/components/NoteTab.test.tsx
+++ b/fe/src/features/note/components/NoteTab.test.tsx
@@ -300,6 +300,68 @@ describe("NoteTab", () => {
     await waitFor(() => expect(deletedId).toBe(1));
   });
 
+  it("툴바 [표 삽입] 클릭 시 표가 본문에 삽입되고 표 편집 컨트롤이 나타난다", async () => {
+    mockTree([
+      { id: 1, title: "노트", parentId: null, sortOrder: 0, children: [] },
+    ]);
+    mockNoteDetail(1, { type: "doc", content: [] }, "노트");
+
+    const user = userEvent.setup();
+    const { container } = renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("노트");
+    });
+
+    // 표 삽입 전에는 표가 없다
+    expect(container.querySelector("table")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "표 삽입" }));
+
+    // 표가 렌더되고 (헤더행 포함 3x3)
+    await waitFor(() => {
+      expect(container.querySelector("table")).not.toBeNull();
+    });
+    expect(container.querySelectorAll("table th")).toHaveLength(3);
+
+    // 커서가 표 안에 있으므로 표 편집 컨트롤이 노출된다
+    expect(screen.getByRole("button", { name: "열 추가" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "행 추가" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "표 삭제" })).toBeInTheDocument();
+  });
+
+  it("표 삽입 후 [행 추가]로 행이 늘고 [표 삭제]로 표가 제거된다", async () => {
+    mockTree([
+      { id: 1, title: "노트", parentId: null, sortOrder: 0, children: [] },
+    ]);
+    mockNoteDetail(1, { type: "doc", content: [] }, "노트");
+
+    const user = userEvent.setup();
+    const { container } = renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("노트");
+    });
+
+    await user.click(screen.getByRole("button", { name: "표 삽입" }));
+    await waitFor(() => {
+      expect(container.querySelector("table")).not.toBeNull();
+    });
+    const rowsBefore = container.querySelectorAll("table tr").length;
+
+    await user.click(screen.getByRole("button", { name: "행 추가" }));
+    await waitFor(() => {
+      expect(container.querySelectorAll("table tr").length).toBe(
+        rowsBefore + 1,
+      );
+    });
+
+    await user.click(screen.getByRole("button", { name: "표 삭제" }));
+    await waitFor(() => {
+      expect(container.querySelector("table")).toBeNull();
+    });
+  });
+
   it("자손이 있는 노트 삭제 시 확인 문구에 하위 개수를 표시한다", async () => {
     mockTree([
       {

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -141,3 +141,36 @@
     @apply font-sans antialiased;
   }
 }
+
+/* 노트 에디터 표 스타일 (#431). prose 기본 표 스타일에 더해
+   셀 경계선·헤더 배경·셀 선택·열 리사이즈 핸들을 명시한다. */
+.tiptap .tableWrapper {
+  @apply my-2 overflow-x-auto;
+}
+
+.tiptap table {
+  @apply w-full table-fixed border-collapse;
+}
+
+.tiptap table td,
+.tiptap table th {
+  @apply border-border relative min-w-24 border px-2 py-1 align-top;
+}
+
+.tiptap table th {
+  @apply bg-muted text-left font-semibold;
+}
+
+/* 셀 드래그 선택 영역 */
+.tiptap table .selectedCell::after {
+  @apply bg-primary/15 pointer-events-none absolute inset-0 z-10 content-[''];
+}
+
+/* 열 너비 리사이즈 핸들 */
+.tiptap table .column-resize-handle {
+  @apply bg-primary pointer-events-none absolute top-0 -right-px bottom-[-2px] w-1;
+}
+
+.tiptap.resize-cursor {
+  cursor: col-resize;
+}


### PR DESCRIPTION
closes #431

## Description

노트 본문에 Notion처럼 행/열을 추가·삭제·편집할 수 있는 표 블록을 추가한다.

## 변경 사항

### 표 확장 (Tiptap v3 TableKit)
- `@tiptap/extension-table@3.23.4` 도입 (v3는 Table/Row/Cell/Header를 `TableKit` 단일 패키지로 통합)
- `NoteEditor`에 `TableKit.configure({ table: { resizable: true } })` 등록 → 열 너비 드래그 리사이즈 지원

### 툴바
- `[표 삽입]` 버튼: 3x3 + 헤더행 표 삽입
- **표 안에 커서가 있을 때만** 표 편집 컨트롤 노출:
  - 열 추가/삭제, 행 추가/삭제, 헤더 행 전환, 표 삭제
- `useEditorState`로 selection 변화를 구독해 표 진입/이탈 시 toolbar가 정확히 리렌더되도록 함 (이게 없으면 `isActive("table")`가 stale이라 컨트롤이 안 뜸)

### 스타일 (index.css)
- 셀 경계선, 헤더 배경(`bg-muted`), 셀 드래그 선택 영역, 열 리사이즈 핸들, 가로 스크롤 래퍼
- #437에서 도입한 `prose` 기본 표 스타일에 더해 편집에 필요한 시각 요소 보강

## 검증

- `npm test`(110, +2 표 통합 테스트) 통과
  - 표 삽입 → `<table>` 렌더 + 헤더셀 3개 + 편집 컨트롤 노출
  - 행 추가 → tr 증가, 표 삭제 → `<table>` 제거
- `npm run build`(typecheck) + lint + format:check 통과
- 배포 후 실제 표 삽입/리사이즈/행열 편집 확인 필요 (사용자)

## 참고

- 저장은 Tiptap JSON 그대로(BE는 content를 JSON으로 저장)라 BE 변경 불필요
- 후속: 셀 정렬/배경색 등 셀 단위 꾸미기는 별도 과제로 분리 가능