### PR TITLE
refactor : FE 공유 프리미티브 추출 (Tier 1)

### DIFF
--- a/fe/src/components/ConfirmDialog.tsx
+++ b/fe/src/components/ConfirmDialog.tsx
@@ -2,7 +2,8 @@ import { Dialog } from "@base-ui/react/dialog";
 import { type ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
-import { DialogPopup } from "@/components/ui/dialog-popup";
+import { DialogFooter } from "@/components/ui/dialog-footer";
+import { Modal } from "@/components/ui/modal";
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -28,37 +29,30 @@ export function ConfirmDialog({
   pending = false,
 }: ConfirmDialogProps) {
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-        <DialogPopup className="max-w-sm">
-          <Dialog.Title className="text-base font-semibold">
-            {title}
-          </Dialog.Title>
-          {description && (
-            <Dialog.Description className="text-muted-foreground mt-2 text-sm">
-              {description}
-            </Dialog.Description>
-          )}
-          <div className="mt-5 flex justify-end gap-2">
-            <Dialog.Close
-              render={
-                <Button variant="ghost" type="button" disabled={pending}>
-                  {cancelLabel}
-                </Button>
-              }
-            />
-            <Button
-              type="button"
-              variant={destructive ? "destructive" : "default"}
-              onClick={onConfirm}
-              disabled={pending}
-            >
-              {pending ? "처리 중..." : confirmLabel}
+    <Modal open={open} onOpenChange={onOpenChange} className="max-w-sm">
+      <Dialog.Title className="text-base font-semibold">{title}</Dialog.Title>
+      {description && (
+        <Dialog.Description className="text-muted-foreground mt-2 text-sm">
+          {description}
+        </Dialog.Description>
+      )}
+      <DialogFooter>
+        <Dialog.Close
+          render={
+            <Button variant="ghost" type="button" disabled={pending}>
+              {cancelLabel}
             </Button>
-          </div>
-        </DialogPopup>
-      </Dialog.Portal>
-    </Dialog.Root>
+          }
+        />
+        <Button
+          type="button"
+          variant={destructive ? "destructive" : "default"}
+          onClick={onConfirm}
+          disabled={pending}
+        >
+          {pending ? "처리 중..." : confirmLabel}
+        </Button>
+      </DialogFooter>
+    </Modal>
   );
 }

--- a/fe/src/components/ui/checkbox.tsx
+++ b/fe/src/components/ui/checkbox.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Checkbox({ className, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type="checkbox"
+      data-slot="checkbox"
+      className={cn(
+        "border-input accent-primary size-4 cursor-pointer rounded border disabled:pointer-events-none disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Checkbox };

--- a/fe/src/components/ui/dialog-footer.tsx
+++ b/fe/src/components/ui/dialog-footer.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * 다이얼로그 하단 액션 영역. 기본은 오른쪽 정렬(취소+제출). 삭제 버튼을 왼쪽에 두는 경우
+ * className에 justify-between을 넘겨 정렬을 바꾼다.
+ */
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn("mt-5 flex items-center justify-end gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+export { DialogFooter };

--- a/fe/src/components/ui/field-error.tsx
+++ b/fe/src/components/ui/field-error.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/** 폼 필드·데이터 로드 실패 등 사용자에게 보이는 오류 메시지. */
+function FieldError({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="field-error"
+      className={cn("text-destructive text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export { FieldError };

--- a/fe/src/components/ui/form-field.tsx
+++ b/fe/src/components/ui/form-field.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+import { FieldError } from "./field-error";
+
+interface FormFieldProps {
+  label: React.ReactNode;
+  /** label의 htmlFor / 컨트롤의 id. 컨트롤이 자체 라벨을 쓰면 생략 가능. */
+  htmlFor?: string;
+  /** 네이티브 input이 아닌 컨트롤(Select 등)을 aria-labelledby로 연결할 때 label의 id. */
+  labelId?: string;
+  error?: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+/** label + 컨트롤 + (선택)에러를 묶는 표준 폼 필드 레이아웃. */
+function FormField({
+  label,
+  htmlFor,
+  labelId,
+  error,
+  className,
+  children,
+}: FormFieldProps) {
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      <label id={labelId} htmlFor={htmlFor} className="text-sm font-medium">
+        {label}
+      </label>
+      {children}
+      {error && <FieldError>{error}</FieldError>}
+    </div>
+  );
+}
+
+export { FormField };

--- a/fe/src/components/ui/menu.tsx
+++ b/fe/src/components/ui/menu.tsx
@@ -1,11 +1,11 @@
 import { Menu as MenuPrimitive } from "@base-ui/react/menu";
-import type { ComponentProps, ReactNode } from "react";
+import type { ComponentProps, ReactElement, ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
 interface MenuProps {
-  /** 트리거로 렌더할 요소(보통 <Button size="icon-sm">). */
-  trigger: ReactNode;
+  /** 트리거로 렌더할 요소(보통 <Button size="icon-sm">). render에 전달되므로 단일 element여야 한다. */
+  trigger: ReactElement;
   children: ReactNode;
 }
 

--- a/fe/src/components/ui/menu.tsx
+++ b/fe/src/components/ui/menu.tsx
@@ -1,0 +1,53 @@
+import { Menu as MenuPrimitive } from "@base-ui/react/menu";
+import type { ComponentProps, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface MenuProps {
+  /** 트리거로 렌더할 요소(보통 <Button size="icon-sm">). */
+  trigger: ReactNode;
+  children: ReactNode;
+}
+
+/** 표준 드롭다운 메뉴: Root + Trigger + Portal/Positioner/Popup을 캡슐화한다. */
+function Menu({ trigger, children }: MenuProps) {
+  return (
+    <MenuPrimitive.Root>
+      <MenuPrimitive.Trigger render={trigger} />
+      <MenuPrimitive.Portal>
+        <MenuPrimitive.Positioner sideOffset={4} align="end" className="z-50">
+          <MenuPrimitive.Popup className="bg-popover text-popover-foreground min-w-32 rounded-md border p-1 shadow-md">
+            {children}
+          </MenuPrimitive.Popup>
+        </MenuPrimitive.Positioner>
+      </MenuPrimitive.Portal>
+    </MenuPrimitive.Root>
+  );
+}
+
+const ITEM_BASE =
+  "flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none";
+const ITEM_VARIANT = {
+  default:
+    "data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
+  destructive: "text-destructive data-[highlighted]:bg-destructive/10",
+};
+
+type MenuItemProps = Omit<
+  ComponentProps<typeof MenuPrimitive.Item>,
+  "className"
+> & {
+  variant?: "default" | "destructive";
+  className?: string;
+};
+
+function MenuItem({ variant = "default", className, ...props }: MenuItemProps) {
+  return (
+    <MenuPrimitive.Item
+      className={cn(ITEM_BASE, ITEM_VARIANT[variant], className)}
+      {...props}
+    />
+  );
+}
+
+export { Menu, MenuItem };

--- a/fe/src/components/ui/modal.tsx
+++ b/fe/src/components/ui/modal.tsx
@@ -1,0 +1,32 @@
+import { Dialog } from "@base-ui/react/dialog";
+import type { ReactNode } from "react";
+
+import { DialogPopup } from "./dialog-popup";
+
+const BACKDROP_CLASS =
+  "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0";
+
+interface ModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** 폭 제어용 className (예: max-w-sm / max-w-md). */
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * 표준 모달 골격: Root + Portal + Backdrop + DialogPopup을 한 번에 캡슐화한다.
+ * 내부에서 base-ui의 Dialog.Title / Dialog.Close 등을 children으로 그대로 사용한다.
+ */
+function Modal({ open, onOpenChange, className, children }: ModalProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className={BACKDROP_CLASS} />
+        <DialogPopup className={className}>{children}</DialogPopup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+export { Modal };

--- a/fe/src/components/ui/select.tsx
+++ b/fe/src/components/ui/select.tsx
@@ -1,0 +1,65 @@
+import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { Check, ChevronDown } from "lucide-react";
+import type { ReactNode } from "react";
+
+export interface SelectOption<T extends string> {
+  value: T;
+  label: ReactNode;
+}
+
+interface SelectProps<T extends string> {
+  value: T;
+  onValueChange: (value: T) => void;
+  options: SelectOption<T>[];
+  ariaLabelledby?: string;
+}
+
+/** 표준 드롭다운 셀렉트. Trigger·Popup·Item 스타일을 일원화한다. */
+function Select<T extends string>({
+  value,
+  onValueChange,
+  options,
+  ariaLabelledby,
+}: SelectProps<T>) {
+  const labelOf = (v: T) => options.find((o) => o.value === v)?.label;
+  return (
+    <SelectPrimitive.Root
+      value={value}
+      onValueChange={(v) => onValueChange(v as T)}
+    >
+      <SelectPrimitive.Trigger
+        aria-labelledby={ariaLabelledby}
+        className="border-input bg-background focus-visible:ring-ring/30 flex h-9 items-center justify-between gap-2 rounded-md border px-3 text-sm shadow-xs focus-visible:ring-2 focus-visible:outline-none"
+      >
+        <SelectPrimitive.Value>
+          {(v) => <span>{labelOf(v as T)}</span>}
+        </SelectPrimitive.Value>
+        <SelectPrimitive.Icon>
+          <ChevronDown className="size-4 opacity-60" />
+        </SelectPrimitive.Icon>
+      </SelectPrimitive.Trigger>
+      <SelectPrimitive.Portal>
+        <SelectPrimitive.Positioner sideOffset={4} className="z-50">
+          <SelectPrimitive.Popup className="bg-popover text-popover-foreground min-w-(--anchor-width) overflow-hidden rounded-md border p-1 shadow-md">
+            {options.map((o) => (
+              <SelectPrimitive.Item
+                key={o.value}
+                value={o.value}
+                className="data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground flex cursor-pointer items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm outline-none"
+              >
+                <SelectPrimitive.ItemText>
+                  <span>{o.label}</span>
+                </SelectPrimitive.ItemText>
+                <SelectPrimitive.ItemIndicator>
+                  <Check className="size-3.5" />
+                </SelectPrimitive.ItemIndicator>
+              </SelectPrimitive.Item>
+            ))}
+          </SelectPrimitive.Popup>
+        </SelectPrimitive.Positioner>
+      </SelectPrimitive.Portal>
+    </SelectPrimitive.Root>
+  );
+}
+
+export { Select };

--- a/fe/src/components/ui/textarea.tsx
+++ b/fe/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input bg-background focus-visible:ring-ring/30 min-h-[3rem] w-full resize-y rounded-md border p-2 text-sm shadow-xs focus-visible:ring-2 focus-visible:outline-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
+++ b/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
@@ -2,7 +2,11 @@ import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { DialogPopup } from "@/components/ui/dialog-popup";
+import { DialogFooter } from "@/components/ui/dialog-footer";
+import { FieldError } from "@/components/ui/field-error";
+import { FormField } from "@/components/ui/form-field";
+import { Modal } from "@/components/ui/modal";
+import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 
 const MAX_LEN = 1000;
@@ -60,68 +64,61 @@ export function FlashcardFormDialog({
   };
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-        <DialogPopup className="max-w-md">
-          <Dialog.Title className="text-base font-semibold">
-            {mode === "create" ? "카드 추가" : "카드 편집"}
-          </Dialog.Title>
+    <Modal open={open} onOpenChange={onOpenChange} className="max-w-md">
+      <Dialog.Title className="text-base font-semibold">
+        {mode === "create" ? "카드 추가" : "카드 편집"}
+      </Dialog.Title>
 
-          <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-4">
-            <CharField
-              id={frontId}
-              label="앞면 (질문)"
-              rows={3}
-              value={front}
-              onChange={setFront}
-              max={MAX_LEN}
-              autoFocus
-            />
-            <CharField
-              id={backId}
-              label="뒷면 (답)"
-              rows={4}
-              value={back}
-              onChange={setBack}
-              max={MAX_LEN}
-            />
+      <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-4">
+        <CharField
+          id={frontId}
+          label="앞면 (질문)"
+          rows={3}
+          value={front}
+          onChange={setFront}
+          max={MAX_LEN}
+          autoFocus
+        />
+        <CharField
+          id={backId}
+          label="뒷면 (답)"
+          rows={4}
+          value={back}
+          onChange={setBack}
+          max={MAX_LEN}
+        />
 
-            {errorMessage && (
-              <p className="text-destructive text-sm">{errorMessage}</p>
-            )}
+        {errorMessage && <FieldError>{errorMessage}</FieldError>}
 
-            <div className="mt-1 flex items-center justify-between gap-2">
-              {mode === "edit" && onDelete ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="text-destructive"
-                  disabled={pending}
-                  onClick={onDelete}
-                >
-                  삭제
+        <DialogFooter className="mt-1 justify-between">
+          {mode === "edit" && onDelete ? (
+            <Button
+              type="button"
+              variant="ghost"
+              className="text-destructive"
+              disabled={pending}
+              onClick={onDelete}
+            >
+              삭제
+            </Button>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2">
+            <Dialog.Close
+              render={
+                <Button variant="ghost" type="button" disabled={pending}>
+                  취소
                 </Button>
-              ) : (
-                <span />
-              )}
-              <div className="flex gap-2">
-                <Dialog.Close
-                  render={
-                    <Button variant="ghost" type="button" disabled={pending}>
-                      취소
-                    </Button>
-                  }
-                />
-                <Button type="submit" disabled={!valid || !dirty || pending}>
-                  {pending ? "저장 중..." : "저장"}
-                </Button>
-              </div>
-            </div>
-          </form>
-        </DialogPopup>
-      </Dialog.Portal>
-    </Dialog.Root>
+              }
+            />
+            <Button type="submit" disabled={!valid || !dirty || pending}>
+              {pending ? "저장 중..." : "저장"}
+            </Button>
+          </div>
+        </DialogFooter>
+      </form>
+    </Modal>
   );
 }
 
@@ -146,17 +143,13 @@ function CharField({
 }: CharFieldProps) {
   const over = value.length > max;
   return (
-    <div className="flex flex-col gap-1.5">
-      <label htmlFor={id} className="text-sm font-medium">
-        {label}
-      </label>
-      <textarea
+    <FormField label={label} htmlFor={id}>
+      <Textarea
         id={id}
         rows={rows}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         autoFocus={autoFocus}
-        className="border-input bg-background focus-visible:ring-ring/30 min-h-[3rem] resize-y rounded-md border p-2 text-sm shadow-xs focus-visible:ring-2 focus-visible:outline-none"
       />
       <span
         className={cn(
@@ -166,6 +159,6 @@ function CharField({
       >
         {value.length} / {max}
       </span>
-    </div>
+    </FormField>
   );
 }

--- a/fe/src/features/material/components/AddMaterialDialog.tsx
+++ b/fe/src/features/material/components/AddMaterialDialog.tsx
@@ -1,11 +1,13 @@
 import { Dialog } from "@base-ui/react/dialog";
-import { Select } from "@base-ui/react/select";
-import { Check, ChevronDown } from "lucide-react";
 import { useEffect, useId, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { DialogPopup } from "@/components/ui/dialog-popup";
+import { DialogFooter } from "@/components/ui/dialog-footer";
+import { FieldError } from "@/components/ui/field-error";
+import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { Select, type SelectOption } from "@/components/ui/select";
 
 import type { MaterialType } from "../api/materials";
 import { useCreateMaterial } from "../hooks/useCreateMaterial";
@@ -17,7 +19,12 @@ interface Props {
   onCreated?: (materialId: number) => void;
 }
 
-const TYPE_OPTIONS: MaterialType[] = ["BOOK", "LECTURE", "WORKBOOK", "MOOC"];
+const TYPE_OPTIONS: SelectOption<MaterialType>[] = (
+  ["BOOK", "LECTURE", "WORKBOOK", "MOOC"] as const
+).map((value) => ({
+  value,
+  label: `${MATERIAL_TYPE_ICONS[value]} ${MATERIAL_TYPE_LABELS[value]}`,
+}));
 
 export function AddMaterialDialog({ open, onOpenChange, onCreated }: Props) {
   const titleId = useId();
@@ -53,109 +60,55 @@ export function AddMaterialDialog({ open, onOpenChange, onCreated }: Props) {
   };
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-        <DialogPopup className="max-w-sm">
-          <Dialog.Title className="text-base font-semibold">
-            학습 자료 추가
-          </Dialog.Title>
+    <Modal open={open} onOpenChange={onOpenChange} className="max-w-sm">
+      <Dialog.Title className="text-base font-semibold">
+        학습 자료 추가
+      </Dialog.Title>
 
-          <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-4">
-            <div className="flex flex-col gap-1.5">
-              <label htmlFor={titleId} className="text-sm font-medium">
-                제목
-              </label>
-              <Input
-                id={titleId}
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder="예: 이펙티브 자바"
-                maxLength={200}
-                autoFocus
-              />
-            </div>
+      <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-4">
+        <FormField label="제목" htmlFor={titleId}>
+          <Input
+            id={titleId}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="예: 이펙티브 자바"
+            maxLength={200}
+            autoFocus
+          />
+        </FormField>
 
-            <div className="flex flex-col gap-1.5">
-              <span id={typeLabelId} className="text-sm font-medium">
-                유형
-              </span>
-              <Select.Root
-                value={type}
-                onValueChange={(value) => setType(value as MaterialType)}
-              >
-                <Select.Trigger
-                  aria-labelledby={typeLabelId}
-                  className="border-input bg-background focus-visible:ring-ring/30 flex h-9 items-center justify-between gap-2 rounded-md border px-3 text-sm shadow-xs focus-visible:ring-2 focus-visible:outline-none"
-                >
-                  <Select.Value>
-                    {(value) => {
-                      const t = value as MaterialType;
-                      return (
-                        <span>
-                          {MATERIAL_TYPE_ICONS[t]} {MATERIAL_TYPE_LABELS[t]}
-                        </span>
-                      );
-                    }}
-                  </Select.Value>
-                  <Select.Icon>
-                    <ChevronDown className="size-4 opacity-60" />
-                  </Select.Icon>
-                </Select.Trigger>
-                <Select.Portal>
-                  <Select.Positioner sideOffset={4} className="z-50">
-                    <Select.Popup className="bg-popover text-popover-foreground min-w-(--anchor-width) overflow-hidden rounded-md border p-1 shadow-md">
-                      {TYPE_OPTIONS.map((value) => (
-                        <Select.Item
-                          key={value}
-                          value={value}
-                          className="data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground flex cursor-pointer items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm outline-none"
-                        >
-                          <Select.ItemText>
-                            <span>
-                              {MATERIAL_TYPE_ICONS[value]}{" "}
-                              {MATERIAL_TYPE_LABELS[value]}
-                            </span>
-                          </Select.ItemText>
-                          <Select.ItemIndicator>
-                            <Check className="size-3.5" />
-                          </Select.ItemIndicator>
-                        </Select.Item>
-                      ))}
-                    </Select.Popup>
-                  </Select.Positioner>
-                </Select.Portal>
-              </Select.Root>
-            </div>
+        <FormField label="유형" labelId={typeLabelId}>
+          <Select
+            value={type}
+            onValueChange={setType}
+            options={TYPE_OPTIONS}
+            ariaLabelledby={typeLabelId}
+          />
+        </FormField>
 
-            {mutation.isError && (
-              <p className="text-destructive text-sm">
-                자료를 추가하지 못했어요. 잠시 후 다시 시도해주세요.
-              </p>
-            )}
+        {mutation.isError && (
+          <FieldError>
+            자료를 추가하지 못했어요. 잠시 후 다시 시도해주세요.
+          </FieldError>
+        )}
 
-            <div className="mt-1 flex justify-end gap-2">
-              <Dialog.Close
-                render={
-                  <Button
-                    variant="ghost"
-                    type="button"
-                    disabled={mutation.isPending}
-                  >
-                    취소
-                  </Button>
-                }
-              />
+        <DialogFooter className="mt-1">
+          <Dialog.Close
+            render={
               <Button
-                type="submit"
-                disabled={!titleValid || mutation.isPending}
+                variant="ghost"
+                type="button"
+                disabled={mutation.isPending}
               >
-                {mutation.isPending ? "추가 중..." : "추가"}
+                취소
               </Button>
-            </div>
-          </form>
-        </DialogPopup>
-      </Dialog.Portal>
-    </Dialog.Root>
+            }
+          />
+          <Button type="submit" disabled={!titleValid || mutation.isPending}>
+            {mutation.isPending ? "추가 중..." : "추가"}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Modal>
   );
 }

--- a/fe/src/features/material/components/EditMaterialDialog.tsx
+++ b/fe/src/features/material/components/EditMaterialDialog.tsx
@@ -1,11 +1,13 @@
 import { Dialog } from "@base-ui/react/dialog";
-import { Select } from "@base-ui/react/select";
-import { Check, ChevronDown } from "lucide-react";
 import { useEffect, useId, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { DialogPopup } from "@/components/ui/dialog-popup";
+import { DialogFooter } from "@/components/ui/dialog-footer";
+import { FieldError } from "@/components/ui/field-error";
+import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { Select, type SelectOption } from "@/components/ui/select";
 
 import type { Material, MaterialStatus } from "../api/materials";
 import { useUpdateMaterial } from "../hooks/useUpdateMaterial";
@@ -16,7 +18,7 @@ interface Props {
   onOpenChange: (open: boolean) => void;
 }
 
-const STATUS_OPTIONS: { value: MaterialStatus; label: string }[] = [
+const STATUS_OPTIONS: SelectOption<MaterialStatus>[] = [
   { value: "ACTIVE", label: "진행 중" },
   { value: "COMPLETED", label: "완료" },
 ];
@@ -54,98 +56,53 @@ export function EditMaterialDialog({ material, open, onOpenChange }: Props) {
   };
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-        <DialogPopup className="max-w-sm">
-          <Dialog.Title className="text-base font-semibold">
-            자료 편집
-          </Dialog.Title>
+    <Modal open={open} onOpenChange={onOpenChange} className="max-w-sm">
+      <Dialog.Title className="text-base font-semibold">자료 편집</Dialog.Title>
 
-          <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-4">
-            <div className="flex flex-col gap-1.5">
-              <label htmlFor={titleId} className="text-sm font-medium">
-                제목
-              </label>
-              <Input
-                id={titleId}
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                maxLength={200}
-                autoFocus
-              />
-            </div>
+      <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-4">
+        <FormField label="제목" htmlFor={titleId}>
+          <Input
+            id={titleId}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={200}
+            autoFocus
+          />
+        </FormField>
 
-            <div className="flex flex-col gap-1.5">
-              <span id={statusLabelId} className="text-sm font-medium">
-                상태
-              </span>
-              <Select.Root
-                value={status}
-                onValueChange={(value) => setStatus(value as MaterialStatus)}
-              >
-                <Select.Trigger
-                  aria-labelledby={statusLabelId}
-                  className="border-input bg-background focus-visible:ring-ring/30 flex h-9 items-center justify-between gap-2 rounded-md border px-3 text-sm shadow-xs focus-visible:ring-2 focus-visible:outline-none"
-                >
-                  <Select.Value>
-                    {(value) =>
-                      STATUS_OPTIONS.find((opt) => opt.value === value)?.label
-                    }
-                  </Select.Value>
-                  <Select.Icon>
-                    <ChevronDown className="size-4 opacity-60" />
-                  </Select.Icon>
-                </Select.Trigger>
-                <Select.Portal>
-                  <Select.Positioner sideOffset={4} className="z-50">
-                    <Select.Popup className="bg-popover text-popover-foreground min-w-(--anchor-width) overflow-hidden rounded-md border p-1 shadow-md">
-                      {STATUS_OPTIONS.map((opt) => (
-                        <Select.Item
-                          key={opt.value}
-                          value={opt.value}
-                          className="data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground flex cursor-pointer items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm outline-none"
-                        >
-                          <Select.ItemText>{opt.label}</Select.ItemText>
-                          <Select.ItemIndicator>
-                            <Check className="size-3.5" />
-                          </Select.ItemIndicator>
-                        </Select.Item>
-                      ))}
-                    </Select.Popup>
-                  </Select.Positioner>
-                </Select.Portal>
-              </Select.Root>
-            </div>
+        <FormField label="상태" labelId={statusLabelId}>
+          <Select
+            value={status}
+            onValueChange={setStatus}
+            options={STATUS_OPTIONS}
+            ariaLabelledby={statusLabelId}
+          />
+        </FormField>
 
-            {mutation.isError && (
-              <p className="text-destructive text-sm">
-                저장에 실패했어요. 잠시 후 다시 시도해주세요.
-              </p>
-            )}
+        {mutation.isError && (
+          <FieldError>저장에 실패했어요. 잠시 후 다시 시도해주세요.</FieldError>
+        )}
 
-            <div className="mt-1 flex justify-end gap-2">
-              <Dialog.Close
-                render={
-                  <Button
-                    variant="ghost"
-                    type="button"
-                    disabled={mutation.isPending}
-                  >
-                    취소
-                  </Button>
-                }
-              />
+        <DialogFooter className="mt-1">
+          <Dialog.Close
+            render={
               <Button
-                type="submit"
-                disabled={!titleValid || !dirty || mutation.isPending}
+                variant="ghost"
+                type="button"
+                disabled={mutation.isPending}
               >
-                {mutation.isPending ? "저장 중..." : "저장"}
+                취소
               </Button>
-            </div>
-          </form>
-        </DialogPopup>
-      </Dialog.Portal>
-    </Dialog.Root>
+            }
+          />
+          <Button
+            type="submit"
+            disabled={!titleValid || !dirty || mutation.isPending}
+          >
+            {mutation.isPending ? "저장 중..." : "저장"}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Modal>
   );
 }

--- a/fe/src/features/material/components/MaterialHeader.tsx
+++ b/fe/src/features/material/components/MaterialHeader.tsx
@@ -1,10 +1,10 @@
-import { Menu } from "@base-ui/react/menu";
 import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Button } from "@/components/ui/button";
+import { Menu, MenuItem } from "@/components/ui/menu";
 
 import type { Material } from "../api/materials";
 import { useDeleteMaterial } from "../hooks/useDeleteMaterial";
@@ -55,33 +55,20 @@ export function MaterialHeader({ material }: Props) {
         </div>
       </div>
 
-      <Menu.Root>
-        <Menu.Trigger
-          render={
-            <Button variant="ghost" size="icon-sm" aria-label="자료 메뉴">
-              <MoreHorizontal className="size-4" />
-            </Button>
-          }
-        />
-        <Menu.Portal>
-          <Menu.Positioner sideOffset={4} align="end" className="z-50">
-            <Menu.Popup className="bg-popover text-popover-foreground min-w-32 rounded-md border p-1 shadow-md">
-              <Menu.Item
-                onClick={() => setEditOpen(true)}
-                className="data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none"
-              >
-                <Pencil className="size-3.5" /> 편집
-              </Menu.Item>
-              <Menu.Item
-                onClick={() => setDeleteOpen(true)}
-                className="text-destructive data-[highlighted]:bg-destructive/10 flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none"
-              >
-                <Trash2 className="size-3.5" /> 삭제
-              </Menu.Item>
-            </Menu.Popup>
-          </Menu.Positioner>
-        </Menu.Portal>
-      </Menu.Root>
+      <Menu
+        trigger={
+          <Button variant="ghost" size="icon-sm" aria-label="자료 메뉴">
+            <MoreHorizontal className="size-4" />
+          </Button>
+        }
+      >
+        <MenuItem onClick={() => setEditOpen(true)}>
+          <Pencil className="size-3.5" /> 편집
+        </MenuItem>
+        <MenuItem variant="destructive" onClick={() => setDeleteOpen(true)}>
+          <Trash2 className="size-3.5" /> 삭제
+        </MenuItem>
+      </Menu>
 
       <EditMaterialDialog
         material={material}

--- a/fe/src/features/note/components/NoteTreeSidebar.tsx
+++ b/fe/src/features/note/components/NoteTreeSidebar.tsx
@@ -1,4 +1,3 @@
-import { Menu } from "@base-ui/react/menu";
 import {
   ChevronDown,
   ChevronRight,
@@ -10,6 +9,7 @@ import {
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Menu, MenuItem } from "@/components/ui/menu";
 import { cn } from "@/lib/utils";
 
 import type { NoteTreeNode } from "../api/notes";
@@ -125,32 +125,22 @@ function NoteTreeItem({
           <span className="truncate">{node.title}</span>
         </button>
 
-        <Menu.Root>
-          <Menu.Trigger
-            render={
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label={`${node.title} 메뉴`}
-                className="size-6 shrink-0 opacity-0 group-hover/note:opacity-100 data-[popup-open]:opacity-100"
-              >
-                <MoreHorizontal className="size-3.5" />
-              </Button>
-            }
-          />
-          <Menu.Portal>
-            <Menu.Positioner sideOffset={4} align="end" className="z-50">
-              <Menu.Popup className="bg-popover text-popover-foreground min-w-28 rounded-md border p-1 shadow-md">
-                <Menu.Item
-                  onClick={() => onRequestDelete(node)}
-                  className="text-destructive data-[highlighted]:bg-destructive/10 flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none"
-                >
-                  <Trash2 className="size-3.5" /> 삭제
-                </Menu.Item>
-              </Menu.Popup>
-            </Menu.Positioner>
-          </Menu.Portal>
-        </Menu.Root>
+        <Menu
+          trigger={
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label={`${node.title} 메뉴`}
+              className="size-6 shrink-0 opacity-0 group-hover/note:opacity-100 data-[popup-open]:opacity-100"
+            >
+              <MoreHorizontal className="size-3.5" />
+            </Button>
+          }
+        >
+          <MenuItem variant="destructive" onClick={() => onRequestDelete(node)}>
+            <Trash2 className="size-3.5" /> 삭제
+          </MenuItem>
+        </Menu>
       </div>
       {hasChildren && expanded && (
         <ul className="flex flex-col gap-0.5">

--- a/fe/src/features/planner/components/calendar/EventFormDialog.tsx
+++ b/fe/src/features/planner/components/calendar/EventFormDialog.tsx
@@ -2,8 +2,12 @@ import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { DialogPopup } from "@/components/ui/dialog-popup";
+import { Checkbox } from "@/components/ui/checkbox";
+import { DialogFooter } from "@/components/ui/dialog-footer";
+import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { Textarea } from "@/components/ui/textarea";
 import { GoogleConnectButton } from "@/features/google/components/GoogleConnectButton";
 
 import type { EventWriteRequest } from "../../api/events";
@@ -124,152 +128,128 @@ export function EventFormDialog({
   };
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-        <DialogPopup className="max-w-md">
-          <Dialog.Title className="text-base font-semibold">
-            {mode === "create" ? "일정 추가" : "일정 편집"}
-          </Dialog.Title>
+    <Modal open={open} onOpenChange={onOpenChange} className="max-w-md">
+      <Dialog.Title className="text-base font-semibold">
+        {mode === "create" ? "일정 추가" : "일정 편집"}
+      </Dialog.Title>
 
-          {!googleConnected ? (
-            <div className="mt-4 flex flex-col gap-4">
-              <p className="text-muted-foreground text-sm">
-                Google 연결이 필요합니다.
-              </p>
-              <div className="flex justify-end gap-2">
-                <Dialog.Close
-                  render={
-                    <Button variant="ghost" type="button">
-                      닫기
-                    </Button>
-                  }
+      {!googleConnected ? (
+        <div className="mt-4 flex flex-col gap-4">
+          <p className="text-muted-foreground text-sm">
+            Google 연결이 필요합니다.
+          </p>
+          <DialogFooter className="mt-0">
+            <Dialog.Close
+              render={
+                <Button variant="ghost" type="button">
+                  닫기
+                </Button>
+              }
+            />
+            <GoogleConnectButton />
+          </DialogFooter>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3">
+          <FormField label="제목" htmlFor={titleId}>
+            <Input
+              id={titleId}
+              value={form.title}
+              onChange={(e) => set("title", e.target.value)}
+              autoFocus
+            />
+          </FormField>
+
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={form.allDay}
+              onChange={(e) => set("allDay", e.target.checked)}
+            />
+            종일
+          </label>
+
+          <FormField label="시작">
+            <div className="flex gap-2">
+              <Input
+                type="date"
+                aria-label="시작 날짜"
+                value={form.startDate}
+                onChange={(e) => set("startDate", e.target.value)}
+              />
+              {!form.allDay && (
+                <Input
+                  type="time"
+                  aria-label="시작 시간"
+                  value={form.startTime}
+                  onChange={(e) => set("startTime", e.target.value)}
                 />
-                <GoogleConnectButton />
-              </div>
+              )}
             </div>
-          ) : (
-            <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3">
-              <Field label="제목" htmlFor={titleId}>
+          </FormField>
+
+          <FormField label="종료">
+            <div className="flex gap-2">
+              <Input
+                type="date"
+                aria-label="종료 날짜"
+                value={form.endDate}
+                onChange={(e) => set("endDate", e.target.value)}
+              />
+              {!form.allDay && (
                 <Input
-                  id={titleId}
-                  value={form.title}
-                  onChange={(e) => set("title", e.target.value)}
-                  autoFocus
+                  type="time"
+                  aria-label="종료 시간"
+                  value={form.endTime}
+                  onChange={(e) => set("endTime", e.target.value)}
                 />
-              </Field>
+              )}
+            </div>
+          </FormField>
 
-              <label className="flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={form.allDay}
-                  onChange={(e) => set("allDay", e.target.checked)}
-                />
-                종일
-              </label>
+          <FormField label="장소 (선택)">
+            <Input
+              value={form.location}
+              onChange={(e) => set("location", e.target.value)}
+            />
+          </FormField>
 
-              <Field label="시작">
-                <div className="flex gap-2">
-                  <Input
-                    type="date"
-                    aria-label="시작 날짜"
-                    value={form.startDate}
-                    onChange={(e) => set("startDate", e.target.value)}
-                  />
-                  {!form.allDay && (
-                    <Input
-                      type="time"
-                      aria-label="시작 시간"
-                      value={form.startTime}
-                      onChange={(e) => set("startTime", e.target.value)}
-                    />
-                  )}
-                </div>
-              </Field>
+          <FormField label="메모 (선택)">
+            <Textarea
+              rows={2}
+              value={form.description}
+              onChange={(e) => set("description", e.target.value)}
+            />
+          </FormField>
 
-              <Field label="종료">
-                <div className="flex gap-2">
-                  <Input
-                    type="date"
-                    aria-label="종료 날짜"
-                    value={form.endDate}
-                    onChange={(e) => set("endDate", e.target.value)}
-                  />
-                  {!form.allDay && (
-                    <Input
-                      type="time"
-                      aria-label="종료 시간"
-                      value={form.endTime}
-                      onChange={(e) => set("endTime", e.target.value)}
-                    />
-                  )}
-                </div>
-              </Field>
-
-              <Field label="장소 (선택)">
-                <Input
-                  value={form.location}
-                  onChange={(e) => set("location", e.target.value)}
-                />
-              </Field>
-
-              <Field label="메모 (선택)">
-                <textarea
-                  rows={2}
-                  value={form.description}
-                  onChange={(e) => set("description", e.target.value)}
-                  className="border-input bg-background focus-visible:ring-ring/30 resize-y rounded-md border p-2 text-sm shadow-xs focus-visible:ring-2 focus-visible:outline-none"
-                />
-              </Field>
-
-              <div className="mt-1 flex items-center justify-between gap-2">
-                {mode === "edit" && onDelete ? (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    className="text-destructive"
-                    disabled={pending}
-                    onClick={onDelete}
-                  >
-                    삭제
+          <DialogFooter className="mt-1 justify-between">
+            {mode === "edit" && onDelete ? (
+              <Button
+                type="button"
+                variant="ghost"
+                className="text-destructive"
+                disabled={pending}
+                onClick={onDelete}
+              >
+                삭제
+              </Button>
+            ) : (
+              <span />
+            )}
+            <div className="flex gap-2">
+              <Dialog.Close
+                render={
+                  <Button variant="ghost" type="button" disabled={pending}>
+                    취소
                   </Button>
-                ) : (
-                  <span />
-                )}
-                <div className="flex gap-2">
-                  <Dialog.Close
-                    render={
-                      <Button variant="ghost" type="button" disabled={pending}>
-                        취소
-                      </Button>
-                    }
-                  />
-                  <Button type="submit" disabled={!valid || pending}>
-                    {pending ? "저장 중..." : "저장"}
-                  </Button>
-                </div>
-              </div>
-            </form>
-          )}
-        </DialogPopup>
-      </Dialog.Portal>
-    </Dialog.Root>
-  );
-}
-
-interface FieldProps {
-  label: string;
-  htmlFor?: string;
-  children: React.ReactNode;
-}
-
-function Field({ label, htmlFor, children }: FieldProps) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <label htmlFor={htmlFor} className="text-sm font-medium">
-        {label}
-      </label>
-      {children}
-    </div>
+                }
+              />
+              <Button type="submit" disabled={!valid || pending}>
+                {pending ? "저장 중..." : "저장"}
+              </Button>
+            </div>
+          </DialogFooter>
+        </form>
+      )}
+    </Modal>
   );
 }

--- a/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
@@ -2,6 +2,7 @@ import { Trash2 } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { parseIsoDate } from "@/features/review/calendar";
 import { cn } from "@/lib/utils";
 
@@ -93,8 +94,7 @@ export function PlannerDayDetailPanel({
                     key={task.id}
                     className="border-border bg-card flex items-center gap-2 rounded-md border p-2 text-sm"
                   >
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={task.completed}
                       onChange={() => onTaskToggle?.(task)}
                       aria-label={`${task.title} 완료`}

--- a/fe/src/features/planner/components/calendar/TaskFormDialog.tsx
+++ b/fe/src/features/planner/components/calendar/TaskFormDialog.tsx
@@ -2,8 +2,10 @@ import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { DialogPopup } from "@/components/ui/dialog-popup";
+import { DialogFooter } from "@/components/ui/dialog-footer";
+import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
 import { GoogleConnectButton } from "@/features/google/components/GoogleConnectButton";
 
 import type { TaskCreateRequest } from "../../api/tasks";
@@ -48,71 +50,60 @@ export function TaskFormDialog({
   };
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-        <DialogPopup className="max-w-sm">
-          <Dialog.Title className="text-base font-semibold">
-            할 일 추가
-          </Dialog.Title>
+    <Modal open={open} onOpenChange={onOpenChange} className="max-w-sm">
+      <Dialog.Title className="text-base font-semibold">
+        할 일 추가
+      </Dialog.Title>
 
-          {!googleConnected ? (
-            <div className="mt-4 flex flex-col gap-4">
-              <p className="text-muted-foreground text-sm">
-                Google 연결이 필요합니다.
-              </p>
-              <div className="flex justify-end gap-2">
-                <Dialog.Close
-                  render={
-                    <Button variant="ghost" type="button">
-                      닫기
-                    </Button>
-                  }
-                />
-                <GoogleConnectButton />
-              </div>
-            </div>
-          ) : (
-            <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3">
-              <div className="flex flex-col gap-1.5">
-                <label htmlFor={titleId} className="text-sm font-medium">
-                  제목
-                </label>
-                <Input
-                  id={titleId}
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  autoFocus
-                />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <label htmlFor={dueId} className="text-sm font-medium">
-                  마감일 (선택)
-                </label>
-                <Input
-                  id={dueId}
-                  type="date"
-                  value={due}
-                  onChange={(e) => setDue(e.target.value)}
-                />
-              </div>
-
-              <div className="mt-1 flex justify-end gap-2">
-                <Dialog.Close
-                  render={
-                    <Button variant="ghost" type="button" disabled={pending}>
-                      취소
-                    </Button>
-                  }
-                />
-                <Button type="submit" disabled={!valid || pending}>
-                  {pending ? "저장 중..." : "저장"}
+      {!googleConnected ? (
+        <div className="mt-4 flex flex-col gap-4">
+          <p className="text-muted-foreground text-sm">
+            Google 연결이 필요합니다.
+          </p>
+          <DialogFooter className="mt-0">
+            <Dialog.Close
+              render={
+                <Button variant="ghost" type="button">
+                  닫기
                 </Button>
-              </div>
-            </form>
-          )}
-        </DialogPopup>
-      </Dialog.Portal>
-    </Dialog.Root>
+              }
+            />
+            <GoogleConnectButton />
+          </DialogFooter>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3">
+          <FormField label="제목" htmlFor={titleId}>
+            <Input
+              id={titleId}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              autoFocus
+            />
+          </FormField>
+          <FormField label="마감일 (선택)" htmlFor={dueId}>
+            <Input
+              id={dueId}
+              type="date"
+              value={due}
+              onChange={(e) => setDue(e.target.value)}
+            />
+          </FormField>
+
+          <DialogFooter className="mt-1">
+            <Dialog.Close
+              render={
+                <Button variant="ghost" type="button" disabled={pending}>
+                  취소
+                </Button>
+              }
+            />
+            <Button type="submit" disabled={!valid || pending}>
+              {pending ? "저장 중..." : "저장"}
+            </Button>
+          </DialogFooter>
+        </form>
+      )}
+    </Modal>
   );
 }


### PR DESCRIPTION
## 이슈
closes #560

컴포넌트 재사용/일관성 전수 조사 결과, 동일 UI가 독립 복붙된 클러스터를 공유 컴포넌트로 일원화한다(Tier 1).

## 신규 공유 컴포넌트 (components/ui)
| 컴포넌트 | 일원화한 중복 |
|---|---|
| `Modal` | Dialog Root+Portal+Backdrop+DialogPopup scaffolding (6×) |
| `Select` | Trigger+Positioner+Popup+Item (2×) |
| `Menu`/`MenuItem` | Popup+Item, default/destructive variant (2×) |
| `FormField` | label+control+error 래퍼 (11× 인라인 + 로컬 Field/CharField) |
| `Textarea` | raw textarea 스타일 (2×) |
| `Checkbox` | raw input checkbox (2×) |
| `FieldError` | text-destructive 오류 메시지 (8×) |
| `DialogFooter` | 취소+제출 액션 영역 (4×+) |

## 리팩터된 소비처
6개 다이얼로그(EventForm·TaskForm·FlashcardForm·AddMaterial·EditMaterial·ConfirmDialog) → Modal/FormField/Textarea/Checkbox/DialogFooter, MaterialHeader·NoteTreeSidebar → Menu, PlannerDayDetailPanel → Checkbox.

## 판단 메모
- LoginPage는 이미 공유 `Label`을 쓰고 의도적 인증화면 스타일(text-xs·중앙 에러)이라 강제 변환 제외.

## 검증
- 순감소 없는 구조 정리(+658/-553), **FE 전체 146개 테스트 통과**, eslint·prettier·tsc 통과
- 기존 다이얼로그 통합테스트가 Modal/FormField 경유 동작을 그대로 커버