### PR TITLE
feat : Planner 이벤트 생성/수정/삭제 UI + 낙관적 갱신

### DIFF
--- a/fe/src/features/planner/api/events.ts
+++ b/fe/src/features/planner/api/events.ts
@@ -1,0 +1,43 @@
+import { client } from "@/shared/api";
+
+import type { PlannerEvent } from "./feed";
+
+export interface EventWriteRequest {
+  title: string;
+  allDay: boolean;
+  /** 종일이면 "2026-06-10", 시간 일정이면 로컬 "2026-06-10T14:00:00" */
+  start: string;
+  end: string;
+  location: string | null;
+  description: string | null;
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export async function createEvent(
+  request: EventWriteRequest,
+): Promise<PlannerEvent> {
+  const { data } = await client.post<ApiEnvelope<PlannerEvent>>(
+    "/planner/calendar/events",
+    request,
+  );
+  return data.data;
+}
+
+export async function updateEvent(
+  eventId: string,
+  request: EventWriteRequest,
+): Promise<PlannerEvent> {
+  const { data } = await client.patch<ApiEnvelope<PlannerEvent>>(
+    `/planner/calendar/events/${eventId}`,
+    request,
+  );
+  return data.data;
+}
+
+export async function deleteEvent(eventId: string): Promise<void> {
+  await client.delete(`/planner/calendar/events/${eventId}`);
+}

--- a/fe/src/features/planner/components/calendar/EventFormDialog.test.tsx
+++ b/fe/src/features/planner/components/calendar/EventFormDialog.test.tsx
@@ -1,0 +1,98 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithRouter } from "@/test/render";
+
+import type { PlannerEvent } from "../../api/feed";
+import { EventFormDialog } from "./EventFormDialog";
+
+const baseProps = {
+  open: true,
+  onOpenChange: () => {},
+  googleConnected: true,
+  defaultDate: "2026-06-10",
+} as const;
+
+describe("EventFormDialog", () => {
+  it("생성: 제목 입력 후 저장하면 기본 시간으로 요청을 만든다", async () => {
+    const onSubmit = vi.fn();
+    renderWithRouter(
+      <EventFormDialog {...baseProps} mode="create" onSubmit={onSubmit} />,
+    );
+
+    await userEvent.type(screen.getByLabelText("제목"), "회의");
+    await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: "회의",
+      allDay: false,
+      start: "2026-06-10T09:00:00",
+      end: "2026-06-10T10:00:00",
+      location: null,
+      description: null,
+    });
+  });
+
+  it("종일을 켜면 날짜만으로 요청을 만든다", async () => {
+    const onSubmit = vi.fn();
+    renderWithRouter(
+      <EventFormDialog {...baseProps} mode="create" onSubmit={onSubmit} />,
+    );
+
+    await userEvent.click(screen.getByLabelText("종일"));
+    await userEvent.type(screen.getByLabelText("제목"), "여행");
+    await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allDay: true,
+        start: "2026-06-10",
+        end: "2026-06-10",
+      }),
+    );
+  });
+
+  it("편집: 기존 값이 채워지고 삭제 버튼이 있다", () => {
+    const event: PlannerEvent = {
+      id: "e1",
+      title: "치과 예약",
+      allDay: false,
+      start: "2026-06-10T14:00:00",
+      end: "2026-06-10T15:00:00",
+      location: "강남",
+      recurring: false,
+      source: "google",
+    };
+    renderWithRouter(
+      <EventFormDialog
+        {...baseProps}
+        mode="edit"
+        event={event}
+        onSubmit={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    expect(screen.getByLabelText("제목")).toHaveValue("치과 예약");
+    expect(screen.getByLabelText("시작 시간")).toHaveValue("14:00");
+    expect(screen.getByRole("button", { name: "삭제" })).toBeInTheDocument();
+  });
+
+  it("미연동이면 연결 CTA를 보여주고 폼은 없다", () => {
+    renderWithRouter(
+      <EventFormDialog
+        {...baseProps}
+        googleConnected={false}
+        mode="create"
+        onSubmit={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Google 연결이 필요합니다.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Google 연결" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("제목")).not.toBeInTheDocument();
+  });
+});

--- a/fe/src/features/planner/components/calendar/EventFormDialog.tsx
+++ b/fe/src/features/planner/components/calendar/EventFormDialog.tsx
@@ -1,0 +1,264 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { useEffect, useId, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { GoogleConnectButton } from "@/features/google/components/GoogleConnectButton";
+
+import type { EventWriteRequest } from "../../api/events";
+import type { PlannerEvent } from "../../api/feed";
+
+interface FormState {
+  title: string;
+  allDay: boolean;
+  startDate: string;
+  startTime: string;
+  endDate: string;
+  endTime: string;
+  location: string;
+  description: string;
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "create" | "edit";
+  googleConnected: boolean;
+  /** 생성 시 기본 날짜(YYYY-MM-DD) */
+  defaultDate: string;
+  /** 편집 대상 일정 */
+  event?: PlannerEvent;
+  pending?: boolean;
+  onSubmit: (values: EventWriteRequest) => void;
+  onDelete?: () => void;
+}
+
+function initialState(
+  mode: "create" | "edit",
+  defaultDate: string,
+  event?: PlannerEvent,
+): FormState {
+  if (mode === "edit" && event) {
+    const allDay = event.allDay;
+    return {
+      title: event.title ?? "",
+      allDay,
+      startDate: event.start.slice(0, 10),
+      startTime: allDay ? "09:00" : event.start.slice(11, 16) || "09:00",
+      endDate: (event.end ?? event.start).slice(0, 10),
+      endTime: allDay ? "10:00" : (event.end ?? "").slice(11, 16) || "10:00",
+      location: event.location ?? "",
+      description: "",
+    };
+  }
+  return {
+    title: "",
+    allDay: false,
+    startDate: defaultDate,
+    startTime: "09:00",
+    endDate: defaultDate,
+    endTime: "10:00",
+    location: "",
+    description: "",
+  };
+}
+
+export function EventFormDialog({
+  open,
+  onOpenChange,
+  mode,
+  googleConnected,
+  defaultDate,
+  event,
+  pending = false,
+  onSubmit,
+  onDelete,
+}: Props) {
+  const titleId = useId();
+  const [form, setForm] = useState<FormState>(() =>
+    initialState(mode, defaultDate, event),
+  );
+
+  useEffect(() => {
+    if (open) {
+      setForm(initialState(mode, defaultDate, event));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  const start = form.allDay
+    ? form.startDate
+    : `${form.startDate}T${form.startTime}:00`;
+  const end = form.allDay ? form.endDate : `${form.endDate}T${form.endTime}:00`;
+  const valid =
+    form.title.trim().length > 0 &&
+    !!form.startDate &&
+    !!form.endDate &&
+    start <= end;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!valid || pending) return;
+    onSubmit({
+      title: form.title.trim(),
+      allDay: form.allDay,
+      start,
+      end,
+      location: form.location.trim() || null,
+      description: form.description.trim() || null,
+    });
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
+        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+          <Dialog.Title className="text-base font-semibold">
+            {mode === "create" ? "일정 추가" : "일정 편집"}
+          </Dialog.Title>
+
+          {!googleConnected ? (
+            <div className="mt-4 flex flex-col gap-4">
+              <p className="text-muted-foreground text-sm">
+                Google 연결이 필요합니다.
+              </p>
+              <div className="flex justify-end gap-2">
+                <Dialog.Close
+                  render={
+                    <Button variant="ghost" type="button">
+                      닫기
+                    </Button>
+                  }
+                />
+                <GoogleConnectButton />
+              </div>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3">
+              <Field label="제목" htmlFor={titleId}>
+                <Input
+                  id={titleId}
+                  value={form.title}
+                  onChange={(e) => set("title", e.target.value)}
+                  autoFocus
+                />
+              </Field>
+
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={form.allDay}
+                  onChange={(e) => set("allDay", e.target.checked)}
+                />
+                종일
+              </label>
+
+              <Field label="시작">
+                <div className="flex gap-2">
+                  <Input
+                    type="date"
+                    aria-label="시작 날짜"
+                    value={form.startDate}
+                    onChange={(e) => set("startDate", e.target.value)}
+                  />
+                  {!form.allDay && (
+                    <Input
+                      type="time"
+                      aria-label="시작 시간"
+                      value={form.startTime}
+                      onChange={(e) => set("startTime", e.target.value)}
+                    />
+                  )}
+                </div>
+              </Field>
+
+              <Field label="종료">
+                <div className="flex gap-2">
+                  <Input
+                    type="date"
+                    aria-label="종료 날짜"
+                    value={form.endDate}
+                    onChange={(e) => set("endDate", e.target.value)}
+                  />
+                  {!form.allDay && (
+                    <Input
+                      type="time"
+                      aria-label="종료 시간"
+                      value={form.endTime}
+                      onChange={(e) => set("endTime", e.target.value)}
+                    />
+                  )}
+                </div>
+              </Field>
+
+              <Field label="장소 (선택)">
+                <Input
+                  value={form.location}
+                  onChange={(e) => set("location", e.target.value)}
+                />
+              </Field>
+
+              <Field label="메모 (선택)">
+                <textarea
+                  rows={2}
+                  value={form.description}
+                  onChange={(e) => set("description", e.target.value)}
+                  className="border-input bg-background focus-visible:ring-ring/30 resize-y rounded-md border p-2 text-sm shadow-xs focus-visible:ring-2 focus-visible:outline-none"
+                />
+              </Field>
+
+              <div className="mt-1 flex items-center justify-between gap-2">
+                {mode === "edit" && onDelete ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="text-destructive"
+                    disabled={pending}
+                    onClick={onDelete}
+                  >
+                    삭제
+                  </Button>
+                ) : (
+                  <span />
+                )}
+                <div className="flex gap-2">
+                  <Dialog.Close
+                    render={
+                      <Button variant="ghost" type="button" disabled={pending}>
+                        취소
+                      </Button>
+                    }
+                  />
+                  <Button type="submit" disabled={!valid || pending}>
+                    {pending ? "저장 중..." : "저장"}
+                  </Button>
+                </div>
+              </div>
+            </form>
+          )}
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+interface FieldProps {
+  label: string;
+  htmlFor?: string;
+  children: React.ReactNode;
+}
+
+function Field({ label, htmlFor, children }: FieldProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor={htmlFor} className="text-sm font-medium">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
@@ -1,4 +1,5 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { delay, http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
@@ -125,5 +126,42 @@ describe("PlannerCalendar", () => {
     expect(
       await screen.findByText("일부 일정을 불러오지 못했습니다."),
     ).toBeInTheDocument();
+  });
+
+  it("+일정으로 일정을 생성하면 POST하고 다이얼로그를 닫는다", async () => {
+    mockGoogleConnected(true);
+    mockFeed({ googleConnected: true });
+    let posted: unknown = null;
+    server.use(
+      http.post(`${API_BASE}/planner/calendar/events`, async ({ request }) => {
+        posted = await request.json();
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            id: "new-1",
+            title: "회의",
+            allDay: false,
+            start: `${TODAY}T09:00:00`,
+            end: `${TODAY}T10:00:00`,
+            location: null,
+            recurring: false,
+            source: "google",
+          },
+        });
+      }),
+    );
+
+    renderWithRouter(<PlannerCalendar />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "일정" }));
+    await userEvent.type(await screen.findByLabelText("제목"), "회의");
+    await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() =>
+      expect(posted).toMatchObject({ title: "회의", allDay: false }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByLabelText("제목")).not.toBeInTheDocument(),
+    );
   });
 });

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -11,11 +11,21 @@ import {
   toIsoDate,
 } from "@/features/review/calendar";
 
+import type { EventWriteRequest } from "../../api/events";
+import type { PlannerEvent } from "../../api/feed";
 import { eventsByDate, reviewsByDate, tasksByDate } from "../../calendar";
+import {
+  useCreateEvent,
+  useDeleteEvent,
+  useUpdateEvent,
+} from "../../hooks/useEventMutations";
 import { usePlannerCalendar } from "../../hooks/usePlannerCalendar";
+import { EventFormDialog } from "./EventFormDialog";
 import { PlannerCalendarCell } from "./PlannerCalendarCell";
 import { PlannerCalendarLegend } from "./PlannerCalendarLegend";
 import { PlannerDayDetailPanel } from "./PlannerDayDetailPanel";
+
+type DialogState = { mode: "create" | "edit"; event?: PlannerEvent };
 
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
 
@@ -42,6 +52,31 @@ export function PlannerCalendar() {
   const tasksMap = useMemo(() => tasksByDate(data?.tasks ?? []), [data]);
   const reviewsMap = useMemo(() => reviewsByDate(data?.reviews ?? []), [data]);
 
+  const googleConnected = data?.googleConnected ?? false;
+
+  const [dialog, setDialog] = useState<DialogState | null>(null);
+  const createEvent = useCreateEvent();
+  const updateEvent = useUpdateEvent();
+  const deleteEvent = useDeleteEvent();
+  const pending =
+    createEvent.isPending || updateEvent.isPending || deleteEvent.isPending;
+
+  const handleSubmit = (values: EventWriteRequest) => {
+    if (dialog?.mode === "edit" && dialog.event) {
+      updateEvent.mutate(
+        { eventId: dialog.event.id, request: values },
+        { onSuccess: () => setDialog(null) },
+      );
+    } else {
+      createEvent.mutate(values, { onSuccess: () => setDialog(null) });
+    }
+  };
+
+  const handleDelete = () => {
+    if (dialog?.mode !== "edit" || !dialog.event) return;
+    deleteEvent.mutate(dialog.event.id, { onSuccess: () => setDialog(null) });
+  };
+
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -66,16 +101,22 @@ export function PlannerCalendar() {
             <ChevronRight className="size-4" />
           </Button>
         </div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => {
-            setCursor(new Date(today.getFullYear(), today.getMonth(), 1));
-            setSelected(todayIso);
-          }}
-        >
-          오늘
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setCursor(new Date(today.getFullYear(), today.getMonth(), 1));
+              setSelected(todayIso);
+            }}
+          >
+            오늘
+          </Button>
+          <Button size="sm" onClick={() => setDialog({ mode: "create" })}>
+            <Plus className="size-3.5" />
+            일정
+          </Button>
+        </div>
       </div>
 
       <GoogleNotConnectedBanner />
@@ -148,10 +189,27 @@ export function PlannerCalendar() {
               events={eventsMap.get(selected) ?? []}
               tasks={tasksMap.get(selected) ?? []}
               reviews={reviewsMap.get(selected) ?? []}
+              onEventClick={(event) => setDialog({ mode: "edit", event })}
             />
           </CardContent>
         </Card>
       </div>
+
+      {dialog && (
+        <EventFormDialog
+          open
+          onOpenChange={(next) => {
+            if (!next) setDialog(null);
+          }}
+          mode={dialog.mode}
+          googleConnected={googleConnected}
+          defaultDate={selected}
+          event={dialog.event}
+          pending={pending}
+          onSubmit={handleSubmit}
+          onDelete={dialog.mode === "edit" ? handleDelete : undefined}
+        />
+      )}
     </div>
   );
 }

--- a/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
@@ -12,6 +12,7 @@ interface Props {
   events: PlannerEvent[];
   tasks: PlannerTask[];
   reviews: PlannerReview[];
+  onEventClick?: (event: PlannerEvent) => void;
 }
 
 function formatHeading(isoDate: string): string {
@@ -24,6 +25,7 @@ export function PlannerDayDetailPanel({
   events,
   tasks,
   reviews,
+  onEventClick,
 }: Props) {
   const isEmpty = events.length + tasks.length + reviews.length === 0;
 
@@ -49,23 +51,26 @@ export function PlannerDayDetailPanel({
               </h3>
               <ul className="flex flex-col gap-1.5">
                 {events.map((event) => (
-                  <li
-                    key={event.id}
-                    className="border-border bg-card flex items-start gap-2 rounded-md border p-2 text-sm"
-                  >
-                    <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
-                      {eventTimeLabel(event)}
-                    </span>
-                    <div className="flex min-w-0 flex-1 flex-col">
-                      <span className="truncate">
-                        {event.title ?? "(제목 없음)"}
+                  <li key={event.id}>
+                    <button
+                      type="button"
+                      onClick={() => onEventClick?.(event)}
+                      className="border-border bg-card hover:bg-muted/50 flex w-full items-start gap-2 rounded-md border p-2 text-left text-sm transition-colors"
+                    >
+                      <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+                        {eventTimeLabel(event)}
                       </span>
-                      {event.location && (
-                        <span className="text-muted-foreground truncate text-xs">
-                          {event.location}
+                      <div className="flex min-w-0 flex-1 flex-col">
+                        <span className="truncate">
+                          {event.title ?? "(제목 없음)"}
                         </span>
-                      )}
-                    </div>
+                        {event.location && (
+                          <span className="text-muted-foreground truncate text-xs">
+                            {event.location}
+                          </span>
+                        )}
+                      </div>
+                    </button>
                   </li>
                 ))}
               </ul>

--- a/fe/src/features/planner/hooks/useEventMutations.ts
+++ b/fe/src/features/planner/hooks/useEventMutations.ts
@@ -1,0 +1,56 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { toast } from "@/shared/lib/toast";
+
+import {
+  createEvent,
+  deleteEvent,
+  type EventWriteRequest,
+  updateEvent,
+} from "../api/events";
+import { plannerKeys } from "../queryKeys";
+
+/**
+ * 일정 쓰기 후 통합 피드를 invalidate해 갱신한다(서버가 캐시를 무효화하므로 재조회로 최신화).
+ */
+export function useCreateEvent() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createEvent,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: plannerKeys.all });
+      toast("일정을 저장했습니다.", "success");
+    },
+    onError: () => toast("일정 저장에 실패했습니다.", "error"),
+  });
+}
+
+export function useUpdateEvent() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      eventId,
+      request,
+    }: {
+      eventId: string;
+      request: EventWriteRequest;
+    }) => updateEvent(eventId, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: plannerKeys.all });
+      toast("일정을 수정했습니다.", "success");
+    },
+    onError: () => toast("일정 수정에 실패했습니다.", "error"),
+  });
+}
+
+export function useDeleteEvent() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteEvent,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: plannerKeys.all });
+      toast("일정을 삭제했습니다.", "success");
+    },
+    onError: () => toast("일정 삭제에 실패했습니다.", "error"),
+  });
+}


### PR DESCRIPTION
## 이슈
closes #483

## 작업 내용
Epic #472 M2 마무리. 통합 캘린더에서 일정 생성/편집/삭제 + react-query invalidate 기반 갱신. (deps #480, #482)

- **`EventFormDialog`** (Base UI Dialog): 제목 / 종일 / 시작·종료(날짜+시간) / 장소 / 메모
  - 종일 토글 시 시간 입력 숨김 → start/end를 날짜("2026-06-10")로, 아니면 datetime("2026-06-10T14:00:00")로 변환(BE 포맷)
  - 편집 시 기존 값 채움 + [삭제] 버튼
  - **미연동 시 폼 대신 "Google 연결이 필요합니다" + 연결 버튼**(#477 `GoogleConnectButton` 재사용)
- **`useCreateEvent`/`useUpdateEvent`/`useDeleteEvent`**: 성공 시 `plannerKeys` invalidate(서버가 캐시 무효화하므로 재조회로 최신화) + 토스트
- **`PlannerCalendar`**: 헤더 **`+일정`** 버튼(생성, 선택된 날짜 기본값), 그날 상세 패널의 **일정 클릭 → 편집/삭제**(복습은 readOnly 유지)

## 테스트 (RTL + MSW)
- `EventFormDialog`: 생성(기본 시간 요청) / 종일(날짜만) / 편집(값 채움+삭제) / 미연동(연결 CTA) — 4
- `PlannerCalendar`: **+일정 → 폼 작성 → 저장 시 POST 호출 + 다이얼로그 닫힘** 통합 — 1
- FE 전체 124개 통과, tsc·eslint·format:check clean

## 비고
- "낙관적 갱신"은 wiki 명시대로 invalidate 기반(서버 캐시 무효화 + 재조회). 메모(description)는 피드가 반환하지 않아 편집 시 미리채움 불가(생성 시에만 입력).
- M2(양방향 쓰기) 완료. 다음 M3는 Google Tasks(#484 BE, #485 FE).