### PR TITLE
feat : Routine RRULE 빌더 + 클라이언트 확장 스캐폴딩 (R0)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventWriteBody.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventWriteBody.java
@@ -2,8 +2,13 @@ package ds.project.orino.planner.google.calendar.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.List;
+
 /**
  * Google Calendar events.insert/patch 요청 바디(필요한 필드만). null 필드는 직렬화에서 제외한다.
+ *
+ * @param recurrence         RRULE 문자열 목록(예: {@code ["RRULE:FREQ=WEEKLY;BYDAY=MO,WE"]}). null이면 단일 일정
+ * @param extendedProperties orino 태깅용 확장 속성(루틴 식별). null이면 미설정
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record GoogleEventWriteBody(
@@ -11,8 +16,16 @@ public record GoogleEventWriteBody(
         String location,
         String description,
         GoogleEventTime start,
-        GoogleEventTime end
+        GoogleEventTime end,
+        List<String> recurrence,
+        GoogleExtendedProperties extendedProperties
 ) {
+
+    /** 반복·태깅 없는 단일 일정 바디. */
+    public GoogleEventWriteBody(String summary, String location, String description,
+                               GoogleEventTime start, GoogleEventTime end) {
+        this(summary, location, description, start, end, null, null);
+    }
 
     /** 시간 일정이면 dateTime+timeZone, 종일이면 date. */
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventsResponse.java
@@ -15,7 +15,9 @@ public record GoogleEventsResponse(List<GoogleEventItem> items) {
             String location,
             String recurringEventId,
             GoogleEventDateTime start,
-            GoogleEventDateTime end
+            GoogleEventDateTime end,
+            List<String> recurrence,
+            GoogleExtendedProperties extendedProperties
     ) {
     }
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleExtendedProperties.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleExtendedProperties.java
@@ -1,0 +1,24 @@
+package ds.project.orino.planner.google.calendar.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+/**
+ * Google 이벤트의 {@code extendedProperties}. orino는 {@code private} 영역만 사용한다.
+ *
+ * <p>{@code private}는 Java 예약어라 필드명은 {@code privateProperties}, JSON 키는 {@code private}로 매핑한다.
+ * 쓰기 시 null 영역은 직렬화에서 제외하고, 읽기 시 알 수 없는 영역(shared 등)은 무시한다.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GoogleExtendedProperties(
+        @JsonProperty("private") Map<String, String> privateProperties
+) {
+
+    public static GoogleExtendedProperties ofPrivate(Map<String, String> privateProperties) {
+        return new GoogleExtendedProperties(privateProperties);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
@@ -6,8 +6,13 @@ import ds.project.orino.planner.google.calendar.dto.GoogleEventWriteBody.GoogleE
 import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse;
 import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventDateTime;
 import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventItem;
+import ds.project.orino.planner.google.calendar.dto.GoogleExtendedProperties;
 import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
 import ds.project.orino.planner.google.config.GoogleOAuthProperties;
+import ds.project.orino.planner.google.recurrence.RecurrenceRule;
+import ds.project.orino.planner.google.recurrence.RecurrenceRuleFactory;
+import ds.project.orino.planner.google.routine.RoutineTag;
+import ds.project.orino.planner.google.routine.RoutineType;
 import ds.project.orino.planner.google.token.GoogleTokenProvider;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -111,6 +116,107 @@ public class GoogleCalendarClient {
         return normalize(item, zone);
     }
 
+    /**
+     * 루틴(반복) 이벤트 생성. {@code recurrence}(RRULE)와 루틴 식별 태그를 함께 기록한다.
+     * 생성된 마스터 이벤트를 정규화해 반환한다.
+     */
+    public PlannerEvent insertRoutineEvent(Long memberId, EventRequest request,
+                                           RecurrenceRule rule, RoutineType type, ZoneId zone) {
+        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
+                .path(PRIMARY_CALENDAR_PATH)
+                .build()
+                .toUri();
+
+        GoogleEventWriteBody body = toRoutineWriteBody(request, rule, type, zone);
+        GoogleEventItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.post()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(body)
+                        .retrieve()
+                        .body(GoogleEventItem.class));
+        return normalize(item, zone);
+    }
+
+    /**
+     * 루틴 마스터 이벤트 수정(patch). 반복 규칙·내용·태그를 갱신한다.
+     * {@code rule}이 null이면 recurrence는 건드리지 않는다(내용만 patch).
+     */
+    public PlannerEvent patchRoutineEvent(Long memberId, String eventId, EventRequest request,
+                                          RecurrenceRule rule, RoutineType type, ZoneId zone) {
+        URI uri = eventUri(eventId);
+        GoogleEventWriteBody body = toRoutineWriteBody(request, rule, type, zone);
+        GoogleEventItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.patch()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(body)
+                        .retrieve()
+                        .body(GoogleEventItem.class));
+        return normalize(item, zone);
+    }
+
+    /**
+     * 루틴 마스터 시리즈 목록 조회. {@code singleEvents=false}로 RRULE을 펼치지 않고 마스터 이벤트를,
+     * {@code privateExtendedProperty=orinoRoutine=1}로 루틴만 필터링해 받는다.
+     *
+     * <p>마스터의 {@code recurrence}·{@code extendedProperties}를 그대로 노출하므로 호출부(시리즈 목록 API)가
+     * RRULE 역파싱과 종류 판별을 수행한다.
+     */
+    public List<GoogleEventItem> listRoutineMasters(Long memberId) {
+        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
+                .path(PRIMARY_CALENDAR_PATH)
+                .queryParam("singleEvents", "false")
+                .queryParam("privateExtendedProperty", RoutineTag.LIST_FILTER)
+                .queryParam("maxResults", "2500")
+                .build()
+                .toUri();
+
+        GoogleEventsResponse response = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.get()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .retrieve()
+                        .body(GoogleEventsResponse.class));
+
+        if (response == null || response.items() == null) {
+            return List.of();
+        }
+        return response.items();
+    }
+
+    /**
+     * 단일 반복 이벤트({@code recurringEventId})를 [timeMin, timeMax) 구간 인스턴스로 펼쳐 조회한다.
+     * events.instances 엔드포인트를 사용하며 응답을 사용자 시간대로 정규화한다.
+     */
+    public List<PlannerEvent> listInstances(Long memberId, String eventId,
+                                            Instant timeMin, Instant timeMax, ZoneId zone) {
+        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
+                .path(PRIMARY_CALENDAR_PATH)
+                .pathSegment(eventId, "instances")
+                .queryParam("timeMin", timeMin.toString())
+                .queryParam("timeMax", timeMax.toString())
+                .queryParam("maxResults", "2500")
+                .build()
+                .toUri();
+
+        GoogleEventsResponse response = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.get()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .retrieve()
+                        .body(GoogleEventsResponse.class));
+
+        if (response == null || response.items() == null) {
+            return List.of();
+        }
+        return response.items().stream()
+                .map(item -> normalize(item, zone))
+                .toList();
+    }
+
     /** 일정 삭제. 없는 id면 404(RESOURCE_NOT_FOUND). */
     public void deleteEvent(Long memberId, String eventId) {
         URI uri = eventUri(eventId);
@@ -133,18 +239,36 @@ public class GoogleCalendarClient {
     }
 
     private GoogleEventWriteBody toWriteBody(EventRequest request, ZoneId zone) {
-        GoogleEventTime start;
-        GoogleEventTime end;
-        if (request.allDay()) {
-            start = new GoogleEventTime(null, request.start(), null);
-            // Google 종일 종료는 배타적(다음 날) → 사용자 inclusive end + 1일
-            end = new GoogleEventTime(null, LocalDate.parse(request.end()).plusDays(1).toString(), null);
-        } else {
-            start = new GoogleEventTime(request.start(), null, zone.getId());
-            end = new GoogleEventTime(request.end(), null, zone.getId());
-        }
         return new GoogleEventWriteBody(
-                request.title(), request.location(), request.description(), start, end);
+                request.title(), request.location(), request.description(),
+                startTime(request, zone), endTime(request, zone));
+    }
+
+    /** 루틴 쓰기 바디: 기본 필드 + recurrence(RRULE) + 루틴 태그. rule이 null이면 recurrence는 비운다. */
+    private GoogleEventWriteBody toRoutineWriteBody(EventRequest request, RecurrenceRule rule,
+                                                    RoutineType type, ZoneId zone) {
+        List<String> recurrence = rule == null
+                ? null
+                : List.of(RecurrenceRuleFactory.toRRule(rule, zone));
+        GoogleExtendedProperties extended =
+                GoogleExtendedProperties.ofPrivate(RoutineTag.privateProperties(type));
+        return new GoogleEventWriteBody(
+                request.title(), request.location(), request.description(),
+                startTime(request, zone), endTime(request, zone), recurrence, extended);
+    }
+
+    private GoogleEventTime startTime(EventRequest request, ZoneId zone) {
+        return request.allDay()
+                ? new GoogleEventTime(null, request.start(), null)
+                : new GoogleEventTime(request.start(), null, zone.getId());
+    }
+
+    private GoogleEventTime endTime(EventRequest request, ZoneId zone) {
+        if (request.allDay()) {
+            // Google 종일 종료는 배타적(다음 날) → 사용자 inclusive end + 1일
+            return new GoogleEventTime(null, LocalDate.parse(request.end()).plusDays(1).toString(), null);
+        }
+        return new GoogleEventTime(request.end(), null, zone.getId());
     }
 
     private PlannerEvent normalize(GoogleEventItem item, ZoneId zone) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceFreq.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceFreq.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.google.recurrence;
+
+/**
+ * RRULE {@code FREQ} 값. Phase 1은 매일/주간/매월만 지원한다.
+ */
+public enum RecurrenceFreq {
+    DAILY,
+    WEEKLY,
+    MONTHLY
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceRule.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceRule.java
@@ -1,0 +1,67 @@
+package ds.project.orino.planner.google.recurrence;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 반복 규칙 값 객체(VO). Google Calendar의 RRULE 한 줄에 대응한다.
+ *
+ * <p>orino는 RRULE을 직접 펼치지 않고 이 VO를 {@link RecurrenceRuleFactory}로 RRULE 문자열과 상호 변환한다.
+ * Phase 1 지원 범위: {@code FREQ=DAILY|WEEKLY|MONTHLY}, {@code INTERVAL}, {@code BYDAY}, {@code BYMONTHDAY},
+ * {@code UNTIL}. {@code BYSETPOS}·복수 RRULE·EXDATE는 미지원.
+ *
+ * @param freq       반복 주기(필수)
+ * @param interval   반복 간격(N). null·1이면 RRULE에서 생략된다. 1 이상
+ * @param byDay      주간 반복 요일 목록(WEEKLY에서만 의미). 비어 있으면 생략
+ * @param byMonthDay 매월 반복 일자 목록(1~31, MONTHLY에서만 의미). 비어 있으면 생략
+ * @param until      종료일(포함). 사용자 시간대 기준 마지막 날. null이면 무한 반복
+ */
+public record RecurrenceRule(
+        RecurrenceFreq freq,
+        Integer interval,
+        List<RecurrenceWeekday> byDay,
+        List<Integer> byMonthDay,
+        LocalDate until
+) {
+
+    public RecurrenceRule {
+        if (freq == null) {
+            throw new IllegalArgumentException("freq는 필수입니다");
+        }
+        if (interval != null && interval < 1) {
+            throw new IllegalArgumentException("interval은 1 이상이어야 합니다: " + interval);
+        }
+        byDay = byDay == null ? List.of() : List.copyOf(byDay);
+        byMonthDay = byMonthDay == null ? List.of() : List.copyOf(byMonthDay);
+        for (Integer day : byMonthDay) {
+            if (day == null || day < 1 || day > 31) {
+                throw new IllegalArgumentException("byMonthDay는 1~31이어야 합니다: " + day);
+            }
+        }
+    }
+
+    /** 매일 반복. */
+    public static RecurrenceRule daily(LocalDate until) {
+        return new RecurrenceRule(RecurrenceFreq.DAILY, null, List.of(), List.of(), until);
+    }
+
+    /** N일 간격 반복. */
+    public static RecurrenceRule everyNDays(int interval, LocalDate until) {
+        return new RecurrenceRule(RecurrenceFreq.DAILY, interval, List.of(), List.of(), until);
+    }
+
+    /** 지정 요일 주간 반복. */
+    public static RecurrenceRule weekly(List<RecurrenceWeekday> byDay, LocalDate until) {
+        return new RecurrenceRule(RecurrenceFreq.WEEKLY, null, byDay, List.of(), until);
+    }
+
+    /** 지정 일자 매월 반복. */
+    public static RecurrenceRule monthly(List<Integer> byMonthDay, LocalDate until) {
+        return new RecurrenceRule(RecurrenceFreq.MONTHLY, null, List.of(), byMonthDay, until);
+    }
+
+    /** RRULE에서 생략 가능한 1을 정규화한 실효 간격. */
+    public int effectiveInterval() {
+        return interval == null ? 1 : interval;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceRuleFactory.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceRuleFactory.java
@@ -1,0 +1,165 @@
+package ds.project.orino.planner.google.recurrence;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link RecurrenceRule} VO ↔ Google Calendar RRULE 문자열 변환기.
+ *
+ * <p>{@code RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE;UNTIL=20261231T145959Z} 형태를 생성·역파싱한다.
+ * {@code UNTIL}은 RFC 5545에 따라 사용자 시간대의 마지막 날 23:59:59를 UTC로 변환해 직렬화한다.
+ */
+public final class RecurrenceRuleFactory {
+
+    private static final String RRULE_PREFIX = "RRULE:";
+    /** UNTIL UTC 직렬화 포맷: 20261231T235959Z. */
+    private static final DateTimeFormatter UNTIL_UTC =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'");
+    private static final DateTimeFormatter UNTIL_DATE_ONLY =
+            DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private RecurrenceRuleFactory() {
+    }
+
+    /**
+     * VO를 RRULE 문자열로 직렬화한다(접두사 {@code RRULE:} 포함).
+     *
+     * @param zone {@code UNTIL}을 UTC로 변환할 때 기준이 되는 사용자 시간대
+     */
+    public static String toRRule(RecurrenceRule rule, ZoneId zone) {
+        StringBuilder sb = new StringBuilder(RRULE_PREFIX);
+        sb.append("FREQ=").append(rule.freq().name());
+
+        if (rule.effectiveInterval() > 1) {
+            sb.append(";INTERVAL=").append(rule.effectiveInterval());
+        }
+        if (!rule.byDay().isEmpty()) {
+            sb.append(";BYDAY=").append(joinByDay(rule.byDay()));
+        }
+        if (!rule.byMonthDay().isEmpty()) {
+            sb.append(";BYMONTHDAY=").append(joinByMonthDay(rule.byMonthDay()));
+        }
+        if (rule.until() != null) {
+            sb.append(";UNTIL=").append(serializeUntil(rule.until(), zone));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * RRULE 문자열을 VO로 역파싱한다. 접두사 {@code RRULE:}는 있어도/없어도 된다.
+     * 시리즈 편집 시 폼을 채우기 위한 용도.
+     *
+     * @param zone {@code UNTIL}(UTC)을 사용자 시간대 날짜로 환산할 때 기준이 되는 시간대
+     */
+    public static RecurrenceRule parse(String rrule, ZoneId zone) {
+        if (rrule == null || rrule.isBlank()) {
+            throw new IllegalArgumentException("RRULE 문자열이 비어 있습니다");
+        }
+        String body = rrule.trim();
+        if (body.regionMatches(true, 0, RRULE_PREFIX, 0, RRULE_PREFIX.length())) {
+            body = body.substring(RRULE_PREFIX.length());
+        }
+
+        RecurrenceFreq freq = null;
+        Integer interval = null;
+        List<RecurrenceWeekday> byDay = List.of();
+        List<Integer> byMonthDay = List.of();
+        LocalDate until = null;
+
+        for (String part : body.split(";")) {
+            if (part.isBlank()) {
+                continue;
+            }
+            int eq = part.indexOf('=');
+            if (eq < 0) {
+                continue;
+            }
+            String key = part.substring(0, eq).trim().toUpperCase();
+            String value = part.substring(eq + 1).trim();
+            switch (key) {
+                case "FREQ" -> freq = RecurrenceFreq.valueOf(value.toUpperCase());
+                case "INTERVAL" -> interval = Integer.valueOf(value);
+                case "BYDAY" -> byDay = parseByDay(value);
+                case "BYMONTHDAY" -> byMonthDay = parseByMonthDay(value);
+                case "UNTIL" -> until = parseUntil(value, zone);
+                default -> {
+                    // BYSETPOS 등 미지원 파트는 무시한다(Phase 1)
+                }
+            }
+        }
+        if (freq == null) {
+            throw new IllegalArgumentException("RRULE에 FREQ가 없습니다: " + rrule);
+        }
+        return new RecurrenceRule(freq, interval, byDay, byMonthDay, until);
+    }
+
+    private static String joinByDay(List<RecurrenceWeekday> byDay) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < byDay.size(); i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append(byDay.get(i).name());
+        }
+        return sb.toString();
+    }
+
+    private static String joinByMonthDay(List<Integer> byMonthDay) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < byMonthDay.size(); i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append(byMonthDay.get(i));
+        }
+        return sb.toString();
+    }
+
+    private static List<RecurrenceWeekday> parseByDay(String value) {
+        List<RecurrenceWeekday> days = new ArrayList<>();
+        for (String code : value.split(",")) {
+            if (!code.isBlank()) {
+                days.add(RecurrenceWeekday.fromCode(code));
+            }
+        }
+        return days;
+    }
+
+    private static List<Integer> parseByMonthDay(String value) {
+        List<Integer> days = new ArrayList<>();
+        for (String day : value.split(",")) {
+            if (!day.isBlank()) {
+                days.add(Integer.valueOf(day.trim()));
+            }
+        }
+        return days;
+    }
+
+    /** 사용자 TZ 마지막 날 23:59:59 → UTC 직렬화. */
+    private static String serializeUntil(LocalDate until, ZoneId zone) {
+        return until.atTime(LocalTime.of(23, 59, 59))
+                .atZone(zone)
+                .withZoneSameInstant(ZoneOffset.UTC)
+                .format(UNTIL_UTC);
+    }
+
+    /** UNTIL 값을 사용자 TZ 날짜로 환산. UTC datetime(...Z) 또는 date-only(yyyyMMdd) 모두 수용. */
+    private static LocalDate parseUntil(String value, ZoneId zone) {
+        String v = value.trim();
+        if (v.endsWith("Z") || v.endsWith("z")) {
+            LocalDateTime utc = LocalDateTime.parse(v.substring(0, v.length() - 1), UNTIL_UTC_PARSE);
+            return utc.atZone(ZoneOffset.UTC).withZoneSameInstant(zone).toLocalDate();
+        }
+        return LocalDate.parse(v, UNTIL_DATE_ONLY);
+    }
+
+    /** UTC datetime 파싱용(말미 Z 제외): yyyyMMdd'T'HHmmss. */
+    private static final DateTimeFormatter UNTIL_UTC_PARSE =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss");
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceWeekday.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceWeekday.java
@@ -1,0 +1,45 @@
+package ds.project.orino.planner.google.recurrence;
+
+import java.time.DayOfWeek;
+import java.util.Map;
+
+/**
+ * RRULE {@code BYDAY} 요일 코드(MO, TU, WE, TH, FR, SA, SU)와 {@link DayOfWeek} 매핑.
+ */
+public enum RecurrenceWeekday {
+    MO(DayOfWeek.MONDAY),
+    TU(DayOfWeek.TUESDAY),
+    WE(DayOfWeek.WEDNESDAY),
+    TH(DayOfWeek.THURSDAY),
+    FR(DayOfWeek.FRIDAY),
+    SA(DayOfWeek.SATURDAY),
+    SU(DayOfWeek.SUNDAY);
+
+    private static final Map<DayOfWeek, RecurrenceWeekday> BY_DAY_OF_WEEK = Map.of(
+            DayOfWeek.MONDAY, MO,
+            DayOfWeek.TUESDAY, TU,
+            DayOfWeek.WEDNESDAY, WE,
+            DayOfWeek.THURSDAY, TH,
+            DayOfWeek.FRIDAY, FR,
+            DayOfWeek.SATURDAY, SA,
+            DayOfWeek.SUNDAY, SU);
+
+    private final DayOfWeek dayOfWeek;
+
+    RecurrenceWeekday(DayOfWeek dayOfWeek) {
+        this.dayOfWeek = dayOfWeek;
+    }
+
+    public DayOfWeek toDayOfWeek() {
+        return dayOfWeek;
+    }
+
+    public static RecurrenceWeekday from(DayOfWeek dayOfWeek) {
+        return BY_DAY_OF_WEEK.get(dayOfWeek);
+    }
+
+    /** RRULE 코드 문자열(MO, TU, ...)을 enum으로 파싱한다. 알 수 없으면 IllegalArgumentException. */
+    public static RecurrenceWeekday fromCode(String code) {
+        return RecurrenceWeekday.valueOf(code.trim().toUpperCase());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineTag.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineTag.java
@@ -1,0 +1,52 @@
+package ds.project.orino.planner.google.routine;
+
+import java.util.Map;
+
+/**
+ * 루틴 이벤트 식별을 위한 {@code extendedProperties.private} 태깅 헬퍼.
+ *
+ * <p>{@code orinoRoutine=1} 센티넬로 루틴 이벤트를 구분하고
+ * {@code events.list?privateExtendedProperty=orinoRoutine=1}로 필터링한다.
+ * {@code orinoRoutineType}으로 습관/일정을 구분한다.
+ */
+public final class RoutineTag {
+
+    public static final String KEY_ROUTINE = "orinoRoutine";
+    public static final String KEY_ROUTINE_TYPE = "orinoRoutineType";
+    public static final String ROUTINE_FLAG = "1";
+
+    /** {@code events.list}의 privateExtendedProperty 필터 값: {@code orinoRoutine=1}. */
+    public static final String LIST_FILTER = KEY_ROUTINE + "=" + ROUTINE_FLAG;
+
+    private RoutineTag() {
+    }
+
+    /** 주어진 종류로 루틴 태그 private 프로퍼티 맵을 만든다. */
+    public static Map<String, String> privateProperties(RoutineType type) {
+        return Map.of(
+                KEY_ROUTINE, ROUTINE_FLAG,
+                KEY_ROUTINE_TYPE, type.code());
+    }
+
+    /** private 프로퍼티 맵이 루틴 이벤트를 가리키는지(센티넬 보유) 판별한다. */
+    public static boolean isRoutine(Map<String, String> privateProperties) {
+        return privateProperties != null
+                && ROUTINE_FLAG.equals(privateProperties.get(KEY_ROUTINE));
+    }
+
+    /** private 프로퍼티에서 루틴 종류를 읽는다. 없거나 알 수 없으면 null. */
+    public static RoutineType routineType(Map<String, String> privateProperties) {
+        if (privateProperties == null) {
+            return null;
+        }
+        String code = privateProperties.get(KEY_ROUTINE_TYPE);
+        if (code == null) {
+            return null;
+        }
+        try {
+            return RoutineType.fromCode(code);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineType.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineType.java
@@ -1,0 +1,34 @@
+package ds.project.orino.planner.google.routine;
+
+/**
+ * 루틴 종류. Google 이벤트의 {@code extendedProperties.private.orinoRoutineType} 값에 대응한다.
+ *
+ * <ul>
+ *   <li>{@link #HABIT} — 종일 체크형 습관(통합 피드에서 완료 체크 가능)</li>
+ *   <li>{@link #SCHEDULE} — 시간 고정 일정(시간 블록으로 렌더, 체크 없음)</li>
+ * </ul>
+ */
+public enum RoutineType {
+    HABIT("habit"),
+    SCHEDULE("schedule");
+
+    private final String code;
+
+    RoutineType(String code) {
+        this.code = code;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    /** {@code "habit"|"schedule"} 코드를 enum으로 파싱한다. 알 수 없으면 IllegalArgumentException. */
+    public static RoutineType fromCode(String code) {
+        for (RoutineType type : values()) {
+            if (type.code.equals(code)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("알 수 없는 routine type: " + code);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/recurrence/RecurrenceRuleFactoryTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/recurrence/RecurrenceRuleFactoryTest.java
@@ -1,0 +1,193 @@
+package ds.project.orino.planner.google.recurrence;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RecurrenceRuleFactoryTest {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");      // UTC+9
+    private static final ZoneId NEW_YORK = ZoneId.of("America/New_York"); // 12월 UTC-5
+
+    @Nested
+    @DisplayName("toRRule: VO → RRULE 직렬화")
+    class ToRRule {
+
+        @Test
+        @DisplayName("매일 반복은 FREQ=DAILY만 출력한다")
+        void daily() {
+            String rrule = RecurrenceRuleFactory.toRRule(RecurrenceRule.daily(null), SEOUL);
+
+            assertThat(rrule).isEqualTo("RRULE:FREQ=DAILY");
+        }
+
+        @Test
+        @DisplayName("N일 간격은 INTERVAL=N을 붙이고, interval=1은 생략한다")
+        void interval() {
+            assertThat(RecurrenceRuleFactory.toRRule(RecurrenceRule.everyNDays(3, null), SEOUL))
+                    .isEqualTo("RRULE:FREQ=DAILY;INTERVAL=3");
+            assertThat(RecurrenceRuleFactory.toRRule(RecurrenceRule.everyNDays(1, null), SEOUL))
+                    .isEqualTo("RRULE:FREQ=DAILY");
+        }
+
+        @Test
+        @DisplayName("주간 반복은 BYDAY를 요일 순서대로 출력한다")
+        void weeklyByDay() {
+            RecurrenceRule rule = RecurrenceRule.weekly(
+                    List.of(RecurrenceWeekday.MO, RecurrenceWeekday.WE, RecurrenceWeekday.FR), null);
+
+            assertThat(RecurrenceRuleFactory.toRRule(rule, SEOUL))
+                    .isEqualTo("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR");
+        }
+
+        @Test
+        @DisplayName("매월 반복은 BYMONTHDAY를 출력한다")
+        void monthlyByMonthDay() {
+            RecurrenceRule rule = RecurrenceRule.monthly(List.of(1, 15), null);
+
+            assertThat(RecurrenceRuleFactory.toRRule(rule, SEOUL))
+                    .isEqualTo("RRULE:FREQ=MONTHLY;BYMONTHDAY=1,15");
+        }
+
+        @Test
+        @DisplayName("UNTIL은 사용자 TZ 마지막날 23:59:59를 UTC로 변환한다 (KST → -9h)")
+        void untilUtcSeoul() {
+            RecurrenceRule rule = RecurrenceRule.daily(LocalDate.of(2026, 12, 31));
+
+            assertThat(RecurrenceRuleFactory.toRRule(rule, SEOUL))
+                    .isEqualTo("RRULE:FREQ=DAILY;UNTIL=20261231T145959Z");
+        }
+
+        @Test
+        @DisplayName("UNTIL UTC 변환이 날짜를 넘기는 경우(EST → +5h, 익일 롤오버)")
+        void untilUtcRollover() {
+            RecurrenceRule rule = RecurrenceRule.daily(LocalDate.of(2026, 12, 31));
+
+            assertThat(RecurrenceRuleFactory.toRRule(rule, NEW_YORK))
+                    .isEqualTo("RRULE:FREQ=DAILY;UNTIL=20270101T045959Z");
+        }
+
+        @Test
+        @DisplayName("모든 파트를 함께 출력한다 (간격+요일+UNTIL)")
+        void combined() {
+            RecurrenceRule rule = new RecurrenceRule(
+                    RecurrenceFreq.WEEKLY, 2,
+                    List.of(RecurrenceWeekday.TU, RecurrenceWeekday.TH),
+                    List.of(),
+                    LocalDate.of(2026, 12, 31));
+
+            assertThat(RecurrenceRuleFactory.toRRule(rule, SEOUL))
+                    .isEqualTo("RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=TU,TH;UNTIL=20261231T145959Z");
+        }
+    }
+
+    @Nested
+    @DisplayName("parse: RRULE → VO 역파싱")
+    class Parse {
+
+        @Test
+        @DisplayName("RRULE: 접두사 유무 모두 수용한다")
+        void prefixOptional() {
+            assertThat(RecurrenceRuleFactory.parse("RRULE:FREQ=DAILY", SEOUL).freq())
+                    .isEqualTo(RecurrenceFreq.DAILY);
+            assertThat(RecurrenceRuleFactory.parse("FREQ=DAILY", SEOUL).freq())
+                    .isEqualTo(RecurrenceFreq.DAILY);
+        }
+
+        @Test
+        @DisplayName("INTERVAL/BYDAY/BYMONTHDAY를 파싱한다")
+        void parts() {
+            RecurrenceRule weekly = RecurrenceRuleFactory.parse(
+                    "RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR", SEOUL);
+            assertThat(weekly.freq()).isEqualTo(RecurrenceFreq.WEEKLY);
+            assertThat(weekly.interval()).isEqualTo(2);
+            assertThat(weekly.byDay())
+                    .containsExactly(RecurrenceWeekday.MO, RecurrenceWeekday.WE, RecurrenceWeekday.FR);
+
+            RecurrenceRule monthly = RecurrenceRuleFactory.parse(
+                    "RRULE:FREQ=MONTHLY;BYMONTHDAY=1,15", SEOUL);
+            assertThat(monthly.byMonthDay()).containsExactly(1, 15);
+        }
+
+        @Test
+        @DisplayName("UNTIL(UTC)을 사용자 TZ 날짜로 환산한다")
+        void untilToLocalDate() {
+            RecurrenceRule rule = RecurrenceRuleFactory.parse(
+                    "RRULE:FREQ=DAILY;UNTIL=20261231T145959Z", SEOUL);
+
+            assertThat(rule.until()).isEqualTo(LocalDate.of(2026, 12, 31));
+        }
+
+        @Test
+        @DisplayName("UNTIL UTC가 익일 04:59:59Z여도 EST 기준 12/31로 환산한다")
+        void untilRollbackToLocalDate() {
+            RecurrenceRule rule = RecurrenceRuleFactory.parse(
+                    "RRULE:FREQ=DAILY;UNTIL=20270101T045959Z", NEW_YORK);
+
+            assertThat(rule.until()).isEqualTo(LocalDate.of(2026, 12, 31));
+        }
+
+        @Test
+        @DisplayName("date-only UNTIL(yyyyMMdd)도 수용한다")
+        void untilDateOnly() {
+            RecurrenceRule rule = RecurrenceRuleFactory.parse(
+                    "RRULE:FREQ=DAILY;UNTIL=20261231", SEOUL);
+
+            assertThat(rule.until()).isEqualTo(LocalDate.of(2026, 12, 31));
+        }
+
+        @Test
+        @DisplayName("미지원 파트(BYSETPOS 등)는 무시한다")
+        void ignoresUnsupported() {
+            RecurrenceRule rule = RecurrenceRuleFactory.parse(
+                    "RRULE:FREQ=MONTHLY;BYSETPOS=1;BYDAY=MO", SEOUL);
+
+            assertThat(rule.freq()).isEqualTo(RecurrenceFreq.MONTHLY);
+            assertThat(rule.byDay()).containsExactly(RecurrenceWeekday.MO);
+        }
+
+        @Test
+        @DisplayName("FREQ가 없으면 예외")
+        void missingFreq() {
+            assertThatThrownBy(() -> RecurrenceRuleFactory.parse("RRULE:INTERVAL=2", SEOUL))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("빈 문자열이면 예외")
+        void blank() {
+            assertThatThrownBy(() -> RecurrenceRuleFactory.parse("  ", SEOUL))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("round-trip: toRRule ↔ parse")
+    class RoundTrip {
+
+        @Test
+        @DisplayName("주간+간격+UNTIL을 직렬화 후 역파싱하면 동등하다")
+        void weeklyRoundTrip() {
+            RecurrenceRule original = new RecurrenceRule(
+                    RecurrenceFreq.WEEKLY, 2,
+                    List.of(RecurrenceWeekday.MO, RecurrenceWeekday.FR),
+                    List.of(),
+                    LocalDate.of(2026, 12, 31));
+
+            String rrule = RecurrenceRuleFactory.toRRule(original, SEOUL);
+            RecurrenceRule parsed = RecurrenceRuleFactory.parse(rrule, SEOUL);
+
+            assertThat(parsed.freq()).isEqualTo(original.freq());
+            assertThat(parsed.effectiveInterval()).isEqualTo(original.effectiveInterval());
+            assertThat(parsed.byDay()).isEqualTo(original.byDay());
+            assertThat(parsed.until()).isEqualTo(original.until());
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/recurrence/RecurrenceRuleTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/recurrence/RecurrenceRuleTest.java
@@ -1,0 +1,65 @@
+package ds.project.orino.planner.google.recurrence;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RecurrenceRuleTest {
+
+    @Test
+    @DisplayName("freq가 null이면 예외")
+    void freqRequired() {
+        assertThatThrownBy(() -> new RecurrenceRule(null, null, List.of(), List.of(), null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("interval은 1 미만이면 예외")
+    void intervalPositive() {
+        assertThatThrownBy(() ->
+                new RecurrenceRule(RecurrenceFreq.DAILY, 0, List.of(), List.of(), null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("byMonthDay는 1~31 범위를 벗어나면 예외")
+    void byMonthDayRange() {
+        assertThatThrownBy(() ->
+                new RecurrenceRule(RecurrenceFreq.MONTHLY, null, List.of(), List.of(32), null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() ->
+                new RecurrenceRule(RecurrenceFreq.MONTHLY, null, List.of(), List.of(0), null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("null 목록은 빈 불변 리스트로 정규화된다")
+    void nullListsNormalized() {
+        RecurrenceRule rule = new RecurrenceRule(RecurrenceFreq.DAILY, null, null, null, null);
+
+        assertThat(rule.byDay()).isEmpty();
+        assertThat(rule.byMonthDay()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("목록은 방어적 복사된다 (원본 변경 영향 없음)")
+    void defensiveCopy() {
+        List<Integer> source = Arrays.asList(1, 15);
+        RecurrenceRule rule = RecurrenceRule.monthly(source, null);
+        source.set(0, 99);
+
+        assertThat(rule.byMonthDay()).containsExactly(1, 15);
+    }
+
+    @Test
+    @DisplayName("effectiveInterval은 null을 1로 본다")
+    void effectiveInterval() {
+        assertThat(RecurrenceRule.daily(null).effectiveInterval()).isEqualTo(1);
+        assertThat(RecurrenceRule.everyNDays(4, null).effectiveInterval()).isEqualTo(4);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RoutineTagTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RoutineTagTest.java
@@ -1,0 +1,63 @@
+package ds.project.orino.planner.google.routine;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RoutineTagTest {
+
+    @Test
+    @DisplayName("habit 태그는 orinoRoutine=1 + orinoRoutineType=habit")
+    void habitProperties() {
+        Map<String, String> props = RoutineTag.privateProperties(RoutineType.HABIT);
+
+        assertThat(props)
+                .containsEntry("orinoRoutine", "1")
+                .containsEntry("orinoRoutineType", "habit");
+    }
+
+    @Test
+    @DisplayName("schedule 태그는 orinoRoutineType=schedule")
+    void scheduleProperties() {
+        Map<String, String> props = RoutineTag.privateProperties(RoutineType.SCHEDULE);
+
+        assertThat(props).containsEntry("orinoRoutineType", "schedule");
+    }
+
+    @Test
+    @DisplayName("list 필터 값은 orinoRoutine=1")
+    void listFilter() {
+        assertThat(RoutineTag.LIST_FILTER).isEqualTo("orinoRoutine=1");
+    }
+
+    @Test
+    @DisplayName("센티넬 보유 여부로 루틴 이벤트를 판별한다")
+    void isRoutine() {
+        assertThat(RoutineTag.isRoutine(Map.of("orinoRoutine", "1"))).isTrue();
+        assertThat(RoutineTag.isRoutine(Map.of("other", "x"))).isFalse();
+        assertThat(RoutineTag.isRoutine(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("루틴 종류를 읽는다 (없거나 알 수 없으면 null)")
+    void routineType() {
+        assertThat(RoutineTag.routineType(RoutineTag.privateProperties(RoutineType.HABIT)))
+                .isEqualTo(RoutineType.HABIT);
+        assertThat(RoutineTag.routineType(Map.of("orinoRoutine", "1"))).isNull();
+        assertThat(RoutineTag.routineType(Map.of("orinoRoutineType", "bogus"))).isNull();
+        assertThat(RoutineTag.routineType(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("RoutineType.fromCode 왕복")
+    void fromCode() {
+        assertThat(RoutineType.fromCode("habit")).isEqualTo(RoutineType.HABIT);
+        assertThat(RoutineType.fromCode("schedule")).isEqualTo(RoutineType.SCHEDULE);
+        assertThatThrownBy(() -> RoutineType.fromCode("nope"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -194,9 +194,15 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
           insertPagePending={createNote.isPending}
         />
         {editor && (
-          // nested: 불릿/태스크 리스트 항목 등 중첩 블록도 개별 드래그 타깃이 되게 한다.
-          // (기본 false면 리스트 전체를 한 블록으로만 잡음)
-          <DragHandle editor={editor} nested className="z-10">
+          // nested: 리스트 항목 등 중첩 블록도 개별(한 줄) 드래그 타깃이 되게 한다.
+          // edgeDetection "none": 기본값(left,top)은 항목 왼쪽 가장자리에서 부모(리스트)를
+          // 우선해 하위 불릿 왼쪽에 호버 시 항목 핸들이 안 뜨고 글자에 대야 떴다. none이면
+          // 커서 위치와 무관하게 가장 깊은 항목이 일관되게 잡혀 행 어디서나 핸들이 뜬다.
+          <DragHandle
+            editor={editor}
+            nested={{ edgeDetection: "none" }}
+            className="z-10"
+          >
             <button
               type="button"
               aria-label="블록 이동"


### PR DESCRIPTION
## 이슈
closes #573

## 작업 내용
- `planner/google/recurrence` 패키지 추가
  - `RecurrenceRule` VO (freq/interval/byDay/byMonthDay/until) — 방어적 복사·검증 포함
  - `RecurrenceRuleFactory` — VO ↔ RRULE 문자열 직렬화/역파싱
  - 매핑: 매일 `FREQ=DAILY` / N일 `INTERVAL=N` / 주간 `WEEKLY;BYDAY=MO,WE,FR` / 매월 `MONTHLY;BYMONTHDAY=1,15`
  - `UNTIL`은 사용자 TZ 마지막날 23:59:59를 UTC로 변환해 직렬화(`...Z`), 역파싱 시 TZ 날짜로 환산 (date-only도 수용)
- `GoogleCalendarClient` 확장
  - `insertRoutineEvent` / `patchRoutineEvent` — `recurrence`(RRULE) + `extendedProperties.private` 태깅 쓰기
  - `listRoutineMasters` — `singleEvents=false` + `privateExtendedProperty=orinoRoutine=1` 마스터 시리즈 조회
  - `listInstances` — events.instances로 단일 반복 이벤트 인스턴스 펼침
- `planner/google/routine` 태깅 헬퍼
  - `RoutineType` (habit/schedule), `RoutineTag` (`orinoRoutine=1`, `orinoRoutineType`, list 필터)
- DTO 확장: `GoogleEventWriteBody`·`GoogleEventsResponse.GoogleEventItem`에 `recurrence`·`extendedProperties` 추가, `GoogleExtendedProperties` 신규
- 단위 테스트: `RecurrenceRuleFactoryTest`(빌드/역파싱·요일·간격·매월·UNTIL UTC 변환·롤오버·round-trip), `RecurrenceRuleTest`(검증·방어적 복사), `RoutineTagTest`

## 검증
- `./gradlew :orino-app-api:test` (recurrence/routine/calendar) ✅
- `./gradlew :orino-app-api:checkstyleMain checkstyleTest` ✅
- R0는 R1+에서 소비할 스캐폴딩(엔드포인트 없음)으로, RRULE 빌드/역파싱·태깅 로직을 단위 테스트로 직접 검증