### PR TITLE
feat : Planner 일 뷰

### DIFF
--- a/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
@@ -276,4 +276,30 @@ describe("PlannerCalendar", () => {
     expect(await screen.findByLabelText("제목")).toBeInTheDocument();
     expect(screen.getByLabelText("시작 시간")).toHaveValue("10:00");
   });
+
+  it("일 뷰로 전환하면 단일 날짜의 시간축과 일정을 보여준다", async () => {
+    mockGoogleConnected(true);
+    mockFeed({
+      events: [
+        {
+          id: "e1",
+          title: "회의",
+          allDay: false,
+          start: `${TODAY}T09:00:00`,
+          end: `${TODAY}T10:00:00`,
+          location: null,
+          recurring: false,
+          source: "google",
+        },
+      ],
+    });
+
+    renderWithRouter(<PlannerCalendar />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "일" }));
+
+    expect(await screen.findByText("9시")).toBeInTheDocument();
+    expect(await screen.findByText("회의")).toBeInTheDocument();
+    expect(screen.getByLabelText(`${TODAY} 9시 일정 추가`)).toBeInTheDocument();
+  });
 });

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
@@ -35,14 +35,14 @@ import { PlannerDayDetailPanel } from "./PlannerDayDetailPanel";
 import { PlannerWeekView } from "./PlannerWeekView";
 import { TaskFormDialog } from "./TaskFormDialog";
 
-type CalendarView = "month" | "week";
+type CalendarView = "month" | "week" | "day";
 type DialogState =
   | { mode: "create"; date?: string; startTime?: string }
   | { mode: "edit"; event: PlannerEvent };
 
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
 
-/** 통합 캘린더 — 월/주 뷰 전환. 일정(Google) + 할 일 + 복습(읽기 전용). */
+/** 통합 캘린더 — 월/주/일 뷰 전환. 일정(Google) + 할 일 + 복습(읽기 전용). */
 export function PlannerCalendar() {
   const today = useMemo(() => startOfDay(new Date()), []);
   const todayIso = toIsoDate(today);
@@ -56,7 +56,8 @@ export function PlannerCalendar() {
     [cursor],
   );
   const week = useMemo(() => weekDays(cursor), [cursor]);
-  const days = view === "month" ? monthDays : week;
+  const single = useMemo(() => [startOfDay(cursor)], [cursor]);
+  const days = view === "month" ? monthDays : view === "week" ? week : single;
   const from = toIsoDate(days[0]);
   const to = toIsoDate(days[days.length - 1]);
 
@@ -100,16 +101,24 @@ export function PlannerCalendar() {
     createTask.mutate(values, { onSuccess: () => setTaskDialogOpen(false) });
   };
 
+  const step = view === "month" ? 0 : view === "week" ? 7 : 1;
   const goPrev = () =>
-    setCursor((c) => (view === "month" ? addMonths(c, -1) : addDays(c, -7)));
+    setCursor((c) => (view === "month" ? addMonths(c, -1) : addDays(c, -step)));
   const goNext = () =>
-    setCursor((c) => (view === "month" ? addMonths(c, 1) : addDays(c, 7)));
+    setCursor((c) => (view === "month" ? addMonths(c, 1) : addDays(c, step)));
 
-  const periodTitle =
-    view === "month"
-      ? `${cursor.getFullYear()}년 ${cursor.getMonth() + 1}월`
-      : `${week[0].getMonth() + 1}월 ${week[0].getDate()}일 – ` +
-        `${week[6].getMonth() + 1}월 ${week[6].getDate()}일`;
+  let periodTitle: string;
+  if (view === "month") {
+    periodTitle = `${cursor.getFullYear()}년 ${cursor.getMonth() + 1}월`;
+  } else if (view === "week") {
+    periodTitle =
+      `${week[0].getMonth() + 1}월 ${week[0].getDate()}일 – ` +
+      `${week[6].getMonth() + 1}월 ${week[6].getDate()}일`;
+  } else {
+    periodTitle =
+      `${single[0].getMonth() + 1}월 ${single[0].getDate()}일 ` +
+      `(${WEEKDAYS[single[0].getDay()]})`;
+  }
 
   return (
     <div className="flex flex-col gap-6">
@@ -135,22 +144,23 @@ export function PlannerCalendar() {
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <div className="flex gap-1">
-            <Button
-              variant={view === "month" ? "default" : "outline"}
-              size="sm"
-              aria-pressed={view === "month"}
-              onClick={() => setView("month")}
-            >
-              월
-            </Button>
-            <Button
-              variant={view === "week" ? "default" : "outline"}
-              size="sm"
-              aria-pressed={view === "week"}
-              onClick={() => setView("week")}
-            >
-              주
-            </Button>
+            {(
+              [
+                ["month", "월"],
+                ["week", "주"],
+                ["day", "일"],
+              ] as const
+            ).map(([value, label]) => (
+              <Button
+                key={value}
+                variant={view === value ? "default" : "outline"}
+                size="sm"
+                aria-pressed={view === value}
+                onClick={() => setView(value)}
+              >
+                {label}
+              </Button>
+            ))}
           </div>
           <Button
             variant="outline"
@@ -189,11 +199,11 @@ export function PlannerCalendar() {
 
       <PlannerCalendarLegend />
 
-      {view === "week" ? (
+      {view !== "month" ? (
         <Card>
           <CardContent>
             <PlannerWeekView
-              days={week}
+              days={view === "week" ? week : single}
               eventsMap={eventsMap}
               tasksMap={tasksMap}
               reviewsMap={reviewsMap}

--- a/fe/src/features/planner/components/calendar/PlannerWeekView.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerWeekView.tsx
@@ -7,9 +7,9 @@ import { HOURS, layoutDayEvents } from "../../weekLayout";
 
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
 const HOUR_PX = 40;
-const GRID_COLS = "grid-cols-[3rem_repeat(7,minmax(0,1fr))]";
 
 interface Props {
+  /** 1일(일 뷰) 또는 7일(주 뷰). */
   days: Date[];
   eventsMap: Map<string, PlannerEvent[]>;
   tasksMap: Map<string, PlannerTask[]>;
@@ -28,11 +28,16 @@ export function PlannerWeekView({
   onEventClick,
   onSlotClick,
 }: Props) {
+  // 컬럼 수는 days 길이에 따라 동적(일=1, 주=7) — Tailwind 동적 클래스 불가라 인라인 스타일.
+  const gridStyle = {
+    gridTemplateColumns: `3rem repeat(${days.length}, minmax(0, 1fr))`,
+  };
+
   return (
     <div className="overflow-x-auto">
-      <div className="min-w-[44rem]">
+      <div style={{ minWidth: days.length > 1 ? "44rem" : undefined }}>
         {/* 요일/날짜 헤더 */}
-        <div className={cn("grid", GRID_COLS)}>
+        <div className="grid" style={gridStyle}>
           <div />
           {days.map((day) => {
             const iso = toIsoDate(day);
@@ -52,7 +57,7 @@ export function PlannerWeekView({
         </div>
 
         {/* 종일/복습/할일 레인 */}
-        <div className={cn("grid border-b", GRID_COLS)}>
+        <div className="grid border-b" style={gridStyle}>
           <div className="text-muted-foreground py-1 pr-1 text-right text-[10px]">
             종일
           </div>
@@ -97,7 +102,7 @@ export function PlannerWeekView({
         </div>
 
         {/* 시간축 그리드 */}
-        <div className={cn("grid", GRID_COLS)}>
+        <div className="grid" style={gridStyle}>
           {/* 시간 라벨 */}
           <div>
             {HOURS.map((h) => (


### PR DESCRIPTION
## 이슈
closes #487

## 작업 내용
Epic #472 M4 마무리. 일 뷰 — 주 뷰 컴포넌트(`PlannerWeekView`)를 단일 날짜 컬럼으로 재사용. (deps #486)

- **`PlannerWeekView` 컬럼 수 동적화**: 그리드 컬럼을 Tailwind 고정 클래스 대신 **인라인 `gridTemplateColumns`**로(`3rem repeat(N, ...)`) — N=1(일)/7(주). 단일 컬럼이면 `min-width`도 해제.
- **`PlannerCalendar`**: `[월][주][일]` 토글. 일 뷰는 하루 시간축 + 종일 레인(주 뷰와 동일 컴포넌트). 기간 네비 일=±1일, 제목 "M월 D일 (요일)". 빈 시간대 클릭→생성 / 일정 블록 클릭→편집은 그대로 동작.

## 테스트
- `PlannerCalendar`: 일 뷰 전환 시 단일 날짜 시간축(`9시`)·일정 블록·해당 슬롯 렌더
- FE 전체 138개 통과, tsc·eslint·format:check clean

## 비고
M4(뷰 확장) 완료. 남은 M5(견고성, 병행): #488 레이트리밋/백오프·메트릭, #489 refresh token 암호화, #490 미연동/오류/revoke UX 일원화.