### PR TITLE
fix : 노트 표 가로 스크롤 + 제목 행 선택화

### DIFF
--- a/fe/src/features/note/components/EditorToolbar.tsx
+++ b/fe/src/features/note/components/EditorToolbar.tsx
@@ -104,11 +104,12 @@ export function EditorToolbar({
       label: "표 삽입",
       icon: Table,
       isActive: () => editor.isActive("table"),
+      // 제목 행은 강제하지 않는다. 필요하면 표 편집의 [헤더] 버튼으로 켠다.
       onClick: () =>
         editor
           .chain()
           .focus()
-          .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+          .insertTable({ rows: 3, cols: 3, withHeaderRow: false })
           .run(),
     },
   ];

--- a/fe/src/features/note/components/NoteTab.test.tsx
+++ b/fe/src/features/note/components/NoteTab.test.tsx
@@ -318,16 +318,44 @@ describe("NoteTab", () => {
 
     await user.click(screen.getByRole("button", { name: "표 삽입" }));
 
-    // 표가 렌더되고 (헤더행 포함 3x3)
+    // 표가 렌더되고 (헤더행 없이 3x3 = td 9개), 제목 행은 기본값이 아니다
     await waitFor(() => {
       expect(container.querySelector("table")).not.toBeNull();
     });
-    expect(container.querySelectorAll("table th")).toHaveLength(3);
+    expect(container.querySelectorAll("table td")).toHaveLength(9);
+    expect(container.querySelectorAll("table th")).toHaveLength(0);
 
     // 커서가 표 안에 있으므로 표 편집 컨트롤이 노출된다
     expect(screen.getByRole("button", { name: "열 추가" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "행 추가" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "표 삭제" })).toBeInTheDocument();
+  });
+
+  it("표 삽입 후 [헤더] 버튼으로 제목 행을 선택적으로 켤 수 있다", async () => {
+    mockTree([
+      { id: 1, title: "노트", parentId: null, sortOrder: 0, children: [] },
+    ]);
+    mockNoteDetail(1, { type: "doc", content: [] }, "노트");
+
+    const user = userEvent.setup();
+    const { container } = renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("노트");
+    });
+
+    await user.click(screen.getByRole("button", { name: "표 삽입" }));
+    await waitFor(() => {
+      expect(container.querySelector("table")).not.toBeNull();
+    });
+    // 기본은 헤더 없음
+    expect(container.querySelectorAll("table th")).toHaveLength(0);
+
+    // 헤더 전환 → 첫 행이 헤더(th)가 된다
+    await user.click(screen.getByRole("button", { name: "헤더 행 전환" }));
+    await waitFor(() => {
+      expect(container.querySelectorAll("table th")).toHaveLength(3);
+    });
   });
 
   it("표 삽입 후 [행 추가]로 행이 늘고 [표 삭제]로 표가 제거된다", async () => {

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -145,11 +145,18 @@
 /* 노트 에디터 표 스타일 (#431). prose 기본 표 스타일에 더해
    셀 경계선·헤더 배경·셀 선택·열 리사이즈 핸들을 명시한다. */
 .tiptap .tableWrapper {
+  /* 표만 가로 스크롤되도록 (Notion처럼 표가 부모를 넘으면 표 영역만 스크롤). */
   @apply my-2 overflow-x-auto;
 }
 
+/* Tiptap resizable 표는 colgroup의 <col> width로 열 너비를 관리한다.
+   table-fixed는 그 너비를 존중하되, w-full(width:100%)은 빼서 표가 부모에
+   강제로 맞춰지지 않고 내용(열 너비 합)만큼만 넓어지게 한다.
+   width:max-content로 prose의 width:100% 기본값을 덮는다. */
 .tiptap table {
-  @apply w-full table-fixed border-collapse;
+  @apply m-0 table-fixed border-collapse;
+  width: max-content;
+  max-width: none;
 }
 
 .tiptap table td,


### PR DESCRIPTION
refs #431

## Description

#438로 추가한 노트 표의 두 가지 UX 문제를 수정한다.

## 문제 1: 표가 화면 전체로 늘어나고 드래그가 번짐

**증상**: 열을 추가하면 표가 부모(화면) 너비에 강제로 맞춰지며 셀이 찌그러지고, 셀 선택 드래그가 표 밖 전체로 번짐. 표 라인을 건드리면 다시 화면 안으로 들어옴.

**원인**: `.tiptap table`에 `w-full`(= `width:100%`) + `table-fixed`가 걸려 표가 항상 부모 100%를 차지. 열 너비 합이 부모를 넘으면 레이아웃이 튐.

**수정**: `w-full` 제거 → `width: max-content`. 표는 열 너비 합(colgroup `<col>` width)만큼만 넓어지고, 부모를 넘으면 `tableWrapper`의 `overflow-x-auto`가 **표 영역만 가로 스크롤** (Notion 방식).
- prose의 `:where(table){width:100%}`는 `.tiptap table`(specificity 우위)로 덮음
- `table-layout: fixed`는 유지 (Tiptap resizable이 colgroup width로 열 너비를 관리)

## 문제 2: 제목 행이 기본 강제

**수정**: `insertTable({ withHeaderRow: false })`로 변경. 제목 행은 기본값이 아니며, 표 편집의 `[헤더]` 버튼으로 선택적으로 켤 수 있다.

## 검증

- `npm test`(12, 헤더 토글 케이스 추가) 통과
  - 표 삽입 → td 9 / th 0 (헤더 없음 확인)
  - `[헤더 행 전환]` → th 3 (첫 행 헤더화)
- `npm run build`(생성 CSS에 `width:max-content;table-layout:fixed` 확인) + lint + format 통과
- 배포 후 실제 가로 스크롤/리사이즈 동작 확인 필요 (사용자)

## 참고

- 시각 동작은 CSS specificity·생성 결과로 검증. 풀스택 미기동이라 브라우저 스크린샷은 배포 후 확인 권장