### PR TITLE
feat : Routine 생성 API + 통합 피드 routine 주석 (R1)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventWriteBody.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventWriteBody.java
@@ -2,8 +2,13 @@ package ds.project.orino.planner.google.calendar.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.List;
+
 /**
  * Google Calendar events.insert/patch 요청 바디(필요한 필드만). null 필드는 직렬화에서 제외한다.
+ *
+ * @param recurrence         RRULE 문자열 목록(예: {@code ["RRULE:FREQ=WEEKLY;BYDAY=MO,WE"]}). null이면 단일 일정
+ * @param extendedProperties orino 태깅용 확장 속성(루틴 식별). null이면 미설정
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record GoogleEventWriteBody(
@@ -11,8 +16,16 @@ public record GoogleEventWriteBody(
         String location,
         String description,
         GoogleEventTime start,
-        GoogleEventTime end
+        GoogleEventTime end,
+        List<String> recurrence,
+        GoogleExtendedProperties extendedProperties
 ) {
+
+    /** 반복·태깅 없는 단일 일정 바디. */
+    public GoogleEventWriteBody(String summary, String location, String description,
+                               GoogleEventTime start, GoogleEventTime end) {
+        this(summary, location, description, start, end, null, null);
+    }
 
     /** 시간 일정이면 dateTime+timeZone, 종일이면 date. */
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventsResponse.java
@@ -15,7 +15,9 @@ public record GoogleEventsResponse(List<GoogleEventItem> items) {
             String location,
             String recurringEventId,
             GoogleEventDateTime start,
-            GoogleEventDateTime end
+            GoogleEventDateTime end,
+            List<String> recurrence,
+            GoogleExtendedProperties extendedProperties
     ) {
     }
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleExtendedProperties.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleExtendedProperties.java
@@ -1,0 +1,24 @@
+package ds.project.orino.planner.google.calendar.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+/**
+ * Google 이벤트의 {@code extendedProperties}. orino는 {@code private} 영역만 사용한다.
+ *
+ * <p>{@code private}는 Java 예약어라 필드명은 {@code privateProperties}, JSON 키는 {@code private}로 매핑한다.
+ * 쓰기 시 null 영역은 직렬화에서 제외하고, 읽기 시 알 수 없는 영역(shared 등)은 무시한다.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GoogleExtendedProperties(
+        @JsonProperty("private") Map<String, String> privateProperties
+) {
+
+    public static GoogleExtendedProperties ofPrivate(Map<String, String> privateProperties) {
+        return new GoogleExtendedProperties(privateProperties);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/PlannerEvent.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/PlannerEvent.java
@@ -11,6 +11,7 @@ package ds.project.orino.planner.google.calendar.dto;
  * @param location  장소(null 가능)
  * @param recurring 반복 일정의 인스턴스 여부
  * @param source    항상 "google"
+ * @param routine   루틴 인스턴스면 주석(type/recurringEventId/done), 아니면 null
  */
 public record PlannerEvent(
         String id,
@@ -20,6 +21,13 @@ public record PlannerEvent(
         String end,
         String location,
         boolean recurring,
-        String source
+        String source,
+        RoutineMeta routine
 ) {
+
+    /** 루틴 주석 없는 일반 일정. */
+    public PlannerEvent(String id, String title, boolean allDay, String start, String end,
+                        String location, boolean recurring, String source) {
+        this(id, title, allDay, start, end, location, recurring, source, null);
+    }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/RoutineMeta.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/RoutineMeta.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.google.calendar.dto;
+
+/**
+ * 통합 피드 일정에 붙는 루틴 주석. 루틴 인스턴스가 아니면 {@link PlannerEvent#routine()}는 null이다.
+ *
+ * @param type             "habit" | "schedule"
+ * @param recurringEventId 마스터 시리즈 id(인스턴스가 가리키는 시리즈)
+ * @param done             habit 완료 여부. R3에서 routine_check 조인 전까지는 false
+ */
+public record RoutineMeta(
+        String type,
+        String recurringEventId,
+        boolean done
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
@@ -8,6 +8,7 @@ import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleE
 import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventItem;
 import ds.project.orino.planner.google.calendar.dto.GoogleExtendedProperties;
 import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
+import ds.project.orino.planner.google.calendar.dto.RoutineMeta;
 import ds.project.orino.planner.google.config.GoogleOAuthProperties;
 import ds.project.orino.planner.google.recurrence.RecurrenceRule;
 import ds.project.orino.planner.google.recurrence.RecurrenceRuleFactory;
@@ -27,6 +28,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Google Calendar API 래퍼. {@code events.list}를 라이브 프록시하고 응답을 사용자 시간대로 정규화한다.
@@ -297,7 +299,24 @@ public class GoogleCalendarClient {
                 endValue,
                 item.location(),
                 item.recurringEventId() != null,
-                "google");
+                "google",
+                toRoutineMeta(item));
+    }
+
+    /** extendedProperties에 루틴 태그가 있으면 피드 주석(type/recurringEventId/done)을 만든다. done은 R3에서 조인. */
+    private RoutineMeta toRoutineMeta(GoogleEventItem item) {
+        if (item.extendedProperties() == null) {
+            return null;
+        }
+        Map<String, String> priv = item.extendedProperties().privateProperties();
+        if (!RoutineTag.isRoutine(priv)) {
+            return null;
+        }
+        RoutineType type = RoutineTag.routineType(priv);
+        return new RoutineMeta(
+                type == null ? null : type.code(),
+                item.recurringEventId(),
+                false);
     }
 
     private String toLocalDateTime(GoogleEventDateTime dateTime, ZoneId zone) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
@@ -6,8 +6,13 @@ import ds.project.orino.planner.google.calendar.dto.GoogleEventWriteBody.GoogleE
 import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse;
 import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventDateTime;
 import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventItem;
+import ds.project.orino.planner.google.calendar.dto.GoogleExtendedProperties;
 import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
 import ds.project.orino.planner.google.config.GoogleOAuthProperties;
+import ds.project.orino.planner.google.recurrence.RecurrenceRule;
+import ds.project.orino.planner.google.recurrence.RecurrenceRuleFactory;
+import ds.project.orino.planner.google.routine.RoutineTag;
+import ds.project.orino.planner.google.routine.RoutineType;
 import ds.project.orino.planner.google.token.GoogleTokenProvider;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -111,6 +116,107 @@ public class GoogleCalendarClient {
         return normalize(item, zone);
     }
 
+    /**
+     * 루틴(반복) 이벤트 생성. {@code recurrence}(RRULE)와 루틴 식별 태그를 함께 기록한다.
+     * 생성된 마스터 이벤트를 정규화해 반환한다.
+     */
+    public PlannerEvent insertRoutineEvent(Long memberId, EventRequest request,
+                                           RecurrenceRule rule, RoutineType type, ZoneId zone) {
+        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
+                .path(PRIMARY_CALENDAR_PATH)
+                .build()
+                .toUri();
+
+        GoogleEventWriteBody body = toRoutineWriteBody(request, rule, type, zone);
+        GoogleEventItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.post()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(body)
+                        .retrieve()
+                        .body(GoogleEventItem.class));
+        return normalize(item, zone);
+    }
+
+    /**
+     * 루틴 마스터 이벤트 수정(patch). 반복 규칙·내용·태그를 갱신한다.
+     * {@code rule}이 null이면 recurrence는 건드리지 않는다(내용만 patch).
+     */
+    public PlannerEvent patchRoutineEvent(Long memberId, String eventId, EventRequest request,
+                                          RecurrenceRule rule, RoutineType type, ZoneId zone) {
+        URI uri = eventUri(eventId);
+        GoogleEventWriteBody body = toRoutineWriteBody(request, rule, type, zone);
+        GoogleEventItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.patch()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(body)
+                        .retrieve()
+                        .body(GoogleEventItem.class));
+        return normalize(item, zone);
+    }
+
+    /**
+     * 루틴 마스터 시리즈 목록 조회. {@code singleEvents=false}로 RRULE을 펼치지 않고 마스터 이벤트를,
+     * {@code privateExtendedProperty=orinoRoutine=1}로 루틴만 필터링해 받는다.
+     *
+     * <p>마스터의 {@code recurrence}·{@code extendedProperties}를 그대로 노출하므로 호출부(시리즈 목록 API)가
+     * RRULE 역파싱과 종류 판별을 수행한다.
+     */
+    public List<GoogleEventItem> listRoutineMasters(Long memberId) {
+        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
+                .path(PRIMARY_CALENDAR_PATH)
+                .queryParam("singleEvents", "false")
+                .queryParam("privateExtendedProperty", RoutineTag.LIST_FILTER)
+                .queryParam("maxResults", "2500")
+                .build()
+                .toUri();
+
+        GoogleEventsResponse response = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.get()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .retrieve()
+                        .body(GoogleEventsResponse.class));
+
+        if (response == null || response.items() == null) {
+            return List.of();
+        }
+        return response.items();
+    }
+
+    /**
+     * 단일 반복 이벤트({@code recurringEventId})를 [timeMin, timeMax) 구간 인스턴스로 펼쳐 조회한다.
+     * events.instances 엔드포인트를 사용하며 응답을 사용자 시간대로 정규화한다.
+     */
+    public List<PlannerEvent> listInstances(Long memberId, String eventId,
+                                            Instant timeMin, Instant timeMax, ZoneId zone) {
+        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
+                .path(PRIMARY_CALENDAR_PATH)
+                .pathSegment(eventId, "instances")
+                .queryParam("timeMin", timeMin.toString())
+                .queryParam("timeMax", timeMax.toString())
+                .queryParam("maxResults", "2500")
+                .build()
+                .toUri();
+
+        GoogleEventsResponse response = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.get()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .retrieve()
+                        .body(GoogleEventsResponse.class));
+
+        if (response == null || response.items() == null) {
+            return List.of();
+        }
+        return response.items().stream()
+                .map(item -> normalize(item, zone))
+                .toList();
+    }
+
     /** 일정 삭제. 없는 id면 404(RESOURCE_NOT_FOUND). */
     public void deleteEvent(Long memberId, String eventId) {
         URI uri = eventUri(eventId);
@@ -133,18 +239,36 @@ public class GoogleCalendarClient {
     }
 
     private GoogleEventWriteBody toWriteBody(EventRequest request, ZoneId zone) {
-        GoogleEventTime start;
-        GoogleEventTime end;
-        if (request.allDay()) {
-            start = new GoogleEventTime(null, request.start(), null);
-            // Google 종일 종료는 배타적(다음 날) → 사용자 inclusive end + 1일
-            end = new GoogleEventTime(null, LocalDate.parse(request.end()).plusDays(1).toString(), null);
-        } else {
-            start = new GoogleEventTime(request.start(), null, zone.getId());
-            end = new GoogleEventTime(request.end(), null, zone.getId());
-        }
         return new GoogleEventWriteBody(
-                request.title(), request.location(), request.description(), start, end);
+                request.title(), request.location(), request.description(),
+                startTime(request, zone), endTime(request, zone));
+    }
+
+    /** 루틴 쓰기 바디: 기본 필드 + recurrence(RRULE) + 루틴 태그. rule이 null이면 recurrence는 비운다. */
+    private GoogleEventWriteBody toRoutineWriteBody(EventRequest request, RecurrenceRule rule,
+                                                    RoutineType type, ZoneId zone) {
+        List<String> recurrence = rule == null
+                ? null
+                : List.of(RecurrenceRuleFactory.toRRule(rule, zone));
+        GoogleExtendedProperties extended =
+                GoogleExtendedProperties.ofPrivate(RoutineTag.privateProperties(type));
+        return new GoogleEventWriteBody(
+                request.title(), request.location(), request.description(),
+                startTime(request, zone), endTime(request, zone), recurrence, extended);
+    }
+
+    private GoogleEventTime startTime(EventRequest request, ZoneId zone) {
+        return request.allDay()
+                ? new GoogleEventTime(null, request.start(), null)
+                : new GoogleEventTime(request.start(), null, zone.getId());
+    }
+
+    private GoogleEventTime endTime(EventRequest request, ZoneId zone) {
+        if (request.allDay()) {
+            // Google 종일 종료는 배타적(다음 날) → 사용자 inclusive end + 1일
+            return new GoogleEventTime(null, LocalDate.parse(request.end()).plusDays(1).toString(), null);
+        }
+        return new GoogleEventTime(request.end(), null, zone.getId());
     }
 
     private PlannerEvent normalize(GoogleEventItem item, ZoneId zone) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceFreq.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceFreq.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.google.recurrence;
+
+/**
+ * RRULE {@code FREQ} 값. Phase 1은 매일/주간/매월만 지원한다.
+ */
+public enum RecurrenceFreq {
+    DAILY,
+    WEEKLY,
+    MONTHLY
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceRule.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceRule.java
@@ -1,0 +1,67 @@
+package ds.project.orino.planner.google.recurrence;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 반복 규칙 값 객체(VO). Google Calendar의 RRULE 한 줄에 대응한다.
+ *
+ * <p>orino는 RRULE을 직접 펼치지 않고 이 VO를 {@link RecurrenceRuleFactory}로 RRULE 문자열과 상호 변환한다.
+ * Phase 1 지원 범위: {@code FREQ=DAILY|WEEKLY|MONTHLY}, {@code INTERVAL}, {@code BYDAY}, {@code BYMONTHDAY},
+ * {@code UNTIL}. {@code BYSETPOS}·복수 RRULE·EXDATE는 미지원.
+ *
+ * @param freq       반복 주기(필수)
+ * @param interval   반복 간격(N). null·1이면 RRULE에서 생략된다. 1 이상
+ * @param byDay      주간 반복 요일 목록(WEEKLY에서만 의미). 비어 있으면 생략
+ * @param byMonthDay 매월 반복 일자 목록(1~31, MONTHLY에서만 의미). 비어 있으면 생략
+ * @param until      종료일(포함). 사용자 시간대 기준 마지막 날. null이면 무한 반복
+ */
+public record RecurrenceRule(
+        RecurrenceFreq freq,
+        Integer interval,
+        List<RecurrenceWeekday> byDay,
+        List<Integer> byMonthDay,
+        LocalDate until
+) {
+
+    public RecurrenceRule {
+        if (freq == null) {
+            throw new IllegalArgumentException("freq는 필수입니다");
+        }
+        if (interval != null && interval < 1) {
+            throw new IllegalArgumentException("interval은 1 이상이어야 합니다: " + interval);
+        }
+        byDay = byDay == null ? List.of() : List.copyOf(byDay);
+        byMonthDay = byMonthDay == null ? List.of() : List.copyOf(byMonthDay);
+        for (Integer day : byMonthDay) {
+            if (day == null || day < 1 || day > 31) {
+                throw new IllegalArgumentException("byMonthDay는 1~31이어야 합니다: " + day);
+            }
+        }
+    }
+
+    /** 매일 반복. */
+    public static RecurrenceRule daily(LocalDate until) {
+        return new RecurrenceRule(RecurrenceFreq.DAILY, null, List.of(), List.of(), until);
+    }
+
+    /** N일 간격 반복. */
+    public static RecurrenceRule everyNDays(int interval, LocalDate until) {
+        return new RecurrenceRule(RecurrenceFreq.DAILY, interval, List.of(), List.of(), until);
+    }
+
+    /** 지정 요일 주간 반복. */
+    public static RecurrenceRule weekly(List<RecurrenceWeekday> byDay, LocalDate until) {
+        return new RecurrenceRule(RecurrenceFreq.WEEKLY, null, byDay, List.of(), until);
+    }
+
+    /** 지정 일자 매월 반복. */
+    public static RecurrenceRule monthly(List<Integer> byMonthDay, LocalDate until) {
+        return new RecurrenceRule(RecurrenceFreq.MONTHLY, null, List.of(), byMonthDay, until);
+    }
+
+    /** RRULE에서 생략 가능한 1을 정규화한 실효 간격. */
+    public int effectiveInterval() {
+        return interval == null ? 1 : interval;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceRuleFactory.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceRuleFactory.java
@@ -1,0 +1,165 @@
+package ds.project.orino.planner.google.recurrence;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link RecurrenceRule} VO ↔ Google Calendar RRULE 문자열 변환기.
+ *
+ * <p>{@code RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE;UNTIL=20261231T145959Z} 형태를 생성·역파싱한다.
+ * {@code UNTIL}은 RFC 5545에 따라 사용자 시간대의 마지막 날 23:59:59를 UTC로 변환해 직렬화한다.
+ */
+public final class RecurrenceRuleFactory {
+
+    private static final String RRULE_PREFIX = "RRULE:";
+    /** UNTIL UTC 직렬화 포맷: 20261231T235959Z. */
+    private static final DateTimeFormatter UNTIL_UTC =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'");
+    private static final DateTimeFormatter UNTIL_DATE_ONLY =
+            DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private RecurrenceRuleFactory() {
+    }
+
+    /**
+     * VO를 RRULE 문자열로 직렬화한다(접두사 {@code RRULE:} 포함).
+     *
+     * @param zone {@code UNTIL}을 UTC로 변환할 때 기준이 되는 사용자 시간대
+     */
+    public static String toRRule(RecurrenceRule rule, ZoneId zone) {
+        StringBuilder sb = new StringBuilder(RRULE_PREFIX);
+        sb.append("FREQ=").append(rule.freq().name());
+
+        if (rule.effectiveInterval() > 1) {
+            sb.append(";INTERVAL=").append(rule.effectiveInterval());
+        }
+        if (!rule.byDay().isEmpty()) {
+            sb.append(";BYDAY=").append(joinByDay(rule.byDay()));
+        }
+        if (!rule.byMonthDay().isEmpty()) {
+            sb.append(";BYMONTHDAY=").append(joinByMonthDay(rule.byMonthDay()));
+        }
+        if (rule.until() != null) {
+            sb.append(";UNTIL=").append(serializeUntil(rule.until(), zone));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * RRULE 문자열을 VO로 역파싱한다. 접두사 {@code RRULE:}는 있어도/없어도 된다.
+     * 시리즈 편집 시 폼을 채우기 위한 용도.
+     *
+     * @param zone {@code UNTIL}(UTC)을 사용자 시간대 날짜로 환산할 때 기준이 되는 시간대
+     */
+    public static RecurrenceRule parse(String rrule, ZoneId zone) {
+        if (rrule == null || rrule.isBlank()) {
+            throw new IllegalArgumentException("RRULE 문자열이 비어 있습니다");
+        }
+        String body = rrule.trim();
+        if (body.regionMatches(true, 0, RRULE_PREFIX, 0, RRULE_PREFIX.length())) {
+            body = body.substring(RRULE_PREFIX.length());
+        }
+
+        RecurrenceFreq freq = null;
+        Integer interval = null;
+        List<RecurrenceWeekday> byDay = List.of();
+        List<Integer> byMonthDay = List.of();
+        LocalDate until = null;
+
+        for (String part : body.split(";")) {
+            if (part.isBlank()) {
+                continue;
+            }
+            int eq = part.indexOf('=');
+            if (eq < 0) {
+                continue;
+            }
+            String key = part.substring(0, eq).trim().toUpperCase();
+            String value = part.substring(eq + 1).trim();
+            switch (key) {
+                case "FREQ" -> freq = RecurrenceFreq.valueOf(value.toUpperCase());
+                case "INTERVAL" -> interval = Integer.valueOf(value);
+                case "BYDAY" -> byDay = parseByDay(value);
+                case "BYMONTHDAY" -> byMonthDay = parseByMonthDay(value);
+                case "UNTIL" -> until = parseUntil(value, zone);
+                default -> {
+                    // BYSETPOS 등 미지원 파트는 무시한다(Phase 1)
+                }
+            }
+        }
+        if (freq == null) {
+            throw new IllegalArgumentException("RRULE에 FREQ가 없습니다: " + rrule);
+        }
+        return new RecurrenceRule(freq, interval, byDay, byMonthDay, until);
+    }
+
+    private static String joinByDay(List<RecurrenceWeekday> byDay) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < byDay.size(); i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append(byDay.get(i).name());
+        }
+        return sb.toString();
+    }
+
+    private static String joinByMonthDay(List<Integer> byMonthDay) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < byMonthDay.size(); i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append(byMonthDay.get(i));
+        }
+        return sb.toString();
+    }
+
+    private static List<RecurrenceWeekday> parseByDay(String value) {
+        List<RecurrenceWeekday> days = new ArrayList<>();
+        for (String code : value.split(",")) {
+            if (!code.isBlank()) {
+                days.add(RecurrenceWeekday.fromCode(code));
+            }
+        }
+        return days;
+    }
+
+    private static List<Integer> parseByMonthDay(String value) {
+        List<Integer> days = new ArrayList<>();
+        for (String day : value.split(",")) {
+            if (!day.isBlank()) {
+                days.add(Integer.valueOf(day.trim()));
+            }
+        }
+        return days;
+    }
+
+    /** 사용자 TZ 마지막 날 23:59:59 → UTC 직렬화. */
+    private static String serializeUntil(LocalDate until, ZoneId zone) {
+        return until.atTime(LocalTime.of(23, 59, 59))
+                .atZone(zone)
+                .withZoneSameInstant(ZoneOffset.UTC)
+                .format(UNTIL_UTC);
+    }
+
+    /** UNTIL 값을 사용자 TZ 날짜로 환산. UTC datetime(...Z) 또는 date-only(yyyyMMdd) 모두 수용. */
+    private static LocalDate parseUntil(String value, ZoneId zone) {
+        String v = value.trim();
+        if (v.endsWith("Z") || v.endsWith("z")) {
+            LocalDateTime utc = LocalDateTime.parse(v.substring(0, v.length() - 1), UNTIL_UTC_PARSE);
+            return utc.atZone(ZoneOffset.UTC).withZoneSameInstant(zone).toLocalDate();
+        }
+        return LocalDate.parse(v, UNTIL_DATE_ONLY);
+    }
+
+    /** UTC datetime 파싱용(말미 Z 제외): yyyyMMdd'T'HHmmss. */
+    private static final DateTimeFormatter UNTIL_UTC_PARSE =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss");
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceWeekday.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/recurrence/RecurrenceWeekday.java
@@ -1,0 +1,45 @@
+package ds.project.orino.planner.google.recurrence;
+
+import java.time.DayOfWeek;
+import java.util.Map;
+
+/**
+ * RRULE {@code BYDAY} 요일 코드(MO, TU, WE, TH, FR, SA, SU)와 {@link DayOfWeek} 매핑.
+ */
+public enum RecurrenceWeekday {
+    MO(DayOfWeek.MONDAY),
+    TU(DayOfWeek.TUESDAY),
+    WE(DayOfWeek.WEDNESDAY),
+    TH(DayOfWeek.THURSDAY),
+    FR(DayOfWeek.FRIDAY),
+    SA(DayOfWeek.SATURDAY),
+    SU(DayOfWeek.SUNDAY);
+
+    private static final Map<DayOfWeek, RecurrenceWeekday> BY_DAY_OF_WEEK = Map.of(
+            DayOfWeek.MONDAY, MO,
+            DayOfWeek.TUESDAY, TU,
+            DayOfWeek.WEDNESDAY, WE,
+            DayOfWeek.THURSDAY, TH,
+            DayOfWeek.FRIDAY, FR,
+            DayOfWeek.SATURDAY, SA,
+            DayOfWeek.SUNDAY, SU);
+
+    private final DayOfWeek dayOfWeek;
+
+    RecurrenceWeekday(DayOfWeek dayOfWeek) {
+        this.dayOfWeek = dayOfWeek;
+    }
+
+    public DayOfWeek toDayOfWeek() {
+        return dayOfWeek;
+    }
+
+    public static RecurrenceWeekday from(DayOfWeek dayOfWeek) {
+        return BY_DAY_OF_WEEK.get(dayOfWeek);
+    }
+
+    /** RRULE 코드 문자열(MO, TU, ...)을 enum으로 파싱한다. 알 수 없으면 IllegalArgumentException. */
+    public static RecurrenceWeekday fromCode(String code) {
+        return RecurrenceWeekday.valueOf(code.trim().toUpperCase());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RecurrenceTextFormatter.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RecurrenceTextFormatter.java
@@ -1,0 +1,56 @@
+package ds.project.orino.planner.google.routine;
+
+import ds.project.orino.planner.google.recurrence.RecurrenceRule;
+import ds.project.orino.planner.google.recurrence.RecurrenceWeekday;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * {@link RecurrenceRule}을 한국어 표시 문구로 변환한다(예: "매주 월·수·금", "3일마다", "매월 1·15일").
+ */
+public final class RecurrenceTextFormatter {
+
+    private static final Map<RecurrenceWeekday, String> WEEKDAY_KO = Map.of(
+            RecurrenceWeekday.MO, "월",
+            RecurrenceWeekday.TU, "화",
+            RecurrenceWeekday.WE, "수",
+            RecurrenceWeekday.TH, "목",
+            RecurrenceWeekday.FR, "금",
+            RecurrenceWeekday.SA, "토",
+            RecurrenceWeekday.SU, "일");
+
+    private RecurrenceTextFormatter() {
+    }
+
+    public static String toKorean(RecurrenceRule rule) {
+        int interval = rule.effectiveInterval();
+        return switch (rule.freq()) {
+            case DAILY -> interval == 1 ? "매일" : interval + "일마다";
+            case WEEKLY -> weekly(rule, interval);
+            case MONTHLY -> monthly(rule, interval);
+        };
+    }
+
+    private static String weekly(RecurrenceRule rule, int interval) {
+        String prefix = interval == 1 ? "매주" : interval + "주마다";
+        if (rule.byDay().isEmpty()) {
+            return prefix;
+        }
+        String days = rule.byDay().stream()
+                .map(WEEKDAY_KO::get)
+                .collect(Collectors.joining("·"));
+        return prefix + " " + days;
+    }
+
+    private static String monthly(RecurrenceRule rule, int interval) {
+        String prefix = interval == 1 ? "매월" : interval + "개월마다";
+        List<Integer> days = rule.byMonthDay();
+        if (days.isEmpty()) {
+            return prefix;
+        }
+        String dayText = days.stream().map(String::valueOf).collect(Collectors.joining("·"));
+        return prefix + " " + dayText + "일";
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineController.java
@@ -1,0 +1,37 @@
+package ds.project.orino.planner.google.routine;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.core.time.UserTimeZone;
+import ds.project.orino.planner.google.routine.dto.RoutineCreateRequest;
+import ds.project.orino.planner.google.routine.dto.RoutineSeriesSummary;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 루틴(반복 이벤트) 시리즈 쓰기 엔드포인트. 미연동 시 409(PLN-ERR-003).
+ * 시간대는 {@code X-Timezone}({@link UserTimeZone}) 기준.
+ */
+@RestController
+@RequestMapping("/api/planner/routines")
+public class RoutineController {
+
+    private final RoutineService routineService;
+
+    public RoutineController(RoutineService routineService) {
+        this.routineService = routineService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<RoutineSeriesSummary>> create(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody RoutineCreateRequest request) {
+        RoutineSeriesSummary created = routineService.create(memberId, request, UserTimeZone.get());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(created));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineRecurrenceMapper.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineRecurrenceMapper.java
@@ -1,0 +1,44 @@
+package ds.project.orino.planner.google.routine;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.google.recurrence.RecurrenceFreq;
+import ds.project.orino.planner.google.recurrence.RecurrenceRule;
+import ds.project.orino.planner.google.recurrence.RecurrenceWeekday;
+import ds.project.orino.planner.google.routine.dto.RoutineRecurrence;
+
+import java.util.List;
+
+/**
+ * 요청·응답 {@link RoutineRecurrence} DTO ↔ {@link RecurrenceRule} VO 변환.
+ * 잘못된 값은 {@link ErrorCode#ROUTINE_INVALID_RULE}(400)로 변환한다.
+ */
+public final class RoutineRecurrenceMapper {
+
+    private RoutineRecurrenceMapper() {
+    }
+
+    /** 요청 DTO → VO. freq/요일 코드/일자 범위가 잘못되면 ROUTINE_INVALID_RULE. */
+    public static RecurrenceRule toRule(RoutineRecurrence dto) {
+        try {
+            RecurrenceFreq freq = RecurrenceFreq.valueOf(dto.freq().trim().toUpperCase());
+            List<RecurrenceWeekday> byDay = dto.byDay() == null
+                    ? List.of()
+                    : dto.byDay().stream().map(RecurrenceWeekday::fromCode).toList();
+            List<Integer> byMonthDay = dto.byMonthDay() == null ? List.of() : dto.byMonthDay();
+            return new RecurrenceRule(freq, dto.interval(), byDay, byMonthDay, dto.until());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new CustomException(ErrorCode.ROUTINE_INVALID_RULE, e);
+        }
+    }
+
+    /** VO → 응답 DTO(정규화된 형태). */
+    public static RoutineRecurrence toDto(RecurrenceRule rule) {
+        List<String> byDay = rule.byDay().isEmpty()
+                ? null
+                : rule.byDay().stream().map(Enum::name).toList();
+        List<Integer> byMonthDay = rule.byMonthDay().isEmpty() ? null : rule.byMonthDay();
+        Integer interval = rule.effectiveInterval() == 1 ? null : rule.effectiveInterval();
+        return new RoutineRecurrence(rule.freq().name(), interval, byDay, byMonthDay, rule.until());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineService.java
@@ -1,0 +1,70 @@
+package ds.project.orino.planner.google.routine;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.google.calendar.dto.EventRequest;
+import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
+import ds.project.orino.planner.google.client.GoogleCalendarClient;
+import ds.project.orino.planner.google.recurrence.RecurrenceRule;
+import ds.project.orino.planner.google.routine.dto.RoutineCreateRequest;
+import ds.project.orino.planner.google.routine.dto.RoutineSeriesSummary;
+import ds.project.orino.redis.planner.google.GoogleCalendarCacheRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.ZoneId;
+
+/**
+ * 루틴(반복 이벤트) 쓰기 오케스트레이션. 규칙→RRULE+태그로 Google {@code events.insert}를 프록시하고
+ * 쓰기 후 통합 피드 캐시를 무효화한다.
+ *
+ * <p>미연동이면 {@link GoogleCalendarClient} 토큰 공급 단계에서 GOOGLE_NOT_CONNECTED(409)가 발생한다.
+ */
+@Service
+public class RoutineService {
+
+    private final GoogleCalendarClient calendarClient;
+    private final GoogleCalendarCacheRepository cacheRepository;
+
+    public RoutineService(GoogleCalendarClient calendarClient,
+                          GoogleCalendarCacheRepository cacheRepository) {
+        this.calendarClient = calendarClient;
+        this.cacheRepository = cacheRepository;
+    }
+
+    /** 루틴 시리즈를 생성하고 요약을 반환한다. */
+    public RoutineSeriesSummary create(Long memberId, RoutineCreateRequest request, ZoneId zone) {
+        RoutineType type = parseType(request.type());
+        RecurrenceRule rule = RoutineRecurrenceMapper.toRule(request.recurrence());
+
+        EventRequest eventRequest = new EventRequest(
+                request.title(), request.allDay(), request.start(), request.end(),
+                null, request.memo());
+
+        PlannerEvent created = calendarClient.insertRoutineEvent(memberId, eventRequest, rule, type, zone);
+        cacheRepository.evictAll(memberId);
+
+        return toSummary(created, type, rule, request.color());
+    }
+
+    private RoutineType parseType(String type) {
+        try {
+            return RoutineType.fromCode(type);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST, e);
+        }
+    }
+
+    private RoutineSeriesSummary toSummary(PlannerEvent event, RoutineType type,
+                                           RecurrenceRule rule, String color) {
+        return new RoutineSeriesSummary(
+                event.id(),
+                type.code(),
+                event.title(),
+                event.allDay(),
+                event.start(),
+                event.allDay() ? null : event.end(),
+                RoutineRecurrenceMapper.toDto(rule),
+                RecurrenceTextFormatter.toKorean(rule),
+                color);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineTag.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineTag.java
@@ -1,0 +1,52 @@
+package ds.project.orino.planner.google.routine;
+
+import java.util.Map;
+
+/**
+ * 루틴 이벤트 식별을 위한 {@code extendedProperties.private} 태깅 헬퍼.
+ *
+ * <p>{@code orinoRoutine=1} 센티넬로 루틴 이벤트를 구분하고
+ * {@code events.list?privateExtendedProperty=orinoRoutine=1}로 필터링한다.
+ * {@code orinoRoutineType}으로 습관/일정을 구분한다.
+ */
+public final class RoutineTag {
+
+    public static final String KEY_ROUTINE = "orinoRoutine";
+    public static final String KEY_ROUTINE_TYPE = "orinoRoutineType";
+    public static final String ROUTINE_FLAG = "1";
+
+    /** {@code events.list}의 privateExtendedProperty 필터 값: {@code orinoRoutine=1}. */
+    public static final String LIST_FILTER = KEY_ROUTINE + "=" + ROUTINE_FLAG;
+
+    private RoutineTag() {
+    }
+
+    /** 주어진 종류로 루틴 태그 private 프로퍼티 맵을 만든다. */
+    public static Map<String, String> privateProperties(RoutineType type) {
+        return Map.of(
+                KEY_ROUTINE, ROUTINE_FLAG,
+                KEY_ROUTINE_TYPE, type.code());
+    }
+
+    /** private 프로퍼티 맵이 루틴 이벤트를 가리키는지(센티넬 보유) 판별한다. */
+    public static boolean isRoutine(Map<String, String> privateProperties) {
+        return privateProperties != null
+                && ROUTINE_FLAG.equals(privateProperties.get(KEY_ROUTINE));
+    }
+
+    /** private 프로퍼티에서 루틴 종류를 읽는다. 없거나 알 수 없으면 null. */
+    public static RoutineType routineType(Map<String, String> privateProperties) {
+        if (privateProperties == null) {
+            return null;
+        }
+        String code = privateProperties.get(KEY_ROUTINE_TYPE);
+        if (code == null) {
+            return null;
+        }
+        try {
+            return RoutineType.fromCode(code);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineType.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineType.java
@@ -1,0 +1,34 @@
+package ds.project.orino.planner.google.routine;
+
+/**
+ * 루틴 종류. Google 이벤트의 {@code extendedProperties.private.orinoRoutineType} 값에 대응한다.
+ *
+ * <ul>
+ *   <li>{@link #HABIT} — 종일 체크형 습관(통합 피드에서 완료 체크 가능)</li>
+ *   <li>{@link #SCHEDULE} — 시간 고정 일정(시간 블록으로 렌더, 체크 없음)</li>
+ * </ul>
+ */
+public enum RoutineType {
+    HABIT("habit"),
+    SCHEDULE("schedule");
+
+    private final String code;
+
+    RoutineType(String code) {
+        this.code = code;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    /** {@code "habit"|"schedule"} 코드를 enum으로 파싱한다. 알 수 없으면 IllegalArgumentException. */
+    public static RoutineType fromCode(String code) {
+        for (RoutineType type : values()) {
+            if (type.code.equals(code)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("알 수 없는 routine type: " + code);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/dto/RoutineCreateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/dto/RoutineCreateRequest.java
@@ -1,0 +1,28 @@
+package ds.project.orino.planner.google.routine.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 루틴 생성 요청. 시간 값은 사용자 시간대 로컬 기준이다.
+ *
+ * @param type       "habit"(종일 체크형) | "schedule"(시간 고정)
+ * @param allDay     종일 여부. habit은 보통 true
+ * @param start      종일이면 날짜("2026-06-20"), 아니면 datetime("2026-06-20T07:00:00")
+ * @param end        종일이면 포함 마지막 날짜(보통 start와 동일), 아니면 종료 datetime
+ * @param recurrence 반복 규칙(필수)
+ * @param memo       메모(Google description으로 저장, null 가능)
+ * @param color      표시 색상(현재 미사용, null 가능)
+ */
+public record RoutineCreateRequest(
+        @NotBlank String type,
+        @NotBlank String title,
+        boolean allDay,
+        @NotNull String start,
+        @NotNull String end,
+        @NotNull @Valid RoutineRecurrence recurrence,
+        String memo,
+        String color
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/dto/RoutineRecurrence.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/dto/RoutineRecurrence.java
@@ -1,0 +1,26 @@
+package ds.project.orino.planner.google.routine.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 루틴 반복 규칙(요청·응답 공용). {@code RecurrenceRule} VO와 1:1 대응한다.
+ *
+ * @param freq       "DAILY" | "WEEKLY" | "MONTHLY"
+ * @param interval   반복 간격(N). null이면 1
+ * @param byDay      WEEKLY 요일 코드 목록(["MO","WE","FR"]). null/빈 값 허용
+ * @param byMonthDay MONTHLY 일자 목록([1,15], 1~31). null/빈 값 허용
+ * @param until      종료일(포함). null이면 무한 반복
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RoutineRecurrence(
+        @NotBlank String freq,
+        Integer interval,
+        List<String> byDay,
+        List<Integer> byMonthDay,
+        LocalDate until
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/dto/RoutineSeriesSummary.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/dto/RoutineSeriesSummary.java
@@ -1,0 +1,29 @@
+package ds.project.orino.planner.google.routine.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * 루틴 시리즈 요약(생성 응답·목록 응답 공용). 마스터 이벤트 한 건을 표현한다.
+ *
+ * @param recurringEventId 마스터 시리즈 id(안정 식별자)
+ * @param type             "habit" | "schedule"
+ * @param allDay           종일 여부
+ * @param start            종일이면 날짜, 시간 루틴이면 datetime
+ * @param end              시간 루틴의 종료 datetime(종일이면 null)
+ * @param recurrence       반복 규칙(정규화된 형태)
+ * @param recurrenceText   한국어 표시 문구("매주 월·수·금")
+ * @param color            표시 색상(null 가능)
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RoutineSeriesSummary(
+        String recurringEventId,
+        String type,
+        String title,
+        boolean allDay,
+        String start,
+        String end,
+        RoutineRecurrence recurrence,
+        String recurrenceText,
+        String color
+) {
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/recurrence/RecurrenceRuleFactoryTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/recurrence/RecurrenceRuleFactoryTest.java
@@ -1,0 +1,193 @@
+package ds.project.orino.planner.google.recurrence;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RecurrenceRuleFactoryTest {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");      // UTC+9
+    private static final ZoneId NEW_YORK = ZoneId.of("America/New_York"); // 12월 UTC-5
+
+    @Nested
+    @DisplayName("toRRule: VO → RRULE 직렬화")
+    class ToRRule {
+
+        @Test
+        @DisplayName("매일 반복은 FREQ=DAILY만 출력한다")
+        void daily() {
+            String rrule = RecurrenceRuleFactory.toRRule(RecurrenceRule.daily(null), SEOUL);
+
+            assertThat(rrule).isEqualTo("RRULE:FREQ=DAILY");
+        }
+
+        @Test
+        @DisplayName("N일 간격은 INTERVAL=N을 붙이고, interval=1은 생략한다")
+        void interval() {
+            assertThat(RecurrenceRuleFactory.toRRule(RecurrenceRule.everyNDays(3, null), SEOUL))
+                    .isEqualTo("RRULE:FREQ=DAILY;INTERVAL=3");
+            assertThat(RecurrenceRuleFactory.toRRule(RecurrenceRule.everyNDays(1, null), SEOUL))
+                    .isEqualTo("RRULE:FREQ=DAILY");
+        }
+
+        @Test
+        @DisplayName("주간 반복은 BYDAY를 요일 순서대로 출력한다")
+        void weeklyByDay() {
+            RecurrenceRule rule = RecurrenceRule.weekly(
+                    List.of(RecurrenceWeekday.MO, RecurrenceWeekday.WE, RecurrenceWeekday.FR), null);
+
+            assertThat(RecurrenceRuleFactory.toRRule(rule, SEOUL))
+                    .isEqualTo("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR");
+        }
+
+        @Test
+        @DisplayName("매월 반복은 BYMONTHDAY를 출력한다")
+        void monthlyByMonthDay() {
+            RecurrenceRule rule = RecurrenceRule.monthly(List.of(1, 15), null);
+
+            assertThat(RecurrenceRuleFactory.toRRule(rule, SEOUL))
+                    .isEqualTo("RRULE:FREQ=MONTHLY;BYMONTHDAY=1,15");
+        }
+
+        @Test
+        @DisplayName("UNTIL은 사용자 TZ 마지막날 23:59:59를 UTC로 변환한다 (KST → -9h)")
+        void untilUtcSeoul() {
+            RecurrenceRule rule = RecurrenceRule.daily(LocalDate.of(2026, 12, 31));
+
+            assertThat(RecurrenceRuleFactory.toRRule(rule, SEOUL))
+                    .isEqualTo("RRULE:FREQ=DAILY;UNTIL=20261231T145959Z");
+        }
+
+        @Test
+        @DisplayName("UNTIL UTC 변환이 날짜를 넘기는 경우(EST → +5h, 익일 롤오버)")
+        void untilUtcRollover() {
+            RecurrenceRule rule = RecurrenceRule.daily(LocalDate.of(2026, 12, 31));
+
+            assertThat(RecurrenceRuleFactory.toRRule(rule, NEW_YORK))
+                    .isEqualTo("RRULE:FREQ=DAILY;UNTIL=20270101T045959Z");
+        }
+
+        @Test
+        @DisplayName("모든 파트를 함께 출력한다 (간격+요일+UNTIL)")
+        void combined() {
+            RecurrenceRule rule = new RecurrenceRule(
+                    RecurrenceFreq.WEEKLY, 2,
+                    List.of(RecurrenceWeekday.TU, RecurrenceWeekday.TH),
+                    List.of(),
+                    LocalDate.of(2026, 12, 31));
+
+            assertThat(RecurrenceRuleFactory.toRRule(rule, SEOUL))
+                    .isEqualTo("RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=TU,TH;UNTIL=20261231T145959Z");
+        }
+    }
+
+    @Nested
+    @DisplayName("parse: RRULE → VO 역파싱")
+    class Parse {
+
+        @Test
+        @DisplayName("RRULE: 접두사 유무 모두 수용한다")
+        void prefixOptional() {
+            assertThat(RecurrenceRuleFactory.parse("RRULE:FREQ=DAILY", SEOUL).freq())
+                    .isEqualTo(RecurrenceFreq.DAILY);
+            assertThat(RecurrenceRuleFactory.parse("FREQ=DAILY", SEOUL).freq())
+                    .isEqualTo(RecurrenceFreq.DAILY);
+        }
+
+        @Test
+        @DisplayName("INTERVAL/BYDAY/BYMONTHDAY를 파싱한다")
+        void parts() {
+            RecurrenceRule weekly = RecurrenceRuleFactory.parse(
+                    "RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR", SEOUL);
+            assertThat(weekly.freq()).isEqualTo(RecurrenceFreq.WEEKLY);
+            assertThat(weekly.interval()).isEqualTo(2);
+            assertThat(weekly.byDay())
+                    .containsExactly(RecurrenceWeekday.MO, RecurrenceWeekday.WE, RecurrenceWeekday.FR);
+
+            RecurrenceRule monthly = RecurrenceRuleFactory.parse(
+                    "RRULE:FREQ=MONTHLY;BYMONTHDAY=1,15", SEOUL);
+            assertThat(monthly.byMonthDay()).containsExactly(1, 15);
+        }
+
+        @Test
+        @DisplayName("UNTIL(UTC)을 사용자 TZ 날짜로 환산한다")
+        void untilToLocalDate() {
+            RecurrenceRule rule = RecurrenceRuleFactory.parse(
+                    "RRULE:FREQ=DAILY;UNTIL=20261231T145959Z", SEOUL);
+
+            assertThat(rule.until()).isEqualTo(LocalDate.of(2026, 12, 31));
+        }
+
+        @Test
+        @DisplayName("UNTIL UTC가 익일 04:59:59Z여도 EST 기준 12/31로 환산한다")
+        void untilRollbackToLocalDate() {
+            RecurrenceRule rule = RecurrenceRuleFactory.parse(
+                    "RRULE:FREQ=DAILY;UNTIL=20270101T045959Z", NEW_YORK);
+
+            assertThat(rule.until()).isEqualTo(LocalDate.of(2026, 12, 31));
+        }
+
+        @Test
+        @DisplayName("date-only UNTIL(yyyyMMdd)도 수용한다")
+        void untilDateOnly() {
+            RecurrenceRule rule = RecurrenceRuleFactory.parse(
+                    "RRULE:FREQ=DAILY;UNTIL=20261231", SEOUL);
+
+            assertThat(rule.until()).isEqualTo(LocalDate.of(2026, 12, 31));
+        }
+
+        @Test
+        @DisplayName("미지원 파트(BYSETPOS 등)는 무시한다")
+        void ignoresUnsupported() {
+            RecurrenceRule rule = RecurrenceRuleFactory.parse(
+                    "RRULE:FREQ=MONTHLY;BYSETPOS=1;BYDAY=MO", SEOUL);
+
+            assertThat(rule.freq()).isEqualTo(RecurrenceFreq.MONTHLY);
+            assertThat(rule.byDay()).containsExactly(RecurrenceWeekday.MO);
+        }
+
+        @Test
+        @DisplayName("FREQ가 없으면 예외")
+        void missingFreq() {
+            assertThatThrownBy(() -> RecurrenceRuleFactory.parse("RRULE:INTERVAL=2", SEOUL))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("빈 문자열이면 예외")
+        void blank() {
+            assertThatThrownBy(() -> RecurrenceRuleFactory.parse("  ", SEOUL))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("round-trip: toRRule ↔ parse")
+    class RoundTrip {
+
+        @Test
+        @DisplayName("주간+간격+UNTIL을 직렬화 후 역파싱하면 동등하다")
+        void weeklyRoundTrip() {
+            RecurrenceRule original = new RecurrenceRule(
+                    RecurrenceFreq.WEEKLY, 2,
+                    List.of(RecurrenceWeekday.MO, RecurrenceWeekday.FR),
+                    List.of(),
+                    LocalDate.of(2026, 12, 31));
+
+            String rrule = RecurrenceRuleFactory.toRRule(original, SEOUL);
+            RecurrenceRule parsed = RecurrenceRuleFactory.parse(rrule, SEOUL);
+
+            assertThat(parsed.freq()).isEqualTo(original.freq());
+            assertThat(parsed.effectiveInterval()).isEqualTo(original.effectiveInterval());
+            assertThat(parsed.byDay()).isEqualTo(original.byDay());
+            assertThat(parsed.until()).isEqualTo(original.until());
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/recurrence/RecurrenceRuleTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/recurrence/RecurrenceRuleTest.java
@@ -1,0 +1,65 @@
+package ds.project.orino.planner.google.recurrence;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RecurrenceRuleTest {
+
+    @Test
+    @DisplayName("freq가 null이면 예외")
+    void freqRequired() {
+        assertThatThrownBy(() -> new RecurrenceRule(null, null, List.of(), List.of(), null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("interval은 1 미만이면 예외")
+    void intervalPositive() {
+        assertThatThrownBy(() ->
+                new RecurrenceRule(RecurrenceFreq.DAILY, 0, List.of(), List.of(), null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("byMonthDay는 1~31 범위를 벗어나면 예외")
+    void byMonthDayRange() {
+        assertThatThrownBy(() ->
+                new RecurrenceRule(RecurrenceFreq.MONTHLY, null, List.of(), List.of(32), null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() ->
+                new RecurrenceRule(RecurrenceFreq.MONTHLY, null, List.of(), List.of(0), null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("null 목록은 빈 불변 리스트로 정규화된다")
+    void nullListsNormalized() {
+        RecurrenceRule rule = new RecurrenceRule(RecurrenceFreq.DAILY, null, null, null, null);
+
+        assertThat(rule.byDay()).isEmpty();
+        assertThat(rule.byMonthDay()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("목록은 방어적 복사된다 (원본 변경 영향 없음)")
+    void defensiveCopy() {
+        List<Integer> source = Arrays.asList(1, 15);
+        RecurrenceRule rule = RecurrenceRule.monthly(source, null);
+        source.set(0, 99);
+
+        assertThat(rule.byMonthDay()).containsExactly(1, 15);
+    }
+
+    @Test
+    @DisplayName("effectiveInterval은 null을 1로 본다")
+    void effectiveInterval() {
+        assertThat(RecurrenceRule.daily(null).effectiveInterval()).isEqualTo(1);
+        assertThat(RecurrenceRule.everyNDays(4, null).effectiveInterval()).isEqualTo(4);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RecurrenceTextFormatterTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RecurrenceTextFormatterTest.java
@@ -1,0 +1,45 @@
+package ds.project.orino.planner.google.routine;
+
+import ds.project.orino.planner.google.recurrence.RecurrenceFreq;
+import ds.project.orino.planner.google.recurrence.RecurrenceRule;
+import ds.project.orino.planner.google.recurrence.RecurrenceWeekday;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecurrenceTextFormatterTest {
+
+    @Test
+    @DisplayName("매일 / N일마다")
+    void daily() {
+        assertThat(RecurrenceTextFormatter.toKorean(RecurrenceRule.daily(null))).isEqualTo("매일");
+        assertThat(RecurrenceTextFormatter.toKorean(RecurrenceRule.everyNDays(3, null)))
+                .isEqualTo("3일마다");
+    }
+
+    @Test
+    @DisplayName("매주 요일 / N주마다 요일")
+    void weekly() {
+        RecurrenceRule weekly = RecurrenceRule.weekly(
+                List.of(RecurrenceWeekday.MO, RecurrenceWeekday.WE, RecurrenceWeekday.FR), null);
+        assertThat(RecurrenceTextFormatter.toKorean(weekly)).isEqualTo("매주 월·수·금");
+
+        RecurrenceRule biweekly = new RecurrenceRule(
+                RecurrenceFreq.WEEKLY, 2, List.of(RecurrenceWeekday.TU), List.of(), null);
+        assertThat(RecurrenceTextFormatter.toKorean(biweekly)).isEqualTo("2주마다 화");
+    }
+
+    @Test
+    @DisplayName("매월 일자 / N개월마다")
+    void monthly() {
+        assertThat(RecurrenceTextFormatter.toKorean(RecurrenceRule.monthly(List.of(1, 15), null)))
+                .isEqualTo("매월 1·15일");
+
+        RecurrenceRule quarterly = new RecurrenceRule(
+                RecurrenceFreq.MONTHLY, 3, List.of(), List.of(1), null);
+        assertThat(RecurrenceTextFormatter.toKorean(quarterly)).isEqualTo("3개월마다 1일");
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RoutineControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RoutineControllerTest.java
@@ -1,0 +1,221 @@
+package ds.project.orino.planner.google.routine;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import ds.project.orino.redis.planner.google.GoogleCalendarCacheRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RoutineControllerTest extends ApiTestSupport {
+
+    /** POST = 생성된 마스터(habit, 종일, RRULE+태그). */
+    private static final String MASTER_JSON = """
+            {"id":"r-habit-1","summary":"운동하기",
+             "start":{"date":"2026-06-20"},"end":{"date":"2026-06-21"},
+             "recurrence":["RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"],
+             "extendedProperties":{"private":{"orinoRoutine":"1","orinoRoutineType":"habit"}}}""";
+    /** GET = singleEvents 펼침 인스턴스(recurringEventId + 태그 상속). */
+    private static final String FEED_JSON = """
+            {"items":[{"id":"r-habit-1_20260622","summary":"운동하기","recurringEventId":"r-habit-1",
+             "start":{"date":"2026-06-22"},"end":{"date":"2026-06-23"},
+             "extendedProperties":{"private":{"orinoRoutine":"1","orinoRoutineType":"habit"}}}]}""";
+
+    private static final HttpServer EVENTS_STUB = createStub();
+
+    private static final String HABIT_BODY = """
+            {"type":"habit","title":"운동하기","allDay":true,
+             "start":"2026-06-20","end":"2026-06-20",
+             "recurrence":{"freq":"WEEKLY","byDay":["MO","WE","FR"]}}""";
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private GoogleAccountRepository googleAccountRepository;
+    @Autowired
+    private GoogleAccessTokenRepository accessTokenRepository;
+    @Autowired
+    private GoogleCalendarCacheRepository cacheRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Long memberId;
+    private String authHeader;
+
+    @DynamicPropertySource
+    static void googleProperties(DynamicPropertyRegistry registry) {
+        String base = "http://127.0.0.1:" + EVENTS_STUB.getAddress().getPort();
+        registry.add("planner.google.client-id", () -> "test-client-id");
+        registry.add("planner.google.client-secret", () -> "test-client-secret");
+        registry.add("planner.google.oauth.calendar-api-base-url", () -> base);
+        registry.add("planner.google.oauth.tasks-api-base-url", () -> base);
+    }
+
+    @AfterAll
+    static void stopStub() {
+        EVENTS_STUB.stop(0);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberId = memberRepository.save(MemberFixture.create()).getId();
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    private void connectGoogle() {
+        googleAccountRepository.save(new GoogleAccount(
+                memberId, "refresh", "scope", "me@gmail.com", "primary", "@default"));
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+    }
+
+    @Test
+    @DisplayName("POST - 루틴을 생성하고 201 시리즈 요약을 반환하며 캐시를 무효화한다")
+    void create() throws Exception {
+        connectGoogle();
+        cacheRepository.save(memberId, "2026-06-01", "2026-06-30", "[]", Duration.ofMinutes(1));
+
+        mockMvc.perform(post("/api/planner/routines")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(HABIT_BODY))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.recurringEventId").value("r-habit-1"))
+                .andExpect(jsonPath("$.data.type").value("habit"))
+                .andExpect(jsonPath("$.data.title").value("운동하기"))
+                .andExpect(jsonPath("$.data.allDay").value(true))
+                .andExpect(jsonPath("$.data.start").value("2026-06-20"))
+                .andExpect(jsonPath("$.data.recurrence.freq").value("WEEKLY"))
+                .andExpect(jsonPath("$.data.recurrence.byDay[0]").value("MO"))
+                .andExpect(jsonPath("$.data.recurrenceText").value("매주 월·수·금"));
+
+        assertThat(cacheRepository.find(memberId, "2026-06-01", "2026-06-30")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("생성된 루틴 인스턴스는 통합 피드에 routine 메타로 노출된다")
+    void feedAnnotatesRoutine() throws Exception {
+        connectGoogle();
+
+        mockMvc.perform(get("/api/planner/calendar")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .param("from", "2026-06-01")
+                        .param("to", "2026-06-30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.events.length()").value(1))
+                .andExpect(jsonPath("$.data.events[0].recurring").value(true))
+                .andExpect(jsonPath("$.data.events[0].routine.type").value("habit"))
+                .andExpect(jsonPath("$.data.events[0].routine.recurringEventId").value("r-habit-1"))
+                .andExpect(jsonPath("$.data.events[0].routine.done").value(false));
+    }
+
+    @Test
+    @DisplayName("미연동 상태에서 생성하면 409(PLN-ERR-003)")
+    void create_notConnected() throws Exception {
+        mockMvc.perform(post("/api/planner/routines")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(HABIT_BODY))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PLN-ERR-003"));
+    }
+
+    @Test
+    @DisplayName("알 수 없는 freq면 400(PLN-ERR-002)")
+    void create_invalidRecurrence() throws Exception {
+        connectGoogle();
+        String body = """
+                {"type":"habit","title":"운동하기","allDay":true,
+                 "start":"2026-06-20","end":"2026-06-20",
+                 "recurrence":{"freq":"YEARLY"}}""";
+
+        mockMvc.perform(post("/api/planner/routines")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("PLN-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("title이 없으면 400")
+    void create_validation() throws Exception {
+        connectGoogle();
+        String body = """
+                {"type":"habit","allDay":true,"start":"2026-06-20","end":"2026-06-20",
+                 "recurrence":{"freq":"DAILY"}}""";
+
+        mockMvc.perform(post("/api/planner/routines")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("recurrence가 없으면 400")
+    void create_missingRecurrence() throws Exception {
+        connectGoogle();
+        String body = """
+                {"type":"habit","title":"운동하기","allDay":true,
+                 "start":"2026-06-20","end":"2026-06-20"}""";
+
+        mockMvc.perform(post("/api/planner/routines")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    private static HttpServer createStub() {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/calendar/v3/calendars/primary/events", exchange -> {
+                String body = "POST".equals(exchange.getRequestMethod()) ? MASTER_JSON : FEED_JSON;
+                respond(exchange, 200, body);
+            });
+            server.createContext("/tasks/v1/lists/@default/tasks", exchange ->
+                    respond(exchange, 200, "{\"items\":[]}"));
+            server.start();
+            return server;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RoutineRecurrenceMapperTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RoutineRecurrenceMapperTest.java
@@ -1,0 +1,77 @@
+package ds.project.orino.planner.google.routine;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.google.recurrence.RecurrenceFreq;
+import ds.project.orino.planner.google.recurrence.RecurrenceRule;
+import ds.project.orino.planner.google.recurrence.RecurrenceWeekday;
+import ds.project.orino.planner.google.routine.dto.RoutineRecurrence;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RoutineRecurrenceMapperTest {
+
+    @Test
+    @DisplayName("요청 DTO → VO (주간 요일·간격·until)")
+    void toRule() {
+        RoutineRecurrence dto = new RoutineRecurrence(
+                "WEEKLY", 2, List.of("MO", "FR"), null, LocalDate.of(2026, 12, 31));
+
+        RecurrenceRule rule = RoutineRecurrenceMapper.toRule(dto);
+
+        assertThat(rule.freq()).isEqualTo(RecurrenceFreq.WEEKLY);
+        assertThat(rule.interval()).isEqualTo(2);
+        assertThat(rule.byDay()).containsExactly(RecurrenceWeekday.MO, RecurrenceWeekday.FR);
+        assertThat(rule.until()).isEqualTo(LocalDate.of(2026, 12, 31));
+    }
+
+    @Test
+    @DisplayName("VO → 응답 DTO (interval=1·빈 목록은 null로 정규화)")
+    void toDto() {
+        RoutineRecurrence dto = RoutineRecurrenceMapper.toDto(RecurrenceRule.daily(null));
+
+        assertThat(dto.freq()).isEqualTo("DAILY");
+        assertThat(dto.interval()).isNull();
+        assertThat(dto.byDay()).isNull();
+        assertThat(dto.byMonthDay()).isNull();
+    }
+
+    @Test
+    @DisplayName("알 수 없는 freq는 ROUTINE_INVALID_RULE")
+    void invalidFreq() {
+        RoutineRecurrence dto = new RoutineRecurrence("YEARLY", null, null, null, null);
+
+        assertThatThrownBy(() -> RoutineRecurrenceMapper.toRule(dto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ROUTINE_INVALID_RULE);
+    }
+
+    @Test
+    @DisplayName("잘못된 요일 코드는 ROUTINE_INVALID_RULE")
+    void invalidWeekday() {
+        RoutineRecurrence dto = new RoutineRecurrence("WEEKLY", null, List.of("XX"), null, null);
+
+        assertThatThrownBy(() -> RoutineRecurrenceMapper.toRule(dto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ROUTINE_INVALID_RULE);
+    }
+
+    @Test
+    @DisplayName("byMonthDay 범위 초과는 ROUTINE_INVALID_RULE")
+    void invalidMonthDay() {
+        RoutineRecurrence dto = new RoutineRecurrence("MONTHLY", null, null, List.of(40), null);
+
+        assertThatThrownBy(() -> RoutineRecurrenceMapper.toRule(dto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ROUTINE_INVALID_RULE);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RoutineTagTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RoutineTagTest.java
@@ -1,0 +1,63 @@
+package ds.project.orino.planner.google.routine;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RoutineTagTest {
+
+    @Test
+    @DisplayName("habit 태그는 orinoRoutine=1 + orinoRoutineType=habit")
+    void habitProperties() {
+        Map<String, String> props = RoutineTag.privateProperties(RoutineType.HABIT);
+
+        assertThat(props)
+                .containsEntry("orinoRoutine", "1")
+                .containsEntry("orinoRoutineType", "habit");
+    }
+
+    @Test
+    @DisplayName("schedule 태그는 orinoRoutineType=schedule")
+    void scheduleProperties() {
+        Map<String, String> props = RoutineTag.privateProperties(RoutineType.SCHEDULE);
+
+        assertThat(props).containsEntry("orinoRoutineType", "schedule");
+    }
+
+    @Test
+    @DisplayName("list 필터 값은 orinoRoutine=1")
+    void listFilter() {
+        assertThat(RoutineTag.LIST_FILTER).isEqualTo("orinoRoutine=1");
+    }
+
+    @Test
+    @DisplayName("센티넬 보유 여부로 루틴 이벤트를 판별한다")
+    void isRoutine() {
+        assertThat(RoutineTag.isRoutine(Map.of("orinoRoutine", "1"))).isTrue();
+        assertThat(RoutineTag.isRoutine(Map.of("other", "x"))).isFalse();
+        assertThat(RoutineTag.isRoutine(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("루틴 종류를 읽는다 (없거나 알 수 없으면 null)")
+    void routineType() {
+        assertThat(RoutineTag.routineType(RoutineTag.privateProperties(RoutineType.HABIT)))
+                .isEqualTo(RoutineType.HABIT);
+        assertThat(RoutineTag.routineType(Map.of("orinoRoutine", "1"))).isNull();
+        assertThat(RoutineTag.routineType(Map.of("orinoRoutineType", "bogus"))).isNull();
+        assertThat(RoutineTag.routineType(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("RoutineType.fromCode 왕복")
+    void fromCode() {
+        assertThat(RoutineType.fromCode("habit")).isEqualTo(RoutineType.HABIT);
+        assertThat(RoutineType.fromCode("schedule")).isEqualTo(RoutineType.SCHEDULE);
+        assertThatThrownBy(() -> RoutineType.fromCode("nope"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     INVALID_STATE("SP-ERR-003", "현재 상태에서 수행할 수 없는 작업입니다.", 409),
 
     // PLANNER (Google Calendar 연동)
+    ROUTINE_INVALID_RULE("PLN-ERR-002", "유효하지 않은 반복 규칙입니다.", 400),
     GOOGLE_NOT_CONNECTED("PLN-ERR-003", "Google 연동이 필요합니다.", 409),
     GOOGLE_API_FAILED("PLN-ERR-004", "Google API 호출에 실패했습니다.", 502),
     GOOGLE_INVALID_GRANT("PLN-ERR-005", "Google 연동이 만료되어 재연결이 필요합니다.", 401);

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -194,9 +194,15 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
           insertPagePending={createNote.isPending}
         />
         {editor && (
-          // nested: 불릿/태스크 리스트 항목 등 중첩 블록도 개별 드래그 타깃이 되게 한다.
-          // (기본 false면 리스트 전체를 한 블록으로만 잡음)
-          <DragHandle editor={editor} nested className="z-10">
+          // nested: 리스트 항목 등 중첩 블록도 개별(한 줄) 드래그 타깃이 되게 한다.
+          // edgeDetection "none": 기본값(left,top)은 항목 왼쪽 가장자리에서 부모(리스트)를
+          // 우선해 하위 불릿 왼쪽에 호버 시 항목 핸들이 안 뜨고 글자에 대야 떴다. none이면
+          // 커서 위치와 무관하게 가장 깊은 항목이 일관되게 잡혀 행 어디서나 핸들이 뜬다.
+          <DragHandle
+            editor={editor}
+            nested={{ edgeDetection: "none" }}
+            className="z-10"
+          >
             <button
               type="button"
               aria-label="블록 이동"


### PR DESCRIPTION
## 이슈
closes #574

> ⚠️ R0(#589, `feat/routine-recurrence-scaffolding`) 위에 쌓인 PR입니다. **#589를 먼저 머지**하면 이 PR의 diff가 R1 변경분만 남습니다.

## 작업 내용
- **`POST /api/planner/routines`** — `RoutineController` / `RoutineService`
  - 요청(type/title/allDay/start/end/recurrence/memo/color) → `RecurrenceRule` + 루틴 태그 → `events.insert` 프록시
  - 응답: 시리즈 요약(`recurringEventId`, type, recurrence, `recurrenceText` 등, §5)
  - 미연동 시 토큰 공급 단계에서 **409 PLN-ERR-003**
  - 잘못된 반복 규칙(freq/요일/일자) → **400 PLN-ERR-002**(`ROUTINE_INVALID_RULE` 신규)
- **DTO** — `RoutineCreateRequest`, `RoutineRecurrence`(요청·응답 공용), `RoutineSeriesSummary`
- **매핑/표시** — `RoutineRecurrenceMapper`(DTO↔VO), `RecurrenceTextFormatter`(한국어: "매주 월·수·금", "3일마다", "매월 1·15일")
- **통합 피드 주석** — `GET /api/planner/calendar`의 펼쳐진 인스턴스에서 `extendedProperties` 태그를 읽어 `routine:{type, recurringEventId, done}` 부여. 루틴이 아니면 `routine: null`. habit `done`은 R3(routine_check 조인)까지 우선 `false`
  - `PlannerEvent`에 `routine` 필드 추가, `GoogleCalendarClient.normalize`에서 태그 판별
- **캐시** — 쓰기 후 `google:cal-cache:*`(`evictAll`) 무효화

## 검증
- `./gradlew :orino-app-api:test`(routine/recurrence/calendar, MockMvc+TestContainers) ✅
- `./gradlew :orino-app-api:checkstyleMain checkstyleTest :orino-common:checkstyleMain` ✅
- 통합 테스트: 생성→201 요약·캐시 무효화 / 생성 인스턴스 피드 routine 주석 / 미연동 409 / 잘못된 freq 400(PLN-ERR-002) / title·recurrence 검증 400
- 단위 테스트: 매퍼(VO↔DTO·400 변환), 텍스트 포맷터