### PR TITLE
chore : 알림 노이즈 정리 (severity 필터·컨트롤플레인 scrape·오탐 룰)

### DIFF
--- a/infra/helm/kube-prometheus-stack/templates/alertmanagerconfig-discord.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/alertmanagerconfig-discord.yaml
@@ -9,6 +9,12 @@ spec:
   # 기존 alertmanager-discord-secret을 직접 참조한다.
   route:
     receiver: discord
+    # warning|critical만 Discord로. severity=none(Watchdog/InfoInhibitor)·info는
+    # 매칭 안 돼 base의 null receiver로 빠져 전송되지 않는다(노이즈 차단).
+    matchers:
+      - name: severity
+        matchType: "=~"
+        value: "warning|critical"
     groupBy:
       - alertname
       - namespace

--- a/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
@@ -19,7 +19,11 @@ spec:
             description: "Pod {{ "{{" }} $labels.pod {{ "}}" }}이 5분간 반복 재시작 중"
 
         - alert: PodOOMKilled
-          expr: kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} == 1
+          # 과거 이력이 아니라 최근(15m) 재시작이 동반된 active OOM만 발동(노이즈 차단)
+          expr: |
+            (kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} == 1)
+            and on(namespace, pod, container)
+            (increase(kube_pod_container_status_restarts_total[15m]) > 0)
           for: 0m
           labels:
             severity: warning
@@ -28,7 +32,11 @@ spec:
             description: "컨테이너 {{ "{{" }} $labels.container {{ "}}" }}이 메모리 부족으로 종료됨"
 
         - alert: PodNotReady
-          expr: kube_pod_status_ready{condition="true"} == 0
+          # 완료된 Job·디버그 파드(phase=Succeeded)는 Ready가 아닌 게 정상 → 제외(오탐 차단)
+          expr: |
+            (kube_pod_status_ready{condition="true"} == 0)
+            unless on(namespace, pod)
+            (kube_pod_status_phase{phase="Succeeded"} == 1)
           for: 10m
           labels:
             severity: warning

--- a/infra/helm/kube-prometheus-stack/values.yaml
+++ b/infra/helm/kube-prometheus-stack/values.yaml
@@ -41,6 +41,12 @@ kube-prometheus-stack:
     enabled: false
   kubeControllerManager:
     enabled: false
+  # kube-scheduler/kube-proxy 메트릭은 127.0.0.1 바인딩이라 스크랩 불가 →
+  # 끄지 않으면 TargetDown/ScrapeTargetDown 상시 firing(노이즈). 스크랩 비활성.
+  kubeScheduler:
+    enabled: false
+  kubeProxy:
+    enabled: false
   kubelet:
     enabled: true
 


### PR DESCRIPTION
## 이슈
closes #542

## 작업 내용
Discord 전달 복구(#539) 후 드러난 알림 폭주를 정리.

### 변경
1. **Discord 라우트 severity 필터** (`alertmanagerconfig-discord.yaml`)
   - `severity=~"warning|critical"`만 Discord로 → Watchdog(none)·InfoInhibitor(none)·CPUThrottlingHigh(info) 등은 base의 null로 빠져 미전송
2. **컨트롤플레인 scrape 비활성** (`values.yaml`)
   - `kubeScheduler.enabled=false`, `kubeProxy.enabled=false` — 메트릭이 127.0.0.1 바인딩이라 스크랩 불가 → 상시 TargetDown/ScrapeTargetDown 제거
3. **오탐 룰 수정** (`prometheusrule.yaml`)
   - `PodOOMKilled`: 최근 15m 재시작 동반 active OOM만 (과거 이력 firing 제거)
   - `PodNotReady`: `phase=Succeeded`(완료 Job·디버그 파드) 제외

### 검증
- `helm template` 통과. 렌더 확인: CRD severity matcher, kube-scheduler/kube-proxy ServiceMonitor 제거, 룰 expr 반영
- **Prometheus 실측**: PodNotReady 오탐 대상 **0건**(완료 Job/디버그 파드 제외됨), PodOOMKilled 오탐 대상 **0건**(과거 이력 제외)

> 이전 단계에서 #541(quota)로 tempo·loki 캐시·KubeStatefulSetReplicasMismatch는 이미 해소됨. 본 PR은 라우팅/룰 레벨 노이즈 정리.
