### PR TITLE
fix : 캘린더 피드 지연 개선 (tasks 캐시 + 소스 병렬 호출)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/PlannerCalendarService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/PlannerCalendarService.java
@@ -8,7 +8,7 @@ import ds.project.orino.planner.google.calendar.dto.PlannerCalendarFeed;
 import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
 import ds.project.orino.planner.google.calendar.dto.PlannerReview;
 import ds.project.orino.planner.google.calendar.dto.PlannerTask;
-import ds.project.orino.planner.google.client.GoogleTasksClient;
+import ds.project.orino.planner.google.task.GoogleTasksQueryService;
 import ds.project.orino.planner.review.dto.CalendarReviewItem;
 import ds.project.orino.planner.review.service.ReviewQueryService;
 import org.springframework.stereotype.Service;
@@ -18,12 +18,19 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 /**
  * 통합 캘린더 피드 조립. 일정(Google)·할 일(M3)·복습(orino 오버레이)을 한 응답으로 모은다.
  *
  * <p>부분 실패 허용: 소스 하나가 실패해도 나머지를 정상 반환하고 {@code partial=true} + {@code errors[]}.
  * 잘못된 기간 요청은 부분 실패가 아니라 400(INVALID_REQUEST)으로 처리한다.
+ *
+ * <p>지연 최적화(#544): 외부 Google API 두 건(일정·할 일)을 직렬로 쌓던 것을 가상 스레드로 병렬 실행하고,
+ * 서브밀리초 DB 조회인 복습은 요청 스레드에서 그대로 수행한다(시간대 ThreadLocal·OSIV 유지). 총 지연이
+ * 직렬 합산에서 max로 줄어든다.
  */
 @Service
 public class PlannerCalendarService {
@@ -31,59 +38,92 @@ public class PlannerCalendarService {
     private static final int MAX_RANGE_DAYS = 100;
 
     private final GoogleEventQueryService googleEventQueryService;
-    private final GoogleTasksClient googleTasksClient;
+    private final GoogleTasksQueryService googleTasksQueryService;
     private final ReviewQueryService reviewQueryService;
+    private final ExecutorService plannerFeedExecutor;
 
     public PlannerCalendarService(GoogleEventQueryService googleEventQueryService,
-                                  GoogleTasksClient googleTasksClient,
-                                  ReviewQueryService reviewQueryService) {
+                                  GoogleTasksQueryService googleTasksQueryService,
+                                  ReviewQueryService reviewQueryService,
+                                  ExecutorService plannerFeedExecutor) {
         this.googleEventQueryService = googleEventQueryService;
-        this.googleTasksClient = googleTasksClient;
+        this.googleTasksQueryService = googleTasksQueryService;
         this.reviewQueryService = reviewQueryService;
+        this.plannerFeedExecutor = plannerFeedExecutor;
     }
 
     public PlannerCalendarFeed getFeed(Long memberId, LocalDate from, LocalDate to, ZoneId zone) {
         validateRange(from, to);
 
+        // 외부 Google API 두 건은 가상 스레드로 동시에 호출한다(zone은 인자로 전달, ThreadLocal 비의존).
+        CompletableFuture<EventsResult> eventsFuture =
+                CompletableFuture.supplyAsync(() -> fetchEvents(memberId, from, to, zone), plannerFeedExecutor);
+        CompletableFuture<TasksResult> tasksFuture =
+                CompletableFuture.supplyAsync(() -> fetchTasks(memberId, from, to), plannerFeedExecutor);
+
+        // 복습은 DB(서브밀리초)라 요청 스레드에서 실행해 UserTimeZone ThreadLocal과 OSIV를 유지한다.
+        ReviewsResult reviewsResult = fetchReviews(memberId, from, to);
+
+        EventsResult eventsResult = eventsFuture.join();
+        TasksResult tasksResult = tasksFuture.join();
+
         List<FeedError> errors = new ArrayList<>();
-
-        boolean googleConnected = false;
-        List<PlannerEvent> events = List.of();
-        try {
-            GoogleEventsView view = googleEventQueryService.getEvents(memberId, from, to, zone);
-            googleConnected = view.connected();
-            events = view.events();
-        } catch (CustomException e) {
-            // invalid_grant면 연동이 만료된 것이라 미연동으로 본다(FE 재연동 CTA).
-            googleConnected = e.getErrorCode() != ErrorCode.GOOGLE_INVALID_GRANT;
-            errors.add(new FeedError("google-events", e.getErrorCode().getMessage()));
-        } catch (RuntimeException e) {
-            googleConnected = true;
-            errors.add(new FeedError("google-events", "일정을 불러오지 못했습니다."));
-        }
-
-        List<PlannerReview> reviews = List.of();
-        try {
-            reviews = reviewQueryService.findCalendar(memberId, from, to).reviews().stream()
-                    .map(PlannerCalendarService::toFeedReview)
-                    .toList();
-        } catch (RuntimeException e) {
-            errors.add(new FeedError("reviews", "복습을 불러오지 못했습니다."));
-        }
-
-        List<PlannerTask> tasks = List.of();
-        if (googleConnected) {
-            try {
-                tasks = googleTasksClient.listTasks(memberId, false).stream()
-                        .filter(task -> withinRange(task.due(), from, to))
-                        .toList();
-            } catch (RuntimeException e) {
-                errors.add(new FeedError("google-tasks", "할 일을 불러오지 못했습니다."));
-            }
-        }
+        eventsResult.error().ifPresent(errors::add);
+        reviewsResult.error().ifPresent(errors::add);
+        tasksResult.error().ifPresent(errors::add);
 
         return new PlannerCalendarFeed(
-                from, to, googleConnected, !errors.isEmpty(), errors, events, tasks, reviews);
+                from, to,
+                eventsResult.connected(),
+                !errors.isEmpty(),
+                errors,
+                eventsResult.events(),
+                tasksResult.tasks(),
+                reviewsResult.reviews());
+    }
+
+    private EventsResult fetchEvents(Long memberId, LocalDate from, LocalDate to, ZoneId zone) {
+        try {
+            GoogleEventsView view = googleEventQueryService.getEvents(memberId, from, to, zone);
+            return new EventsResult(view.connected(), view.events(), Optional.empty());
+        } catch (CustomException e) {
+            // invalid_grant면 연동이 만료된 것이라 미연동으로 본다(FE 재연동 CTA).
+            boolean connected = e.getErrorCode() != ErrorCode.GOOGLE_INVALID_GRANT;
+            return new EventsResult(connected, List.of(),
+                    Optional.of(new FeedError("google-events", e.getErrorCode().getMessage())));
+        } catch (RuntimeException e) {
+            return new EventsResult(true, List.of(),
+                    Optional.of(new FeedError("google-events", "일정을 불러오지 못했습니다.")));
+        }
+    }
+
+    private ReviewsResult fetchReviews(Long memberId, LocalDate from, LocalDate to) {
+        try {
+            List<PlannerReview> reviews = reviewQueryService.findCalendar(memberId, from, to).reviews().stream()
+                    .map(PlannerCalendarService::toFeedReview)
+                    .toList();
+            return new ReviewsResult(reviews, Optional.empty());
+        } catch (RuntimeException e) {
+            return new ReviewsResult(List.of(), Optional.of(new FeedError("reviews", "복습을 불러오지 못했습니다.")));
+        }
+    }
+
+    private TasksResult fetchTasks(Long memberId, LocalDate from, LocalDate to) {
+        try {
+            List<PlannerTask> tasks = googleTasksQueryService.listTasks(memberId, false).stream()
+                    .filter(task -> withinRange(task.due(), from, to))
+                    .toList();
+            return new TasksResult(tasks, Optional.empty());
+        } catch (CustomException e) {
+            // 미연동/연동만료는 오류가 아니라 '할 일 없음'으로 본다(일정 소스와 동일 처리, partial 미표기).
+            if (e.getErrorCode() == ErrorCode.GOOGLE_NOT_CONNECTED
+                    || e.getErrorCode() == ErrorCode.GOOGLE_INVALID_GRANT) {
+                return new TasksResult(List.of(), Optional.empty());
+            }
+            return new TasksResult(List.of(), Optional.of(new FeedError("google-tasks", "할 일을 불러오지 못했습니다.")));
+        } catch (RuntimeException e) {
+            return new TasksResult(List.of(), Optional.of(new FeedError("google-tasks", "할 일을 불러오지 못했습니다.")));
+        }
     }
 
     /** due(날짜) 마감이 [from, to] 구간 안인 할 일만 캘린더에 배치한다(마감 없는 할 일은 제외). */
@@ -111,5 +151,14 @@ public class PlannerCalendarService {
                 || ChronoUnit.DAYS.between(from, to) > MAX_RANGE_DAYS) {
             throw new CustomException(ErrorCode.INVALID_REQUEST);
         }
+    }
+
+    private record EventsResult(boolean connected, List<PlannerEvent> events, Optional<FeedError> error) {
+    }
+
+    private record ReviewsResult(List<PlannerReview> reviews, Optional<FeedError> error) {
+    }
+
+    private record TasksResult(List<PlannerTask> tasks, Optional<FeedError> error) {
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/PlannerFeedExecutorConfig.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/PlannerFeedExecutorConfig.java
@@ -1,0 +1,22 @@
+package ds.project.orino.planner.google.calendar;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * 통합 피드의 독립 소스(일정·할 일)를 동시에 호출하기 위한 실행기.
+ *
+ * <p>대부분이 외부 Google API 블로킹 I/O라 가상 스레드(Java 21+)가 적합하다. 직렬 합산되던 외부 호출을
+ * 병렬화해 calendar 지연(#544)을 max로 단축한다.
+ */
+@Configuration
+public class PlannerFeedExecutorConfig {
+
+    @Bean(destroyMethod = "close")
+    public ExecutorService plannerFeedExecutor() {
+        return Executors.newVirtualThreadPerTaskExecutor();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/GoogleTaskController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/GoogleTaskController.java
@@ -2,7 +2,6 @@ package ds.project.orino.planner.google.task;
 
 import ds.project.orino.common.response.ApiResponse;
 import ds.project.orino.planner.google.calendar.dto.PlannerTask;
-import ds.project.orino.planner.google.client.GoogleTasksClient;
 import ds.project.orino.planner.google.task.dto.TaskCreateRequest;
 import ds.project.orino.planner.google.task.dto.TaskUpdateRequest;
 import ds.project.orino.planner.google.task.dto.TasksResponse;
@@ -27,10 +26,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/planner/tasks")
 public class GoogleTaskController {
 
-    private final GoogleTasksClient googleTasksClient;
+    private final GoogleTasksQueryService googleTasksQueryService;
+    private final GoogleTasksCommandService googleTasksCommandService;
 
-    public GoogleTaskController(GoogleTasksClient googleTasksClient) {
-        this.googleTasksClient = googleTasksClient;
+    public GoogleTaskController(GoogleTasksQueryService googleTasksQueryService,
+                                GoogleTasksCommandService googleTasksCommandService) {
+        this.googleTasksQueryService = googleTasksQueryService;
+        this.googleTasksCommandService = googleTasksCommandService;
     }
 
     @GetMapping
@@ -38,14 +40,14 @@ public class GoogleTaskController {
             @AuthenticationPrincipal Long memberId,
             @RequestParam(defaultValue = "false") boolean showCompleted) {
         return ApiResponse.success(
-                new TasksResponse(googleTasksClient.listTasks(memberId, showCompleted)));
+                new TasksResponse(googleTasksQueryService.listTasks(memberId, showCompleted)));
     }
 
     @PostMapping
     public ResponseEntity<ApiResponse<PlannerTask>> create(
             @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody TaskCreateRequest request) {
-        PlannerTask created = googleTasksClient.insertTask(memberId, request);
+        PlannerTask created = googleTasksCommandService.create(memberId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(created));
     }
 
@@ -54,14 +56,14 @@ public class GoogleTaskController {
             @AuthenticationPrincipal Long memberId,
             @PathVariable String taskId,
             @RequestBody TaskUpdateRequest request) {
-        return ApiResponse.success(googleTasksClient.patchTask(memberId, taskId, request));
+        return ApiResponse.success(googleTasksCommandService.update(memberId, taskId, request));
     }
 
     @DeleteMapping("/{taskId}")
     public ApiResponse<Void> delete(
             @AuthenticationPrincipal Long memberId,
             @PathVariable String taskId) {
-        googleTasksClient.deleteTask(memberId, taskId);
+        googleTasksCommandService.delete(memberId, taskId);
         return ApiResponse.success();
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/GoogleTasksCommandService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/GoogleTasksCommandService.java
@@ -1,0 +1,43 @@
+package ds.project.orino.planner.google.task;
+
+import ds.project.orino.planner.google.calendar.dto.PlannerTask;
+import ds.project.orino.planner.google.client.GoogleTasksClient;
+import ds.project.orino.planner.google.task.dto.TaskCreateRequest;
+import ds.project.orino.planner.google.task.dto.TaskUpdateRequest;
+import ds.project.orino.redis.planner.google.GoogleTasksCacheRepository;
+import org.springframework.stereotype.Service;
+
+/**
+ * 할 일 쓰기(생성/수정/삭제) 오케스트레이션. Google 프록시 후 해당 사용자 단기 캐시를 무효화한다.
+ *
+ * <p>미연동이면 {@link GoogleTasksClient}의 토큰 공급 단계에서 GOOGLE_NOT_CONNECTED(409)가 발생한다.
+ */
+@Service
+public class GoogleTasksCommandService {
+
+    private final GoogleTasksClient tasksClient;
+    private final GoogleTasksCacheRepository cacheRepository;
+
+    public GoogleTasksCommandService(GoogleTasksClient tasksClient,
+                                     GoogleTasksCacheRepository cacheRepository) {
+        this.tasksClient = tasksClient;
+        this.cacheRepository = cacheRepository;
+    }
+
+    public PlannerTask create(Long memberId, TaskCreateRequest request) {
+        PlannerTask created = tasksClient.insertTask(memberId, request);
+        cacheRepository.evictAll(memberId);
+        return created;
+    }
+
+    public PlannerTask update(Long memberId, String taskId, TaskUpdateRequest request) {
+        PlannerTask updated = tasksClient.patchTask(memberId, taskId, request);
+        cacheRepository.evictAll(memberId);
+        return updated;
+    }
+
+    public void delete(Long memberId, String taskId) {
+        tasksClient.deleteTask(memberId, taskId);
+        cacheRepository.evictAll(memberId);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/GoogleTasksQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/task/GoogleTasksQueryService.java
@@ -1,0 +1,69 @@
+package ds.project.orino.planner.google.task;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.google.calendar.dto.PlannerTask;
+import ds.project.orino.planner.google.client.GoogleTasksClient;
+import ds.project.orino.redis.planner.google.GoogleTasksCacheRepository;
+import org.springframework.stereotype.Service;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 할 일 조회: 단기 캐시(~60초) + 라이브 프록시. 통합 피드(#479)와 단독 목록 조회가 이 결과를 사용한다.
+ *
+ * <p>매 요청 Tasks API를 라이브 호출하던 지연(#544)을 일정과 동일한 캐시 패턴으로 흡수한다.
+ * 미연동/연동만료는 {@link GoogleTasksClient}가 예외로 던지므로 캐시하지 않고 그대로 전파한다
+ * (단독 엔드포인트의 409 시맨틱 보존, 피드에서는 호출부가 빈 목록으로 처리).
+ */
+@Service
+public class GoogleTasksQueryService {
+
+    private static final Duration CACHE_TTL = Duration.ofSeconds(60);
+    private static final TypeReference<List<PlannerTask>> TASK_LIST = new TypeReference<>() {
+    };
+
+    private final GoogleTasksClient tasksClient;
+    private final GoogleTasksCacheRepository cacheRepository;
+    private final ObjectMapper objectMapper;
+
+    public GoogleTasksQueryService(GoogleTasksClient tasksClient,
+                                   GoogleTasksCacheRepository cacheRepository,
+                                   ObjectMapper objectMapper) {
+        this.tasksClient = tasksClient;
+        this.cacheRepository = cacheRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    public List<PlannerTask> listTasks(Long memberId, boolean showCompleted) {
+        Optional<String> cached = cacheRepository.find(memberId, showCompleted);
+        if (cached.isPresent()) {
+            return deserialize(cached.get());
+        }
+
+        List<PlannerTask> tasks = tasksClient.listTasks(memberId, showCompleted);
+        cacheRepository.save(memberId, showCompleted, serialize(tasks), CACHE_TTL);
+        return tasks;
+    }
+
+    private String serialize(List<PlannerTask> tasks) {
+        try {
+            return objectMapper.writeValueAsString(tasks);
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.GOOGLE_API_FAILED, e);
+        }
+    }
+
+    private List<PlannerTask> deserialize(String json) {
+        try {
+            return objectMapper.readValue(json, TASK_LIST);
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.GOOGLE_API_FAILED, e);
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/task/GoogleTasksQueryServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/task/GoogleTasksQueryServiceTest.java
@@ -1,0 +1,164 @@
+package ds.project.orino.planner.google.task;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.planner.google.calendar.dto.PlannerTask;
+import ds.project.orino.planner.google.task.dto.TaskCreateRequest;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.IntegrationTest;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@IntegrationTest
+class GoogleTasksQueryServiceTest {
+
+    private static final HttpServer TASKS_STUB = createStub();
+    private static final AtomicInteger LIST_CALL_COUNT = new AtomicInteger();
+    private static final String LIST_BODY = """
+            {"items":[{"id":"t1","title":"리포트 제출","status":"needsAction","due":"2026-06-12T00:00:00.000Z"}]}""";
+
+    @Autowired
+    private GoogleTasksQueryService tasksQueryService;
+    @Autowired
+    private GoogleTasksCommandService tasksCommandService;
+    @Autowired
+    private GoogleAccountRepository accountRepository;
+    @Autowired
+    private GoogleAccessTokenRepository accessTokenRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Long memberId;
+
+    @DynamicPropertySource
+    static void googleProperties(DynamicPropertyRegistry registry) {
+        String base = "http://127.0.0.1:" + TASKS_STUB.getAddress().getPort();
+        registry.add("planner.google.client-id", () -> "test-client-id");
+        registry.add("planner.google.client-secret", () -> "test-client-secret");
+        registry.add("planner.google.oauth.tasks-api-base-url", () -> base);
+    }
+
+    @AfterAll
+    static void stopStub() {
+        TASKS_STUB.stop(0);
+    }
+
+    @BeforeEach
+    void setUp() {
+        LIST_CALL_COUNT.set(0);
+        dbCleaner.clean();
+        memberId = memberRepository.save(MemberFixture.create()).getId();
+    }
+
+    private void connect() {
+        accountRepository.save(new GoogleAccount(
+                memberId, "refresh", "scope", "me@gmail.com", "primary", "@default"));
+        // access token을 미리 캐시해 refresh grant 없이 tasks 호출만 일어나게 한다.
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+    }
+
+    @Test
+    @DisplayName("미연동이면 GOOGLE_NOT_CONNECTED를 전파하고 Google을 호출하지 않는다")
+    void listTasks_notConnected() {
+        assertThatThrownBy(() -> tasksQueryService.listTasks(memberId, false))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.GOOGLE_NOT_CONNECTED);
+
+        assertThat(LIST_CALL_COUNT.get()).isZero();
+    }
+
+    @Test
+    @DisplayName("할 일 목록을 정규화해 반환한다")
+    void listTasks_normalizes() {
+        connect();
+
+        List<PlannerTask> tasks = tasksQueryService.listTasks(memberId, false);
+
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).id()).isEqualTo("t1");
+        assertThat(tasks.get(0).due()).isEqualTo("2026-06-12");
+        assertThat(tasks.get(0).completed()).isFalse();
+        assertThat(tasks.get(0).source()).isEqualTo("google");
+    }
+
+    @Test
+    @DisplayName("재조회는 단기 캐시로 흡수해 Google을 한 번만 호출한다")
+    void listTasks_caches() {
+        connect();
+
+        List<PlannerTask> first = tasksQueryService.listTasks(memberId, false);
+        List<PlannerTask> second = tasksQueryService.listTasks(memberId, false);
+
+        assertThat(LIST_CALL_COUNT.get()).isEqualTo(1);
+        assertThat(first).hasSize(1);
+        assertThat(second).hasSize(1);
+        assertThat(second.get(0).id()).isEqualTo("t1");
+    }
+
+    @Test
+    @DisplayName("쓰기(생성) 후에는 캐시가 무효화되어 다음 조회가 Google을 다시 호출한다")
+    void write_evictsCache() {
+        connect();
+
+        tasksQueryService.listTasks(memberId, false); // 1회 호출 + 캐시 적재
+        tasksCommandService.create(memberId, new TaskCreateRequest("새 할일", "2026-06-12", null)); // evict
+        tasksQueryService.listTasks(memberId, false); // 캐시 미스 → 재호출
+
+        assertThat(LIST_CALL_COUNT.get()).isEqualTo(2);
+    }
+
+    private static HttpServer createStub() {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/tasks/v1/lists/@default/tasks", exchange -> {
+                if ("GET".equals(exchange.getRequestMethod())) {
+                    LIST_CALL_COUNT.incrementAndGet();
+                    respond(exchange, LIST_BODY);
+                } else {
+                    respond(exchange, """
+                            {"id":"t1","title":"새 할일","status":"needsAction","due":"2026-06-12T00:00:00.000Z"}""");
+                }
+            });
+            server.start();
+            return server;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void respond(HttpExchange exchange, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+}

--- a/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/google/GoogleTasksCacheRepository.java
+++ b/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/google/GoogleTasksCacheRepository.java
@@ -1,0 +1,46 @@
+package ds.project.orino.redis.planner.google;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * 통합 피드 할 일 조회의 단기 캐시. 키 {@code google:tasks-cache:{memberId}:{showCompleted}}.
+ *
+ * <p>Tasks API는 캐시가 없어 매 요청 라이브 호출되던 지연 요인이었다(#544). 일정 캐시와 동일하게
+ * 직렬화된 응답(JSON 문자열)을 단기(~60초) 보관하고, 쓰기 후엔 해당 사용자 캐시를 무효화한다.
+ */
+@Repository
+public class GoogleTasksCacheRepository {
+
+    private static final String KEY_PREFIX = "google:tasks-cache:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public GoogleTasksCacheRepository(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(Long memberId, boolean showCompleted, String json, Duration ttl) {
+        redisTemplate.opsForValue().set(key(memberId, showCompleted), json, ttl);
+    }
+
+    public Optional<String> find(Long memberId, boolean showCompleted) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(key(memberId, showCompleted)));
+    }
+
+    /** 해당 사용자의 모든 할 일 캐시를 무효화한다(쓰기 후 호출). 단일 사용자/저트래픽이라 keys 패턴 삭제로 충분. */
+    public void evictAll(Long memberId) {
+        Set<String> keys = redisTemplate.keys(KEY_PREFIX + memberId + ":*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+
+    private String key(Long memberId, boolean showCompleted) {
+        return KEY_PREFIX + memberId + ":" + showCompleted;
+    }
+}


### PR DESCRIPTION
## 이슈
closes #544

## 작업 내용
`GET /api/planner/calendar`의 p95 500~1200ms 지연 SLO 위반 해소. 원인은 `getFeed()`가 3개 소스를 **직렬** 실행하며, 그중 둘이 외부 Google API HTTP 호출(events·tasks)이고 **tasks는 캐시가 없어 매 요청 라이브 호출**되던 점.

### 1. tasks Redis 캐시 추가 (최대 기여 요인 제거)
- `GoogleTasksQueryService` 신설 — 조회에 단기 캐시(60s) 적용 (일정 `GoogleEventQueryService`와 동일 패턴)
- `GoogleTasksCommandService` 신설 — 생성/수정/삭제 후 캐시 무효화
- `GoogleTasksCacheRepository` 신설 — `google:tasks-cache:{memberId}:{showCompleted}` 키 (calendar 캐시 미러)
- `GoogleTaskController`가 Query/Command 서비스 경유로 전환

### 2. 소스 병렬 실행 (직렬 합산 → max)
- 외부 Google API 2건(일정·할일)을 **가상 스레드**(`PlannerFeedExecutorConfig`)로 동시 호출
- DB 조회인 복습(서브밀리초)은 **요청 스레드에서 유지** — `UserTimeZone` ThreadLocal·OSIV가 깨지지 않게 함
- 미연동/연동만료 시 tasks는 오류가 아닌 '빈 목록'으로 처리해 기존 `partial=false` 시맨틱 보존

## 검증
- 신규 `GoogleTasksQueryServiceTest` (4): 미연동 전파·정규화·캐시 흡수·쓰기 후 무효화
- 기존 `GoogleTaskControllerTest`(5)·`PlannerCalendarControllerTest`(5)·`GoogleEventQueryServiceTest`(4) 회귀 통과
- `:orino-app-api:test` 전체 통과, checkstyle 통과
- 비고: 실제 Google OAuth 연동이 필요한 라이브 검증은 로컬 불가하여, HTTP 스텁 기반 통합테스트(전체 Spring 컨텍스트 부팅)로 캐시·병렬 경로·부분실패를 검증함