### PR TITLE
chore : SealedSecret 마스터키 자동 회전 비활성화

### DIFF
--- a/infra/helm/sealed-secrets/values.yaml
+++ b/infra/helm/sealed-secrets/values.yaml
@@ -1,4 +1,7 @@
 sealed-secrets:
+  # 마스터키 자동 회전 비활성화(고정 키). 오프라인 백업 1회로 영구 복원 가능해지고,
+  # 회전으로 백업이 stale 되어 복호화 불능이 되는 사고를 방지한다. (#316)
+  keyrenewperiod: "0"
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
## 이슈
#316

## 작업 내용
- `sealed-secrets` 차트에 `keyrenewperiod: "0"` 추가 → 컨트롤러 `--key-renew-period 0` (마스터키 자동 회전 비활성화)

## 배경
sealed-secrets 마스터키는 기본 30일마다 회전한다(현재 키 3개: 3/26·4/25·5/25 생성). 회전이 켜져 있으면 새 키로 암호화된 SealedSecret은 **이전에 받아둔 오프라인 백업으로 복원할 수 없어** 백업이 계속 stale해진다 — 백업이 있어도 복호화 불능이 되는 사고로 이어질 수 있다.

단일 사용자 클러스터에선 키를 고정하고 **한 번만 오프라인 백업**하는 편이 단순·안전하다(회전마다 재백업·모니터링 불필요). 기존 3개 키는 컨트롤러가 그대로 보관하여 과거 SealedSecret 복호화도 유지된다.

## 후속 (이 PR과 별개, 수동)
- [ ] 현재 마스터키 오프라인 백업 → 1Password 저장 (#316)
- [ ] 추출·복원 절차 Wiki 문서화 (Backup-Recovery §4.3)