### PR TITLE
chore : Trivy 통과 위해 apk upgrade 레이어 캐시 무효화 (FE/BE)

### DIFF
--- a/.github/workflows/be-cd.yml
+++ b/.github/workflows/be-cd.yml
@@ -53,6 +53,8 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CACHEBUST=${{ github.sha }}
           cache-from: type=gha,scope=be
           cache-to: type=gha,mode=max,scope=be
 
@@ -80,4 +82,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CACHEBUST=${{ github.sha }}
           cache-from: type=gha,scope=be

--- a/.github/workflows/be-ci.yml
+++ b/.github/workflows/be-ci.yml
@@ -49,6 +49,8 @@ jobs:
           push: false
           load: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-scan
+          build-args: |
+            CACHEBUST=${{ github.sha }}
           cache-from: type=gha,scope=be
           cache-to: type=gha,mode=max,scope=be
 

--- a/.github/workflows/fe-cd.yml
+++ b/.github/workflows/fe-cd.yml
@@ -53,6 +53,8 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CACHEBUST=${{ github.sha }}
           cache-from: type=gha,scope=fe
           cache-to: type=gha,mode=max,scope=fe
 
@@ -79,4 +81,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CACHEBUST=${{ github.sha }}
           cache-from: type=gha,scope=fe

--- a/be/Dockerfile
+++ b/be/Dockerfile
@@ -21,7 +21,9 @@ RUN ./gradlew :orino-app-api:build -x test --no-daemon
 FROM eclipse-temurin:25-jre-alpine
 # 베이스 이미지의 alpine OS 패키지를 최신 보안 패치로 갱신한다.
 # (예: openssl/libssl3/libcrypto3 CVE-2026-45447) upstream 재빌드 전까지 신규 OS CVE를 흡수.
-RUN apk --no-cache upgrade
+# CACHEBUST를 RUN에서 참조해 gha 레이어 캐시가 stale한 apk upgrade 결과를 재사용하지 않게 한다.
+ARG CACHEBUST=unknown
+RUN echo "cachebust ${CACHEBUST}" && apk --no-cache upgrade
 WORKDIR /app
 COPY --from=builder /app/orino-app-api/build/libs/*.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/fe/Dockerfile
+++ b/fe/Dockerfile
@@ -6,7 +6,10 @@ COPY . .
 RUN npm run build
 
 FROM nginx:alpine
-RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*
+# CACHEBUST(빌드마다 변하는 값)을 RUN에서 참조해 이 레이어 캐시를 무효화한다.
+# 그러지 않으면 gha 레이어 캐시가 패치 공개 전의 apk upgrade 결과를 재사용해 신규 CVE를 흡수하지 못한다.
+ARG CACHEBUST=unknown
+RUN echo "cachebust ${CACHEBUST}" && apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80


### PR DESCRIPTION
## 이슈
closes #507

## 작업 내용
FE CD의 Trivy 스캔이 `ghcr.io/wcorn/orino/fe`의 alpine HIGH CVE(openssl `CVE-2026-45447` 3.5.6-r0→3.5.7-r0, libxml2 `CVE-2026-6732`)로 실패했다.

**원인**: Dockerfile에 `apk upgrade`가 있는데도 CD가 `cache-from/to: type=gha`로 **apk-upgrade 레이어를 캐시**해, 패치 공개 전 stale 레이어(openssl 3.5.6-r0)를 재사용했다. (로컬 `--no-cache` 빌드는 0 vulnerabilities로 확인)
BE도 동일 구조(latent) — #494에선 apk 라인을 새로 추가해 캐시 미스로 통과했을 뿐, 다음에 동일 재발.

**조치**: apk upgrade 레이어를 빌드마다 무효화하도록 `ARG CACHEBUST`를 RUN에서 참조(`echo $CACHEBUST`)하고, CD/CI가 `build-args: CACHEBUST=${{ github.sha }}`를 전달.
- `fe/Dockerfile`, `be/Dockerfile`
- `fe-cd.yml`, `be-cd.yml`, `be-ci.yml`(BE CI/CD가 scope=be 캐시 공유)
- builder 스테이지(npm ci/build, gradle build) 캐시는 그대로 유지 — apk 레이어만 재실행

## 검증 (로컬)
- CACHEBUST를 바꿔 두 번 빌드 → **apk 레이어만 재빌드**, npm builder 레이어는 CACHED 유지
- CACHEBUST 빌드 FE 이미지 Trivy(CI 동일: `--severity CRITICAL,HIGH`): **alpine 0**

```
┌──────────────────────────────┬────────┬─────────────────┐
│            Target            │  Type  │ Vulnerabilities │
├──────────────────────────────┼────────┼─────────────────┤
│ orino-fe (alpine 3.23.4)     │ alpine │        0        │
└──────────────────────────────┴────────┴─────────────────┘
```