### PR TITLE
fix : 플래너 캘린더 풀폭 정렬 + 반응형 셀 높이

### DIFF
--- a/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
@@ -211,7 +211,7 @@ export function PlannerCalendar() {
           </CardContent>
         </Card>
       ) : (
-        <div className="mx-auto grid w-full max-w-6xl gap-6 lg:grid-cols-[1fr_24rem]">
+        <div className="grid gap-6 lg:grid-cols-[1fr_24rem]">
           <Card>
             <CardContent className="flex flex-col gap-2">
               <div className="grid grid-cols-7 gap-1">
@@ -235,7 +235,7 @@ export function PlannerCalendar() {
                   {Array.from({ length: 42 }, (_, i) => (
                     <div
                       key={i}
-                      className="bg-muted/50 aspect-square animate-pulse rounded-md"
+                      className="bg-muted/50 min-h-20 animate-pulse rounded-md sm:min-h-24 lg:min-h-28"
                     />
                   ))}
                 </div>

--- a/fe/src/features/planner/components/calendar/PlannerCalendarCell.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendarCell.tsx
@@ -61,7 +61,7 @@ export function PlannerCalendarCell({
       aria-pressed={isSelected}
       onClick={() => onSelect(isoDate)}
       className={cn(
-        "flex aspect-square flex-col gap-1 overflow-hidden rounded-md border p-1.5 text-left transition-colors",
+        "flex min-h-20 flex-col gap-1 rounded-md border p-1.5 text-left transition-colors sm:min-h-24 lg:min-h-28",
         inMonth ? "bg-card" : "bg-muted/30 text-muted-foreground",
         isToday ? "border-primary" : "border-border",
         isSelected && "ring-primary ring-2",


### PR DESCRIPTION
## 이슈
closes #554

## 작업 내용
월간 캘린더만 `max-w-6xl mx-auto`로 가운데 정렬되어 헤더(풀폭)와 어긋나고 양옆 여백이 생기던 문제 해결.

- 캘린더 컨테이너에서 `max-w-6xl mx-auto` 제거 → 다른 모든 페이지(`<main>` flex-1)와 동일한 풀폭, 헤더 가장자리와 정렬 일치
- 풀폭에선 정사각형 셀이 과하게 커지므로 직사각형 `min-h`로: `min-h-20 sm:min-h-24 lg:min-h-28` (모바일 80 / 태블릿 96 / 데스크탑 112px) — 반응형 min-height(월간 캘린더 표준)
- 로딩 스켈레톤도 동일 높이

## 검증
- PlannerCalendar.test 11개 통과, eslint·prettier 통과