### PR TITLE
chore : BE CI 병렬화 (test ‖ image-scan)

### DIFF
--- a/.github/workflows/be-ci.yml
+++ b/.github/workflows/be-ci.yml
@@ -15,10 +15,11 @@ concurrency:
   group: be-ci-${{ github.ref }}
   cancel-in-progress: true
 
+# test와 image-scan은 서로 독립이다(이미지 빌드는 builder 스테이지에서 자체적으로 소스를 컴파일).
+# 한 잡에서 순차로 돌리면 wall-clock = 합(테스트+이미지빌드)이 되므로 별도 잡으로 병렬 실행한다.
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
@@ -35,13 +36,18 @@ jobs:
         working-directory: be
         run: ./gradlew build
 
+  image-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       # CD와 동일한 이미지 취약점 게이트를 PR 단계에서도 검사한다.
       # CD에만 두면 머지 후에야 push가 막혀 배포가 조용히 실패한다.
       # gha 캐시로 Docker 빌더 stage의 Gradle 의존성/컴파일 레이어를 재사용한다.
-      # scope=be로 BE CI/CD가 캐시를 공유한다.
+      # scope=be로 BE CI/CD가 캐시를 공유한다(CD가 이 캐시를 재사용해 빠르게 빌드).
       - name: Build image for scan
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## 이슈
closes #511

## 작업 내용
BE CI가 한 잡에서 순차 실행하던 것을 독립적인 두 잡으로 분리해 병렬화한다.

**측정값(기존, 단일 잡 순차 ~377s):**
| 스텝 | 시간 |
|---|---|
| Build and Test (gradle) | 203s |
| Build image for scan (Docker, 자체 컴파일) | 129s |
| Trivy | 24s |

테스트와 이미지 빌드+스캔은 서로 독립(Docker builder 스테이지가 소스를 자체 컴파일)이라 순차일 이유가 없다.

**변경:**
- `test` 잡: JDK/Gradle 셋업 + `./gradlew build`
- `image-scan` 잡: Docker Buildx + 이미지 빌드 + Trivy
- 두 잡 병렬 → wall-clock ≈ max(203s, 153s) ≈ **210s** (기존 377s 대비 ~40% 단축)
- gha 캐시 `scope=be` 그대로 유지 → BE CD가 계속 이 캐시를 재사용해 빠르게 빌드

## 범위 밖(변경 없음)
- **FE CI**(~66s): 이미 빠르고, 잡 분리 시 `npm ci`(15s)가 잡마다 중복돼 오히려 손해
- **BE/FE CD**(~108s): scan→push가 본질적 순차 + CI의 gha 캐시 재사용으로 이미 빠름

## 검증
실제 단축은 머지 후 다음 BE PR에서 확인 가능(잡 병렬은 GitHub Actions 동작상 보장). YAML 파싱 OK, 스텝 내용은 기존과 동일(잡만 분리).