### PR TITLE
feat : Ansible argocd_bootstrap 롤 — ArgoCD 부트스트랩 역공학 (#461 Phase 4)

### DIFF
--- a/infra/ansible/README.md
+++ b/infra/ansible/README.md
@@ -21,6 +21,7 @@ ansible-playbook site.yml --ask-become-pass     # sudo 비밀번호 입력
 | `kubeadm_prereqs` | 커널 모듈(overlay/br_netfilter) + 네트워크 sysctl + swap off |
 | `container_runtime` | containerd 서비스 보장 (config 무중단 위해 미변경) |
 | `kubeadm` | 클러스터 init/join + Calico CNI — 현 클러스터 역공학, **신규 노드 전용** |
+| `argocd_bootstrap` | ArgoCD helm 설치 + AppProject/root(App-of-Apps) apply — **미설치 시에만** |
 
 ### ⚠️ `kubeadm` 롤 안전·한계
 - **기존 멤버 노드(`/etc/kubernetes/kubelet.conf` 존재)에는 전부 skip** — 멤버십 가드로
@@ -31,8 +32,15 @@ ansible-playbook site.yml --ask-become-pass     # sudo 비밀번호 입력
   Calico v3.31.4). 진짜 새 노드 부트스트랩 시 검증 필요.
 - Calico 는 GitOps 미관리라 이 롤이 manifest 로 설치(podSubnet 에 맞춰 CIDR 치환).
 
-## 로드맵 (#461)
+### ⚠️ `argocd_bootstrap` 롤 안전·한계
+- **이미 설치돼 있으면(`argocd-server` 디플로이 존재) 전체 skip** — 운영 ArgoCD 에 helm 재설치/재apply 안 함. note1 적용 시 조회만 돌고 changed=0(무중단).
+- ArgoCD 본체는 chicken-and-egg 라 GitOps 밖 → 이 롤이 helm(argo-cd v9.4.10)으로 최초 설치 후 AppProject(orino) → root(App-of-Apps) 순서로 apply. 그 뒤는 ArgoCD 가 GitOps 로 가져간다.
+- values/project/root 소스는 항상 **repo main** raw URL. 단일 클러스터라 실증 테스트 불가(역공학).
+
+## 로드맵 (#461) — 완료
 - [x] Phase 1: `node_os` (sysctl)
 - [x] Phase 2: `container_runtime` (containerd) + kubeadm 사전조건(`kubeadm_prereqs`)
 - [x] Phase 3: `kubeadm` (init/join + Calico)
-- [ ] Phase 4: `argocd-bootstrap` (argocd 설치 + root app/project)
+- [x] Phase 4: `argocd_bootstrap` (argocd 설치 + root app/project)
+
+→ **OS 설치를 제외한 노드~ArgoCD 부트스트랩 전 구간이 코드화**됐다. 새 노드는 `ansible-playbook site.yml` 한 번으로 클러스터 조인까지(신규 control-plane이면 ArgoCD 부트스트랩까지) 재현된다.

--- a/infra/ansible/roles/argocd_bootstrap/defaults/main.yml
+++ b/infra/ansible/roles/argocd_bootstrap/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+# ArgoCD 부트스트랩 — 현 설치 역공학 (#461 Phase 4).
+# ArgoCD 본체는 chicken-and-egg 라 GitOps 관리 밖이다. helm 으로 최초 설치하고
+# AppProject(orino) + root(App-of-Apps) 를 apply 하면 그 뒤는 ArgoCD 가 가져간다.
+# (values.yaml 헤더에 기록된 수동 부트스트랩 절차를 코드화)
+
+argocd_bootstrap_namespace: argocd
+argocd_bootstrap_helm_repo_name: argo
+argocd_bootstrap_helm_repo_url: https://argoproj.github.io/argo-helm
+argocd_bootstrap_chart: argo-cd
+argocd_bootstrap_chart_version: "9.4.10"   # 현 클러스터와 동일 (app v3.3.3)
+
+# 부트스트랩 소스는 항상 repo main (GitOps 단일 진실).
+argocd_bootstrap_raw_base: "https://raw.githubusercontent.com/wcorn/orino/main/infra"
+argocd_bootstrap_values_url: "{{ argocd_bootstrap_raw_base }}/helm/argocd/values.yaml"
+argocd_bootstrap_project_url: "{{ argocd_bootstrap_raw_base }}/argocd/project/project.yaml"
+argocd_bootstrap_root_app_url: "{{ argocd_bootstrap_raw_base }}/argocd/app-of-apps/root-app.yaml"
+
+# helm CLI (부트스트랩 도구) — 신규 노드용, note1 과 동일 버전 핀.
+argocd_bootstrap_helm_version: "v3.20.1"
+argocd_bootstrap_kubeconfig: /etc/kubernetes/admin.conf

--- a/infra/ansible/roles/argocd_bootstrap/tasks/main.yml
+++ b/infra/ansible/roles/argocd_bootstrap/tasks/main.yml
@@ -1,0 +1,83 @@
+---
+# ArgoCD 부트스트랩. (#461 Phase 4) — control-plane 에서만, 최초 1회.
+#
+# ⚠️ 안전장치: 이미 ArgoCD 가 설치돼 있으면(argocd-server 디플로이 존재) 부트스트랩
+#    블록 전체를 skip 한다. 운영 ArgoCD 에 helm 재설치/재apply 하지 않는다.
+#    → note1(설치됨) 적용 시 조회 태스크만 돌고 changed=0(무중단).
+#
+# ⚠️ 단일 클러스터라 실증 테스트 불가(역공학). 본체는 chicken-and-egg 로 GitOps 밖이며
+#    values/project/root 소스는 항상 repo main 을 가리킨다.
+
+- name: Control-plane kubeconfig 존재 확인
+  ansible.builtin.stat:
+    path: "{{ argocd_bootstrap_kubeconfig }}"
+  register: argocd_bootstrap_admin_conf
+
+- name: ArgoCD 설치 여부 확인 (control-plane)
+  ansible.builtin.command:
+    cmd: >
+      kubectl --kubeconfig {{ argocd_bootstrap_kubeconfig }}
+      -n {{ argocd_bootstrap_namespace }} get deploy argocd-server
+  register: argocd_bootstrap_check
+  changed_when: false
+  failed_when: false
+  when:
+    - inventory_hostname in groups['control_plane']
+    - argocd_bootstrap_admin_conf.stat.exists
+
+- name: ArgoCD 부트스트랩 (미설치 control-plane 에서만)
+  when:
+    - inventory_hostname in groups['control_plane']
+    - argocd_bootstrap_admin_conf.stat.exists
+    - argocd_bootstrap_check.rc is defined
+    - argocd_bootstrap_check.rc != 0
+  block:
+    - name: Helm CLI 설치 (신규 노드 부트스트랩 도구)
+      ansible.builtin.unarchive:
+        src: "https://get.helm.sh/helm-{{ argocd_bootstrap_helm_version }}-linux-amd64.tar.gz"
+        dest: /usr/local/bin
+        remote_src: true
+        extra_opts:
+          - --strip-components=1
+          - linux-amd64/helm
+        creates: /usr/local/bin/helm
+
+    - name: Argo helm 저장소 추가
+      ansible.builtin.command:
+        cmd: >
+          helm repo add {{ argocd_bootstrap_helm_repo_name }}
+          {{ argocd_bootstrap_helm_repo_url }} --force-update
+      changed_when: false
+
+    - name: Helm 저장소 갱신
+      ansible.builtin.command:
+        cmd: helm repo update {{ argocd_bootstrap_helm_repo_name }}
+      changed_when: false
+
+    - name: ArgoCD helm 설치 (values 는 repo main)
+      ansible.builtin.command:
+        cmd: >
+          helm upgrade --install argocd
+          {{ argocd_bootstrap_helm_repo_name }}/{{ argocd_bootstrap_chart }}
+          --namespace {{ argocd_bootstrap_namespace }} --create-namespace
+          --version {{ argocd_bootstrap_chart_version }}
+          -f {{ argocd_bootstrap_values_url }}
+          --kubeconfig {{ argocd_bootstrap_kubeconfig }}
+      changed_when: true
+
+    # AppProject 는 root 앱(project: orino)보다 먼저 있어야 한다.
+    - name: AppProject(orino) apply
+      ansible.builtin.command:
+        cmd: >
+          kubectl --kubeconfig {{ argocd_bootstrap_kubeconfig }}
+          apply -f {{ argocd_bootstrap_project_url }}
+      register: argocd_bootstrap_project
+      changed_when: "'created' in argocd_bootstrap_project.stdout or 'configured' in argocd_bootstrap_project.stdout"
+
+    - name: Root App-of-Apps apply (이후는 ArgoCD 가 GitOps 로 가져감)
+      ansible.builtin.command:
+        cmd: >
+          kubectl --kubeconfig {{ argocd_bootstrap_kubeconfig }}
+          apply -f {{ argocd_bootstrap_root_app_url }}
+      register: argocd_bootstrap_root
+      changed_when: "'created' in argocd_bootstrap_root.stdout or 'configured' in argocd_bootstrap_root.stdout"

--- a/infra/ansible/site.yml
+++ b/infra/ansible/site.yml
@@ -9,3 +9,4 @@
     - kubeadm_prereqs
     - container_runtime
     - kubeadm
+    - argocd_bootstrap


### PR DESCRIPTION
## 이슈
closes #461 (마지막 Phase 4 — 4개 Phase 전부 완료)

## 작업 내용
ArgoCD 본체 부트스트랩(chicken-and-egg 라 GitOps 관리 밖)을 코드화한 `argocd_bootstrap` 롤 추가. values.yaml 헤더에 기록돼 있던 수동 절차를 그대로 IaC化.

- **helm CLI 설치**(v3.20.1, note1과 동일) — 신규 노드 부트스트랩 도구
- **ArgoCD helm 설치**: `argo/argo-cd` **v9.4.10**(현 클러스터와 동일, app v3.3.3), values 는 repo main raw URL
- **AppProject(orino) → root(App-of-Apps) 순서로 apply** (root 가 `project: orino` 참조하므로 project 선행) → 이후는 ArgoCD 가 GitOps 로 인수
- `site.yml`에 롤 추가, README 갱신(로드맵 완료)

## 안전 설계 (운영 무중단)
- **설치 가드**: `argocd-server` 디플로이 존재 시 부트스트랩 블록 **전체 skip**. 운영 ArgoCD 에 helm 재설치/재apply 안 함
- 확인: note1 에 argocd-server(v3.3.3) 존재 → 적용 시 **조회 태스크만, changed=0(무중단)**. 설치/apply 경로는 **미설치 control-plane 에서만**
- note2(worker)는 admin.conf 없음 + control_plane 그룹 아님 → 전부 skip
- merge 시 Ansible CI 자동 apply → no-op

## 한계 (정직하게)
- 단일 클러스터라 **실증 테스트 불가**(역공학). 차트/values/project/root 소스는 현 설치 그대로 핀(main 기준)

## 검증
- `ansible-playbook site.yml --syntax-check` ✅ / `ansible-lint` ✅ (production profile, 0 violation)

---
이 PR 머지로 **#461 완료** — OS 설치를 제외한 노드~ArgoCD 부트스트랩 전 구간(`node_os` → `kubeadm_prereqs` → `container_runtime` → `kubeadm` → `argocd_bootstrap`)이 코드화됨.