### PR TITLE
chore : AppProject를 GitOps로 관리 (orino-project Application)

### DIFF
--- a/infra/argocd/applications/orino-project-app.yaml
+++ b/infra/argocd/applications/orino-project-app.yaml
@@ -1,0 +1,25 @@
+# AppProject 'orino'를 GitOps로 관리한다. root 앱(applications/ 관리)이 이 Application을
+# 만들고, 이 Application이 infra/argocd/project 의 AppProject를 sync → project.yaml 변경이
+# 머지만으로 반영된다. (기존엔 project가 아무 앱에도 안 잡혀 수동 apply 필요했음)
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: orino-project
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: orino
+  source:
+    repoURL: https://github.com/wcorn/orino.git
+    targetRevision: main
+    path: infra/argocd/project
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: false   # AppProject 실수 삭제 방지(삭제되면 모든 앱이 project를 잃음)
+    syncOptions:
+      - ApplyOutOfSyncOnly=true


### PR DESCRIPTION
## 배경
AppProject(`infra/argocd/project/project.yaml`)가 **어느 ArgoCD 앱에도 잡혀있지 않아**, project.yaml에 namespace를 추가해도 라이브에 자동 반영되지 않고 **수동 `kubectl apply`가 필요**했다(metallb/cert-manager/tailscale 추가 때마다 발생한 빈틈).

## 작업 내용
- root 앱이 관리하는 `infra/argocd/applications/` 에 **`orino-project` Application** 추가
- 이 Application이 `infra/argocd/project` 의 AppProject를 sync → **이후 project 변경은 머지만으로 반영**
- `prune: false` — AppProject 실수 삭제 방지(삭제 시 전 앱이 project를 잃음)

## 머지 후
- root 앱이 orino-project 앱 생성 → 라이브 AppProject(이미 tailscale 포함) adopt → Synced
- 앞으로 namespace 추가 등은 PR 머지만으로 자동 반영

## 정석화 맥락
GitOps 정석: app-of-apps의 root가 project까지 self-manage. 최초 seed는 별도(Ansible argocd-bootstrap, #461 Phase 4).