### PR TITLE
feat : Planner events insert/patch/delete 프록시 + 캐시 무효화

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/GoogleEventCommandService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/GoogleEventCommandService.java
@@ -1,0 +1,45 @@
+package ds.project.orino.planner.google.calendar;
+
+import ds.project.orino.planner.google.calendar.dto.EventRequest;
+import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
+import ds.project.orino.planner.google.client.GoogleCalendarClient;
+import ds.project.orino.redis.planner.google.GoogleCalendarCacheRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.ZoneId;
+
+/**
+ * 일정 쓰기(생성/수정/삭제) 오케스트레이션. Google 프록시 후 해당 사용자 단기 캐시를 무효화한다.
+ *
+ * <p>미연동이면 {@link GoogleCalendarClient}의 토큰 공급 단계에서 GOOGLE_NOT_CONNECTED(409)가 발생한다.
+ * 반복 일정 편집은 단일 인스턴스 patch 우선("이 일정 이후 전체"는 차기).
+ */
+@Service
+public class GoogleEventCommandService {
+
+    private final GoogleCalendarClient calendarClient;
+    private final GoogleCalendarCacheRepository cacheRepository;
+
+    public GoogleEventCommandService(GoogleCalendarClient calendarClient,
+                                     GoogleCalendarCacheRepository cacheRepository) {
+        this.calendarClient = calendarClient;
+        this.cacheRepository = cacheRepository;
+    }
+
+    public PlannerEvent create(Long memberId, EventRequest request, ZoneId zone) {
+        PlannerEvent created = calendarClient.insertEvent(memberId, request, zone);
+        cacheRepository.evictAll(memberId);
+        return created;
+    }
+
+    public PlannerEvent update(Long memberId, String eventId, EventRequest request, ZoneId zone) {
+        PlannerEvent updated = calendarClient.patchEvent(memberId, eventId, request, zone);
+        cacheRepository.evictAll(memberId);
+        return updated;
+    }
+
+    public void delete(Long memberId, String eventId) {
+        calendarClient.deleteEvent(memberId, eventId);
+        cacheRepository.evictAll(memberId);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/GoogleEventController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/GoogleEventController.java
@@ -1,0 +1,57 @@
+package ds.project.orino.planner.google.calendar;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.core.time.UserTimeZone;
+import ds.project.orino.planner.google.calendar.dto.EventRequest;
+import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Google Calendar 일정 양방향 쓰기 프록시. 미연동 시 409(PLN-ERR-003).
+ * 시간대는 {@code X-Timezone}({@link UserTimeZone}) 기준.
+ */
+@RestController
+@RequestMapping("/api/planner/calendar/events")
+public class GoogleEventController {
+
+    private final GoogleEventCommandService googleEventCommandService;
+
+    public GoogleEventController(GoogleEventCommandService googleEventCommandService) {
+        this.googleEventCommandService = googleEventCommandService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<PlannerEvent>> create(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody EventRequest request) {
+        PlannerEvent created = googleEventCommandService.create(memberId, request, UserTimeZone.get());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(created));
+    }
+
+    @PatchMapping("/{eventId}")
+    public ApiResponse<PlannerEvent> update(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String eventId,
+            @Valid @RequestBody EventRequest request) {
+        return ApiResponse.success(
+                googleEventCommandService.update(memberId, eventId, request, UserTimeZone.get()));
+    }
+
+    @DeleteMapping("/{eventId}")
+    public ApiResponse<Void> delete(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String eventId) {
+        googleEventCommandService.delete(memberId, eventId);
+        return ApiResponse.success();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/EventRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/EventRequest.java
@@ -1,0 +1,20 @@
+package ds.project.orino.planner.google.calendar.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 일정 생성/수정 요청. 시간 값은 사용자 시간대 로컬 기준이다.
+ *
+ * @param allDay 종일 여부. 종일이면 start/end는 날짜("2026-06-10"), 아니면 datetime("2026-06-10T14:00:00")
+ * @param end    종일이면 포함 마지막 날짜(서버가 Google 배타적 종료로 보정)
+ */
+public record EventRequest(
+        @NotBlank String title,
+        boolean allDay,
+        @NotNull String start,
+        @NotNull String end,
+        String location,
+        String description
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventWriteBody.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventWriteBody.java
@@ -1,0 +1,21 @@
+package ds.project.orino.planner.google.calendar.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Google Calendar events.insert/patch 요청 바디(필요한 필드만). null 필드는 직렬화에서 제외한다.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record GoogleEventWriteBody(
+        String summary,
+        String location,
+        String description,
+        GoogleEventTime start,
+        GoogleEventTime end
+) {
+
+    /** 시간 일정이면 dateTime+timeZone, 종일이면 date. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record GoogleEventTime(String dateTime, String date, String timeZone) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
@@ -1,5 +1,8 @@
 package ds.project.orino.planner.google.client;
 
+import ds.project.orino.planner.google.calendar.dto.EventRequest;
+import ds.project.orino.planner.google.calendar.dto.GoogleEventWriteBody;
+import ds.project.orino.planner.google.calendar.dto.GoogleEventWriteBody.GoogleEventTime;
 import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse;
 import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventDateTime;
 import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventItem;
@@ -7,6 +10,7 @@ import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
 import ds.project.orino.planner.google.config.GoogleOAuthProperties;
 import ds.project.orino.planner.google.token.GoogleTokenProvider;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -71,6 +75,76 @@ public class GoogleCalendarClient {
         return response.items().stream()
                 .map(item -> normalize(item, zone))
                 .toList();
+    }
+
+    /** 일정 생성. 생성된 이벤트를 정규화해 반환한다. */
+    public PlannerEvent insertEvent(Long memberId, EventRequest request, ZoneId zone) {
+        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
+                .path(PRIMARY_CALENDAR_PATH)
+                .build()
+                .toUri();
+
+        GoogleEventWriteBody body = toWriteBody(request, zone);
+        GoogleEventItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.post()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(body)
+                        .retrieve()
+                        .body(GoogleEventItem.class));
+        return normalize(item, zone);
+    }
+
+    /** 일정 단일 인스턴스 수정(patch). 없는 id면 404(RESOURCE_NOT_FOUND). */
+    public PlannerEvent patchEvent(Long memberId, String eventId, EventRequest request, ZoneId zone) {
+        URI uri = eventUri(eventId);
+        GoogleEventWriteBody body = toWriteBody(request, zone);
+        GoogleEventItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.patch()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(body)
+                        .retrieve()
+                        .body(GoogleEventItem.class));
+        return normalize(item, zone);
+    }
+
+    /** 일정 삭제. 없는 id면 404(RESOURCE_NOT_FOUND). */
+    public void deleteEvent(Long memberId, String eventId) {
+        URI uri = eventUri(eventId);
+        tokenProvider.executeWithRetry(memberId, accessToken -> {
+            googleRestClient.delete()
+                    .uri(uri)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .toBodilessEntity();
+            return null;
+        });
+    }
+
+    private URI eventUri(String eventId) {
+        return UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
+                .path(PRIMARY_CALENDAR_PATH)
+                .pathSegment(eventId)
+                .build()
+                .toUri();
+    }
+
+    private GoogleEventWriteBody toWriteBody(EventRequest request, ZoneId zone) {
+        GoogleEventTime start;
+        GoogleEventTime end;
+        if (request.allDay()) {
+            start = new GoogleEventTime(null, request.start(), null);
+            // Google 종일 종료는 배타적(다음 날) → 사용자 inclusive end + 1일
+            end = new GoogleEventTime(null, LocalDate.parse(request.end()).plusDays(1).toString(), null);
+        } else {
+            start = new GoogleEventTime(request.start(), null, zone.getId());
+            end = new GoogleEventTime(request.end(), null, zone.getId());
+        }
+        return new GoogleEventWriteBody(
+                request.title(), request.location(), request.description(), start, end);
     }
 
     private PlannerEvent normalize(GoogleEventItem item, ZoneId zone) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleApiConfig.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleApiConfig.java
@@ -6,11 +6,12 @@ import ds.project.orino.planner.google.token.GoogleUnauthorizedException;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.client.RestClient;
 
 import java.io.IOException;
+import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -30,8 +31,12 @@ public class GoogleApiConfig {
 
     @Bean
     public RestClient googleRestClient(GoogleApiProperties props) {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(props.connectTimeout());
+        // JDK HttpURLConnection(SimpleClientHttpRequestFactory)은 PATCH를 지원하지 않으므로
+        // java.net.http 기반 JdkClientHttpRequestFactory를 쓴다(의존성 추가 없음, PATCH 지원).
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(props.connectTimeout())
+                .build();
+        JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
         factory.setReadTimeout(props.readTimeout());
 
         return RestClient.builder()
@@ -39,8 +44,12 @@ public class GoogleApiConfig {
                 .defaultStatusHandler(
                         statusCode -> statusCode.isError(),
                         (request, response) -> {
-                            if (response.getStatusCode().value() == 401) {
+                            int statusCode = response.getStatusCode().value();
+                            if (statusCode == 401) {
                                 throw new GoogleUnauthorizedException();
+                            }
+                            if (statusCode == 404) {
+                                throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
                             }
                             String body = readBody(response);
                             if (body.contains("invalid_grant")) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/GoogleEventControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/GoogleEventControllerTest.java
@@ -1,0 +1,183 @@
+package ds.project.orino.planner.google.calendar;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import ds.project.orino.redis.planner.google.GoogleCalendarCacheRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GoogleEventControllerTest extends ApiTestSupport {
+
+    private static final HttpServer EVENTS_STUB = createStub();
+    private static final String EVENT_JSON = """
+            {"id":"g-evt-1","summary":"치과 예약","location":"강남",
+             "start":{"dateTime":"2026-06-10T05:00:00Z"},"end":{"dateTime":"2026-06-10T06:00:00Z"}}""";
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private GoogleAccountRepository googleAccountRepository;
+    @Autowired
+    private GoogleAccessTokenRepository accessTokenRepository;
+    @Autowired
+    private GoogleCalendarCacheRepository cacheRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Long memberId;
+    private String authHeader;
+
+    @DynamicPropertySource
+    static void googleProperties(DynamicPropertyRegistry registry) {
+        String base = "http://127.0.0.1:" + EVENTS_STUB.getAddress().getPort();
+        registry.add("planner.google.client-id", () -> "test-client-id");
+        registry.add("planner.google.client-secret", () -> "test-client-secret");
+        registry.add("planner.google.oauth.calendar-api-base-url", () -> base);
+    }
+
+    @AfterAll
+    static void stopStub() {
+        EVENTS_STUB.stop(0);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberId = memberRepository.save(MemberFixture.create()).getId();
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    private void connectGoogle() {
+        googleAccountRepository.save(new GoogleAccount(
+                memberId, "refresh", "scope", "me@gmail.com", "primary", "@default"));
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+    }
+
+    private static final String CREATE_BODY = """
+            {"title":"치과 예약","allDay":false,
+             "start":"2026-06-10T14:00:00","end":"2026-06-10T15:00:00","location":"강남"}""";
+
+    @Test
+    @DisplayName("POST - 일정을 생성하고 201로 정규화된 이벤트를 반환하며 캐시를 무효화한다")
+    void create() throws Exception {
+        connectGoogle();
+        cacheRepository.save(memberId, "2026-06-01", "2026-06-30", "[]", Duration.ofMinutes(1));
+
+        mockMvc.perform(post("/api/planner/calendar/events")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(CREATE_BODY))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.id").value("g-evt-1"))
+                .andExpect(jsonPath("$.data.title").value("치과 예약"))
+                .andExpect(jsonPath("$.data.allDay").value(false))
+                .andExpect(jsonPath("$.data.start").value("2026-06-10T14:00:00"))
+                .andExpect(jsonPath("$.data.source").value("google"));
+
+        assertThat(cacheRepository.find(memberId, "2026-06-01", "2026-06-30")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("PATCH - 일정을 수정하고 200으로 반환한다")
+    void update() throws Exception {
+        connectGoogle();
+
+        mockMvc.perform(patch("/api/planner/calendar/events/g-evt-1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(CREATE_BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value("g-evt-1"))
+                .andExpect(jsonPath("$.data.title").value("치과 예약"));
+    }
+
+    @Test
+    @DisplayName("DELETE - 일정을 삭제하고 200 success를 반환한다")
+    void deleteEvent() throws Exception {
+        connectGoogle();
+
+        mockMvc.perform(delete("/api/planner/calendar/events/g-evt-1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("요청에 성공하였습니다."));
+    }
+
+    @Test
+    @DisplayName("미연동 상태에서 생성하면 409(PLN-ERR-003)")
+    void create_notConnected() throws Exception {
+        mockMvc.perform(post("/api/planner/calendar/events")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(CREATE_BODY))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PLN-ERR-003"));
+    }
+
+    @Test
+    @DisplayName("title이 없으면 400")
+    void create_validation() throws Exception {
+        connectGoogle();
+
+        mockMvc.perform(post("/api/planner/calendar/events")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"allDay\":false,\"start\":\"2026-06-10T14:00:00\",\"end\":\"2026-06-10T15:00:00\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    private static HttpServer createStub() {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/calendar/v3/calendars/primary/events", exchange -> {
+                if ("DELETE".equals(exchange.getRequestMethod())) {
+                    exchange.sendResponseHeaders(204, -1);
+                    exchange.close();
+                    return;
+                }
+                respond(exchange, 200, EVENT_JSON);
+            });
+            server.start();
+            return server;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/GoogleEventControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/GoogleEventControllerTest.java
@@ -150,7 +150,8 @@ class GoogleEventControllerTest extends ApiTestSupport {
         mockMvc.perform(post("/api/planner/calendar/events")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"allDay\":false,\"start\":\"2026-06-10T14:00:00\",\"end\":\"2026-06-10T15:00:00\"}"))
+                        .content("""
+                                {"allDay":false,"start":"2026-06-10T14:00:00","end":"2026-06-10T15:00:00"}"""))
                 .andExpect(status().isBadRequest());
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/config/GoogleApiConfigTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/config/GoogleApiConfigTest.java
@@ -80,6 +80,7 @@ class GoogleApiConfigTest {
             server.createContext("/server-error", ex -> respond(ex, 500, "{\"error\":\"backendError\"}"));
             server.createContext("/invalid-grant", ex -> respond(ex, 400, "{\"error\":\"invalid_grant\"}"));
             server.createContext("/unauthorized", ex -> respond(ex, 401, "{\"error\":\"unauthorized\"}"));
+            server.createContext("/not-found", ex -> respond(ex, 404, "{\"error\":\"notFound\"}"));
             server.start();
             baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
 
@@ -127,6 +128,16 @@ class GoogleApiConfigTest {
             assertThatThrownBy(() ->
                     client.get().uri(baseUrl + "/unauthorized").retrieve().body(String.class))
                     .isInstanceOf(GoogleUnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("404 응답은 RESOURCE_NOT_FOUND(404)로 매핑한다")
+        void notFoundMapsToResourceNotFound() {
+            assertThatThrownBy(() ->
+                    client.get().uri(baseUrl + "/not-found").retrieve().body(String.class))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
         }
     }
 

--- a/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/google/GoogleCalendarCacheRepository.java
+++ b/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/google/GoogleCalendarCacheRepository.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * 통합 피드 일정 조회의 단기 캐시. 키 {@code google:cal-cache:{memberId}:{from}:{to}}.
@@ -29,6 +30,14 @@ public class GoogleCalendarCacheRepository {
 
     public Optional<String> find(Long memberId, String from, String to) {
         return Optional.ofNullable(redisTemplate.opsForValue().get(key(memberId, from, to)));
+    }
+
+    /** 해당 사용자의 모든 기간 캐시를 무효화한다(쓰기 후 호출). 단일 사용자/저트래픽이라 keys 패턴 삭제로 충분. */
+    public void evictAll(Long memberId) {
+        Set<String> keys = redisTemplate.keys(KEY_PREFIX + memberId + ":*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
     }
 
     private String key(Long memberId, String from, String to) {


### PR DESCRIPTION
## 이슈
closes #482

## 작업 내용
Epic #472 M2. Google Calendar 일정 양방향 쓰기(생성/수정/삭제) 프록시 + 쓰기 후 캐시 무효화. (deps #478)

### API (`/api/planner/calendar/events`)
| Method | Path | 응답 |
|--------|------|------|
| POST | `/events` | **201** 생성된 이벤트(정규화) |
| PATCH | `/events/{eventId}` | **200** 수정된 이벤트 |
| DELETE | `/events/{eventId}` | **200** success |

- **`GoogleCalendarClient`** insert/patch/delete + `EventRequest → Google 바디` 변환
  - 시간 일정: `dateTime` + `timeZone`(사용자 TZ) / 종일: `date`, 종료는 사용자 inclusive end를 Google 배타적 종료로 보정(+1일)
  - access token은 `executeWithRetry`(#476)로 공급·401 재시도
- **`GoogleEventCommandService`**: 쓰기 성공 후 `google:cal-cache:{memberId}:*` 전부 무효화(`evictAll`)
- **미연동 → 409(PLN-ERR-003)**: 토큰 공급 단계에서 자연 발생 / **없는 id → 404(RESOURCE_NOT_FOUND)**
- 반복 일정 편집은 단일 인스턴스 patch 우선("이 일정 이후 전체"는 차기)

### 인프라/공유 변경
- **RestClient 팩토리 교체**: `SimpleClientHttpRequestFactory`(JDK `HttpURLConnection`)는 **PATCH를 지원하지 않아**("Invalid HTTP method: PATCH") `JdkClientHttpRequestFactory`(java.net.http)로 교체. 의존성 추가 없음, 모든 Google 호출에 적용.
- `GoogleApiConfig` status handler에 **404 → RESOURCE_NOT_FOUND** 매핑 추가(patch/delete의 not-found 처리)

## 테스트
- `GoogleEventControllerTest`(IntegrationTest, JDK HttpServer 스텁) 5/5: 생성(201+정규화+**캐시 무효화 검증**) / 수정(200) / 삭제(200) / 미연동(409) / title 누락(400)
- `GoogleApiConfigTest`에 404→RESOURCE_NOT_FOUND 추가
- app-api + redis 전체 스위트 + checkstyle 통과

## 참고
FE 이벤트 생성/수정/삭제 UI + 낙관적 갱신은 #483(M2 FE).