### PR TITLE
chore : Terraform apply trust main 전용 축소 + 워크플로우 role 분기 (#497 후속 2/2)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -29,10 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # PR 은 plan(읽기 전용) role, main push 는 apply(쓰기) role 을 assume.
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::012900311331:role/github-actions-terraform
+          role-to-assume: ${{ github.event_name == 'pull_request' && 'arn:aws:iam::012900311331:role/github-actions-terraform-plan' || 'arn:aws:iam::012900311331:role/github-actions-terraform' }}
           aws-region: ap-northeast-2
 
       - uses: hashicorp/setup-terraform@v3

--- a/infra/terraform/cicd.tf
+++ b/infra/terraform/cicd.tf
@@ -1,10 +1,8 @@
 # GitHub Actions CI/CD — 정적 AWS 키 없이 OIDC로 terraform 실행.
-# 신뢰 경계에 따라 role 을 분리한다(2단계 마이그레이션):
-#   apply role(쓰기) — 기존 단일 role. 현재는 repo 전체 워크플로우가 assume.
-#   plan  role(읽기) — 신규. PR(sub=pull_request)만 assume. 미신뢰 PR 은 미리보기만.
-# 이 PR(Phase 1)은 plan role 을 만들고 apply IAM 을 스코핑한다. 워크플로우 분기와
-# apply trust 축소(main push 전용)는 plan role 이 생긴 뒤 Phase 2(후속 PR)에서 한다
-# — 그래야 PR plan 이 끊기지 않고(부트스트랩) 두 PR 모두 CI 가 통과한다.
+# 워크플로우(.github/workflows/terraform.yml)가 이벤트별로 다른 role을 assume한다:
+#   PR(untrusted)       → terraform-plan  role (읽기 전용)  → terraform plan
+#   main 머지(trusted)  → terraform-apply role (쓰기 가능)  → terraform apply
+# 미신뢰 PR(포크 포함)은 plan(미리보기)만 가능, 어떤 AWS 리소스도 변경 불가.
 
 resource "aws_iam_openid_connect_provider" "github" {
   url             = "https://token.actions.githubusercontent.com"
@@ -12,25 +10,13 @@ resource "aws_iam_openid_connect_provider" "github" {
   thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
 }
 
-# 기존 단일 role(terraform_ci)을 apply role로 명칭 정리. AWS 이름은 유지 → state만 이동(재생성 없음).
-moved {
-  from = aws_iam_role.terraform_ci
-  to   = aws_iam_role.terraform_apply
-}
-
-moved {
-  from = aws_iam_role_policy.terraform_ci
-  to   = aws_iam_role_policy.terraform_apply
-}
-
 # ---------------------------------------------------------------------------
-# apply role — 쓰기 권한. (Phase 2 에서 trust 를 main push 전용으로 좁힐 예정)
+# apply role — main 브랜치 push 만 assume 가능(머지 후 trusted 경로). 쓰기 권한.
 # ---------------------------------------------------------------------------
 resource "aws_iam_role" "terraform_apply" {
   name = "github-actions-terraform"
 
-  # 현재는 wcorn/orino 의 모든 워크플로우가 assume 가능(기존 동작 유지).
-  # plan role 이 생성된 뒤(Phase 2) main push 전용으로 좁힌다 — 그래야 부트스트랩이 끊기지 않음.
+  # main 브랜치 워크플로우만 assume(PR·다른 브랜치·다른 repo 차단).
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
@@ -38,8 +24,10 @@ resource "aws_iam_role" "terraform_apply" {
       Principal = { Federated = aws_iam_openid_connect_provider.github.arn }
       Action    = "sts:AssumeRoleWithWebIdentity"
       Condition = {
-        StringEquals = { "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com" }
-        StringLike   = { "token.actions.githubusercontent.com:sub" = "repo:wcorn/orino:*" }
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          "token.actions.githubusercontent.com:sub" = "repo:wcorn/orino:ref:refs/heads/main"
+        }
       }
     }]
   })


### PR DESCRIPTION
## 이슈
closes #497

## 작업 내용
#497 후속 role 분리의 **Phase 2(마무리)**. Phase 1(PR #516, 머지·apply 완료)에서 plan role 과 스코핑된 apply 정책이 생성됐다. 이제 워크플로우를 role 별로 분기하고 apply trust 를 좁힌다.

- **워크플로우**: `Configure AWS credentials` 가 이벤트별로 role 분기
  - PR → `github-actions-terraform-plan` (읽기 전용)
  - main push → `github-actions-terraform` (쓰기)
- **apply role trust 축소**: `sub=repo:wcorn/orino:*`(StringLike) → `sub=repo:wcorn/orino:ref:refs/heads/main`(StringEquals) — main push 만 assume 가능
- Phase 1 에서 적용 완료된 `moved` 블록 제거(정리)

### 결과 (최종 상태)
- 미신뢰 PR(포크 포함)은 **plan 미리보기만**, 어떤 AWS 리소스도 변경 불가
- **apply 는 main 머지 경로에서만** 실행
- apply role 은 `iam:*` 없이 스코핑된 권한(Phase 1)

## 검증
- `terraform fmt -check -recursive` / `terraform validate` 통과
- plan role 은 Phase 1 apply 에서 생성 완료 → **이 PR 의 PR plan 체크도 plan role 로 정상 통과**(부트스트랩 해소)
- plan role 읽기 권한으로 state 읽기 + 리소스 refresh 가능(route53/s3/iam Get·List)

## 머지 후
- main push apply 가 apply role trust 를 main-only 로 축소. 이 apply 의 토큰 sub(`ref:refs/heads/main`)은 축소 전/후 trust 모두에 매칭되어 끊김 없음