### PR TITLE
fix : 모바일 반응형 보강 (다이얼로그 오버플로우·Toaster·연동카드)

### DIFF
--- a/fe/src/components/ConfirmDialog.tsx
+++ b/fe/src/components/ConfirmDialog.tsx
@@ -2,6 +2,7 @@ import { Dialog } from "@base-ui/react/dialog";
 import { type ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
+import { DialogPopup } from "@/components/ui/dialog-popup";
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -30,7 +31,7 @@ export function ConfirmDialog({
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+        <DialogPopup className="max-w-sm">
           <Dialog.Title className="text-base font-semibold">
             {title}
           </Dialog.Title>
@@ -56,7 +57,7 @@ export function ConfirmDialog({
               {pending ? "처리 중..." : confirmLabel}
             </Button>
           </div>
-        </Dialog.Popup>
+        </DialogPopup>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/fe/src/components/Toaster.tsx
+++ b/fe/src/components/Toaster.tsx
@@ -25,7 +25,7 @@ export function Toaster() {
           role="status"
           aria-live="polite"
           className={cn(
-            "pointer-events-auto flex w-72 items-start justify-between gap-2 rounded-lg border px-3 py-2 text-sm shadow-md",
+            "pointer-events-auto flex w-72 max-w-[calc(100vw-2rem)] items-start justify-between gap-2 rounded-lg border px-3 py-2 text-sm shadow-md",
             VARIANT_STYLES[toast.variant],
           )}
         >

--- a/fe/src/components/ui/dialog-popup.tsx
+++ b/fe/src/components/ui/dialog-popup.tsx
@@ -1,0 +1,20 @@
+import { Dialog } from "@base-ui/react/dialog";
+import type { ComponentProps } from "react";
+
+import { cn } from "@/lib/utils";
+
+const POPUP_CLASS =
+  "bg-background fixed top-1/2 left-1/2 z-50 max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0";
+
+type DialogPopupProps = ComponentProps<typeof Dialog.Popup> & {
+  className?: string;
+};
+
+/**
+ * 공유 다이얼로그 본문(Popup). 중앙 정렬 + 진입/종료 애니메이션을 캡슐화하고,
+ * 좁거나 짧은 뷰포트에서 넘치지 않도록 max-height·세로 스크롤·좌우 안전 여백을 보장한다.
+ * 폭은 호출부에서 className(max-w-*)으로 지정한다.
+ */
+export function DialogPopup({ className, ...props }: DialogPopupProps) {
+  return <Dialog.Popup className={cn(POPUP_CLASS, className)} {...props} />;
+}

--- a/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
+++ b/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
@@ -2,6 +2,7 @@ import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { DialogPopup } from "@/components/ui/dialog-popup";
 import { cn } from "@/lib/utils";
 
 const MAX_LEN = 1000;
@@ -62,7 +63,7 @@ export function FlashcardFormDialog({
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+        <DialogPopup className="max-w-md">
           <Dialog.Title className="text-base font-semibold">
             {mode === "create" ? "카드 추가" : "카드 편집"}
           </Dialog.Title>
@@ -118,7 +119,7 @@ export function FlashcardFormDialog({
               </div>
             </div>
           </form>
-        </Dialog.Popup>
+        </DialogPopup>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/fe/src/features/google/components/GoogleConnectionCard.tsx
+++ b/fe/src/features/google/components/GoogleConnectionCard.tsx
@@ -26,7 +26,7 @@ export function GoogleConnectionCard() {
           <p className="text-muted-foreground text-sm">불러오는 중…</p>
         ) : status?.connected ? (
           <>
-            <dl className="grid grid-cols-[5rem_1fr] gap-y-1 text-sm">
+            <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm sm:grid-cols-[5rem_1fr]">
               <dt className="text-muted-foreground">상태</dt>
               <dd>연결됨</dd>
               {status.googleEmail && (

--- a/fe/src/features/material/components/AddMaterialDialog.tsx
+++ b/fe/src/features/material/components/AddMaterialDialog.tsx
@@ -4,6 +4,7 @@ import { Check, ChevronDown } from "lucide-react";
 import { useEffect, useId, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { DialogPopup } from "@/components/ui/dialog-popup";
 import { Input } from "@/components/ui/input";
 
 import type { MaterialType } from "../api/materials";
@@ -55,7 +56,7 @@ export function AddMaterialDialog({ open, onOpenChange, onCreated }: Props) {
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+        <DialogPopup className="max-w-sm">
           <Dialog.Title className="text-base font-semibold">
             학습 자료 추가
           </Dialog.Title>
@@ -153,7 +154,7 @@ export function AddMaterialDialog({ open, onOpenChange, onCreated }: Props) {
               </Button>
             </div>
           </form>
-        </Dialog.Popup>
+        </DialogPopup>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/fe/src/features/material/components/EditMaterialDialog.tsx
+++ b/fe/src/features/material/components/EditMaterialDialog.tsx
@@ -4,6 +4,7 @@ import { Check, ChevronDown } from "lucide-react";
 import { useEffect, useId, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { DialogPopup } from "@/components/ui/dialog-popup";
 import { Input } from "@/components/ui/input";
 
 import type { Material, MaterialStatus } from "../api/materials";
@@ -56,7 +57,7 @@ export function EditMaterialDialog({ material, open, onOpenChange }: Props) {
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+        <DialogPopup className="max-w-sm">
           <Dialog.Title className="text-base font-semibold">
             자료 편집
           </Dialog.Title>
@@ -143,7 +144,7 @@ export function EditMaterialDialog({ material, open, onOpenChange }: Props) {
               </Button>
             </div>
           </form>
-        </Dialog.Popup>
+        </DialogPopup>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/fe/src/features/planner/components/calendar/EventFormDialog.tsx
+++ b/fe/src/features/planner/components/calendar/EventFormDialog.tsx
@@ -2,6 +2,7 @@ import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { DialogPopup } from "@/components/ui/dialog-popup";
 import { Input } from "@/components/ui/input";
 import { GoogleConnectButton } from "@/features/google/components/GoogleConnectButton";
 
@@ -126,7 +127,7 @@ export function EventFormDialog({
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+        <DialogPopup className="max-w-md">
           <Dialog.Title className="text-base font-semibold">
             {mode === "create" ? "일정 추가" : "일정 편집"}
           </Dialog.Title>
@@ -250,7 +251,7 @@ export function EventFormDialog({
               </div>
             </form>
           )}
-        </Dialog.Popup>
+        </DialogPopup>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/fe/src/features/planner/components/calendar/TaskFormDialog.tsx
+++ b/fe/src/features/planner/components/calendar/TaskFormDialog.tsx
@@ -2,6 +2,7 @@ import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { DialogPopup } from "@/components/ui/dialog-popup";
 import { Input } from "@/components/ui/input";
 import { GoogleConnectButton } from "@/features/google/components/GoogleConnectButton";
 
@@ -50,7 +51,7 @@ export function TaskFormDialog({
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-        <Dialog.Popup className="bg-background fixed top-1/2 left-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border p-6 shadow-lg transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+        <DialogPopup className="max-w-sm">
           <Dialog.Title className="text-base font-semibold">
             할 일 추가
           </Dialog.Title>
@@ -110,7 +111,7 @@ export function TaskFormDialog({
               </div>
             </form>
           )}
-        </Dialog.Popup>
+        </DialogPopup>
       </Dialog.Portal>
     </Dialog.Root>
   );


### PR DESCRIPTION
## 이슈
closes #558

전체 레이아웃·컴포넌트 감사에서 확인된 모바일 반응형 실이슈 3건 보강 (의도된 중앙정렬 뷰·컨테이너 스크롤은 오탐으로 제외).

## 작업 내용
### 1. 다이얼로그 모바일 오버플로우 + 중복 제거 (핵심)
- 6개 다이얼로그(`EventFormDialog`·`TaskFormDialog`·`FlashcardFormDialog`·`AddMaterialDialog`·`EditMaterialDialog`·`ConfirmDialog`)가 공유 래퍼 없이 `Dialog.Popup`에 동일 className을 복붙하고, 모두 `max-h`/`overflow-y-auto`가 없어 짧은 뷰포트(가로 모드·작은 폰)에서 폼이 넘쳐 제출 버튼이 안 잡히던 문제
- 공유 `DialogPopup` 컴포넌트로 추출 → `max-h-[calc(100dvh-2rem)]` + `overflow-y-auto` + 좌우 안전 여백(`w-[calc(100%-2rem)]`) 보장. 폭만 호출부에서 `max-w-*`로 전달
- 결과: 버그 + className 중복 동시 해결

### 2. Toaster 고정폭
- `w-72`(288px 고정) → `max-w-[calc(100vw-2rem)]` 추가로 좁은 폰에서 잘림 방지

### 3. GoogleConnectionCard 라벨 컬럼
- `grid-cols-[5rem_1fr]` → `grid-cols-[auto_1fr] sm:grid-cols-[5rem_1fr]`로 모바일 라벨 cramp 해소

## 검증
- FE 전체 146개 테스트 통과(다이얼로그 통합테스트가 DialogPopup 경유 동작 커버), eslint·prettier·tsc 통과
- 비고: 오버플로우/뷰포트 동작은 jsdom에서 레이아웃 계산이 없어 클래스 계약으로 보장(브라우저 육안확인은 로그인 필요)