### PR TITLE
chore : Grafana 기본 대시보드 비활성화 (노이즈 제거)

### DIFF
--- a/infra/helm/kube-prometheus-stack/values.yaml
+++ b/infra/helm/kube-prometheus-stack/values.yaml
@@ -46,9 +46,9 @@ kube-prometheus-stack:
 
   grafana:
     adminPassword: admin
-    # 표준 Kubernetes/노드/파드 대시보드 활성화 — 로그 조사 시 리소스 컨텍스트 확보.
-    # 커스텀 대시보드(SLO·Logs)는 grafana_dashboard ConfigMap으로 별도 프로비저닝.
-    defaultDashboardsEnabled: true
+    # 표준 대시보드 비활성화 — 안 보는 대시보드는 노이즈.
+    # 실제로 쓰는 커스텀 대시보드(SLO·Logs)만 grafana_dashboard ConfigMap으로 프로비저닝.
+    defaultDashboardsEnabled: false
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
## 이슈
closes #532

## 작업 내용
- `defaultDashboardsEnabled: true → false` — 안 보는 kube-prometheus-stack 기본 대시보드(~25종) 제거
- 실제 쓰는 커스텀 대시보드(**SLO**, **Logs (App)**)만 유지

### 검증
- `helm template` 통과 — `grafana_dashboard` ConfigMap **27 → 2**(dashboard-logs-overview, dashboard-slo-overview)만 잔존 확인

> #530에서 컨텍스트용으로 켰으나, 안 보는 대시보드는 노이즈라는 피드백 반영.