### PR TITLE
feat : Ansible 노드 IaC 스켈레톤 + node-os 롤 (inotify sysctl)

### DIFF
--- a/infra/ansible/README.md
+++ b/infra/ansible/README.md
@@ -1,0 +1,26 @@
+# Ansible — 노드 부트스트랩 IaC
+
+note1/note2 의 **OS 설치를 제외한 설정을 코드로** 관리한다 (#461).
+ArgoCD(워크로드) 아래 레이어 — 노드 OS · 클러스터 · ArgoCD 부트스트랩을 점진적으로 코드화.
+
+## 실행
+```bash
+cd infra/ansible
+ansible-playbook site.yml --ask-become-pass     # sudo 비밀번호 입력
+# 특정 노드만: ansible-playbook site.yml --limit note2 --ask-become-pass
+```
+
+- 접속: inventory(`note1`=192.168.0.18, `note2`=192.168.0.8), user `dongseok`, key `~/.ssh/home.pem`
+- **idempotent** — 여러 번 실행해도 안전, 새 노드 조인 시에도 동일 명령
+- 비밀번호/키는 커밋하지 않는다(런타임 입력 또는 ansible-vault)
+
+## 롤
+| 롤 | 내용 |
+|---|---|
+| `node-os` | 커널 sysctl (inotify 등). 값은 `roles/node-os/defaults/main.yml` 에서 관리 |
+
+## 로드맵 (#461)
+- [x] Phase 1: `node-os` (sysctl)
+- [ ] Phase 2: `container-runtime` (containerd) + kubeadm 사전조건
+- [ ] Phase 3: `kubeadm` (init/join)
+- [ ] Phase 4: `argocd-bootstrap` (argocd 설치 + root app/project)

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -1,0 +1,11 @@
+[defaults]
+inventory = inventory.ini
+roles_path = roles
+host_key_checking = False
+interpreter_python = auto_silent
+# 깔끔한 결과 출력 (YAML 형식)
+callback_result_format = yaml
+
+[privilege_escalation]
+become = True
+become_method = sudo

--- a/infra/ansible/inventory.ini
+++ b/infra/ansible/inventory.ini
@@ -1,0 +1,16 @@
+# Orino 클러스터 노드. 접속 유저/키는 ~/.ssh/config(note1/note2)에 정의돼 있으면 그걸 사용.
+# become(sudo) 비밀번호는 절대 커밋하지 않는다 → 실행 시 --ask-become-pass.
+[control_plane]
+note1 ansible_host=192.168.0.18
+
+[workers]
+note2 ansible_host=192.168.0.8
+
+[orino_nodes:children]
+control_plane
+workers
+
+[orino_nodes:vars]
+ansible_user=dongseok
+ansible_ssh_private_key_file=~/.ssh/home.pem
+ansible_python_interpreter=/usr/bin/python3

--- a/infra/ansible/roles/node-os/defaults/main.yml
+++ b/infra/ansible/roles/node-os/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# 노드 커널 sysctl.
+# inotify 인스턴스 기본값(128) 고갈로 containerd 의 컨테이너 생성이 막혀
+# MySQL 백업(microdnf)·MetalLB speaker 가 "too many open files" 로 실패했음 → 상향. (#461)
+node_os_sysctls:
+  fs.inotify.max_user_instances: "1024"   # 기본 128 → 1024
+  fs.inotify.max_user_watches: "524288"   # 기본 ~119k → 524288

--- a/infra/ansible/roles/node-os/tasks/main.yml
+++ b/infra/ansible/roles/node-os/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: 커널 sysctl 적용 (영구 /etc/sysctl.d + 즉시 반영)
+  ansible.posix.sysctl:
+    name: "{{ item.key }}"
+    value: "{{ item.value }}"
+    sysctl_file: /etc/sysctl.d/99-orino.conf
+    sysctl_set: true
+    reload: true
+    state: present
+  loop: "{{ node_os_sysctls | dict2items }}"
+  loop_control:
+    label: "{{ item.key }} = {{ item.value }}"

--- a/infra/ansible/site.yml
+++ b/infra/ansible/site.yml
@@ -1,0 +1,8 @@
+---
+# Orino 노드: OS 설치를 제외한 모든 설정을 코드로 관리한다 (#461).
+# ArgoCD(워크로드) 아래의 노드 OS 레이어.
+- name: 노드 OS 설정
+  hosts: orino_nodes
+  become: true
+  roles:
+    - node-os


### PR DESCRIPTION
## 이슈
#461 (Phase 1)

## 작업 내용
- `infra/ansible/` 도입 — 노드 OS를 코드로 관리하는 Ansible 레이어(ArgoCD 아래)
  - `inventory.ini`(note1/note2), `ansible.cfg`, `site.yml`, `roles/node-os`, `README.md`
- `node-os` 롤: 커널 sysctl
  - `fs.inotify.max_user_instances` 128 → **1024**
  - `fs.inotify.max_user_watches` ~119k → **524288**
  - `/etc/sysctl.d/99-orino.conf` 영구 적용 + 즉시 반영

## 배경 (근본 원인 해결)
오늘 inotify 인스턴스 고갈(기본 128, 사용 153)로 containerd 컨테이너 생성이 막혀 **MySQL 백업(microdnf)·MetalLB speaker 가 'too many open files' 로 두 번 실패**했다. 두 사건의 공통 뿌리. 양쪽 노드에 상향.

## 검증
- `ansible-playbook` 양쪽 노드 적용 → `instances=1024 watches=524288` 확인
- 영구 파일 `/etc/sysctl.d/99-orino.conf` 기록 확인
- **idempotent**: 재실행 시 `changed=0`
- 비밀번호/키 미커밋(런타임 `--ask-become-pass`)

## 다음 (#461)
Phase 2 container-runtime/kubeadm 사전조건 → Phase 3 kubeadm → Phase 4 argocd-bootstrap