### PR TITLE
chore : argocd dex 메모리·controller cpu limit 상향

### DIFF
--- a/infra/helm/argocd/values.yaml
+++ b/infra/helm/argocd/values.yaml
@@ -17,7 +17,8 @@ controller:
       cpu: 250m
       memory: 512Mi
     limits:
-      cpu: 500m
+      # 자기관리 편입으로 관리 앱이 1개 늘어 reconcile 부하 증가 → 500m에서 29% throttle.
+      cpu: 750m
       memory: 1Gi
 
 server:
@@ -63,7 +64,8 @@ dex:
       memory: 32Mi
     limits:
       cpu: 50m
-      memory: 64Mi
+      # 평상 사용량이 ~57Mi라 64Mi limit의 90%에 상시 근접(ContainerMemoryNearLimit) → 128Mi.
+      memory: 128Mi
 
 notifications:
   # 컨트롤러만 이 차트가 띄운다. config(cm/secret)는 전용 argocd-notifications 앱이 소유하므로


### PR DESCRIPTION
## 이슈
closes #561

## 작업 내용

ArgoCD 자기관리 편입(#553) 안착 후 argocd 네임스페이스에 남은 info/warning 알림 2종 정리.

- **dex memory limit 64Mi → 128Mi**: `argocd-dex-server`가 ~57Mi 사용으로 64Mi의 90% 상시 근접(ContainerMemoryNearLimit). limit이 과소.
- **controller cpu limit 500m → 750m**: `argocd-application-controller`가 500m에서 29% throttle. 자기관리로 관리 앱이 1개(argocd 자신) 늘며 reconcile 부하 증가한 부수효과.

## 검증
- `helm template`: application-controller StatefulSet cpu limit **750m**, dex memory limit **128Mi** 확인
- argocd ns compute-quota 여유 내: 변경 후 limits.cpu 64% / limits.memory 70% (requests 불변)
- 머지 후: dex 메모리 사용률 < 90%, controller throttle < 25% 확인 예정
