### PR TITLE
feat : Planner Google access token 자동 갱신 + revoke 처리

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/token/GoogleTokenProvider.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/token/GoogleTokenProvider.java
@@ -1,0 +1,118 @@
+package ds.project.orino.planner.google.token;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.planner.google.config.GoogleApiProperties;
+import ds.project.orino.planner.google.config.GoogleOAuthProperties;
+import ds.project.orino.planner.google.oauth.dto.GoogleTokenResponse;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+/**
+ * Google access token 공급자. Redis 캐시 우선, miss 시 refresh grant로 재발급·재캐시한다.
+ *
+ * <p>refresh가 {@code invalid_grant}면 {@link GoogleAccount#markRevoked()} 후 재연동 예외(PLN-ERR-005)를 던지고,
+ * 연동이 없거나 revoked면 PLN-ERR-003을 던진다. access token 만료로 API가 401을 주면
+ * {@link #executeWithRetry}가 1회 강제 갱신 후 재시도한다.
+ *
+ * <p>트랜잭션 self-invocation 함정을 피하려 revoked 마킹은 dirty-checking 대신 명시적 save로 영속화한다.
+ */
+@Component
+public class GoogleTokenProvider {
+
+    /** access token 만료 직전 갱신을 위한 캐시 TTL 여유분. */
+    private static final long TTL_SKEW_SECONDS = 60;
+
+    private final GoogleAccountRepository accountRepository;
+    private final GoogleAccessTokenRepository accessTokenRepository;
+    private final RestClient googleRestClient;
+    private final GoogleApiProperties apiProperties;
+    private final GoogleOAuthProperties oauthProperties;
+
+    public GoogleTokenProvider(GoogleAccountRepository accountRepository,
+                               GoogleAccessTokenRepository accessTokenRepository,
+                               RestClient googleRestClient,
+                               GoogleApiProperties apiProperties,
+                               GoogleOAuthProperties oauthProperties) {
+        this.accountRepository = accountRepository;
+        this.accessTokenRepository = accessTokenRepository;
+        this.googleRestClient = googleRestClient;
+        this.apiProperties = apiProperties;
+        this.oauthProperties = oauthProperties;
+    }
+
+    /** 유효한 access token 반환. 캐시 hit→사용 / miss→refresh grant 재발급·재캐시. */
+    public String getValidAccessToken(Long memberId) {
+        return accessTokenRepository.findByMemberId(memberId)
+                .orElseGet(() -> refreshAndCache(memberId));
+    }
+
+    /**
+     * access token으로 Google API를 호출하되, 401({@link GoogleUnauthorizedException})이면 토큰을
+     * 1회 강제 갱신한 뒤 재시도한다.
+     */
+    public <T> T executeWithRetry(Long memberId, Function<String, T> apiCall) {
+        String accessToken = getValidAccessToken(memberId);
+        try {
+            return apiCall.apply(accessToken);
+        } catch (GoogleUnauthorizedException e) {
+            return apiCall.apply(forceRefresh(memberId));
+        }
+    }
+
+    private String forceRefresh(Long memberId) {
+        accessTokenRepository.deleteByMemberId(memberId);
+        return refreshAndCache(memberId);
+    }
+
+    private String refreshAndCache(Long memberId) {
+        GoogleAccount account = accountRepository.findByMemberId(memberId)
+                .filter(a -> !a.isRevoked())
+                .orElseThrow(() -> new CustomException(ErrorCode.GOOGLE_NOT_CONNECTED));
+
+        GoogleTokenResponse token = requestRefreshGrant(account);
+        cacheAccessToken(memberId, token);
+        return token.accessToken();
+    }
+
+    private GoogleTokenResponse requestRefreshGrant(GoogleAccount account) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("grant_type", "refresh_token");
+        form.add("refresh_token", account.getRefreshToken());
+        form.add("client_id", apiProperties.clientId());
+        form.add("client_secret", apiProperties.clientSecret());
+
+        try {
+            return googleRestClient.post()
+                    .uri(oauthProperties.tokenUri())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(form)
+                    .retrieve()
+                    .body(GoogleTokenResponse.class);
+        } catch (CustomException e) {
+            if (e.getErrorCode() == ErrorCode.GOOGLE_INVALID_GRANT) {
+                account.markRevoked();
+                accountRepository.save(account);
+            }
+            throw e;
+        }
+    }
+
+    private void cacheAccessToken(Long memberId, GoogleTokenResponse token) {
+        if (token == null || token.accessToken() == null) {
+            throw new CustomException(ErrorCode.GOOGLE_API_FAILED);
+        }
+        long expiresIn = token.expiresIn() != null ? token.expiresIn() : TTL_SKEW_SECONDS * 2;
+        long ttl = Math.max(TTL_SKEW_SECONDS, expiresIn - TTL_SKEW_SECONDS);
+        accessTokenRepository.save(memberId, token.accessToken(), Duration.ofSeconds(ttl));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/token/GoogleUnauthorizedException.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/token/GoogleUnauthorizedException.java
@@ -1,0 +1,14 @@
+package ds.project.orino.planner.google.token;
+
+/**
+ * Google API 호출이 401(access token 만료/무효)을 반환했음을 알리는 센티넬.
+ *
+ * <p>Calendar/Tasks 클라이언트(M1+)가 401 응답에서 던지면, {@link GoogleTokenProvider#executeWithRetry}
+ * 가 access token을 1회 강제 갱신한 뒤 재시도한다.
+ */
+public class GoogleUnauthorizedException extends RuntimeException {
+
+    public GoogleUnauthorizedException() {
+        super("Google API responded 401 Unauthorized");
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/token/GoogleTokenProviderTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/token/GoogleTokenProviderTest.java
@@ -1,0 +1,197 @@
+package ds.project.orino.planner.google.token;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.IntegrationTest;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@IntegrationTest
+class GoogleTokenProviderTest {
+
+    private static final HttpServer GOOGLE_STUB = createStub();
+
+    @Autowired
+    private GoogleTokenProvider tokenProvider;
+    @Autowired
+    private GoogleAccountRepository accountRepository;
+    @Autowired
+    private GoogleAccessTokenRepository accessTokenRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Long memberId;
+
+    @DynamicPropertySource
+    static void googleProperties(DynamicPropertyRegistry registry) {
+        String base = "http://127.0.0.1:" + GOOGLE_STUB.getAddress().getPort();
+        registry.add("planner.google.client-id", () -> "test-client-id");
+        registry.add("planner.google.client-secret", () -> "test-client-secret");
+        registry.add("planner.google.oauth.token-uri", () -> base + "/token");
+    }
+
+    @AfterAll
+    static void stopStub() {
+        GOOGLE_STUB.stop(0);
+    }
+
+    @BeforeEach
+    void setUp() {
+        dbCleaner.clean();
+        memberId = memberRepository.save(MemberFixture.create()).getId();
+    }
+
+    private GoogleAccount saveAccount(String refreshToken) {
+        return accountRepository.save(new GoogleAccount(
+                memberId, refreshToken, "scope", "me@gmail.com", "primary", "@default"));
+    }
+
+    @Test
+    @DisplayName("캐시 hit이면 refresh 없이 캐시된 access token을 반환한다")
+    void getValidAccessToken_cacheHit() {
+        saveAccount("good-refresh");
+        accessTokenRepository.save(memberId, "cached-access", Duration.ofMinutes(30));
+
+        assertThat(tokenProvider.getValidAccessToken(memberId)).isEqualTo("cached-access");
+    }
+
+    @Test
+    @DisplayName("캐시 miss면 refresh grant로 재발급하고 재캐시한다")
+    void getValidAccessToken_cacheMiss_refreshes() {
+        saveAccount("good-refresh");
+
+        String token = tokenProvider.getValidAccessToken(memberId);
+
+        assertThat(token).isEqualTo("refreshed-access");
+        assertThat(accessTokenRepository.findByMemberId(memberId)).contains("refreshed-access");
+    }
+
+    @Test
+    @DisplayName("연동이 없으면 GOOGLE_NOT_CONNECTED(409)")
+    void getValidAccessToken_notConnected() {
+        assertThatThrownBy(() -> tokenProvider.getValidAccessToken(memberId))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.GOOGLE_NOT_CONNECTED);
+    }
+
+    @Test
+    @DisplayName("revoked 연동이면 GOOGLE_NOT_CONNECTED(409)")
+    void getValidAccessToken_revoked() {
+        GoogleAccount account = saveAccount("good-refresh");
+        account.markRevoked();
+        accountRepository.save(account);
+
+        assertThatThrownBy(() -> tokenProvider.getValidAccessToken(memberId))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.GOOGLE_NOT_CONNECTED);
+    }
+
+    @Test
+    @DisplayName("refresh가 invalid_grant면 revoked 마킹 후 GOOGLE_INVALID_GRANT(401)")
+    void refresh_invalidGrant_marksRevoked() {
+        saveAccount("bad-refresh");
+
+        assertThatThrownBy(() -> tokenProvider.getValidAccessToken(memberId))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.GOOGLE_INVALID_GRANT);
+
+        assertThat(accountRepository.findByMemberId(memberId).orElseThrow().isRevoked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("executeWithRetry는 401이면 토큰을 강제 갱신 후 1회 재시도한다")
+    void executeWithRetry_retriesOnUnauthorized() {
+        saveAccount("good-refresh");
+        accessTokenRepository.save(memberId, "old-access", Duration.ofMinutes(30));
+
+        AtomicInteger calls = new AtomicInteger();
+        List<String> tokensSeen = new ArrayList<>();
+
+        String result = tokenProvider.executeWithRetry(memberId, token -> {
+            tokensSeen.add(token);
+            if (calls.getAndIncrement() == 0) {
+                throw new GoogleUnauthorizedException();
+            }
+            return token;
+        });
+
+        assertThat(result).isEqualTo("refreshed-access");
+        assertThat(tokensSeen).containsExactly("old-access", "refreshed-access");
+        assertThat(accessTokenRepository.findByMemberId(memberId)).contains("refreshed-access");
+    }
+
+    @Test
+    @DisplayName("executeWithRetry는 정상 호출이면 재시도하지 않고 결과를 반환한다")
+    void executeWithRetry_noRetryOnSuccess() {
+        saveAccount("good-refresh");
+        accessTokenRepository.save(memberId, "cached-access", Duration.ofMinutes(30));
+
+        AtomicInteger calls = new AtomicInteger();
+        String result = tokenProvider.executeWithRetry(memberId, token -> {
+            calls.incrementAndGet();
+            return "ok:" + token;
+        });
+
+        assertThat(result).isEqualTo("ok:cached-access");
+        assertThat(calls.get()).isEqualTo(1);
+    }
+
+    private static HttpServer createStub() {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/token", exchange -> {
+                String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+                if (body.contains("refresh_token=bad-refresh")) {
+                    respond(exchange, 400, "{\"error\":\"invalid_grant\"}");
+                } else {
+                    respond(exchange, 200,
+                            "{\"access_token\":\"refreshed-access\",\"expires_in\":3600,\"token_type\":\"Bearer\"}");
+                }
+            });
+            server.start();
+            return server;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+}


### PR DESCRIPTION
## 이슈
closes #476

## 작업 내용
Epic #472 M0 마무리. Google access token 공급/자동 갱신 + 만료/revoke 처리. (deps #473 config, #474 google_account/Redis, #475 OAuth)

- **`GoogleTokenProvider.getValidAccessToken(memberId)`**: Redis 캐시 hit→사용 / miss→refresh grant 재발급+재캐시
  - refresh가 `invalid_grant` → `GoogleAccount.markRevoked()`(명시적 save로 영속화) + **PLN-ERR-005**(401, 재연동 유도)
  - 연동 없음/revoked → **PLN-ERR-003**(409)
  - 캐시 TTL = `expires_in - 60s`
- **`executeWithRetry(memberId, apiCall)`**: API가 401(`GoogleUnauthorizedException`)을 주면 access token을 1회 강제 갱신 후 재시도 (아키텍처 §8 "1회 자동 재시도")
- **`GoogleUnauthorizedException`**: Calendar/Tasks 클라이언트(M1+ #478)가 401 응답에서 던질 센티넬 — 토큰 401 검출과 갱신 책임을 분리

### 설계 메모
- revoked 마킹을 dirty-checking 대신 **명시적 `save`**로 처리 — `executeWithRetry`→`getValidAccessToken` self-invocation이 `@Transactional` 프록시를 우회해 detached 엔티티 mutation이 유실되는 함정 회피.
- `#473` `googleRestClient`의 `defaultStatusHandler`가 refresh grant의 `invalid_grant` 본문을 GOOGLE_INVALID_GRANT로 매핑하는 것을 그대로 활용.

## 테스트
`GoogleTokenProviderTest` (IntegrationTest, JDK `HttpServer`로 token 엔드포인트 스텁) — 7/7:
- 캐시 hit→갱신 안 함 / 캐시 miss→refresh 재발급+재캐시
- 미연동→PLN-ERR-003 / revoked→PLN-ERR-003
- invalid_grant→revoked 마킹 + PLN-ERR-005
- executeWithRetry: 401 시 강제 갱신 후 재시도 / 정상 시 재시도 없음