### PR TITLE
perf : 자료 목록 due 복습 카운트 쿼리 최적화 (member_id 인덱스)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyMaterialService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/material/service/StudyMaterialService.java
@@ -38,12 +38,12 @@ public class StudyMaterialService {
         if (materials.isEmpty()) {
             return List.of();
         }
-        return mapWithCounts(materials);
+        return mapWithCounts(memberId, materials);
     }
 
     public MaterialResponse findOne(Long memberId, Long materialId) {
         StudyMaterial material = getOwnedMaterial(memberId, materialId);
-        return mapWithCounts(List.of(material)).get(0);
+        return mapWithCounts(memberId, List.of(material)).get(0);
     }
 
     @Transactional
@@ -65,7 +65,7 @@ public class StudyMaterialService {
         if (request.status() != null) {
             material.updateStatus(request.status());
         }
-        return mapWithCounts(List.of(material)).get(0);
+        return mapWithCounts(memberId, List.of(material)).get(0);
     }
 
     @Transactional
@@ -79,12 +79,12 @@ public class StudyMaterialService {
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
     }
 
-    private List<MaterialResponse> mapWithCounts(List<StudyMaterial> materials) {
+    private List<MaterialResponse> mapWithCounts(Long memberId, List<StudyMaterial> materials) {
         List<Long> ids = materials.stream().map(StudyMaterial::getId).toList();
         Map<Long, Long> flashcardCounts = toCountMap(
                 studyMaterialRepository.countFlashcardsByMaterialIds(ids));
         Map<Long, Long> dueReviewCounts = toCountMap(
-                studyMaterialRepository.countDueReviewsByMaterialIds(ids, clock.instant()));
+                studyMaterialRepository.countDueReviewsByMaterialIds(memberId, ids, clock.instant()));
         return materials.stream()
                 .map(m -> MaterialResponse.of(m,
                         flashcardCounts.getOrDefault(m.getId(), 0L),

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/material/repository/StudyMaterialRepository.java
@@ -34,16 +34,20 @@ public interface StudyMaterialRepository extends JpaRepository<StudyMaterial, Lo
             """, nativeQuery = true)
     List<MaterialCountRow> countFlashcardsByMaterialIds(@Param("materialIds") Collection<Long> materialIds);
 
+    // member_id 조건을 명시해 review_schedule의 (member_id, scheduled_at, status)
+    // 인덱스를 활용한다. (member_id 없이 flashcard JOIN만으로는 인덱스 효율이 낮음)
     @Query(value = """
             SELECT f.material_id AS materialId, COUNT(r.id) AS count
             FROM review_schedule r
             JOIN flashcard f ON f.id = r.flashcard_id
-            WHERE f.material_id IN (:materialIds)
+            WHERE r.member_id = :memberId
+              AND f.material_id IN (:materialIds)
               AND r.status = 'PENDING'
               AND r.scheduled_at <= :now
             GROUP BY f.material_id
             """, nativeQuery = true)
     List<MaterialCountRow> countDueReviewsByMaterialIds(
+            @Param("memberId") Long memberId,
             @Param("materialIds") Collection<Long> materialIds,
             @Param("now") Instant now);
 }


### PR DESCRIPTION
## Description

prod 실측에서 `GET /api/planner/materials`가 데이터가 거의 없는데도 ~0.6~1.0초로 느린 문제를 개선한다.

## 측정 (prod 실측)

| API | 콜드 | 웜 |
|---|---|---|
| /planner/materials | 0.87s | 0.60s |
| /planner/reviews/calendar | 0.90s | 0.59s |
| 가벼운 API(today 등) | — | ~0.30s |

baseline ~0.3s는 네트워크 경로(Cloudflare tunnel→istio→BE)로 보이며, materials의 **추가 0.3s가 쿼리 비용**.

## 원인

`countDueReviewsByMaterialIds`가 **member_id 조건 없이** flashcard JOIN만 수행:
```sql
FROM review_schedule r JOIN flashcard f ON f.id = r.flashcard_id
WHERE f.material_id IN (:ids) AND r.status='PENDING' AND r.scheduled_at <= :now
```
review_schedule의 주 인덱스는 `(member_id, scheduled_at, status)`인데 member_id가 없어 이 인덱스를 못 타고 비효율적 스캔.

## 변경 사항

- 쿼리에 `r.member_id = :memberId` 조건 추가 → 인덱스 활용
- `mapWithCounts(memberId, materials)`로 시그니처 변경, 호출부(findAll/findOne/update) memberId 전달

## 검증
- BE `./gradlew build`(checkstyle + 전체 테스트) 통과
- StudyMaterial 테스트: due 카운트 정확성 유지 (memberId 필터 추가해도 동일 결과 — 어차피 자기 자료만 조회)

## 참고
- flashcard_id 인덱스(`idx_review_schedule_flashcard_sequence`)는 이미 존재 → JOIN 자체는 인덱스 탐. 문제는 member_id 누락이었음.
- calendar 645ms는 인덱스는 적절하나 범위 스캔 + rows 직렬화. 데이터 늘면 Redis 캐싱 등 별도 검토.
- 노트 페이지 4개 API는 React Query 독립 호출이라 병렬화 여지 → 별도 검토.