### PR TITLE
fix : 표 삽입 시 페이지 전체가 좌우로 늘어나는 문제 (main min-width)

### DIFF
--- a/fe/src/app/layout/AppLayout.tsx
+++ b/fe/src/app/layout/AppLayout.tsx
@@ -68,7 +68,7 @@ export function AppLayout() {
           open={mobileMenuOpen}
           onClose={() => setMobileMenuOpen(false)}
         />
-        <main className="flex-1 p-6">
+        <main className="min-w-0 flex-1 p-6">
           <Outlet />
         </main>
       </div>


### PR DESCRIPTION
refs #431

## Description

노트에 넓은 표를 넣으면 "표만 좌우 스크롤"되지 않고 **페이지 전체가 좌우로 늘어나** 화면 전체를 드래그해야 하던 문제를 해결한다.

## 근본 원인 (실제 브라우저로 추적)

prod에 직접 로그인해 표를 삽입하고 DOM을 측정한 결과:
- `.tableWrapper`는 `overflow-x-auto`로 정상 (자기 안에선 스크롤 가능)
- 하지만 부모 체인을 타고 올라가면 **`AppLayout`의 `<main className="flex-1 p-6">`**이 표 너비만큼 늘어남
- `<main>`은 flex 자식인데 `min-width: auto`(기본값)라 콘텐츠(넓은 표)를 밀어내지 못하고 같이 늘어남 → `documentElement.scrollWidth > viewport` → 페이지 전체 가로 스크롤

`#431`/#440/#441에서 `NoteEditor`와 `.tableWrapper`에 `min-w-0`을 넣었지만, **그 바깥 공통 레이아웃의 `<main>`을 놓친 것**이 진짜 원인이었다.

## 변경 사항

```diff
- <main className="flex-1 p-6">
+ <main className="min-w-0 flex-1 p-6">
```

## 검증 (실제 측정)

| | 수정 전 | 수정 후 |
|---|---|---|
| pageOverflows | **true** (docScrollW 1443 > vw 1280) | **false** |
| main width | 콘텐츠만큼 늘어남(1219) | 부모에 맞음(760) |
| tableWrapper | overflow-x:auto (무력) | overflow-x:auto + **scrollWorks: true** |

- prod에서 표 삽입 + 열 추가로 재현 → 수정(probe, AppLayout 구조 모사) 후 표만 스크롤 확인
- lint + format + AppLayout 테스트 통과

## 회고

`#431` 표 기능부터 가로 스크롤 수정(#440, #441)까지 NoteEditor 안쪽만 봤는데, 페이지를 넓힌 건 **공통 레이아웃의 main**이었다. CSS 추측 대신 실제 브라우저로 부모 체인을 측정해 단번에 범인을 특정했다.