### PR TITLE
chore : 테스트 반복/혼재 JSON 리터럴 명명 상수화

### DIFF
--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/GoogleEventControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/GoogleEventControllerTest.java
@@ -85,6 +85,8 @@ class GoogleEventControllerTest extends ApiTestSupport {
     private static final String CREATE_BODY = """
             {"title":"치과 예약","allDay":false,
              "start":"2026-06-10T14:00:00","end":"2026-06-10T15:00:00","location":"강남"}""";
+    private static final String MISSING_TITLE_BODY = """
+            {"allDay":false,"start":"2026-06-10T14:00:00","end":"2026-06-10T15:00:00"}""";
 
     @Test
     @DisplayName("POST - 일정을 생성하고 201로 정규화된 이벤트를 반환하며 캐시를 무효화한다")
@@ -150,8 +152,7 @@ class GoogleEventControllerTest extends ApiTestSupport {
         mockMvc.perform(post("/api/planner/calendar/events")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"allDay":false,"start":"2026-06-10T14:00:00","end":"2026-06-10T15:00:00"}"""))
+                        .content(MISSING_TITLE_BODY))
                 .andExpect(status().isBadRequest());
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/PlannerCalendarControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/PlannerCalendarControllerTest.java
@@ -42,10 +42,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class PlannerCalendarControllerTest extends ApiTestSupport {
 
+    private static final String EMPTY_ITEMS = "{\"items\":[]}";
+
     private static final HttpServer EVENTS_STUB = createStub();
     private static volatile int responseStatus = 200;
-    private static volatile String responseBody = "{\"items\":[]}";
-    private static volatile String tasksBody = "{\"items\":[]}";
+    private static volatile String responseBody = EMPTY_ITEMS;
+    private static volatile String tasksBody = EMPTY_ITEMS;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -85,7 +87,7 @@ class PlannerCalendarControllerTest extends ApiTestSupport {
         responseBody = """
                 {"items":[{"id":"e1","summary":"회의",
                  "start":{"dateTime":"2026-06-10T05:00:00Z"},"end":{"dateTime":"2026-06-10T06:00:00Z"}}]}""";
-        tasksBody = "{\"items\":[]}";
+        tasksBody = EMPTY_ITEMS;
         dbCleaner.clean();
         Member member = memberRepository.save(MemberFixture.create());
         memberId = member.getId();

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
@@ -69,16 +69,11 @@ describe("PlannerCalendar", () => {
     mockFeed(
       {
         events: [
-          {
-            id: "e1",
-            title: "회의",
-            allDay: false,
+          googleEvent({
             start: `${TODAY}T14:00:00`,
             end: `${TODAY}T15:00:00`,
             location: "3층",
-            recurring: false,
-            source: "google",
-          },
+          }),
         ],
         reviews: [
           {
@@ -155,6 +150,20 @@ describe("PlannerCalendar", () => {
     source: "google",
   };
 
+  function googleEvent(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "e1",
+      title: "회의",
+      allDay: false,
+      start: `${TODAY}T09:00:00`,
+      end: `${TODAY}T10:00:00`,
+      location: null,
+      recurring: false,
+      source: "google",
+      ...overrides,
+    };
+  }
+
   it("할 일 완료 토글: 체크박스를 누르면 PATCH한다", async () => {
     mockGoogleConnected(true);
     mockFeed({ tasks: [taskOnToday] });
@@ -226,16 +235,7 @@ describe("PlannerCalendar", () => {
         posted = await request.json();
         return HttpResponse.json({
           code: "OK",
-          data: {
-            id: "new-1",
-            title: "회의",
-            allDay: false,
-            start: `${TODAY}T09:00:00`,
-            end: `${TODAY}T10:00:00`,
-            location: null,
-            recurring: false,
-            source: "google",
-          },
+          data: googleEvent({ id: "new-1" }),
         });
       }),
     );
@@ -258,18 +258,7 @@ describe("PlannerCalendar", () => {
     mockGoogleConnected(true);
     mockFeed({
       googleConnected: true,
-      events: [
-        {
-          id: "e1",
-          title: "회의",
-          allDay: false,
-          start: `${TODAY}T09:00:00`,
-          end: `${TODAY}T10:00:00`,
-          location: null,
-          recurring: false,
-          source: "google",
-        },
-      ],
+      events: [googleEvent()],
     });
 
     renderWithRouter(<PlannerCalendar />);
@@ -298,18 +287,7 @@ describe("PlannerCalendar", () => {
   it("일 뷰로 전환하면 단일 날짜의 시간축과 일정을 보여준다", async () => {
     mockGoogleConnected(true);
     mockFeed({
-      events: [
-        {
-          id: "e1",
-          title: "회의",
-          allDay: false,
-          start: `${TODAY}T09:00:00`,
-          end: `${TODAY}T10:00:00`,
-          location: null,
-          recurring: false,
-          source: "google",
-        },
-      ],
+      events: [googleEvent()],
     });
 
     renderWithRouter(<PlannerCalendar />);


### PR DESCRIPTION
## 이슈
closes #520

## 작업 내용
테스트의 inline 리터럴을 코드베이스 전반 점검해, **반복되거나 의도를 담는 것만** 명명 상수/팩토리로 정리했다. 자명·1회성은 그대로 둠(이슈 가이드 "무분별한 상수화 지양").

- **`GoogleEventControllerTest`**(#520 발단): `CREATE_BODY`/`EVENT_JSON` 상수와 섞여 있던 inline no-title 바디 → **`MISSING_TITLE_BODY`** 상수로 일관화
- **`PlannerCalendarControllerTest`**: 반복된 escaped `"{\"items\":[]}"` 3곳 → **`EMPTY_ITEMS`** 상수
- **`PlannerCalendar.test.tsx`**(FE): 4개 테스트에 반복되던 동일 Google event 객체(~10줄×4) → **`googleEvent(overrides)` 팩토리**로 DRY

## 점검 후 그대로 둔 것 (의도적)
- `.content("{}")`(빈 바디 검증) 등 **자명한 1회성 리터럴**
- `responseBody = """..."""` 같은 **테스트별 스텁 데이터**(각자 다른 값, inline이 더 읽기 좋음)
- `{"completed":true}` 등 짧고 자명한 단일 사용 바디

## 검증
- 프로덕션 코드 무변경(테스트만)
- BE: checkstyle + 영향 테스트(GoogleEvent/PlannerCalendar Controller) 통과
- FE: 전체 142개 통과, tsc·eslint·format:check clean