### PR TITLE
feat : Ansible kubeadm 롤 — 클러스터 init/join 역공학 (#461 Phase 3)

### DIFF
--- a/infra/ansible/README.md
+++ b/infra/ansible/README.md
@@ -17,10 +17,22 @@ ansible-playbook site.yml --ask-become-pass     # sudo 비밀번호 입력
 ## 롤
 | 롤 | 내용 |
 |---|---|
-| `node_os` | 커널 sysctl (inotify 등). 값은 `roles/node_os/defaults/main.yml` 에서 관리 |
+| `node_os` | 커널 sysctl (inotify 등). 값은 `roles/node_os/defaults/main.yml` |
+| `kubeadm_prereqs` | 커널 모듈(overlay/br_netfilter) + 네트워크 sysctl + swap off |
+| `container_runtime` | containerd 서비스 보장 (config 무중단 위해 미변경) |
+| `kubeadm` | 클러스터 init/join + Calico CNI — 현 클러스터 역공학, **신규 노드 전용** |
+
+### ⚠️ `kubeadm` 롤 안전·한계
+- **기존 멤버 노드(`/etc/kubernetes/kubelet.conf` 존재)에는 전부 skip** — 멤버십 가드로
+  init/join 이 운영 노드에 재실행되지 않는다. note1/note2 적용 시 changed=0(무중단).
+- **신규 노드에서만** 저장소·패키지·init/join·Calico 설치 경로가 돈다.
+- init/join 경로는 운영 클러스터가 하나뿐이라 **실증 테스트 불가**(역공학). 값은
+  `roles/kubeadm/defaults/main.yml` 에 현 노드 그대로 핀(k8s 1.34.5, podSubnet 10.244.0.0/16,
+  Calico v3.31.4). 진짜 새 노드 부트스트랩 시 검증 필요.
+- Calico 는 GitOps 미관리라 이 롤이 manifest 로 설치(podSubnet 에 맞춰 CIDR 치환).
 
 ## 로드맵 (#461)
 - [x] Phase 1: `node_os` (sysctl)
-- [ ] Phase 2: `container-runtime` (containerd) + kubeadm 사전조건
-- [ ] Phase 3: `kubeadm` (init/join)
+- [x] Phase 2: `container_runtime` (containerd) + kubeadm 사전조건(`kubeadm_prereqs`)
+- [x] Phase 3: `kubeadm` (init/join + Calico)
 - [ ] Phase 4: `argocd-bootstrap` (argocd 설치 + root app/project)

--- a/infra/ansible/roles/kubeadm/defaults/main.yml
+++ b/infra/ansible/roles/kubeadm/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# 현 클러스터 역공학 값 (#461 Phase 3). 신규 노드 부트스트랩 재현용.
+# 모두 운영 노드(note1/note2)에서 그대로 떠온 값 — 변경 시 클러스터와 어긋남 주의.
+
+# pkgs.k8s.io 저장소 마이너 스트림 + 패키지 핀(현 노드와 동일, hold).
+kubeadm_repo_stream: "v1.34"
+kubeadm_pkg_version: "1.34.5-1.1"
+kubeadm_kubernetes_version: "v1.34.5"
+
+# 클러스터 네트워킹 (kubeadm-config ClusterConfiguration 에서).
+kubeadm_pod_subnet: "10.244.0.0/16"
+kubeadm_service_subnet: "10.96.0.0/12"
+kubeadm_dns_domain: "cluster.local"
+kubeadm_image_repository: "registry.k8s.io"
+
+# 런타임/엔드포인트.
+kubeadm_cri_socket: "unix:///var/run/containerd/containerd.sock"
+kubeadm_advertise_address: "192.168.0.18"   # note1 (단일 control-plane)
+
+# CNI: Calico (manifest 설치, GitOps 미관리 → 부트스트랩 단계에서 설치).
+# 주의: 기본 manifest 의 CALICO_IPV4POOL_CIDR 은 192.168.0.0/16 이므로
+# podSubnet(10.244.0.0/16)에 맞추려면 적용 전 CIDR 을 교체해야 한다(아래 task 참고).
+kubeadm_calico_version: "v3.31.4"
+kubeadm_calico_manifest_url: "https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/calico.yaml"

--- a/infra/ansible/roles/kubeadm/tasks/main.yml
+++ b/infra/ansible/roles/kubeadm/tasks/main.yml
@@ -1,0 +1,132 @@
+---
+# kubeadm: 현 클러스터 역공학 + 신규 노드 부트스트랩. (#461 Phase 3)
+#
+# ⚠️ 안전장치: 이미 클러스터 멤버인 노드(/etc/kubernetes/kubelet.conf 존재)에는
+#    아무 것도 실행하지 않는다(블록 전체 skip). init/join 을 운영 노드에 다시 돌리면
+#    클러스터가 깨지므로, 멤버십을 먼저 확인하고 프로비저닝 블록을 통째로 가드한다.
+#    → note1/note2(기존 멤버)에는 stat 한 번만 돌고 changed=0.
+#
+# ⚠️ init/join 경로는 운영 클러스터가 하나뿐이라 실증 테스트 불가(역공학 코드).
+#    진짜 새 노드에서 검증 전까지는 "기존 클러스터 무중단"만 보증한다.
+
+- name: 클러스터 멤버십 확인 (kubelet.conf)
+  ansible.builtin.stat:
+    path: /etc/kubernetes/kubelet.conf
+  register: kubeadm_kubelet_conf
+
+- name: 신규 노드 프로비저닝 (기존 멤버는 전체 skip)
+  when: not kubeadm_kubelet_conf.stat.exists
+  block:
+    # --- Kubernetes apt 저장소 (현 노드와 동일) ---
+    - name: Apt 키링 디렉터리 생성
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: "0755"
+
+    - name: Kubernetes apt GPG 키 설치
+      ansible.builtin.get_url:
+        url: "https://pkgs.k8s.io/core:/stable:/{{ kubeadm_repo_stream }}/deb/Release.key"
+        dest: /etc/apt/keyrings/kubernetes-apt-keyring.asc
+        mode: "0644"
+
+    - name: Kubernetes apt 저장소 등록
+      ansible.builtin.deb822_repository:
+        name: kubernetes
+        types: [deb]
+        uris: "https://pkgs.k8s.io/core:/stable:/{{ kubeadm_repo_stream }}/deb/"
+        suites: "/"
+        signed_by: /etc/apt/keyrings/kubernetes-apt-keyring.asc
+        enabled: true
+
+    # --- 패키지 설치 + hold ---
+    - name: Kubelet/kubeadm/kubectl 설치 (버전 핀)
+      ansible.builtin.apt:
+        name:
+          - "kubelet={{ kubeadm_pkg_version }}"
+          - "kubeadm={{ kubeadm_pkg_version }}"
+          - "kubectl={{ kubeadm_pkg_version }}"
+        update_cache: true
+        allow_change_held_packages: true
+
+    - name: Kubelet/kubeadm/kubectl hold (자동 업그레이드 방지)
+      ansible.builtin.dpkg_selections:
+        name: "{{ item }}"
+        selection: hold
+      loop:
+        - kubelet
+        - kubeadm
+        - kubectl
+
+    - name: Kubelet 부팅 시 활성화 (start 는 kubeadm 이 수행)
+      ansible.builtin.systemd_service:
+        name: kubelet
+        enabled: true
+
+    # --- control-plane: kubeadm init (최초 1회) ---
+    - name: Kubeadm init 설정 파일 생성 (control-plane)
+      ansible.builtin.template:
+        src: kubeadm-init-config.yaml.j2
+        dest: /etc/kubernetes/orino-kubeadm-init.yaml
+        mode: "0600"
+      when: inventory_hostname in groups['control_plane']
+
+    - name: Kubeadm init 실행 (control-plane)
+      ansible.builtin.command:
+        cmd: kubeadm init --config /etc/kubernetes/orino-kubeadm-init.yaml
+        creates: /etc/kubernetes/admin.conf
+      when: inventory_hostname in groups['control_plane']
+
+    - name: Root kubeconfig 디렉터리 생성 (control-plane)
+      ansible.builtin.file:
+        path: /root/.kube
+        state: directory
+        mode: "0700"
+      when: inventory_hostname in groups['control_plane']
+
+    - name: Admin.conf 를 root kubeconfig 로 배치 (control-plane)
+      ansible.builtin.copy:
+        src: /etc/kubernetes/admin.conf
+        dest: /root/.kube/config
+        remote_src: true
+        mode: "0600"
+      when: inventory_hostname in groups['control_plane']
+
+    # --- CNI: Calico (control-plane) ---
+    # 주의: podSubnet 10.244.0.0/16 사용 → 적용 전 manifest 의
+    #       CALICO_IPV4POOL_CIDR(기본 192.168.0.0/16)을 10.244.0.0/16 으로 교체해야 한다.
+    - name: Calico manifest 내려받기 (control-plane)
+      ansible.builtin.get_url:
+        url: "{{ kubeadm_calico_manifest_url }}"
+        dest: /etc/kubernetes/orino-calico.yaml
+        mode: "0644"
+      when: inventory_hostname in groups['control_plane']
+
+    - name: Calico IPPool CIDR 을 podSubnet 에 맞춤 (control-plane)
+      ansible.builtin.replace:
+        path: /etc/kubernetes/orino-calico.yaml
+        regexp: '192\.168\.0\.0/16'
+        replace: "{{ kubeadm_pod_subnet }}"
+      when: inventory_hostname in groups['control_plane']
+
+    - name: Calico 설치 (control-plane)
+      ansible.builtin.command:
+        cmd: kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f /etc/kubernetes/orino-calico.yaml
+      register: kubeadm_calico_apply
+      changed_when: "'created' in kubeadm_calico_apply.stdout or 'configured' in kubeadm_calico_apply.stdout"
+      when: inventory_hostname in groups['control_plane']
+
+    # --- worker: kubeadm join (최초 1회) ---
+    - name: Join 커맨드 생성 (control-plane 에서, 워커용)
+      ansible.builtin.command: kubeadm token create --print-join-command
+      delegate_to: "{{ groups['control_plane'][0] }}"
+      run_once: true
+      register: kubeadm_join_cmd
+      changed_when: false
+      when: inventory_hostname in groups['workers']
+
+    - name: Kubeadm join 실행 (worker)
+      ansible.builtin.command:
+        cmd: "{{ kubeadm_join_cmd.stdout }} --cri-socket {{ kubeadm_cri_socket }}"
+        creates: /etc/kubernetes/kubelet.conf
+      when: inventory_hostname in groups['workers']

--- a/infra/ansible/roles/kubeadm/templates/kubeadm-init-config.yaml.j2
+++ b/infra/ansible/roles/kubeadm/templates/kubeadm-init-config.yaml.j2
@@ -1,0 +1,16 @@
+# kubeadm init 설정 — 현 클러스터 역공학 (#461 Phase 3). 신규 control-plane 부트스트랩용.
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: {{ kubeadm_advertise_address }}
+nodeRegistration:
+  criSocket: {{ kubeadm_cri_socket }}
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+kubernetesVersion: {{ kubeadm_kubernetes_version }}
+imageRepository: {{ kubeadm_image_repository }}
+networking:
+  podSubnet: {{ kubeadm_pod_subnet }}
+  serviceSubnet: {{ kubeadm_service_subnet }}
+  dnsDomain: {{ kubeadm_dns_domain }}

--- a/infra/ansible/site.yml
+++ b/infra/ansible/site.yml
@@ -8,3 +8,4 @@
     - node_os
     - kubeadm_prereqs
     - container_runtime
+    - kubeadm


### PR DESCRIPTION
## 이슈
Refs #461 (Phase 3 — 에픽이라 closes 아님)

## 작업 내용
현 클러스터를 역공학해 **신규 노드 부트스트랩**을 코드화한 `kubeadm` 롤 추가.

- **apt 저장소/패키지**: `pkgs.k8s.io v1.34` repo+key, `kubelet/kubeadm/kubectl=1.34.5-1.1` 핀 설치 + `apt-mark hold`
- **control-plane**: `kubeadm init`(템플릿: advertise 192.168.0.18, podSubnet 10.244.0.0/16, serviceSubnet 10.96.0.0/12, CRI containerd) + root kubeconfig + **Calico v3.31.4** manifest 설치(podSubnet 맞춰 CIDR 치환)
- **worker**: control-plane 토큰으로 `kubeadm join`
- `site.yml`에 `kubeadm` 롤 추가, README 갱신

## 안전 설계 (운영 클러스터 무중단)
- **멤버십 가드**: `/etc/kubernetes/kubelet.conf` 존재 시 프로비저닝 블록 **전체 skip**. init/join 이 운영 노드에 재실행되지 않음
- 정찰 확인: note1/note2 모두 kubelet.conf 존재 → 적용 시 **stat 1회만, changed=0(무중단)**. init/join/패키지/Calico 경로는 **진짜 새 노드에서만** 실행
- merge 시 Ansible CI 자동 apply → 기존 노드엔 no-op(recap `ok=… changed=0`)

## 한계 (정직하게)
- init/join 경로는 운영 클러스터가 **하나뿐이라 실증 테스트 불가**(역공학 코드). 값은 현 노드 그대로 핀 — 진짜 새 노드 부트스트랩 시 검증 필요
- Calico 는 GitOps 미관리라 이 롤이 manifest 로 설치

## 검증
- `ansible-playbook site.yml --syntax-check` ✅ / `ansible-lint` ✅ (production profile, 0 violation)