### PR TITLE
feat : Planner events.list 라이브 프록시 + 단기 캐시

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/GoogleEventQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/GoogleEventQueryService.java
@@ -1,0 +1,89 @@
+package ds.project.orino.planner.google.calendar;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.planner.google.calendar.dto.GoogleEventsView;
+import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
+import ds.project.orino.planner.google.client.GoogleCalendarClient;
+import ds.project.orino.redis.planner.google.GoogleCalendarCacheRepository;
+import org.springframework.stereotype.Service;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 일정 조회: 미연동 처리 + 단기 캐시(~60초) + 라이브 프록시. 통합 피드(#479)가 이 결과를 합류시킨다.
+ *
+ * <p>Google이 유일한 진실이라 로컬 미러를 두지 않고, 뷰 전환의 중복 호출만 Redis로 흡수한다.
+ */
+@Service
+public class GoogleEventQueryService {
+
+    private static final Duration CACHE_TTL = Duration.ofSeconds(60);
+    private static final TypeReference<List<PlannerEvent>> EVENT_LIST = new TypeReference<>() {
+    };
+
+    private final GoogleAccountRepository accountRepository;
+    private final GoogleCalendarClient calendarClient;
+    private final GoogleCalendarCacheRepository cacheRepository;
+    private final ObjectMapper objectMapper;
+
+    public GoogleEventQueryService(GoogleAccountRepository accountRepository,
+                                   GoogleCalendarClient calendarClient,
+                                   GoogleCalendarCacheRepository cacheRepository,
+                                   ObjectMapper objectMapper) {
+        this.accountRepository = accountRepository;
+        this.calendarClient = calendarClient;
+        this.cacheRepository = cacheRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /** [from, to] 날짜 구간의 일정을 조회한다. 미연동이면 connected=false + 빈 목록. */
+    public GoogleEventsView getEvents(Long memberId, LocalDate from, LocalDate to, ZoneId zone) {
+        if (!isConnected(memberId)) {
+            return GoogleEventsView.notConnected();
+        }
+
+        Optional<String> cached = cacheRepository.find(memberId, from.toString(), to.toString());
+        if (cached.isPresent()) {
+            return GoogleEventsView.connected(deserialize(cached.get()));
+        }
+
+        Instant timeMin = from.atStartOfDay(zone).toInstant();
+        Instant timeMax = to.plusDays(1).atStartOfDay(zone).toInstant();
+        List<PlannerEvent> events = calendarClient.listEvents(memberId, timeMin, timeMax, zone);
+
+        cacheRepository.save(memberId, from.toString(), to.toString(), serialize(events), CACHE_TTL);
+        return GoogleEventsView.connected(events);
+    }
+
+    private boolean isConnected(Long memberId) {
+        return accountRepository.findByMemberId(memberId)
+                .filter(account -> !account.isRevoked())
+                .isPresent();
+    }
+
+    private String serialize(List<PlannerEvent> events) {
+        try {
+            return objectMapper.writeValueAsString(events);
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.GOOGLE_API_FAILED, e);
+        }
+    }
+
+    private List<PlannerEvent> deserialize(String json) {
+        try {
+            return objectMapper.readValue(json, EVENT_LIST);
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.GOOGLE_API_FAILED, e);
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventsResponse.java
@@ -1,0 +1,26 @@
+package ds.project.orino.planner.google.calendar.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/** Google Calendar events.list 응답(필요한 필드만). */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GoogleEventsResponse(List<GoogleEventItem> items) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GoogleEventItem(
+            String id,
+            String summary,
+            String location,
+            String recurringEventId,
+            GoogleEventDateTime start,
+            GoogleEventDateTime end
+    ) {
+    }
+
+    /** start/end는 시간 일정이면 dateTime(RFC3339), 종일이면 date("yyyy-MM-dd"). */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GoogleEventDateTime(String dateTime, String date) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventsView.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventsView.java
@@ -1,0 +1,17 @@
+package ds.project.orino.planner.google.calendar.dto;
+
+import java.util.List;
+
+/**
+ * 일정 조회 결과. 미연동이면 connected=false + 빈 목록. 통합 피드(#479)가 googleConnected로 노출한다.
+ */
+public record GoogleEventsView(boolean connected, List<PlannerEvent> events) {
+
+    public static GoogleEventsView notConnected() {
+        return new GoogleEventsView(false, List.of());
+    }
+
+    public static GoogleEventsView connected(List<PlannerEvent> events) {
+        return new GoogleEventsView(true, events);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/PlannerEvent.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/PlannerEvent.java
@@ -1,0 +1,25 @@
+package ds.project.orino.planner.google.calendar.dto;
+
+/**
+ * 통합 캘린더 피드의 일정(event). Google 응답을 사용자 시간대로 정규화한 형태.
+ *
+ * @param id        Google event id
+ * @param title     제목(summary, null 가능)
+ * @param allDay    종일 일정 여부
+ * @param start     종일이면 날짜("2026-06-10"), 시간 일정이면 사용자 TZ 로컬 datetime("2026-06-10T14:00:00")
+ * @param end       종료(종일은 포함 마지막 날짜로 보정)
+ * @param location  장소(null 가능)
+ * @param recurring 반복 일정의 인스턴스 여부
+ * @param source    항상 "google"
+ */
+public record PlannerEvent(
+        String id,
+        String title,
+        boolean allDay,
+        String start,
+        String end,
+        String location,
+        boolean recurring,
+        String source
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
@@ -1,0 +1,114 @@
+package ds.project.orino.planner.google.client;
+
+import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse;
+import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventDateTime;
+import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventItem;
+import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
+import ds.project.orino.planner.google.config.GoogleOAuthProperties;
+import ds.project.orino.planner.google.token.GoogleTokenProvider;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Google Calendar API 래퍼. {@code events.list}를 라이브 프록시하고 응답을 사용자 시간대로 정규화한다.
+ *
+ * <p>{@code singleEvents=true&orderBy=startTime}로 RRULE 반복을 기간 내 인스턴스로 펼쳐 받아
+ * orino는 RRULE을 직접 구현하지 않는다. access token은 {@link GoogleTokenProvider#executeWithRetry}로
+ * 공급·401 재시도한다(만료 시 1회 자동 갱신).
+ */
+@Component
+public class GoogleCalendarClient {
+
+    /** 사용자 TZ 로컬 datetime 포맷(오프셋 없이 "2026-06-10T14:00:00"). */
+    private static final DateTimeFormatter LOCAL_DATETIME =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    private static final String PRIMARY_CALENDAR_PATH = "/calendar/v3/calendars/primary/events";
+
+    private final GoogleTokenProvider tokenProvider;
+    private final RestClient googleRestClient;
+    private final GoogleOAuthProperties oauthProperties;
+
+    public GoogleCalendarClient(GoogleTokenProvider tokenProvider,
+                                RestClient googleRestClient,
+                                GoogleOAuthProperties oauthProperties) {
+        this.tokenProvider = tokenProvider;
+        this.googleRestClient = googleRestClient;
+        this.oauthProperties = oauthProperties;
+    }
+
+    /** [timeMin, timeMax) 구간의 primary 캘린더 일정을 조회해 사용자 시간대로 정규화한다. */
+    public List<PlannerEvent> listEvents(Long memberId, Instant timeMin, Instant timeMax, ZoneId zone) {
+        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
+                .path(PRIMARY_CALENDAR_PATH)
+                .queryParam("timeMin", timeMin.toString())
+                .queryParam("timeMax", timeMax.toString())
+                .queryParam("singleEvents", "true")
+                .queryParam("orderBy", "startTime")
+                .queryParam("maxResults", "2500")
+                .build()
+                .toUri();
+
+        GoogleEventsResponse response = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.get()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .retrieve()
+                        .body(GoogleEventsResponse.class));
+
+        if (response == null || response.items() == null) {
+            return List.of();
+        }
+        return response.items().stream()
+                .map(item -> normalize(item, zone))
+                .toList();
+    }
+
+    private PlannerEvent normalize(GoogleEventItem item, ZoneId zone) {
+        GoogleEventDateTime start = item.start();
+        GoogleEventDateTime end = item.end();
+        boolean allDay = start != null && start.date() != null;
+
+        String startValue;
+        String endValue;
+        if (allDay) {
+            startValue = start.date();
+            // Google 종일 종료는 배타적(다음 날) → 포함 마지막 날짜로 보정
+            endValue = (end != null && end.date() != null)
+                    ? LocalDate.parse(end.date()).minusDays(1).toString()
+                    : start.date();
+        } else {
+            startValue = toLocalDateTime(start, zone);
+            endValue = toLocalDateTime(end, zone);
+        }
+
+        return new PlannerEvent(
+                item.id(),
+                item.summary(),
+                allDay,
+                startValue,
+                endValue,
+                item.location(),
+                item.recurringEventId() != null,
+                "google");
+    }
+
+    private String toLocalDateTime(GoogleEventDateTime dateTime, ZoneId zone) {
+        if (dateTime == null || dateTime.dateTime() == null) {
+            return null;
+        }
+        return OffsetDateTime.parse(dateTime.dateTime())
+                .atZoneSameInstant(zone)
+                .toLocalDateTime()
+                .format(LOCAL_DATETIME);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleApiConfig.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleApiConfig.java
@@ -2,6 +2,7 @@ package ds.project.orino.planner.google.config;
 
 import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.google.token.GoogleUnauthorizedException;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,8 +20,9 @@ import java.nio.charset.StandardCharsets;
  * (의존성 0 추가, Jackson 재사용). OAuth 토큰 엔드포인트와 Calendar/Tasks 엔드포인트는
  * 호스트가 다르므로 baseUrl 을 두지 않고 호출부에서 절대 URI 를 지정한다.
  *
- * <p>{@code defaultStatusHandler} 가 4xx/5xx 응답을 {@link CustomException} 으로 매핑한다.
- * 응답 본문에 {@code invalid_grant} 가 있으면 재연동 필요(401)로, 그 외는 Google API 실패(502)로 본다.
+ * <p>{@code defaultStatusHandler} 가 4xx/5xx 응답을 매핑한다: API 401 → {@link GoogleUnauthorizedException}
+ * (access token 만료, {@code executeWithRetry}가 1회 갱신 후 재시도) / 본문에 {@code invalid_grant} →
+ * 재연동 필요(PLN-ERR-005) / 그 외 → Google API 실패(PLN-ERR-004).
  */
 @Configuration
 @EnableConfigurationProperties({GoogleApiProperties.class, GoogleOAuthProperties.class})
@@ -37,6 +39,9 @@ public class GoogleApiConfig {
                 .defaultStatusHandler(
                         statusCode -> statusCode.isError(),
                         (request, response) -> {
+                            if (response.getStatusCode().value() == 401) {
+                                throw new GoogleUnauthorizedException();
+                            }
                             String body = readBody(response);
                             if (body.contains("invalid_grant")) {
                                 throw new CustomException(ErrorCode.GOOGLE_INVALID_GRANT);

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/GoogleEventQueryServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/GoogleEventQueryServiceTest.java
@@ -40,7 +40,7 @@ class GoogleEventQueryServiceTest {
     private static final LocalDate TO = LocalDate.of(2026, 6, 30);
 
     private static final HttpServer EVENTS_STUB = createStub();
-    private static final AtomicInteger callCount = new AtomicInteger();
+    private static final AtomicInteger CALL_COUNT = new AtomicInteger();
     private static volatile String responseBody = "{\"items\":[]}";
 
     @Autowired
@@ -71,7 +71,7 @@ class GoogleEventQueryServiceTest {
 
     @BeforeEach
     void setUp() {
-        callCount.set(0);
+        CALL_COUNT.set(0);
         responseBody = "{\"items\":[]}";
         dbCleaner.clean();
         memberId = memberRepository.save(MemberFixture.create()).getId();
@@ -91,7 +91,7 @@ class GoogleEventQueryServiceTest {
 
         assertThat(view.connected()).isFalse();
         assertThat(view.events()).isEmpty();
-        assertThat(callCount.get()).isZero();
+        assertThat(CALL_COUNT.get()).isZero();
     }
 
     @Test
@@ -156,7 +156,7 @@ class GoogleEventQueryServiceTest {
         GoogleEventsView first = eventQueryService.getEvents(memberId, FROM, TO, SEOUL);
         GoogleEventsView second = eventQueryService.getEvents(memberId, FROM, TO, SEOUL);
 
-        assertThat(callCount.get()).isEqualTo(1);
+        assertThat(CALL_COUNT.get()).isEqualTo(1);
         assertThat(first.events()).hasSize(1);
         assertThat(second.events()).hasSize(1);
         assertThat(second.events().get(0).start()).isEqualTo("2026-06-10T14:00:00");
@@ -170,7 +170,7 @@ class GoogleEventQueryServiceTest {
         try {
             HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
             server.createContext("/calendar/v3/calendars/primary/events", exchange -> {
-                callCount.incrementAndGet();
+                CALL_COUNT.incrementAndGet();
                 respond(exchange, 200, responseBody);
             });
             server.start();

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/GoogleEventQueryServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/GoogleEventQueryServiceTest.java
@@ -1,0 +1,191 @@
+package ds.project.orino.planner.google.calendar;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.planner.google.calendar.dto.GoogleEventsView;
+import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.IntegrationTest;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class GoogleEventQueryServiceTest {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+    private static final LocalDate FROM = LocalDate.of(2026, 6, 1);
+    private static final LocalDate TO = LocalDate.of(2026, 6, 30);
+
+    private static final HttpServer EVENTS_STUB = createStub();
+    private static final AtomicInteger callCount = new AtomicInteger();
+    private static volatile String responseBody = "{\"items\":[]}";
+
+    @Autowired
+    private GoogleEventQueryService eventQueryService;
+    @Autowired
+    private GoogleAccountRepository accountRepository;
+    @Autowired
+    private GoogleAccessTokenRepository accessTokenRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Long memberId;
+
+    @DynamicPropertySource
+    static void googleProperties(DynamicPropertyRegistry registry) {
+        String base = "http://127.0.0.1:" + EVENTS_STUB.getAddress().getPort();
+        registry.add("planner.google.client-id", () -> "test-client-id");
+        registry.add("planner.google.client-secret", () -> "test-client-secret");
+        registry.add("planner.google.oauth.calendar-api-base-url", () -> base);
+    }
+
+    @AfterAll
+    static void stopStub() {
+        EVENTS_STUB.stop(0);
+    }
+
+    @BeforeEach
+    void setUp() {
+        callCount.set(0);
+        responseBody = "{\"items\":[]}";
+        dbCleaner.clean();
+        memberId = memberRepository.save(MemberFixture.create()).getId();
+    }
+
+    private void connect() {
+        accountRepository.save(new GoogleAccount(
+                memberId, "refresh", "scope", "me@gmail.com", "primary", "@default"));
+        // access token을 미리 캐시해 refresh grant 없이 events 호출만 일어나게 한다.
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+    }
+
+    @Test
+    @DisplayName("미연동이면 connected=false와 빈 목록을 반환하고 Google을 호출하지 않는다")
+    void getEvents_notConnected() {
+        GoogleEventsView view = eventQueryService.getEvents(memberId, FROM, TO, SEOUL);
+
+        assertThat(view.connected()).isFalse();
+        assertThat(view.events()).isEmpty();
+        assertThat(callCount.get()).isZero();
+    }
+
+    @Test
+    @DisplayName("revoked 연동이면 connected=false")
+    void getEvents_revoked() {
+        GoogleAccount account = new GoogleAccount(memberId, "r", "s", "me@gmail.com", "primary", "@default");
+        account.markRevoked();
+        accountRepository.save(account);
+
+        GoogleEventsView view = eventQueryService.getEvents(memberId, FROM, TO, SEOUL);
+
+        assertThat(view.connected()).isFalse();
+        assertThat(view.events()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("시간/종일/반복 일정을 사용자 시간대로 정규화한다")
+    void getEvents_normalizes() {
+        connect();
+        responseBody = """
+                {"items":[
+                  {"id":"e1","summary":"회의","location":"3층",
+                   "start":{"dateTime":"2026-06-10T05:00:00Z"},"end":{"dateTime":"2026-06-10T06:00:00Z"}},
+                  {"id":"e2","summary":"여행",
+                   "start":{"date":"2026-06-12"},"end":{"date":"2026-06-14"}},
+                  {"id":"e3","summary":"스탠드업","recurringEventId":"r1",
+                   "start":{"dateTime":"2026-06-11T00:00:00Z"},"end":{"dateTime":"2026-06-11T00:30:00Z"}}
+                ]}""";
+
+        GoogleEventsView view = eventQueryService.getEvents(memberId, FROM, TO, SEOUL);
+
+        assertThat(view.connected()).isTrue();
+        assertThat(view.events()).hasSize(3);
+
+        PlannerEvent timed = find(view.events(), "e1");
+        assertThat(timed.allDay()).isFalse();
+        assertThat(timed.title()).isEqualTo("회의");
+        assertThat(timed.start()).isEqualTo("2026-06-10T14:00:00");
+        assertThat(timed.end()).isEqualTo("2026-06-10T15:00:00");
+        assertThat(timed.location()).isEqualTo("3층");
+        assertThat(timed.recurring()).isFalse();
+        assertThat(timed.source()).isEqualTo("google");
+
+        PlannerEvent allDay = find(view.events(), "e2");
+        assertThat(allDay.allDay()).isTrue();
+        assertThat(allDay.start()).isEqualTo("2026-06-12");
+        assertThat(allDay.end()).isEqualTo("2026-06-13"); // 배타적 종료(06-14) → 포함 마지막날
+
+        PlannerEvent recurring = find(view.events(), "e3");
+        assertThat(recurring.recurring()).isTrue();
+        assertThat(recurring.start()).isEqualTo("2026-06-11T09:00:00");
+    }
+
+    @Test
+    @DisplayName("같은 구간 재조회는 단기 캐시로 흡수해 Google을 한 번만 호출한다")
+    void getEvents_caches() {
+        connect();
+        responseBody = """
+                {"items":[{"id":"e1","summary":"회의",
+                 "start":{"dateTime":"2026-06-10T05:00:00Z"},"end":{"dateTime":"2026-06-10T06:00:00Z"}}]}""";
+
+        GoogleEventsView first = eventQueryService.getEvents(memberId, FROM, TO, SEOUL);
+        GoogleEventsView second = eventQueryService.getEvents(memberId, FROM, TO, SEOUL);
+
+        assertThat(callCount.get()).isEqualTo(1);
+        assertThat(first.events()).hasSize(1);
+        assertThat(second.events()).hasSize(1);
+        assertThat(second.events().get(0).start()).isEqualTo("2026-06-10T14:00:00");
+    }
+
+    private static PlannerEvent find(List<PlannerEvent> events, String id) {
+        return events.stream().filter(e -> e.id().equals(id)).findFirst().orElseThrow();
+    }
+
+    private static HttpServer createStub() {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/calendar/v3/calendars/primary/events", exchange -> {
+                callCount.incrementAndGet();
+                respond(exchange, 200, responseBody);
+            });
+            server.start();
+            return server;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/config/GoogleApiConfigTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/config/GoogleApiConfigTest.java
@@ -4,6 +4,7 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.google.token.GoogleUnauthorizedException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -78,6 +79,7 @@ class GoogleApiConfigTest {
             server.createContext("/ok", ex -> respond(ex, 200, "{\"ok\":true}"));
             server.createContext("/server-error", ex -> respond(ex, 500, "{\"error\":\"backendError\"}"));
             server.createContext("/invalid-grant", ex -> respond(ex, 400, "{\"error\":\"invalid_grant\"}"));
+            server.createContext("/unauthorized", ex -> respond(ex, 401, "{\"error\":\"unauthorized\"}"));
             server.start();
             baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
 
@@ -117,6 +119,14 @@ class GoogleApiConfigTest {
                     .isInstanceOf(CustomException.class)
                     .extracting(e -> ((CustomException) e).getErrorCode())
                     .isEqualTo(ErrorCode.GOOGLE_INVALID_GRANT);
+        }
+
+        @Test
+        @DisplayName("401 응답은 GoogleUnauthorizedException으로 매핑한다(토큰 갱신 트리거)")
+        void unauthorizedMapsToGoogleUnauthorized() {
+            assertThatThrownBy(() ->
+                    client.get().uri(baseUrl + "/unauthorized").retrieve().body(String.class))
+                    .isInstanceOf(GoogleUnauthorizedException.class);
         }
     }
 

--- a/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/google/GoogleCalendarCacheRepository.java
+++ b/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/google/GoogleCalendarCacheRepository.java
@@ -1,0 +1,37 @@
+package ds.project.orino.redis.planner.google;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * 통합 피드 일정 조회의 단기 캐시. 키 {@code google:cal-cache:{memberId}:{from}:{to}}.
+ *
+ * <p>뷰 전환/리렌더의 중복 호출(~60초)만 흡수한다. 직렬화된 응답(JSON 문자열)을 그대로 저장하며,
+ * 쓰기 후엔 해당 사용자 캐시를 무효화한다(쓰기 프록시 M2 #482에서 evict 추가).
+ */
+@Repository
+public class GoogleCalendarCacheRepository {
+
+    private static final String KEY_PREFIX = "google:cal-cache:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public GoogleCalendarCacheRepository(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(Long memberId, String from, String to, String json, Duration ttl) {
+        redisTemplate.opsForValue().set(key(memberId, from, to), json, ttl);
+    }
+
+    public Optional<String> find(Long memberId, String from, String to) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(key(memberId, from, to)));
+    }
+
+    private String key(Long memberId, String from, String to) {
+        return KEY_PREFIX + memberId + ":" + from + ":" + to;
+    }
+}


### PR DESCRIPTION
## 이슈
closes #478

## 작업 내용
Epic #472 M1. Google Calendar `events.list`를 라이브 프록시하고 사용자 시간대로 정규화 + Redis 단기 캐시. (deps #476)

- **`GoogleCalendarClient.listEvents(memberId, timeMin, timeMax, zone)`**: `singleEvents=true&orderBy=startTime`로 RRULE 반복을 인스턴스로 펼쳐 받는다(orino는 RRULE 미구현). `GoogleTokenProvider.executeWithRetry`로 access token 공급·401 재시도.
  - **정규화**: 시간 일정은 사용자 TZ 로컬 datetime(`2026-06-10T14:00:00`), 종일은 날짜(`date`) + 종료는 Google 배타적 종료를 포함 마지막 날로 보정, 반복 인스턴스는 `recurring:true`.
- **`GoogleEventQueryService.getEvents(memberId, from, to, zone)`** → `GoogleEventsView(connected, events)`:
  - 미연동/revoked → `connected=false` + 빈 목록(Google 미호출)
  - 단기 캐시(~60초) `google:cal-cache:{memberId}:{from}:{to}` hit→캐시 / miss→프록시 후 저장
- **`GoogleApiConfig`**: API **401 → `GoogleUnauthorizedException`** 중앙화. default status handler가 모든 4xx를 먼저 가로채 per-request onStatf가 안 먹는 문제를 해결해, #476의 `executeWithRetry`가 실제로 트리거되게 함.
- `ObjectMapper`는 **Jackson 3(`tools.jackson`)** 사용(Boot 4 기본 빈).

## 테스트
- `GoogleEventQueryServiceTest`(IntegrationTest, JDK HttpServer 스텁) 4/4: 시간/종일/반복 정규화(Asia/Seoul TZ), 단기 캐시(재조회 시 Google 1회만), 미연동/revoked→빈 목록
- `GoogleApiConfigTest`에 401→`GoogleUnauthorizedException` 매핑 추가(StatusHandler 4/4)
- app-api 전체 + redis 스위트 통과

## 참고
통합 피드 엔드포인트(events+reviews 합류)는 #479에서 이 `GoogleEventsView`를 사용한다.