### PR TITLE
feat : Planner Google 연결/해제 UI + 미연동 CTA

### DIFF
--- a/fe/src/app/layout/Sidebar.tsx
+++ b/fe/src/app/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Calendar, CheckSquare, Home } from "lucide-react";
+import { BookOpen, Calendar, CheckSquare, Home, Settings } from "lucide-react";
 import { NavLink } from "react-router-dom";
 
 import { useTodayReviews } from "@/features/review/hooks/useTodayReviews";
@@ -15,6 +15,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/planner/materials", label: "학습 자료", icon: BookOpen },
   { to: "/planner/reviews/today", label: "오늘 복습", icon: CheckSquare },
   { to: "/planner/calendar", label: "복습 캘린더", icon: Calendar },
+  { to: "/planner/settings", label: "연동 설정", icon: Settings },
 ];
 
 interface SidebarProps {

--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -20,6 +20,10 @@ export const importReviewCalendar = () =>
   import("../pages/planner/ReviewCalendarPage").then((m) => ({
     default: m.ReviewCalendarPage,
   }));
+export const importPlannerSettings = () =>
+  import("../pages/planner/PlannerSettingsPage").then((m) => ({
+    default: m.PlannerSettingsPage,
+  }));
 
 /**
  * 로그인 후 idle 시간에 페이지 청크를 미리 받아둔다.

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -5,11 +5,13 @@ import { PrivateRoute } from "../features/auth/components/PrivateRoute";
 import { PublicRoute } from "../features/auth/components/PublicRoute";
 import { LandingPage } from "../pages/LandingPage";
 import { LoginPage } from "../pages/LoginPage";
+import { PlannerCallbackRedirect } from "../pages/planner/PlannerCallbackRedirect";
 import { AppLayout } from "./layout/AppLayout";
 import {
   importHome,
   importMaterialDetail,
   importMaterialList,
+  importPlannerSettings,
   importReviewCalendar,
   importTodayReviews,
 } from "./routeImports";
@@ -21,6 +23,7 @@ const MaterialListPage = lazy(importMaterialList);
 const MaterialDetailPage = lazy(importMaterialDetail);
 const TodayReviewsPage = lazy(importTodayReviews);
 const ReviewCalendarPage = lazy(importReviewCalendar);
+const PlannerSettingsPage = lazy(importPlannerSettings);
 
 function RouteFallback() {
   return <div className="text-muted-foreground p-6 text-sm">불러오는 중…</div>;
@@ -75,6 +78,16 @@ export function AppRouter() {
               </Suspense>
             }
           />
+          <Route
+            path="/planner/settings"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <PlannerSettingsPage />
+              </Suspense>
+            }
+          />
+          {/* OAuth 콜백 복귀 지점: 토스트 후 캘린더로 */}
+          <Route path="/planner" element={<PlannerCallbackRedirect />} />
         </Route>
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/fe/src/features/google/api/googleApi.ts
+++ b/fe/src/features/google/api/googleApi.ts
@@ -1,0 +1,33 @@
+import { client } from "@/shared/api";
+
+export interface GoogleStatus {
+  connected: boolean;
+  googleEmail: string | null;
+  scopes: string[] | null;
+  connectedAt: string | null;
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+/** 연동 상태 조회. 미연동이면 connected=false, 나머지 null. */
+export async function fetchGoogleStatus(): Promise<GoogleStatus> {
+  const { data } =
+    await client.get<ApiEnvelope<GoogleStatus>>("/planner/google/status");
+  return data.data;
+}
+
+/** 동의 화면 인증 URL 발급 (서버가 state를 생성·저장). */
+export async function fetchGoogleAuthUrl(): Promise<string> {
+  const { data } = await client.get<ApiEnvelope<{ authorizationUrl: string }>>(
+    "/planner/google/oauth/url",
+  );
+  return data.data.authorizationUrl;
+}
+
+/** 연동 해제 (revoke + 삭제). */
+export async function disconnectGoogle(): Promise<void> {
+  await client.post("/planner/google/disconnect");
+}

--- a/fe/src/features/google/api/googleApi.ts
+++ b/fe/src/features/google/api/googleApi.ts
@@ -14,8 +14,9 @@ interface ApiEnvelope<T> {
 
 /** 연동 상태 조회. 미연동이면 connected=false, 나머지 null. */
 export async function fetchGoogleStatus(): Promise<GoogleStatus> {
-  const { data } =
-    await client.get<ApiEnvelope<GoogleStatus>>("/planner/google/status");
+  const { data } = await client.get<ApiEnvelope<GoogleStatus>>(
+    "/planner/google/status",
+  );
   return data.data;
 }
 

--- a/fe/src/features/google/components/GoogleConnectButton.test.tsx
+++ b/fe/src/features/google/components/GoogleConnectButton.test.tsx
@@ -1,0 +1,50 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { GoogleConnectButton } from "./GoogleConnectButton";
+
+const API_BASE = "https://api.orino.dev/api";
+
+describe("GoogleConnectButton", () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // URL 인스턴스로 교체: origin/protocol을 보존해 jsdom XHR이 깨지지 않으면서
+    // href는 settable이라 리다이렉트 대상을 검증할 수 있다.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: new URL("http://localhost:3000/"),
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("클릭하면 인증 URL을 받아 그 주소로 리다이렉트한다", async () => {
+    const authUrl = "https://accounts.google.com/o/oauth2/v2/auth?client_id=x";
+    server.use(
+      http.get(`${API_BASE}/planner/google/oauth/url`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: { authorizationUrl: authUrl },
+        }),
+      ),
+    );
+
+    renderWithRouter(<GoogleConnectButton />);
+    await userEvent.click(screen.getByRole("button", { name: "Google 연결" }));
+
+    await waitFor(() => expect(window.location.href).toBe(authUrl));
+  });
+});

--- a/fe/src/features/google/components/GoogleConnectButton.tsx
+++ b/fe/src/features/google/components/GoogleConnectButton.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+
+import { useGoogleConnect } from "../hooks/useGoogleConnect";
+
+interface GoogleConnectButtonProps {
+  variant?: "default" | "outline";
+  size?: "default" | "sm";
+  className?: string;
+  children?: ReactNode;
+}
+
+/** Google 동의 화면으로 이동시키는 연결 버튼. */
+export function GoogleConnectButton({
+  variant = "default",
+  size = "default",
+  className,
+  children,
+}: GoogleConnectButtonProps) {
+  const connect = useGoogleConnect();
+
+  return (
+    <Button
+      variant={variant}
+      size={size}
+      className={className}
+      disabled={connect.isPending}
+      onClick={() => connect.mutate()}
+    >
+      {connect.isPending ? "연결 중…" : (children ?? "Google 연결")}
+    </Button>
+  );
+}

--- a/fe/src/features/google/components/GoogleConnectionCard.test.tsx
+++ b/fe/src/features/google/components/GoogleConnectionCard.test.tsx
@@ -98,7 +98,9 @@ describe("GoogleConnectionCard", () => {
       </>,
     );
 
-    await userEvent.click(await screen.findByRole("button", { name: "연결 해제" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "연결 해제" }),
+    );
 
     expect(await screen.findByText("연결되지 않음")).toBeInTheDocument();
     expect(

--- a/fe/src/features/google/components/GoogleConnectionCard.test.tsx
+++ b/fe/src/features/google/components/GoogleConnectionCard.test.tsx
@@ -1,0 +1,108 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Toaster } from "@/components/Toaster";
+import { useToastStore } from "@/shared/lib/toast";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { GoogleConnectionCard } from "./GoogleConnectionCard";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function mockStatus(data: {
+  connected: boolean;
+  googleEmail: string | null;
+  scopes: string[] | null;
+  connectedAt: string | null;
+}) {
+  server.use(
+    http.get(`${API_BASE}/planner/google/status`, () =>
+      HttpResponse.json({ code: "OK", data }),
+    ),
+  );
+}
+
+describe("GoogleConnectionCard", () => {
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [] });
+  });
+
+  it("미연동이면 '연결되지 않음'과 연결 버튼을 보여준다", async () => {
+    mockStatus({
+      connected: false,
+      googleEmail: null,
+      scopes: null,
+      connectedAt: null,
+    });
+
+    renderWithRouter(<GoogleConnectionCard />);
+
+    expect(await screen.findByText("연결되지 않음")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Google 연결" }),
+    ).toBeInTheDocument();
+  });
+
+  it("연동되면 계정/연결일과 해제 버튼을 보여준다", async () => {
+    mockStatus({
+      connected: true,
+      googleEmail: "me@gmail.com",
+      scopes: ["https://www.googleapis.com/auth/calendar"],
+      connectedAt: "2026-06-15T10:00:00",
+    });
+
+    renderWithRouter(<GoogleConnectionCard />);
+
+    expect(await screen.findByText("me@gmail.com")).toBeInTheDocument();
+    expect(screen.getByText("연결됨")).toBeInTheDocument();
+    expect(screen.getByText("2026년 6월 15일")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "연결 해제" }),
+    ).toBeInTheDocument();
+  });
+
+  it("연결 해제를 누르면 disconnect 후 미연동 상태로 바뀌고 토스트를 띄운다", async () => {
+    let connected = true;
+    server.use(
+      http.get(`${API_BASE}/planner/google/status`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: connected
+            ? {
+                connected: true,
+                googleEmail: "me@gmail.com",
+                scopes: ["s"],
+                connectedAt: "2026-06-15T10:00:00",
+              }
+            : {
+                connected: false,
+                googleEmail: null,
+                scopes: null,
+                connectedAt: null,
+              },
+        }),
+      ),
+      http.post(`${API_BASE}/planner/google/disconnect`, () => {
+        connected = false;
+        return HttpResponse.json({ code: "OK", data: null });
+      }),
+    );
+
+    renderWithRouter(
+      <>
+        <GoogleConnectionCard />
+        <Toaster />
+      </>,
+    );
+
+    await userEvent.click(await screen.findByRole("button", { name: "연결 해제" }));
+
+    expect(await screen.findByText("연결되지 않음")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Google 연동을 해제했습니다."),
+    ).toBeInTheDocument();
+  });
+});

--- a/fe/src/features/google/components/GoogleConnectionCard.tsx
+++ b/fe/src/features/google/components/GoogleConnectionCard.tsx
@@ -1,0 +1,63 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+import { useDisconnectGoogle } from "../hooks/useDisconnectGoogle";
+import { useGoogleStatus } from "../hooks/useGoogleStatus";
+import { GoogleConnectButton } from "./GoogleConnectButton";
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "-";
+  const date = new Date(iso);
+  return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+}
+
+/** Google 연동 상태 카드 (연동 설정 화면). 연결됨: 계정/연결일 + 해제 / 미연동: 연결 CTA. */
+export function GoogleConnectionCard() {
+  const { data: status, isLoading } = useGoogleStatus();
+  const disconnect = useDisconnectGoogle();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Google 연동</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {isLoading ? (
+          <p className="text-muted-foreground text-sm">불러오는 중…</p>
+        ) : status?.connected ? (
+          <>
+            <dl className="grid grid-cols-[5rem_1fr] gap-y-1 text-sm">
+              <dt className="text-muted-foreground">상태</dt>
+              <dd>연결됨</dd>
+              {status.googleEmail && (
+                <>
+                  <dt className="text-muted-foreground">계정</dt>
+                  <dd>{status.googleEmail}</dd>
+                </>
+              )}
+              <dt className="text-muted-foreground">연결일</dt>
+              <dd>{formatDate(status.connectedAt)}</dd>
+            </dl>
+            <div>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={disconnect.isPending}
+                onClick={() => disconnect.mutate()}
+              >
+                {disconnect.isPending ? "해제 중…" : "연결 해제"}
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="text-muted-foreground text-sm">연결되지 않음</p>
+            <div>
+              <GoogleConnectButton />
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/fe/src/features/google/components/GoogleNotConnectedBanner.test.tsx
+++ b/fe/src/features/google/components/GoogleNotConnectedBanner.test.tsx
@@ -1,0 +1,50 @@
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { GoogleNotConnectedBanner } from "./GoogleNotConnectedBanner";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function mockConnected(connected: boolean) {
+  server.use(
+    http.get(`${API_BASE}/planner/google/status`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          connected,
+          googleEmail: connected ? "me@gmail.com" : null,
+          scopes: connected ? ["s"] : null,
+          connectedAt: connected ? "2026-06-15T10:00:00" : null,
+        },
+      }),
+    ),
+  );
+}
+
+describe("GoogleNotConnectedBanner", () => {
+  it("미연동이면 경고 배너와 연결 CTA를 보여준다", async () => {
+    mockConnected(false);
+
+    renderWithRouter(<GoogleNotConnectedBanner />);
+
+    const banner = await screen.findByRole("alert");
+    expect(banner).toHaveTextContent("Google 캘린더가 연결되지 않았습니다");
+    expect(
+      screen.getByRole("button", { name: "Google 연결" }),
+    ).toBeInTheDocument();
+  });
+
+  it("연동된 경우 아무것도 렌더하지 않는다", async () => {
+    mockConnected(true);
+
+    renderWithRouter(<GoogleNotConnectedBanner />);
+
+    await waitFor(() =>
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/fe/src/features/google/components/GoogleNotConnectedBanner.tsx
+++ b/fe/src/features/google/components/GoogleNotConnectedBanner.tsx
@@ -1,0 +1,29 @@
+import { AlertTriangle } from "lucide-react";
+
+import { useGoogleStatus } from "../hooks/useGoogleStatus";
+import { GoogleConnectButton } from "./GoogleConnectButton";
+
+/**
+ * 미연동 CTA 배너. 통합 캘린더 상단에 노출한다.
+ * 로딩/에러/연결됨 상태에서는 렌더하지 않는다(복습은 그대로 표시).
+ */
+export function GoogleNotConnectedBanner() {
+  const { data: status } = useGoogleStatus();
+
+  if (!status || status.connected) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm dark:border-amber-900/60 dark:bg-amber-950/40"
+    >
+      <span className="flex items-center gap-2 text-amber-700 dark:text-amber-300">
+        <AlertTriangle className="size-4" />
+        Google 캘린더가 연결되지 않았습니다.
+      </span>
+      <GoogleConnectButton variant="outline" size="sm" />
+    </div>
+  );
+}

--- a/fe/src/features/google/hooks/useDisconnectGoogle.ts
+++ b/fe/src/features/google/hooks/useDisconnectGoogle.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { toast } from "@/shared/lib/toast";
+
+import { disconnectGoogle } from "../api/googleApi";
+import { googleKeys } from "../queryKeys";
+
+export function useDisconnectGoogle() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: disconnectGoogle,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: googleKeys.all });
+      toast("Google 연동을 해제했습니다.", "success");
+    },
+    onError: () => {
+      toast("연동 해제에 실패했습니다. 다시 시도해 주세요.", "error");
+    },
+  });
+}

--- a/fe/src/features/google/hooks/useGoogleConnect.ts
+++ b/fe/src/features/google/hooks/useGoogleConnect.ts
@@ -1,0 +1,21 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { toast } from "@/shared/lib/toast";
+
+import { fetchGoogleAuthUrl } from "../api/googleApi";
+
+/**
+ * Google 연결 시작. 인증 URL을 받아 브라우저를 동의 화면으로 top-level redirect한다.
+ * (콜백은 서버가 처리 후 `/planner?google=connected|error`로 되돌린다)
+ */
+export function useGoogleConnect() {
+  return useMutation({
+    mutationFn: fetchGoogleAuthUrl,
+    onSuccess: (authorizationUrl) => {
+      window.location.href = authorizationUrl;
+    },
+    onError: () => {
+      toast("Google 연결을 시작하지 못했습니다. 다시 시도해 주세요.", "error");
+    },
+  });
+}

--- a/fe/src/features/google/hooks/useGoogleStatus.ts
+++ b/fe/src/features/google/hooks/useGoogleStatus.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchGoogleStatus } from "../api/googleApi";
+import { googleKeys } from "../queryKeys";
+
+export function useGoogleStatus() {
+  return useQuery({
+    queryKey: googleKeys.status,
+    queryFn: fetchGoogleStatus,
+    staleTime: 60 * 1000,
+  });
+}

--- a/fe/src/features/google/queryKeys.ts
+++ b/fe/src/features/google/queryKeys.ts
@@ -1,0 +1,4 @@
+export const googleKeys = {
+  all: ["google"] as const,
+  status: ["google", "status"] as const,
+};

--- a/fe/src/pages/planner/PlannerCallbackRedirect.test.tsx
+++ b/fe/src/pages/planner/PlannerCallbackRedirect.test.tsx
@@ -1,0 +1,53 @@
+import { screen } from "@testing-library/react";
+import { Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Toaster } from "@/components/Toaster";
+import { useToastStore } from "@/shared/lib/toast";
+import { renderWithRouter } from "@/test/render";
+
+import { PlannerCallbackRedirect } from "./PlannerCallbackRedirect";
+
+function renderAt(entry: string) {
+  return renderWithRouter(
+    <>
+      <Toaster />
+      <Routes>
+        <Route path="/planner" element={<PlannerCallbackRedirect />} />
+        <Route path="/planner/calendar" element={<div>복습 캘린더</div>} />
+      </Routes>
+    </>,
+    { initialEntries: [entry] },
+  );
+}
+
+describe("PlannerCallbackRedirect", () => {
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [] });
+  });
+
+  it("google=connected면 성공 토스트 후 캘린더로 이동한다", async () => {
+    renderAt("/planner?google=connected");
+
+    expect(await screen.findByText("복습 캘린더")).toBeInTheDocument();
+    expect(
+      screen.getByText("Google 캘린더가 연결되었습니다."),
+    ).toBeInTheDocument();
+  });
+
+  it("google=error면 에러 토스트 후 캘린더로 이동한다", async () => {
+    renderAt("/planner?google=error");
+
+    expect(await screen.findByText("복습 캘린더")).toBeInTheDocument();
+    expect(
+      screen.getByText("Google 연결에 실패했습니다. 다시 시도해 주세요."),
+    ).toBeInTheDocument();
+  });
+
+  it("파라미터가 없으면 토스트 없이 캘린더로 이동한다", async () => {
+    renderAt("/planner");
+
+    expect(await screen.findByText("복습 캘린더")).toBeInTheDocument();
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+});

--- a/fe/src/pages/planner/PlannerCallbackRedirect.tsx
+++ b/fe/src/pages/planner/PlannerCallbackRedirect.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from "react";
+import { Navigate, useSearchParams } from "react-router-dom";
+
+import { toast } from "@/shared/lib/toast";
+
+/**
+ * OAuth 콜백 복귀 지점(`/planner?google=connected|error`). 결과 토스트를 띄우고
+ * 통합 캘린더로 보낸다. (서버 콜백이 이 경로로 302 redirect)
+ */
+export function PlannerCallbackRedirect() {
+  const [params] = useSearchParams();
+  const google = params.get("google");
+  const fired = useRef(false);
+
+  useEffect(() => {
+    if (fired.current) return;
+    fired.current = true;
+    if (google === "connected") {
+      toast("Google 캘린더가 연결되었습니다.", "success");
+    } else if (google === "error") {
+      toast("Google 연결에 실패했습니다. 다시 시도해 주세요.", "error");
+    }
+  }, [google]);
+
+  return <Navigate to="/planner/calendar" replace />;
+}

--- a/fe/src/pages/planner/PlannerSettingsPage.tsx
+++ b/fe/src/pages/planner/PlannerSettingsPage.tsx
@@ -1,0 +1,12 @@
+import { GoogleConnectionCard } from "@/features/google/components/GoogleConnectionCard";
+
+export function PlannerSettingsPage() {
+  return (
+    <div className="flex flex-col gap-6">
+      <h1 className="text-xl font-semibold">연동 설정</h1>
+      <div className="max-w-md">
+        <GoogleConnectionCard />
+      </div>
+    </div>
+  );
+}

--- a/fe/src/pages/planner/ReviewCalendarPage.tsx
+++ b/fe/src/pages/planner/ReviewCalendarPage.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { GoogleNotConnectedBanner } from "@/features/google/components/GoogleNotConnectedBanner";
 import {
   addMonths,
   groupByDate,
@@ -74,6 +75,8 @@ export function ReviewCalendarPage() {
           오늘
         </Button>
       </div>
+
+      <GoogleNotConnectedBanner />
 
       <CalendarLegend />
 

--- a/fe/src/test/mocks/handlers.ts
+++ b/fe/src/test/mocks/handlers.ts
@@ -35,4 +35,17 @@ export const handlers = [
   http.post(`${API_BASE}/auth/logout`, () => {
     return HttpResponse.json({ code: "OK", data: null });
   }),
+
+  // 기본값: Google 미연동. 연동 상태를 검증하는 테스트는 server.use로 덮어쓴다.
+  http.get(`${API_BASE}/planner/google/status`, () => {
+    return HttpResponse.json({
+      code: "OK",
+      data: {
+        connected: false,
+        googleEmail: null,
+        scopes: null,
+        connectedAt: null,
+      },
+    });
+  }),
 ];


### PR DESCRIPTION
## 이슈
closes #477

## 작업 내용
Epic #472 M0 마무리(첫 FE). Google 연동 상태 표시·연결·해제 + 미연동 CTA + 콜백 토스트. (deps #475 OAuth API)

### features/google
- **api** `googleApi.ts`: `fetchGoogleStatus` / `fetchGoogleAuthUrl` / `disconnectGoogle` + `queryKeys`
- **hooks**: `useGoogleStatus`(useQuery) / `useGoogleConnect`(인증 URL 받아 동의화면으로 top-level redirect) / `useDisconnectGoogle`(해제 + invalidate + 토스트)
- **components**:
  - `GoogleConnectButton` — 연결 버튼(pending 처리)
  - `GoogleConnectionCard` — 연동 설정 카드(연결됨: 계정/연결일 + 해제 / 미연동: 연결 CTA)
  - `GoogleNotConnectedBanner` — 캘린더 상단 미연동 경고 배너 + CTA(연결됨/로딩 시 숨김)

### 화면/라우팅
- **연동 설정 페이지** `/planner/settings` + 사이드바 "연동 설정" 메뉴
- **콜백 복귀** `/planner?google=connected|error`(서버 302 목적지) → 결과 토스트 후 `/planner/calendar`로 이동(`PlannerCallbackRedirect`)
- **복습 캘린더** 상단에 미연동 배너 노출(복습은 그대로 표시)
- 기본 MSW 핸들러(google status 미연동) 추가 — 연동 검증 테스트는 `server.use`로 덮어씀

## 테스트 (RTL + MSW, 9종)
- `GoogleConnectionCard`: 미연동/연동 렌더 + 해제→미연동 전환 + 토스트
- `GoogleNotConnectedBanner`: 미연동 배너 노출 / 연동 시 미렌더
- `GoogleConnectButton`: 클릭→인증 URL redirect (location을 URL 인스턴스로 교체해 검증)
- `PlannerCallbackRedirect`: connected/error 토스트 + 캘린더 이동 / 파라미터 없으면 토스트 없음
- 전체 FE 스위트 122개 통과, tsc·eslint clean

## 참고
실제 OAuth 왕복(동의→콜백)은 배포된 BE(#475 머지됨) 기준 동작하며, 여기서는 MSW로 상태별 UI를 검증했다.