### PR TITLE
chore : Terraform plan role 추가 + apply IAM 스코핑 (#497 후속 1/2)

### DIFF
--- a/infra/terraform/cicd.tf
+++ b/infra/terraform/cicd.tf
@@ -1,7 +1,10 @@
 # GitHub Actions CI/CD — 정적 AWS 키 없이 OIDC로 terraform 실행.
-# 워크플로우(.github/workflows/terraform.yml)가 이 role을 assume:
-#   PR → terraform plan, main 머지 → terraform apply (자동).
-# OIDC 인프라 자체도 IaC로 관리(최초 1회 수동 apply로 부트스트랩).
+# 신뢰 경계에 따라 role 을 분리한다(2단계 마이그레이션):
+#   apply role(쓰기) — 기존 단일 role. 현재는 repo 전체 워크플로우가 assume.
+#   plan  role(읽기) — 신규. PR(sub=pull_request)만 assume. 미신뢰 PR 은 미리보기만.
+# 이 PR(Phase 1)은 plan role 을 만들고 apply IAM 을 스코핑한다. 워크플로우 분기와
+# apply trust 축소(main push 전용)는 plan role 이 생긴 뒤 Phase 2(후속 PR)에서 한다
+# — 그래야 PR plan 이 끊기지 않고(부트스트랩) 두 PR 모두 CI 가 통과한다.
 
 resource "aws_iam_openid_connect_provider" "github" {
   url             = "https://token.actions.githubusercontent.com"
@@ -9,10 +12,25 @@ resource "aws_iam_openid_connect_provider" "github" {
   thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
 }
 
-resource "aws_iam_role" "terraform_ci" {
+# 기존 단일 role(terraform_ci)을 apply role로 명칭 정리. AWS 이름은 유지 → state만 이동(재생성 없음).
+moved {
+  from = aws_iam_role.terraform_ci
+  to   = aws_iam_role.terraform_apply
+}
+
+moved {
+  from = aws_iam_role_policy.terraform_ci
+  to   = aws_iam_role_policy.terraform_apply
+}
+
+# ---------------------------------------------------------------------------
+# apply role — 쓰기 권한. (Phase 2 에서 trust 를 main push 전용으로 좁힐 예정)
+# ---------------------------------------------------------------------------
+resource "aws_iam_role" "terraform_apply" {
   name = "github-actions-terraform"
 
-  # wcorn/orino 저장소의 워크플로우만 assume 가능(다른 repo/계정 차단)
+  # 현재는 wcorn/orino 의 모든 워크플로우가 assume 가능(기존 동작 유지).
+  # plan role 이 생성된 뒤(Phase 2) main push 전용으로 좁힌다 — 그래야 부트스트랩이 끊기지 않음.
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
@@ -27,12 +45,9 @@ resource "aws_iam_role" "terraform_ci" {
   })
 }
 
-# terraform이 관리하는 리소스 범위의 권한(Route53 / S3 orino-* / IAM).
-# NOTE: iam 은 terraform 이 IAM 사용자·키·이 role 자체를 관리하므로 넓게 부여.
-#       trust 가 repo 로 제한돼 노출은 한정적이나, 추후 최소권한 스코핑 여지.
-resource "aws_iam_role_policy" "terraform_ci" {
-  name = "terraform-ci"
-  role = aws_iam_role.terraform_ci.id
+resource "aws_iam_role_policy" "terraform_apply" {
+  name = "terraform-apply"
+  role = aws_iam_role.terraform_apply.id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -55,17 +70,113 @@ resource "aws_iam_role_policy" "terraform_ci" {
         Action   = ["s3:ListAllMyBuckets"]
         Resource = "*"
       },
+      # iam:* 대신 terraform 이 실제 관리하는 리소스(유저·인라인정책·액세스키·role·OIDC)
+      # 라이프사이클 액션만 부여. 로그인프로필·MFA·SAML·관리형정책 연결·권한경계 등 미사용 위험 액션 제외.
       {
-        Sid      = "IAM"
-        Effect   = "Allow"
-        Action   = ["iam:*"]
+        Sid    = "IamUsers"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateUser", "iam:GetUser", "iam:DeleteUser", "iam:UpdateUser",
+          "iam:TagUser", "iam:UntagUser", "iam:ListUserTags", "iam:ListUsers",
+          "iam:PutUserPolicy", "iam:GetUserPolicy", "iam:DeleteUserPolicy", "iam:ListUserPolicies",
+          "iam:CreateAccessKey", "iam:DeleteAccessKey", "iam:UpdateAccessKey",
+          "iam:ListAccessKeys", "iam:GetAccessKeyLastUsed",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "IamRoles"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateRole", "iam:GetRole", "iam:DeleteRole", "iam:UpdateRole",
+          "iam:UpdateAssumeRolePolicy", "iam:TagRole", "iam:UntagRole", "iam:ListRoleTags",
+          "iam:PutRolePolicy", "iam:GetRolePolicy", "iam:DeleteRolePolicy", "iam:ListRolePolicies",
+          "iam:ListAttachedRolePolicies", "iam:ListInstanceProfilesForRole", "iam:ListRoles",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "IamOidc"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateOpenIDConnectProvider", "iam:GetOpenIDConnectProvider",
+          "iam:DeleteOpenIDConnectProvider", "iam:UpdateOpenIDConnectProviderThumbprint",
+          "iam:TagOpenIDConnectProvider", "iam:UntagOpenIDConnectProvider",
+          "iam:ListOpenIDConnectProviderTags", "iam:ListOpenIDConnectProviders",
+        ]
         Resource = "*"
       },
     ]
   })
 }
 
-output "terraform_ci_role_arn" {
-  description = "GitHub Actions가 assume할 terraform CI role ARN"
-  value       = aws_iam_role.terraform_ci.arn
+# ---------------------------------------------------------------------------
+# plan role — PR 만 assume 가능(untrusted). 읽기 전용 + state(orino-terraform-state) 읽기.
+# 미신뢰 PR(포크 포함)은 plan(미리보기)만 가능, 어떤 리소스도 변경 불가.
+# ---------------------------------------------------------------------------
+resource "aws_iam_role" "terraform_plan" {
+  name = "github-actions-terraform-plan"
+
+  # pull_request 이벤트 토큰만 assume. push/main 은 apply role 만 사용.
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = aws_iam_openid_connect_provider.github.arn }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          "token.actions.githubusercontent.com:sub" = "repo:wcorn/orino:pull_request"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "terraform_plan" {
+  name = "terraform-plan"
+  role = aws_iam_role.terraform_plan.id
+
+  # plan 은 state 읽기 + 리소스 refresh(읽기)만 필요. 백엔드에 lock 테이블이 없어 쓰기 없음.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "Route53Read"
+        Effect   = "Allow"
+        Action   = ["route53:Get*", "route53:List*"]
+        Resource = "*"
+      },
+      {
+        # orino-* (state 버킷 orino-terraform-state 포함) 읽기.
+        Sid      = "S3Read"
+        Effect   = "Allow"
+        Action   = ["s3:Get*", "s3:List*"]
+        Resource = ["arn:aws:s3:::orino-*", "arn:aws:s3:::orino-*/*"]
+      },
+      {
+        Sid      = "S3ListAll"
+        Effect   = "Allow"
+        Action   = ["s3:ListAllMyBuckets"]
+        Resource = "*"
+      },
+      {
+        Sid      = "IamRead"
+        Effect   = "Allow"
+        Action   = ["iam:Get*", "iam:List*", "iam:GenerateServiceLastAccessedDetails"]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+output "terraform_apply_role_arn" {
+  description = "main 머지 시 apply에 사용하는 role ARN"
+  value       = aws_iam_role.terraform_apply.arn
+}
+
+output "terraform_plan_role_arn" {
+  description = "PR plan(읽기 전용)에 사용하는 role ARN"
+  value       = aws_iam_role.terraform_plan.arn
 }


### PR DESCRIPTION
## 이슈
#497 (Phase 2 머지 시 closes)

## 배경
#497 후속("plan/apply role 분리 + IAM 스코핑")을 **2단계로 분리**한다. 한 PR에 다 넣으면 신규 plan role 이 없는 상태에서 워크플로우가 그 role 을 assume하려다 PR plan 체크가 실패(부트스트랩)하기 때문. 단계를 나눠 **두 PR 모두 CI 통과**하도록 한다.

### 이 PR = Phase 1 (plan role 생성 + IAM 스코핑)
- **plan role 신규**(`github-actions-terraform-plan`, 읽기 전용): trust `sub=repo:wcorn/orino:pull_request` — PR 만 assume
- **apply role IAM 스코핑**: `iam:*` → terraform 이 실제 관리하는 라이프사이클 액션(유저·인라인정책·액세스키·role·OIDC)만. 로그인프로필·MFA·SAML·관리형정책 연결·권한경계 등 미사용 위험 액션 제외
- 기존 단일 role 을 apply role 로 명칭 정리(`moved` 블록, AWS 이름 `github-actions-terraform` 유지 → 재생성 없음)
- **워크플로우·apply trust 는 그대로 유지** → 기존 apply role(repo 전체 trust)로 **PR plan 정상 통과**. 머지 후 apply 가 plan role 을 생성

### 다음 = Phase 2 (별도 PR, 이 PR 머지·apply 후)
- 워크플로우를 이벤트별 plan/apply role 분기로 전환
- apply role trust 를 `ref:refs/heads/main`(main push 전용)으로 축소
- 그 시점엔 plan role 이 이미 존재 → Phase 2 의 PR plan 도 정상 통과

## 검증
- `terraform fmt -check -recursive` / `terraform validate` 통과
- PR diff = `infra/terraform/cicd.tf` 단일 파일(워크플로우 변경 없음)
- 최신 main 위로 리베이스 완료

## ⚠️ 머지 후 apply 시 참고
- apply role 의 스코핑된 IAM 정책은 **이 PR 머지 시 apply 가 자기 자신의 정책을 교체**하면서 적용된다. plan(읽기)으로는 write 액션을 최종 검증할 수 없으므로 정책 액션 목록 리뷰 권장. 누락 시 apply 중단 → 액션 추가 후 재apply로 복구 가능