### PR TITLE
feat : Planner 통합 월 뷰 (events + reviews 통합 렌더)

### DIFF
--- a/fe/src/features/planner/api/feed.ts
+++ b/fe/src/features/planner/api/feed.ts
@@ -1,0 +1,66 @@
+import { client } from "@/shared/api";
+
+export interface PlannerEvent {
+  id: string;
+  title: string | null;
+  allDay: boolean;
+  /** 종일이면 "2026-06-10", 시간 일정이면 사용자 TZ 로컬 "2026-06-10T14:00:00" */
+  start: string;
+  end: string | null;
+  location: string | null;
+  recurring: boolean;
+  source: "google";
+}
+
+export interface PlannerTask {
+  id: string;
+  title: string;
+  due: string | null;
+  completed: boolean;
+  source: "google";
+}
+
+export type PlannerReviewStatus = "PENDING" | "COMPLETED";
+
+export interface PlannerReview {
+  id: number;
+  /** ISO datetime. 캘린더 그룹/분류는 날짜 부분(slice 0..10)으로 한다. */
+  scheduledAt: string;
+  status: PlannerReviewStatus;
+  materialTitle: string;
+  front: string;
+  readOnly: boolean;
+  source: "review";
+}
+
+export interface FeedError {
+  source: string;
+  message: string;
+}
+
+export interface PlannerCalendarFeed {
+  from: string;
+  to: string;
+  googleConnected: boolean;
+  partial: boolean;
+  errors: FeedError[];
+  events: PlannerEvent[];
+  tasks: PlannerTask[];
+  reviews: PlannerReview[];
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export async function fetchPlannerCalendar(
+  from: string,
+  to: string,
+): Promise<PlannerCalendarFeed> {
+  const { data } = await client.get<ApiEnvelope<PlannerCalendarFeed>>(
+    "/planner/calendar",
+    { params: { from, to } },
+  );
+  return data.data;
+}

--- a/fe/src/features/planner/calendar.ts
+++ b/fe/src/features/planner/calendar.ts
@@ -1,0 +1,76 @@
+import {
+  parseIsoDate,
+  type ReviewBucket,
+  startOfDay,
+} from "@/features/review/calendar";
+
+import type { PlannerEvent, PlannerReview, PlannerTask } from "./api/feed";
+
+/** ISO datetime/date에서 로컬 날짜 키(YYYY-MM-DD)만 추출. */
+export function dateKey(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+function groupByDateKey<T>(
+  items: T[],
+  keyOf: (item: T) => string | null,
+): Map<string, T[]> {
+  const map = new Map<string, T[]>();
+  for (const item of items) {
+    const key = keyOf(item);
+    if (!key) {
+      continue;
+    }
+    const list = map.get(key);
+    if (list) {
+      list.push(item);
+    } else {
+      map.set(key, [item]);
+    }
+  }
+  return map;
+}
+
+export function eventsByDate(
+  events: PlannerEvent[],
+): Map<string, PlannerEvent[]> {
+  return groupByDateKey(events, (e) => dateKey(e.start));
+}
+
+export function tasksByDate(tasks: PlannerTask[]): Map<string, PlannerTask[]> {
+  return groupByDateKey(tasks, (t) => (t.due ? dateKey(t.due) : null));
+}
+
+export function reviewsByDate(
+  reviews: PlannerReview[],
+): Map<string, PlannerReview[]> {
+  return groupByDateKey(reviews, (r) => dateKey(r.scheduledAt));
+}
+
+/** 복습 분류(밀림/오늘/예정/완료) — 기존 bucketStyles와 동일 기준. */
+export function classifyFeedReview(
+  review: PlannerReview,
+  today: Date,
+): ReviewBucket {
+  if (review.status === "COMPLETED") {
+    return "completed";
+  }
+  const scheduled = parseIsoDate(dateKey(review.scheduledAt)).getTime();
+  const todayMid = startOfDay(today).getTime();
+  if (scheduled < todayMid) {
+    return "overdue";
+  }
+  if (scheduled === todayMid) {
+    return "today";
+  }
+  return "upcoming";
+}
+
+/** 시간 일정 "2026-06-10T14:00:00" → "14:00", 종일이면 "종일". */
+export function eventTimeLabel(event: PlannerEvent): string {
+  if (event.allDay) {
+    return "종일";
+  }
+  const time = event.start.slice(11, 16);
+  return time || "종일";
+}

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
@@ -1,0 +1,129 @@
+import { screen } from "@testing-library/react";
+import { delay, http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { startOfDay, toIsoDate } from "@/features/review/calendar";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { PlannerCalendar } from "./PlannerCalendar";
+
+const API_BASE = "https://api.orino.dev/api";
+const TODAY = toIsoDate(startOfDay(new Date()));
+
+interface FeedOverrides {
+  googleConnected?: boolean;
+  partial?: boolean;
+  events?: unknown[];
+  reviews?: unknown[];
+  tasks?: unknown[];
+}
+
+function mockFeed(
+  overrides: FeedOverrides = {},
+  options?: { delayMs?: number },
+) {
+  server.use(
+    http.get(`${API_BASE}/planner/calendar`, async () => {
+      if (options?.delayMs) {
+        await delay(options.delayMs);
+      }
+      return HttpResponse.json({
+        code: "OK",
+        data: {
+          from: TODAY,
+          to: TODAY,
+          googleConnected: overrides.googleConnected ?? true,
+          partial: overrides.partial ?? false,
+          errors: [],
+          events: overrides.events ?? [],
+          tasks: overrides.tasks ?? [],
+          reviews: overrides.reviews ?? [],
+        },
+      });
+    }),
+  );
+}
+
+function mockGoogleConnected(connected: boolean) {
+  server.use(
+    http.get(`${API_BASE}/planner/google/status`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          connected,
+          googleEmail: connected ? "me@gmail.com" : null,
+          scopes: connected ? ["s"] : null,
+          connectedAt: connected ? "2026-06-15T10:00:00" : null,
+        },
+      }),
+    ),
+  );
+}
+
+describe("PlannerCalendar", () => {
+  it("로딩 중 스켈레톤을 보이고, 이후 일정과 복습을 그날 상세에 렌더한다", async () => {
+    mockGoogleConnected(true);
+    mockFeed(
+      {
+        events: [
+          {
+            id: "e1",
+            title: "회의",
+            allDay: false,
+            start: `${TODAY}T14:00:00`,
+            end: `${TODAY}T15:00:00`,
+            location: "3층",
+            recurring: false,
+            source: "google",
+          },
+        ],
+        reviews: [
+          {
+            id: 1,
+            scheduledAt: `${TODAY}T04:00:00`,
+            status: "PENDING",
+            materialTitle: "이펙티브 자바",
+            front: "Q1",
+            readOnly: true,
+            source: "review",
+          },
+        ],
+      },
+      { delayMs: 50 },
+    );
+
+    renderWithRouter(<PlannerCalendar />);
+
+    expect(screen.getByLabelText("불러오는 중")).toBeInTheDocument();
+
+    expect(await screen.findByText("회의")).toBeInTheDocument();
+    expect(screen.getByText("이펙티브 자바")).toBeInTheDocument();
+    expect(screen.getByText("Q1")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "오늘 복습 하러가기" }),
+    ).toBeInTheDocument();
+  });
+
+  it("미연동이면 연결 배너를 보여준다", async () => {
+    mockGoogleConnected(false);
+    mockFeed({ googleConnected: false });
+
+    renderWithRouter(<PlannerCalendar />);
+
+    expect(
+      await screen.findByText(/Google 캘린더가 연결되지 않았습니다/),
+    ).toBeInTheDocument();
+  });
+
+  it("부분 실패면 경고 배너를 보여준다", async () => {
+    mockGoogleConnected(true);
+    mockFeed({ partial: true });
+
+    renderWithRouter(<PlannerCalendar />);
+
+    expect(
+      await screen.findByText("일부 일정을 불러오지 못했습니다."),
+    ).toBeInTheDocument();
+  });
+});

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
@@ -1,0 +1,157 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { GoogleNotConnectedBanner } from "@/features/google/components/GoogleNotConnectedBanner";
+import {
+  addMonths,
+  monthGridDays,
+  startOfDay,
+  toIsoDate,
+} from "@/features/review/calendar";
+
+import { eventsByDate, reviewsByDate, tasksByDate } from "../../calendar";
+import { usePlannerCalendar } from "../../hooks/usePlannerCalendar";
+import { PlannerCalendarCell } from "./PlannerCalendarCell";
+import { PlannerCalendarLegend } from "./PlannerCalendarLegend";
+import { PlannerDayDetailPanel } from "./PlannerDayDetailPanel";
+
+const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
+
+/** 통합 캘린더 월 뷰 — 일정(Google) + 할 일 + 복습(읽기 전용)을 한 그리드에 렌더한다. */
+export function PlannerCalendar() {
+  const today = useMemo(() => startOfDay(new Date()), []);
+  const todayIso = toIsoDate(today);
+
+  const [cursor, setCursor] = useState(
+    () => new Date(today.getFullYear(), today.getMonth(), 1),
+  );
+  const [selected, setSelected] = useState<string>(todayIso);
+
+  const gridDays = useMemo(
+    () => monthGridDays(cursor.getFullYear(), cursor.getMonth()),
+    [cursor],
+  );
+  const from = toIsoDate(gridDays[0]);
+  const to = toIsoDate(gridDays[gridDays.length - 1]);
+
+  const { data, isLoading } = usePlannerCalendar(from, to);
+
+  const eventsMap = useMemo(() => eventsByDate(data?.events ?? []), [data]);
+  const tasksMap = useMemo(() => tasksByDate(data?.tasks ?? []), [data]);
+  const reviewsMap = useMemo(() => reviewsByDate(data?.reviews ?? []), [data]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="이전 달"
+            onClick={() => setCursor((c) => addMonths(c, -1))}
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <h1 className="text-xl font-semibold">
+            {cursor.getFullYear()}년 {cursor.getMonth() + 1}월
+          </h1>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="다음 달"
+            onClick={() => setCursor((c) => addMonths(c, 1))}
+          >
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            setCursor(new Date(today.getFullYear(), today.getMonth(), 1));
+            setSelected(todayIso);
+          }}
+        >
+          오늘
+        </Button>
+      </div>
+
+      <GoogleNotConnectedBanner />
+
+      {data?.partial && (
+        <div
+          role="alert"
+          className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-700 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-300"
+        >
+          일부 일정을 불러오지 못했습니다.
+        </div>
+      )}
+
+      <PlannerCalendarLegend />
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_20rem]">
+        <Card>
+          <CardContent className="flex flex-col gap-2">
+            <div className="grid grid-cols-7 gap-1">
+              {WEEKDAYS.map((w, i) => (
+                <div
+                  key={w}
+                  className={
+                    "text-muted-foreground py-1 text-center text-xs font-medium" +
+                    (i === 0 ? " text-red-500" : "")
+                  }
+                >
+                  {w}
+                </div>
+              ))}
+            </div>
+            {isLoading ? (
+              <div className="grid grid-cols-7 gap-1" aria-label="불러오는 중">
+                {Array.from({ length: 42 }, (_, i) => (
+                  <div
+                    key={i}
+                    className="bg-muted/50 min-h-16 animate-pulse rounded-md"
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="grid grid-cols-7 gap-1">
+                {gridDays.map((date) => {
+                  const iso = toIsoDate(date);
+                  return (
+                    <PlannerCalendarCell
+                      key={iso}
+                      date={date}
+                      isoDate={iso}
+                      inMonth={date.getMonth() === cursor.getMonth()}
+                      isToday={iso === todayIso}
+                      isSelected={iso === selected}
+                      events={eventsMap.get(iso) ?? []}
+                      tasks={tasksMap.get(iso) ?? []}
+                      reviews={reviewsMap.get(iso) ?? []}
+                      today={today}
+                      onSelect={setSelected}
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent>
+            <PlannerDayDetailPanel
+              isoDate={selected}
+              events={eventsMap.get(selected) ?? []}
+              tasks={tasksMap.get(selected) ?? []}
+              reviews={reviewsMap.get(selected) ?? []}
+            />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/planner/components/calendar/PlannerCalendarCell.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendarCell.tsx
@@ -1,0 +1,92 @@
+import {
+  BUCKET_DOT,
+  BUCKET_ORDER,
+} from "@/features/review/components/calendar/bucketStyles";
+import { cn } from "@/lib/utils";
+
+import type { PlannerEvent, PlannerReview, PlannerTask } from "../../api/feed";
+import { classifyFeedReview } from "../../calendar";
+import { EVENT_DOT, TASK_DOT } from "./sourceStyles";
+
+interface Props {
+  date: Date;
+  isoDate: string;
+  inMonth: boolean;
+  isToday: boolean;
+  isSelected: boolean;
+  events: PlannerEvent[];
+  tasks: PlannerTask[];
+  reviews: PlannerReview[];
+  today: Date;
+  onSelect: (isoDate: string) => void;
+}
+
+const MAX_DOTS = 5;
+
+export function PlannerCalendarCell({
+  date,
+  isoDate,
+  inMonth,
+  isToday,
+  isSelected,
+  events,
+  tasks,
+  reviews,
+  today,
+  onSelect,
+}: Props) {
+  const reviewDots = BUCKET_ORDER.flatMap((bucket) =>
+    reviews
+      .filter((r) => classifyFeedReview(r, today) === bucket)
+      .map(() => BUCKET_DOT[bucket]),
+  );
+  const dots = [
+    ...events.map(() => EVENT_DOT),
+    ...tasks.map(() => TASK_DOT),
+    ...reviewDots,
+  ];
+  const shown = dots.slice(0, MAX_DOTS);
+  const overflow = dots.length - shown.length;
+  const total = events.length + tasks.length + reviews.length;
+
+  return (
+    <button
+      type="button"
+      aria-label={
+        `${isoDate}` +
+        (total > 0
+          ? ` 일정 ${events.length} 할일 ${tasks.length} 복습 ${reviews.length}`
+          : "")
+      }
+      aria-pressed={isSelected}
+      onClick={() => onSelect(isoDate)}
+      className={cn(
+        "flex min-h-16 flex-col gap-1 rounded-md border p-1.5 text-left transition-colors",
+        inMonth ? "bg-card" : "bg-muted/30 text-muted-foreground",
+        isToday ? "border-primary" : "border-border",
+        isSelected && "ring-primary ring-2",
+      )}
+    >
+      <span
+        className={cn(
+          "text-xs font-medium",
+          isToday && "text-primary font-semibold",
+        )}
+      >
+        {date.getDate()}
+      </span>
+      {shown.length > 0 && (
+        <span className="flex flex-wrap items-center gap-0.5">
+          {shown.map((dot, i) => (
+            <span key={i} className={cn("size-1.5 rounded-full", dot)} />
+          ))}
+          {overflow > 0 && (
+            <span className="text-muted-foreground text-[10px]">
+              +{overflow}
+            </span>
+          )}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/fe/src/features/planner/components/calendar/PlannerCalendarLegend.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendarLegend.tsx
@@ -1,0 +1,32 @@
+import {
+  BUCKET_DOT,
+  BUCKET_LABEL,
+  BUCKET_ORDER,
+} from "@/features/review/components/calendar/bucketStyles";
+import { cn } from "@/lib/utils";
+
+import { EVENT_DOT, EVENT_LABEL, TASK_DOT, TASK_LABEL } from "./sourceStyles";
+
+const SOURCE_ITEMS = [
+  { dot: EVENT_DOT, label: EVENT_LABEL },
+  { dot: TASK_DOT, label: TASK_LABEL },
+];
+
+export function PlannerCalendarLegend() {
+  return (
+    <ul className="text-muted-foreground flex flex-wrap gap-x-3 gap-y-1 text-xs">
+      {SOURCE_ITEMS.map((item) => (
+        <li key={item.label} className="flex items-center gap-1.5">
+          <span className={cn("size-2 rounded-full", item.dot)} />
+          {item.label}
+        </li>
+      ))}
+      {BUCKET_ORDER.map((bucket) => (
+        <li key={bucket} className="flex items-center gap-1.5">
+          <span className={cn("size-2 rounded-full", BUCKET_DOT[bucket])} />
+          {BUCKET_LABEL[bucket]}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
@@ -1,0 +1,125 @@
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import { parseIsoDate } from "@/features/review/calendar";
+import { cn } from "@/lib/utils";
+
+import type { PlannerEvent, PlannerReview, PlannerTask } from "../../api/feed";
+import { eventTimeLabel } from "../../calendar";
+
+interface Props {
+  isoDate: string;
+  events: PlannerEvent[];
+  tasks: PlannerTask[];
+  reviews: PlannerReview[];
+}
+
+function formatHeading(isoDate: string): string {
+  const d = parseIsoDate(isoDate);
+  return `${d.getMonth() + 1}월 ${d.getDate()}일`;
+}
+
+export function PlannerDayDetailPanel({
+  isoDate,
+  events,
+  tasks,
+  reviews,
+}: Props) {
+  const isEmpty = events.length + tasks.length + reviews.length === 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-base font-medium">{formatHeading(isoDate)}</h2>
+        {reviews.length > 0 && (
+          <Link to="/planner/reviews/today">
+            <Button size="sm">오늘 복습 하러가기</Button>
+          </Link>
+        )}
+      </div>
+
+      {isEmpty ? (
+        <p className="text-muted-foreground text-sm">이 날 일정이 없어요.</p>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {events.length > 0 && (
+            <section className="flex flex-col gap-2">
+              <h3 className="text-muted-foreground text-xs font-medium">
+                일정 ({events.length})
+              </h3>
+              <ul className="flex flex-col gap-1.5">
+                {events.map((event) => (
+                  <li
+                    key={event.id}
+                    className="border-border bg-card flex items-start gap-2 rounded-md border p-2 text-sm"
+                  >
+                    <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+                      {eventTimeLabel(event)}
+                    </span>
+                    <div className="flex min-w-0 flex-1 flex-col">
+                      <span className="truncate">
+                        {event.title ?? "(제목 없음)"}
+                      </span>
+                      {event.location && (
+                        <span className="text-muted-foreground truncate text-xs">
+                          {event.location}
+                        </span>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {tasks.length > 0 && (
+            <section className="flex flex-col gap-2">
+              <h3 className="text-muted-foreground text-xs font-medium">
+                할 일 ({tasks.length})
+              </h3>
+              <ul className="flex flex-col gap-1.5">
+                {tasks.map((task) => (
+                  <li
+                    key={task.id}
+                    className="border-border bg-card flex items-center gap-2 rounded-md border p-2 text-sm"
+                  >
+                    <span aria-hidden>{task.completed ? "☑" : "☐"}</span>
+                    <span
+                      className={cn(
+                        "truncate",
+                        task.completed && "text-muted-foreground line-through",
+                      )}
+                    >
+                      {task.title}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {reviews.length > 0 && (
+            <section className="flex flex-col gap-2">
+              <h3 className="text-muted-foreground text-xs font-medium">
+                복습 (읽기 전용)
+              </h3>
+              <ul className="flex flex-col gap-1.5">
+                {reviews.map((review) => (
+                  <li
+                    key={review.id}
+                    className="border-border bg-card flex flex-col rounded-md border p-2 text-sm"
+                  >
+                    <span className="text-muted-foreground truncate text-xs">
+                      {review.materialTitle}
+                    </span>
+                    <span className="truncate">{review.front}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/fe/src/features/planner/components/calendar/sourceStyles.ts
+++ b/fe/src/features/planner/components/calendar/sourceStyles.ts
@@ -1,0 +1,6 @@
+/** 통합 캘린더의 비-복습 소스 색상. 복습은 기존 bucketStyles 사용. */
+export const EVENT_DOT = "bg-blue-500";
+export const TASK_DOT = "bg-emerald-500";
+
+export const EVENT_LABEL = "일정";
+export const TASK_LABEL = "할 일";

--- a/fe/src/features/planner/hooks/usePlannerCalendar.ts
+++ b/fe/src/features/planner/hooks/usePlannerCalendar.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchPlannerCalendar } from "../api/feed";
+import { plannerKeys } from "../queryKeys";
+
+export function usePlannerCalendar(from: string, to: string) {
+  return useQuery({
+    queryKey: plannerKeys.calendar(from, to),
+    queryFn: () => fetchPlannerCalendar(from, to),
+    staleTime: 60 * 1000,
+  });
+}

--- a/fe/src/features/planner/queryKeys.ts
+++ b/fe/src/features/planner/queryKeys.ts
@@ -1,0 +1,5 @@
+export const plannerKeys = {
+  all: ["planner"] as const,
+  calendar: (from: string, to: string) =>
+    ["planner", "calendar", from, to] as const,
+};


### PR DESCRIPTION
## 이슈
closes #480

## 작업 내용
Epic #472 M1. 통합 캘린더 피드(#479)를 월 그리드로 렌더한다. 기존 복습 캘린더 유틸/스타일을 재사용한다. (deps #477, #479)

- **`features/planner/api/feed.ts`**: 통합 피드 타입(events/tasks/reviews) + `usePlannerCalendar(from,to)` 훅 + queryKeys
- **`PlannerCalendar`**: 월 네비 + 범례 + 6주 그리드 + 그날 상세 패널 + **로딩 스켈레톤** + 부분 실패 경고 배너
- **`PlannerCalendarCell`**: 일정🟦 / 할일🟩 / 복습(밀림·오늘·예정·완료 상태색) 구분 점 + `+N` 오버플로
- **`PlannerDayDetailPanel`**: 일정(시간·장소) / 할 일(완료 취소선) / **복습(읽기 전용)** 섹션 + `오늘 복습 하러가기` 연결
- **재사용**: `monthGridDays`/`toIsoDate`/`addMonths`/`startOfDay`(review/calendar), `bucketStyles`(복습 상태색), **`GoogleNotConnectedBanner`(#477)** 미연동 배너
  - 피드의 복습 shape은 기존 `CalendarReview`와 달라 `classifyFeedReview`로 동일 기준 분류
- 할 일은 BE가 아직 빈 배열(M3 #484) — 표시 로직만 미리 둠

## 테스트
`PlannerCalendar.test.tsx` (RTL + MSW) 3/3: 로딩 스켈레톤→일정+복습 병합 렌더 + 오늘 복습 링크 / 미연동 배너 / 부분 실패 경고
- FE 전체 125개 통과, format:check·eslint·tsc clean

## 참고
이 컴포넌트를 라우트(`/planner/calendar`)에 연결하고 복습 전용 캘린더를 승격·대체하는 작업은 **#481**에서 한다(현재는 미라우팅, 단위 테스트로 검증).