### PR TITLE
fix : MySQL 백업 CronJob이 OL9 이미지에서 실패하던 문제

### DIFF
--- a/infra/helm/mysql-backup/templates/cronjob.yaml
+++ b/infra/helm/mysql-backup/templates/cronjob.yaml
@@ -34,8 +34,9 @@ spec:
                   echo "  size: $(du -h ${BACKUP_FILE} | cut -f1)"
 
                   echo "[2/3] awscli v2 설치"
-                  apt-get update -qq
-                  apt-get install -y -qq --no-install-recommends curl unzip ca-certificates >/dev/null
+                  # mysql:8.4.4 는 Oracle Linux 9 기반이라 apt-get 이 없다 (microdnf 사용).
+                  # curl·ca-certificates 는 이미지에 기본 포함, unzip 만 추가 설치한다.
+                  microdnf install -y unzip
                   curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscli.zip
                   unzip -q /tmp/awscli.zip -d /tmp
                   AWS=/tmp/aws/dist/aws


### PR DESCRIPTION
## 이슈
#314

## 작업 내용
- MySQL 백업 CronJob의 awscli 설치 단계를 `apt-get` → `microdnf install -y unzip` 으로 교체

## 배경 (백업이 0건이던 원인)
`mysql:8.4.4` 공식 이미지는 **Oracle Linux 9.5 기반**이라 `apt-get` 이 없다(`microdnf` 사용). 기존 스크립트는 `[2/3]` 단계에서 `apt-get update` 를 호출했고, `set -euo pipefail` 때문에 매일 새벽 백업 잡이 **즉시 실패** → `orino-mysql-backup` 버킷에 백업이 **단 한 건도 없는 상태**였다.

검증 (`mysql:8.4.4` 컨테이너):
- 이미지 기본 포함: `curl`, `gzip`, `mysqldump`
- 누락: `apt-get`, `unzip`, `aws`
- `microdnf install -y unzip` → awscli zip 다운로드 → 압축해제까지 정상 동작 확인 (aws 실행은 x86_64 클러스터 노드에서 동작)

## 머지 후 확인 필요
- [ ] ArgoCD sync 후 CronJob 수동 트리거 → `s3://orino-mysql-backup/` 에 파일 생성 확인
- [ ] 복구 리허설 (#317)