### PR TITLE
feat : Planner 통합 캘린더 피드 엔드포인트 (events + reviews)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/PlannerCalendarController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/PlannerCalendarController.java
@@ -1,0 +1,39 @@
+package ds.project.orino.planner.google.calendar;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.core.time.UserTimeZone;
+import ds.project.orino.planner.google.calendar.dto.PlannerCalendarFeed;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+/**
+ * 통합 캘린더 피드 엔드포인트. 일정+할일+복습을 한 번의 호출로 반환한다.
+ * 시간대는 {@code X-Timezone}({@link UserTimeZone}) 기준.
+ */
+@RestController
+@RequestMapping("/api/planner/calendar")
+public class PlannerCalendarController {
+
+    private final PlannerCalendarService plannerCalendarService;
+
+    public PlannerCalendarController(PlannerCalendarService plannerCalendarService) {
+        this.plannerCalendarService = plannerCalendarService;
+    }
+
+    @GetMapping
+    public ApiResponse<PlannerCalendarFeed> feed(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false) String view) {
+        // view(month|week|day)는 표시 힌트이며 서버 응답에는 영향을 주지 않는다.
+        return ApiResponse.success(
+                plannerCalendarService.getFeed(memberId, from, to, UserTimeZone.get()));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/PlannerCalendarService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/PlannerCalendarService.java
@@ -1,0 +1,93 @@
+package ds.project.orino.planner.google.calendar;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.google.calendar.dto.FeedError;
+import ds.project.orino.planner.google.calendar.dto.GoogleEventsView;
+import ds.project.orino.planner.google.calendar.dto.PlannerCalendarFeed;
+import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
+import ds.project.orino.planner.google.calendar.dto.PlannerReview;
+import ds.project.orino.planner.google.calendar.dto.PlannerTask;
+import ds.project.orino.planner.review.dto.CalendarReviewItem;
+import ds.project.orino.planner.review.service.ReviewQueryService;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 통합 캘린더 피드 조립. 일정(Google)·할 일(M3)·복습(orino 오버레이)을 한 응답으로 모은다.
+ *
+ * <p>부분 실패 허용: 소스 하나가 실패해도 나머지를 정상 반환하고 {@code partial=true} + {@code errors[]}.
+ * 잘못된 기간 요청은 부분 실패가 아니라 400(INVALID_REQUEST)으로 처리한다.
+ */
+@Service
+public class PlannerCalendarService {
+
+    private static final int MAX_RANGE_DAYS = 100;
+
+    private final GoogleEventQueryService googleEventQueryService;
+    private final ReviewQueryService reviewQueryService;
+
+    public PlannerCalendarService(GoogleEventQueryService googleEventQueryService,
+                                  ReviewQueryService reviewQueryService) {
+        this.googleEventQueryService = googleEventQueryService;
+        this.reviewQueryService = reviewQueryService;
+    }
+
+    public PlannerCalendarFeed getFeed(Long memberId, LocalDate from, LocalDate to, ZoneId zone) {
+        validateRange(from, to);
+
+        List<FeedError> errors = new ArrayList<>();
+
+        boolean googleConnected = false;
+        List<PlannerEvent> events = List.of();
+        try {
+            GoogleEventsView view = googleEventQueryService.getEvents(memberId, from, to, zone);
+            googleConnected = view.connected();
+            events = view.events();
+        } catch (CustomException e) {
+            // invalid_grant면 연동이 만료된 것이라 미연동으로 본다(FE 재연동 CTA).
+            googleConnected = e.getErrorCode() != ErrorCode.GOOGLE_INVALID_GRANT;
+            errors.add(new FeedError("google-events", e.getErrorCode().getMessage()));
+        } catch (RuntimeException e) {
+            googleConnected = true;
+            errors.add(new FeedError("google-events", "일정을 불러오지 못했습니다."));
+        }
+
+        List<PlannerReview> reviews = List.of();
+        try {
+            reviews = reviewQueryService.findCalendar(memberId, from, to).reviews().stream()
+                    .map(PlannerCalendarService::toFeedReview)
+                    .toList();
+        } catch (RuntimeException e) {
+            errors.add(new FeedError("reviews", "복습을 불러오지 못했습니다."));
+        }
+
+        List<PlannerTask> tasks = List.of(); // M3(#484)에서 합류
+
+        return new PlannerCalendarFeed(
+                from, to, googleConnected, !errors.isEmpty(), errors, events, tasks, reviews);
+    }
+
+    private static PlannerReview toFeedReview(CalendarReviewItem item) {
+        return new PlannerReview(
+                item.id(),
+                item.scheduledAt(),
+                item.status().name(),
+                item.flashcard().material().title(),
+                item.flashcard().front(),
+                true,
+                "review");
+    }
+
+    private void validateRange(LocalDate from, LocalDate to) {
+        if (from == null || to == null || to.isBefore(from)
+                || ChronoUnit.DAYS.between(from, to) > MAX_RANGE_DAYS) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/FeedError.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/FeedError.java
@@ -1,0 +1,5 @@
+package ds.project.orino.planner.google.calendar.dto;
+
+/** 통합 피드의 소스별 실패 정보. (예: source="google-events") */
+public record FeedError(String source, String message) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/PlannerCalendarFeed.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/PlannerCalendarFeed.java
@@ -1,0 +1,22 @@
+package ds.project.orino.planner.google.calendar.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 통합 캘린더 피드 — 일정(Google) + 할 일(Google Tasks) + 복습(orino, 읽기 전용)을 한 번에 반환한다.
+ *
+ * <p>부분 실패 허용: 한 소스가 실패해도 200으로 나머지를 반환하고 {@code partial=true} + {@code errors[]}.
+ * 시간 값은 사용자 시간대(X-Timezone) 기준으로 정규화된다.
+ */
+public record PlannerCalendarFeed(
+        LocalDate from,
+        LocalDate to,
+        boolean googleConnected,
+        boolean partial,
+        List<FeedError> errors,
+        List<PlannerEvent> events,
+        List<PlannerTask> tasks,
+        List<PlannerReview> reviews
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/PlannerReview.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/PlannerReview.java
@@ -1,0 +1,18 @@
+package ds.project.orino.planner.google.calendar.dto;
+
+import java.time.Instant;
+
+/**
+ * 통합 피드의 복습 항목(읽기 전용 오버레이). orino가 복습의 source of truth.
+ * 평가는 기존 오늘 복습 화면에서만 하므로 {@code readOnly=true}.
+ */
+public record PlannerReview(
+        Long id,
+        Instant scheduledAt,
+        String status,
+        String materialTitle,
+        String front,
+        boolean readOnly,
+        String source
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/PlannerTask.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/PlannerTask.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.google.calendar.dto;
+
+/**
+ * 통합 피드의 할 일(Google Tasks) 항목. M3(#484)에서 합류하며, 그 전까지는 항상 빈 목록이다.
+ */
+public record PlannerTask(
+        String id,
+        String title,
+        String due,
+        boolean completed,
+        String source
+) {
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/PlannerCalendarControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/PlannerCalendarControllerTest.java
@@ -1,0 +1,183 @@
+package ds.project.orino.planner.google.calendar;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.math.BigDecimal;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class PlannerCalendarControllerTest extends ApiTestSupport {
+
+    private static final HttpServer EVENTS_STUB = createStub();
+    private static volatile int responseStatus = 200;
+    private static volatile String responseBody = "{\"items\":[]}";
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+    @Autowired
+    private FlashcardRepository flashcardRepository;
+    @Autowired
+    private ReviewScheduleRepository reviewScheduleRepository;
+    @Autowired
+    private GoogleAccountRepository googleAccountRepository;
+    @Autowired
+    private GoogleAccessTokenRepository accessTokenRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Long memberId;
+    private String authHeader;
+
+    @DynamicPropertySource
+    static void googleProperties(DynamicPropertyRegistry registry) {
+        String base = "http://127.0.0.1:" + EVENTS_STUB.getAddress().getPort();
+        registry.add("planner.google.client-id", () -> "test-client-id");
+        registry.add("planner.google.client-secret", () -> "test-client-secret");
+        registry.add("planner.google.oauth.calendar-api-base-url", () -> base);
+    }
+
+    @AfterAll
+    static void stopStub() {
+        EVENTS_STUB.stop(0);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        responseStatus = 200;
+        responseBody = """
+                {"items":[{"id":"e1","summary":"회의",
+                 "start":{"dateTime":"2026-06-10T05:00:00Z"},"end":{"dateTime":"2026-06-10T06:00:00Z"}}]}""";
+        dbCleaner.clean();
+        Member member = memberRepository.save(MemberFixture.create());
+        memberId = member.getId();
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(memberId, "이펙티브 자바", MaterialType.BOOK));
+        Flashcard card = flashcardRepository.save(new Flashcard(memberId, material.getId(), "Q", "A"));
+        reviewScheduleRepository.save(new ReviewSchedule(
+                memberId, card.getId(), 1, atTestZone(LocalDate.of(2026, 6, 11).atTime(4, 0)),
+                6, new BigDecimal("2.50")));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    private void connectGoogle() {
+        googleAccountRepository.save(new GoogleAccount(
+                memberId, "refresh", "scope", "me@gmail.com", "primary", "@default"));
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+    }
+
+    private org.springframework.test.web.servlet.ResultActions requestFeed(String from, String to) throws Exception {
+        return mockMvc.perform(get("/api/planner/calendar")
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .param("from", from)
+                .param("to", to));
+    }
+
+    @Test
+    @DisplayName("연동 시 일정과 복습을 한 응답으로 병합한다")
+    void mergesEventsAndReviews() throws Exception {
+        connectGoogle();
+
+        requestFeed("2026-06-01", "2026-06-30")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.googleConnected").value(true))
+                .andExpect(jsonPath("$.data.partial").value(false))
+                .andExpect(jsonPath("$.data.events.length()").value(1))
+                .andExpect(jsonPath("$.data.events[0].title").value("회의"))
+                .andExpect(jsonPath("$.data.reviews.length()").value(1))
+                .andExpect(jsonPath("$.data.reviews[0].readOnly").value(true))
+                .andExpect(jsonPath("$.data.reviews[0].source").value("review"))
+                .andExpect(jsonPath("$.data.reviews[0].materialTitle").value("이펙티브 자바"))
+                .andExpect(jsonPath("$.data.tasks.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("Google 일정이 실패해도 200으로 복습을 반환하고 partial+errors로 표기한다")
+    void partialWhenGoogleFails() throws Exception {
+        connectGoogle();
+        responseStatus = 500;
+        responseBody = "{\"error\":\"backendError\"}";
+
+        requestFeed("2026-06-01", "2026-06-30")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.partial").value(true))
+                .andExpect(jsonPath("$.data.errors.length()").value(1))
+                .andExpect(jsonPath("$.data.errors[0].source").value("google-events"))
+                .andExpect(jsonPath("$.data.events.length()").value(0))
+                .andExpect(jsonPath("$.data.reviews.length()").value(1));
+    }
+
+    @Test
+    @DisplayName("미연동이면 googleConnected=false, events 빈 배열, 복습은 정상")
+    void notConnected() throws Exception {
+        requestFeed("2026-06-01", "2026-06-30")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.googleConnected").value(false))
+                .andExpect(jsonPath("$.data.partial").value(false))
+                .andExpect(jsonPath("$.data.events.length()").value(0))
+                .andExpect(jsonPath("$.data.reviews.length()").value(1));
+    }
+
+    @Test
+    @DisplayName("to가 from보다 빠르면 400")
+    void invalidRange() throws Exception {
+        requestFeed("2026-06-30", "2026-06-01")
+                .andExpect(status().isBadRequest());
+    }
+
+    private static HttpServer createStub() {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/calendar/v3/calendars/primary/events", exchange ->
+                    respond(exchange, responseStatus, responseBody));
+            server.start();
+            return server;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+}


### PR DESCRIPTION
## 이슈
closes #479

## 작업 내용
Epic #472 M1. 일정(Google) + 복습(orino 오버레이)을 한 번의 호출로 모으는 통합 피드. (deps #478)

- **`PlannerCalendarController`** `GET /api/planner/calendar?from&to&view` — `X-Timezone`(`UserTimeZone`) 기준. `view`(month|week|day)는 표시 힌트라 응답에 영향 없음.
- **`PlannerCalendarService`**: 소스 병합
  - 일정: `GoogleEventQueryService.getEvents`(#478) — 미연동이면 빈 배열 + `googleConnected=false`
  - 복습: 기존 **`ReviewQueryService.findCalendar` 재사용** → `readOnly=true`, `source="review"` 오버레이로 합류
  - 할 일: 빈 배열 (M3 #484에서 합류)
- **부분 실패 모델**: 한 소스가 실패해도 **200**으로 나머지를 반환하고 `partial=true` + `errors[{source,message}]`. `invalid_grant`(연동 만료)은 `googleConnected=false`로 표기(재연동 CTA).
- 잘못된 기간(`to < from`, 100일 초과)은 부분 실패가 아니라 **400**.

응답 형태:
```json
{ "from":"2026-06-01","to":"2026-06-30",
  "googleConnected":true,"partial":false,"errors":[],
  "events":[...],"tasks":[],"reviews":[{"readOnly":true,"source":"review",...}] }
```

## 테스트
`PlannerCalendarControllerTest`(IntegrationTest, JDK HttpServer로 events 스텁) 4/4:
- 병합(events+reviews 동시) / Google 실패→partial+errors+복습 정상 / 미연동→googleConnected=false+복습 정상 / 잘못된 범위→400
- checkstyle + app-api 전체 스위트 통과

## 참고
이 피드를 FE 통합 월 뷰(#480)가 react-query 키 1개로 소비한다. tasks 합류는 M3(#484).