### PR TITLE
style : 플래너 캘린더 셀 정사각형화 및 레이아웃 폭 정리

### DIFF
--- a/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
@@ -211,7 +211,7 @@ export function PlannerCalendar() {
           </CardContent>
         </Card>
       ) : (
-        <div className="grid gap-6 lg:grid-cols-[1fr_20rem]">
+        <div className="mx-auto grid w-full max-w-6xl gap-6 lg:grid-cols-[1fr_24rem]">
           <Card>
             <CardContent className="flex flex-col gap-2">
               <div className="grid grid-cols-7 gap-1">
@@ -235,7 +235,7 @@ export function PlannerCalendar() {
                   {Array.from({ length: 42 }, (_, i) => (
                     <div
                       key={i}
-                      className="bg-muted/50 min-h-16 animate-pulse rounded-md"
+                      className="bg-muted/50 aspect-square animate-pulse rounded-md"
                     />
                   ))}
                 </div>

--- a/fe/src/features/planner/components/calendar/PlannerCalendarCell.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendarCell.tsx
@@ -61,7 +61,7 @@ export function PlannerCalendarCell({
       aria-pressed={isSelected}
       onClick={() => onSelect(isoDate)}
       className={cn(
-        "flex min-h-16 flex-col gap-1 rounded-md border p-1.5 text-left transition-colors",
+        "flex aspect-square flex-col gap-1 overflow-hidden rounded-md border p-1.5 text-left transition-colors",
         inMonth ? "bg-card" : "bg-muted/30 text-muted-foreground",
         isToday ? "border-primary" : "border-border",
         isSelected && "ring-primary ring-2",


### PR DESCRIPTION
## 이슈
closes #545
## 작업 내용
- 월간 캘린더 날짜 셀을 `min-h-16` → `aspect-square`로 변경 (풀스크린에서 납작한 직사각형 → 정사각형)
- 셀에 `overflow-hidden` 추가로 콘텐츠 넘침 방지
- 캘린더 레이아웃에 `max-w-6xl mx-auto` 적용 — 폭 상한(1152px) + 중앙 정렬로 과도하게 넓어지는 문제 해결
- 오른쪽 일정 리스트 폭 `20rem` → `24rem`(320→384px) 확대로 가독성 개선
- 로딩 스켈레톤도 `aspect-square`로 통일

## 검증
- Prettier / ESLint 통과
- `PlannerCalendar.test.tsx` 11개 통과
- 점(dot) 기반 셀 특성상 세로 공간이 불필요하여 정사각형이 가장 자연스러운 비율