### PR TITLE
perf : 이미지 즉시 미리보기 + 라우트 prefetch (체감 속도)

### DIFF
--- a/fe/src/app/providers.tsx
+++ b/fe/src/app/providers.tsx
@@ -10,6 +10,7 @@ import { useLocation } from "react-router-dom";
 
 import { reissue } from "../features/auth/api/auth";
 import { getAccessToken } from "../features/auth/store/authStore";
+import { prefetchRoutes } from "./routeImports";
 
 interface AuthContextType {
   isAuthenticated: boolean;
@@ -48,6 +49,11 @@ function AuthProvider({ children }: { children: ReactNode }) {
 
   const isAuthenticated = getAccessToken() !== null;
   const refresh = () => setVersion((v) => v + 1);
+
+  // 로그인 상태면 idle 시간에 페이지 청크를 미리 받아 진입 지연을 없앤다.
+  useEffect(() => {
+    if (isAuthenticated) prefetchRoutes();
+  }, [isAuthenticated]);
 
   if (loading) return null;
 

--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -1,0 +1,41 @@
+// 페이지 lazy import 함수 + prefetch.
+// router.tsx에서 분리해 컴포넌트 외 export로 인한 fast-refresh 경고를 피한다.
+// lazy()와 prefetch가 같은 import 함수를 공유 → prefetch가 받아둔 청크를 진입 시 재사용.
+
+export const importHome = () =>
+  import("../pages/HomePage").then((m) => ({ default: m.HomePage }));
+export const importMaterialList = () =>
+  import("../pages/planner/MaterialListPage").then((m) => ({
+    default: m.MaterialListPage,
+  }));
+export const importMaterialDetail = () =>
+  import("../pages/planner/MaterialDetailPage").then((m) => ({
+    default: m.MaterialDetailPage,
+  }));
+export const importTodayReviews = () =>
+  import("../pages/planner/TodayReviewsPage").then((m) => ({
+    default: m.TodayReviewsPage,
+  }));
+export const importReviewCalendar = () =>
+  import("../pages/planner/ReviewCalendarPage").then((m) => ({
+    default: m.ReviewCalendarPage,
+  }));
+
+/**
+ * 로그인 후 idle 시간에 페이지 청크를 미리 받아둔다.
+ * lazy로 초기 번들은 가볍게 유지하면서, 실제 진입 시에는 이미 캐시돼 즉시 렌더된다.
+ */
+export function prefetchRoutes() {
+  const run = () => {
+    void importMaterialDetail();
+    void importMaterialList();
+    void importTodayReviews();
+    void importReviewCalendar();
+    void importHome();
+  };
+  if (typeof requestIdleCallback === "function") {
+    requestIdleCallback(run);
+  } else {
+    setTimeout(run, 1500);
+  }
+}

--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -26,12 +26,17 @@ export const importReviewCalendar = () =>
  * lazy로 초기 번들은 가볍게 유지하면서, 실제 진입 시에는 이미 캐시돼 즉시 렌더된다.
  */
 export function prefetchRoutes() {
+  // 테스트 환경에서는 prefetch를 건너뛴다. idle 콜백이 테스트 teardown 후
+  // 동적 import를 실행해 EnvironmentTeardownError를 일으키기 때문.
+  if (import.meta.env.MODE === "test") return;
+
   const run = () => {
-    void importMaterialDetail();
-    void importMaterialList();
-    void importTodayReviews();
-    void importReviewCalendar();
-    void importHome();
+    const ignore = () => {};
+    void importMaterialDetail().catch(ignore);
+    void importMaterialList().catch(ignore);
+    void importTodayReviews().catch(ignore);
+    void importReviewCalendar().catch(ignore);
+    void importHome().catch(ignore);
   };
   if (typeof requestIdleCallback === "function") {
     requestIdleCallback(run);

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -6,32 +6,21 @@ import { PublicRoute } from "../features/auth/components/PublicRoute";
 import { LandingPage } from "../pages/LandingPage";
 import { LoginPage } from "../pages/LoginPage";
 import { AppLayout } from "./layout/AppLayout";
+import {
+  importHome,
+  importMaterialDetail,
+  importMaterialList,
+  importReviewCalendar,
+  importTodayReviews,
+} from "./routeImports";
 
 // 로그인 후에만 쓰는 페이지들은 lazy 로드해 초기 번들에서 분리한다.
 // (특히 Tiptap 에디터가 무거운 MaterialDetailPage)
-const HomePage = lazy(() =>
-  import("../pages/HomePage").then((m) => ({ default: m.HomePage })),
-);
-const MaterialListPage = lazy(() =>
-  import("../pages/planner/MaterialListPage").then((m) => ({
-    default: m.MaterialListPage,
-  })),
-);
-const MaterialDetailPage = lazy(() =>
-  import("../pages/planner/MaterialDetailPage").then((m) => ({
-    default: m.MaterialDetailPage,
-  })),
-);
-const TodayReviewsPage = lazy(() =>
-  import("../pages/planner/TodayReviewsPage").then((m) => ({
-    default: m.TodayReviewsPage,
-  })),
-);
-const ReviewCalendarPage = lazy(() =>
-  import("../pages/planner/ReviewCalendarPage").then((m) => ({
-    default: m.ReviewCalendarPage,
-  })),
-);
+const HomePage = lazy(importHome);
+const MaterialListPage = lazy(importMaterialList);
+const MaterialDetailPage = lazy(importMaterialDetail);
+const TodayReviewsPage = lazy(importTodayReviews);
+const ReviewCalendarPage = lazy(importReviewCalendar);
 
 function RouteFallback() {
   return <div className="text-muted-foreground p-6 text-sm">불러오는 중…</div>;

--- a/fe/src/features/note/components/NoteTab.test.tsx
+++ b/fe/src/features/note/components/NoteTab.test.tsx
@@ -372,12 +372,17 @@ describe("NoteTab", () => {
     ) as HTMLInputElement;
     await user.upload(input, file);
 
+    // 이미지가 즉시 삽입된다 (즉시 미리보기 → 업로드 후 공개 URL로 교체)
+    await waitFor(() => {
+      expect(container.querySelector("img")).not.toBeNull();
+    });
     await waitFor(() => expect(presignCalled).toBe(true));
     await waitFor(() => expect(putCalled).toBe(true));
+    // 업로드 완료 후 최종 src는 실제 공개 URL
     await waitFor(() => {
-      const img = container.querySelector("img");
-      expect(img).not.toBeNull();
-      expect(img?.getAttribute("src")).toBe(publicUrl);
+      expect(container.querySelector("img")?.getAttribute("src")).toBe(
+        publicUrl,
+      );
     });
   });
 

--- a/fe/src/features/note/editor/imageUpload.ts
+++ b/fe/src/features/note/editor/imageUpload.ts
@@ -3,20 +3,60 @@ import type { Editor } from "@tiptap/react";
 import { uploadNoteImage } from "../api/images";
 
 /**
- * 파일을 업로드하고 에디터에 이미지 노드를 삽입한다.
- * 업로드 중에는 임시 placeholder 없이 완료 후 삽입한다(단순화).
+ * 이미지를 즉시 미리보기로 삽입하고, 백그라운드 업로드 완료 후 실제 URL로 교체한다.
+ *
+ * 1) 로컬 blob URL을 만들어 바로 <img>로 삽입 → 업로드를 기다리지 않고 즉시 보인다.
+ * 2) presigned URL로 업로드 → 완료되면 해당 노드의 src를 공개 URL로 교체.
+ * 3) blob URL은 해제.
+ *
+ * 업로드 실패 시 임시 이미지 노드를 제거한다.
  */
 export async function uploadAndInsertImage(
   editor: Editor,
   file: File,
 ): Promise<void> {
   if (!file.type.startsWith("image/")) return;
+
+  const blobUrl = URL.createObjectURL(file);
+  editor.chain().focus().setImage({ src: blobUrl }).run();
+
   try {
     const url = await uploadNoteImage(file);
-    editor.chain().focus().setImage({ src: url }).run();
+    replaceImageSrc(editor, blobUrl, url);
   } catch {
-    // 업로드 실패는 조용히 무시 (토스트는 호출부에서 처리 가능)
+    removeImageBySrc(editor, blobUrl);
+  } finally {
+    URL.revokeObjectURL(blobUrl);
   }
+}
+
+/** 문서에서 src가 일치하는 image 노드를 찾아 새 src로 교체한다. */
+function replaceImageSrc(editor: Editor, fromSrc: string, toSrc: string): void {
+  const { state, view } = editor;
+  state.doc.descendants((node, pos) => {
+    if (node.type.name === "image" && node.attrs.src === fromSrc) {
+      const tr = view.state.tr.setNodeMarkup(pos, undefined, {
+        ...node.attrs,
+        src: toSrc,
+      });
+      view.dispatch(tr);
+      return false;
+    }
+    return true;
+  });
+}
+
+/** 업로드 실패 시 임시 blob src 이미지 노드를 제거한다. */
+function removeImageBySrc(editor: Editor, src: string): void {
+  const { state, view } = editor;
+  state.doc.descendants((node, pos) => {
+    if (node.type.name === "image" && node.attrs.src === src) {
+      const tr = view.state.tr.delete(pos, pos + node.nodeSize);
+      view.dispatch(tr);
+      return false;
+    }
+    return true;
+  });
 }
 
 /** 클립보드/드롭 데이터에서 이미지 파일들을 추출한다. */

--- a/fe/src/test/setup.ts
+++ b/fe/src/test/setup.ts
@@ -5,6 +5,14 @@ import { afterAll, afterEach, beforeAll } from "vitest";
 
 import { server } from "./mocks/server";
 
+// jsdom에는 URL.createObjectURL/revokeObjectURL이 없어 이미지 즉시 미리보기용 polyfill.
+if (!URL.createObjectURL) {
+  URL.createObjectURL = () => "blob:mock";
+}
+if (!URL.revokeObjectURL) {
+  URL.revokeObjectURL = () => {};
+}
+
 beforeAll(() => server.listen());
 afterEach(() => {
   server.resetHandlers();


### PR DESCRIPTION
## Description

사용자 피드백 2건의 체감 속도 문제를 해결한다.
1. "이미지 업로드하면 완료 후에야 보임" → 즉시 미리보기
2. "페이지 접근하면 컴포넌트가 느리게 뜸" → lazy 청크 prefetch

## 변경 사항

### 이미지 즉시 미리보기 (`imageUpload.ts`)
- 기존: `await uploadNoteImage()` **완료 후** `setImage` → 업로드(2~수초) 끝나야 보임
- 변경: 로컬 `URL.createObjectURL(file)`로 **즉시 `<img>` 삽입** → 백그라운드 업로드 완료 시 해당 노드 src를 공개 URL로 교체 (Notion 방식)
- 실패 시 임시 노드 제거, blob URL revoke

### 라우트 prefetch (`routeImports.ts`, `providers.tsx`)
- 원인: #443에서 모든 페이지를 lazy로 분리 → 초기 진입은 빨라졌지만 **각 페이지 첫 진입 시 청크(특히 MaterialDetail+tiptap 569kB)를 그제서야 다운로드** → "느리게 뜸"
- 변경: 로그인 후 `requestIdleCallback`으로 페이지 청크를 **미리 받아둠**. lazy(초기 경량) 유지 + prefetch(진입 즉시 렌더) 양립
- import 함수/prefetch를 `routeImports.ts`로 분리해 fast-refresh 경고 회피

## 검증
- `npm test`(113) + build + lint + format 통과
- jsdom `URL.createObjectURL` polyfill 추가
- 이미지: 즉시 삽입 → 업로드 후 공개 URL 교체 검증

## 참고 (전반적 optimize는 별도)
사용자가 "이미지뿐 아니라 모든 데이터 optimize"를 언급. 이 PR은 즉시 체감되는 2건만 처리하고, BE 쿼리/응답·렌더링 등 전반 최적화는 실측 후 별도 진행 예정.