### PR TITLE
fix : 표가 페이지 전체를 넓히던 문제 (flex min-width 누락)

### DIFF
--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -137,7 +137,10 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
   };
 
   return (
-    <div className="flex flex-col gap-3">
+    // min-w-0: 부모(md:flex-row) flex 자식의 기본 min-width:auto 때문에
+    // 넓은 표가 들어오면 에디터가 부모를 넘어 페이지 전체가 늘어난다.
+    // min-w-0으로 콘텐츠가 부모 너비를 못 넘게 하고, 표는 tableWrapper에서만 스크롤.
+    <div className="flex min-w-0 flex-col gap-3">
       <div className="flex items-center gap-3">
         <Input
           value={title}

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -145,8 +145,10 @@
 /* 노트 에디터 표 스타일 (#431). prose 기본 표 스타일에 더해
    셀 경계선·헤더 배경·셀 선택·열 리사이즈 핸들을 명시한다. */
 .tiptap .tableWrapper {
-  /* 표만 가로 스크롤되도록 (Notion처럼 표가 부모를 넘으면 표 영역만 스크롤). */
-  @apply my-2 overflow-x-auto;
+  /* 표만 가로 스크롤되도록 (Notion처럼 표가 부모를 넘으면 표 영역만 스크롤).
+     max-width:100% + min-width:0이 없으면 wrapper가 자식 표(max-content) 너비만큼
+     늘어나 페이지 전체가 가로로 넓어진다. 부모 너비로 제약해 wrapper 안에서만 스크롤. */
+  @apply my-2 max-w-full min-w-0 overflow-x-auto;
 }
 
 /* Tiptap resizable 표는 colgroup의 <col> width로 열 너비를 관리한다.


### PR DESCRIPTION
refs #431

## Description

#440 머지 후에도 "표만 좌우 스크롤되지 않고 페이지 전체가 좌우로 늘어나는" 문제가 남아 있어 추가 수정한다.

## 원인

`#440`에서 `.tiptap table`을 `width:max-content`로 바꾸고 `.tableWrapper`에 `overflow-x-auto`를 줬지만, 그 위 **flex 컨테이너 체인의 `min-width` 누락** 때문에 넓은 표가 에디터를 부모 밖으로 밀어냈다.

- flex 자식은 기본 `min-width: auto` → 콘텐츠(넓은 표)만큼 늘어나려 함
- `NoteTab`의 에디터 칸은 이미 `min-w-0 flex-1`이었지만, 그 **안쪽 `NoteEditor` 최상위 `flex flex-col`에 `min-w-0`이 없어** 거기서 콘텐츠가 넘쳐 페이지 전체가 늘어났다

실제 Tiptap v3 DOM 구조 확인: `.tableWrapper > table[style="min-width"][width:max-content]` (colgroup으로 열 너비 관리).

## 변경 사항

- `NoteEditor` 최상위 `flex flex-col`에 `min-w-0` 추가 → 콘텐츠가 부모 너비를 못 넘게
- `.tableWrapper`에 `max-w-full min-w-0` 추가 → 표가 넘쳐도 wrapper 안에서만 가로 스크롤

이제 flex 자식 체인 전체(`NoteTab min-w-0 flex-1` → `NoteEditor min-w-0` → `.tableWrapper max-w-full overflow-x-auto`)가 갖춰져 표만 스크롤된다.

## 검증

- build + lint + format + test 통과
- 생성 CSS: `.tableWrapper{max-width:100%;min-width:0;overflow-x:auto}` 확인
- 배포 후 실제로 표만 좌우 스크롤되는지 확인 필요 (사용자)