### PR TITLE
feat : img.orino.dev를 istio 경유 MinIO로 이전

### DIFF
--- a/infra/helm/istio-gateway/templates/virtualservice-img.yaml
+++ b/infra/helm/istio-gateway/templates/virtualservice-img.yaml
@@ -1,0 +1,18 @@
+# img.orino.dev → MinIO(S3 호환). 브라우저가 presigned URL로 직접 PUT/GET.
+# cloudflared 직결 라우팅을 istio 경유로 이전. Host(img.orino.dev) 보존 → MinIO 서명 검증 정상. (#456)
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: img
+  namespace: istio-ingress
+spec:
+  hosts:
+    - "img.orino.dev"
+  gateways:
+    - orino-gateway
+  http:
+    - route:
+        - destination:
+            host: minio.orino.svc.cluster.local
+            port:
+              number: 9000

--- a/infra/terraform/route53.tf
+++ b/infra/terraform/route53.tf
@@ -94,3 +94,14 @@ resource "aws_route53_record" "api" {
     ignore_changes = [records, ttl]
   }
 }
+
+resource "aws_route53_record" "img" {
+  zone_id = aws_route53_zone.orino.zone_id
+  name    = "img.orino.dev"
+  type    = "A"
+  ttl     = 60
+  records = ["210.183.38.83"]
+  lifecycle {
+    ignore_changes = [records, ttl]
+  }
+}


### PR DESCRIPTION
## 이슈
#456

## 작업 내용
- **VirtualService `img`**: `img.orino.dev` → `minio.orino.svc.cluster.local:9000` (Host 보존 → MinIO presigned 서명 검증 정상)
- **img.orino.dev A레코드** → `210.183.38.83` (terraform apply 완료)
- 인증서 `orino-tls`에 이미 img.orino.dev 포함, Gateway 443 `*.orino.dev` 매칭 → TLS 자동

## 배경
기존 img.orino.dev는 cloudflared 터널 → MinIO 직결. 이를 istio 경유로 이전(직결 경로 통일). cloudflared 제거의 선행.

## 머지 후 검증
- [ ] https://img.orino.dev (via .240) → MinIO 응답 (TLS 유효)
- [ ] 노트 이미지 업로드(presigned PUT)/조회 정상

## 다음 (마지막)
cloudflared 완전 제거 (helm chart, argocd app, SealedSecret, terraform tunnel/provider/DNS)