### PR TITLE
feat : Route53 zone + MetalLB(L2) + istio LoadBalancer (#456 0~2단계)

### DIFF
--- a/infra/argocd/applications/metallb-app.yaml
+++ b/infra/argocd/applications/metallb-app.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metallb
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: orino
+
+  source:
+    repoURL: https://github.com/wcorn/orino.git
+    targetRevision: main
+    path: infra/helm/metallb
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: metallb-system
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infra/helm/istio-gateway/values.yaml
+++ b/infra/helm/istio-gateway/values.yaml
@@ -1,6 +1,10 @@
 gateway:
   service:
-    type: ClusterIP
+    # Cloudflare 제거 → 집 회선 직결(#456). MetalLB가 LAN VIP 192.168.0.240 할당,
+    # 공유기 443 → .240 포워딩. 80은 전환 중 cloudflared 내부 경로용으로 유지.
+    type: LoadBalancer
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: "192.168.0.240"
 
   # 외부 트래픽 진입점이므로 HA 구성 (최소 2 replica)
   replicaCount: 2

--- a/infra/helm/metallb/Chart.yaml
+++ b/infra/helm/metallb/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: metallb
+description: MetalLB — 베어메탈 L2 LoadBalancer (istio gateway VIP 할당)
+type: application
+version: 1.0.0
+appVersion: "0.16.1"
+
+dependencies:
+  - name: metallb
+    version: 0.16.1
+    repository: https://metallb.github.io/metallb
+
+keywords:
+  - metallb
+  - loadbalancer
+  - bare-metal

--- a/infra/helm/metallb/templates/ipaddresspool.yaml
+++ b/infra/helm/metallb/templates/ipaddresspool.yaml
@@ -1,0 +1,13 @@
+# MetalLB CRD(IPAddressPool)는 의존 차트가 설치한 CRD 위에 생성된다.
+# ArgoCD가 CRD 설치 전에 dry-run 하다 실패하지 않도록 sync-wave + SkipDryRun 적용.
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: {{ .Values.addressPool.name }}
+  namespace: metallb-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  addresses:
+    {{- toYaml .Values.addressPool.addresses | nindent 4 }}

--- a/infra/helm/metallb/templates/l2advertisement.yaml
+++ b/infra/helm/metallb/templates/l2advertisement.yaml
@@ -1,0 +1,12 @@
+# 위 풀을 L2(ARP)로 광고. VIP 가 note1/note2 중 살아있는 노드에서 응답(failover).
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: {{ .Values.addressPool.name }}
+  namespace: metallb-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  ipAddressPools:
+    - {{ .Values.addressPool.name }}

--- a/infra/helm/metallb/values.yaml
+++ b/infra/helm/metallb/values.yaml
@@ -1,0 +1,21 @@
+# L2(ARP) 광고할 VIP 풀. 공유기 DHCP 대여 범위(~.239) 밖이라 충돌 없음.
+# istio-gateway(LoadBalancer)가 .240 을 할당받고, 공유기 443 → .240 포워딩.
+addressPool:
+  name: orino-pool
+  addresses:
+    - 192.168.0.240-192.168.0.250
+
+metallb:
+  # L2 모드만 사용 — BGP/FRR 불필요하므로 frr-k8s 비활성화(컴포넌트 경량화)
+  frrk8s:
+    enabled: false
+  speaker:
+    frr:
+      enabled: false
+    resources:
+      requests: {cpu: 25m, memory: 64Mi}
+      limits: {cpu: 100m, memory: 128Mi}
+  controller:
+    resources:
+      requests: {cpu: 25m, memory: 64Mi}
+      limits: {cpu: 100m, memory: 128Mi}

--- a/infra/terraform/route53.tf
+++ b/infra/terraform/route53.tf
@@ -1,0 +1,21 @@
+# Route 53 — orino.dev 권한 DNS (Cloudflare 제거 → 가비아에서 NS 위임). 이슈 #456
+#
+# Phase 0: hosted zone 만 생성해 NS 4개를 확보한다.
+#   → 가비아 콘솔에서 이 NS 로 위임(전파 수시간~1일)하면 Route53 이 권한 DNS 가 된다.
+# A 레코드(orino/api/img)는 DDNS(ddns-updater)가 동적 WAN IP 로 관리하므로
+# 별도 단계에서 ignore_changes 와 함께 추가한다.
+
+resource "aws_route53_zone" "orino" {
+  name    = "orino.dev"
+  comment = "orino.dev authoritative DNS — Cloudflare 제거, 집 회선 직결 (#456)"
+}
+
+output "route53_orino_zone_id" {
+  description = "orino.dev Route53 hosted zone ID (cert-manager / DDNS / A레코드에서 참조)"
+  value       = aws_route53_zone.orino.zone_id
+}
+
+output "route53_orino_name_servers" {
+  description = "가비아 콘솔에 입력할 NS 4개 (orino.dev 위임용)"
+  value       = aws_route53_zone.orino.name_servers
+}


### PR DESCRIPTION
## 이슈
#456 (0단계 Route53 zone + 2단계 MetalLB/LoadBalancer)

## 1) Route53 hosted zone (0단계, terraform apply 완료)
- `infra/terraform/route53.tf`: `aws_route53_zone.orino` + outputs(NS, zone_id)
- 이미 apply됨. **NS 위임 전파 확인됨**(`dig NS orino.dev` → awsdns)
- NS: ns-1296.awsdns-34.org / ns-1612.awsdns-09.co.uk / ns-385.awsdns-48.com / ns-994.awsdns-60.net
- zone_id: `Z018202013XAUKBKU2J8V`

## 2) MetalLB + istio LoadBalancer (2단계)
- `infra/helm/metallb/` wrapper 차트(0.16.1) + `metallb-app` (L2 모드, frr-k8s 비활성화)
- IPAddressPool `192.168.0.240-250` + L2Advertisement (CR은 sync-wave+SkipDryRun으로 CRD 순서 처리)
- `istio-gateway` Service ClusterIP → **LoadBalancer**, `metallb.universe.tf/loadBalancerIPs: 192.168.0.240` 고정
  → 공유기 443 포워딩 대상(`orino_https TCP 443 → 192.168.0.240`)

## 영향
- **현재 cloudflared 경로 무영향**: LoadBalancer도 ClusterIP를 유지하므로 cloudflared의 in-cluster 접근 그대로
- 80 리스너 유지(전환 중 cloudflared 내부 경로용), cloudflared 제거는 맨 마지막 단계

## 머지 후 검증
- [ ] MetalLB controller/speaker Running
- [ ] istio-gateway svc EXTERNAL-IP = 192.168.0.240
- [ ] 공유기 443 → .240 외부 도달 (TLS는 다음 단계 cert-manager 후)

## 다음 단계
Route53 IAM(terraform) + cert-manager(DNS-01) + DDNS + Gateway 443/TLS + img VS, 마지막에 cloudflared 제거