### PR TITLE
chore : monitoring info 알림 정리 (requests.cpu quota + CPU throttle)

### DIFF
--- a/infra/helm/argocd/values.yaml
+++ b/infra/helm/argocd/values.yaml
@@ -43,7 +43,8 @@ repoServer:
       cpu: 50m
       memory: 128Mi
     limits:
-      cpu: 500m
+      # 매니페스트 생성 버스트로 500m에서 32% CPU throttle 발생 → 750m로 상향.
+      cpu: 750m
       memory: 768Mi
 
 # ApplicationSet 미사용 중이지만 App of Apps 보완재로 구동

--- a/infra/helm/kube-prometheus-stack/templates/alertmanagerconfig-discord.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/alertmanagerconfig-discord.yaml
@@ -9,6 +9,12 @@ spec:
   # 기존 alertmanager-discord-secret을 직접 참조한다.
   route:
     receiver: discord
+    # warning|critical만 Discord로. severity=none(Watchdog/InfoInhibitor)·info는
+    # 매칭 안 돼 base의 null receiver로 빠져 전송되지 않는다(노이즈 차단).
+    matchers:
+      - name: severity
+        matchType: "=~"
+        value: "warning|critical"
     groupBy:
       - alertname
       - namespace

--- a/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
@@ -19,7 +19,11 @@ spec:
             description: "Pod {{ "{{" }} $labels.pod {{ "}}" }}이 5분간 반복 재시작 중"
 
         - alert: PodOOMKilled
-          expr: kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} == 1
+          # 과거 이력이 아니라 최근(15m) 재시작이 동반된 active OOM만 발동(노이즈 차단)
+          expr: |
+            (kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} == 1)
+            and on(namespace, pod, container)
+            (increase(kube_pod_container_status_restarts_total[15m]) > 0)
           for: 0m
           labels:
             severity: warning
@@ -28,7 +32,11 @@ spec:
             description: "컨테이너 {{ "{{" }} $labels.container {{ "}}" }}이 메모리 부족으로 종료됨"
 
         - alert: PodNotReady
-          expr: kube_pod_status_ready{condition="true"} == 0
+          # 완료된 Job·디버그 파드(phase=Succeeded)는 Ready가 아닌 게 정상 → 제외(오탐 차단)
+          expr: |
+            (kube_pod_status_ready{condition="true"} == 0)
+            unless on(namespace, pod)
+            (kube_pod_status_phase{phase="Succeeded"} == 1)
           for: 10m
           labels:
             severity: warning

--- a/infra/helm/kube-prometheus-stack/values.yaml
+++ b/infra/helm/kube-prometheus-stack/values.yaml
@@ -152,5 +152,6 @@ kube-prometheus-stack:
         cpu: 50m
         memory: 32Mi
       limits:
-        cpu: 200m
+        # scrape 시 버스트로 200m에서 25% CPU throttle 발생 → 300m로 상향.
+        cpu: 300m
         memory: 128Mi

--- a/infra/helm/kube-prometheus-stack/values.yaml
+++ b/infra/helm/kube-prometheus-stack/values.yaml
@@ -41,6 +41,12 @@ kube-prometheus-stack:
     enabled: false
   kubeControllerManager:
     enabled: false
+  # kube-scheduler/kube-proxy 메트릭은 127.0.0.1 바인딩이라 스크랩 불가 →
+  # 끄지 않으면 TargetDown/ScrapeTargetDown 상시 firing(노이즈). 스크랩 비활성.
+  kubeScheduler:
+    enabled: false
+  kubeProxy:
+    enabled: false
   kubelet:
     enabled: true
 

--- a/infra/helm/platform-policies/values.yaml
+++ b/infra/helm/platform-policies/values.yaml
@@ -36,7 +36,10 @@ namespaces:
     resourceQuota:
       enabled: true
       requests:
-        cpu: "2"
+        # requests.cpu는 네임스페이스 reservation 캡. 관측 스택 requests 합(약 1845m)이
+        # hard=2에 92% 도달해 KubeQuotaAlmostFull 발화·신규 파드 admission이 막힘.
+        # 클러스터 총 32코어(2노드×16) 기준 3으로 상향해 여유 확보(약 61%).
+        cpu: "3"
         memory: 8Gi
       limits:
         # limits.cpu는 네임스페이스 정책 상한(클러스터 총합 기준 버스트 상한, 예약/하드웨어 아님).


### PR DESCRIPTION
## 이슈
closes #550

## 작업 내용

monitoring 네임스페이스에서 지속 발화하던 info 레벨 알림 2종 정리. #541에서 `limits.cpu`만 손댔던 것의 후속.

### KubeQuotaAlmostFull (3일째 firing)
- `compute-quota`의 `requests.cpu` 사용 1845m / hard 2000m = **92%** → 90% 임계 초과, 신규 파드 admission 차단 위험
- monitoring `requests.cpu` **`"2" → "3"`** (32코어 클러스터 reservation 캡, 약 61%로 해소)

### CPUThrottlingHigh
- node-exporter (scrape 버스트, throttle 25%): cpu limit **`200m → 300m`**
- argocd repo-server (매니페스트 생성 버스트, throttle 32%): cpu limit **`500m → 750m`**

### 검증
- `helm template`로 3개 모두 렌더링 확인
  - platform-policies → `requests.cpu: "3"`
  - kube-prometheus-stack → node-exporter `cpu: 300m`
  - argo/argo-cd 9.4.10 + values → repo-server `cpu: 750m`
- ⚠️ ArgoCD 본체는 GitOps 밖(수동 배포)이라, argocd values 변경분은 머지 후 `note1`에서 `helm upgrade argocd argo/argo-cd --version 9.4.10 -f values.yaml` 수동 반영 필요. 나머지 2개는 ArgoCD 자동 sync.
