### PR TITLE
feat : 노트 이미지 업로드 (presigned URL → MinIO)

### DIFF
--- a/be/orino-app-api/build.gradle
+++ b/be/orino-app-api/build.gradle
@@ -16,6 +16,9 @@ dependencies {
     implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
     implementation 'org.springframework.boot:spring-boot-starter-opentelemetry'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    // 노트 이미지 업로드: MinIO(S3 호환) presigned PUT URL 발급
+    implementation platform('software.amazon.awssdk:bom:2.34.0')
+    implementation 'software.amazon.awssdk:s3'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/image/config/ImageStorageConfig.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/image/config/ImageStorageConfig.java
@@ -1,0 +1,35 @@
+package ds.project.orino.planner.image.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.net.URI;
+
+/**
+ * MinIO presigned URL 발급용 S3Presigner 빈.
+ * <p>
+ * endpoint를 공개 주소(img.orino.dev)로 설정해, 서명된 URL을 브라우저가 그대로
+ * PUT/GET 할 수 있게 한다. path-style(버킷을 경로로)로 강제해 MinIO와 호환한다.
+ */
+@Configuration
+@EnableConfigurationProperties(ImageStorageProperties.class)
+public class ImageStorageConfig {
+
+    @Bean
+    public S3Presigner imageS3Presigner(ImageStorageProperties props) {
+        return S3Presigner.builder()
+                .region(Region.of(props.region()))
+                .endpointOverride(URI.create(props.endpoint()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(props.accessKey(), props.secretKey())))
+                .serviceConfiguration(software.amazon.awssdk.services.s3.S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build())
+                .build();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/image/config/ImageStorageProperties.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/image/config/ImageStorageProperties.java
@@ -1,0 +1,24 @@
+package ds.project.orino.planner.image.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 노트 이미지 저장소(MinIO, S3 호환) 설정.
+ *
+ * @param endpoint            브라우저가 presigned URL로 접근할 공개 주소 (예: https://img.orino.dev)
+ * @param bucket              버킷명 (note-images)
+ * @param region              S3 region (MinIO는 무관, 서명용 임의값)
+ * @param accessKey           MinIO access key
+ * @param secretKey           MinIO secret key
+ * @param presignExpirySeconds presigned URL 유효 시간(초)
+ */
+@ConfigurationProperties(prefix = "storage.image")
+public record ImageStorageProperties(
+        String endpoint,
+        String bucket,
+        String region,
+        String accessKey,
+        String secretKey,
+        long presignExpirySeconds
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/image/controller/ImageController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/image/controller/ImageController.java
@@ -1,0 +1,35 @@
+package ds.project.orino.planner.image.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.image.dto.ImageUploadUrlRequest;
+import ds.project.orino.planner.image.dto.ImageUploadUrlResponse;
+import ds.project.orino.planner.image.service.ImageStorageService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/planner/images")
+public class ImageController {
+
+    private final ImageStorageService imageStorageService;
+
+    public ImageController(ImageStorageService imageStorageService) {
+        this.imageStorageService = imageStorageService;
+    }
+
+    /**
+     * 노트 이미지 업로드용 presigned PUT URL을 발급한다.
+     * 브라우저는 uploadUrl로 이미지를 직접 PUT 한 뒤 publicUrl을 노트에 삽입한다.
+     */
+    @PostMapping("/upload-url")
+    public ApiResponse<ImageUploadUrlResponse> createUploadUrl(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody ImageUploadUrlRequest request) {
+        return ApiResponse.success(
+                imageStorageService.createUploadUrl(memberId, request.contentType()));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/image/dto/ImageUploadUrlRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/image/dto/ImageUploadUrlRequest.java
@@ -1,0 +1,17 @@
+package ds.project.orino.planner.image.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * presigned 업로드 URL 발급 요청.
+ *
+ * @param contentType 업로드할 이미지 MIME 타입 (image/* 만 허용)
+ */
+public record ImageUploadUrlRequest(
+        @NotBlank
+        @Pattern(regexp = "image/(png|jpeg|jpg|gif|webp|svg\\+xml)",
+                message = "지원하지 않는 이미지 형식입니다.")
+        String contentType
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/image/dto/ImageUploadUrlResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/image/dto/ImageUploadUrlResponse.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.image.dto;
+
+/**
+ * presigned 업로드 URL 발급 응답.
+ *
+ * @param uploadUrl 브라우저가 이미지 바이너리를 PUT 할 presigned URL (만료 있음)
+ * @param publicUrl 업로드 후 노트에 저장/표시할 공개 URL
+ */
+public record ImageUploadUrlResponse(
+        String uploadUrl,
+        String publicUrl
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/image/service/ImageStorageService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/image/service/ImageStorageService.java
@@ -1,0 +1,66 @@
+package ds.project.orino.planner.image.service;
+
+import ds.project.orino.planner.image.config.ImageStorageProperties;
+import ds.project.orino.planner.image.dto.ImageUploadUrlResponse;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 노트 이미지 업로드용 presigned URL을 발급한다.
+ * <p>
+ * 바이너리는 BE를 거치지 않고 브라우저가 presigned URL로 MinIO에 직접 PUT 한다.
+ */
+@Service
+public class ImageStorageService {
+
+    private static final Map<String, String> EXTENSIONS = Map.of(
+            "image/png", "png",
+            "image/jpeg", "jpg",
+            "image/jpg", "jpg",
+            "image/gif", "gif",
+            "image/webp", "webp",
+            "image/svg+xml", "svg");
+
+    private final S3Presigner presigner;
+    private final ImageStorageProperties props;
+
+    public ImageStorageService(S3Presigner imageS3Presigner, ImageStorageProperties props) {
+        this.presigner = imageS3Presigner;
+        this.props = props;
+    }
+
+    /**
+     * memberId별 경로에 랜덤 키를 생성하고 presigned PUT URL과 공개 URL을 반환한다.
+     */
+    public ImageUploadUrlResponse createUploadUrl(Long memberId, String contentType) {
+        String ext = EXTENSIONS.getOrDefault(contentType, "bin");
+        String key = "%d/%s.%s".formatted(memberId, UUID.randomUUID(), ext);
+
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(props.bucket())
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofSeconds(props.presignExpirySeconds()))
+                .putObjectRequest(objectRequest)
+                .build();
+
+        String uploadUrl = presigner.presignPutObject(presignRequest).url().toString();
+        String publicUrl = "%s/%s/%s".formatted(
+                stripTrailingSlash(props.endpoint()), props.bucket(), key);
+
+        return new ImageUploadUrlResponse(uploadUrl, publicUrl);
+    }
+
+    private String stripTrailingSlash(String s) {
+        return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
+}

--- a/be/orino-app-api/src/main/resources/application.yml
+++ b/be/orino-app-api/src/main/resources/application.yml
@@ -18,6 +18,18 @@ jwt:
   access-token-expiration: 1800000
   refresh-token-expiration: 1209600000
 
+# 노트 이미지 저장소(MinIO, S3 호환).
+# endpoint는 브라우저가 presigned URL로 직접 PUT/GET 할 공개 주소(img.orino.dev).
+# BE는 URL 서명만 하므로 이 주소로 네트워크 호출은 하지 않는다.
+storage:
+  image:
+    endpoint: ${IMAGE_STORAGE_ENDPOINT:https://img.orino.dev}
+    bucket: ${IMAGE_STORAGE_BUCKET:note-images}
+    region: ${IMAGE_STORAGE_REGION:us-east-1}
+    access-key: ${MINIO_ROOT_USER:minioadmin}
+    secret-key: ${MINIO_ROOT_PASSWORD:minioadmin}
+    presign-expiry-seconds: ${IMAGE_STORAGE_PRESIGN_EXPIRY:300}
+
 management:
   tracing:
     sampling:

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/image/controller/ImageControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/image/controller/ImageControllerTest.java
@@ -1,0 +1,78 @@
+package ds.project.orino.planner.image.controller;
+
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ImageControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    @Test
+    @DisplayName("POST upload-url - presigned 업로드 URL과 공개 URL을 발급한다")
+    void createUploadUrl() throws Exception {
+        mockMvc.perform(post("/api/planner/images/upload-url")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"contentType": "image/png"}
+                                """))
+                .andExpect(status().isOk())
+                // uploadUrl: presigned (서명 쿼리 포함), note-images 버킷, png 확장
+                .andExpect(jsonPath("$.data.uploadUrl", containsString("note-images/")))
+                .andExpect(jsonPath("$.data.uploadUrl", containsString("X-Amz-Signature")))
+                // publicUrl: img.orino.dev 공개 주소
+                .andExpect(jsonPath("$.data.publicUrl", startsWith("https://img.orino.dev/note-images/")))
+                .andExpect(jsonPath("$.data.publicUrl", containsString(".png")));
+    }
+
+    @Test
+    @DisplayName("POST upload-url - 이미지가 아닌 contentType은 400")
+    void rejectNonImage() throws Exception {
+        mockMvc.perform(post("/api/planner/images/upload-url")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"contentType": "application/pdf"}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST upload-url - 인증 없으면 401")
+    void requiresAuth() throws Exception {
+        mockMvc.perform(post("/api/planner/images/upload-url")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"contentType": "image/png"}
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -15,6 +15,7 @@
         "@tanstack/react-query": "^5.96.1",
         "@tiptap/extension-drag-handle": "3.23.4",
         "@tiptap/extension-drag-handle-react": "3.23.4",
+        "@tiptap/extension-image": "^3.23.4",
         "@tiptap/extension-placeholder": "^3.23.4",
         "@tiptap/extension-table": "^3.23.4",
         "@tiptap/extension-task-item": "^3.23.4",
@@ -3336,6 +3337,19 @@
       "peerDependencies": {
         "@tiptap/core": "3.23.4",
         "@tiptap/pm": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-image": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.23.4.tgz",
+      "integrity": "sha512-qandp5HLRl+n8D61+LCT67qtb1uSKffyEGD0fVTkg/RfbyFsJvCDFbjVEoiIG8JOx8O5DehgrDCvS35QOWgr2A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-italic": {

--- a/fe/package.json
+++ b/fe/package.json
@@ -23,6 +23,7 @@
     "@tanstack/react-query": "^5.96.1",
     "@tiptap/extension-drag-handle": "3.23.4",
     "@tiptap/extension-drag-handle-react": "3.23.4",
+    "@tiptap/extension-image": "^3.23.4",
     "@tiptap/extension-placeholder": "^3.23.4",
     "@tiptap/extension-table": "^3.23.4",
     "@tiptap/extension-task-item": "^3.23.4",

--- a/fe/src/features/note/api/images.ts
+++ b/fe/src/features/note/api/images.ts
@@ -1,0 +1,35 @@
+import axios from "axios";
+
+import { client } from "@/shared/api";
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+interface UploadUrlResponse {
+  uploadUrl: string;
+  publicUrl: string;
+}
+
+/**
+ * 이미지를 MinIO에 업로드하고 공개 URL을 반환한다.
+ *
+ * 1) BE에 presigned PUT URL 요청 (인증 필요 → client 사용)
+ * 2) presigned URL로 이미지 바이너리를 직접 PUT (BE 안 거침, 순수 axios로
+ *    Authorization 헤더 없이 전송)
+ * 3) 노트에 삽입할 공개 URL 반환
+ */
+export async function uploadNoteImage(file: File): Promise<string> {
+  const { data } = await client.post<ApiEnvelope<UploadUrlResponse>>(
+    "/planner/images/upload-url",
+    { contentType: file.type },
+  );
+  const { uploadUrl, publicUrl } = data.data;
+
+  await axios.put(uploadUrl, file, {
+    headers: { "Content-Type": file.type },
+  });
+
+  return publicUrl;
+}

--- a/fe/src/features/note/components/EditorToolbar.tsx
+++ b/fe/src/features/note/components/EditorToolbar.tsx
@@ -7,6 +7,7 @@ import {
   FilePlus,
   Heading1,
   Heading2,
+  ImagePlus,
   Italic,
   List,
   ListOrdered,
@@ -15,9 +16,12 @@ import {
   Table,
   Trash2,
 } from "lucide-react";
+import { useRef } from "react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+
+import { uploadAndInsertImage } from "../editor/imageUpload";
 
 interface Props {
   editor: Editor | null;
@@ -42,6 +46,7 @@ export function EditorToolbar({
     editor,
     selector: ({ editor }) => editor?.isActive("table") ?? false,
   });
+  const imageInputRef = useRef<HTMLInputElement>(null);
 
   if (!editor) return null;
 
@@ -137,6 +142,28 @@ export function EditorToolbar({
           </Button>
         );
       })}
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        aria-label="이미지 추가"
+        onClick={() => imageInputRef.current?.click()}
+      >
+        <ImagePlus className="size-4" />
+      </Button>
+      <input
+        ref={imageInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        className="hidden"
+        aria-hidden
+        onChange={(e) => {
+          const files = Array.from(e.target.files ?? []);
+          files.forEach((file) => void uploadAndInsertImage(editor, file));
+          e.target.value = "";
+        }}
+      />
       {onInsertPage && (
         <>
           <span className="bg-border mx-1 w-px self-stretch" aria-hidden />

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { DragHandle } from "@tiptap/extension-drag-handle-react";
+import Image from "@tiptap/extension-image";
 import Placeholder from "@tiptap/extension-placeholder";
 import { TableKit } from "@tiptap/extension-table";
 import TaskItem from "@tiptap/extension-task-item";
@@ -14,6 +15,7 @@ import { Input } from "@/components/ui/input";
 
 import type { NoteContent, NoteDetail } from "../api/notes";
 import { ChildPage, collectChildPageIds } from "../editor/childPage";
+import { extractImageFiles, uploadAndInsertImage } from "../editor/imageUpload";
 import { useAutoSaveNote } from "../hooks/useAutoSaveNote";
 import { useCreateNote, useDeleteNote } from "../hooks/useNoteMutations";
 import { noteKeys } from "../queryKeys";
@@ -50,6 +52,9 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
   // 본문에 현재 박혀 있는 childPage noteId 집합 (삭제 diff 기준).
   // NoteTab이 key={note.id}로 리마운트하므로 마운트 시점 content 기준으로 1회 초기화한다.
   const childIdsRef = useRef<Set<number>>(collectChildPageIds(note.content));
+  // editorProps 핸들러(handlePaste/handleDrop)는 생성 시점 클로저라 editor를
+  // 직접 못 잡으므로 ref로 우회한다.
+  const editorRef = useRef<ReturnType<typeof useEditor>>(null);
 
   const editor = useEditor(
     {
@@ -58,6 +63,7 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
         TaskList,
         TaskItem.configure({ nested: true }),
         TableKit.configure({ table: { resizable: true } }),
+        Image.configure({ inline: false }),
         Placeholder.configure({
           placeholder: "내용을 입력하거나 페이지를 추가하세요...",
         }),
@@ -70,6 +76,30 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
             "prose prose-sm dark:prose-invert max-w-none min-h-[40svh] focus:outline-none py-4 pr-4 pl-10",
           "aria-label": "노트 본문",
         },
+        // 클립보드 붙여넣기로 이미지 업로드
+        handlePaste: (_view, event) => {
+          const files = extractImageFiles(event.clipboardData);
+          if (files.length === 0) return false;
+          event.preventDefault();
+          files.forEach((file) => {
+            if (editorRef.current)
+              void uploadAndInsertImage(editorRef.current, file);
+          });
+          return true;
+        },
+        // 드래그앤드롭으로 이미지 업로드
+        handleDrop: (_view, event) => {
+          const files = extractImageFiles(
+            (event as DragEvent).dataTransfer ?? null,
+          );
+          if (files.length === 0) return false;
+          event.preventDefault();
+          files.forEach((file) => {
+            if (editorRef.current)
+              void uploadAndInsertImage(editorRef.current, file);
+          });
+          return true;
+        },
       },
       onUpdate: ({ editor }) => {
         const json = editor.getJSON() as NoteContent;
@@ -79,6 +109,7 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
     },
     [note.id],
   );
+  editorRef.current = editor;
 
   // 노트 전환은 NoteTab의 key={note.id} 리마운트로 처리되므로
   // setContent를 수동 호출하지 않는다. (editor 재생성마다 setContent가

--- a/fe/src/features/note/components/NoteTab.test.tsx
+++ b/fe/src/features/note/components/NoteTab.test.tsx
@@ -331,6 +331,56 @@ describe("NoteTab", () => {
     expect(screen.getByRole("button", { name: "표 삭제" })).toBeInTheDocument();
   });
 
+  it("툴바 [이미지 추가]로 파일 선택 시 presign→PUT 후 본문에 이미지가 삽입된다", async () => {
+    mockTree([
+      { id: 1, title: "노트", parentId: null, sortOrder: 0, children: [] },
+    ]);
+    mockNoteDetail(1, { type: "doc", content: [] }, "노트");
+
+    let presignCalled = false;
+    let putCalled = false;
+    const publicUrl = "https://img.orino.dev/note-images/1/abc.png";
+    server.use(
+      http.post(`${API_BASE}/planner/images/upload-url`, () => {
+        presignCalled = true;
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            uploadUrl:
+              "https://img.orino.dev/note-images/1/abc.png?X-Amz-Signature=x",
+            publicUrl,
+          },
+        });
+      }),
+      http.put("https://img.orino.dev/note-images/:bucket/*", () => {
+        putCalled = true;
+        return new HttpResponse(null, { status: 200 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    const { container } = renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("노트");
+    });
+    expect(container.querySelector("img")).toBeNull();
+
+    const file = new File(["fake"], "shot.png", { type: "image/png" });
+    const input = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    await user.upload(input, file);
+
+    await waitFor(() => expect(presignCalled).toBe(true));
+    await waitFor(() => expect(putCalled).toBe(true));
+    await waitFor(() => {
+      const img = container.querySelector("img");
+      expect(img).not.toBeNull();
+      expect(img?.getAttribute("src")).toBe(publicUrl);
+    });
+  });
+
   it("표 삽입 후 [헤더] 버튼으로 제목 행을 선택적으로 켤 수 있다", async () => {
     mockTree([
       { id: 1, title: "노트", parentId: null, sortOrder: 0, children: [] },

--- a/fe/src/features/note/editor/imageUpload.ts
+++ b/fe/src/features/note/editor/imageUpload.ts
@@ -1,0 +1,28 @@
+import type { Editor } from "@tiptap/react";
+
+import { uploadNoteImage } from "../api/images";
+
+/**
+ * 파일을 업로드하고 에디터에 이미지 노드를 삽입한다.
+ * 업로드 중에는 임시 placeholder 없이 완료 후 삽입한다(단순화).
+ */
+export async function uploadAndInsertImage(
+  editor: Editor,
+  file: File,
+): Promise<void> {
+  if (!file.type.startsWith("image/")) return;
+  try {
+    const url = await uploadNoteImage(file);
+    editor.chain().focus().setImage({ src: url }).run();
+  } catch {
+    // 업로드 실패는 조용히 무시 (토스트는 호출부에서 처리 가능)
+  }
+}
+
+/** 클립보드/드롭 데이터에서 이미지 파일들을 추출한다. */
+export function extractImageFiles(dataTransfer: DataTransfer | null): File[] {
+  if (!dataTransfer) return [];
+  return Array.from(dataTransfer.files).filter((f) =>
+    f.type.startsWith("image/"),
+  );
+}

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -178,6 +178,18 @@
   margin-bottom: 0;
 }
 
+.tiptap img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.375rem;
+  margin: 0.5em 0;
+}
+
+/* 선택된 이미지 강조 */
+.tiptap img.ProseMirror-selectednode {
+  outline: 2px solid var(--primary);
+}
+
 /* 노트 에디터 표 스타일 (#431). prose 기본 표 스타일에 더해
    셀 경계선·헤더 배경·셀 선택·열 리사이즈 핸들을 명시한다. */
 .tiptap .tableWrapper {

--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -94,6 +94,17 @@ spec:
               value: {{ .Values.env.REDIS_PORT | quote }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.env.OTEL_EXPORTER_OTLP_ENDPOINT | quote }}
+            # 노트 이미지 presigned URL 발급용 MinIO 자격증명
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-secret
+                  key: rootUser
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-secret
+                  key: rootPassword
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           lifecycle:


### PR DESCRIPTION
closes #431

## Description

노트 본문에 이미지를 추가한다. **presigned URL 방식** — 이미지 바이너리는 BE를 거치지 않고 브라우저가 MinIO에 직접 PUT 한다.

선행: #444(img.orino.dev + note-images 버킷) 머지 + 배포 완료.

## 흐름

```
1. FE → BE: presigned PUT URL 요청 (contentType)
2. BE: MinIO presigned PUT URL 서명 → { uploadUrl, publicUrl } (네트워크 호출 0)
3. FE → MinIO: uploadUrl로 이미지 직접 PUT (BE 안 거침)
4. FE: publicUrl(https://img.orino.dev/note-images/<key>)을 노트 image 노드에 삽입
```

## 변경 사항

### BE
- `POST /api/planner/images/upload-url`: presigned PUT URL + publicUrl 발급
  - AWS S3 SDK v2 presigner, MinIO endpoint=`img.orino.dev`, path-style
  - `contentType` image/* 검증, `memberId/<uuid>.<ext>` 키
  - `ImageStorageProperties`/`Config`/`Service`/`Controller` + DTO 2종
- `application.yml`: `storage.image.*` (endpoint/bucket/region/creds/expiry)
- 테스트: presigned URL 발급, 비이미지 거부(400), 인증 필요(401)

### Infra
- `be` deployment에 `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` env (minio-secret)

### FE
- `@tiptap/extension-image` 도입
- 업로드 3경로: **클립보드 붙여넣기**, **드래그앤드롭**, **툴바 [이미지 추가]** 파일 선택
- `api/images.ts`: presign 요청 → presigned URL 직접 PUT (Authorization 헤더 없이 순수 axios)
- 이미지 스타일(max-width 100%, 선택 강조)
- 테스트: 파일 선택 → presign→PUT→`<img>` 삽입 검증

## 검증
- BE `./gradlew build`(checkstyle + 전체 테스트) 통과
- FE `npm test`(113) + build + lint + format 통과

## 사용자 작업 (머지 후)
1. BE 재배포 (ArgoCD) — MinIO env 주입
2. **CORS 확인**: 브라우저가 `orino.dev`에서 `img.orino.dev`로 PUT(cross-origin)하므로 MinIO CORS 허용 필요. 막히면 MinIO에 CORS 설정 추가(후속).
3. 실제 노트에서 이미지 붙여넣기/드롭/업로드 → img.orino.dev 표시 확인

## 보안
- presigned PUT은 서명이 인증이라 버킷 anonymous write 불필요 (read만 public)
- 5분 만료, memberId별 경로