### PR TITLE
fix : SLO 대시보드 No data (지연 버킷 le 라벨 + 가용성 zero-fill)

### DIFF
--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/slo-overview.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/slo-overview.json
@@ -252,7 +252,7 @@
       "datasource": {"type": "prometheus", "uid": "prometheus"},
       "targets": [
         {
-          "expr": "1 - ((sum(rate(istio_request_duration_milliseconds_count{destination_service_name=\"$service\",reporter=\"destination\"}[30d])) - sum(rate(istio_request_duration_milliseconds_bucket{destination_service_name=\"$service\",reporter=\"destination\",le=\"500\"}[30d]))) / sum(rate(istio_request_duration_milliseconds_count{destination_service_name=\"$service\",reporter=\"destination\"}[30d])))",
+          "expr": "1 - ((sum(rate(istio_request_duration_milliseconds_count{destination_service_name=\"$service\",reporter=\"destination\"}[30d])) - sum(rate(istio_request_duration_milliseconds_bucket{destination_service_name=\"$service\",reporter=\"destination\",le=\"500.0\"}[30d]))) / sum(rate(istio_request_duration_milliseconds_count{destination_service_name=\"$service\",reporter=\"destination\"}[30d])))",
           "legendFormat": "30d fast_ratio",
           "refId": "A"
         }
@@ -320,7 +320,7 @@
       "description": "30일 윈도우 누적 위반율을 SLO 5% 예산 대비 환산.",
       "targets": [
         {
-          "expr": "((sum(rate(istio_request_duration_milliseconds_count{destination_service_name=\"$service\",reporter=\"destination\"}[30d])) - sum(rate(istio_request_duration_milliseconds_bucket{destination_service_name=\"$service\",reporter=\"destination\",le=\"500\"}[30d]))) / sum(rate(istio_request_duration_milliseconds_count{destination_service_name=\"$service\",reporter=\"destination\"}[30d]))) / 0.05",
+          "expr": "((sum(rate(istio_request_duration_milliseconds_count{destination_service_name=\"$service\",reporter=\"destination\"}[30d])) - sum(rate(istio_request_duration_milliseconds_bucket{destination_service_name=\"$service\",reporter=\"destination\",le=\"500.0\"}[30d]))) / sum(rate(istio_request_duration_milliseconds_count{destination_service_name=\"$service\",reporter=\"destination\"}[30d]))) / 0.05",
           "legendFormat": "budget_used",
           "refId": "A"
         }

--- a/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
@@ -152,22 +152,38 @@ spec:
         # 가용성 SLI: 5xx / 전체 요청 비율
         - record: slo:availability:error_ratio:rate5m
           expr: |
-            sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination",response_code=~"5.."}[5m]))
+            (
+              sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination",response_code=~"5.."}[5m]))
+              or
+              0 * sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination"}[5m]))
+            )
             /
             sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination"}[5m]))
         - record: slo:availability:error_ratio:rate30m
           expr: |
-            sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination",response_code=~"5.."}[30m]))
+            (
+              sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination",response_code=~"5.."}[30m]))
+              or
+              0 * sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination"}[30m]))
+            )
             /
             sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination"}[30m]))
         - record: slo:availability:error_ratio:rate1h
           expr: |
-            sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination",response_code=~"5.."}[1h]))
+            (
+              sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination",response_code=~"5.."}[1h]))
+              or
+              0 * sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination"}[1h]))
+            )
             /
             sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination"}[1h]))
         - record: slo:availability:error_ratio:rate6h
           expr: |
-            sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination",response_code=~"5.."}[6h]))
+            (
+              sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination",response_code=~"5.."}[6h]))
+              or
+              0 * sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination"}[6h]))
+            )
             /
             sum by (destination_service_name) (rate(istio_requests_total{destination_service_name=~"be|fe",reporter="destination"}[6h]))
 
@@ -177,7 +193,7 @@ spec:
             (
               sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[5m]))
               -
-              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_bucket{destination_service_name=~"be|fe",reporter="destination",le="500"}[5m]))
+              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_bucket{destination_service_name=~"be|fe",reporter="destination",le="500.0"}[5m]))
             )
             /
             sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[5m]))
@@ -186,7 +202,7 @@ spec:
             (
               sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[30m]))
               -
-              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_bucket{destination_service_name=~"be|fe",reporter="destination",le="500"}[30m]))
+              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_bucket{destination_service_name=~"be|fe",reporter="destination",le="500.0"}[30m]))
             )
             /
             sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[30m]))
@@ -195,7 +211,7 @@ spec:
             (
               sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[1h]))
               -
-              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_bucket{destination_service_name=~"be|fe",reporter="destination",le="500"}[1h]))
+              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_bucket{destination_service_name=~"be|fe",reporter="destination",le="500.0"}[1h]))
             )
             /
             sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[1h]))
@@ -204,7 +220,7 @@ spec:
             (
               sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[6h]))
               -
-              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_bucket{destination_service_name=~"be|fe",reporter="destination",le="500"}[6h]))
+              sum by (destination_service_name) (rate(istio_request_duration_milliseconds_bucket{destination_service_name=~"be|fe",reporter="destination",le="500.0"}[6h]))
             )
             /
             sum by (destination_service_name) (rate(istio_request_duration_milliseconds_count{destination_service_name=~"be|fe",reporter="destination"}[6h]))


### PR DESCRIPTION
## 이슈
closes #534

## 작업 내용
SLO 대시보드가 전 패널 No data였던 원인을 수정.

### 원인
1. **지연 버킷 라벨 불일치** — 룰/대시보드가 `le="500"`을 조회하나 실제 istio 히스토그램 라벨은 `le="500.0"` → 매칭 0 → 지연 SLI/번레이트가 **처음부터** 빈 결과
2. **가용성 zero-fill 누락** — `5xx/total`에서 최근 5xx가 없으면 분자가 비어 division 결과 empty → 트래픽이 있어도 "No data"

### 변경
- `prometheusrule.yaml`: 지연 recording rule 4종 `le="500"` → `le="500.0"`
- `prometheusrule.yaml`: 가용성 recording rule 4종 zero-fill `( 5xx or 0 * total ) / total` → 5xx 없을 때 0% 표시(번레이트 알림 로직엔 영향 없음, 0<임계)
- `slo-overview.json`: 30일 누적 지연 패널 2종 `le="500"` → `le="500.0"`

### 검증
- `helm template` 통과(exit 0), 대시보드 JSON 유효
- **Prometheus 실측**: 보정된 지연 slow_ratio = be/fe 2 series(0=100% fast), 가용성 error_ratio = be/fe 2 series(0=100% avail). 기존엔 0 series(No data)
- 부수 조치: be/fe 롤아웃 재시작으로 사이드카 destination 메트릭 정상화(파드가 메시 구성 이후 미재시작 상태였음)

> 지연 번레이트 알림도 이 버그로 그동안 평가 불능이었음 → 함께 정상화.
