### PR TITLE
fix : 노트 에디터 리스트 항목을 개별 드래그 블록으로 (DragHandle nested)

### DIFF
--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -194,7 +194,9 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
           insertPagePending={createNote.isPending}
         />
         {editor && (
-          <DragHandle editor={editor} className="z-10">
+          // nested: 불릿/태스크 리스트 항목 등 중첩 블록도 개별 드래그 타깃이 되게 한다.
+          // (기본 false면 리스트 전체를 한 블록으로만 잡음)
+          <DragHandle editor={editor} nested className="z-10">
             <button
               type="button"
               aria-label="블록 이동"


### PR DESCRIPTION
## 이슈
closes #568

## 증상
- 불릿/태스크 리스트가 **리스트 전체 = 한 블록**으로 잡혀 개별 항목 이동 불가
- (1차 수정 후) 항목에 호버해도 6점 핸들이 즉시 안 뜨고, **하위(Tab) 불릿은 왼쪽에 호버하면 안 뜨고 글자에 대야** 떴다. 블록 단위는 한 줄이어야 함.

## 원인
1. Tiptap v3 `DragHandle` **`nested` 기본 `false`** → 최상위 블록만 타깃 (리스트 전체)
2. `nested` 기본 **edge detection이 `['left','top']`(threshold 12px)** → 항목 **왼쪽 가장자리에 호버하면 부모(리스트)를 우선**. 그래서 하위 불릿 왼쪽/경계에서 항목 핸들이 안 뜨고 글자(중앙)에 대야 떴다.

## 조치
`<DragHandle nested={{ edgeDetection: 'none' }}>`
- `nested`: 리스트 항목 등 중첩 블록을 개별(한 줄) 타깃화
- `edgeDetection: 'none'`: 커서 위치가 타깃 선택을 안 바꾸게 → 행 어디에 호버하든(왼쪽 거터 포함) 가장 깊은 항목이 일관되게 잡혀 핸들이 뜬다

## 검증
- eslint·prettier·npm run build(tsc -b) 통과
- ⚠️ 드래그/호버는 UI 상호작용이라 단위 테스트 불가 → 로컬/머지 후 육안 확인 권장