### PR TITLE
feat : 노트 이미지용 img.orino.dev + MinIO note-images 버킷

### DIFF
--- a/infra/helm/minio/values.yaml
+++ b/infra/helm/minio/values.yaml
@@ -33,3 +33,7 @@ minio:
     - name: orino
       policy: none
       purge: false
+    # 노트 이미지: img.orino.dev로 공개 서빙. download = anonymous read-only.
+    - name: note-images
+      policy: download
+      purge: false

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -155,6 +155,8 @@ module "cloudflare_tunnel" {
     { hostname = "orino.dev", service = "http://istio-gateway.istio-ingress.svc.cluster.local:80" },
     { hostname = "api.orino.dev", service = "http://istio-gateway.istio-ingress.svc.cluster.local:80" },
     { hostname = "telemetry.orino.dev", service = "http://istio-gateway.istio-ingress.svc.cluster.local:80" },
+    # 노트 이미지: MinIO(S3 호환)로 직접 라우팅. note-images 버킷은 public read.
+    { hostname = "img.orino.dev", service = "http://minio.orino.svc.cluster.local:9000" },
     { service = "http_status:404" },
   ]
 
@@ -162,5 +164,6 @@ module "cloudflare_tunnel" {
     "orino.dev",
     "api.orino.dev",
     "telemetry.orino.dev",
+    "img.orino.dev",
   ]
 }


### PR DESCRIPTION
## Description

노트 이미지(붙여넣기/업로드) 기능의 **선행 인프라**. MinIO에 공개 read 버킷을 만들고 cloudflared로 img.orino.dev를 통해 서빙한다. (BE 업로드 + FE 확장은 후속 PR-3)

## 변경 사항

### Cloudflare Tunnel (terraform `main.tf`)
- ingress에 `img.orino.dev` → `minio.orino.svc:9000` 라우팅 추가
- `dns_hostnames`에 `img.orino.dev` CNAME 추가

### MinIO (`infra/helm/minio/values.yaml`)
- `note-images` 버킷 추가, `policy: download` (anonymous read-only)
- 노트 이미지는 `https://img.orino.dev/note-images/<key>`로 공개 접근

## 검증
- `terraform validate` + `fmt` 통과
- `helm template` 렌더링 확인: `createBucket note-images "download"` + `mc anonymous set download`

## 사용자 작업 (머지 후)
1. **terraform apply** — img.orino.dev tunnel ingress + DNS 생성
   - tunnel config 변경이라 secret/token 재발급 불필요 (ingress만 PATCH)
2. **ArgoCD sync** — MinIO note-images 버킷 생성 (post-job)
3. 확인: `https://img.orino.dev/` 접근 시 MinIO 응답, note-images 버킷 anonymous read

## 보안 메모
- note-images는 **공개 read**라 URL 아는 사람은 누구나 이미지 조회 가능 (노트 첨부 이미지 특성상 허용)
- 쓰기는 BE만 (PR-3에서 MinIO 자격증명으로 업로드) → anonymous write 아님