### PR TITLE
refactor : FE 상태 컴포넌트 통일 (Tier 2)

### DIFF
--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -1,6 +1,8 @@
 import { lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 
+import { LoadingText } from "@/components/ui/loading-text";
+
 import { PrivateRoute } from "../features/auth/components/PrivateRoute";
 import { PublicRoute } from "../features/auth/components/PublicRoute";
 import { LandingPage } from "../pages/LandingPage";
@@ -26,7 +28,7 @@ const PlannerCalendarPage = lazy(importPlannerCalendar);
 const PlannerSettingsPage = lazy(importPlannerSettings);
 
 function RouteFallback() {
-  return <div className="text-muted-foreground p-6 text-sm">불러오는 중…</div>;
+  return <LoadingText className="p-6" />;
 }
 
 export function AppRouter() {

--- a/fe/src/components/ui/empty-state.tsx
+++ b/fe/src/components/ui/empty-state.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * 빈 상태·완료 상태 등 중앙 정렬 안내 레이아웃. 내용(메시지·액션 버튼)은 children으로 구성한다.
+ * 높이는 기본 min-h-[40svh]이며 className(min-h-[30svh] 등)으로 덮어쓴다.
+ */
+function EmptyState({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-state"
+      className={cn(
+        "flex min-h-[40svh] flex-col items-center justify-center gap-4 text-center",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { EmptyState };

--- a/fe/src/components/ui/loading-text.tsx
+++ b/fe/src/components/ui/loading-text.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/** 데이터 로딩 중 표시하는 표준 안내 텍스트. 기본 문구 "불러오는 중…". */
+function LoadingText({
+  className,
+  children = "불러오는 중…",
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="loading-text"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    >
+      {children}
+    </p>
+  );
+}
+
+export { LoadingText };

--- a/fe/src/features/flashcard/components/EmptyFlashcardState.tsx
+++ b/fe/src/features/flashcard/components/EmptyFlashcardState.tsx
@@ -1,6 +1,7 @@
 import { Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 
 interface Props {
   onAdd: () => void;
@@ -8,11 +9,11 @@ interface Props {
 
 export function EmptyFlashcardState({ onAdd }: Props) {
   return (
-    <div className="flex min-h-[30svh] flex-col items-center justify-center gap-4 text-center">
+    <EmptyState className="min-h-[30svh]">
       <p className="text-muted-foreground text-sm">아직 카드가 없습니다.</p>
       <Button onClick={onAdd}>
         <Plus className="size-4" /> 첫 카드 추가
       </Button>
-    </div>
+    </EmptyState>
   );
 }

--- a/fe/src/features/flashcard/components/FlashcardListTab.tsx
+++ b/fe/src/features/flashcard/components/FlashcardListTab.tsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Button } from "@/components/ui/button";
+import { FieldError } from "@/components/ui/field-error";
+import { LoadingText } from "@/components/ui/loading-text";
 import { toast } from "@/shared/lib/toast";
 
 import type { Flashcard } from "../api/flashcards";
@@ -55,12 +57,10 @@ export function FlashcardListTab({ materialId }: Props) {
   };
 
   if (flashcardsQuery.isLoading) {
-    return <p className="text-muted-foreground text-sm">불러오는 중...</p>;
+    return <LoadingText />;
   }
   if (flashcardsQuery.isError || !flashcardsQuery.data) {
-    return (
-      <p className="text-destructive text-sm">카드를 불러오지 못했어요.</p>
-    );
+    return <FieldError>카드를 불러오지 못했어요.</FieldError>;
   }
 
   const flashcards = flashcardsQuery.data;

--- a/fe/src/features/google/components/GoogleConnectionCard.tsx
+++ b/fe/src/features/google/components/GoogleConnectionCard.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { LoadingText } from "@/components/ui/loading-text";
 
 import { useDisconnectGoogle } from "../hooks/useDisconnectGoogle";
 import { useGoogleStatus } from "../hooks/useGoogleStatus";
@@ -23,7 +24,7 @@ export function GoogleConnectionCard() {
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
         {isLoading ? (
-          <p className="text-muted-foreground text-sm">불러오는 중…</p>
+          <LoadingText />
         ) : status?.connected ? (
           <>
             <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm sm:grid-cols-[5rem_1fr]">

--- a/fe/src/features/material/components/EmptyMaterialState.tsx
+++ b/fe/src/features/material/components/EmptyMaterialState.tsx
@@ -1,6 +1,7 @@
 import { Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 
 interface Props {
   onAdd: () => void;
@@ -8,13 +9,13 @@ interface Props {
 
 export function EmptyMaterialState({ onAdd }: Props) {
   return (
-    <div className="flex min-h-[40svh] flex-col items-center justify-center gap-4 text-center">
+    <EmptyState>
       <p className="text-muted-foreground text-sm">
         아직 등록된 학습 자료가 없습니다.
       </p>
       <Button onClick={onAdd}>
         <Plus className="size-4" /> 첫 자료 추가
       </Button>
-    </div>
+    </EmptyState>
   );
 }

--- a/fe/src/features/note/components/NoteTab.tsx
+++ b/fe/src/features/note/components/NoteTab.tsx
@@ -4,6 +4,9 @@ import { useSearchParams } from "react-router-dom";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { FieldError } from "@/components/ui/field-error";
+import { LoadingText } from "@/components/ui/loading-text";
 
 import type { NoteTreeNode } from "../api/notes";
 import { useNoteDetail } from "../hooks/useNoteDetail";
@@ -93,23 +96,21 @@ export function NoteTab({ materialId }: Props) {
   };
 
   if (treeQuery.isLoading) {
-    return <p className="text-muted-foreground text-sm">불러오는 중...</p>;
+    return <LoadingText />;
   }
   if (treeQuery.isError) {
-    return (
-      <p className="text-destructive text-sm">노트를 불러오지 못했어요.</p>
-    );
+    return <FieldError>노트를 불러오지 못했어요.</FieldError>;
   }
 
   // 빈 상태: 노트 0개 + 선택된 노트도 없음 (생성 직후 refetch 전이면 에디터로 진행)
   if (tree.length === 0 && activeNoteId == null) {
     return (
-      <div className="flex min-h-[40svh] flex-col items-center justify-center gap-4 text-center">
+      <EmptyState>
         <p className="text-muted-foreground text-sm">아직 노트가 없습니다.</p>
         <Button onClick={handleAddRoot} disabled={createNote.isPending}>
           <Plus className="size-4" /> 첫 노트 만들기
         </Button>
-      </div>
+      </EmptyState>
     );
   }
 
@@ -148,9 +149,9 @@ export function NoteTab({ materialId }: Props) {
             왼쪽에서 노트를 선택하거나 새로 만드세요.
           </p>
         ) : detailQuery.isLoading ? (
-          <p className="text-muted-foreground text-sm">불러오는 중...</p>
+          <LoadingText />
         ) : detailQuery.isError || !detailQuery.data ? (
-          <p className="text-destructive text-sm">노트를 불러오지 못했어요.</p>
+          <FieldError>노트를 불러오지 못했어요.</FieldError>
         ) : (
           <NoteEditor
             key={detailQuery.data.id}

--- a/fe/src/features/review/components/CompletionState.tsx
+++ b/fe/src/features/review/components/CompletionState.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 
 interface Props {
   count: number;
@@ -8,7 +9,7 @@ interface Props {
 
 export function CompletionState({ count }: Props) {
   return (
-    <div className="flex min-h-[40svh] flex-col items-center justify-center gap-4 text-center">
+    <EmptyState>
       <p className="text-foreground text-2xl font-medium">
         🎉 오늘 복습 {count}개 모두 완료!
       </p>
@@ -21,6 +22,6 @@ export function CompletionState({ count }: Props) {
           <Button>학습 자료 보기</Button>
         </Link>
       </div>
-    </div>
+    </EmptyState>
   );
 }

--- a/fe/src/features/review/components/EmptyTodayState.tsx
+++ b/fe/src/features/review/components/EmptyTodayState.tsx
@@ -1,14 +1,15 @@
 import { Link } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export function EmptyTodayState() {
   return (
-    <div className="flex min-h-[40svh] flex-col items-center justify-center gap-4 text-center">
+    <EmptyState>
       <p className="text-foreground text-lg">오늘은 복습할 카드가 없어요! 🌱</p>
       <Link to="/home">
         <Button variant="outline">홈으로</Button>
       </Link>
-    </div>
+    </EmptyState>
   );
 }

--- a/fe/src/pages/planner/MaterialDetailPage.tsx
+++ b/fe/src/pages/planner/MaterialDetailPage.tsx
@@ -1,6 +1,8 @@
 import { Tabs } from "@base-ui/react/tabs";
 import { useParams, useSearchParams } from "react-router-dom";
 
+import { FieldError } from "@/components/ui/field-error";
+import { LoadingText } from "@/components/ui/loading-text";
 import { FlashcardListTab } from "@/features/flashcard/components/FlashcardListTab";
 import { MaterialHeader } from "@/features/material/components/MaterialHeader";
 import { useMaterial } from "@/features/material/hooks/useMaterial";
@@ -38,12 +40,10 @@ export function MaterialDetailPage() {
   const materialQuery = useMaterial(materialId);
 
   if (materialQuery.isLoading) {
-    return <p className="text-muted-foreground text-sm">불러오는 중...</p>;
+    return <LoadingText />;
   }
   if (materialQuery.isError || !materialQuery.data) {
-    return (
-      <p className="text-destructive text-sm">자료를 불러오지 못했어요.</p>
-    );
+    return <FieldError>자료를 불러오지 못했어요.</FieldError>;
   }
 
   return (

--- a/fe/src/pages/planner/MaterialListPage.tsx
+++ b/fe/src/pages/planner/MaterialListPage.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
+import { LoadingText } from "@/components/ui/loading-text";
 import { AddMaterialDialog } from "@/features/material/components/AddMaterialDialog";
 import { EmptyMaterialState } from "@/features/material/components/EmptyMaterialState";
 import { MaterialCard } from "@/features/material/components/MaterialCard";
@@ -27,7 +28,7 @@ export function MaterialListPage() {
       </div>
 
       {isLoading ? (
-        <p className="text-muted-foreground text-sm">불러오는 중...</p>
+        <LoadingText />
       ) : !materials || materials.length === 0 ? (
         <EmptyMaterialState onAdd={() => setDialogOpen(true)} />
       ) : (

--- a/fe/src/pages/planner/TodayReviewsPage.tsx
+++ b/fe/src/pages/planner/TodayReviewsPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+import { FieldError } from "@/components/ui/field-error";
+import { LoadingText } from "@/components/ui/loading-text";
 import { type TodayReview } from "@/features/review/api/reviews";
 import { CompletionState } from "@/features/review/components/CompletionState";
 import { EmptyTodayState } from "@/features/review/components/EmptyTodayState";
@@ -21,12 +23,10 @@ export function TodayReviewsPage() {
   }, [data, queue]);
 
   if (isLoading || (data && queue === null)) {
-    return <p className="text-muted-foreground text-sm">불러오는 중...</p>;
+    return <LoadingText />;
   }
   if (isError || !data || !queue) {
-    return (
-      <p className="text-destructive text-sm">복습을 불러오지 못했어요.</p>
-    );
+    return <FieldError>복습을 불러오지 못했어요.</FieldError>;
   }
 
   const reviews = queue;


### PR DESCRIPTION
## 이슈
closes #564

로딩/빈상태/에러 표시가 페이지마다 독립 인라인으로 복붙되어 있어 공유 컴포넌트로 통일한다(Tier 2).

## 신규 (components/ui)
| 컴포넌트 | 통일한 중복 |
|---|---|
| `LoadingText` | '불러오는 중' 인라인 8× (router·NoteTab·FlashcardListTab·MaterialDetail·TodayReviews·MaterialList·GoogleConnectionCard) |
| `EmptyState` | 중앙정렬 안내 레이아웃 `min-h-40svh ...` |

## 리팩터
- `EmptyFlashcardState`·`EmptyMaterialState`·`EmptyTodayState`·`CompletionState` + `NoteTab` 인라인 빈상태 → `EmptyState`
- 데이터 로드 에러(`text-destructive text-sm`) 5× → Tier 1 `FieldError` 재사용 (신규 컴포넌트 없이 일원화)
- 로딩 8× → `LoadingText`

## 검증
- eslint·prettier·**npm run build(tsc -b)**·FE 전체 146개 테스트 통과
- 빌드 게이트 포함(지난 tsc -b 누락 재발 방지)