### PR TITLE
fix : monitoring ResourceQuota limits.cpu 8→16 (quota 차단 해소)

### DIFF
--- a/infra/helm/platform-policies/values.yaml
+++ b/infra/helm/platform-policies/values.yaml
@@ -39,7 +39,10 @@ namespaces:
         cpu: "2"
         memory: 8Gi
       limits:
-        cpu: "8"
+        # limits.cpu는 네임스페이스 정책 상한(클러스터 총합 기준 버스트 상한, 예약/하드웨어 아님).
+        # 8코어는 관측 스택 limit 합보다 작아 loki 캐시·tempo·admission job이 막혀 있었음.
+        # 클러스터 총 32코어(2노드×16) 중 절반인 16으로 상향해 스택을 여유롭게 수용.
+        cpu: "16"
         memory: 16Gi
 
   - name: argocd


### PR DESCRIPTION
## 이슈
closes #540

## 작업 내용
monitoring `compute-quota`의 `limits.cpu=8`이 관측 스택 수요보다 작아 컴포넌트들이 스케줄 차단되던 문제 해결.

### 증거 (FailedCreate, quota full at 8000m)
- `loki-chunks-cache-0`/`loki-results-cache-0`: 24h째 0/1 (각 limits.cpu=1)
- `kube-prometheus-stack-admission-patch` job 반복 실패
- `tempo-0`: 재생성 차단 (#537 cpu limit 500m→1000m가 8000m 초과 노출)

→ `KubeStatefulSetReplicasMismatch`(loki 캐시) 알림의 실제 원인.

### 변경
- `platform-policies/values.yaml`: monitoring `resourceQuota.limits.cpu` **8 → 16**
- limits.cpu는 버스트 상한(예약 아님), 노드 각 16코어/실사용 ~3% → 안전

### 검증
- `helm template` 통과, monitoring quota `limits.cpu: 16` 렌더 확인
- 머지·동기화 후: loki 캐시 1/1, tempo-0 1/1(1.5Gi), admission job 정상 + 관련 알림 자동 해소 예정

> 배경: tempo-0가 CrashLoop(구 512Mi)로 새 limit을 못 받아 파드를 재생성하다 quota 차단을 발견. #537(tempo 1.5Gi)은 이미 머지됨.
