### PR TITLE
feat : Planner Google OAuth url/callback/status/disconnect

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleApiConfig.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleApiConfig.java
@@ -23,7 +23,7 @@ import java.nio.charset.StandardCharsets;
  * 응답 본문에 {@code invalid_grant} 가 있으면 재연동 필요(401)로, 그 외는 Google API 실패(502)로 본다.
  */
 @Configuration
-@EnableConfigurationProperties(GoogleApiProperties.class)
+@EnableConfigurationProperties({GoogleApiProperties.class, GoogleOAuthProperties.class})
 public class GoogleApiConfig {
 
     @Bean

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleOAuthProperties.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleOAuthProperties.java
@@ -1,0 +1,24 @@
+package ds.project.orino.planner.google.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Google OAuth 엔드포인트 및 콜백 후 FE 리다이렉트 설정.
+ *
+ * <p>엔드포인트 URI는 기본값이 Google 운영 주소이며, 테스트에서 스텁 서버로 덮어쓸 수 있도록 주입 가능하게 둔다.
+ *
+ * @param authorizationUri   동의 화면 URL (auth code grant)
+ * @param tokenUri           code/refresh → token 교환 엔드포인트
+ * @param revokeUri          토큰 revoke 엔드포인트 (연동 해제)
+ * @param calendarApiBaseUrl Calendar API base (primary 캘린더 조회용)
+ * @param frontendUrl        콜백 후 리다이렉트할 FE base URL
+ */
+@ConfigurationProperties(prefix = "planner.google.oauth")
+public record GoogleOAuthProperties(
+        String authorizationUri,
+        String tokenUri,
+        String revokeUri,
+        String calendarApiBaseUrl,
+        String frontendUrl
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/GoogleOAuthController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/GoogleOAuthController.java
@@ -1,0 +1,58 @@
+package ds.project.orino.planner.google.oauth;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.google.oauth.dto.GoogleAuthUrlResponse;
+import ds.project.orino.planner.google.oauth.dto.GoogleStatusResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+/**
+ * Google 연동 OAuth/상태 API. 콜백(/oauth/callback)만 permitAll(브라우저 top-level redirect, JWT 헤더 없음),
+ * 나머지는 JWT 인증.
+ */
+@RestController
+@RequestMapping("/api/planner/google")
+public class GoogleOAuthController {
+
+    private final GoogleOAuthService googleOAuthService;
+
+    public GoogleOAuthController(GoogleOAuthService googleOAuthService) {
+        this.googleOAuthService = googleOAuthService;
+    }
+
+    @GetMapping("/oauth/url")
+    public ApiResponse<GoogleAuthUrlResponse> authorizationUrl(@AuthenticationPrincipal Long memberId) {
+        return ApiResponse.success(
+                new GoogleAuthUrlResponse(googleOAuthService.createAuthorizationUrl(memberId)));
+    }
+
+    @GetMapping("/oauth/callback")
+    public ResponseEntity<Void> callback(
+            @RequestParam(required = false) String code,
+            @RequestParam(required = false) String state,
+            @RequestParam(required = false) String error) {
+        String redirectUrl = googleOAuthService.handleCallback(code, state, error);
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(URI.create(redirectUrl))
+                .build();
+    }
+
+    @GetMapping("/status")
+    public ApiResponse<GoogleStatusResponse> status(@AuthenticationPrincipal Long memberId) {
+        return ApiResponse.success(googleOAuthService.getStatus(memberId));
+    }
+
+    @PostMapping("/disconnect")
+    public ApiResponse<Void> disconnect(@AuthenticationPrincipal Long memberId) {
+        googleOAuthService.disconnect(memberId);
+        return ApiResponse.success();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/GoogleOAuthService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/GoogleOAuthService.java
@@ -1,0 +1,219 @@
+package ds.project.orino.planner.google.oauth;
+
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.planner.google.config.GoogleApiProperties;
+import ds.project.orino.planner.google.config.GoogleOAuthProperties;
+import ds.project.orino.planner.google.oauth.dto.GooglePrimaryCalendar;
+import ds.project.orino.planner.google.oauth.dto.GoogleStatusResponse;
+import ds.project.orino.planner.google.oauth.dto.GoogleTokenResponse;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import ds.project.orino.redis.planner.google.GoogleOAuthStateRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Google OAuth 연동: 인증 URL 발급, 콜백 토큰 교환, 연동 상태/해제.
+ *
+ * <p>BE가 refresh token을 독점 보관하고 모든 Google API를 프록시한다(BFF). refresh=DB, access=Redis,
+ * state=Redis(5분). 콜백 시점엔 JWT가 없어 url 발급 때 state↔memberId를 Redis에 묶어 콜백에서 복원한다.
+ */
+@Service
+public class GoogleOAuthService {
+
+    private static final Logger log = LoggerFactory.getLogger(GoogleOAuthService.class);
+
+    /** access token 만료 직전 갱신을 위한 캐시 TTL 여유분. */
+    private static final long TTL_SKEW_SECONDS = 60;
+    /** Google Tasks 기본 task list 별칭. 실제 id 해석은 Tasks 프록시(M3)에서 필요 시 보강. */
+    private static final String DEFAULT_TASK_LIST = "@default";
+    /** primary 캘린더 별칭(events.list 등에 그대로 사용 가능). */
+    private static final String PRIMARY_CALENDAR = "primary";
+
+    private final GoogleApiProperties apiProperties;
+    private final GoogleOAuthProperties oauthProperties;
+    private final RestClient googleRestClient;
+    private final GoogleAccountRepository accountRepository;
+    private final GoogleAccessTokenRepository accessTokenRepository;
+    private final GoogleOAuthStateRepository oauthStateRepository;
+
+    public GoogleOAuthService(GoogleApiProperties apiProperties,
+                              GoogleOAuthProperties oauthProperties,
+                              RestClient googleRestClient,
+                              GoogleAccountRepository accountRepository,
+                              GoogleAccessTokenRepository accessTokenRepository,
+                              GoogleOAuthStateRepository oauthStateRepository) {
+        this.apiProperties = apiProperties;
+        this.oauthProperties = oauthProperties;
+        this.googleRestClient = googleRestClient;
+        this.accountRepository = accountRepository;
+        this.accessTokenRepository = accessTokenRepository;
+        this.oauthStateRepository = oauthStateRepository;
+    }
+
+    /** 동의 화면 인증 URL 발급. state(memberId 바인딩)를 Redis(5분)에 저장한다. */
+    public String createAuthorizationUrl(Long memberId) {
+        String state = UUID.randomUUID().toString();
+        oauthStateRepository.save(state, memberId);
+
+        return UriComponentsBuilder.fromUriString(oauthProperties.authorizationUri())
+                .queryParam("client_id", apiProperties.clientId())
+                .queryParam("redirect_uri", apiProperties.redirectUri())
+                .queryParam("response_type", "code")
+                .queryParam("scope", String.join(" ", apiProperties.scopes()))
+                .queryParam("access_type", "offline")
+                .queryParam("prompt", "consent")
+                .queryParam("state", state)
+                .build()
+                .toUriString();
+    }
+
+    /**
+     * OAuth 콜백 처리. state 검증 → code 교환 → refresh DB 저장 + access Redis 캐시.
+     * 성공/실패에 따라 FE 리다이렉트 URL을 반환한다(예외를 던지지 않는다 — 브라우저 redirect).
+     */
+    @Transactional
+    public String handleCallback(String code, String state, String error) {
+        Optional<Long> memberIdOpt = (state == null) ? Optional.empty() : oauthStateRepository.findMemberId(state);
+        if (state != null) {
+            oauthStateRepository.delete(state); // 1회성 소비
+        }
+        if (memberIdOpt.isEmpty()) {
+            log.warn("Google OAuth callback: invalid/expired state");
+            return redirect("error");
+        }
+        if (error != null || code == null) {
+            log.warn("Google OAuth callback: denied or missing code (error={})", error);
+            return redirect("error");
+        }
+
+        Long memberId = memberIdOpt.get();
+        try {
+            GoogleTokenResponse token = exchangeCodeForToken(code);
+            String email = fetchPrimaryCalendarEmail(token.accessToken());
+            upsertAccount(memberId, token, email);
+            cacheAccessToken(memberId, token);
+            return redirect("connected");
+        } catch (RuntimeException e) {
+            log.warn("Google OAuth callback failed for member {}: {}", memberId, e.getMessage());
+            return redirect("error");
+        }
+    }
+
+    /** 연동 상태 조회. 미연동 또는 revoked면 connected=false. */
+    @Transactional(readOnly = true)
+    public GoogleStatusResponse getStatus(Long memberId) {
+        return accountRepository.findByMemberId(memberId)
+                .filter(account -> !account.isRevoked())
+                .map(account -> GoogleStatusResponse.connected(
+                        account.getGoogleEmail(),
+                        splitScopes(account.getScopes()),
+                        account.getConnectedAt()))
+                .orElseGet(GoogleStatusResponse::disconnected);
+    }
+
+    /** 연동 해제: Google revoke(실패해도 진행) + DB row 삭제 + Redis access 삭제. 멱등. */
+    @Transactional
+    public void disconnect(Long memberId) {
+        accountRepository.findByMemberId(memberId).ifPresent(account -> {
+            revokeQuietly(account.getRefreshToken());
+            accountRepository.deleteByMemberId(memberId);
+        });
+        accessTokenRepository.deleteByMemberId(memberId);
+    }
+
+    private GoogleTokenResponse exchangeCodeForToken(String code) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("code", code);
+        form.add("client_id", apiProperties.clientId());
+        form.add("client_secret", apiProperties.clientSecret());
+        form.add("redirect_uri", apiProperties.redirectUri());
+        form.add("grant_type", "authorization_code");
+
+        return googleRestClient.post()
+                .uri(oauthProperties.tokenUri())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(form)
+                .retrieve()
+                .body(GoogleTokenResponse.class);
+    }
+
+    /** primary 캘린더 id(=계정 이메일) 조회. 실패해도 연동은 진행(null 반환). */
+    private String fetchPrimaryCalendarEmail(String accessToken) {
+        try {
+            GooglePrimaryCalendar calendar = googleRestClient.get()
+                    .uri(oauthProperties.calendarApiBaseUrl() + "/calendar/v3/calendars/primary")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .body(GooglePrimaryCalendar.class);
+            return calendar != null ? calendar.id() : null;
+        } catch (RuntimeException e) {
+            log.warn("primary 캘린더 조회 실패(연동은 계속): {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private void upsertAccount(Long memberId, GoogleTokenResponse token, String email) {
+        Optional<GoogleAccount> existing = accountRepository.findByMemberId(memberId);
+        if (existing.isPresent()) {
+            GoogleAccount account = existing.get();
+            // 재동의 시 refresh_token이 비어 오면 기존 값을 유지한다.
+            String refreshToken = token.refreshToken() != null ? token.refreshToken() : account.getRefreshToken();
+            account.reconnect(refreshToken, token.scope(), email, PRIMARY_CALENDAR, DEFAULT_TASK_LIST);
+        } else {
+            accountRepository.save(new GoogleAccount(
+                    memberId, token.refreshToken(), token.scope(), email, PRIMARY_CALENDAR, DEFAULT_TASK_LIST));
+        }
+    }
+
+    private void cacheAccessToken(Long memberId, GoogleTokenResponse token) {
+        if (token.accessToken() == null || token.expiresIn() == null) {
+            return;
+        }
+        long ttl = Math.max(TTL_SKEW_SECONDS, token.expiresIn() - TTL_SKEW_SECONDS);
+        accessTokenRepository.save(memberId, token.accessToken(), Duration.ofSeconds(ttl));
+    }
+
+    private void revokeQuietly(String refreshToken) {
+        try {
+            MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+            form.add("token", refreshToken);
+            googleRestClient.post()
+                    .uri(oauthProperties.revokeUri())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(form)
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (RuntimeException e) {
+            log.warn("Google revoke 실패(로컬 정리는 계속): {}", e.getMessage());
+        }
+    }
+
+    private String redirect(String result) {
+        return UriComponentsBuilder.fromUriString(oauthProperties.frontendUrl())
+                .path("/planner")
+                .queryParam("google", result)
+                .build()
+                .toUriString();
+    }
+
+    private List<String> splitScopes(String scopes) {
+        if (scopes == null || scopes.isBlank()) {
+            return List.of();
+        }
+        return List.of(scopes.trim().split("\\s+"));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/dto/GoogleAuthUrlResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/dto/GoogleAuthUrlResponse.java
@@ -1,0 +1,5 @@
+package ds.project.orino.planner.google.oauth.dto;
+
+/** 동의 화면 인증 URL 응답. */
+public record GoogleAuthUrlResponse(String authorizationUrl) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/dto/GooglePrimaryCalendar.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/dto/GooglePrimaryCalendar.java
@@ -1,0 +1,11 @@
+package ds.project.orino.planner.google.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Calendar API의 primary 캘린더 조회 응답 일부.
+ * primary 캘린더의 {@code id}는 연동 계정 이메일과 같아 표시용 email로 재사용한다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GooglePrimaryCalendar(String id, String summary) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/dto/GoogleStatusResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/dto/GoogleStatusResponse.java
@@ -1,0 +1,23 @@
+package ds.project.orino.planner.google.oauth.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Google 연동 상태. 미연동(또는 revoked)이면 connected=false, 나머지 필드는 null.
+ */
+public record GoogleStatusResponse(
+        boolean connected,
+        String googleEmail,
+        List<String> scopes,
+        Instant connectedAt
+) {
+
+    public static GoogleStatusResponse disconnected() {
+        return new GoogleStatusResponse(false, null, null, null);
+    }
+
+    public static GoogleStatusResponse connected(String googleEmail, List<String> scopes, Instant connectedAt) {
+        return new GoogleStatusResponse(true, googleEmail, scopes, connectedAt);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/dto/GoogleTokenResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/dto/GoogleTokenResponse.java
@@ -1,0 +1,19 @@
+package ds.project.orino.planner.google.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Google OAuth token 엔드포인트 응답 (snake_case).
+ *
+ * <p>refresh_token은 access_type=offline + prompt=consent 동의 시 발급된다(재동의 시 갱신).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GoogleTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("expires_in") Long expiresIn,
+        @JsonProperty("scope") String scope,
+        @JsonProperty("token_type") String tokenType
+) {
+}

--- a/be/orino-app-api/src/main/resources/application.yml
+++ b/be/orino-app-api/src/main/resources/application.yml
@@ -43,6 +43,13 @@ planner:
       - https://www.googleapis.com/auth/tasks
     connect-timeout: ${GOOGLE_CONNECT_TIMEOUT:5s}
     read-timeout: ${GOOGLE_READ_TIMEOUT:10s}
+    oauth:
+      authorization-uri: ${GOOGLE_AUTH_URI:https://accounts.google.com/o/oauth2/v2/auth}
+      token-uri: ${GOOGLE_TOKEN_URI:https://oauth2.googleapis.com/token}
+      revoke-uri: ${GOOGLE_REVOKE_URI:https://oauth2.googleapis.com/revoke}
+      calendar-api-base-url: ${GOOGLE_CALENDAR_API_BASE_URL:https://www.googleapis.com}
+      # 콜백 후 리다이렉트할 FE base URL (local Vite 3000, prod orino.dev)
+      frontend-url: ${FRONTEND_URL:http://localhost:3000}
 
 management:
   tracing:

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/oauth/GoogleOAuthControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/oauth/GoogleOAuthControllerTest.java
@@ -1,0 +1,235 @@
+package ds.project.orino.planner.google.oauth;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import ds.project.orino.redis.planner.google.GoogleOAuthStateRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GoogleOAuthControllerTest extends ApiTestSupport {
+
+    private static final HttpServer GOOGLE_STUB = createStub();
+
+    @Autowired
+    private GoogleAccountRepository accountRepository;
+    @Autowired
+    private GoogleOAuthStateRepository oauthStateRepository;
+    @Autowired
+    private GoogleAccessTokenRepository accessTokenRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Long memberId;
+    private String authHeader;
+
+    @DynamicPropertySource
+    static void googleProperties(DynamicPropertyRegistry registry) {
+        String base = "http://127.0.0.1:" + GOOGLE_STUB.getAddress().getPort();
+        registry.add("planner.google.client-id", () -> "test-client-id");
+        registry.add("planner.google.client-secret", () -> "test-client-secret");
+        registry.add("planner.google.redirect-uri",
+                () -> "http://localhost:8080/api/planner/google/oauth/callback");
+        registry.add("planner.google.oauth.token-uri", () -> base + "/token");
+        registry.add("planner.google.oauth.revoke-uri", () -> base + "/revoke");
+        registry.add("planner.google.oauth.calendar-api-base-url", () -> base);
+        registry.add("planner.google.oauth.frontend-url", () -> "http://localhost:3000");
+    }
+
+    @AfterAll
+    static void stopStub() {
+        GOOGLE_STUB.stop(0);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberId = memberRepository.save(MemberFixture.create()).getId();
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    @Test
+    @DisplayName("GET /oauth/url - 인증 URL을 발급하고 state를 Redis에 저장한다")
+    void authorizationUrl() throws Exception {
+        String url = mockMvc.perform(get("/api/planner/google/oauth/url")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.authorizationUrl").exists())
+                .andReturn().getResponse().getContentAsString();
+
+        String authorizationUrl = com.jayway.jsonpath.JsonPath.read(url, "$.data.authorizationUrl");
+        assertThat(authorizationUrl)
+                .contains("client_id=test-client-id")
+                .contains("access_type=offline")
+                .contains("prompt=consent")
+                .contains("response_type=code");
+
+        String state = UriComponentsBuilder.fromUriString(authorizationUrl)
+                .build().getQueryParams().getFirst("state");
+        assertThat(state).isNotBlank();
+        assertThat(oauthStateRepository.findMemberId(state)).contains(memberId);
+    }
+
+    @Test
+    @DisplayName("GET /oauth/url - 인증 없이 호출하면 401")
+    void authorizationUrl_requiresAuth() throws Exception {
+        mockMvc.perform(get("/api/planner/google/oauth/url"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("GET /oauth/callback - 유효한 state면 토큰 교환 후 연동하고 connected로 리다이렉트한다")
+    void callback_validState() throws Exception {
+        oauthStateRepository.save("state-ok", memberId);
+
+        mockMvc.perform(get("/api/planner/google/oauth/callback")
+                        .param("code", "auth-code")
+                        .param("state", "state-ok"))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("http://localhost:3000/planner?google=connected"));
+
+        GoogleAccount account = accountRepository.findByMemberId(memberId).orElseThrow();
+        assertThat(account.getRefreshToken()).isEqualTo("stub-refresh");
+        assertThat(account.getGoogleEmail()).isEqualTo("me@gmail.com");
+        assertThat(account.getScopes()).contains("calendar");
+        assertThat(account.isRevoked()).isFalse();
+        assertThat(accessTokenRepository.findByMemberId(memberId)).contains("stub-access");
+        // state는 1회성 소비
+        assertThat(oauthStateRepository.findMemberId("state-ok")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("GET /oauth/callback - 유효하지 않은 state면 error로 리다이렉트한다")
+    void callback_invalidState() throws Exception {
+        mockMvc.perform(get("/api/planner/google/oauth/callback")
+                        .param("code", "auth-code")
+                        .param("state", "unknown-state"))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("http://localhost:3000/planner?google=error"));
+
+        assertThat(accountRepository.findByMemberId(memberId)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("GET /oauth/callback - 토큰 교환 실패면 error로 리다이렉트한다")
+    void callback_tokenExchangeFails() throws Exception {
+        oauthStateRepository.save("state-bad", memberId);
+
+        mockMvc.perform(get("/api/planner/google/oauth/callback")
+                        .param("code", "bad-code")
+                        .param("state", "state-bad"))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("http://localhost:3000/planner?google=error"));
+
+        assertThat(accountRepository.findByMemberId(memberId)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("GET /status - 연동된 경우 connected=true와 상세를 반환한다")
+    void status_connected() throws Exception {
+        accountRepository.save(new GoogleAccount(
+                memberId, "refresh", "https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/tasks",
+                "me@gmail.com", "primary", "@default"));
+
+        mockMvc.perform(get("/api/planner/google/status")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.connected").value(true))
+                .andExpect(jsonPath("$.data.googleEmail").value("me@gmail.com"))
+                .andExpect(jsonPath("$.data.scopes.length()").value(2))
+                .andExpect(jsonPath("$.data.connectedAt").exists());
+    }
+
+    @Test
+    @DisplayName("GET /status - 미연동이면 connected=false")
+    void status_notConnected() throws Exception {
+        mockMvc.perform(get("/api/planner/google/status")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.connected").value(false))
+                .andExpect(jsonPath("$.data.googleEmail").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("POST /disconnect - 연동을 해제하고 DB row와 access 캐시를 삭제한다")
+    void disconnect() throws Exception {
+        accountRepository.save(new GoogleAccount(memberId, "refresh", "scope", "me@gmail.com", "primary", "@default"));
+        accessTokenRepository.save(memberId, "cached-access", java.time.Duration.ofMinutes(30));
+
+        mockMvc.perform(post("/api/planner/google/disconnect")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("요청에 성공하였습니다."));
+
+        assertThat(accountRepository.findByMemberId(memberId)).isEmpty();
+        assertThat(accessTokenRepository.findByMemberId(memberId)).isEmpty();
+    }
+
+    private static HttpServer createStub() {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/token", exchange -> {
+                String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+                if (body.contains("code=bad-code")) {
+                    respond(exchange, 400, "{\"error\":\"invalid_grant\"}");
+                } else {
+                    respond(exchange, 200, """
+                            {"access_token":"stub-access","refresh_token":"stub-refresh","expires_in":3600,\
+                            "scope":"https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/tasks",\
+                            "token_type":"Bearer"}""");
+                }
+            });
+            server.createContext("/calendar/v3/calendars/primary", exchange ->
+                    respond(exchange, 200, "{\"id\":\"me@gmail.com\",\"summary\":\"me@gmail.com\"}"));
+            server.createContext("/revoke", exchange -> respond(exchange, 200, ""));
+            server.start();
+            return server;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length > 0) {
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+        }
+        exchange.sendResponseHeaders(status, bytes.length == 0 ? -1 : bytes.length);
+        if (bytes.length > 0) {
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        } else {
+            exchange.close();
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
@@ -11,6 +11,7 @@ public class DbCleaner {
             "flashcard",
             "note",
             "study_material",
+            "google_account",
             "member"
     };
 

--- a/be/orino-core-web/src/main/java/ds/project/orino/core/security/SecurityConfig.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/security/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/**",
+                                "/api/planner/google/oauth/callback",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**"
                         ).permitAll()

--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -122,6 +122,8 @@ spec:
                   optional: true
             - name: GOOGLE_REDIRECT_URI
               value: {{ .Values.env.GOOGLE_REDIRECT_URI | quote }}
+            - name: FRONTEND_URL
+              value: {{ .Values.env.FRONTEND_URL | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           lifecycle:

--- a/infra/helm/be/values.yaml
+++ b/infra/helm/be/values.yaml
@@ -13,6 +13,8 @@ env:
   OTEL_EXPORTER_OTLP_ENDPOINT: http://alloy.monitoring.svc.cluster.local:4318
   # Planner Google OAuth 콜백 URI (Google Cloud Console 승인 리디렉션 URI와 일치해야 함)
   GOOGLE_REDIRECT_URI: https://api.orino.dev/api/planner/google/oauth/callback
+  # OAuth 콜백 후 리다이렉트할 FE base URL
+  FRONTEND_URL: https://orino.dev
 
 resources:
   requests:


### PR DESCRIPTION
## 이슈
closes #475

## 작업 내용
Epic #472 M0. Google OAuth 연동 — 인증 URL 발급, 콜백 토큰 교환, 연동 상태/해제. BE가 refresh token을 독점 보관하는 BFF 프록시. (deps #473 config/RestClient, #474 google_account/Redis)

### API (`/api/planner/google`)
| Method | Path | 설명 |
|--------|------|------|
| GET | `/oauth/url` | 인증 URL 발급 (state=memberId 바인딩, `access_type=offline`+`prompt=consent`) |
| GET | `/oauth/callback` | 콜백 — state 검증 → code 교환 → refresh DB 저장 + access Redis 캐시, **302** FE 리다이렉트 (permitAll) |
| GET | `/status` | 연동 상태 (connected/email/scopes/connectedAt) |
| POST | `/disconnect` | revoke + DB row 삭제 + Redis 정리 (멱등) |

### 구현 포인트
- **`GoogleOAuthService`**: 콜백은 예외를 던지지 않고 성공/실패에 따라 `{FE}/planner?google=connected|error`로 리다이렉트. primary 캘린더 조회로 표시용 email 확보(실패해도 연동은 진행). access TTL은 `expires_in - 60s`.
  - 재동의 시 `reconnect(...)`로 갱신, refresh_token이 비어 오면 기존 값 유지.
  - task list는 `@default` 별칭 사용(실제 id 해석은 Tasks 프록시 M3 #484에서 필요 시 보강).
- **`GoogleOAuthProperties`**(`planner.google.oauth.*`): 엔드포인트 URI + FE redirect URL. `#473` 레코드를 깨지 않도록 분리, 테스트에서 스텁 서버로 주입 가능.
- **SecurityConfig**: 콜백만 permitAll(브라우저 top-level redirect라 JWT 없음).
- **인프라**: `FRONTEND_URL` env(prod=`https://orino.dev`) 추가.
- **DbCleaner**: `google_account` 추가(테스트 격리).

## 테스트
`GoogleOAuthControllerTest` (IntegrationTest, JDK `HttpServer`로 token/calendar/revoke 스텁, `@DynamicPropertySource`로 엔드포인트 주입) — 8/8:
- `/oauth/url` 발급 + state Redis 저장 / 미인증 401
- 콜백: 유효 state→connected 리다이렉트 + DB/Redis 반영 + state 1회성 소비 / 무효 state→error / 토큰 교환 실패→error
- `/status` 연동·미연동 / `/disconnect` 삭제·캐시 정리
- app-api 전체 스위트 + helm 렌더링 검증 완료