### PR TITLE
fix : tempo OOM CrashLoop (resources 미적용 + 과샘플링)

### DIFF
--- a/infra/helm/istiod/templates/telemetry.yaml
+++ b/infra/helm/istiod/templates/telemetry.yaml
@@ -7,4 +7,4 @@ spec:
   tracing:
     - providers:
         - name: tempo
-      randomSamplingPercentage: 100
+      randomSamplingPercentage: 10

--- a/infra/helm/istiod/values.yaml
+++ b/infra/helm/istiod/values.yaml
@@ -3,7 +3,7 @@ istiod:
     enablePrometheusMerge: true
     defaultConfig:
       tracing:
-        sampling: 100
+        sampling: 10   # 100→10: 트레이스 인입량↓ (tempo 블록 증가 억제). Telemetry API와 일치
     extensionProviders:
       - name: tempo
         opentelemetry:

--- a/infra/helm/tempo/values.yaml
+++ b/infra/helm/tempo/values.yaml
@@ -27,17 +27,19 @@ tempo:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:4318
-    retention: 720h  # 30일
+    retention: 168h  # 7일 (블록 수↓ → blocklist 폴링 메모리↓, OOM 재발 방지. 트레이스는 단기 디버깅 데이터)
+
+    # 차트는 컨테이너 resources를 .Values.tempo.resources(이 위치)에서 읽는다.
+    # top-level resources에 두면 무시되고 LimitRange 기본값(512Mi)이 적용돼 OOM 발생했음.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 1536Mi   # 512Mi→1.5Gi: WAL replay + 블록 완료 + blocklist 폴링 OOM(137) 방지
 
   persistence:
     enabled: true
     storageClassName: longhorn
     size: 5Gi
-
-  resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      cpu: 500m
-      memory: 512Mi


### PR DESCRIPTION
## 이슈
closes #536

## 작업 내용
tempo-0가 37시간째 OOMKilled CrashLoop(434회)인 문제 수정.

### 원인
1. **resources 미적용** — `tempo/values.yaml`의 `resources`가 top-level에 있어 무시됨. 차트는 `.Values.tempo.resources`(중첩)에서 읽음 → 컨테이너 limit 미설정 → LimitRange 기본값 512Mi 적용 → WAL replay + 블록 완료 + 블록 720개 blocklist 폴링에서 OOM
2. **과샘플링/장기보존** — istio 100% 샘플링 + 30일 보존으로 블록 지속 증가

### 변경
- `tempo/values.yaml`: `resources`를 `tempo.tempo.resources`로 이동 + limit **512Mi→1.5Gi**, request 512Mi
- `tempo/values.yaml`: retention **720h→168h(7일)** — 블록 수↓ → blocklist 메모리↓
- `istiod/values.yaml` + `istiod/templates/telemetry.yaml`: 트레이스 샘플링 **100→10**

### 검증
- `helm template` 통과(tempo·istiod exit 0)
- 렌더 확인: tempo 컨테이너 `resources.limits.memory=1536Mi`(기존 `{}`였음), `block_retention=168h`, istio `sampling=10`/`randomSamplingPercentage=10`
- 머지 후 ArgoCD 동기화 시 tempo-0 재기동되며 OOM 해소 예상

> 제 직전 로그 작업과 무관한 기존 장애. loki-0은 정상(2/2).
