### PR TITLE
feat : Routine routine_check 테이블 + 체크 토글 + 피드 done 조인 (R3)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/PlannerCalendarService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/PlannerCalendarService.java
@@ -2,12 +2,15 @@ package ds.project.orino.planner.google.calendar;
 
 import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.routine.repository.RoutineCheckRepository;
 import ds.project.orino.planner.google.calendar.dto.FeedError;
 import ds.project.orino.planner.google.calendar.dto.GoogleEventsView;
 import ds.project.orino.planner.google.calendar.dto.PlannerCalendarFeed;
 import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
 import ds.project.orino.planner.google.calendar.dto.PlannerReview;
 import ds.project.orino.planner.google.calendar.dto.PlannerTask;
+import ds.project.orino.planner.google.calendar.dto.RoutineMeta;
+import ds.project.orino.planner.google.routine.RoutineType;
 import ds.project.orino.planner.google.task.GoogleTasksQueryService;
 import ds.project.orino.planner.review.dto.CalendarReviewItem;
 import ds.project.orino.planner.review.service.ReviewQueryService;
@@ -19,8 +22,10 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
 
 /**
  * 통합 캘린더 피드 조립. 일정(Google)·할 일(M3)·복습(orino 오버레이)을 한 응답으로 모은다.
@@ -40,15 +45,18 @@ public class PlannerCalendarService {
     private final GoogleEventQueryService googleEventQueryService;
     private final GoogleTasksQueryService googleTasksQueryService;
     private final ReviewQueryService reviewQueryService;
+    private final RoutineCheckRepository routineCheckRepository;
     private final ExecutorService plannerFeedExecutor;
 
     public PlannerCalendarService(GoogleEventQueryService googleEventQueryService,
                                   GoogleTasksQueryService googleTasksQueryService,
                                   ReviewQueryService reviewQueryService,
+                                  RoutineCheckRepository routineCheckRepository,
                                   ExecutorService plannerFeedExecutor) {
         this.googleEventQueryService = googleEventQueryService;
         this.googleTasksQueryService = googleTasksQueryService;
         this.reviewQueryService = reviewQueryService;
+        this.routineCheckRepository = routineCheckRepository;
         this.plannerFeedExecutor = plannerFeedExecutor;
     }
 
@@ -72,14 +80,64 @@ public class PlannerCalendarService {
         reviewsResult.error().ifPresent(errors::add);
         tasksResult.error().ifPresent(errors::add);
 
+        // 습관 인스턴스 done 오버레이는 요청 스레드(OSIV)에서 DB batch 로드로 적용한다.
+        List<PlannerEvent> events = applyRoutineChecks(memberId, eventsResult.events(), from, to);
+
         return new PlannerCalendarFeed(
                 from, to,
                 eventsResult.connected(),
                 !errors.isEmpty(),
                 errors,
-                eventsResult.events(),
+                events,
                 tasksResult.tasks(),
                 reviewsResult.reviews());
+    }
+
+    /**
+     * habit 루틴 인스턴스에 {@code routine_check} 완료 여부를 조인한다. 기간 내 체크 행을 한 번에 로드해(N+1 회피)
+     * {@code (recurringEventId, instanceDate)}로 매칭한다. habit 인스턴스가 없으면 DB를 건드리지 않고,
+     * 오버레이 실패 시에는 피드를 막지 않도록 원본(done=false)을 유지한다.
+     */
+    private List<PlannerEvent> applyRoutineChecks(Long memberId, List<PlannerEvent> events,
+                                                  LocalDate from, LocalDate to) {
+        if (events.stream().noneMatch(PlannerCalendarService::isHabitInstance)) {
+            return events;
+        }
+        try {
+            Set<String> checkedKeys = routineCheckRepository
+                    .findByMemberIdAndInstanceDateBetween(memberId, from, to).stream()
+                    .map(c -> checkKey(c.getRecurringEventId(), c.getInstanceDate().toString()))
+                    .collect(Collectors.toSet());
+            return events.stream()
+                    .map(event -> applyDone(event, checkedKeys))
+                    .toList();
+        } catch (RuntimeException e) {
+            return events;
+        }
+    }
+
+    private static boolean isHabitInstance(PlannerEvent event) {
+        return event.routine() != null
+                && RoutineType.HABIT.code().equals(event.routine().type());
+    }
+
+    private static PlannerEvent applyDone(PlannerEvent event, Set<String> checkedKeys) {
+        if (!isHabitInstance(event)) {
+            return event;
+        }
+        boolean done = checkedKeys.contains(
+                checkKey(event.routine().recurringEventId(), event.start()));
+        if (done == event.routine().done()) {
+            return event;
+        }
+        RoutineMeta updated = new RoutineMeta(
+                event.routine().type(), event.routine().recurringEventId(), done);
+        return new PlannerEvent(event.id(), event.title(), event.allDay(), event.start(),
+                event.end(), event.location(), event.recurring(), event.source(), updated);
+    }
+
+    private static String checkKey(String recurringEventId, String instanceDate) {
+        return recurringEventId + "|" + instanceDate;
     }
 
     private EventsResult fetchEvents(Long memberId, LocalDate from, LocalDate to, ZoneId zone) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
@@ -84,6 +84,20 @@ public class GoogleCalendarClient {
                 .toList();
     }
 
+    /**
+     * 단일 이벤트를 원본(raw) 형태로 조회한다. extendedProperties·recurrence를 그대로 노출해 호출부가
+     * 루틴 종류 판별 등에 사용한다. 없는 id면 404(RESOURCE_NOT_FOUND).
+     */
+    public GoogleEventItem getEvent(Long memberId, String eventId) {
+        URI uri = eventUri(eventId);
+        return tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.get()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .retrieve()
+                        .body(GoogleEventItem.class));
+    }
+
     /** 일정 생성. 생성된 이벤트를 정규화해 반환한다. */
     public PlannerEvent insertEvent(Long memberId, EventRequest request, ZoneId zone) {
         URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineCheckService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineCheckService.java
@@ -1,0 +1,68 @@
+package ds.project.orino.planner.google.routine;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.routine.entity.RoutineCheck;
+import ds.project.orino.domain.planner.routine.repository.RoutineCheckRepository;
+import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventItem;
+import ds.project.orino.planner.google.client.GoogleCalendarClient;
+import ds.project.orino.planner.google.routine.dto.RoutineCheckResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+/**
+ * 습관 완료 체크 토글. {@code done=true}면 행 upsert(존재=완료), {@code done=false}면 행 삭제(부재=미완료).
+ *
+ * <p>대상이 habit 루틴인지 Google 마스터 이벤트의 {@code orinoRoutineType} 태그로 검증한다.
+ * schedule(시간 고정)이거나 루틴이 아니면 400(체크 비대상). 없는 시리즈면 getEvent가 404를 던진다.
+ * 미연동이면 토큰 공급 단계에서 409.
+ */
+@Service
+public class RoutineCheckService {
+
+    private final GoogleCalendarClient calendarClient;
+    private final RoutineCheckRepository routineCheckRepository;
+
+    public RoutineCheckService(GoogleCalendarClient calendarClient,
+                               RoutineCheckRepository routineCheckRepository) {
+        this.calendarClient = calendarClient;
+        this.routineCheckRepository = routineCheckRepository;
+    }
+
+    @Transactional
+    public RoutineCheckResponse toggle(Long memberId, String recurringEventId,
+                                       LocalDate date, boolean done) {
+        requireHabit(memberId, recurringEventId);
+
+        if (done) {
+            check(memberId, recurringEventId, date);
+        } else {
+            routineCheckRepository.deleteByMemberIdAndRecurringEventIdAndInstanceDate(
+                    memberId, recurringEventId, date);
+        }
+        return new RoutineCheckResponse(recurringEventId, date, done);
+    }
+
+    /** habit이 아니면 400. 시리즈가 없으면 getEvent가 404(RESOURCE_NOT_FOUND). */
+    private void requireHabit(Long memberId, String recurringEventId) {
+        GoogleEventItem master = calendarClient.getEvent(memberId, recurringEventId);
+        Map<String, String> priv = master.extendedProperties() == null
+                ? null
+                : master.extendedProperties().privateProperties();
+        if (RoutineTag.routineType(priv) != RoutineType.HABIT) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    /** 멱등 upsert: 이미 있으면 그대로 둔다. */
+    private void check(Long memberId, String recurringEventId, LocalDate date) {
+        boolean exists = routineCheckRepository
+                .existsByMemberIdAndRecurringEventIdAndInstanceDate(memberId, recurringEventId, date);
+        if (!exists) {
+            routineCheckRepository.save(new RoutineCheck(memberId, recurringEventId, date));
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineController.java
@@ -2,6 +2,8 @@ package ds.project.orino.planner.google.routine;
 
 import ds.project.orino.common.response.ApiResponse;
 import ds.project.orino.core.time.UserTimeZone;
+import ds.project.orino.planner.google.routine.dto.RoutineCheckRequest;
+import ds.project.orino.planner.google.routine.dto.RoutineCheckResponse;
 import ds.project.orino.planner.google.routine.dto.RoutineCreateRequest;
 import ds.project.orino.planner.google.routine.dto.RoutineListResponse;
 import ds.project.orino.planner.google.routine.dto.RoutineSeriesSummary;
@@ -10,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,11 +28,14 @@ public class RoutineController {
 
     private final RoutineService routineService;
     private final RoutineQueryService routineQueryService;
+    private final RoutineCheckService routineCheckService;
 
     public RoutineController(RoutineService routineService,
-                             RoutineQueryService routineQueryService) {
+                             RoutineQueryService routineQueryService,
+                             RoutineCheckService routineCheckService) {
         this.routineService = routineService;
         this.routineQueryService = routineQueryService;
+        this.routineCheckService = routineCheckService;
     }
 
     @PostMapping
@@ -44,5 +50,15 @@ public class RoutineController {
     public ApiResponse<RoutineListResponse> list(@AuthenticationPrincipal Long memberId) {
         return ApiResponse.success(
                 new RoutineListResponse(routineQueryService.list(memberId, UserTimeZone.get())));
+    }
+
+    /** 습관 완료 체크 토글. schedule 루틴에 호출하면 400(체크 비대상). */
+    @PostMapping("/{recurringEventId}/check")
+    public ApiResponse<RoutineCheckResponse> check(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String recurringEventId,
+            @Valid @RequestBody RoutineCheckRequest request) {
+        return ApiResponse.success(
+                routineCheckService.toggle(memberId, recurringEventId, request.date(), request.done()));
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/dto/RoutineCheckRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/dto/RoutineCheckRequest.java
@@ -1,0 +1,17 @@
+package ds.project.orino.planner.google.routine.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+/**
+ * 습관 완료 체크 토글 요청.
+ *
+ * @param date 완료 인스턴스의 사용자 시간대 로컬 날짜("2026-06-20")
+ * @param done true=체크(upsert) / false=해제(delete)
+ */
+public record RoutineCheckRequest(
+        @NotNull LocalDate date,
+        boolean done
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/dto/RoutineCheckResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/dto/RoutineCheckResponse.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.google.routine.dto;
+
+import java.time.LocalDate;
+
+/**
+ * 습관 완료 체크 토글 결과.
+ */
+public record RoutineCheckResponse(
+        String recurringEventId,
+        LocalDate date,
+        boolean done
+) {
+}

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/024-create-routine-check.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/024-create-routine-check.yaml
@@ -1,0 +1,64 @@
+databaseChangeLog:
+  - changeSet:
+      id: 024-create-routine-check
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: routine_check
+      changes:
+        - createTable:
+            tableName: routine_check
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_routine_check_member
+                    references: member(id)
+              - column:
+                  name: recurring_event_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: instance_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: checked_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: routine_check
+            columnNames: member_id, recurring_event_id, instance_date
+            constraintName: uk_routine_check_instance
+        - createIndex:
+            tableName: routine_check
+            indexName: idx_routine_check_member_date
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: instance_date

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -45,3 +45,5 @@ databaseChangeLog:
       file: db/changelog/changes/022-review-schedule-datetime.yaml
   - include:
       file: db/changelog/changes/023-create-google-account.yaml
+  - include:
+      file: db/changelog/changes/024-create-routine-check.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RoutineCheckControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RoutineCheckControllerTest.java
@@ -1,0 +1,223 @@
+package ds.project.orino.planner.google.routine;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.domain.planner.routine.entity.RoutineCheck;
+import ds.project.orino.domain.planner.routine.repository.RoutineCheckRepository;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RoutineCheckControllerTest extends ApiTestSupport {
+
+    private static final String HABIT_MASTER = """
+            {"id":"r-habit-1","summary":"운동하기","start":{"date":"2026-06-20"},"end":{"date":"2026-06-21"},
+             "recurrence":["RRULE:FREQ=DAILY"],
+             "extendedProperties":{"private":{"orinoRoutine":"1","orinoRoutineType":"habit"}}}""";
+    private static final String SCHEDULE_MASTER = """
+            {"id":"r-sched-1","summary":"스탠드업",
+             "start":{"dateTime":"2026-06-20T00:00:00Z"},"end":{"dateTime":"2026-06-20T00:15:00Z"},
+             "recurrence":["RRULE:FREQ=DAILY"],
+             "extendedProperties":{"private":{"orinoRoutine":"1","orinoRoutineType":"schedule"}}}""";
+    /** 피드 GET: 2026-06-20 habit 인스턴스 1건. */
+    private static final String FEED_JSON = """
+            {"items":[{"id":"r-habit-1_20260620","summary":"운동하기","recurringEventId":"r-habit-1",
+             "start":{"date":"2026-06-20"},"end":{"date":"2026-06-21"},
+             "extendedProperties":{"private":{"orinoRoutine":"1","orinoRoutineType":"habit"}}}]}""";
+
+    private static final HttpServer EVENTS_STUB = createStub();
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private GoogleAccountRepository googleAccountRepository;
+    @Autowired
+    private GoogleAccessTokenRepository accessTokenRepository;
+    @Autowired
+    private RoutineCheckRepository routineCheckRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Long memberId;
+    private String authHeader;
+
+    @DynamicPropertySource
+    static void googleProperties(DynamicPropertyRegistry registry) {
+        String base = "http://127.0.0.1:" + EVENTS_STUB.getAddress().getPort();
+        registry.add("planner.google.client-id", () -> "test-client-id");
+        registry.add("planner.google.client-secret", () -> "test-client-secret");
+        registry.add("planner.google.oauth.calendar-api-base-url", () -> base);
+        registry.add("planner.google.oauth.tasks-api-base-url", () -> base);
+    }
+
+    @AfterAll
+    static void stopStub() {
+        EVENTS_STUB.stop(0);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberId = memberRepository.save(MemberFixture.create()).getId();
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    private void connectGoogle() {
+        googleAccountRepository.save(new GoogleAccount(
+                memberId, "refresh", "scope", "me@gmail.com", "primary", "@default"));
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+    }
+
+    private org.springframework.test.web.servlet.ResultActions check(String id, String body) throws Exception {
+        return mockMvc.perform(post("/api/planner/routines/{id}/check", id)
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body));
+    }
+
+    private org.springframework.test.web.servlet.ResultActions feed() throws Exception {
+        return mockMvc.perform(get("/api/planner/calendar")
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .param("from", "2026-06-01")
+                .param("to", "2026-06-30"));
+    }
+
+    @Test
+    @DisplayName("done=true 체크 후 통합 피드 인스턴스에 done=true가 반영된다")
+    void check_thenFeedShowsDone() throws Exception {
+        connectGoogle();
+
+        check("r-habit-1", "{\"date\":\"2026-06-20\",\"done\":true}")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recurringEventId").value("r-habit-1"))
+                .andExpect(jsonPath("$.data.date").value("2026-06-20"))
+                .andExpect(jsonPath("$.data.done").value(true));
+
+        assertThat(routineCheckRepository.existsByMemberIdAndRecurringEventIdAndInstanceDate(
+                memberId, "r-habit-1", LocalDate.of(2026, 6, 20))).isTrue();
+
+        feed()
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.events[0].routine.recurringEventId").value("r-habit-1"))
+                .andExpect(jsonPath("$.data.events[0].routine.done").value(true));
+    }
+
+    @Test
+    @DisplayName("done=false 해제 시 행이 삭제되고 피드 done=false")
+    void uncheck_removesRowAndFeedDoneFalse() throws Exception {
+        connectGoogle();
+        routineCheckRepository.save(new RoutineCheck(memberId, "r-habit-1", LocalDate.of(2026, 6, 20)));
+
+        check("r-habit-1", "{\"date\":\"2026-06-20\",\"done\":false}")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.done").value(false));
+
+        assertThat(routineCheckRepository.existsByMemberIdAndRecurringEventIdAndInstanceDate(
+                memberId, "r-habit-1", LocalDate.of(2026, 6, 20))).isFalse();
+
+        feed()
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.events[0].routine.done").value(false));
+    }
+
+    @Test
+    @DisplayName("schedule 루틴에 체크하면 400(체크 비대상)")
+    void check_schedule_returns400() throws Exception {
+        connectGoogle();
+
+        check("r-sched-1", "{\"date\":\"2026-06-20\",\"done\":true}")
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("미연동 상태면 409(PLN-ERR-003)")
+    void check_notConnected_409() throws Exception {
+        check("r-habit-1", "{\"date\":\"2026-06-20\",\"done\":true}")
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PLN-ERR-003"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 시리즈면 404")
+    void check_missingSeries_404() throws Exception {
+        connectGoogle();
+
+        check("r-missing", "{\"date\":\"2026-06-20\",\"done\":true}")
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("date가 없으면 400")
+    void check_validation() throws Exception {
+        connectGoogle();
+
+        check("r-habit-1", "{\"done\":true}")
+                .andExpect(status().isBadRequest());
+    }
+
+    private static HttpServer createStub() {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/calendar/v3/calendars/primary/events", RoutineCheckControllerTest::handleEvents);
+            server.createContext("/tasks/v1/lists/@default/tasks", exchange ->
+                    respond(exchange, 200, "{\"items\":[]}"));
+            server.start();
+            return server;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /** base 경로(GET)=피드 인스턴스, .../events/{id}(GET)=마스터 단건(getEvent), 모르는 id=404. */
+    private static void handleEvents(HttpExchange exchange) throws IOException {
+        String path = exchange.getRequestURI().getPath();
+        String suffix = path.substring(path.indexOf("/events") + "/events".length());
+        if (suffix.isEmpty() || suffix.equals("/")) {
+            respond(exchange, 200, FEED_JSON);
+            return;
+        }
+        String id = suffix.startsWith("/") ? suffix.substring(1) : suffix;
+        switch (id) {
+            case "r-habit-1" -> respond(exchange, 200, HABIT_MASTER);
+            case "r-sched-1" -> respond(exchange, 200, SCHEDULE_MASTER);
+            default -> respond(exchange, 404, "{\"error\":\"notFound\"}");
+        }
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 public class DbCleaner {
 
     private static final String[] TABLES_IN_FK_ORDER = {
+            "routine_check",
             "review_schedule",
             "flashcard",
             "note",

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/routine/entity/RoutineCheck.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/routine/entity/RoutineCheck.java
@@ -1,0 +1,97 @@
+package ds.project.orino.domain.planner.routine.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * 습관 루틴의 날짜별 완료 오버레이. 행의 존재 = 완료(체크), 부재 = 미완료.
+ *
+ * <p>Google이 진실 원천인 루틴 시리즈 위에 orino가 얹는 유일한 신규 테이블. 완료 boolean을 따로 두지 않고
+ * {@code (member_id, recurring_event_id, instance_date)} UNIQUE 행의 유무로 상태를 표현한다.
+ */
+@Entity
+@Table(
+        name = "routine_check",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_routine_check_instance",
+                columnNames = {"member_id", "recurring_event_id", "instance_date"}))
+@EntityListeners(AuditingEntityListener.class)
+public class RoutineCheck {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    /** Google 반복 이벤트의 recurringEventId(시리즈 안정 키). */
+    @Column(name = "recurring_event_id", nullable = false, length = 255)
+    private String recurringEventId;
+
+    /** 완료한 인스턴스의 날짜(사용자 시간대 로컬 날짜). */
+    @Column(name = "instance_date", nullable = false)
+    private LocalDate instanceDate;
+
+    /** 체크 시각(UTC). */
+    @Column(name = "checked_at", nullable = false)
+    private Instant checkedAt;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected RoutineCheck() {
+    }
+
+    public RoutineCheck(Long memberId, String recurringEventId, LocalDate instanceDate) {
+        this.memberId = memberId;
+        this.recurringEventId = recurringEventId;
+        this.instanceDate = instanceDate;
+        this.checkedAt = Instant.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public String getRecurringEventId() {
+        return recurringEventId;
+    }
+
+    public LocalDate getInstanceDate() {
+        return instanceDate;
+    }
+
+    public Instant getCheckedAt() {
+        return checkedAt;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/routine/repository/RoutineCheckRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/routine/repository/RoutineCheckRepository.java
@@ -1,0 +1,24 @@
+package ds.project.orino.domain.planner.routine.repository;
+
+import ds.project.orino.domain.planner.routine.entity.RoutineCheck;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface RoutineCheckRepository extends JpaRepository<RoutineCheck, Long> {
+
+    Optional<RoutineCheck> findByMemberIdAndRecurringEventIdAndInstanceDate(
+            Long memberId, String recurringEventId, LocalDate instanceDate);
+
+    boolean existsByMemberIdAndRecurringEventIdAndInstanceDate(
+            Long memberId, String recurringEventId, LocalDate instanceDate);
+
+    void deleteByMemberIdAndRecurringEventIdAndInstanceDate(
+            Long memberId, String recurringEventId, LocalDate instanceDate);
+
+    /** 통합 피드 done 조인용 batch 로드: [from, to] 구간의 완료 행을 한 번에 가져온다(N+1 회피). */
+    List<RoutineCheck> findByMemberIdAndInstanceDateBetween(
+            Long memberId, LocalDate from, LocalDate to);
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/routine/repository/RoutineCheckRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/routine/repository/RoutineCheckRepositoryTest.java
@@ -1,0 +1,74 @@
+package ds.project.orino.domain.planner.routine.repository;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.routine.entity.RoutineCheck;
+import ds.project.orino.domain.support.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RepositoryTest
+@Transactional
+class RoutineCheckRepositoryTest {
+
+    @Autowired
+    private RoutineCheckRepository routineCheckRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        memberId = memberRepository.save(new Member("routineuser", "encodedPassword")).getId();
+    }
+
+    @Test
+    @DisplayName("(member, recurringEventId, instanceDate) 중복 저장은 UNIQUE 위반")
+    void uniqueConstraint() {
+        routineCheckRepository.saveAndFlush(
+                new RoutineCheck(memberId, "r-1", LocalDate.of(2026, 6, 20)));
+
+        assertThatThrownBy(() -> routineCheckRepository.saveAndFlush(
+                new RoutineCheck(memberId, "r-1", LocalDate.of(2026, 6, 20))))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("findByMemberIdAndInstanceDateBetween은 구간 내 행만 batch 로드한다")
+    void findBetween() {
+        routineCheckRepository.save(new RoutineCheck(memberId, "r-1", LocalDate.of(2026, 6, 1)));
+        routineCheckRepository.save(new RoutineCheck(memberId, "r-1", LocalDate.of(2026, 6, 20)));
+        routineCheckRepository.save(new RoutineCheck(memberId, "r-2", LocalDate.of(2026, 7, 5)));
+
+        List<RoutineCheck> found = routineCheckRepository.findByMemberIdAndInstanceDateBetween(
+                memberId, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 30));
+
+        assertThat(found).hasSize(2)
+                .allSatisfy(c -> assertThat(c.getInstanceDate()).isBetween(
+                        LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 30)));
+    }
+
+    @Test
+    @DisplayName("delete 후 exists는 false")
+    void deleteAndExists() {
+        routineCheckRepository.saveAndFlush(
+                new RoutineCheck(memberId, "r-1", LocalDate.of(2026, 6, 20)));
+
+        routineCheckRepository.deleteByMemberIdAndRecurringEventIdAndInstanceDate(
+                memberId, "r-1", LocalDate.of(2026, 6, 20));
+
+        assertThat(routineCheckRepository.existsByMemberIdAndRecurringEventIdAndInstanceDate(
+                memberId, "r-1", LocalDate.of(2026, 6, 20))).isFalse();
+    }
+}


### PR DESCRIPTION
## 이슈
closes #578

## 작업 내용
- **Liquibase `024-create-routine-check`** — `routine_check` 테이블
  - `(member_id, recurring_event_id, instance_date)` UNIQUE + `(member_id, instance_date)` INDEX
  - 완료 boolean 없이 **행의 존재 = 완료** 오버레이(체크=upsert, 해제=delete)
- **`RoutineCheck` 엔티티 + `RoutineCheckRepository`** (JPA Auditing, domain-rdb)
- **`POST /api/planner/routines/{recurringEventId}/check`** `{date, done}`
  - `done=true` 멱등 upsert / `done=false` delete
  - habit 여부를 `getEvent`로 `orinoRoutineType` 태그 검증 → **schedule이면 400**(체크 비대상)
  - 없는 시리즈는 `getEvent` 404, 미연동은 토큰 단계 409
- **`GoogleCalendarClient.getEvent`** — raw 단건 조회(태그 판별용) 추가
- **통합 피드 done 조인** — 기간 내 `routine_check`를 batch 로드(N+1 회피)해 habit 인스턴스 `done` 오버레이
  - 피드 캐시는 `done=false` 원본을 저장하고 **매 요청 DB에서 done을 덮어쓰므로 체크 토글에 캐시 무효화 불필요**
  - 오버레이 실패가 피드 전체를 막지 않도록 폴백(원본 유지)
- `DbCleaner`에 `routine_check` 추가

## 검증
- `./gradlew :orino-domain-rdb:test :orino-app-api:test`(routine/calendar, MockMvc+TestContainers) ✅
- `./gradlew checkstyleMain checkstyleTest`(app-api, domain-rdb) ✅
- 통합 테스트: 체크→피드 done=true / 해제→행 삭제·done=false / schedule 400 / 미연동 409 / 없는 시리즈 404 / date 검증 400
- 리포지토리 테스트: UNIQUE 위반, `between` batch 로드, delete 후 exists=false
- 시간대: 요청 `date`(사용자 로컬)와 인스턴스 `start` 날짜가 동일 키로 매칭(X-Timezone Asia/Seoul)