### PR TITLE
chore : Trivy HIGH CVE 대응 (netty 4.2.15 + alpine openssl)

### DIFF
--- a/be/Dockerfile
+++ b/be/Dockerfile
@@ -19,6 +19,9 @@ COPY . .
 RUN ./gradlew :orino-app-api:build -x test --no-daemon
 
 FROM eclipse-temurin:25-jre-alpine
+# 베이스 이미지의 alpine OS 패키지를 최신 보안 패치로 갱신한다.
+# (예: openssl/libssl3/libcrypto3 CVE-2026-45447) upstream 재빌드 전까지 신규 OS CVE를 흡수.
+RUN apk --no-cache upgrade
 WORKDIR /app
 COPY --from=builder /app/orino-app-api/build/libs/*.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -21,7 +21,7 @@ subprojects {
 
     ext['jackson-2-bom.version'] = '2.21.2'
     ext['jackson-bom.version'] = '3.1.2'
-    ext['netty.version'] = '4.2.13.Final'
+    ext['netty.version'] = '4.2.15.Final'
     ext['spring-security.version'] = '7.0.5'
     ext['tomcat.version'] = '11.0.22'
 


### PR DESCRIPTION
## 이슈
closes #493

## 작업 내용
BE 이미지 Trivy 스캔(CRITICAL,HIGH / exit-code 1)이 신규 공개 CVE로 실패해 main·모든 신규 PR이 막힌 상태를 해소한다. 코드 변경 없이 라이브 취약점 DB 갱신으로 발생한 것이라, 기존 `build.gradle` CVE 핀 블록 컨벤션에 맞춰 버전을 올린다.

- **netty** 핀 `4.2.13.Final` → `4.2.15.Final`
  - `CVE-2026-44249`, `CVE-2026-45416` (netty-handler)
  - `CVE-2026-45674`, `CVE-2026-47691` (netty-resolver-dns, DNS 캐시 포이즈닝)
  - 4건 모두 4.2.15.Final에서 수정
- **alpine openssl** — `Dockerfile` 런타임 스테이지에 `apk --no-cache upgrade`
  - `CVE-2026-45447` (openssl/libssl3/libcrypto3 Heap UAF, fixed 3.5.7-r0)
  - upstream(temurin alpine) 재빌드 전까지 신규 OS CVE를 흡수

## 검증
로컬에서 이미지 빌드 후 CI와 동일 조건(`trivy image --severity CRITICAL,HIGH --exit-code 1`) 스캔:

```
┌────────────────────────────────────┬────────┬─────────────────┐
│               Target               │  Type  │ Vulnerabilities │
├────────────────────────────────────┼────────┼─────────────────┤
│ orino-be (alpine 3.23.4)           │ alpine │        0        │
│ app/app.jar                        │  jar   │        0        │
└────────────────────────────────────┴────────┴─────────────────┘
```