### PR TITLE
feat : Planner Google Tasks 프록시 + 통합 피드 합류

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/PlannerCalendarService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/PlannerCalendarService.java
@@ -8,6 +8,7 @@ import ds.project.orino.planner.google.calendar.dto.PlannerCalendarFeed;
 import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
 import ds.project.orino.planner.google.calendar.dto.PlannerReview;
 import ds.project.orino.planner.google.calendar.dto.PlannerTask;
+import ds.project.orino.planner.google.client.GoogleTasksClient;
 import ds.project.orino.planner.review.dto.CalendarReviewItem;
 import ds.project.orino.planner.review.service.ReviewQueryService;
 import org.springframework.stereotype.Service;
@@ -30,11 +31,14 @@ public class PlannerCalendarService {
     private static final int MAX_RANGE_DAYS = 100;
 
     private final GoogleEventQueryService googleEventQueryService;
+    private final GoogleTasksClient googleTasksClient;
     private final ReviewQueryService reviewQueryService;
 
     public PlannerCalendarService(GoogleEventQueryService googleEventQueryService,
+                                  GoogleTasksClient googleTasksClient,
                                   ReviewQueryService reviewQueryService) {
         this.googleEventQueryService = googleEventQueryService;
+        this.googleTasksClient = googleTasksClient;
         this.reviewQueryService = reviewQueryService;
     }
 
@@ -67,10 +71,28 @@ public class PlannerCalendarService {
             errors.add(new FeedError("reviews", "복습을 불러오지 못했습니다."));
         }
 
-        List<PlannerTask> tasks = List.of(); // M3(#484)에서 합류
+        List<PlannerTask> tasks = List.of();
+        if (googleConnected) {
+            try {
+                tasks = googleTasksClient.listTasks(memberId, false).stream()
+                        .filter(task -> withinRange(task.due(), from, to))
+                        .toList();
+            } catch (RuntimeException e) {
+                errors.add(new FeedError("google-tasks", "할 일을 불러오지 못했습니다."));
+            }
+        }
 
         return new PlannerCalendarFeed(
                 from, to, googleConnected, !errors.isEmpty(), errors, events, tasks, reviews);
+    }
+
+    /** due(날짜) 마감이 [from, to] 구간 안인 할 일만 캘린더에 배치한다(마감 없는 할 일은 제외). */
+    private static boolean withinRange(String due, LocalDate from, LocalDate to) {
+        if (due == null) {
+            return false;
+        }
+        LocalDate dueDate = LocalDate.parse(due);
+        return !dueDate.isBefore(from) && !dueDate.isAfter(to);
     }
 
     private static PlannerReview toFeedReview(CalendarReviewItem item) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/PlannerTask.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/PlannerTask.java
@@ -1,13 +1,16 @@
 package ds.project.orino.planner.google.calendar.dto;
 
 /**
- * 통합 피드의 할 일(Google Tasks) 항목. M3(#484)에서 합류하며, 그 전까지는 항상 빈 목록이다.
+ * 통합 피드/Tasks 응답의 할 일(Google Tasks) 항목.
+ *
+ * @param due 마감일(날짜 "2026-06-12") 또는 null
  */
 public record PlannerTask(
         String id,
         String title,
         String due,
         boolean completed,
+        String notes,
         String source
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleTasksClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleTasksClient.java
@@ -1,0 +1,142 @@
+package ds.project.orino.planner.google.client;
+
+import ds.project.orino.planner.google.calendar.dto.PlannerTask;
+import ds.project.orino.planner.google.config.GoogleOAuthProperties;
+import ds.project.orino.planner.google.task.dto.GoogleTaskWriteBody;
+import ds.project.orino.planner.google.task.dto.GoogleTasksResponse;
+import ds.project.orino.planner.google.task.dto.GoogleTasksResponse.GoogleTaskItem;
+import ds.project.orino.planner.google.task.dto.TaskCreateRequest;
+import ds.project.orino.planner.google.task.dto.TaskUpdateRequest;
+import ds.project.orino.planner.google.token.GoogleTokenProvider;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * Google Tasks API 래퍼. 기본 task list("@default")에 대해 list/insert/patch/delete를 프록시한다.
+ *
+ * <p>Tasks는 Calendar와 호스트가 다르다(tasks.googleapis.com). access token은
+ * {@link GoogleTokenProvider#executeWithRetry}로 공급·401 재시도한다. 미연동이면 GOOGLE_NOT_CONNECTED(409).
+ */
+@Component
+public class GoogleTasksClient {
+
+    private static final String TASKS_PATH = "/tasks/v1/lists/@default/tasks";
+    private static final String STATUS_COMPLETED = "completed";
+    private static final String STATUS_NEEDS_ACTION = "needsAction";
+
+    private final GoogleTokenProvider tokenProvider;
+    private final RestClient googleRestClient;
+    private final GoogleOAuthProperties oauthProperties;
+
+    public GoogleTasksClient(GoogleTokenProvider tokenProvider,
+                             RestClient googleRestClient,
+                             GoogleOAuthProperties oauthProperties) {
+        this.tokenProvider = tokenProvider;
+        this.googleRestClient = googleRestClient;
+        this.oauthProperties = oauthProperties;
+    }
+
+    public List<PlannerTask> listTasks(Long memberId, boolean showCompleted) {
+        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.tasksApiBaseUrl())
+                .path(TASKS_PATH)
+                .queryParam("showCompleted", showCompleted)
+                .queryParam("showHidden", showCompleted)
+                .queryParam("maxResults", "100")
+                .build()
+                .toUri();
+
+        GoogleTasksResponse response = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.get()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .retrieve()
+                        .body(GoogleTasksResponse.class));
+
+        if (response == null || response.items() == null) {
+            return List.of();
+        }
+        return response.items().stream().map(GoogleTasksClient::normalize).toList();
+    }
+
+    public PlannerTask insertTask(Long memberId, TaskCreateRequest request) {
+        GoogleTaskWriteBody body = new GoogleTaskWriteBody(
+                request.title(), request.notes(), toGoogleDue(request.due()), null);
+        GoogleTaskItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.post()
+                        .uri(tasksUri())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(body)
+                        .retrieve()
+                        .body(GoogleTaskItem.class));
+        return normalize(item);
+    }
+
+    public PlannerTask patchTask(Long memberId, String taskId, TaskUpdateRequest request) {
+        String status = request.completed() == null
+                ? null
+                : (request.completed() ? STATUS_COMPLETED : STATUS_NEEDS_ACTION);
+        GoogleTaskWriteBody body = new GoogleTaskWriteBody(
+                request.title(), request.notes(), toGoogleDue(request.due()), status);
+
+        GoogleTaskItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.patch()
+                        .uri(taskUri(taskId))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(body)
+                        .retrieve()
+                        .body(GoogleTaskItem.class));
+        return normalize(item);
+    }
+
+    public void deleteTask(Long memberId, String taskId) {
+        tokenProvider.executeWithRetry(memberId, accessToken -> {
+            googleRestClient.delete()
+                    .uri(taskUri(taskId))
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .toBodilessEntity();
+            return null;
+        });
+    }
+
+    private URI tasksUri() {
+        return UriComponentsBuilder.fromUriString(oauthProperties.tasksApiBaseUrl())
+                .path(TASKS_PATH)
+                .build()
+                .toUri();
+    }
+
+    private URI taskUri(String taskId) {
+        return UriComponentsBuilder.fromUriString(oauthProperties.tasksApiBaseUrl())
+                .path(TASKS_PATH)
+                .pathSegment(taskId)
+                .build()
+                .toUri();
+    }
+
+    private static PlannerTask normalize(GoogleTaskItem item) {
+        String due = (item.due() != null && item.due().length() >= 10)
+                ? item.due().substring(0, 10)
+                : null;
+        return new PlannerTask(
+                item.id(),
+                item.title(),
+                due,
+                STATUS_COMPLETED.equals(item.status()),
+                item.notes(),
+                "google");
+    }
+
+    /** 날짜("2026-06-12") → Google due RFC3339(자정 UTC). null이면 null. */
+    private static String toGoogleDue(String date) {
+        return date != null ? date + "T00:00:00.000Z" : null;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleOAuthProperties.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleOAuthProperties.java
@@ -11,6 +11,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @param tokenUri           code/refresh → token 교환 엔드포인트
  * @param revokeUri          토큰 revoke 엔드포인트 (연동 해제)
  * @param calendarApiBaseUrl Calendar API base (primary 캘린더 조회용)
+ * @param tasksApiBaseUrl    Tasks API base (Calendar와 호스트가 다름)
  * @param frontendUrl        콜백 후 리다이렉트할 FE base URL
  */
 @ConfigurationProperties(prefix = "planner.google.oauth")
@@ -19,6 +20,7 @@ public record GoogleOAuthProperties(
         String tokenUri,
         String revokeUri,
         String calendarApiBaseUrl,
+        String tasksApiBaseUrl,
         String frontendUrl
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/GoogleTaskController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/GoogleTaskController.java
@@ -1,0 +1,67 @@
+package ds.project.orino.planner.google.task;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.google.calendar.dto.PlannerTask;
+import ds.project.orino.planner.google.client.GoogleTasksClient;
+import ds.project.orino.planner.google.task.dto.TaskCreateRequest;
+import ds.project.orino.planner.google.task.dto.TaskUpdateRequest;
+import ds.project.orino.planner.google.task.dto.TasksResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Google Tasks 프록시(기본 task list). 미연동 시 409(PLN-ERR-003).
+ */
+@RestController
+@RequestMapping("/api/planner/tasks")
+public class GoogleTaskController {
+
+    private final GoogleTasksClient googleTasksClient;
+
+    public GoogleTaskController(GoogleTasksClient googleTasksClient) {
+        this.googleTasksClient = googleTasksClient;
+    }
+
+    @GetMapping
+    public ApiResponse<TasksResponse> list(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam(defaultValue = "false") boolean showCompleted) {
+        return ApiResponse.success(
+                new TasksResponse(googleTasksClient.listTasks(memberId, showCompleted)));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<PlannerTask>> create(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody TaskCreateRequest request) {
+        PlannerTask created = googleTasksClient.insertTask(memberId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(created));
+    }
+
+    @PatchMapping("/{taskId}")
+    public ApiResponse<PlannerTask> update(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String taskId,
+            @RequestBody TaskUpdateRequest request) {
+        return ApiResponse.success(googleTasksClient.patchTask(memberId, taskId, request));
+    }
+
+    @DeleteMapping("/{taskId}")
+    public ApiResponse<Void> delete(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String taskId) {
+        googleTasksClient.deleteTask(memberId, taskId);
+        return ApiResponse.success();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/dto/GoogleTaskWriteBody.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/dto/GoogleTaskWriteBody.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.google.task.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/** Google Tasks tasks.insert/patch 요청 바디. null 필드는 직렬화 제외(patch 부분 갱신). */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record GoogleTaskWriteBody(
+        String title,
+        String notes,
+        String due,
+        String status
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/dto/GoogleTasksResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/dto/GoogleTasksResponse.java
@@ -1,0 +1,21 @@
+package ds.project.orino.planner.google.task.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/** Google Tasks tasks.list 응답(필요한 필드만). */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GoogleTasksResponse(List<GoogleTaskItem> items) {
+
+    /** status: "needsAction" | "completed". due: RFC3339(날짜만 의미). */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GoogleTaskItem(
+            String id,
+            String title,
+            String notes,
+            String status,
+            String due
+    ) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/dto/TaskCreateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/dto/TaskCreateRequest.java
@@ -1,0 +1,11 @@
+package ds.project.orino.planner.google.task.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** 할 일 생성 요청. due는 마감 날짜("2026-06-12") 또는 null. */
+public record TaskCreateRequest(
+        @NotBlank String title,
+        String due,
+        String notes
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/dto/TaskUpdateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/dto/TaskUpdateRequest.java
@@ -1,0 +1,12 @@
+package ds.project.orino.planner.google.task.dto;
+
+/**
+ * 할 일 수정/완료 토글 요청. 모든 필드 선택(부분 갱신). completed로 완료/미완료 토글.
+ */
+public record TaskUpdateRequest(
+        String title,
+        String due,
+        String notes,
+        Boolean completed
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/dto/TasksResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/dto/TasksResponse.java
@@ -1,0 +1,9 @@
+package ds.project.orino.planner.google.task.dto;
+
+import ds.project.orino.planner.google.calendar.dto.PlannerTask;
+
+import java.util.List;
+
+/** 할 일 목록 응답. */
+public record TasksResponse(List<PlannerTask> tasks) {
+}

--- a/be/orino-app-api/src/main/resources/application.yml
+++ b/be/orino-app-api/src/main/resources/application.yml
@@ -48,6 +48,7 @@ planner:
       token-uri: ${GOOGLE_TOKEN_URI:https://oauth2.googleapis.com/token}
       revoke-uri: ${GOOGLE_REVOKE_URI:https://oauth2.googleapis.com/revoke}
       calendar-api-base-url: ${GOOGLE_CALENDAR_API_BASE_URL:https://www.googleapis.com}
+      tasks-api-base-url: ${GOOGLE_TASKS_API_BASE_URL:https://tasks.googleapis.com}
       # 콜백 후 리다이렉트할 FE base URL (local Vite 3000, prod orino.dev)
       frontend-url: ${FRONTEND_URL:http://localhost:3000}
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/PlannerCalendarControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/PlannerCalendarControllerTest.java
@@ -45,6 +45,7 @@ class PlannerCalendarControllerTest extends ApiTestSupport {
     private static final HttpServer EVENTS_STUB = createStub();
     private static volatile int responseStatus = 200;
     private static volatile String responseBody = "{\"items\":[]}";
+    private static volatile String tasksBody = "{\"items\":[]}";
 
     @Autowired
     private MemberRepository memberRepository;
@@ -70,6 +71,7 @@ class PlannerCalendarControllerTest extends ApiTestSupport {
         registry.add("planner.google.client-id", () -> "test-client-id");
         registry.add("planner.google.client-secret", () -> "test-client-secret");
         registry.add("planner.google.oauth.calendar-api-base-url", () -> base);
+        registry.add("planner.google.oauth.tasks-api-base-url", () -> base);
     }
 
     @AfterAll
@@ -83,6 +85,7 @@ class PlannerCalendarControllerTest extends ApiTestSupport {
         responseBody = """
                 {"items":[{"id":"e1","summary":"회의",
                  "start":{"dateTime":"2026-06-10T05:00:00Z"},"end":{"dateTime":"2026-06-10T06:00:00Z"}}]}""";
+        tasksBody = "{\"items\":[]}";
         dbCleaner.clean();
         Member member = memberRepository.save(MemberFixture.create());
         memberId = member.getId();
@@ -160,11 +163,34 @@ class PlannerCalendarControllerTest extends ApiTestSupport {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    @DisplayName("연동 시 due가 기간 내인 할 일만 피드 tasks에 합류한다(정규화)")
+    void mergesTasks() throws Exception {
+        connectGoogle();
+        tasksBody = """
+                {"items":[
+                  {"id":"t1","title":"리포트 제출","status":"needsAction","due":"2026-06-12T00:00:00.000Z"},
+                  {"id":"t2","title":"기간 밖","status":"needsAction","due":"2026-07-15T00:00:00.000Z"},
+                  {"id":"t3","title":"마감 없음","status":"needsAction"}
+                ]}""";
+
+        requestFeed("2026-06-01", "2026-06-30")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.partial").value(false))
+                .andExpect(jsonPath("$.data.tasks.length()").value(1))
+                .andExpect(jsonPath("$.data.tasks[0].id").value("t1"))
+                .andExpect(jsonPath("$.data.tasks[0].due").value("2026-06-12"))
+                .andExpect(jsonPath("$.data.tasks[0].completed").value(false))
+                .andExpect(jsonPath("$.data.tasks[0].source").value("google"));
+    }
+
     private static HttpServer createStub() {
         try {
             HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
             server.createContext("/calendar/v3/calendars/primary/events", exchange ->
                     respond(exchange, responseStatus, responseBody));
+            server.createContext("/tasks/v1/lists/@default/tasks", exchange ->
+                    respond(exchange, 200, tasksBody));
             server.start();
             return server;
         } catch (IOException e) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/task/GoogleTaskControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/task/GoogleTaskControllerTest.java
@@ -1,0 +1,175 @@
+package ds.project.orino.planner.google.task;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GoogleTaskControllerTest extends ApiTestSupport {
+
+    private static final HttpServer TASKS_STUB = createStub();
+    private static final String NEEDS_ACTION = """
+            {"id":"t1","title":"리포트 제출","status":"needsAction","due":"2026-06-12T00:00:00.000Z"}""";
+    private static final String COMPLETED = """
+            {"id":"t1","title":"리포트 제출","status":"completed","due":"2026-06-12T00:00:00.000Z"}""";
+    private static final String LIST_BODY = "{\"items\":[" + NEEDS_ACTION + "]}";
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private GoogleAccountRepository googleAccountRepository;
+    @Autowired
+    private GoogleAccessTokenRepository accessTokenRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Long memberId;
+    private String authHeader;
+
+    @DynamicPropertySource
+    static void googleProperties(DynamicPropertyRegistry registry) {
+        String base = "http://127.0.0.1:" + TASKS_STUB.getAddress().getPort();
+        registry.add("planner.google.client-id", () -> "test-client-id");
+        registry.add("planner.google.client-secret", () -> "test-client-secret");
+        registry.add("planner.google.oauth.tasks-api-base-url", () -> base);
+    }
+
+    @AfterAll
+    static void stopStub() {
+        TASKS_STUB.stop(0);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberId = memberRepository.save(MemberFixture.create()).getId();
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    private void connectGoogle() {
+        googleAccountRepository.save(new GoogleAccount(
+                memberId, "refresh", "scope", "me@gmail.com", "primary", "@default"));
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+    }
+
+    @Test
+    @DisplayName("GET - 할 일 목록을 정규화해 반환한다")
+    void list() throws Exception {
+        connectGoogle();
+
+        mockMvc.perform(get("/api/planner/tasks").header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.tasks.length()").value(1))
+                .andExpect(jsonPath("$.data.tasks[0].id").value("t1"))
+                .andExpect(jsonPath("$.data.tasks[0].due").value("2026-06-12"))
+                .andExpect(jsonPath("$.data.tasks[0].completed").value(false));
+    }
+
+    @Test
+    @DisplayName("POST - 할 일을 생성하고 201로 반환한다")
+    void create() throws Exception {
+        connectGoogle();
+
+        mockMvc.perform(post("/api/planner/tasks")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title":"리포트 제출","due":"2026-06-12"}"""))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.id").value("t1"))
+                .andExpect(jsonPath("$.data.title").value("리포트 제출"))
+                .andExpect(jsonPath("$.data.completed").value(false));
+    }
+
+    @Test
+    @DisplayName("PATCH - completed=true로 완료 토글한다")
+    void completeToggle() throws Exception {
+        connectGoogle();
+
+        mockMvc.perform(patch("/api/planner/tasks/t1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"completed":true}"""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.completed").value(true));
+    }
+
+    @Test
+    @DisplayName("DELETE - 할 일을 삭제하고 200 success를 반환한다")
+    void deleteTask() throws Exception {
+        connectGoogle();
+
+        mockMvc.perform(delete("/api/planner/tasks/t1").header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("요청에 성공하였습니다."));
+    }
+
+    @Test
+    @DisplayName("미연동 상태에서 목록 조회하면 409(PLN-ERR-003)")
+    void list_notConnected() throws Exception {
+        mockMvc.perform(get("/api/planner/tasks").header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PLN-ERR-003"));
+    }
+
+    private static HttpServer createStub() {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/tasks/v1/lists/@default/tasks", exchange -> {
+                String method = exchange.getRequestMethod();
+                switch (method) {
+                    case "DELETE" -> {
+                        exchange.sendResponseHeaders(204, -1);
+                        exchange.close();
+                    }
+                    case "GET" -> respond(exchange, LIST_BODY);
+                    case "PATCH" -> respond(exchange, COMPLETED);
+                    default -> respond(exchange, NEEDS_ACTION);
+                }
+            });
+            server.start();
+            return server;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void respond(HttpExchange exchange, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+}


### PR DESCRIPTION
## 이슈
closes #484

## 작업 내용
Epic #472 M3. Google Tasks 프록시(기본 task list) + 통합 피드 `tasks[]` 합류. (deps #476, #482)

### API (`/api/planner/tasks`)
| Method | Path | 설명 |
|--------|------|------|
| GET | `/tasks?showCompleted` | 목록(정규화) |
| POST | `/tasks` | 생성 → 201 |
| PATCH | `/tasks/{taskId}` | 수정/**완료 토글**(`completed`) |
| DELETE | `/tasks/{taskId}` | 삭제 |

- **`GoogleTasksClient`**: `@default` task list에 list/insert/patch/delete. Tasks는 Calendar와 호스트가 달라(`tasks.googleapis.com`) `tasksApiBaseUrl` 분리.
  - 정규화: Google `status`("completed"/"needsAction") ↔ `completed`, `due` RFC3339 ↔ 날짜("2026-06-12"). 완료 토글은 `status` patch.
  - access token은 `executeWithRetry`(#476)로 공급·401 재시도. 미연동 → **409(PLN-ERR-003)**.
- **통합 피드 합류**: `PlannerCalendarService`가 연동 시 tasks를 조회해 **due가 [from,to] 안인 것만** `tasks[]`에 배치(마감 없는 할 일은 캘린더 제외). tasks 실패는 부분 실패(`google-tasks`)로 격리.
- `PlannerTask`에 `notes` 추가, `GoogleOAuthProperties`에 `tasksApiBaseUrl`(+yml).

## 테스트
- `GoogleTaskControllerTest` 5/5: 목록/생성(201)/완료 토글/삭제/미연동(409)
- `PlannerCalendarControllerTest`에 합류 테스트 추가(due 기간 필터 + 정규화) — 5/5
- `./gradlew build`(checkstyle 포함) + app-api 전체 스위트 통과

## 비고
- tasks는 캐시하지 않고 피드 조회 시 라이브 fetch(단일 사용자/저트래픽). events 캐시는 task 변경과 무관.
- FE 태스크 표시·완료 토글·CRUD는 #485(M3 FE).