### PR TITLE
feat : Planner google_account 테이블 + 엔티티/리포지토리 + Redis 토큰/state

### DIFF
--- a/be/orino-app-api/src/main/resources/db/changelog/changes/023-create-google-account.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/023-create-google-account.yaml
@@ -1,0 +1,67 @@
+databaseChangeLog:
+  - changeSet:
+      id: 023-create-google-account
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: google_account
+      changes:
+        - createTable:
+            tableName: google_account
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uk_google_account_member
+                    foreignKeyName: fk_google_account_member
+                    references: member(id)
+              - column:
+                  name: google_email
+                  type: VARCHAR(255)
+              - column:
+                  name: refresh_token
+                  type: VARCHAR(512)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: scopes
+                  type: VARCHAR(512)
+              - column:
+                  name: primary_calendar_id
+                  type: VARCHAR(255)
+              - column:
+                  name: task_list_id
+                  type: VARCHAR(255)
+              - column:
+                  name: connected_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: revoked
+                  type: BIT(1)
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -43,3 +43,5 @@ databaseChangeLog:
       file: db/changelog/changes/021-alter-note-tree.yaml
   - include:
       file: db/changelog/changes/022-review-schedule-datetime.yaml
+  - include:
+      file: db/changelog/changes/023-create-google-account.yaml

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/google/entity/GoogleAccount.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/google/entity/GoogleAccount.java
@@ -1,0 +1,138 @@
+package ds.project.orino.domain.planner.google.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+/**
+ * Google OAuth 연동 자격증명. 단일 사용자라 1 row지만 {@code member_id} UNIQUE로 멀티유저 확장 여지를 남긴다.
+ *
+ * <p>refresh token은 영속 보관(연결 해제까지). access token/oauth-state는 Redis(휘발).
+ * 일정/할 일은 Google이 source of truth이므로 orino에 저장하지 않는다.
+ */
+@Entity
+@Table(name = "google_account")
+@EntityListeners(AuditingEntityListener.class)
+public class GoogleAccount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false, unique = true)
+    private Long memberId;
+
+    @Column(name = "google_email", length = 255)
+    private String googleEmail;
+
+    @Column(name = "refresh_token", nullable = false, length = 512)
+    private String refreshToken;
+
+    @Column(length = 512)
+    private String scopes;
+
+    @Column(name = "primary_calendar_id", length = 255)
+    private String primaryCalendarId;
+
+    @Column(name = "task_list_id", length = 255)
+    private String taskListId;
+
+    @Column(name = "connected_at", nullable = false)
+    private Instant connectedAt;
+
+    @Column(nullable = false)
+    private boolean revoked = false;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected GoogleAccount() {
+    }
+
+    public GoogleAccount(Long memberId, String refreshToken, String scopes,
+                         String googleEmail, String primaryCalendarId, String taskListId) {
+        this.memberId = memberId;
+        this.refreshToken = refreshToken;
+        this.scopes = scopes;
+        this.googleEmail = googleEmail;
+        this.primaryCalendarId = primaryCalendarId;
+        this.taskListId = taskListId;
+        this.connectedAt = Instant.now();
+        this.revoked = false;
+    }
+
+    /** 재연동(re-consent): refresh token·메타데이터를 갱신하고 revoked를 해제한다. */
+    public void reconnect(String refreshToken, String scopes, String googleEmail,
+                          String primaryCalendarId, String taskListId) {
+        this.refreshToken = refreshToken;
+        this.scopes = scopes;
+        this.googleEmail = googleEmail;
+        this.primaryCalendarId = primaryCalendarId;
+        this.taskListId = taskListId;
+        this.connectedAt = Instant.now();
+        this.revoked = false;
+    }
+
+    /** invalid_grant 등으로 refresh token이 무효화됐을 때 마킹. FE 재연동 CTA 유도. */
+    public void markRevoked() {
+        this.revoked = true;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public String getGoogleEmail() {
+        return googleEmail;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public String getScopes() {
+        return scopes;
+    }
+
+    public String getPrimaryCalendarId() {
+        return primaryCalendarId;
+    }
+
+    public String getTaskListId() {
+        return taskListId;
+    }
+
+    public Instant getConnectedAt() {
+        return connectedAt;
+    }
+
+    public boolean isRevoked() {
+        return revoked;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/google/repository/GoogleAccountRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/google/repository/GoogleAccountRepository.java
@@ -1,0 +1,15 @@
+package ds.project.orino.domain.planner.google.repository;
+
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GoogleAccountRepository extends JpaRepository<GoogleAccount, Long> {
+
+    Optional<GoogleAccount> findByMemberId(Long memberId);
+
+    boolean existsByMemberId(Long memberId);
+
+    void deleteByMemberId(Long memberId);
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/google/repository/GoogleAccountRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/google/repository/GoogleAccountRepositoryTest.java
@@ -1,0 +1,121 @@
+package ds.project.orino.domain.planner.google.repository;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.support.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RepositoryTest
+@Transactional
+class GoogleAccountRepositoryTest {
+
+    @Autowired
+    private GoogleAccountRepository googleAccountRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        memberId = memberRepository.save(new Member("googleuser", "encodedPassword")).getId();
+    }
+
+    @Test
+    @DisplayName("GoogleAccount를 저장하고 memberId로 조회한다")
+    void save_and_findByMemberId() {
+        GoogleAccount account = new GoogleAccount(
+                memberId, "refresh-token", "scope-a scope-b",
+                "me@gmail.com", "primary", "tasklist-1");
+
+        googleAccountRepository.save(account);
+        Optional<GoogleAccount> found = googleAccountRepository.findByMemberId(memberId);
+
+        assertThat(found).isPresent();
+        GoogleAccount saved = found.get();
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getMemberId()).isEqualTo(memberId);
+        assertThat(saved.getRefreshToken()).isEqualTo("refresh-token");
+        assertThat(saved.getScopes()).isEqualTo("scope-a scope-b");
+        assertThat(saved.getGoogleEmail()).isEqualTo("me@gmail.com");
+        assertThat(saved.getPrimaryCalendarId()).isEqualTo("primary");
+        assertThat(saved.getTaskListId()).isEqualTo("tasklist-1");
+        assertThat(saved.getConnectedAt()).isNotNull();
+        assertThat(saved.isRevoked()).isFalse();
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("memberId 존재 여부를 확인한다")
+    void existsByMemberId() {
+        googleAccountRepository.save(new GoogleAccount(memberId, "t", null, null, null, null));
+
+        assertThat(googleAccountRepository.existsByMemberId(memberId)).isTrue();
+        assertThat(googleAccountRepository.existsByMemberId(memberId + 999)).isFalse();
+    }
+
+    @Test
+    @DisplayName("memberId로 GoogleAccount를 삭제한다")
+    void deleteByMemberId() {
+        googleAccountRepository.save(new GoogleAccount(memberId, "t", null, null, null, null));
+
+        googleAccountRepository.deleteByMemberId(memberId);
+
+        assertThat(googleAccountRepository.findByMemberId(memberId)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("member_id는 UNIQUE — 같은 member로 두 row를 저장하면 실패한다")
+    void memberId_isUnique() {
+        googleAccountRepository.saveAndFlush(new GoogleAccount(memberId, "t1", null, null, null, null));
+
+        assertThatThrownBy(() ->
+                googleAccountRepository.saveAndFlush(new GoogleAccount(memberId, "t2", null, null, null, null)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("markRevoked는 revoked를 true로 마킹한다")
+    void markRevoked() {
+        GoogleAccount account = googleAccountRepository.save(
+                new GoogleAccount(memberId, "t", null, null, null, null));
+
+        account.markRevoked();
+        googleAccountRepository.save(account);
+
+        assertThat(googleAccountRepository.findByMemberId(memberId))
+                .get().extracting(GoogleAccount::isRevoked).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("reconnect는 refresh token·메타데이터를 갱신하고 revoked를 해제한다")
+    void reconnect() {
+        GoogleAccount account = new GoogleAccount(memberId, "old-token", "old-scope", null, null, null);
+        account.markRevoked();
+        googleAccountRepository.save(account);
+
+        account.reconnect("new-token", "new-scope", "new@gmail.com", "primary", "tasklist-2");
+        googleAccountRepository.save(account);
+
+        GoogleAccount reloaded = googleAccountRepository.findByMemberId(memberId).orElseThrow();
+        assertThat(reloaded.getRefreshToken()).isEqualTo("new-token");
+        assertThat(reloaded.getScopes()).isEqualTo("new-scope");
+        assertThat(reloaded.getGoogleEmail()).isEqualTo("new@gmail.com");
+        assertThat(reloaded.getPrimaryCalendarId()).isEqualTo("primary");
+        assertThat(reloaded.getTaskListId()).isEqualTo("tasklist-2");
+        assertThat(reloaded.isRevoked()).isFalse();
+    }
+}

--- a/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/google/GoogleAccessTokenRepository.java
+++ b/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/google/GoogleAccessTokenRepository.java
@@ -1,0 +1,41 @@
+package ds.project.orino.redis.planner.google;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Google access token 캐시. 키 {@code google:access:{memberId}}, TTL = expires_in(여유 차감).
+ *
+ * <p>access token은 단명(~1h)이라 Redis 자동 만료가 적합하다. miss/401 시 {@code GoogleTokenProvider}가
+ * refresh grant로 재발급해 다시 캐시한다(#476).
+ */
+@Repository
+public class GoogleAccessTokenRepository {
+
+    private static final String KEY_PREFIX = "google:access:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public GoogleAccessTokenRepository(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(Long memberId, String accessToken, Duration ttl) {
+        redisTemplate.opsForValue().set(key(memberId), accessToken, ttl);
+    }
+
+    public Optional<String> findByMemberId(Long memberId) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(key(memberId)));
+    }
+
+    public void deleteByMemberId(Long memberId) {
+        redisTemplate.delete(key(memberId));
+    }
+
+    private String key(Long memberId) {
+        return KEY_PREFIX + memberId;
+    }
+}

--- a/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/google/GoogleOAuthStateRepository.java
+++ b/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/google/GoogleOAuthStateRepository.java
@@ -1,0 +1,43 @@
+package ds.project.orino.redis.planner.google;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * OAuth state ↔ memberId 바인딩 저장소. 키 {@code google:oauth-state:{state}}, TTL 5분.
+ *
+ * <p>콜백 시점엔 JWT가 없으므로 url 발급 시 state에 memberId를 묶어 저장하고 콜백에서 복원한다(#475).
+ * 1회성 단명 저장으로 CSRF 방지를 겸한다.
+ */
+@Repository
+public class GoogleOAuthStateRepository {
+
+    private static final String KEY_PREFIX = "google:oauth-state:";
+    private static final Duration TTL = Duration.ofMinutes(5);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public GoogleOAuthStateRepository(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(String state, Long memberId) {
+        redisTemplate.opsForValue().set(key(state), String.valueOf(memberId), TTL);
+    }
+
+    public Optional<Long> findMemberId(String state) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(key(state)))
+                .map(Long::valueOf);
+    }
+
+    public void delete(String state) {
+        redisTemplate.delete(key(state));
+    }
+
+    private String key(String state) {
+        return KEY_PREFIX + state;
+    }
+}

--- a/be/orino-domain-redis/src/test/java/ds/project/orino/redis/planner/google/GoogleAccessTokenRepositoryTest.java
+++ b/be/orino-domain-redis/src/test/java/ds/project/orino/redis/planner/google/GoogleAccessTokenRepositoryTest.java
@@ -1,0 +1,54 @@
+package ds.project.orino.redis.planner.google;
+
+import ds.project.orino.redis.support.RedisTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RedisTest
+class GoogleAccessTokenRepositoryTest {
+
+    @Autowired
+    private GoogleAccessTokenRepository accessTokenRepository;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Test
+    @DisplayName("access token을 저장하고 조회한다")
+    void save_and_find() {
+        accessTokenRepository.save(1L, "access-token", Duration.ofMinutes(30));
+
+        assertThat(accessTokenRepository.findByMemberId(1L)).contains("access-token");
+    }
+
+    @Test
+    @DisplayName("저장 시 TTL이 설정된다")
+    void save_setsTtl() {
+        accessTokenRepository.save(2L, "access-token", Duration.ofMinutes(30));
+
+        Long ttl = redisTemplate.getExpire("google:access:2");
+        assertThat(ttl).isBetween(1L, 1800L);
+    }
+
+    @Test
+    @DisplayName("access token을 삭제한다")
+    void delete() {
+        accessTokenRepository.save(3L, "access-token", Duration.ofMinutes(5));
+
+        accessTokenRepository.deleteByMemberId(3L);
+
+        assertThat(accessTokenRepository.findByMemberId(3L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 memberId 조회 시 빈 Optional을 반환한다")
+    void find_notFound() {
+        assertThat(accessTokenRepository.findByMemberId(999L)).isEmpty();
+    }
+}

--- a/be/orino-domain-redis/src/test/java/ds/project/orino/redis/planner/google/GoogleOAuthStateRepositoryTest.java
+++ b/be/orino-domain-redis/src/test/java/ds/project/orino/redis/planner/google/GoogleOAuthStateRepositoryTest.java
@@ -1,0 +1,52 @@
+package ds.project.orino.redis.planner.google;
+
+import ds.project.orino.redis.support.RedisTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RedisTest
+class GoogleOAuthStateRepositoryTest {
+
+    @Autowired
+    private GoogleOAuthStateRepository oauthStateRepository;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Test
+    @DisplayName("state ↔ memberId를 저장하고 조회한다")
+    void save_and_findMemberId() {
+        oauthStateRepository.save("state-abc", 42L);
+
+        assertThat(oauthStateRepository.findMemberId("state-abc")).contains(42L);
+    }
+
+    @Test
+    @DisplayName("저장 시 5분 TTL이 설정된다")
+    void save_setsTtl() {
+        oauthStateRepository.save("state-ttl", 1L);
+
+        Long ttl = redisTemplate.getExpire("google:oauth-state:state-ttl");
+        assertThat(ttl).isBetween(1L, 300L);
+    }
+
+    @Test
+    @DisplayName("state를 삭제한다 (콜백 1회성 검증)")
+    void delete() {
+        oauthStateRepository.save("state-del", 1L);
+
+        oauthStateRepository.delete("state-del");
+
+        assertThat(oauthStateRepository.findMemberId("state-del")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 state 조회 시 빈 Optional을 반환한다")
+    void findMemberId_notFound() {
+        assertThat(oauthStateRepository.findMemberId("nonexistent")).isEmpty();
+    }
+}


### PR DESCRIPTION
## 이슈
closes #474

## 작업 내용
Epic #472 M0. Google 연동 자격증명 영속 저장(`google_account`) + Redis 토큰/state 저장소. 일정/할 일은 Google이 source of truth라 로컬 미러 없음.

### RDB (orino-domain-rdb, `domain.planner.google`)
- **Liquibase `023-create-google-account`**: `member` FK, `member_id` UNIQUE, `DATETIME(6)`, `created_at`/`updated_at`, preCondition `tableExists` 가드
  - `revoked`는 **`BIT(1)`** — `BOOLEAN`이면 MySQL `tinyint`으로 생성돼 Hibernate `validate`(boolean→`bit` 기대)와 불일치
- **`GoogleAccount`** 엔티티 (인라인 auditing 패턴) + **`GoogleAccountRepository`**
  - 도메인 메서드: `reconnect(...)`(재연동 시 토큰·메타 갱신 + revoked 해제), `markRevoked()`(invalid_grant)

### Redis (orino-domain-redis, `redis.planner.google`)
- **`GoogleAccessTokenRepository`** — `google:access:{memberId}`, TTL=expires_in (#476 자동 갱신에서 사용)
- **`GoogleOAuthStateRepository`** — `google:oauth-state:{state}`, TTL 5분 (#475 콜백 검증/CSRF)
- 기존 `RefreshTokenRepository` 관심사-단위 컨벤션에 맞춰 2개로 분리

## 테스트
- `GoogleAccountRepositoryTest` (TestContainers MySQL): 저장/조회, `existsByMemberId`, `deleteByMemberId`, **member_id UNIQUE 위반**, `markRevoked`, `reconnect` — 6/6
- `GoogleAccessTokenRepositoryTest` / `GoogleOAuthStateRepositoryTest` (TestContainers Redis): 저장/조회/삭제 + **TTL 검증**(`getExpire`) — 4/4 + 4/4
- **`SchemaValidationTest`**: Liquibase 적용 + Hibernate `validate`로 changelog↔엔티티 정합성 통과