### PR TITLE
feat : Planner 태스크 표시·완료 토글·CRUD

### DIFF
--- a/fe/src/app/router.test.tsx
+++ b/fe/src/app/router.test.tsx
@@ -190,9 +190,9 @@ describe("AppRouter", () => {
 
     renderApp(["/planner/calendar"]);
 
-    // 통합 범례의 "할 일"은 통합 뷰에만 있다(기존 복습 전용 캘린더와 구분).
+    // "+할 일" 버튼은 통합 뷰에만 있다(기존 복습 전용 캘린더와 구분).
     await waitFor(() => {
-      expect(screen.getByText("할 일")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "할 일" })).toBeInTheDocument();
     });
     expect(screen.getByRole("button", { name: "오늘" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "캘린더" })).toBeInTheDocument();

--- a/fe/src/features/planner/api/tasks.ts
+++ b/fe/src/features/planner/api/tasks.ts
@@ -1,0 +1,47 @@
+import { client } from "@/shared/api";
+
+import type { PlannerTask } from "./feed";
+
+export interface TaskCreateRequest {
+  title: string;
+  /** 마감일 "2026-06-12" 또는 null */
+  due: string | null;
+  notes?: string | null;
+}
+
+export interface TaskUpdateRequest {
+  title?: string | null;
+  due?: string | null;
+  notes?: string | null;
+  completed?: boolean;
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export async function createTask(
+  request: TaskCreateRequest,
+): Promise<PlannerTask> {
+  const { data } = await client.post<ApiEnvelope<PlannerTask>>(
+    "/planner/tasks",
+    request,
+  );
+  return data.data;
+}
+
+export async function updateTask(
+  taskId: string,
+  request: TaskUpdateRequest,
+): Promise<PlannerTask> {
+  const { data } = await client.patch<ApiEnvelope<PlannerTask>>(
+    `/planner/tasks/${taskId}`,
+    request,
+  );
+  return data.data;
+}
+
+export async function deleteTask(taskId: string): Promise<void> {
+  await client.delete(`/planner/tasks/${taskId}`);
+}

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
@@ -128,6 +128,77 @@ describe("PlannerCalendar", () => {
     ).toBeInTheDocument();
   });
 
+  const taskOnToday = {
+    id: "t1",
+    title: "리포트",
+    due: TODAY,
+    completed: false,
+    notes: null,
+    source: "google",
+  };
+
+  it("할 일 완료 토글: 체크박스를 누르면 PATCH한다", async () => {
+    mockGoogleConnected(true);
+    mockFeed({ tasks: [taskOnToday] });
+    let patched: unknown = null;
+    server.use(
+      http.patch(`${API_BASE}/planner/tasks/t1`, async ({ request }) => {
+        patched = await request.json();
+        return HttpResponse.json({
+          code: "OK",
+          data: { ...taskOnToday, completed: true },
+        });
+      }),
+    );
+
+    renderWithRouter(<PlannerCalendar />);
+
+    await userEvent.click(await screen.findByLabelText("리포트 완료"));
+
+    await waitFor(() => expect(patched).toMatchObject({ completed: true }));
+  });
+
+  it("할 일 삭제: 삭제 버튼을 누르면 DELETE한다", async () => {
+    mockGoogleConnected(true);
+    mockFeed({ tasks: [taskOnToday] });
+    let deleted = false;
+    server.use(
+      http.delete(`${API_BASE}/planner/tasks/t1`, () => {
+        deleted = true;
+        return HttpResponse.json({ code: "OK", data: null });
+      }),
+    );
+
+    renderWithRouter(<PlannerCalendar />);
+
+    await userEvent.click(await screen.findByLabelText("리포트 삭제"));
+
+    await waitFor(() => expect(deleted).toBe(true));
+  });
+
+  it("+할 일로 할 일을 생성하면 POST한다", async () => {
+    mockGoogleConnected(true);
+    mockFeed({ googleConnected: true });
+    let posted: unknown = null;
+    server.use(
+      http.post(`${API_BASE}/planner/tasks`, async ({ request }) => {
+        posted = await request.json();
+        return HttpResponse.json({
+          code: "OK",
+          data: { ...taskOnToday, id: "new" },
+        });
+      }),
+    );
+
+    renderWithRouter(<PlannerCalendar />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "할 일" }));
+    await userEvent.type(await screen.findByLabelText("제목"), "리포트");
+    await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() => expect(posted).toMatchObject({ title: "리포트" }));
+  });
+
   it("+일정으로 일정을 생성하면 POST하고 다이얼로그를 닫는다", async () => {
     mockGoogleConnected(true);
     mockFeed({ googleConnected: true });

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
+import { CheckSquare, ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,7 @@ import {
 
 import type { EventWriteRequest } from "../../api/events";
 import type { PlannerEvent } from "../../api/feed";
+import type { TaskCreateRequest } from "../../api/tasks";
 import { eventsByDate, reviewsByDate, tasksByDate } from "../../calendar";
 import {
   useCreateEvent,
@@ -20,10 +21,16 @@ import {
   useUpdateEvent,
 } from "../../hooks/useEventMutations";
 import { usePlannerCalendar } from "../../hooks/usePlannerCalendar";
+import {
+  useCreateTask,
+  useDeleteTask,
+  useUpdateTask,
+} from "../../hooks/useTaskMutations";
 import { EventFormDialog } from "./EventFormDialog";
 import { PlannerCalendarCell } from "./PlannerCalendarCell";
 import { PlannerCalendarLegend } from "./PlannerCalendarLegend";
 import { PlannerDayDetailPanel } from "./PlannerDayDetailPanel";
+import { TaskFormDialog } from "./TaskFormDialog";
 
 type DialogState = { mode: "create" | "edit"; event?: PlannerEvent };
 
@@ -77,6 +84,15 @@ export function PlannerCalendar() {
     deleteEvent.mutate(dialog.event.id, { onSuccess: () => setDialog(null) });
   };
 
+  const [taskDialogOpen, setTaskDialogOpen] = useState(false);
+  const createTask = useCreateTask();
+  const updateTask = useUpdateTask();
+  const deleteTask = useDeleteTask();
+
+  const handleTaskCreate = (values: TaskCreateRequest) => {
+    createTask.mutate(values, { onSuccess: () => setTaskDialogOpen(false) });
+  };
+
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -111,6 +127,13 @@ export function PlannerCalendar() {
             }}
           >
             오늘
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setTaskDialogOpen(true)}
+          >
+            <CheckSquare className="size-3.5" />할 일
           </Button>
           <Button size="sm" onClick={() => setDialog({ mode: "create" })}>
             <Plus className="size-3.5" />
@@ -190,6 +213,13 @@ export function PlannerCalendar() {
               tasks={tasksMap.get(selected) ?? []}
               reviews={reviewsMap.get(selected) ?? []}
               onEventClick={(event) => setDialog({ mode: "edit", event })}
+              onTaskToggle={(task) =>
+                updateTask.mutate({
+                  taskId: task.id,
+                  request: { completed: !task.completed },
+                })
+              }
+              onTaskDelete={(task) => deleteTask.mutate(task.id)}
             />
           </CardContent>
         </Card>
@@ -210,6 +240,15 @@ export function PlannerCalendar() {
           onDelete={dialog.mode === "edit" ? handleDelete : undefined}
         />
       )}
+
+      <TaskFormDialog
+        open={taskDialogOpen}
+        onOpenChange={setTaskDialogOpen}
+        googleConnected={googleConnected}
+        defaultDue={selected}
+        pending={createTask.isPending}
+        onSubmit={handleTaskCreate}
+      />
     </div>
   );
 }

--- a/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
@@ -1,3 +1,4 @@
+import { Trash2 } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
@@ -13,6 +14,8 @@ interface Props {
   tasks: PlannerTask[];
   reviews: PlannerReview[];
   onEventClick?: (event: PlannerEvent) => void;
+  onTaskToggle?: (task: PlannerTask) => void;
+  onTaskDelete?: (task: PlannerTask) => void;
 }
 
 function formatHeading(isoDate: string): string {
@@ -26,6 +29,8 @@ export function PlannerDayDetailPanel({
   tasks,
   reviews,
   onEventClick,
+  onTaskToggle,
+  onTaskDelete,
 }: Props) {
   const isEmpty = events.length + tasks.length + reviews.length === 0;
 
@@ -88,15 +93,28 @@ export function PlannerDayDetailPanel({
                     key={task.id}
                     className="border-border bg-card flex items-center gap-2 rounded-md border p-2 text-sm"
                   >
-                    <span aria-hidden>{task.completed ? "☑" : "☐"}</span>
+                    <input
+                      type="checkbox"
+                      checked={task.completed}
+                      onChange={() => onTaskToggle?.(task)}
+                      aria-label={`${task.title} 완료`}
+                    />
                     <span
                       className={cn(
-                        "truncate",
+                        "min-w-0 flex-1 truncate",
                         task.completed && "text-muted-foreground line-through",
                       )}
                     >
                       {task.title}
                     </span>
+                    <button
+                      type="button"
+                      onClick={() => onTaskDelete?.(task)}
+                      aria-label={`${task.title} 삭제`}
+                      className="text-muted-foreground hover:text-destructive shrink-0"
+                    >
+                      <Trash2 className="size-3.5" />
+                    </button>
                   </li>
                 ))}
               </ul>

--- a/fe/src/features/planner/components/calendar/TaskFormDialog.test.tsx
+++ b/fe/src/features/planner/components/calendar/TaskFormDialog.test.tsx
@@ -1,0 +1,46 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithRouter } from "@/test/render";
+
+import { TaskFormDialog } from "./TaskFormDialog";
+
+const baseProps = {
+  open: true,
+  onOpenChange: () => {},
+  defaultDue: "2026-06-12",
+} as const;
+
+describe("TaskFormDialog", () => {
+  it("제목을 입력하고 저장하면 기본 마감일과 함께 요청을 만든다", async () => {
+    const onSubmit = vi.fn();
+    renderWithRouter(
+      <TaskFormDialog {...baseProps} googleConnected onSubmit={onSubmit} />,
+    );
+
+    await userEvent.type(screen.getByLabelText("제목"), "리포트 제출");
+    await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: "리포트 제출",
+      due: "2026-06-12",
+    });
+  });
+
+  it("미연동이면 연결 CTA를 보여주고 폼은 없다", () => {
+    renderWithRouter(
+      <TaskFormDialog
+        {...baseProps}
+        googleConnected={false}
+        onSubmit={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Google 연결이 필요합니다.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Google 연결" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("제목")).not.toBeInTheDocument();
+  });
+});

--- a/fe/src/features/planner/components/calendar/TaskFormDialog.tsx
+++ b/fe/src/features/planner/components/calendar/TaskFormDialog.tsx
@@ -1,0 +1,117 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { useEffect, useId, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { GoogleConnectButton } from "@/features/google/components/GoogleConnectButton";
+
+import type { TaskCreateRequest } from "../../api/tasks";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  googleConnected: boolean;
+  /** 기본 마감일(YYYY-MM-DD) */
+  defaultDue: string;
+  pending?: boolean;
+  onSubmit: (values: TaskCreateRequest) => void;
+}
+
+export function TaskFormDialog({
+  open,
+  onOpenChange,
+  googleConnected,
+  defaultDue,
+  pending = false,
+  onSubmit,
+}: Props) {
+  const titleId = useId();
+  const dueId = useId();
+  const [title, setTitle] = useState("");
+  const [due, setDue] = useState(defaultDue);
+
+  useEffect(() => {
+    if (open) {
+      setTitle("");
+      setDue(defaultDue);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const valid = title.trim().length > 0;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!valid || pending) return;
+    onSubmit({ title: title.trim(), due: due || null });
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
+        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+          <Dialog.Title className="text-base font-semibold">
+            할 일 추가
+          </Dialog.Title>
+
+          {!googleConnected ? (
+            <div className="mt-4 flex flex-col gap-4">
+              <p className="text-muted-foreground text-sm">
+                Google 연결이 필요합니다.
+              </p>
+              <div className="flex justify-end gap-2">
+                <Dialog.Close
+                  render={
+                    <Button variant="ghost" type="button">
+                      닫기
+                    </Button>
+                  }
+                />
+                <GoogleConnectButton />
+              </div>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3">
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor={titleId} className="text-sm font-medium">
+                  제목
+                </label>
+                <Input
+                  id={titleId}
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  autoFocus
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor={dueId} className="text-sm font-medium">
+                  마감일 (선택)
+                </label>
+                <Input
+                  id={dueId}
+                  type="date"
+                  value={due}
+                  onChange={(e) => setDue(e.target.value)}
+                />
+              </div>
+
+              <div className="mt-1 flex justify-end gap-2">
+                <Dialog.Close
+                  render={
+                    <Button variant="ghost" type="button" disabled={pending}>
+                      취소
+                    </Button>
+                  }
+                />
+                <Button type="submit" disabled={!valid || pending}>
+                  {pending ? "저장 중..." : "저장"}
+                </Button>
+              </div>
+            </form>
+          )}
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/fe/src/features/planner/hooks/useTaskMutations.ts
+++ b/fe/src/features/planner/hooks/useTaskMutations.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { toast } from "@/shared/lib/toast";
+
+import {
+  createTask,
+  deleteTask,
+  type TaskUpdateRequest,
+  updateTask,
+} from "../api/tasks";
+import { plannerKeys } from "../queryKeys";
+
+export function useCreateTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createTask,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: plannerKeys.all });
+      toast("할 일을 추가했습니다.", "success");
+    },
+    onError: () => toast("할 일 추가에 실패했습니다.", "error"),
+  });
+}
+
+/** 완료 토글/수정. 토글이 잦아 성공 토스트는 생략하고 invalidate로만 갱신한다. */
+export function useUpdateTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      taskId,
+      request,
+    }: {
+      taskId: string;
+      request: TaskUpdateRequest;
+    }) => updateTask(taskId, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: plannerKeys.all });
+    },
+    onError: () => toast("할 일 변경에 실패했습니다.", "error"),
+  });
+}
+
+export function useDeleteTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteTask,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: plannerKeys.all });
+      toast("할 일을 삭제했습니다.", "success");
+    },
+    onError: () => toast("할 일 삭제에 실패했습니다.", "error"),
+  });
+}


### PR DESCRIPTION
## 이슈
closes #485

## 작업 내용
Epic #472 M3 마무리. 통합 캘린더에서 할 일 표시 + 완료 토글 + 생성/삭제. (deps #484, #483)

- **Tasks API/훅** (`api/tasks.ts`, `useTaskMutations`): create/update(토글)/delete → `plannerKeys` invalidate. 토글은 잦아 토스트 생략, 생성/삭제는 토스트.
- **`TaskFormDialog`**: 제목 + 마감일(선택) 생성 폼. 미연동 시 "Google 연결이 필요합니다" + 연결 버튼(#477 재사용).
- **그날 상세 패널**: 할 일에 **체크박스 완료 토글**(완료 시 취소선) + **삭제 버튼**. 복습은 readOnly 유지.
- **헤더 `+할 일` 버튼** → 생성 다이얼로그(선택된 날짜를 기본 마감일로).
- 셀의 할 일 칩(🟩 점)은 기존 표시 유지.

## 테스트 (RTL + MSW)
- `TaskFormDialog`: 생성(제목+마감일 요청) / 미연동(연결 CTA) — 2
- `PlannerCalendar`: 완료 토글 PATCH / 삭제 DELETE / `+할 일` 생성 POST — 3
- `+할 일` 버튼 추가로 "할 일" 텍스트가 범례·버튼 두 곳이 되어 `router.test.tsx` 마커를 버튼 기준으로 갱신
- FE 전체 129개 통과, tsc·eslint·format:check clean

## 비고
- M3(태스크) 완료. 다음 M4는 뷰 확장(#486 주 뷰, #487 일 뷰).