### PR TITLE
feat : Terraform CI/CD (GitHub Actions OIDC, plan on PR / apply on merge)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,60 @@
+name: Terraform
+
+on:
+  pull_request:
+    paths:
+      - 'infra/terraform/**'
+      - '.github/workflows/terraform.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'infra/terraform/**'
+
+# OIDC로 AWS 자격증명을 받기 위해 id-token 필요. 정적 키 없음.
+permissions:
+  id-token: write
+  contents: read
+
+# apply 동시 실행 방지(state 잠금 + 추가 안전장치). 실행 중 취소 안 함.
+concurrency:
+  group: terraform-apply
+  cancel-in-progress: false
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra/terraform
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::012900311331:role/github-actions-terraform
+          aws-region: ap-northeast-2
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.14.8"
+
+      - name: Terraform init
+        run: terraform init -input=false
+
+      - name: Terraform format check
+        run: terraform fmt -check -recursive
+
+      # PR: plan 만(변경 미리보기). 결과는 job summary에 출력.
+      - name: Terraform plan
+        if: github.event_name == 'pull_request'
+        run: |
+          echo '### Terraform Plan' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          terraform plan -input=false -no-color 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      # main 머지: 자동 apply.
+      - name: Terraform apply
+        if: github.event_name == 'push'
+        run: terraform apply -auto-approve -input=false

--- a/infra/terraform/cicd.tf
+++ b/infra/terraform/cicd.tf
@@ -1,0 +1,71 @@
+# GitHub Actions CI/CD — 정적 AWS 키 없이 OIDC로 terraform 실행.
+# 워크플로우(.github/workflows/terraform.yml)가 이 role을 assume:
+#   PR → terraform plan, main 머지 → terraform apply (자동).
+# OIDC 인프라 자체도 IaC로 관리(최초 1회 수동 apply로 부트스트랩).
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+resource "aws_iam_role" "terraform_ci" {
+  name = "github-actions-terraform"
+
+  # wcorn/orino 저장소의 워크플로우만 assume 가능(다른 repo/계정 차단)
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = aws_iam_openid_connect_provider.github.arn }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = { "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com" }
+        StringLike   = { "token.actions.githubusercontent.com:sub" = "repo:wcorn/orino:*" }
+      }
+    }]
+  })
+}
+
+# terraform이 관리하는 리소스 범위의 권한(Route53 / S3 orino-* / IAM).
+# NOTE: iam 은 terraform 이 IAM 사용자·키·이 role 자체를 관리하므로 넓게 부여.
+#       trust 가 repo 로 제한돼 노출은 한정적이나, 추후 최소권한 스코핑 여지.
+resource "aws_iam_role_policy" "terraform_ci" {
+  name = "terraform-ci"
+  role = aws_iam_role.terraform_ci.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "Route53"
+        Effect   = "Allow"
+        Action   = ["route53:*"]
+        Resource = "*"
+      },
+      {
+        Sid      = "S3Buckets"
+        Effect   = "Allow"
+        Action   = ["s3:*"]
+        Resource = ["arn:aws:s3:::orino-*", "arn:aws:s3:::orino-*/*"]
+      },
+      {
+        Sid      = "S3ListAll"
+        Effect   = "Allow"
+        Action   = ["s3:ListAllMyBuckets"]
+        Resource = "*"
+      },
+      {
+        Sid      = "IAM"
+        Effect   = "Allow"
+        Action   = ["iam:*"]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+output "terraform_ci_role_arn" {
+  description = "GitHub Actions가 assume할 terraform CI role ARN"
+  value       = aws_iam_role.terraform_ci.arn
+}


### PR DESCRIPTION
## 이슈
#497

## 작업 내용
- **OIDC provider + CI role**(`github-actions-terraform`)을 terraform으로 추가(`cicd.tf`). trust는 `repo:wcorn/orino:*`로 제한. **부트스트랩 apply 완료**(role 이미 존재).
- **`.github/workflows/terraform.yml`**: `infra/terraform/**` 변경 시 — PR→`terraform plan`(job summary 출력), main 머지→`terraform apply -auto-approve`.
- **정적 AWS 키 없음**(OIDC STS 단기 자격증명), 변수 비밀 없음(aws_region 기본값만).

## 보안
- 정적 키 0, trust를 repo로 제한.
- iam 권한은 terraform이 IAM 사용자·키·role을 관리하므로 넓게 부여(추후 최소권한 스코핑은 #497 후속).

## 이 PR에서 자체 검증
- terraform 경로 변경이라 **이 PR에서 plan 잡이 실행**됨 → OIDC assume + plan 동작 확인 가능.
- 머지 시 첫 apply가 S3 SSE drift 5건(aws provider 버전 차이, 무해) 정리.

## 다음 (#497)
Ansible CI/CD (Tailscale subnet router + ephemeral 러너)