### PR TITLE
feat : Routine 시리즈 목록 API (R2)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineController.java
@@ -3,18 +3,20 @@ package ds.project.orino.planner.google.routine;
 import ds.project.orino.common.response.ApiResponse;
 import ds.project.orino.core.time.UserTimeZone;
 import ds.project.orino.planner.google.routine.dto.RoutineCreateRequest;
+import ds.project.orino.planner.google.routine.dto.RoutineListResponse;
 import ds.project.orino.planner.google.routine.dto.RoutineSeriesSummary;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 루틴(반복 이벤트) 시리즈 쓰기 엔드포인트. 미연동 시 409(PLN-ERR-003).
+ * 루틴(반복 이벤트) 시리즈 엔드포인트. 미연동 시 409(PLN-ERR-003).
  * 시간대는 {@code X-Timezone}({@link UserTimeZone}) 기준.
  */
 @RestController
@@ -22,9 +24,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class RoutineController {
 
     private final RoutineService routineService;
+    private final RoutineQueryService routineQueryService;
 
-    public RoutineController(RoutineService routineService) {
+    public RoutineController(RoutineService routineService,
+                             RoutineQueryService routineQueryService) {
         this.routineService = routineService;
+        this.routineQueryService = routineQueryService;
     }
 
     @PostMapping
@@ -33,5 +38,11 @@ public class RoutineController {
             @Valid @RequestBody RoutineCreateRequest request) {
         RoutineSeriesSummary created = routineService.create(memberId, request, UserTimeZone.get());
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(created));
+    }
+
+    @GetMapping
+    public ApiResponse<RoutineListResponse> list(@AuthenticationPrincipal Long memberId) {
+        return ApiResponse.success(
+                new RoutineListResponse(routineQueryService.list(memberId, UserTimeZone.get())));
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineQueryService.java
@@ -1,0 +1,83 @@
+package ds.project.orino.planner.google.routine;
+
+import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventDateTime;
+import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventItem;
+import ds.project.orino.planner.google.client.GoogleCalendarClient;
+import ds.project.orino.planner.google.recurrence.RecurrenceRule;
+import ds.project.orino.planner.google.recurrence.RecurrenceRuleFactory;
+import ds.project.orino.planner.google.routine.dto.RoutineSeriesSummary;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * 루틴 시리즈 목록 조회. {@code singleEvents=false}로 마스터만 받아 RRULE을 역파싱하고
+ * 종류·한글 요약과 함께 관리 화면용 시리즈 요약으로 매핑한다.
+ *
+ * <p>미연동이면 {@link GoogleCalendarClient} 토큰 공급 단계에서 GOOGLE_NOT_CONNECTED(409)가 발생한다.
+ */
+@Service
+public class RoutineQueryService {
+
+    private static final DateTimeFormatter LOCAL_DATETIME =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+    private final GoogleCalendarClient calendarClient;
+
+    public RoutineQueryService(GoogleCalendarClient calendarClient) {
+        this.calendarClient = calendarClient;
+    }
+
+    /** 루틴 마스터 시리즈 목록. 반복 규칙이 없는 항목(비정상 마스터)은 제외한다. */
+    public List<RoutineSeriesSummary> list(Long memberId, ZoneId zone) {
+        return calendarClient.listRoutineMasters(memberId).stream()
+                .map(item -> toSummary(item, zone))
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private RoutineSeriesSummary toSummary(GoogleEventItem item, ZoneId zone) {
+        if (item.recurrence() == null || item.recurrence().isEmpty()) {
+            return null;
+        }
+        RecurrenceRule rule = RecurrenceRuleFactory.parse(item.recurrence().get(0), zone);
+
+        boolean allDay = item.start() != null && item.start().date() != null;
+        String start = allDay ? item.start().date() : toLocalDateTime(item.start(), zone);
+        String end = allDay ? null : toLocalDateTime(item.end(), zone);
+
+        return new RoutineSeriesSummary(
+                item.id(),
+                routineTypeCode(item),
+                item.summary(),
+                allDay,
+                start,
+                end,
+                RoutineRecurrenceMapper.toDto(rule),
+                RecurrenceTextFormatter.toKorean(rule),
+                null);
+    }
+
+    private String routineTypeCode(GoogleEventItem item) {
+        Map<String, String> priv = item.extendedProperties() == null
+                ? null
+                : item.extendedProperties().privateProperties();
+        RoutineType type = RoutineTag.routineType(priv);
+        return type == null ? null : type.code();
+    }
+
+    private String toLocalDateTime(GoogleEventDateTime dateTime, ZoneId zone) {
+        if (dateTime == null || dateTime.dateTime() == null) {
+            return null;
+        }
+        return OffsetDateTime.parse(dateTime.dateTime())
+                .atZoneSameInstant(zone)
+                .toLocalDateTime()
+                .format(LOCAL_DATETIME);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/dto/RoutineListResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/dto/RoutineListResponse.java
@@ -1,0 +1,9 @@
+package ds.project.orino.planner.google.routine.dto;
+
+import java.util.List;
+
+/**
+ * 루틴 시리즈 목록 응답. 관리 화면이 시리즈 단위로 렌더한다.
+ */
+public record RoutineListResponse(List<RoutineSeriesSummary> routines) {
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RoutineQueryControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RoutineQueryControllerTest.java
@@ -1,0 +1,145 @@
+package ds.project.orino.planner.google.routine;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RoutineQueryControllerTest extends ApiTestSupport {
+
+    /** singleEvents=false 마스터 목록: habit(종일), schedule(시간), recurrence 없는 비정상 항목(필터 대상). */
+    private static final String MASTERS_JSON = """
+            {"items":[
+              {"id":"r-habit-1","summary":"운동하기",
+               "start":{"date":"2026-06-20"},"end":{"date":"2026-06-21"},
+               "recurrence":["RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"],
+               "extendedProperties":{"private":{"orinoRoutine":"1","orinoRoutineType":"habit"}}},
+              {"id":"r-sched-1","summary":"스탠드업",
+               "start":{"dateTime":"2026-06-20T00:00:00Z"},"end":{"dateTime":"2026-06-20T00:15:00Z"},
+               "recurrence":["RRULE:FREQ=DAILY"],
+               "extendedProperties":{"private":{"orinoRoutine":"1","orinoRoutineType":"schedule"}}},
+              {"id":"r-broken","summary":"규칙 없음",
+               "start":{"date":"2026-06-20"},"end":{"date":"2026-06-21"},
+               "extendedProperties":{"private":{"orinoRoutine":"1","orinoRoutineType":"habit"}}}
+            ]}""";
+
+    private static final HttpServer EVENTS_STUB = createStub();
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private GoogleAccountRepository googleAccountRepository;
+    @Autowired
+    private GoogleAccessTokenRepository accessTokenRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Long memberId;
+    private String authHeader;
+
+    @DynamicPropertySource
+    static void googleProperties(DynamicPropertyRegistry registry) {
+        String base = "http://127.0.0.1:" + EVENTS_STUB.getAddress().getPort();
+        registry.add("planner.google.client-id", () -> "test-client-id");
+        registry.add("planner.google.client-secret", () -> "test-client-secret");
+        registry.add("planner.google.oauth.calendar-api-base-url", () -> base);
+    }
+
+    @AfterAll
+    static void stopStub() {
+        EVENTS_STUB.stop(0);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberId = memberRepository.save(MemberFixture.create()).getId();
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    private void connectGoogle() {
+        googleAccountRepository.save(new GoogleAccount(
+                memberId, "refresh", "scope", "me@gmail.com", "primary", "@default"));
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+    }
+
+    @Test
+    @DisplayName("GET - 마스터 시리즈를 종류·반복 요약과 함께 반환하고 규칙 없는 항목은 제외한다")
+    void list() throws Exception {
+        connectGoogle();
+
+        mockMvc.perform(get("/api/planner/routines")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.routines.length()").value(2))
+                // habit(종일)
+                .andExpect(jsonPath("$.data.routines[0].recurringEventId").value("r-habit-1"))
+                .andExpect(jsonPath("$.data.routines[0].type").value("habit"))
+                .andExpect(jsonPath("$.data.routines[0].allDay").value(true))
+                .andExpect(jsonPath("$.data.routines[0].start").value("2026-06-20"))
+                .andExpect(jsonPath("$.data.routines[0].recurrence.freq").value("WEEKLY"))
+                .andExpect(jsonPath("$.data.routines[0].recurrence.byDay[2]").value("FR"))
+                .andExpect(jsonPath("$.data.routines[0].recurrenceText").value("매주 월·수·금"))
+                // schedule(시간) - 사용자 TZ(Asia/Seoul, +9)로 정규화
+                .andExpect(jsonPath("$.data.routines[1].type").value("schedule"))
+                .andExpect(jsonPath("$.data.routines[1].allDay").value(false))
+                .andExpect(jsonPath("$.data.routines[1].start").value("2026-06-20T09:00:00"))
+                .andExpect(jsonPath("$.data.routines[1].end").value("2026-06-20T09:15:00"))
+                .andExpect(jsonPath("$.data.routines[1].recurrenceText").value("매일"));
+    }
+
+    @Test
+    @DisplayName("미연동 상태에서 조회하면 409(PLN-ERR-003)")
+    void list_notConnected() throws Exception {
+        mockMvc.perform(get("/api/planner/routines")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PLN-ERR-003"));
+    }
+
+    private static HttpServer createStub() {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/calendar/v3/calendars/primary/events", exchange ->
+                    respond(exchange, 200, MASTERS_JSON));
+            server.start();
+            return server;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+}


### PR DESCRIPTION
## 이슈
closes #576

## 작업 내용
- **`GET /api/planner/routines`** — 관리 화면용 루틴 시리즈 목록
  - `listRoutineMasters`(R0)로 `singleEvents=false` + `privateExtendedProperty=orinoRoutine=1` 마스터만 조회
  - `RoutineQueryService`: 마스터 → `RoutineSeriesSummary` 매핑
    - RRULE 역파싱(`RecurrenceRuleFactory.parse`) + 종류 판별(`RoutineTag`) + 한글 요약(`RecurrenceTextFormatter`)
    - 종일/시간 일정 `start`·`end`를 사용자 TZ로 정규화(종일은 `end` 생략)
    - `recurrence`가 없는 비정상 마스터는 목록에서 제외
  - 응답: `RoutineListResponse`(`routines[]`, §5), 미연동 시 409(PLN-ERR-003)

## 검증
- `./gradlew :orino-app-api:test`(routine/recurrence/calendar, MockMvc+TestContainers) ✅
- `./gradlew :orino-app-api:checkstyleMain checkstyleTest` ✅
- 통합 테스트: habit(종일)·schedule(시간 TZ 정규화) 시리즈가 종류·`recurrenceText`와 함께 노출 / 규칙 없는 항목 필터링 / 미연동 409