### PR TITLE
refactor : FE 중복 정리 (Tier 3)

### DIFF
--- a/fe/src/components/Toaster.tsx
+++ b/fe/src/components/Toaster.tsx
@@ -1,5 +1,6 @@
 import { X } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useToastStore } from "@/shared/lib/toast";
 
@@ -30,14 +31,15 @@ export function Toaster() {
           )}
         >
           <span className="flex-1">{toast.message}</span>
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="icon-sm"
             onClick={() => dismiss(toast.id)}
             aria-label="알림 닫기"
-            className="opacity-70 hover:opacity-100"
+            className="size-6 shrink-0 opacity-70 hover:opacity-100"
           >
             <X className="size-3.5" />
-          </button>
+          </Button>
         </div>
       ))}
     </div>

--- a/fe/src/features/material/components/MaterialCard.tsx
+++ b/fe/src/features/material/components/MaterialCard.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 
 import type { Material } from "../api/materials";
 import { MATERIAL_TYPE_ICONS, MATERIAL_TYPE_LABELS } from "../utils";
+import { MaterialMeta } from "./MaterialMeta";
 
 interface Props {
   material: Material;
@@ -27,22 +28,7 @@ export function MaterialCard({ material }: Props) {
           </span>
           <div className="flex min-w-0 flex-1 flex-col gap-1">
             <h2 className="truncate text-base font-medium">{material.title}</h2>
-            <div className="text-muted-foreground flex flex-wrap gap-x-3 text-xs">
-              <span>{MATERIAL_TYPE_LABELS[material.type]}</span>
-              <span>카드 {material.flashcardCount}장</span>
-              <span>
-                오늘 복습{" "}
-                <span
-                  className={
-                    material.dueReviewCount > 0
-                      ? "text-primary font-medium"
-                      : undefined
-                  }
-                >
-                  {material.dueReviewCount}건
-                </span>
-              </span>
-            </div>
+            <MaterialMeta material={material} />
           </div>
         </CardContent>
       </Card>

--- a/fe/src/features/material/components/MaterialHeader.tsx
+++ b/fe/src/features/material/components/MaterialHeader.tsx
@@ -8,8 +8,9 @@ import { Menu, MenuItem } from "@/components/ui/menu";
 
 import type { Material } from "../api/materials";
 import { useDeleteMaterial } from "../hooks/useDeleteMaterial";
-import { MATERIAL_TYPE_ICONS, MATERIAL_TYPE_LABELS } from "../utils";
+import { MATERIAL_TYPE_ICONS } from "../utils";
 import { EditMaterialDialog } from "./EditMaterialDialog";
+import { MaterialMeta } from "./MaterialMeta";
 
 interface Props {
   material: Material;
@@ -37,22 +38,7 @@ export function MaterialHeader({ material }: Props) {
       </span>
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <h1 className="truncate text-xl font-semibold">{material.title}</h1>
-        <div className="text-muted-foreground flex flex-wrap gap-x-3 text-xs">
-          <span>{MATERIAL_TYPE_LABELS[material.type]}</span>
-          <span>카드 {material.flashcardCount}장</span>
-          <span>
-            오늘 복습{" "}
-            <span
-              className={
-                material.dueReviewCount > 0
-                  ? "text-primary font-medium"
-                  : undefined
-              }
-            >
-              {material.dueReviewCount}건
-            </span>
-          </span>
-        </div>
+        <MaterialMeta material={material} />
       </div>
 
       <Menu

--- a/fe/src/features/material/components/MaterialMeta.tsx
+++ b/fe/src/features/material/components/MaterialMeta.tsx
@@ -1,0 +1,22 @@
+import type { Material } from "../api/materials";
+import { MATERIAL_TYPE_LABELS } from "../utils";
+
+/** 자료 메타 한 줄: 유형 · 카드 수 · 오늘 복습 수(>0이면 강조). 목록 카드·상세 헤더가 공유한다. */
+export function MaterialMeta({ material }: { material: Material }) {
+  return (
+    <div className="text-muted-foreground flex flex-wrap gap-x-3 text-xs">
+      <span>{MATERIAL_TYPE_LABELS[material.type]}</span>
+      <span>카드 {material.flashcardCount}장</span>
+      <span>
+        오늘 복습{" "}
+        <span
+          className={
+            material.dueReviewCount > 0 ? "text-primary font-medium" : undefined
+          }
+        >
+          {material.dueReviewCount}건
+        </span>
+      </span>
+    </div>
+  );
+}

--- a/fe/src/features/planner/components/calendar/PlannerWeekView.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerWeekView.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import type { PlannerEvent, PlannerReview, PlannerTask } from "../../api/feed";
 import { eventTimeLabel } from "../../calendar";
 import { HOURS, layoutDayEvents } from "../../weekLayout";
+import { EVENT_DOT, TASK_DOT } from "./sourceStyles";
 
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
 const HOUR_PX = 40;
@@ -78,7 +79,10 @@ export function PlannerWeekView({
                     key={e.id}
                     type="button"
                     onClick={() => onEventClick(e)}
-                    className="truncate rounded bg-blue-500 px-1 text-left text-[10px] text-white"
+                    className={cn(
+                      "truncate rounded px-1 text-left text-[10px] text-white",
+                      EVENT_DOT,
+                    )}
                   >
                     {e.title ?? "(제목 없음)"}
                   </button>
@@ -86,7 +90,10 @@ export function PlannerWeekView({
                 {dayTasks.map((t) => (
                   <span
                     key={t.id}
-                    className="truncate rounded bg-emerald-500 px-1 text-[10px] text-white"
+                    className={cn(
+                      "truncate rounded px-1 text-[10px] text-white",
+                      TASK_DOT,
+                    )}
                   >
                     ☑ {t.title}
                   </span>
@@ -147,7 +154,10 @@ export function PlannerWeekView({
                       left: `${p.left * 100}%`,
                       width: `${p.width * 100}%`,
                     }}
-                    className="absolute overflow-hidden rounded border border-blue-600 bg-blue-500 px-1 py-0.5 text-left text-[10px] leading-tight text-white"
+                    className={cn(
+                      "absolute overflow-hidden rounded border border-blue-600 px-1 py-0.5 text-left text-[10px] leading-tight text-white",
+                      EVENT_DOT,
+                    )}
                   >
                     <span className="block truncate font-medium">
                       {p.event.title ?? "(제목 없음)"}

--- a/fe/src/shared/error/ErrorBoundary.tsx
+++ b/fe/src/shared/error/ErrorBoundary.tsx
@@ -1,6 +1,8 @@
 import { faro } from "@grafana/faro-react";
 import { Component, type ErrorInfo, type ReactNode } from "react";
 
+import { Button } from "@/components/ui/button";
+
 interface Props {
   children: ReactNode;
   fallback?: ReactNode;
@@ -35,12 +37,9 @@ export class ErrorBoundary extends Component<Props, State> {
             <p className="text-muted-foreground text-sm">
               문제가 발생했습니다.
             </p>
-            <button
-              onClick={() => window.location.reload()}
-              className="text-primary text-sm underline"
-            >
+            <Button variant="link" onClick={() => window.location.reload()}>
               새로고침
-            </button>
+            </Button>
           </div>
         )
       );


### PR DESCRIPTION
## 이슈
closes #566

전수 조사에서 확인된 **방어 가능한 실질 중복**만 선별 정리(Tier 3).

## 작업 내용
- **MaterialMeta 신설** — MaterialCard·MaterialHeader가 복붙하던 메타행(유형·카드수·오늘복습, dueReview>0 강조)을 일원화
- **주간뷰 배지색 상수화** — 이미 `sourceStyles`에 있던 `EVENT_DOT`/`TASK_DOT`를 재사용해 raw `bg-blue-500`/`bg-emerald-500` 3곳 제거 (색 변경 시 단일 출처)
- **raw `<button>` → `<Button>`** — Toaster 닫기(ghost icon-sm), ErrorBoundary 새로고침(link variant)

## 의도적으로 제외 (가치 대비 churn)
- 아이콘 크기 상수(size-3.5 vs size-4), `text-[10px]` 토큰화, hover 값 표준화 — 미세 일관성이라 제외
- 캘린더 셀·주간뷰 슬롯 등 본질이 커스텀인 버튼은 `<Button>` 강제하지 않음

## 검증
- eslint·prettier·**npm run build(tsc -b)**·FE 전체 146개 테스트 통과