### PR TITLE
feat : 캘린더 복귀 시 SWR 재검증 (focus/visibility refetch)

### DIFF
--- a/fe/src/app/focusRevalidation.test.ts
+++ b/fe/src/app/focusRevalidation.test.ts
@@ -1,0 +1,46 @@
+import { focusManager } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { installFocusRevalidation } from "./focusRevalidation";
+
+function setVisibility(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+describe("installFocusRevalidation", () => {
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    installFocusRevalidation();
+    // focusManager는 구독자가 있어야 이벤트 setup이 활성화된다(QueryClient mount 대용).
+    unsubscribe = focusManager.subscribe(() => {});
+  });
+
+  afterEach(() => {
+    unsubscribe();
+    setVisibility("visible");
+    focusManager.setFocused(undefined);
+  });
+
+  it("visibilitychange(hidden) 신호로 unfocused가 된다(탭 전환 복귀 경로)", () => {
+    setVisibility("hidden");
+    window.dispatchEvent(new Event("visibilitychange"));
+
+    expect(focusManager.isFocused()).toBe(false);
+  });
+
+  it("window focus 신호로 focused가 된다(다른 창/앱 복귀 경로 — RQ 기본은 미구독)", () => {
+    // 먼저 unfocused로 만든 뒤, focus 이벤트만으로 다시 focused가 되는지 확인한다.
+    setVisibility("hidden");
+    window.dispatchEvent(new Event("visibilitychange"));
+    expect(focusManager.isFocused()).toBe(false);
+
+    setVisibility("visible");
+    window.dispatchEvent(new Event("focus"));
+
+    expect(focusManager.isFocused()).toBe(true);
+  });
+});

--- a/fe/src/app/focusRevalidation.ts
+++ b/fe/src/app/focusRevalidation.ts
@@ -1,0 +1,25 @@
+import { focusManager } from "@tanstack/react-query";
+
+/**
+ * 앱 복귀(재포커스) 시 활성 쿼리를 재검증하기 위한 focus 신호 구독.
+ *
+ * React Query v5 기본 focusManager는 `visibilitychange`만 구독한다. 다른 탭에서 보다 돌아온
+ * 경우는 그걸로 잡히지만, 다른 창/앱에서 (탭이 계속 보이는 채로) 돌아온 경우는 window `focus`가
+ * 필요하다. 두 신호를 모두 구독해 "화면이 방금 다시 보이게 됨"을 빠짐없이 잡는다.
+ *
+ * 재검증 여부는 각 쿼리의 staleTime(=연사 dedupe 창)이 결정하므로, 여기서는 신호만 전달한다.
+ */
+export function installFocusRevalidation(): void {
+  focusManager.setEventListener((handleFocus) => {
+    if (typeof window === "undefined" || !window.addEventListener) {
+      return () => {};
+    }
+    const onFocus = () => handleFocus(document.visibilityState === "visible");
+    window.addEventListener("visibilitychange", onFocus, false);
+    window.addEventListener("focus", onFocus, false);
+    return () => {
+      window.removeEventListener("visibilitychange", onFocus);
+      window.removeEventListener("focus", onFocus);
+    };
+  });
+}

--- a/fe/src/app/providers.tsx
+++ b/fe/src/app/providers.tsx
@@ -10,7 +10,11 @@ import { useLocation } from "react-router-dom";
 
 import { reissue } from "../features/auth/api/auth";
 import { getAccessToken } from "../features/auth/store/authStore";
+import { installFocusRevalidation } from "./focusRevalidation";
 import { prefetchRoutes } from "./routeImports";
+
+// 복귀(visibilitychange + window focus) 시 활성 쿼리를 재검증하도록 focus 신호를 구독한다.
+installFocusRevalidation();
 
 interface AuthContextType {
   isAuthenticated: boolean;

--- a/fe/src/features/planner/hooks/usePlannerCalendar.test.tsx
+++ b/fe/src/features/planner/hooks/usePlannerCalendar.test.tsx
@@ -1,0 +1,125 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { installFocusRevalidation } from "@/app/focusRevalidation";
+import { server } from "@/test/mocks/server";
+
+import { usePlannerCalendar } from "./usePlannerCalendar";
+
+const CALENDAR_URL = "https://api.orino.dev/api/planner/calendar";
+const FROM = "2026-06-01";
+const TO = "2026-06-30";
+
+function setVisibility(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+/** 실제 복귀처럼 unfocus→focus 전이를 만들어 RQ의 window-focus refetch 판정을 트리거한다. */
+function refocus() {
+  setVisibility("hidden");
+  window.dispatchEvent(new Event("visibilitychange"));
+  setVisibility("visible");
+  window.dispatchEvent(new Event("focus"));
+}
+
+/** events 개수만 다른 최소 피드 응답(envelope). */
+function feedResponse(eventCount: number) {
+  return HttpResponse.json({
+    data: {
+      from: FROM,
+      to: TO,
+      googleConnected: true,
+      partial: false,
+      errors: [],
+      events: Array.from({ length: eventCount }, (_, i) => ({
+        id: `e${i}`,
+        title: "일정",
+        allDay: false,
+        start: "2026-06-10T09:00:00",
+        end: "2026-06-10T10:00:00",
+        location: null,
+        recurring: false,
+        source: "google",
+      })),
+      tasks: [],
+      reviews: [],
+    },
+  });
+}
+
+/** GET 호출마다 events 개수를 1씩 늘려 응답한다(재호출 여부를 데이터로 식별). */
+function installCountingHandler(): () => number {
+  let calls = 0;
+  server.use(
+    http.get(CALENDAR_URL, () => {
+      calls += 1;
+      return feedResponse(calls);
+    }),
+  );
+  return () => calls;
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("usePlannerCalendar 복귀 재검증", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    server.resetHandlers();
+    setVisibility("visible");
+  });
+
+  it("dedupe 창(8초) 안의 재포커스는 refetch하지 않는다", async () => {
+    installFocusRevalidation();
+    const callCount = installCountingHandler();
+
+    const { result } = renderHook(() => usePlannerCalendar(FROM, TO), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data?.events).toHaveLength(1));
+    expect(callCount()).toBe(1);
+
+    // 초기 로드 직후(8초 이내) 복귀 → stale 아님 → refetch 스킵
+    refocus();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(callCount()).toBe(1);
+    expect(result.current.data?.events).toHaveLength(1);
+  });
+
+  it("dedupe 창을 지난 뒤 복귀하면 SWR로 재검증한다(옛 값 유지 후 교체)", async () => {
+    installFocusRevalidation();
+    const callCount = installCountingHandler();
+    const baseNow = Date.now();
+
+    const { result } = renderHook(() => usePlannerCalendar(FROM, TO), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data?.events).toHaveLength(1));
+    expect(callCount()).toBe(1);
+
+    // 9초 경과를 시뮬레이션(staleTime 8초 초과) → 복귀 시 stale로 판정되어 refetch
+    vi.spyOn(Date, "now").mockReturnValue(baseNow + 9000);
+    refocus();
+
+    // SWR: refetch 중에도 이전 데이터는 유지되다가 완료 후 교체된다.
+    await waitFor(() => expect(callCount()).toBe(2));
+    await waitFor(() => expect(result.current.data?.events).toHaveLength(2));
+  });
+});

--- a/fe/src/features/planner/hooks/usePlannerCalendar.ts
+++ b/fe/src/features/planner/hooks/usePlannerCalendar.ts
@@ -3,10 +3,15 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchPlannerCalendar } from "../api/feed";
 import { plannerKeys } from "../queryKeys";
 
+// 복귀(재포커스) 재검증 시 연사를 막는 dedupe 창. 이 시간 내 재포커스는 refetch를 건너뛴다.
+const REVALIDATE_DEDUPE_MS = 8 * 1000;
+
 export function usePlannerCalendar(from: string, to: string) {
   return useQuery({
     queryKey: plannerKeys.calendar(from, to),
     queryFn: () => fetchPlannerCalendar(from, to),
-    staleTime: 60 * 1000,
+    // 복귀 시 보이는 캘린더만 SWR 재검증한다(옛 값 유지 후 조용히 교체). staleTime이 곧 연사 dedupe 창.
+    staleTime: REVALIDATE_DEDUPE_MS,
+    refetchOnWindowFocus: true,
   });
 }


### PR DESCRIPTION
## 이슈
closes #548

## 작업 내용
앱(탭/창)으로 복귀했을 때 마운트된 캘린더가 자동 갱신되지 않던 문제(`refetchOnWindowFocus: false`)를 해결한다. **A안** — FE 복귀 트리거만, 외부 편집 즉시성은 BE 60s TTL 바닥 허용. 웹훅/syncToken 미도입.

설계 4조각은 대부분 React Query 내장 동작과 맞물리며, 실제 추가 코드는 두 군데뿐:

### 1. `installFocusRevalidation` (`app/focusRevalidation.ts`)
- focusManager를 `visibilitychange` + window `focus` **두 신호** 모두 구독
- RQ v5 기본 focusManager는 `visibilitychange`만 구독 → 다른 창/앱에서 (탭이 보이는 채로) 복귀하는 경로가 새는 것을 막음
- `providers.tsx`에서 1회 설치

### 2. `usePlannerCalendar` 쿼리 옵션
- `refetchOnWindowFocus: true`
- `staleTime: 8s` — **복귀 dedupe 창** 역할(8초 내 재포커스는 refetch 스킵, 포커스 흔들림에 API 난타 방지)

### RQ 기본 동작으로 충족(별도 코드 없음)
- SWR 렌더(옛 값 유지 후 조용히 교체), 동일 queryKey in-flight dedupe, active(보이는) 쿼리만 refetch, 백그라운드 refetch 실패 시 옛 값 유지

## 동작
복귀 → (마지막 fetch 8초 초과 시) 백그라운드 refetch → 빈 화면 없이 ≤60s 신선도로 수렴. BE 60s 캐시가 외부 편집 반영의 바닥이며, 즉시성이 더 필요하면 별도로 BE TTL/우회를 검토.

## 검증
- 신규 테스트: `focusRevalidation.test.ts`(두 신호 구독) + `usePlannerCalendar.test.tsx`(복귀 refetch / dedupe 창 내 스킵)
- FE 전체 146개 통과, prettier·eslint·tsc 통과