### PR TITLE
feat : Loki 캐싱으로 S3 GET 절감 (#467 후속)

### DIFF
--- a/infra/helm/loki/values.yaml
+++ b/infra/helm/loki/values.yaml
@@ -55,10 +55,18 @@ loki:
       storageClass: longhorn
       size: 10Gi
 
+  # caching: 반복 LogQL 쿼리(Grafana 대시보드 새로고침)에서 S3 chunk GET 을 절감한다.
+  # 서브차트가 memcached 를 자체 배포 — 기본값은 수 GB라 취미 클러스터에 맞게 작게 운용.
   chunksCache:
-    enabled: false
+    enabled: true
+    allocatedMemory: 256   # memcached -m, 기본 8192MB → 256MB
+    allocatedCPU: 100m     # 기본 500m
+    writebackSizeLimit: 50MB
   resultsCache:
-    enabled: false
+    enabled: true
+    allocatedMemory: 128   # 기본 1024MB → 128MB
+    allocatedCPU: 100m
+    defaultValidity: 12h
 
   gateway:
     enabled: false


### PR DESCRIPTION
## 이슈
closes #467

## 작업 내용
#467 의 후속 Todo("효과 보고 → Loki/Tempo(11%) 추가 검토")를 구현. Thanos caching bucket(이미 머지·가동 중, #471)과 동일한 전략을 Loki 로 확장해 S3 GET 요청을 추가 절감한다.

### Loki (차트 네이티브)
- `chunksCache.enabled: true` (memcached 256MB) — 반복 LogQL 쿼리(Grafana 대시보드 새로고침)에서 S3 chunk GET 을 캐시 히트로 대체
- `resultsCache.enabled: true` (memcached 128MB) — 동일 쿼리 결과 캐싱으로 chunk 재조회 자체를 회피
- 서브차트가 memcached 를 자체 배포 — 기본값(수 GB)을 취미 클러스터에 맞게 축소

### Tempo 는 이번 범위에서 제외
- monolithic `tempo` 차트(1.24.4)는 configmap 이 `tpl .Values.config` 하나만 렌더 — `structuredConfig`/`extraConfig`/머지 훅이 없어 `cache:` 블록만 끼워넣을 방법이 없고 config 통째 오버라이드 외 경로가 없음. 네이티브 memcached 템플릿도 없음
- trace 는 조회 빈도가 낮아 11% 중 S3 GET 기여가 작음 → 비용 대비 이득이 작아 제외
- 추후 trace 쿼리 S3 GET 이 실제 문제되면 `tempo-distributed` 차트(네이티브 `cache.caches` + `memcached.enabled`)로 깔끔하게 전환 검토

## 검증
- `helm template` 렌더 성공 + 출력 YAML 유효
- chunks-cache(`-m 256`)/results-cache(`-m 128`) memcached StatefulSet 렌더 확인

## 참고
- 효과(cache hit / S3 GET 감소)는 배포 후 며칠 관측 필요
- Thanos(63%, 최대 범인)는 caching bucket 적용 완료(#471)