### PR TITLE
feat : Route53 A레코드 (orino.dev/api → 집 공인IP 직결)

### DIFF
--- a/infra/terraform/route53.tf
+++ b/infra/terraform/route53.tf
@@ -69,3 +69,28 @@ output "route53_dns_secret_access_key" {
   value       = aws_iam_access_key.route53_dns.secret
   sensitive   = true
 }
+
+# A 레코드 — 집 공인(WAN) IP 직결. 초기값은 현재 IP, 이후 DDNS(ddns-updater)가
+# 동적 IP 변경 시 갱신하므로 records/ttl 변경은 terraform 이 무시. 이슈 #456
+# (img.orino.dev 는 istio VirtualService 단계에서 함께 추가)
+resource "aws_route53_record" "apex" {
+  zone_id = aws_route53_zone.orino.zone_id
+  name    = "orino.dev"
+  type    = "A"
+  ttl     = 60
+  records = ["210.183.38.83"]
+  lifecycle {
+    ignore_changes = [records, ttl]
+  }
+}
+
+resource "aws_route53_record" "api" {
+  zone_id = aws_route53_zone.orino.zone_id
+  name    = "api.orino.dev"
+  type    = "A"
+  ttl     = 60
+  records = ["210.183.38.83"]
+  lifecycle {
+    ignore_changes = [records, ttl]
+  }
+}


### PR DESCRIPTION
## 이슈
#456

## 작업 내용
- `orino.dev`, `api.orino.dev` A레코드 → `210.183.38.83`(집 WAN IP), TTL 60. **terraform apply 완료**
- DDNS(ddns-updater)가 동적 IP 갱신하므로 `records`/`ttl` `ignore_changes`
- NS 위임 후 A레코드가 없어 공개 NXDOMAIN(다운)이던 것 복구

## 검증
- 공개 DNS: orino.dev/api.orino.dev → 210.183.38.83 (Route53 권한)
- **직결 HTTPS TTFB 12~26ms** (기존 Cloudflare LAX 경유 ~870ms) — 유효 LE 인증서
- (참고) 테스트 mac의 스테일 DNS 캐시가 한동안 Cloudflare로 가니, 외부망/캐시 만료 후 직결 반영

## 다음
DDNS(자동 A레코드 갱신) → img VS(+img A레코드) → cloudflared 제거