### PR TITLE
feat : Ansible kubeadm 사전조건 + containerd 롤 (#461 Phase 2)

### DIFF
--- a/infra/ansible/roles/container_runtime/defaults/main.yml
+++ b/infra/ansible/roles/container_runtime/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# 컨테이너 런타임. 클러스터는 containerd 사용. (#461 Phase 2)
+container_runtime_service: containerd

--- a/infra/ansible/roles/container_runtime/tasks/main.yml
+++ b/infra/ansible/roles/container_runtime/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+# 컨테이너 런타임(containerd) 서비스 보장. (#461 Phase 2)
+#
+# 주의: config.toml(SystemdCgroup=true 등)은 운영 클러스터 무중단을 위해
+# 이 롤에서 재작성하지 않는다. 잘못된 재템플릿/재시작은 모든 컨테이너를
+# 중단시킬 수 있다. 현재 노드는 이미 SystemdCgroup=true 로 구성돼 있으며,
+# 신규 노드 부트스트랩 시의 containerd config 관리는 kubeadm 단계(Phase 3)에서 다룬다.
+
+- name: 런타임 서비스 활성화 + 구동 (containerd, 재시작하지 않음)
+  ansible.builtin.systemd_service:
+    name: "{{ container_runtime_service }}"
+    enabled: true
+    state: started

--- a/infra/ansible/roles/kubeadm_prereqs/defaults/main.yml
+++ b/infra/ansible/roles/kubeadm_prereqs/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# kubeadm/CNI 가 요구하는 노드 사전조건. (#461 Phase 2)
+# overlay: containerd overlayfs 스냅샷터, br_netfilter: bridge 트래픽 iptables 경유.
+kubeadm_prereqs_kernel_modules:
+  - overlay
+  - br_netfilter
+
+# Pod 네트워킹 사전조건 sysctl. br_netfilter 로드 후 적용해야 한다.
+kubeadm_prereqs_sysctls:
+  net.ipv4.ip_forward: "1"
+  net.bridge.bridge-nf-call-iptables: "1"
+  net.bridge.bridge-nf-call-ip6tables: "1"

--- a/infra/ansible/roles/kubeadm_prereqs/tasks/main.yml
+++ b/infra/ansible/roles/kubeadm_prereqs/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+# kubeadm 사전조건: 커널 모듈 + 네트워크 sysctl + swap off. (#461 Phase 2)
+# 운영 클러스터는 이미 이 상태라 적용 시 거의 changed=0(무중단). 신규 노드 재현용.
+# 기존 kubeadm 생성 파일(k8s.conf 등)은 건드리지 않고 orino- 전용 파일로 관리한다.
+
+- name: 커널 모듈 부팅 시 자동 로드 (/etc/modules-load.d)
+  ansible.builtin.copy:
+    dest: /etc/modules-load.d/orino-k8s.conf
+    content: "{{ kubeadm_prereqs_kernel_modules | join('\n') }}\n"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: 커널 모듈 즉시 로드
+  community.general.modprobe:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ kubeadm_prereqs_kernel_modules }}"
+
+- name: 네트워크 sysctl 적용 (영구 /etc/sysctl.d + 즉시 반영)
+  ansible.posix.sysctl:
+    name: "{{ item.key }}"
+    value: "{{ item.value }}"
+    sysctl_file: /etc/sysctl.d/99-orino-k8s.conf
+    sysctl_set: true
+    reload: true
+    state: present
+  loop: "{{ kubeadm_prereqs_sysctls | dict2items }}"
+  loop_control:
+    label: "{{ item.key }} = {{ item.value }}"
+
+- name: 스왑 비활성화 (현재 활성일 때만)
+  ansible.builtin.command: swapoff -a
+  when: ansible_swaptotal_mb | default(0) | int > 0
+  changed_when: true
+
+- name: /etc/fstab swap 항목 주석 처리 (재부팅 후에도 off 유지)
+  ansible.builtin.replace:
+    path: /etc/fstab
+    regexp: '^([^#].*\bswap\b.*)$'
+    replace: '# \1'

--- a/infra/ansible/site.yml
+++ b/infra/ansible/site.yml
@@ -6,3 +6,5 @@
   become: true
   roles:
     - node_os
+    - kubeadm_prereqs
+    - container_runtime


### PR DESCRIPTION
## 이슈
Refs #461 (Phase 2 — 에픽이라 closes 아님)

## 작업 내용
- **`kubeadm_prereqs` 롤**: kubeadm/CNI 사전조건을 코드화
  - 커널 모듈 `overlay`, `br_netfilter` — `/etc/modules-load.d/orino-k8s.conf` 영구화 + 즉시 로드
  - 네트워크 sysctl `net.ipv4.ip_forward`, `net.bridge.bridge-nf-call-iptables/ip6tables` — `/etc/sysctl.d/99-orino-k8s.conf`
  - swap off — 현재 활성일 때만 `swapoff` + `/etc/fstab` swap 항목 주석
- **`container_runtime` 롤**: containerd 서비스 활성화/구동 보장
  - ⚠️ 운영 클러스터 무중단을 위해 `config.toml`(SystemdCgroup) 재작성·재시작은 **하지 않음**. 현 노드는 이미 SystemdCgroup=true. 신규 노드 config 관리는 Phase 3(kubeadm)에서.
- `site.yml`에 두 롤 추가 (기존 `node_os` 다음)

## 검증
- `ansible-playbook site.yml --syntax-check` ✅ / `ansible-lint` ✅ (production profile, 0 violation)
- 노드 정찰(읽기 전용)로 현재 상태 = 롤이 보장하는 상태 일치 확인 → 첫 apply는 orino- 전용 config 파일 2개 생성(현 상태 코드화), 이후 changed=0. **containerd 재시작·모듈 reload 없음(무중단)**
  - fstab swap 라인 이미 주석(`#/swap.img`) → changed=0, swap 0개 → swapoff skip
- merge 시 Ansible CI(`ANSIBLE_APPLY_ENABLED=true`)가 tailnet 경유로 자동 apply → recap으로 결과 확인