### PR TITLE
perf : FE 코드 스플리팅 + 노트 블록 간격 축소 + 하위페이지 드래그

### DIFF
--- a/fe/src/app/providers.tsx
+++ b/fe/src/app/providers.tsx
@@ -62,7 +62,16 @@ export function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(
     () =>
       new QueryClient({
-        defaultOptions: { queries: { retry: false } },
+        defaultOptions: {
+          queries: {
+            retry: false,
+            // 탭/페이지 왕복 시 즉시 재요청하지 않도록 기본 staleTime을 둔다.
+            // (개별 훅에서 staleTime: Infinity 등으로 덮어쓸 수 있음)
+            staleTime: 60 * 1000,
+            gcTime: 10 * 60 * 1000,
+            refetchOnWindowFocus: false,
+          },
+        },
       }),
   );
   return (

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -1,15 +1,41 @@
+import { lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 
 import { PrivateRoute } from "../features/auth/components/PrivateRoute";
 import { PublicRoute } from "../features/auth/components/PublicRoute";
-import { HomePage } from "../pages/HomePage";
 import { LandingPage } from "../pages/LandingPage";
 import { LoginPage } from "../pages/LoginPage";
-import { MaterialDetailPage } from "../pages/planner/MaterialDetailPage";
-import { MaterialListPage } from "../pages/planner/MaterialListPage";
-import { ReviewCalendarPage } from "../pages/planner/ReviewCalendarPage";
-import { TodayReviewsPage } from "../pages/planner/TodayReviewsPage";
 import { AppLayout } from "./layout/AppLayout";
+
+// 로그인 후에만 쓰는 페이지들은 lazy 로드해 초기 번들에서 분리한다.
+// (특히 Tiptap 에디터가 무거운 MaterialDetailPage)
+const HomePage = lazy(() =>
+  import("../pages/HomePage").then((m) => ({ default: m.HomePage })),
+);
+const MaterialListPage = lazy(() =>
+  import("../pages/planner/MaterialListPage").then((m) => ({
+    default: m.MaterialListPage,
+  })),
+);
+const MaterialDetailPage = lazy(() =>
+  import("../pages/planner/MaterialDetailPage").then((m) => ({
+    default: m.MaterialDetailPage,
+  })),
+);
+const TodayReviewsPage = lazy(() =>
+  import("../pages/planner/TodayReviewsPage").then((m) => ({
+    default: m.TodayReviewsPage,
+  })),
+);
+const ReviewCalendarPage = lazy(() =>
+  import("../pages/planner/ReviewCalendarPage").then((m) => ({
+    default: m.ReviewCalendarPage,
+  })),
+);
+
+function RouteFallback() {
+  return <div className="text-muted-foreground p-6 text-sm">불러오는 중…</div>;
+}
 
 export function AppRouter() {
   return (
@@ -20,14 +46,46 @@ export function AppRouter() {
       </Route>
       <Route element={<PrivateRoute />}>
         <Route element={<AppLayout />}>
-          <Route path="/home" element={<HomePage />} />
-          <Route path="/planner/materials" element={<MaterialListPage />} />
+          <Route
+            path="/home"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <HomePage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/planner/materials"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <MaterialListPage />
+              </Suspense>
+            }
+          />
           <Route
             path="/planner/materials/:id"
-            element={<MaterialDetailPage />}
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <MaterialDetailPage />
+              </Suspense>
+            }
           />
-          <Route path="/planner/reviews/today" element={<TodayReviewsPage />} />
-          <Route path="/planner/calendar" element={<ReviewCalendarPage />} />
+          <Route
+            path="/planner/reviews/today"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <TodayReviewsPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/planner/calendar"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <ReviewCalendarPage />
+              </Suspense>
+            }
+          />
         </Route>
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/fe/src/features/note/editor/childPage.test.ts
+++ b/fe/src/features/note/editor/childPage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { collectChildPageIds } from "./childPage";
+import { ChildPage, collectChildPageIds } from "./childPage";
 
 describe("collectChildPageIds", () => {
   it("중첩 doc에서 모든 childPage noteId를 수집한다", () => {
@@ -41,5 +41,12 @@ describe("collectChildPageIds", () => {
       content: [{ type: "childPage", attrs: { title: "noid" } }],
     };
     expect(collectChildPageIds(doc).size).toBe(0);
+  });
+});
+
+describe("ChildPage 노드 스펙", () => {
+  it("드래그로 순서 이동이 가능하도록 draggable=true 이다", () => {
+    // DragHandle이 블록을 드래그하려면 노드가 draggable이어야 한다.
+    expect(ChildPage.config.draggable).toBe(true);
   });
 });

--- a/fe/src/features/note/editor/childPage.ts
+++ b/fe/src/features/note/editor/childPage.ts
@@ -33,7 +33,7 @@ export const ChildPage = Node.create<ChildPageOptions>({
   group: "block",
   atom: true,
   selectable: true,
-  draggable: false,
+  draggable: true,
 
   addOptions() {
     return {

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -142,6 +142,42 @@
   }
 }
 
+/* 노트 본문 블록 간격을 Notion 수준으로 축소.
+   prose 기본 margin(문단 1.14em, heading 위 1.6em 등)이 너무 넓어 적용.
+   .tiptap 자식 셀렉터가 prose의 :where() specificity를 이긴다.
+   첫 블록의 위 여백은 제거해 상단 정렬. */
+.tiptap > :first-child {
+  margin-top: 0;
+}
+
+.tiptap p,
+.tiptap ul,
+.tiptap ol,
+.tiptap blockquote,
+.tiptap pre {
+  margin-top: 0.15em;
+  margin-bottom: 0.15em;
+}
+
+.tiptap h1,
+.tiptap h2,
+.tiptap h3,
+.tiptap h4 {
+  margin-top: 0.8em;
+  margin-bottom: 0.2em;
+  line-height: 1.3;
+}
+
+.tiptap li {
+  margin-top: 0.1em;
+  margin-bottom: 0.1em;
+}
+
+.tiptap li > p {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
 /* 노트 에디터 표 스타일 (#431). prose 기본 표 스타일에 더해
    셀 경계선·헤더 배경·셀 선택·열 리사이즈 핸들을 명시한다. */
 .tiptap .tableWrapper {

--- a/fe/vite.config.ts
+++ b/fe/vite.config.ts
@@ -32,6 +32,26 @@ export default defineConfig(() => {
       // Grafana 에러 화면에서 unminified stack을 보여준다.
       // 소스는 이미 공개 저장소이므로 .map 공개 노출 무관.
       sourcemap: true,
+      rollupOptions: {
+        output: {
+          // 무거운 의존성을 별도 청크로 분리해 초기 로딩/캐시 효율을 높인다.
+          // 경로 기준이라 @tiptap/pm처럼 entry 없는 서브패키지도 안전하게 묶인다.
+          manualChunks(id) {
+            if (!id.includes("node_modules")) return undefined;
+            if (/[\\/]node_modules[\\/]@tiptap[\\/]/.test(id)) return "tiptap";
+            if (/[\\/]node_modules[\\/]prosemirror-/.test(id)) return "tiptap";
+            if (/[\\/]node_modules[\\/]@grafana[\\/]/.test(id)) return "faro";
+            if (
+              /[\\/]node_modules[\\/](react|react-dom|react-router|react-router-dom)[\\/]/.test(
+                id,
+              )
+            ) {
+              return "react";
+            }
+            return undefined;
+          },
+        },
+      },
     },
     server: {
       host: "0.0.0.0",


### PR DESCRIPTION
## Description

사용자 요청 3건을 한 PR로 처리한다 (FE만, 독립적).
1. "뭔가 느림 → optimize" — 코드 스플리팅 + 캐시
2. "탭(블록) 간격 너무 넓음 → Notion 기준 축소"
3. "탭(하위 페이지)이 한 블록으로 묶여 이동 안 됨" → 드래그 가능하게

## 변경 사항

### 성능
- **라우트 lazy loading**: 플래너 페이지(Home/MaterialList/MaterialDetail/TodayReviews/ReviewCalendar)를 `React.lazy` + `Suspense`로 분리. 인증 페이지(Landing/Login)는 정적 유지.
- **vite manualChunks**(경로 기준): `tiptap` / `react` / `faro` 청크 분리
- **QueryClient 기본값**: `staleTime 60s` + `gcTime 10m` + `refetchOnWindowFocus: false`

번들 변화:
| | Before | After |
|---|---|---|
| 초기 진입 | 단일 1,152 kB | index 140kB + react 230kB (tiptap 미로드) |
| Tiptap | 항상 포함 | `tiptap` 569kB 청크 — 노트 페이지 진입 시에만 |
| 각 페이지 | 한 청크 | 페이지별 청크(MaterialDetail 78kB 등) |

→ 랜딩/로그인/홈 진입 시 무거운 에디터 코드를 받지 않아 초기 로딩 개선.

### 노트 블록 간격 (Notion 기준)
- `index.css`에 `.tiptap` 블록 margin 축소: 문단/목록 `0.15em`, heading 위 `0.8em`, 리스트 항목 `0.1em`. prose의 넓은 기본 margin(문단 1.14em 등)을 `.tiptap` specificity로 덮음.

### 하위 페이지 드래그
- `childPage.ts` `draggable: false → true` → DragHandle(grip)로 순서 이동 가능
- draggable 검증 테스트 추가

## 검증
- `npm run build`: 청크 분리 확인 (tiptap/react/faro/페이지별)
- `npm test`(111) + lint + format 통과
- 배포 후 확인 필요: 초기 로딩 체감, 노트 간격, 하위 페이지 drag 이동

## 제외
- NoteEditor onUpdate의 getJSON/collectChildPageIds 매 입력 호출 최적화는 변경 감지 캐싱이 필요해 버그 위험이 있어 이번엔 제외 (자동저장은 이미 2초 디바운스라 저장 자체는 부담 없음). 필요 시 후속.