### PR TITLE
chore : ArgoCD 본체를 App-of-Apps 자기관리로 편입

### DIFF
--- a/infra/argocd/applications/argocd-app.yaml
+++ b/infra/argocd/applications/argocd-app.yaml
@@ -1,0 +1,44 @@
+# ArgoCD 본체를 자기관리(self-management)한다.
+# 최초 설치는 chicken-and-egg라 Ansible(argocd_bootstrap role)이 담당하고,
+# 그 이후 values 변경은 이 Application이 다른 앱처럼 GitOps로 자동 반영한다.
+#
+# multi-source: upstream argo-cd 차트 + repo의 helm/argocd/values.yaml($values).
+# values.yaml은 top-level 단일 파일이라 부트스트랩 role의 `-f values.yaml` 과 동일 소스를 공유한다.
+# prune:false — 오설정이 ArgoCD 자기 컴포넌트 삭제로 번지지 않게(orino-project 앱과 동일 보수 정책).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd
+  namespace: argocd
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-running.discord: ""
+    notifications.argoproj.io/subscribe.on-sync-succeeded.discord: ""
+    notifications.argoproj.io/subscribe.on-sync-failed.discord: ""
+    notifications.argoproj.io/subscribe.on-health-degraded.discord: ""
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: orino
+
+  sources:
+    - repoURL: https://argoproj.github.io/argo-helm
+      chart: argo-cd
+      targetRevision: 9.4.10
+      helm:
+        valueFiles:
+          - $values/infra/helm/argocd/values.yaml
+    - repoURL: https://github.com/wcorn/orino.git
+      targetRevision: main
+      ref: values
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infra/argocd/project/project.yaml
+++ b/infra/argocd/project/project.yaml
@@ -10,6 +10,8 @@ spec:
 
   sourceRepos:
     - https://github.com/wcorn/orino.git
+    # ArgoCD 자기관리 Application(argocd-app.yaml)이 upstream argo-cd 차트를 multi-source로 참조.
+    - https://argoproj.github.io/argo-helm
 
   destinations:
     - server: https://kubernetes.default.svc

--- a/infra/helm/argocd/values.yaml
+++ b/infra/helm/argocd/values.yaml
@@ -1,11 +1,10 @@
-# ArgoCD 본체는 chicken-and-egg 문제로 GitOps 관리 밖이다.
-# 배포/업그레이드는 note1에서 수동으로 실행한다:
-#
-#   ssh note1 "helm repo update argo && \
-#     helm upgrade argocd argo/argo-cd --namespace argocd --version 9.4.10 \
-#       -f values.yaml"
-#
-# values 변경 시 이 파일을 먼저 갱신한 뒤 수동 apply.
+# ArgoCD 본체 values. 단일 진실(single source of truth)로 두 경로가 공유한다:
+#   1. 최초 설치(chicken-and-egg): Ansible argocd_bootstrap role 이
+#      `helm upgrade --install argocd argo/argo-cd --version 9.4.10 -f <이 파일>` 로 부트스트랩.
+#   2. 이후 업그레이드: 자기관리 Application(infra/argocd/applications/argocd-app.yaml)이
+#      이 파일을 $values 로 참조해 GitOps 자동 반영(self-heal). 수동 helm upgrade 불필요.
+# 차트 버전(9.4.10)을 올릴 때는 argocd-app.yaml 의 targetRevision 과
+# argocd_bootstrap 의 chart_version 을 함께 맞춘다.
 
 configs:
   params:


### PR DESCRIPTION
## 이슈
closes #552

## 작업 내용

ArgoCD 본체(`helm/argocd/values.yaml`) 변경이 어떤 자동 경로로도 반영되지 않던 공백을 해소한다. 운영 모델은 수동 배포 없이 **Ansible 또는 App-of-Apps 자동 반영**만 사용하므로, ArgoCD를 자기관리 Application으로 App-of-Apps에 편입했다.

### 변경
- **`applications/argocd-app.yaml` (신규)**: multi-source self-managed Application
  - source 1: upstream `argo/argo-cd` 9.4.10 차트
  - source 2: 이 repo(`ref: values`) → `$values/infra/helm/argocd/values.yaml`
  - `prune: false` + `selfHeal: true` — `orino-project` 앱과 동일한 보수 정책(오설정이 ArgoCD 자기 컴포넌트 삭제로 번지지 않게)
- **`project.yaml`**: `sourceRepos`에 `https://argoproj.github.io/argo-helm` 추가 (multi-source 검증 통과용). AppProject는 `orino-project` 앱이 GitOps 관리 → 머지만으로 반영
- **`helm/argocd/values.yaml`**: 헤더 주석을 "수동 helm upgrade" → "부트스트랩만 Ansible, 이후 자기관리" 로 갱신

### 설계 메모
- values.yaml을 top-level 단일 파일로 유지 → Ansible `argocd_bootstrap` role의 `-f values.yaml` 소비와 **동일 소스 공유**(이중 관리·포맷 분기 없음)
- 최초 설치(chicken-and-egg)는 그대로 Ansible 담당, 이후 업그레이드만 GitOps로 이관

### 검증
- 3개 YAML 파싱 OK
- `helm template argo/argo-cd 9.4.10 -f helm/argocd/values.yaml` 렌더 정상 → repo-server `cpu: 750m` 확인
- 머지 후: `argocd` Application Synced/Healthy + repo-server limit 750m 반영(= #550 잔여분 자동 해소) 확인 예정
