### PR TITLE
feat : istio Gateway 443 HTTPS + Certificate (orino-tls)

### DIFF
--- a/infra/helm/istio-gateway/templates/certificate.yaml
+++ b/infra/helm/istio-gateway/templates/certificate.yaml
@@ -1,0 +1,19 @@
+# cert-manager Certificate — Let's Encrypt(Route53 DNS-01)로 발급해 orino-tls Secret 생성.
+# istio Gateway 443 이 이 secret 으로 TLS 종단한다. 이슈 #456
+# (cert-manager CRD라 ArgoCD 적용 순서 대비 SkipDryRun)
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: orino-tls
+  namespace: istio-ingress
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  secretName: orino-tls
+  issuerRef:
+    name: letsencrypt-route53
+    kind: ClusterIssuer
+  dnsNames:
+    - orino.dev
+    - api.orino.dev
+    - img.orino.dev

--- a/infra/helm/istio-gateway/templates/gateway.yaml
+++ b/infra/helm/istio-gateway/templates/gateway.yaml
@@ -7,10 +7,22 @@ spec:
   selector:
     istio: gateway
   servers:
+    # 80: 전환 중 cloudflared 내부 경로용으로 유지. cloudflared 제거 시 함께 정리.
     - port:
         number: 80
         name: http
         protocol: HTTP
+      hosts:
+        - "orino.dev"
+        - "*.orino.dev"
+    # 443: 집 회선 직결 HTTPS. cert-manager 발급 TLS secret(orino-tls)으로 종단. (#456)
+    - port:
+        number: 443
+        name: https
+        protocol: HTTPS
+      tls:
+        mode: SIMPLE
+        credentialName: orino-tls
       hosts:
         - "orino.dev"
         - "*.orino.dev"


### PR DESCRIPTION
## 이슈
#456

## 작업 내용
- **Certificate** `orino-tls`(istio-ingress ns): `orino.dev`/`api.orino.dev`/`img.orino.dev` → ClusterIssuer `letsencrypt-route53`(Route53 DNS-01)로 발급 → `orino-tls` Secret 생성
- **istio Gateway 443 HTTPS** 서버 추가, `credentialName: orino-tls`로 TLS 종단
- 80은 전환 중 cloudflared 내부 경로용 유지(cloudflared 제거 시 정리)

## 머지 후 검증
- [ ] Certificate `orino-tls` Ready=True (DNS-01 실제 발급 — TXT 생성→LE 검증, 1~3분)
- [ ] `orino-tls` Secret 생성(istio-ingress)
- [ ] `https://api.orino.dev`(via .240) TLS 핸드셰이크 정상 + 유효 인증서
- [ ] 한국 TTFB 측정(cloudflare 경유 872ms 대비)

## 다음
DDNS(A레코드 자동 갱신) → img VS → cloudflared 제거(맨 마지막)