### PR TITLE
fix : 알림 Discord 전달 복구 (operator가 webhook_url_file 거부)

### DIFF
--- a/infra/helm/kube-prometheus-stack/templates/alertmanagerconfig-discord.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/alertmanagerconfig-discord.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: orino-discord
+  namespace: monitoring
+spec:
+  # matchers 없음 → (alertmanagerConfigMatcherStrategy: None과 함께) 전 네임스페이스 catch-all.
+  # operator가 거부하던 raw discord webhook_url_file 대신, CRD의 apiURL(SecretKeySelector)로
+  # 기존 alertmanager-discord-secret을 직접 참조한다.
+  route:
+    receiver: discord
+    groupBy:
+      - alertname
+      - namespace
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 4h
+  receivers:
+    - name: discord
+      discordConfigs:
+        - apiURL:
+            name: alertmanager-discord-secret
+            key: DISCORD_WEBHOOK_URL
+          sendResolved: true

--- a/infra/helm/kube-prometheus-stack/values.yaml
+++ b/infra/helm/kube-prometheus-stack/values.yaml
@@ -105,28 +105,15 @@ kube-prometheus-stack:
             datasourceUid: prometheus
 
   alertmanager:
-    config:
-      global:
-        resolve_timeout: 5m
-      route:
-        receiver: discord
-        group_by:
-          - alertname
-          - namespace
-        group_wait: 30s
-        group_interval: 5m
-        repeat_interval: 4h
-        routes:
-          - receiver: discord
-            matchers:
-              - severity=~"critical|warning"
-      receivers:
-        - name: discord
-          discord_configs:
-            - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord-secret/DISCORD_WEBHOOK_URL
+    # alertmanager.config를 직접 지정하지 않는다 → 차트 기본 config(null receiver +
+    # Watchdog→null + inhibit_rules)를 그대로 사용. Watchdog(항상 firing)는 null로 버려진다.
+    # 실제 Discord 라우팅은 AlertmanagerConfig CRD(orino-discord)가 catch-all로 담당한다.
+    # (raw config에 discord를 넣으면 operator가 webhook_url_file를 거부해 전체가 null로
+    #  fallback됐던 문제 회피 — CRD의 apiURL(SecretKeySelector)로 secret 안전 참조)
     alertmanagerSpec:
-      secrets:
-        - alertmanager-discord-secret
+      # CRD 라우트를 네임스페이스로 가두지 않음 → orino 등 전 네임스페이스 알림 catch-all
+      alertmanagerConfigMatcherStrategy:
+        type: None
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
## 이슈
closes #538

## 작업 내용
**37시간 동안 tempo 다운을 몰랐던 진짜 원인 = 알림이 처음부터 한 번도 전달된 적이 없음.**

- Prometheus는 정상 발동(32건 firing, AM 도달)하지만 AM config가 차트 기본 `receiver: "null"`로 fallback → 전부 버려짐
- 원인: discord `webhook_url_file`을 prometheus-operator(v0.89)가 거부([#7159](https://github.com/prometheus-operator/prometheus-operator/issues/7159)) → config 통째 reject. `discord total=0` 확정

### 변경
- `kube-prometheus-stack/values.yaml`: raw `alertmanager.config`에서 깨진 discord 제거 → base는 `null` + Watchdog 라우트
- 신규 `templates/alertmanagerconfig-discord.yaml`: AlertmanagerConfig CRD가 `apiURL`(SecretKeySelector)로 기존 `alertmanager-discord-secret`(monitoring ns) 참조 — operator가 허용하는 방식
- `alertmanagerSpec.alertmanagerConfigMatcherStrategy.type: None` → orino 등 전 네임스페이스 catch-all

### 검증
- `helm template` 통과. 렌더 확인: AlertmanagerConfig `orino-discord`(apiURL→DISCORD_WEBHOOK_URL), Alertmanager CR `matcherStrategy: None`, base config는 null+Watchdog(깨진 discord 제거됨)
- 머지 후: `alertmanager_notifications_total{integration="discord"}`가 0→증가, Discord에 알림 도착 확인 예정

### 범위 결정
- 외부 dead-man's-switch는 개인 프로젝트라 미도입. Discord 복구되면 향후 config 깨짐은 기존 `PrometheusOperatorSyncFailed` 알림이 자가신고
