### PR TITLE
feat : Planner Google API 레이트리밋/백오프 + 메트릭

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleApiConfig.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleApiConfig.java
@@ -3,6 +3,7 @@ package ds.project.orino.planner.google.config;
 import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
 import ds.project.orino.planner.google.token.GoogleUnauthorizedException;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,13 +25,16 @@ import java.nio.charset.StandardCharsets;
  * <p>{@code defaultStatusHandler} 가 4xx/5xx 응답을 매핑한다: API 401 → {@link GoogleUnauthorizedException}
  * (access token 만료, {@code executeWithRetry}가 1회 갱신 후 재시도) / 본문에 {@code invalid_grant} →
  * 재연동 필요(PLN-ERR-005) / 그 외 → Google API 실패(PLN-ERR-004).
+ *
+ * <p>{@link GoogleApiRetryInterceptor} 가 429/5xx에 지수 백오프 재시도 + {@code google.api.calls{result}}
+ * 메트릭을 집계한다.
  */
 @Configuration
 @EnableConfigurationProperties({GoogleApiProperties.class, GoogleOAuthProperties.class})
 public class GoogleApiConfig {
 
     @Bean
-    public RestClient googleRestClient(GoogleApiProperties props) {
+    public RestClient googleRestClient(GoogleApiProperties props, MeterRegistry meterRegistry) {
         // JDK HttpURLConnection(SimpleClientHttpRequestFactory)은 PATCH를 지원하지 않으므로
         // java.net.http 기반 JdkClientHttpRequestFactory를 쓴다(의존성 추가 없음, PATCH 지원).
         HttpClient httpClient = HttpClient.newBuilder()
@@ -41,6 +45,8 @@ public class GoogleApiConfig {
 
         return RestClient.builder()
                 .requestFactory(factory)
+                .requestInterceptor(new GoogleApiRetryInterceptor(
+                        meterRegistry, props.retryMaxAttempts(), props.retryBackoff()))
                 .defaultStatusHandler(
                         statusCode -> statusCode.isError(),
                         (request, response) -> {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleApiProperties.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleApiProperties.java
@@ -15,8 +15,10 @@ import java.util.List;
  * @param clientSecret   OAuth 2.0 클라이언트 secret
  * @param redirectUri    승인된 리디렉션 URI (Google Cloud Console 등록값과 일치해야 함)
  * @param scopes         요청 scope 목록 (calendar + tasks)
- * @param connectTimeout Google API 연결 타임아웃
- * @param readTimeout    Google API 응답 타임아웃
+ * @param connectTimeout   Google API 연결 타임아웃
+ * @param readTimeout      Google API 응답 타임아웃
+ * @param retryMaxAttempts 429/5xx 시 재시도 횟수(지수 백오프)
+ * @param retryBackoff     첫 재시도 기본 대기(이후 2배씩)
  */
 @ConfigurationProperties(prefix = "planner.google")
 public record GoogleApiProperties(
@@ -25,6 +27,8 @@ public record GoogleApiProperties(
         String redirectUri,
         List<String> scopes,
         Duration connectTimeout,
-        Duration readTimeout
+        Duration readTimeout,
+        int retryMaxAttempts,
+        Duration retryBackoff
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleApiRetryInterceptor.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/config/GoogleApiRetryInterceptor.java
@@ -1,0 +1,99 @@
+package ds.project.orino.planner.google.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.IOException;
+import java.time.Duration;
+
+/**
+ * Google API 호출의 견고성: 429/5xx에 짧은 지수 백오프로 1~2회 재시도하고,
+ * 호출 결과를 {@code google.api.calls{result}} 카운터로 집계한다.
+ *
+ * <p>5xx는 결과가 불확실하므로 멱등이 아닌 POST(생성)는 재시도하지 않는다(중복 생성 방지).
+ * 429(레이트리밋)는 요청이 처리되지 않았으므로 모든 메서드에 재시도한다.
+ */
+public class GoogleApiRetryInterceptor implements ClientHttpRequestInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(GoogleApiRetryInterceptor.class);
+    private static final int TOO_MANY_REQUESTS = 429;
+    private static final String METRIC_NAME = "google.api.calls";
+
+    private final MeterRegistry meterRegistry;
+    private final int maxAttempts;
+    private final Duration baseBackoff;
+
+    public GoogleApiRetryInterceptor(MeterRegistry meterRegistry, int maxAttempts, Duration baseBackoff) {
+        this.meterRegistry = meterRegistry;
+        this.maxAttempts = maxAttempts;
+        this.baseBackoff = baseBackoff;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body,
+                                        ClientHttpRequestExecution execution) throws IOException {
+        int retries = 0;
+        while (true) {
+            ClientHttpResponse response;
+            try {
+                response = execution.execute(request, body);
+            } catch (IOException e) {
+                record("error");
+                throw e;
+            }
+
+            int status = response.getStatusCode().value();
+            if (canRetry(status, request.getMethod()) && retries < maxAttempts) {
+                retries++;
+                response.close();
+                backoff(retries);
+                log.warn("Google API {} {} → {} 재시도 {}/{}",
+                        request.getMethod(), request.getURI(), status, retries, maxAttempts);
+                continue;
+            }
+
+            record(resultOf(status));
+            return response;
+        }
+    }
+
+    private boolean canRetry(int status, HttpMethod method) {
+        if (status == TOO_MANY_REQUESTS) {
+            return true; // 레이트리밋: 요청이 처리되지 않음 → 모든 메서드 재시도 안전
+        }
+        if (status < 500) {
+            return false;
+        }
+        // 5xx: 처리 여부 불확실 → POST(생성)는 중복 방지 위해 재시도 안 함
+        return method != HttpMethod.POST;
+    }
+
+    private void backoff(int attempt) {
+        long millis = baseBackoff.toMillis() * (1L << (attempt - 1));
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void record(String result) {
+        meterRegistry.counter(METRIC_NAME, "result", result).increment();
+    }
+
+    private static String resultOf(int status) {
+        if (status >= 500) {
+            return "server_error";
+        }
+        if (status >= 400) {
+            return "client_error";
+        }
+        return "success";
+    }
+}

--- a/be/orino-app-api/src/main/resources/application.yml
+++ b/be/orino-app-api/src/main/resources/application.yml
@@ -43,6 +43,8 @@ planner:
       - https://www.googleapis.com/auth/tasks
     connect-timeout: ${GOOGLE_CONNECT_TIMEOUT:5s}
     read-timeout: ${GOOGLE_READ_TIMEOUT:10s}
+    retry-max-attempts: ${GOOGLE_RETRY_MAX_ATTEMPTS:2}
+    retry-backoff: ${GOOGLE_RETRY_BACKOFF:200ms}
     oauth:
       authorization-uri: ${GOOGLE_AUTH_URI:https://accounts.google.com/o/oauth2/v2/auth}
       token-uri: ${GOOGLE_TOKEN_URI:https://oauth2.googleapis.com/token}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/config/GoogleApiConfigTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/config/GoogleApiConfigTest.java
@@ -5,6 +5,8 @@ import com.sun.net.httpserver.HttpServer;
 import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
 import ds.project.orino.planner.google.token.GoogleUnauthorizedException;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +22,7 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,6 +36,7 @@ class GoogleApiConfigTest {
 
         private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
                 .withConfiguration(AutoConfigurations.of())
+                .withBean(MeterRegistry.class, SimpleMeterRegistry::new)
                 .withUserConfiguration(GoogleApiConfig.class);
 
         @Test
@@ -72,22 +76,30 @@ class GoogleApiConfigTest {
         private HttpServer server;
         private String baseUrl;
         private RestClient client;
+        private SimpleMeterRegistry meterRegistry;
+        private final AtomicInteger flakyHits = new AtomicInteger();
 
         @BeforeEach
         void startStubServer() throws IOException {
+            flakyHits.set(0);
             server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
             server.createContext("/ok", ex -> respond(ex, 200, "{\"ok\":true}"));
             server.createContext("/server-error", ex -> respond(ex, 500, "{\"error\":\"backendError\"}"));
             server.createContext("/invalid-grant", ex -> respond(ex, 400, "{\"error\":\"invalid_grant\"}"));
             server.createContext("/unauthorized", ex -> respond(ex, 401, "{\"error\":\"unauthorized\"}"));
             server.createContext("/not-found", ex -> respond(ex, 404, "{\"error\":\"notFound\"}"));
+            // 첫 호출은 503, 두 번째부터 200 → 재시도 성공 검증용
+            server.createContext("/flaky", ex ->
+                    respond(ex, flakyHits.getAndIncrement() == 0 ? 503 : 200, "{\"ok\":true}"));
             server.start();
             baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
 
+            meterRegistry = new SimpleMeterRegistry();
             GoogleApiProperties props = new GoogleApiProperties(
                     "cid", "secret", "http://localhost/cb",
-                    List.of("scope"), Duration.ofSeconds(2), Duration.ofSeconds(5));
-            client = new GoogleApiConfig().googleRestClient(props);
+                    List.of("scope"), Duration.ofSeconds(2), Duration.ofSeconds(5),
+                    2, Duration.ofMillis(1));
+            client = new GoogleApiConfig().googleRestClient(props, meterRegistry);
         }
 
         @AfterEach
@@ -138,6 +150,24 @@ class GoogleApiConfigTest {
                     .isInstanceOf(CustomException.class)
                     .extracting(e -> ((CustomException) e).getErrorCode())
                     .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("503 후 200이면 지수 백오프로 재시도해 성공한다")
+        void retriesOnServerErrorThenSucceeds() {
+            String body = client.get().uri(baseUrl + "/flaky").retrieve().body(String.class);
+
+            assertThat(body).contains("ok");
+            assertThat(flakyHits.get()).isEqualTo(2); // 503 → 재시도 → 200
+        }
+
+        @Test
+        @DisplayName("호출 결과를 google.api.calls{result} 메트릭으로 집계한다")
+        void recordsCallMetric() {
+            client.get().uri(baseUrl + "/ok").retrieve().body(String.class);
+
+            double success = meterRegistry.counter("google.api.calls", "result", "success").count();
+            assertThat(success).isEqualTo(1.0);
         }
     }
 


### PR DESCRIPTION
## 이슈
closes #488

## 작업 내용
Epic #472 M5. Google API 호출 견고성 — 백오프 재시도 + 메트릭. (deps #478/#482/#484)

- **`GoogleApiRetryInterceptor`** (`ClientHttpRequestInterceptor`, 모든 Google 호출에 일괄 적용):
  - **429/5xx 지수 백오프 재시도**(기본 2회, base 200ms→2배씩)
  - 5xx는 **멱등 메서드만 재시도**(POST 생성은 중복 방지 위해 재시도 안 함), 429는 요청이 처리되지 않았으므로 전 메서드 재시도
  - **`google.api.calls{result}` 메트릭**(`success`/`client_error`/`server_error`/`error`) — [관측성](https://github.com/wcorn/orino/wiki/Observability)
- `GoogleApiProperties`에 `retry-max-attempts`(기본 2)/`retry-backoff`(기본 200ms) + yml(`${ENV:default}`)
- `googleRestClient` 빈에 인터셉터 + `MeterRegistry` 주입

## partial/errors 표준화
통합 피드의 소스별 부분 실패(`partial`+`errors[{source,message}]`)는 #479(events/reviews)·#484(tasks)에서 이미 일관 적용됨 — `google-events`/`google-tasks`/`reviews`. 이번 변경으로 그 아래 HTTP 계층의 재시도/집계가 더해진다.

## 테스트
- `GoogleApiConfigTest`(StatusHandler, JDK HttpServer 스텁): 503→200 재시도 성공(2회 호출) / `google.api.calls{result=success}` 집계 — StatusHandler 7/7
- app-api 전체 스위트 + checkstyle 통과

## 비고
- 백오프는 단일 사용자/저트래픽 기준 동기 `Thread.sleep`. 기존 5xx→GOOGLE_API_FAILED, 401→GoogleUnauthorizedException 매핑은 재시도 소진 후 그대로 적용된다.