### PR TITLE
feat : Thanos caching bucket(memcached)로 S3 GET 절감

### DIFF
--- a/infra/helm/thanos/templates/caching-bucket-configmap.yaml
+++ b/infra/helm/thanos/templates/caching-bucket-configmap.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.storegateway.cachingBucket.enabled }}
+# store-gateway 의 caching-bucket 설정. S3 메타데이터/청크 subrange 를 memcached 에 캐싱.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: thanos-caching-bucket
+  labels:
+    app.kubernetes.io/name: thanos
+    app.kubernetes.io/component: storegateway
+data:
+  caching-bucket.yml: |
+    type: MEMCACHED
+    config:
+      addresses:
+        - thanos-memcached-bucket:11211
+      timeout: 500ms
+      max_idle_connections: 100
+      max_async_concurrency: 20
+      max_async_buffer_size: 10000
+      max_item_size: 5MiB
+      max_get_multi_concurrency: 100
+    chunk_subrange_size: 16000
+    chunk_object_attrs_ttl: 24h
+    chunk_subrange_ttl: 24h
+    max_chunks_get_range_requests: 3
+    blocks_iter_ttl: 5m
+    metafile_exists_ttl: 2h
+    metafile_doesnt_exist_ttl: 15m
+    metafile_content_ttl: 24h
+    metafile_max_size: 1MiB
+{{- end }}

--- a/infra/helm/thanos/templates/memcached-bucket-deployment.yaml
+++ b/infra/helm/thanos/templates/memcached-bucket-deployment.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.storegateway.cachingBucket.enabled }}
+# Thanos store-gateway 의 caching-bucket 외부 backend.
+# S3 의 list/exists/attributes/get-range(청크 subrange) + meta.json 을 캐싱해
+# 반복 쿼리 시 S3 GET 호출을 크게 줄인다.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: thanos-memcached-bucket
+  labels:
+    app.kubernetes.io/name: thanos
+    app.kubernetes.io/component: memcached-bucket
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: thanos
+      app.kubernetes.io/component: memcached-bucket
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: thanos
+        app.kubernetes.io/component: memcached-bucket
+    spec:
+      containers:
+        - name: memcached
+          image: {{ .Values.memcached.image }}
+          args:
+            - -m {{ .Values.memcached.allocatedMemoryMB }}
+            - -I {{ .Values.memcached.maxItemSize }}
+            - -c {{ .Values.memcached.maxConnections }}
+          ports:
+            - name: memcached
+              containerPort: 11211
+          readinessProbe:
+            tcpSocket: {port: memcached}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket: {port: memcached}
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.memcached.resources | nindent 12 }}
+{{- end }}

--- a/infra/helm/thanos/templates/memcached-bucket-service.yaml
+++ b/infra/helm/thanos/templates/memcached-bucket-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.storegateway.cachingBucket.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: thanos-memcached-bucket
+  labels:
+    app.kubernetes.io/name: thanos
+    app.kubernetes.io/component: memcached-bucket
+spec:
+  clusterIP: None
+  ports:
+    - name: memcached
+      port: 11211
+      targetPort: memcached
+  selector:
+    app.kubernetes.io/name: thanos
+    app.kubernetes.io/component: memcached-bucket
+{{- end }}

--- a/infra/helm/thanos/templates/storegateway-statefulset.yaml
+++ b/infra/helm/thanos/templates/storegateway-statefulset.yaml
@@ -29,6 +29,10 @@ spec:
             - --objstore.config-file=/etc/thanos/objstore.yml
             - --http-address=0.0.0.0:9090
             - --grpc-address=0.0.0.0:10901
+            {{- if .Values.storegateway.cachingBucket.enabled }}
+            # S3 메타/청크 subrange 를 memcached 에 캐싱해 GET 호출을 대폭 줄인다.
+            - --store.caching-bucket.config-file=/etc/thanos-caching/caching-bucket.yml
+            {{- end }}
           ports:
             - name: http
               containerPort: 9090
@@ -47,12 +51,21 @@ spec:
               mountPath: /var/thanos/store
             - name: objstore-config
               mountPath: /etc/thanos
+            {{- if .Values.storegateway.cachingBucket.enabled }}
+            - name: caching-bucket-config
+              mountPath: /etc/thanos-caching
+            {{- end }}
           resources:
             {{- toYaml .Values.storegateway.resources | nindent 12 }}
       volumes:
         - name: objstore-config
           secret:
             secretName: {{ .Values.objstoreSecret }}
+        {{- if .Values.storegateway.cachingBucket.enabled }}
+        - name: caching-bucket-config
+          configMap:
+            name: thanos-caching-bucket
+        {{- end }}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim

--- a/infra/helm/thanos/values.yaml
+++ b/infra/helm/thanos/values.yaml
@@ -22,6 +22,9 @@ storegateway:
   replicas: 1
   storageClass: longhorn
   storageSize: 5Gi
+  # caching bucket: S3 GET 요청 절감(메타/청크 subrange 를 memcached 캐싱)
+  cachingBucket:
+    enabled: true
   resources:
     requests:
       cpu: 100m
@@ -29,6 +32,20 @@ storegateway:
     limits:
       cpu: 500m
       memory: 512Mi
+
+# store-gateway caching-bucket 외부 backend (작게 — 취미 클러스터)
+memcached:
+  image: memcached:1.6.38-alpine
+  allocatedMemoryMB: 256
+  maxItemSize: 5m
+  maxConnections: 1024
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 320Mi
 
 compactor:
   retentionRaw: 30d


### PR DESCRIPTION
## 이슈
#467

## 작업 내용
- **memcached**(256MB) Deployment + Service (`thanos-memcached-bucket`, monitoring ns)
- **caching-bucket ConfigMap**: S3 메타(exists/content/iter) + 청크 subrange 캐싱 TTL 설정
- **store-gateway**: `--store.caching-bucket.config-file` arg + ConfigMap 마운트(`/etc/thanos-caching`)

## 배경
per-bucket 진단에서 **Thanos GET이 S3 요청의 63%(108k/day)**로 1위 — store-gateway가 쿼리/대시보드 새로고침마다 블록 메타·청크를 S3에서 재조회(Thanos 정상 동작). caching bucket으로 반복 호출을 memcached에서 처리해 S3 GET을 대폭 감축. Thanos 공식 권장 최적화.

- index-header는 store-gateway의 기존 data-dir PVC로 이미 영구 캐시됨
- MinIO 이전 대신 caching bucket 선택: 메트릭을 durable S3에 유지 + 단일노드 MinIO SPOF 회피

## 머지 후 검증
- [ ] thanos-memcached-bucket + store-gateway Running
- [ ] store-gateway가 caching-bucket 설정 로드 (로그)
- [ ] 며칠 뒤 thanos 버킷 GET 요청 급감 확인 (CloudWatch/CE)

참고: https://thanos.io/tip/components/store.md/#caching-bucket