### PR TITLE
chore : ArgoCD 프로젝트에 metallb-system·cert-manager destination 추가

### DIFF
--- a/infra/argocd/project/project.yaml
+++ b/infra/argocd/project/project.yaml
@@ -28,6 +28,10 @@ spec:
       namespace: cloudflared
     - server: https://kubernetes.default.svc
       namespace: monitoring
+    - server: https://kubernetes.default.svc
+      namespace: metallb-system
+    - server: https://kubernetes.default.svc
+      namespace: cert-manager
 
   clusterResourceWhitelist:
     - group: "*"


### PR DESCRIPTION
## 이슈
#456

## 작업 내용
- `orino` AppProject 의 허용 destination 에 `metallb-system`, `cert-manager` 추가

## 배경
PR #459 머지 후 `metallb` Application 이 `InvalidSpecError: destination ... namespace 'metallb-system' do not match any allowed destinations` 로 sync 실패. ArgoCD AppProject는 destination namespace를 화이트리스트로 제한하는데 metallb-system이 빠져 있었다. cert-manager(다음 단계)도 미리 추가.

## 머지 후
- metallb Application sync → MetalLB 배포 → istio-gateway .240 할당 검증