### PR TITLE
feat : Planner 주 뷰 (시간축 그리드)

### DIFF
--- a/fe/src/features/planner/components/calendar/EventFormDialog.tsx
+++ b/fe/src/features/planner/components/calendar/EventFormDialog.tsx
@@ -26,6 +26,8 @@ interface Props {
   googleConnected: boolean;
   /** 생성 시 기본 날짜(YYYY-MM-DD) */
   defaultDate: string;
+  /** 생성 시 기본 시작 시각("HH:mm"). 주 뷰 슬롯 클릭에서 사용. */
+  defaultStartTime?: string;
   /** 편집 대상 일정 */
   event?: PlannerEvent;
   pending?: boolean;
@@ -33,9 +35,16 @@ interface Props {
   onDelete?: () => void;
 }
 
+/** "09:00" → "10:00" (다음 정시, 23시는 23:59). */
+function nextHour(time: string): string {
+  const hour = Number(time.slice(0, 2));
+  return hour >= 23 ? "23:59" : `${String(hour + 1).padStart(2, "0")}:00`;
+}
+
 function initialState(
   mode: "create" | "edit",
   defaultDate: string,
+  defaultStartTime: string,
   event?: PlannerEvent,
 ): FormState {
   if (mode === "edit" && event) {
@@ -55,9 +64,9 @@ function initialState(
     title: "",
     allDay: false,
     startDate: defaultDate,
-    startTime: "09:00",
+    startTime: defaultStartTime,
     endDate: defaultDate,
-    endTime: "10:00",
+    endTime: nextHour(defaultStartTime),
     location: "",
     description: "",
   };
@@ -69,6 +78,7 @@ export function EventFormDialog({
   mode,
   googleConnected,
   defaultDate,
+  defaultStartTime = "09:00",
   event,
   pending = false,
   onSubmit,
@@ -76,12 +86,12 @@ export function EventFormDialog({
 }: Props) {
   const titleId = useId();
   const [form, setForm] = useState<FormState>(() =>
-    initialState(mode, defaultDate, event),
+    initialState(mode, defaultDate, defaultStartTime, event),
   );
 
   useEffect(() => {
     if (open) {
-      setForm(initialState(mode, defaultDate, event));
+      setForm(initialState(mode, defaultDate, defaultStartTime, event));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
@@ -235,4 +235,45 @@ describe("PlannerCalendar", () => {
       expect(screen.queryByLabelText("제목")).not.toBeInTheDocument(),
     );
   });
+
+  it("주 뷰로 전환하면 시간축과 시간대 일정 블록을 보여준다", async () => {
+    mockGoogleConnected(true);
+    mockFeed({
+      googleConnected: true,
+      events: [
+        {
+          id: "e1",
+          title: "회의",
+          allDay: false,
+          start: `${TODAY}T09:00:00`,
+          end: `${TODAY}T10:00:00`,
+          location: null,
+          recurring: false,
+          source: "google",
+        },
+      ],
+    });
+
+    renderWithRouter(<PlannerCalendar />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "주" }));
+
+    expect(await screen.findByText("9시")).toBeInTheDocument();
+    expect(await screen.findByText("회의")).toBeInTheDocument();
+  });
+
+  it("주 뷰 빈 시간대 클릭 시 그 시각으로 생성 다이얼로그가 열린다", async () => {
+    mockGoogleConnected(true);
+    mockFeed({ googleConnected: true });
+
+    renderWithRouter(<PlannerCalendar />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "주" }));
+    await userEvent.click(
+      await screen.findByLabelText(`${TODAY} 10시 일정 추가`),
+    );
+
+    expect(await screen.findByLabelText("제목")).toBeInTheDocument();
+    expect(screen.getByLabelText("시작 시간")).toHaveValue("10:00");
+  });
 });

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { GoogleNotConnectedBanner } from "@/features/google/components/GoogleNotConnectedBanner";
 import {
+  addDays,
   addMonths,
   monthGridDays,
   startOfDay,
@@ -26,32 +27,38 @@ import {
   useDeleteTask,
   useUpdateTask,
 } from "../../hooks/useTaskMutations";
+import { weekDays } from "../../weekLayout";
 import { EventFormDialog } from "./EventFormDialog";
 import { PlannerCalendarCell } from "./PlannerCalendarCell";
 import { PlannerCalendarLegend } from "./PlannerCalendarLegend";
 import { PlannerDayDetailPanel } from "./PlannerDayDetailPanel";
+import { PlannerWeekView } from "./PlannerWeekView";
 import { TaskFormDialog } from "./TaskFormDialog";
 
-type DialogState = { mode: "create" | "edit"; event?: PlannerEvent };
+type CalendarView = "month" | "week";
+type DialogState =
+  | { mode: "create"; date?: string; startTime?: string }
+  | { mode: "edit"; event: PlannerEvent };
 
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
 
-/** 통합 캘린더 월 뷰 — 일정(Google) + 할 일 + 복습(읽기 전용)을 한 그리드에 렌더한다. */
+/** 통합 캘린더 — 월/주 뷰 전환. 일정(Google) + 할 일 + 복습(읽기 전용). */
 export function PlannerCalendar() {
   const today = useMemo(() => startOfDay(new Date()), []);
   const todayIso = toIsoDate(today);
 
-  const [cursor, setCursor] = useState(
-    () => new Date(today.getFullYear(), today.getMonth(), 1),
-  );
+  const [view, setView] = useState<CalendarView>("month");
+  const [cursor, setCursor] = useState<Date>(today);
   const [selected, setSelected] = useState<string>(todayIso);
 
-  const gridDays = useMemo(
+  const monthDays = useMemo(
     () => monthGridDays(cursor.getFullYear(), cursor.getMonth()),
     [cursor],
   );
-  const from = toIsoDate(gridDays[0]);
-  const to = toIsoDate(gridDays[gridDays.length - 1]);
+  const week = useMemo(() => weekDays(cursor), [cursor]);
+  const days = view === "month" ? monthDays : week;
+  const from = toIsoDate(days[0]);
+  const to = toIsoDate(days[days.length - 1]);
 
   const { data, isLoading } = usePlannerCalendar(from, to);
 
@@ -69,7 +76,7 @@ export function PlannerCalendar() {
     createEvent.isPending || updateEvent.isPending || deleteEvent.isPending;
 
   const handleSubmit = (values: EventWriteRequest) => {
-    if (dialog?.mode === "edit" && dialog.event) {
+    if (dialog?.mode === "edit") {
       updateEvent.mutate(
         { eventId: dialog.event.id, request: values },
         { onSuccess: () => setDialog(null) },
@@ -80,7 +87,7 @@ export function PlannerCalendar() {
   };
 
   const handleDelete = () => {
-    if (dialog?.mode !== "edit" || !dialog.event) return;
+    if (dialog?.mode !== "edit") return;
     deleteEvent.mutate(dialog.event.id, { onSuccess: () => setDialog(null) });
   };
 
@@ -93,6 +100,17 @@ export function PlannerCalendar() {
     createTask.mutate(values, { onSuccess: () => setTaskDialogOpen(false) });
   };
 
+  const goPrev = () =>
+    setCursor((c) => (view === "month" ? addMonths(c, -1) : addDays(c, -7)));
+  const goNext = () =>
+    setCursor((c) => (view === "month" ? addMonths(c, 1) : addDays(c, 7)));
+
+  const periodTitle =
+    view === "month"
+      ? `${cursor.getFullYear()}년 ${cursor.getMonth() + 1}월`
+      : `${week[0].getMonth() + 1}월 ${week[0].getDate()}일 – ` +
+        `${week[6].getMonth() + 1}월 ${week[6].getDate()}일`;
+
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -100,29 +118,45 @@ export function PlannerCalendar() {
           <Button
             variant="ghost"
             size="icon-sm"
-            aria-label="이전 달"
-            onClick={() => setCursor((c) => addMonths(c, -1))}
+            aria-label="이전 기간"
+            onClick={goPrev}
           >
             <ChevronLeft className="size-4" />
           </Button>
-          <h1 className="text-xl font-semibold">
-            {cursor.getFullYear()}년 {cursor.getMonth() + 1}월
-          </h1>
+          <h1 className="text-xl font-semibold">{periodTitle}</h1>
           <Button
             variant="ghost"
             size="icon-sm"
-            aria-label="다음 달"
-            onClick={() => setCursor((c) => addMonths(c, 1))}
+            aria-label="다음 기간"
+            onClick={goNext}
           >
             <ChevronRight className="size-4" />
           </Button>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex gap-1">
+            <Button
+              variant={view === "month" ? "default" : "outline"}
+              size="sm"
+              aria-pressed={view === "month"}
+              onClick={() => setView("month")}
+            >
+              월
+            </Button>
+            <Button
+              variant={view === "week" ? "default" : "outline"}
+              size="sm"
+              aria-pressed={view === "week"}
+              onClick={() => setView("week")}
+            >
+              주
+            </Button>
+          </div>
           <Button
             variant="outline"
             size="sm"
             onClick={() => {
-              setCursor(new Date(today.getFullYear(), today.getMonth(), 1));
+              setCursor(today);
               setSelected(todayIso);
             }}
           >
@@ -155,75 +189,100 @@ export function PlannerCalendar() {
 
       <PlannerCalendarLegend />
 
-      <div className="grid gap-6 lg:grid-cols-[1fr_20rem]">
-        <Card>
-          <CardContent className="flex flex-col gap-2">
-            <div className="grid grid-cols-7 gap-1">
-              {WEEKDAYS.map((w, i) => (
-                <div
-                  key={w}
-                  className={
-                    "text-muted-foreground py-1 text-center text-xs font-medium" +
-                    (i === 0 ? " text-red-500" : "")
-                  }
-                >
-                  {w}
-                </div>
-              ))}
-            </div>
-            {isLoading ? (
-              <div className="grid grid-cols-7 gap-1" aria-label="불러오는 중">
-                {Array.from({ length: 42 }, (_, i) => (
-                  <div
-                    key={i}
-                    className="bg-muted/50 min-h-16 animate-pulse rounded-md"
-                  />
-                ))}
-              </div>
-            ) : (
-              <div className="grid grid-cols-7 gap-1">
-                {gridDays.map((date) => {
-                  const iso = toIsoDate(date);
-                  return (
-                    <PlannerCalendarCell
-                      key={iso}
-                      date={date}
-                      isoDate={iso}
-                      inMonth={date.getMonth() === cursor.getMonth()}
-                      isToday={iso === todayIso}
-                      isSelected={iso === selected}
-                      events={eventsMap.get(iso) ?? []}
-                      tasks={tasksMap.get(iso) ?? []}
-                      reviews={reviewsMap.get(iso) ?? []}
-                      today={today}
-                      onSelect={setSelected}
-                    />
-                  );
-                })}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
+      {view === "week" ? (
         <Card>
           <CardContent>
-            <PlannerDayDetailPanel
-              isoDate={selected}
-              events={eventsMap.get(selected) ?? []}
-              tasks={tasksMap.get(selected) ?? []}
-              reviews={reviewsMap.get(selected) ?? []}
+            <PlannerWeekView
+              days={week}
+              eventsMap={eventsMap}
+              tasksMap={tasksMap}
+              reviewsMap={reviewsMap}
+              todayIso={todayIso}
               onEventClick={(event) => setDialog({ mode: "edit", event })}
-              onTaskToggle={(task) =>
-                updateTask.mutate({
-                  taskId: task.id,
-                  request: { completed: !task.completed },
+              onSlotClick={(isoDate, hour) =>
+                setDialog({
+                  mode: "create",
+                  date: isoDate,
+                  startTime: `${String(hour).padStart(2, "0")}:00`,
                 })
               }
-              onTaskDelete={(task) => deleteTask.mutate(task.id)}
             />
           </CardContent>
         </Card>
-      </div>
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-[1fr_20rem]">
+          <Card>
+            <CardContent className="flex flex-col gap-2">
+              <div className="grid grid-cols-7 gap-1">
+                {WEEKDAYS.map((w, i) => (
+                  <div
+                    key={w}
+                    className={
+                      "text-muted-foreground py-1 text-center text-xs font-medium" +
+                      (i === 0 ? " text-red-500" : "")
+                    }
+                  >
+                    {w}
+                  </div>
+                ))}
+              </div>
+              {isLoading ? (
+                <div
+                  className="grid grid-cols-7 gap-1"
+                  aria-label="불러오는 중"
+                >
+                  {Array.from({ length: 42 }, (_, i) => (
+                    <div
+                      key={i}
+                      className="bg-muted/50 min-h-16 animate-pulse rounded-md"
+                    />
+                  ))}
+                </div>
+              ) : (
+                <div className="grid grid-cols-7 gap-1">
+                  {monthDays.map((date) => {
+                    const iso = toIsoDate(date);
+                    return (
+                      <PlannerCalendarCell
+                        key={iso}
+                        date={date}
+                        isoDate={iso}
+                        inMonth={date.getMonth() === cursor.getMonth()}
+                        isToday={iso === todayIso}
+                        isSelected={iso === selected}
+                        events={eventsMap.get(iso) ?? []}
+                        tasks={tasksMap.get(iso) ?? []}
+                        reviews={reviewsMap.get(iso) ?? []}
+                        today={today}
+                        onSelect={setSelected}
+                      />
+                    );
+                  })}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent>
+              <PlannerDayDetailPanel
+                isoDate={selected}
+                events={eventsMap.get(selected) ?? []}
+                tasks={tasksMap.get(selected) ?? []}
+                reviews={reviewsMap.get(selected) ?? []}
+                onEventClick={(event) => setDialog({ mode: "edit", event })}
+                onTaskToggle={(task) =>
+                  updateTask.mutate({
+                    taskId: task.id,
+                    request: { completed: !task.completed },
+                  })
+                }
+                onTaskDelete={(task) => deleteTask.mutate(task.id)}
+              />
+            </CardContent>
+          </Card>
+        </div>
+      )}
 
       {dialog && (
         <EventFormDialog
@@ -233,8 +292,13 @@ export function PlannerCalendar() {
           }}
           mode={dialog.mode}
           googleConnected={googleConnected}
-          defaultDate={selected}
-          event={dialog.event}
+          defaultDate={
+            dialog.mode === "create" ? (dialog.date ?? selected) : selected
+          }
+          defaultStartTime={
+            dialog.mode === "create" ? dialog.startTime : undefined
+          }
+          event={dialog.mode === "edit" ? dialog.event : undefined}
           pending={pending}
           onSubmit={handleSubmit}
           onDelete={dialog.mode === "edit" ? handleDelete : undefined}

--- a/fe/src/features/planner/components/calendar/PlannerWeekView.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerWeekView.tsx
@@ -1,0 +1,162 @@
+import { toIsoDate } from "@/features/review/calendar";
+import { cn } from "@/lib/utils";
+
+import type { PlannerEvent, PlannerReview, PlannerTask } from "../../api/feed";
+import { eventTimeLabel } from "../../calendar";
+import { HOURS, layoutDayEvents } from "../../weekLayout";
+
+const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
+const HOUR_PX = 40;
+const GRID_COLS = "grid-cols-[3rem_repeat(7,minmax(0,1fr))]";
+
+interface Props {
+  days: Date[];
+  eventsMap: Map<string, PlannerEvent[]>;
+  tasksMap: Map<string, PlannerTask[]>;
+  reviewsMap: Map<string, PlannerReview[]>;
+  todayIso: string;
+  onEventClick: (event: PlannerEvent) => void;
+  onSlotClick: (isoDate: string, hour: number) => void;
+}
+
+export function PlannerWeekView({
+  days,
+  eventsMap,
+  tasksMap,
+  reviewsMap,
+  todayIso,
+  onEventClick,
+  onSlotClick,
+}: Props) {
+  return (
+    <div className="overflow-x-auto">
+      <div className="min-w-[44rem]">
+        {/* 요일/날짜 헤더 */}
+        <div className={cn("grid", GRID_COLS)}>
+          <div />
+          {days.map((day) => {
+            const iso = toIsoDate(day);
+            return (
+              <div
+                key={iso}
+                className={cn(
+                  "py-1 text-center text-xs font-medium",
+                  iso === todayIso && "text-primary font-semibold",
+                  day.getDay() === 0 && "text-red-500",
+                )}
+              >
+                {WEEKDAYS[day.getDay()]} {day.getDate()}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* 종일/복습/할일 레인 */}
+        <div className={cn("grid border-b", GRID_COLS)}>
+          <div className="text-muted-foreground py-1 pr-1 text-right text-[10px]">
+            종일
+          </div>
+          {days.map((day) => {
+            const iso = toIsoDate(day);
+            const allDayEvents = (eventsMap.get(iso) ?? []).filter(
+              (e) => e.allDay,
+            );
+            const dayTasks = tasksMap.get(iso) ?? [];
+            const reviewCount = (reviewsMap.get(iso) ?? []).length;
+            return (
+              <div
+                key={iso}
+                className="border-border/50 flex min-h-7 flex-col gap-0.5 border-l p-0.5"
+              >
+                {allDayEvents.map((e) => (
+                  <button
+                    key={e.id}
+                    type="button"
+                    onClick={() => onEventClick(e)}
+                    className="truncate rounded bg-blue-500 px-1 text-left text-[10px] text-white"
+                  >
+                    {e.title ?? "(제목 없음)"}
+                  </button>
+                ))}
+                {dayTasks.map((t) => (
+                  <span
+                    key={t.id}
+                    className="truncate rounded bg-emerald-500 px-1 text-[10px] text-white"
+                  >
+                    ☑ {t.title}
+                  </span>
+                ))}
+                {reviewCount > 0 && (
+                  <span className="bg-primary text-primary-foreground truncate rounded px-1 text-[10px]">
+                    복습 {reviewCount}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* 시간축 그리드 */}
+        <div className={cn("grid", GRID_COLS)}>
+          {/* 시간 라벨 */}
+          <div>
+            {HOURS.map((h) => (
+              <div
+                key={h}
+                style={{ height: HOUR_PX }}
+                className="text-muted-foreground pr-1 text-right text-[10px]"
+              >
+                {h}시
+              </div>
+            ))}
+          </div>
+
+          {/* 요일별 컬럼 */}
+          {days.map((day) => {
+            const iso = toIsoDate(day);
+            const positioned = layoutDayEvents(eventsMap.get(iso) ?? []);
+            return (
+              <div
+                key={iso}
+                className="border-border/50 relative border-l"
+                style={{ height: HOUR_PX * 24 }}
+              >
+                {HOURS.map((h) => (
+                  <button
+                    key={h}
+                    type="button"
+                    onClick={() => onSlotClick(iso, h)}
+                    style={{ height: HOUR_PX }}
+                    aria-label={`${iso} ${h}시 일정 추가`}
+                    className="border-border/40 hover:bg-muted/40 block w-full border-t"
+                  />
+                ))}
+                {positioned.map((p) => (
+                  <button
+                    key={p.event.id}
+                    type="button"
+                    onClick={() => onEventClick(p.event)}
+                    style={{
+                      top: `${p.top * 100}%`,
+                      height: `${p.height * 100}%`,
+                      left: `${p.left * 100}%`,
+                      width: `${p.width * 100}%`,
+                    }}
+                    className="absolute overflow-hidden rounded border border-blue-600 bg-blue-500 px-1 py-0.5 text-left text-[10px] leading-tight text-white"
+                  >
+                    <span className="block truncate font-medium">
+                      {p.event.title ?? "(제목 없음)"}
+                    </span>
+                    <span className="block truncate opacity-90">
+                      {eventTimeLabel(p.event)}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/planner/weekLayout.test.ts
+++ b/fe/src/features/planner/weekLayout.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import type { PlannerEvent } from "./api/feed";
+import { layoutDayEvents, weekDays } from "./weekLayout";
+
+function timed(id: string, start: string, end: string | null): PlannerEvent {
+  return {
+    id,
+    title: id,
+    allDay: false,
+    start,
+    end,
+    location: null,
+    recurring: false,
+    source: "google",
+  };
+}
+
+describe("weekDays", () => {
+  it("cursor가 속한 일요일 시작 주의 7일을 반환한다", () => {
+    // 2026-06-10은 수요일
+    const days = weekDays(new Date(2026, 5, 10));
+    expect(days).toHaveLength(7);
+    expect(days[0].getDay()).toBe(0); // 일요일
+    expect(days[0].getDate()).toBe(7); // 6/7(일)
+    expect(days[6].getDate()).toBe(13); // 6/13(토)
+  });
+});
+
+describe("layoutDayEvents", () => {
+  it("종일/날짜 일정은 제외한다", () => {
+    const allDay: PlannerEvent = {
+      ...timed("a", "2026-06-10", null),
+      allDay: true,
+    };
+    expect(layoutDayEvents([allDay])).toHaveLength(0);
+  });
+
+  it("겹치지 않는 일정은 전체 너비를 차지한다", () => {
+    const result = layoutDayEvents([
+      timed("a", "2026-06-10T09:00:00", "2026-06-10T10:00:00"),
+      timed("b", "2026-06-10T11:00:00", "2026-06-10T12:00:00"),
+    ]);
+    expect(result).toHaveLength(2);
+    for (const p of result) {
+      expect(p.left).toBe(0);
+      expect(p.width).toBe(1);
+    }
+    const a = result.find((p) => p.event.id === "a")!;
+    expect(a.top).toBeCloseTo(9 / 24);
+    expect(a.height).toBeCloseTo(1 / 24);
+  });
+
+  it("겹치는 두 일정은 절반씩 나눠 나란히 배치한다", () => {
+    const result = layoutDayEvents([
+      timed("a", "2026-06-10T09:00:00", "2026-06-10T10:30:00"),
+      timed("b", "2026-06-10T10:00:00", "2026-06-10T11:00:00"),
+    ]);
+    expect(result).toHaveLength(2);
+    const a = result.find((p) => p.event.id === "a")!;
+    const b = result.find((p) => p.event.id === "b")!;
+    expect(a.width).toBeCloseTo(0.5);
+    expect(b.width).toBeCloseTo(0.5);
+    expect(new Set([a.left, b.left])).toEqual(new Set([0, 0.5]));
+  });
+
+  it("끝나는 일정의 컬럼을 재사용한다(3개: A겹침B, A끝난뒤 C)", () => {
+    const result = layoutDayEvents([
+      timed("a", "2026-06-10T09:00:00", "2026-06-10T10:00:00"),
+      timed("b", "2026-06-10T09:30:00", "2026-06-10T11:00:00"),
+      timed("c", "2026-06-10T10:00:00", "2026-06-10T10:45:00"),
+    ]);
+    // A,B 겹침 → 2컬럼. C는 A 끝난 뒤 시작이라 A 컬럼 재사용(같은 클러스터, 2컬럼 유지)
+    const c = result.find((p) => p.event.id === "c")!;
+    expect(c.width).toBeCloseTo(0.5);
+    expect(c.left).toBe(0);
+  });
+
+  it("end가 없으면 1시간으로, 너무 짧으면 최소 30분으로 본다", () => {
+    const result = layoutDayEvents([
+      timed("a", "2026-06-10T09:00:00", null),
+      timed("b", "2026-06-10T13:00:00", "2026-06-10T13:05:00"),
+    ]);
+    const a = result.find((p) => p.event.id === "a")!;
+    const b = result.find((p) => p.event.id === "b")!;
+    expect(a.height).toBeCloseTo(1 / 24); // 1시간
+    expect(b.height).toBeCloseTo(0.5 / 24); // 최소 30분
+  });
+});

--- a/fe/src/features/planner/weekLayout.ts
+++ b/fe/src/features/planner/weekLayout.ts
@@ -1,0 +1,93 @@
+import { addDays, startOfDay } from "@/features/review/calendar";
+
+import type { PlannerEvent } from "./api/feed";
+
+export const HOURS = Array.from({ length: 24 }, (_, i) => i);
+const MINUTES_PER_DAY = 24 * 60;
+
+/** cursor가 속한 일요일 시작 주의 7일. */
+export function weekDays(cursor: Date): Date[] {
+  const base = startOfDay(cursor);
+  const sunday = addDays(base, -base.getDay());
+  return Array.from({ length: 7 }, (_, i) => addDays(sunday, i));
+}
+
+/** "2026-06-10T14:30:00" → 자정 기준 분(870). */
+function minutesOf(datetime: string): number {
+  const hour = Number(datetime.slice(11, 13));
+  const minute = Number(datetime.slice(14, 16));
+  return hour * 60 + minute;
+}
+
+export interface PositionedEvent {
+  event: PlannerEvent;
+  /** 모두 0..1 비율: top/height는 하루 높이 대비, left/width는 컬럼 너비 대비. */
+  top: number;
+  height: number;
+  left: number;
+  width: number;
+}
+
+interface Block {
+  event: PlannerEvent;
+  startMin: number;
+  endMin: number;
+}
+
+/**
+ * 하루의 시간대 일정(종일 제외)을 겹침 분할 배치한다.
+ * 겹치는 일정들은 한 클러스터로 묶어 컬럼을 나눠(left/width) 나란히 둔다.
+ */
+export function layoutDayEvents(events: PlannerEvent[]): PositionedEvent[] {
+  const blocks: Block[] = events
+    .filter((e) => !e.allDay && e.start.includes("T"))
+    .map((e) => {
+      const startMin = minutesOf(e.start);
+      const endMin = e.end ? minutesOf(e.end) : startMin + 60;
+      return {
+        event: e,
+        startMin,
+        endMin: Math.min(Math.max(endMin, startMin + 30), MINUTES_PER_DAY),
+      };
+    })
+    .sort((a, b) => a.startMin - b.startMin || a.endMin - b.endMin);
+
+  const result: PositionedEvent[] = [];
+  let cluster: { block: Block; col: number }[] = [];
+  let columns: number[] = []; // 컬럼별 마지막 endMin
+  let clusterEnd = -1;
+
+  const flush = () => {
+    const cols = columns.length || 1;
+    for (const { block, col } of cluster) {
+      result.push({
+        event: block.event,
+        top: block.startMin / MINUTES_PER_DAY,
+        height: (block.endMin - block.startMin) / MINUTES_PER_DAY,
+        left: col / cols,
+        width: 1 / cols,
+      });
+    }
+    cluster = [];
+    columns = [];
+    clusterEnd = -1;
+  };
+
+  for (const block of blocks) {
+    if (cluster.length > 0 && block.startMin >= clusterEnd) {
+      flush();
+    }
+    let col = columns.findIndex((end) => end <= block.startMin);
+    if (col === -1) {
+      col = columns.length;
+      columns.push(block.endMin);
+    } else {
+      columns[col] = block.endMin;
+    }
+    cluster.push({ block, col });
+    clusterEnd = Math.max(clusterEnd, block.endMin);
+  }
+  flush();
+
+  return result;
+}


### PR DESCRIPTION
## 이슈
closes #486

## 작업 내용
Epic #472 M4. 월/주 뷰 전환 + 주 뷰(시간축 그리드). (deps #480)

- **`weekLayout.ts`** (순수, 테스트 핵심): 주 7일 계산(`weekDays`) + **시간대 일정 겹침 분할 배치**(`layoutDayEvents`) — 겹치는 일정을 클러스터로 묶어 컬럼을 나눠 left/width 산출, 끝난 일정의 컬럼 재사용.
- **`PlannerWeekView`**: 24h 좌측 시간축 + 7일 컬럼 그리드. 상단 **종일/복습/할일 레인**. 시간대 일정은 절대 배치 블록(겹침 분할). 빈 시간대 클릭 → 그 시각 일정 생성, 일정 블록 클릭 → 편집.
- **`PlannerCalendar`**: **[월][주] 토글** + 기간 네비(월 ±1개월 / 주 ±7일) + 제목 적응. 월=그리드+상세패널, 주=시간축 그리드.
- **`EventFormDialog`**: `defaultStartTime` 추가 — 주 뷰 슬롯 클릭 시 클릭한 시각이 기본 시작 시간(+1h 종료).

## 테스트 (Vitest + RTL)
- `weekLayout`: 주 날짜 / 종일 제외 / 비겹침 전체너비 / 겹침 절반분할 / 컬럼 재사용 / 기본·최소 길이 — 6
- `PlannerCalendar`: 주 뷰 전환 시 시간축+일정 블록 / 빈 슬롯 클릭→그 시각 생성 다이얼로그 — 2
- FE 전체 137개 통과, tsc·eslint·format:check clean

## 비고
- 드래그 이동/리사이즈는 범위 밖(차기). 일 뷰는 #487에서 이 컴포넌트를 단일 컬럼으로 재사용 예정.