### PR TITLE
feat : telemetry 직결 + 인증서/DNS wildcard화

### DIFF
--- a/infra/helm/istio-gateway/templates/certificate.yaml
+++ b/infra/helm/istio-gateway/templates/certificate.yaml
@@ -13,7 +13,8 @@ spec:
   issuerRef:
     name: letsencrypt-route53
     kind: ClusterIssuer
+  # wildcard — 모든 서브도메인(api/img/telemetry/향후) 커버. apex는 별도 명시 필요.
+  # 새 서브도메인 추가 시 인증서 변경 불필요(VirtualService만 추가).
   dnsNames:
     - orino.dev
-    - api.orino.dev
-    - img.orino.dev
+    - "*.orino.dev"

--- a/infra/terraform/route53.tf
+++ b/infra/terraform/route53.tf
@@ -70,9 +70,9 @@ output "route53_dns_secret_access_key" {
   sensitive   = true
 }
 
-# A 레코드 — 집 공인(WAN) IP 직결. 초기값은 현재 IP, 이후 DDNS(ddns-updater)가
-# 동적 IP 변경 시 갱신하므로 records/ttl 변경은 terraform 이 무시. 이슈 #456
-# (img.orino.dev 는 istio VirtualService 단계에서 함께 추가)
+# A 레코드 — 집 공인(WAN) IP 직결. 이슈 #456
+# apex + wildcard 로 모든 서브도메인(api/img/telemetry/향후) 커버 → 새 서브도메인은
+# VirtualService 만 추가하면 됨(DNS/인증서 무변경). IP 변경 시 수동 갱신 대비 ignore_changes.
 resource "aws_route53_record" "apex" {
   zone_id = aws_route53_zone.orino.zone_id
   name    = "orino.dev"
@@ -84,20 +84,9 @@ resource "aws_route53_record" "apex" {
   }
 }
 
-resource "aws_route53_record" "api" {
+resource "aws_route53_record" "wildcard" {
   zone_id = aws_route53_zone.orino.zone_id
-  name    = "api.orino.dev"
-  type    = "A"
-  ttl     = 60
-  records = ["210.183.38.83"]
-  lifecycle {
-    ignore_changes = [records, ttl]
-  }
-}
-
-resource "aws_route53_record" "img" {
-  zone_id = aws_route53_zone.orino.zone_id
-  name    = "img.orino.dev"
+  name    = "*.orino.dev"
   type    = "A"
   ttl     = 60
   records = ["210.183.38.83"]


### PR DESCRIPTION
## 이슈
#456

## 작업 내용
- **인증서/DNS를 wildcard로 전환** (개별 나열 → 와일드카드)
  - Certificate dnsNames: `orino.dev` + `*.orino.dev`
  - Route53: `orino.dev`(apex) + `*.orino.dev` (api/img/telemetry/**향후 전부** 커버). terraform apply 완료
- **telemetry.orino.dev 직결 이전** (VS는 기존 → DNS/cert만 추가하면 동작)
- (부수) img.orino.dev A레코드가 유실돼 있었는데 wildcard로 자동 복구

## 왜 wildcard
- DNS-01(Route53) 사용 중이라 wildcard 인증서 제약 없음. Gateway도 이미 `*.orino.dev`
- **새 서브도메인 = VirtualService만 추가** (DNS/인증서 무변경) → churn 제거
- 단일 사용자라 wildcard 키 노출 우려 무의미

## 검증
- Route53: orino.dev + *.orino.dev → 모든 호스트(+임의 서브도메인) WAN IP 해석 확인
- 머지 후: cert-manager가 orino-tls를 wildcard로 재발급 → telemetry 포함 전부 TLS 유효

## 머지 후 검증 → 마지막 단계
전체 직결(orino/api/img/telemetry) TLS 정상 확인 후 **cloudflared 완전 제거**(#456 종료)