### PR TITLE
feat : BE graceful shutdown + startupProbe 보강

### DIFF
--- a/be/orino-app-api/src/main/resources/application.yml
+++ b/be/orino-app-api/src/main/resources/application.yml
@@ -6,6 +6,12 @@ spring:
       - mysql
       - actuator
       - redis
+  # 종료 시 처리 중인 요청을 끝까지 마친 뒤 종료 (기본 IMMEDIATE → graceful)
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
+
+server:
+  shutdown: graceful
 
 jwt:
   secret: ${JWT_SECRET:default-dev-secret-key-must-be-at-least-256-bits-long-for-hs256}

--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -98,19 +98,28 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           lifecycle:
             preStop:
+              # endpoint deregister가 전파되어 새 트래픽이 끊길 때까지 대기한 뒤
+              # SIGTERM이 전달되어 Spring graceful shutdown이 시작된다.
               exec:
-                command: ["sh", "-c", "sleep 5"]
+                command: ["sh", "-c", "sleep 20"]
+          # 기동 완료(Liquibase 마이그레이션 포함)까지 대기. 통과 전에는
+          # liveness/readiness를 평가하지 않아 느린 기동에도 강제 재시작되지 않는다.
+          # 최대 10s * 30 = 300s 허용.
+          startupProbe:
+            httpGet:
+              path: /health/readiness
+              port: 9090
+            periodSeconds: 10
+            failureThreshold: 30
           readinessProbe:
             httpGet:
               path: /health/readiness
               port: 9090
-            initialDelaySeconds: 30
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /health/liveness
               port: 9090
-            initialDelaySeconds: 60
             periodSeconds: 30
       volumes:
         - name: tmp


### PR DESCRIPTION
closes #433

## Description

liveness/readiness 처리를 철저히 하기 위해 graceful shutdown과 startupProbe를 보강한다.

## 현황 (이미 양호한 부분)

- ✅ Actuator probe 분리: `/health/liveness`, `/health/readiness` (port 9090)
- ✅ readiness 그룹에 `readinessState, db, redis` 포함 → **MySQL/Redis 실패 시 readiness DOWN**이 이미 동작
- ✅ initContainer로 mysql/redis 기동 대기, `terminationGracePeriodSeconds: 60`

→ "DB/redis 실패 시 readiness fail"은 이미 구현되어 있어 추가 작업 없음.

## 변경 사항

### BE (`application.yml`)
- `server.shutdown: graceful` — 종료 시 in-flight 요청을 마친 뒤 종료 (기본 IMMEDIATE)
- `spring.lifecycle.timeout-per-shutdown-phase: 30s`

### Infra (`be/templates/deployment.yaml`)
- preStop `sleep 5` → `sleep 20`
  - endpoint deregister가 전파되어 새 트래픽이 끊긴 뒤 SIGTERM → graceful shutdown 시작
  - 타임라인: preStop 20s + graceful 30s < terminationGracePeriodSeconds 60s (여유 확보)
- `startupProbe` 추가 (`/health/readiness`, 10s * 30 = 최대 300s)
  - 기동 완료(Liquibase 마이그레이션 포함) 전까지 liveness/readiness 미평가
  - 느린 기동에도 liveness가 강제 재시작시키지 않음
- readiness/liveness의 고정 `initialDelaySeconds` 제거 (startupProbe가 기동 게이트 역할 대체)

## 종료 타임라인

```
Pod 종료 시작
 ├─ preStop: sleep 20s        (endpoint deregister 전파, 새 트래픽 차단)
 ├─ SIGTERM → Spring graceful (in-flight 요청 최대 30s 처리)
 └─ terminationGracePeriod 60s (위 둘의 상한, 여유)
```

## 검증

- `./gradlew :orino-app-api:test --tests *ActuatorSecurityTest` 통과 (graceful 설정으로 컨텍스트 정상 로딩)
- `helm template` 렌더링 정상 (startupProbe/preStop/probe)
- 배포 후 확인 필요 (사용자):
  - 롤링 업데이트 중 in-flight 요청 무중단
  - pod 종료 시 graceful drain 로그
  - MySQL/Redis 차단 시 readiness 503 → 트래픽 제외 (회귀)

## 회귀 영향

- BE 설정 추가 + K8s probe 보강만, 애플리케이션 로직 변화 없음