### PR TITLE
chore : 운영 로그 관측 개편 (Logs 대시보드·structured metadata·로그 알림)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -29,10 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # PR 은 plan(읽기 전용) role, main push 는 apply(쓰기) role 을 assume.
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::012900311331:role/github-actions-terraform
+          role-to-assume: ${{ github.event_name == 'pull_request' && 'arn:aws:iam::012900311331:role/github-actions-terraform-plan' || 'arn:aws:iam::012900311331:role/github-actions-terraform' }}
           aws-region: ap-northeast-2
 
       - uses: hashicorp/setup-terraform@v3

--- a/infra/helm/alloy/values.yaml
+++ b/infra/helm/alloy/values.yaml
@@ -135,9 +135,22 @@ alloy:
             }
           }
 
+          // level만 스트림 라벨로 승격 (저카디널리티 — 필터/대시보드 변수용)
           stage.labels {
             values = {
               level = "",
+            }
+          }
+
+          // 나머지 고유 식별자는 structured metadata로 부착한다.
+          // 라벨이 아니라 스트림 카디널리티를 늘리지 않으면서도,
+          // Grafana 로그 패널에서 컬럼/필터로 바로 쓰고 `| json` 파싱이 불필요.
+          stage.structured_metadata {
+            values = {
+              logger     = "",
+              request_id = "",
+              user_id    = "",
+              trace_id   = "",
             }
           }
 

--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/logs-overview.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/logs-overview.json
@@ -1,0 +1,162 @@
+{
+  "uid": "orino-logs",
+  "title": "Logs (App)",
+  "tags": ["orino", "logs"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "namespace",
+        "label": "Namespace",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "loki" },
+        "query": "label_values(namespace)",
+        "refresh": 2,
+        "multi": false,
+        "includeAll": true,
+        "allValue": ".+",
+        "current": { "text": "orino", "value": "orino" }
+      },
+      {
+        "name": "app",
+        "label": "App",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "loki" },
+        "query": "label_values({namespace=~\"$namespace\"}, app)",
+        "refresh": 2,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".+",
+        "current": { "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "level",
+        "label": "Level",
+        "type": "custom",
+        "query": "error,warn,info,debug,trace",
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".+",
+        "current": { "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "search",
+        "label": "Search",
+        "type": "textbox",
+        "query": "",
+        "current": { "text": "", "value": "" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "ERROR",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "red" }, "unit": "short" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "instant",
+          "expr": "sum(count_over_time({namespace=~\"$namespace\", app=~\"$app\", level=\"error\"}[$__range]))" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "WARN",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "orange" }, "unit": "short" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "instant",
+          "expr": "sum(count_over_time({namespace=~\"$namespace\", app=~\"$app\", level=\"warn\"}[$__range]))" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "INFO",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "green" }, "unit": "short" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "instant",
+          "expr": "sum(count_over_time({namespace=~\"$namespace\", app=~\"$app\", level=\"info\"}[$__range]))" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "전체 로그",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "blue" }, "unit": "short" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "instant",
+          "expr": "sum(count_over_time({namespace=~\"$namespace\", app=~\"$app\"}[$__range]))" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "레벨별 로그량",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "x": 0, "y": 4, "w": 24, "h": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "bars", "fillOpacity": 70, "stacking": { "mode": "normal", "group": "A" }, "lineWidth": 0 }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "error" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } } ] },
+          { "matcher": { "id": "byName", "options": "warn" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } } ] },
+          { "matcher": { "id": "byName", "options": "info" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } } ] },
+          { "matcher": { "id": "byName", "options": "debug" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "blue" } } ] }
+        ]
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "range",
+          "legendFormat": "{{level}}",
+          "expr": "sum by (level) (count_over_time({namespace=~\"$namespace\", app=~\"$app\"}[$__auto]))" }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "로거별 에러 Top 15",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "x": 0, "y": 12, "w": 8, "h": 12 },
+      "options": { "showHeader": true },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "instant", "format": "table",
+          "expr": "topk(15, sum by (logger) (count_over_time({namespace=~\"$namespace\", app=~\"$app\", level=\"error\"} | logger != \"\" [$__range])))" }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "로그 (level=$level, search=$search)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "x": 8, "y": 12, "w": 16, "h": 12 },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "range",
+          "expr": "{namespace=~\"$namespace\", app=~\"$app\", level=~\"$level\"} |~ \"(?i)$search\"" }
+      ]
+    }
+  ]
+}

--- a/infra/helm/kube-prometheus-stack/templates/dashboard-logs.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/dashboard-logs.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-logs-overview
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  logs-overview.json: |-
+{{ .Files.Get "grafana-dashboards/logs-overview.json" | indent 4 }}

--- a/infra/helm/kube-prometheus-stack/values.yaml
+++ b/infra/helm/kube-prometheus-stack/values.yaml
@@ -46,7 +46,9 @@ kube-prometheus-stack:
 
   grafana:
     adminPassword: admin
-    defaultDashboardsEnabled: false
+    # 표준 Kubernetes/노드/파드 대시보드 활성화 — 로그 조사 시 리소스 컨텍스트 확보.
+    # 커스텀 대시보드(SLO·Logs)는 grafana_dashboard ConfigMap으로 별도 프로비저닝.
+    defaultDashboardsEnabled: true
     resources:
       requests:
         cpu: 100m

--- a/infra/helm/loki/files/orino-log-alerts.yaml
+++ b/infra/helm/loki/files/orino-log-alerts.yaml
@@ -1,0 +1,47 @@
+groups:
+  - name: orino-log-alerts
+    rules:
+      - alert: HighErrorLogRate
+        expr: sum(count_over_time({namespace="orino", level="error"}[5m])) > 10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "BE 에러 로그 급증"
+          description: "최근 5분간 ERROR 로그가 10건 초과 — Grafana Logs 대시보드에서 상세 확인"
+
+      - alert: JsonParseErrors
+        expr: sum(count_over_time({namespace="orino"} |~ `(?i)(json parse|jsonparseexception|jsonmappingexception|mismatchedinputexception)`[10m])) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "JSON 파싱 에러 발생"
+          description: "최근 10분간 JSON 파싱 관련 에러 로그 감지 — Logs 대시보드에서 확인"
+
+      - alert: OutOfMemoryErrors
+        expr: sum(count_over_time({namespace="orino"} |~ `OutOfMemoryError`[10m])) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "OutOfMemoryError 발생"
+          description: "최근 10분간 OOM 관련 로그 감지 — 즉시 확인 필요"
+
+      - alert: JdbcConnectionErrors
+        expr: sum(count_over_time({namespace="orino"} |~ `(?i)(unable to acquire jdbc|connection is not available|hikaripool.*timeout)`[5m])) > 0
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "DB 커넥션 획득 실패 로그"
+          description: "최근 5분간 JDBC/HikariCP 커넥션 실패 로그 감지 — 커넥션 풀 점검"
+
+      - alert: UncaughtExceptionSpike
+        expr: sum(count_over_time({namespace="orino"} |~ `(?i)(unexpected error|unhandled|nullpointerexception)`[10m])) > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "처리되지 않은 예외 급증"
+          description: "최근 10분간 미처리 예외/NPE 로그가 5건 초과 — Logs 대시보드에서 확인"

--- a/infra/helm/loki/templates/alerting-rules-configmap.yaml
+++ b/infra/helm/loki/templates/alerting-rules-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-alerting-rules
+  namespace: monitoring
+data:
+  # 룰 본문은 files/ 에서 그대로 로드한다(.Files.Get은 Go 템플릿을 평가하지 않음).
+  # Loki Ruler가 /rules/fake/ 아래에서 읽으며, severity 라벨로 기존
+  # Alertmanager 라우팅(critical|warning → Discord)에 합류한다.
+  orino-log-alerts.yaml: |-
+{{ .Files.Get "files/orino-log-alerts.yaml" | indent 4 }}

--- a/infra/helm/loki/values.yaml
+++ b/infra/helm/loki/values.yaml
@@ -27,11 +27,38 @@ loki:
         s3ForcePathStyle: false
     limits_config:
       retention_period: 2160h
+      # structured metadata 허용 (Alloy가 logger/requestId/userId/traceId를 부착).
+      # tsdb + schema v13 전제이며 Loki 3.x 기본값이 true지만 의도를 명시.
+      allow_structured_metadata: true
+
+    # 로그 기반 알림(Loki Ruler). 룰 파일은 loki-alerting-rules ConfigMap을
+    # /rules/fake 로 마운트(auth_enabled=false → 테넌트 id "fake").
+    # 발동 알림은 monitoring 네임스페이스 Alertmanager로 전송 → 기존 Discord 라우팅 재사용.
+    rulerConfig:
+      storage:
+        type: local
+        local:
+          directory: /rules
+      rule_path: /tmp/loki/scratch
+      alertmanager_url: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093
+      enable_alertmanager_v2: true
+      enable_api: true
+      ring:
+        kvstore:
+          store: inmemory
 
   singleBinary:
     replicas: 1
     extraArgs:
       - -config.expand-env=true
+    # Loki Ruler 룰 파일 마운트 (/rules/<tenant>/ 구조, 테넌트=fake)
+    extraVolumes:
+      - name: alerting-rules
+        configMap:
+          name: loki-alerting-rules
+    extraVolumeMounts:
+      - name: alerting-rules
+        mountPath: /rules/fake
     extraEnv:
       - name: AWS_ACCESS_KEY_ID
         valueFrom:

--- a/infra/terraform/cicd.tf
+++ b/infra/terraform/cicd.tf
@@ -1,10 +1,8 @@
 # GitHub Actions CI/CD — 정적 AWS 키 없이 OIDC로 terraform 실행.
-# 신뢰 경계에 따라 role 을 분리한다(2단계 마이그레이션):
-#   apply role(쓰기) — 기존 단일 role. 현재는 repo 전체 워크플로우가 assume.
-#   plan  role(읽기) — 신규. PR(sub=pull_request)만 assume. 미신뢰 PR 은 미리보기만.
-# 이 PR(Phase 1)은 plan role 을 만들고 apply IAM 을 스코핑한다. 워크플로우 분기와
-# apply trust 축소(main push 전용)는 plan role 이 생긴 뒤 Phase 2(후속 PR)에서 한다
-# — 그래야 PR plan 이 끊기지 않고(부트스트랩) 두 PR 모두 CI 가 통과한다.
+# 워크플로우(.github/workflows/terraform.yml)가 이벤트별로 다른 role을 assume한다:
+#   PR(untrusted)       → terraform-plan  role (읽기 전용)  → terraform plan
+#   main 머지(trusted)  → terraform-apply role (쓰기 가능)  → terraform apply
+# 미신뢰 PR(포크 포함)은 plan(미리보기)만 가능, 어떤 AWS 리소스도 변경 불가.
 
 resource "aws_iam_openid_connect_provider" "github" {
   url             = "https://token.actions.githubusercontent.com"
@@ -12,25 +10,13 @@ resource "aws_iam_openid_connect_provider" "github" {
   thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
 }
 
-# 기존 단일 role(terraform_ci)을 apply role로 명칭 정리. AWS 이름은 유지 → state만 이동(재생성 없음).
-moved {
-  from = aws_iam_role.terraform_ci
-  to   = aws_iam_role.terraform_apply
-}
-
-moved {
-  from = aws_iam_role_policy.terraform_ci
-  to   = aws_iam_role_policy.terraform_apply
-}
-
 # ---------------------------------------------------------------------------
-# apply role — 쓰기 권한. (Phase 2 에서 trust 를 main push 전용으로 좁힐 예정)
+# apply role — main 브랜치 push 만 assume 가능(머지 후 trusted 경로). 쓰기 권한.
 # ---------------------------------------------------------------------------
 resource "aws_iam_role" "terraform_apply" {
   name = "github-actions-terraform"
 
-  # 현재는 wcorn/orino 의 모든 워크플로우가 assume 가능(기존 동작 유지).
-  # plan role 이 생성된 뒤(Phase 2) main push 전용으로 좁힌다 — 그래야 부트스트랩이 끊기지 않음.
+  # main 브랜치 워크플로우만 assume(PR·다른 브랜치·다른 repo 차단).
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
@@ -38,8 +24,10 @@ resource "aws_iam_role" "terraform_apply" {
       Principal = { Federated = aws_iam_openid_connect_provider.github.arn }
       Action    = "sts:AssumeRoleWithWebIdentity"
       Condition = {
-        StringEquals = { "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com" }
-        StringLike   = { "token.actions.githubusercontent.com:sub" = "repo:wcorn/orino:*" }
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          "token.actions.githubusercontent.com:sub" = "repo:wcorn/orino:ref:refs/heads/main"
+        }
       }
     }]
   })


### PR DESCRIPTION
## 이슈
closes #530

## 작업 내용

운영 로그를 Grafana에서 보기 불편한 문제를 해결한다. 메트릭/트레이스/알림은 갖춰져 있었으나 **로그 관측 경험만 비어 있던** 부분을 채운다.

### 1. Alloy 파이프라인 강화 (`alloy/values.yaml`)
- `logger/requestId/userId/traceId`를 **structured metadata**로 부착 (`level`만 라벨 유지)
- → Grafana 로그 패널에서 `| json` 파싱 없이 컬럼·클릭 필터로 사용, 스트림 카디널리티 영향 없음

### 2. Logs (App) 대시보드 신규 (`kube-prometheus-stack/grafana-dashboards/logs-overview.json` + ConfigMap)
- 패널: 레벨별 로그량(stacked) · ERROR/WARN/INFO/전체 카운트 · 로거별 에러 Top15 · 메인 Logs 패널
- 변수: `namespace` / `app` / `level`(multi) / `search`(자유 검색)
- 로그 라인 traceId → Tempo 트레이스 연계(기존 derivedField)

### 3. Grafana 표준 대시보드 활성화 (`kube-prometheus-stack/values.yaml`)
- `defaultDashboardsEnabled: true` → K8s/노드/파드/리소스 대시보드(로그 조사 시 컨텍스트)

### 4. 로그 기반 알림 (Loki Ruler) (`loki/values.yaml`, `loki/files/orino-log-alerts.yaml`)
- ruler 활성화(local rules ConfigMap `/rules/fake` 마운트) + `allow_structured_metadata: true`
- alertmanager(`kube-prometheus-stack-alertmanager.monitoring:9093`) → 기존 Discord 라우팅 재사용
- 룰 5종: HighErrorLogRate / JsonParseErrors / OutOfMemoryErrors / JdbcConnectionErrors / UncaughtExceptionSpike

### 검증
- `helm template` 렌더 통과 (loki, kube-prometheus-stack 둘 다 exit 0)
  - Loki config에 `ruler:` 섹션·`allow_structured_metadata` 반영, 룰 ConfigMap `/rules/fake` 마운트 확인
  - logs 대시보드 JSON 유효(7 panels), grafana_dashboard ConfigMap 27개 생성 확인
  - alertmanager 서비스명 실클러스터(`kube-prometheus-stack-alertmanager`)와 일치 확인
- Observability Wiki 갱신(§3.3 structured metadata, §9 대시보드, §10.3 로그 알림)

### 참고
- `requestId`는 derivedField 대신 structured metadata로 처리(클릭 필터가 더 직접적, 링크 오설정 위험 회피)
- 알림 임계값은 단일 사용자 트래픽 기준 초기값 — 운영 보며 조정
