### PR TITLE
feat : Routine 시리즈 편집/삭제 3-scope (R4)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
@@ -29,6 +29,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Google Calendar API 래퍼. {@code events.list}를 라이브 프록시하고 응답을 사용자 시간대로 정규화한다.
@@ -143,7 +144,7 @@ public class GoogleCalendarClient {
                 .build()
                 .toUri();
 
-        GoogleEventWriteBody body = toRoutineWriteBody(request, rule, type, zone);
+        GoogleEventWriteBody body = toRoutineWriteBody(request, rule, RoutineTag.privateProperties(type), zone);
         GoogleEventItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
                 googleRestClient.post()
                         .uri(uri)
@@ -162,7 +163,7 @@ public class GoogleCalendarClient {
     public PlannerEvent patchRoutineEvent(Long memberId, String eventId, EventRequest request,
                                           RecurrenceRule rule, RoutineType type, ZoneId zone) {
         URI uri = eventUri(eventId);
-        GoogleEventWriteBody body = toRoutineWriteBody(request, rule, type, zone);
+        GoogleEventWriteBody body = toRoutineWriteBody(request, rule, RoutineTag.privateProperties(type), zone);
         GoogleEventItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
                 googleRestClient.patch()
                         .uri(uri)
@@ -172,6 +173,65 @@ public class GoogleCalendarClient {
                         .retrieve()
                         .body(GoogleEventItem.class));
         return normalize(item, zone);
+    }
+
+    /**
+     * 마스터의 recurrence(RRULE)만 patch한다. start/end/내용은 건드리지 않는다(Google patch 병합).
+     * following 분할 시 마스터 UNTIL 절단에 쓴다.
+     */
+    public PlannerEvent patchEventRecurrence(Long memberId, String eventId, RecurrenceRule rule, ZoneId zone) {
+        URI uri = eventUri(eventId);
+        GoogleEventWriteBody body = new GoogleEventWriteBody(
+                null, null, null, null, null,
+                List.of(RecurrenceRuleFactory.toRRule(rule, zone)), null);
+        GoogleEventItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.patch()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(body)
+                        .retrieve()
+                        .body(GoogleEventItem.class));
+        return normalize(item, zone);
+    }
+
+    /**
+     * following 분할로 새 루틴 시리즈를 생성한다. 루틴 태그 + 분할 출처 마커({@code orinoRoutineSplitOf})를 함께
+     * 기록해 재시도 시 {@link #findForkedSeries}로 중복 생성을 막는다.
+     */
+    public PlannerEvent insertForkedSeries(Long memberId, EventRequest request, RecurrenceRule rule,
+                                           RoutineType type, String splitMarker, ZoneId zone) {
+        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
+                .path(PRIMARY_CALENDAR_PATH)
+                .build()
+                .toUri();
+
+        GoogleEventWriteBody body =
+                toRoutineWriteBody(request, rule, RoutineTag.splitProperties(type, splitMarker), zone);
+        GoogleEventItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.post()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(body)
+                        .retrieve()
+                        .body(GoogleEventItem.class));
+        return normalize(item, zone);
+    }
+
+    /** 주어진 분할 마커로 이미 생성된 forked 시리즈를 찾는다(idempotent 복구용). */
+    public Optional<GoogleEventItem> findForkedSeries(Long memberId, String splitMarker) {
+        return listRoutineMasters(memberId).stream()
+                .filter(item -> splitMarker.equals(splitMarkerOf(item)))
+                .findFirst();
+    }
+
+    private static String splitMarkerOf(GoogleEventItem item) {
+        if (item.extendedProperties() == null
+                || item.extendedProperties().privateProperties() == null) {
+            return null;
+        }
+        return item.extendedProperties().privateProperties().get(RoutineTag.KEY_SPLIT_OF);
     }
 
     /**
@@ -262,12 +322,11 @@ public class GoogleCalendarClient {
 
     /** 루틴 쓰기 바디: 기본 필드 + recurrence(RRULE) + 루틴 태그. rule이 null이면 recurrence는 비운다. */
     private GoogleEventWriteBody toRoutineWriteBody(EventRequest request, RecurrenceRule rule,
-                                                    RoutineType type, ZoneId zone) {
+                                                    Map<String, String> privateProps, ZoneId zone) {
         List<String> recurrence = rule == null
                 ? null
                 : List.of(RecurrenceRuleFactory.toRRule(rule, zone));
-        GoogleExtendedProperties extended =
-                GoogleExtendedProperties.ofPrivate(RoutineTag.privateProperties(type));
+        GoogleExtendedProperties extended = GoogleExtendedProperties.ofPrivate(privateProps);
         return new GoogleEventWriteBody(
                 request.title(), request.location(), request.description(),
                 startTime(request, zone), endTime(request, zone), recurrence, extended);

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineController.java
@@ -5,18 +5,25 @@ import ds.project.orino.core.time.UserTimeZone;
 import ds.project.orino.planner.google.routine.dto.RoutineCheckRequest;
 import ds.project.orino.planner.google.routine.dto.RoutineCheckResponse;
 import ds.project.orino.planner.google.routine.dto.RoutineCreateRequest;
+import ds.project.orino.planner.google.routine.dto.RoutineEditRequest;
 import ds.project.orino.planner.google.routine.dto.RoutineListResponse;
 import ds.project.orino.planner.google.routine.dto.RoutineSeriesSummary;
 import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 /**
  * 루틴(반복 이벤트) 시리즈 엔드포인트. 미연동 시 409(PLN-ERR-003).
@@ -29,13 +36,16 @@ public class RoutineController {
     private final RoutineService routineService;
     private final RoutineQueryService routineQueryService;
     private final RoutineCheckService routineCheckService;
+    private final RoutineSeriesService routineSeriesService;
 
     public RoutineController(RoutineService routineService,
                              RoutineQueryService routineQueryService,
-                             RoutineCheckService routineCheckService) {
+                             RoutineCheckService routineCheckService,
+                             RoutineSeriesService routineSeriesService) {
         this.routineService = routineService;
         this.routineQueryService = routineQueryService;
         this.routineCheckService = routineCheckService;
+        this.routineSeriesService = routineSeriesService;
     }
 
     @PostMapping
@@ -60,5 +70,31 @@ public class RoutineController {
             @Valid @RequestBody RoutineCheckRequest request) {
         return ApiResponse.success(
                 routineCheckService.toggle(memberId, recurringEventId, request.date(), request.done()));
+    }
+
+    /** 시리즈/인스턴스 편집. scope=all|following|instance, following/instance는 instanceDate 필요. */
+    @PatchMapping("/{eventId}")
+    public ApiResponse<RoutineSeriesSummary> edit(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String eventId,
+            @RequestParam String scope,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate instanceDate,
+            @Valid @RequestBody RoutineEditRequest request) {
+        return ApiResponse.success(routineSeriesService.edit(
+                memberId, eventId, RoutineScope.from(scope), instanceDate, request, UserTimeZone.get()));
+    }
+
+    /** 시리즈/인스턴스 삭제. scope=all|following|instance, following/instance는 instanceDate 필요. */
+    @DeleteMapping("/{eventId}")
+    public ApiResponse<Void> delete(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String eventId,
+            @RequestParam String scope,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate instanceDate) {
+        routineSeriesService.delete(
+                memberId, eventId, RoutineScope.from(scope), instanceDate, UserTimeZone.get());
+        return ApiResponse.success();
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineScope.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineScope.java
@@ -1,0 +1,34 @@
+package ds.project.orino.planner.google.routine;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+
+/**
+ * 시리즈 편집/삭제 적용 범위.
+ *
+ * <ul>
+ *   <li>{@link #ALL} — 전체 시리즈(마스터)</li>
+ *   <li>{@link #FOLLOWING} — 이 인스턴스 이후 모두(마스터 UNTIL 분할 + 새 시리즈)</li>
+ *   <li>{@link #INSTANCE} — 이 인스턴스 하나(예외 처리)</li>
+ * </ul>
+ *
+ * <p>{@link #FOLLOWING}·{@link #INSTANCE}는 {@code instanceDate}가 필요하다.
+ */
+public enum RoutineScope {
+    ALL,
+    FOLLOWING,
+    INSTANCE;
+
+    /** 쿼리 파라미터 문자열을 enum으로 파싱한다. 알 수 없으면 400. */
+    public static RoutineScope from(String scope) {
+        try {
+            return RoutineScope.valueOf(scope.trim().toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST, e);
+        }
+    }
+
+    public boolean requiresInstanceDate() {
+        return this == FOLLOWING || this == INSTANCE;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineSeriesService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineSeriesService.java
@@ -1,0 +1,184 @@
+package ds.project.orino.planner.google.routine;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.routine.repository.RoutineCheckRepository;
+import ds.project.orino.planner.google.calendar.dto.EventRequest;
+import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventItem;
+import ds.project.orino.planner.google.calendar.dto.PlannerEvent;
+import ds.project.orino.planner.google.client.GoogleCalendarClient;
+import ds.project.orino.planner.google.recurrence.RecurrenceRule;
+import ds.project.orino.planner.google.recurrence.RecurrenceRuleFactory;
+import ds.project.orino.planner.google.routine.dto.RoutineEditRequest;
+import ds.project.orino.planner.google.routine.dto.RoutineSeriesSummary;
+import ds.project.orino.redis.planner.google.GoogleCalendarCacheRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Map;
+
+/**
+ * 루틴 시리즈 편집/삭제 오케스트레이션 (3-scope: all / following / instance).
+ *
+ * <p>Google이 진실 원천이라 단일 호출이 없는 "이후 모두"는 ①마스터 RRULE {@code UNTIL}=분할 전날 절단 →
+ * ②새 시리즈 insert(태그 복사)의 2-step으로 처리한다. ②는 분할 마커로 멱등 복구되며(재시도 시 중복 생성 방지),
+ * 그 후 {@code routine_check}를 분할 경계로 이관/정리한다. 쓰기 후 통합 피드 캐시를 무효화한다.
+ */
+@Service
+public class RoutineSeriesService {
+
+    private final GoogleCalendarClient calendarClient;
+    private final RoutineCheckRepository routineCheckRepository;
+    private final GoogleCalendarCacheRepository cacheRepository;
+
+    public RoutineSeriesService(GoogleCalendarClient calendarClient,
+                                RoutineCheckRepository routineCheckRepository,
+                                GoogleCalendarCacheRepository cacheRepository) {
+        this.calendarClient = calendarClient;
+        this.routineCheckRepository = routineCheckRepository;
+        this.cacheRepository = cacheRepository;
+    }
+
+    @Transactional
+    public RoutineSeriesSummary edit(Long memberId, String eventId, RoutineScope scope,
+                                     LocalDate instanceDate, RoutineEditRequest request, ZoneId zone) {
+        requireInstanceDate(scope, instanceDate);
+        GoogleEventItem master = calendarClient.getEvent(memberId, eventId);
+        RoutineType type = requireRoutineType(master);
+        RecurrenceRule rule = RoutineRecurrenceMapper.toRule(request.recurrence());
+        EventRequest event = toEventRequest(request);
+
+        RoutineSeriesSummary summary = switch (scope) {
+            case ALL -> {
+                PlannerEvent updated =
+                        calendarClient.patchRoutineEvent(memberId, eventId, event, rule, type, zone);
+                yield summary(eventId, updated.title(), updated.allDay(),
+                        updated.start(), updated.end(), type, rule);
+            }
+            case INSTANCE -> {
+                String instanceId = resolveInstanceId(memberId, eventId, instanceDate, zone);
+                PlannerEvent updated = calendarClient.patchEvent(memberId, instanceId, event, zone);
+                yield summary(eventId, updated.title(), updated.allDay(),
+                        updated.start(), updated.end(), type, rule);
+            }
+            case FOLLOWING -> editFollowing(memberId, eventId, master, type, instanceDate, event, rule, zone);
+        };
+
+        cacheRepository.evictAll(memberId);
+        return summary;
+    }
+
+    @Transactional
+    public void delete(Long memberId, String eventId, RoutineScope scope,
+                       LocalDate instanceDate, ZoneId zone) {
+        requireInstanceDate(scope, instanceDate);
+
+        switch (scope) {
+            case ALL -> {
+                calendarClient.deleteEvent(memberId, eventId);
+                routineCheckRepository.deleteByMemberIdAndRecurringEventId(memberId, eventId);
+            }
+            case INSTANCE -> {
+                String instanceId = resolveInstanceId(memberId, eventId, instanceDate, zone);
+                calendarClient.deleteEvent(memberId, instanceId);
+                routineCheckRepository.deleteByMemberIdAndRecurringEventIdAndInstanceDate(
+                        memberId, eventId, instanceDate);
+            }
+            case FOLLOWING -> {
+                truncateMaster(memberId, eventId, instanceDate, zone);
+                routineCheckRepository.deleteByMemberIdAndRecurringEventIdAndInstanceDateGreaterThanEqual(
+                        memberId, eventId, instanceDate);
+            }
+            default -> throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        cacheRepository.evictAll(memberId);
+    }
+
+    /**
+     * 이후 모두 편집: ①마스터 UNTIL 절단 → ②새 시리즈 fork(마커로 멱등) → 체크 {@code >= instanceDate} 이관.
+     */
+    private RoutineSeriesSummary editFollowing(Long memberId, String masterId, GoogleEventItem master,
+                                               RoutineType type, LocalDate instanceDate,
+                                               EventRequest event, RecurrenceRule newRule, ZoneId zone) {
+        truncateMaster(memberId, masterId, master, instanceDate, zone);
+
+        String marker = RoutineTag.splitMarker(masterId, instanceDate.toString());
+        String newId = calendarClient.findForkedSeries(memberId, marker)
+                .map(GoogleEventItem::id)
+                .orElseGet(() -> calendarClient
+                        .insertForkedSeries(memberId, event, newRule, type, marker, zone).id());
+
+        routineCheckRepository.migrateFollowing(memberId, masterId, newId, instanceDate);
+
+        return summary(newId, event.title(), event.allDay(), event.start(), event.end(), type, newRule);
+    }
+
+    /** 마스터 recurrence의 UNTIL을 instanceDate 전날로 절단(idempotent). */
+    private void truncateMaster(Long memberId, String masterId, LocalDate instanceDate, ZoneId zone) {
+        truncateMaster(memberId, masterId, calendarClient.getEvent(memberId, masterId), instanceDate, zone);
+    }
+
+    private void truncateMaster(Long memberId, String masterId, GoogleEventItem master,
+                                LocalDate instanceDate, ZoneId zone) {
+        RecurrenceRule current = parseMasterRule(master);
+        RecurrenceRule truncated = new RecurrenceRule(current.freq(), current.interval(),
+                current.byDay(), current.byMonthDay(), instanceDate.minusDays(1));
+        calendarClient.patchEventRecurrence(memberId, masterId, truncated, zone);
+    }
+
+    private String resolveInstanceId(Long memberId, String masterId, LocalDate instanceDate, ZoneId zone) {
+        Instant timeMin = instanceDate.atStartOfDay(zone).toInstant();
+        Instant timeMax = instanceDate.plusDays(1).atStartOfDay(zone).toInstant();
+        return calendarClient.listInstances(memberId, masterId, timeMin, timeMax, zone).stream()
+                .filter(e -> e.start() != null && e.start().startsWith(instanceDate.toString()))
+                .findFirst()
+                .map(PlannerEvent::id)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    private RecurrenceRule parseMasterRule(GoogleEventItem master) {
+        if (master.recurrence() == null || master.recurrence().isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        return RecurrenceRuleFactory.parse(master.recurrence().get(0), ZoneId.of("UTC"));
+    }
+
+    private RoutineType requireRoutineType(GoogleEventItem master) {
+        Map<String, String> priv = master.extendedProperties() == null
+                ? null
+                : master.extendedProperties().privateProperties();
+        RoutineType type = RoutineTag.routineType(priv);
+        if (type == null) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        return type;
+    }
+
+    private void requireInstanceDate(RoutineScope scope, LocalDate instanceDate) {
+        if (scope.requiresInstanceDate() && instanceDate == null) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    private EventRequest toEventRequest(RoutineEditRequest request) {
+        return new EventRequest(request.title(), request.allDay(), request.start(), request.end(),
+                null, request.memo());
+    }
+
+    private RoutineSeriesSummary summary(String recurringEventId, String title, boolean allDay,
+                                         String start, String end, RoutineType type, RecurrenceRule rule) {
+        return new RoutineSeriesSummary(
+                recurringEventId,
+                type.code(),
+                title,
+                allDay,
+                start,
+                allDay ? null : end,
+                RoutineRecurrenceMapper.toDto(rule),
+                RecurrenceTextFormatter.toKorean(rule),
+                null);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineTag.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/RoutineTag.java
@@ -14,6 +14,8 @@ public final class RoutineTag {
     public static final String KEY_ROUTINE = "orinoRoutine";
     public static final String KEY_ROUTINE_TYPE = "orinoRoutineType";
     public static final String ROUTINE_FLAG = "1";
+    /** following 분할로 생성된 시리즈의 분할 출처 마커(idempotent 복구용): {@code {oldMasterId}@{instanceDate}}. */
+    public static final String KEY_SPLIT_OF = "orinoRoutineSplitOf";
 
     /** {@code events.list}의 privateExtendedProperty 필터 값: {@code orinoRoutine=1}. */
     public static final String LIST_FILTER = KEY_ROUTINE + "=" + ROUTINE_FLAG;
@@ -26,6 +28,19 @@ public final class RoutineTag {
         return Map.of(
                 KEY_ROUTINE, ROUTINE_FLAG,
                 KEY_ROUTINE_TYPE, type.code());
+    }
+
+    /** 분할 마커를 포함한 루틴 태그 맵. following 분할로 생성된 새 시리즈에 사용한다. */
+    public static Map<String, String> splitProperties(RoutineType type, String splitMarker) {
+        return Map.of(
+                KEY_ROUTINE, ROUTINE_FLAG,
+                KEY_ROUTINE_TYPE, type.code(),
+                KEY_SPLIT_OF, splitMarker);
+    }
+
+    /** following 분할 마커 값: {@code {oldMasterId}@{instanceDate}}. */
+    public static String splitMarker(String oldMasterId, String instanceDate) {
+        return oldMasterId + "@" + instanceDate;
     }
 
     /** private 프로퍼티 맵이 루틴 이벤트를 가리키는지(센티넬 보유) 판별한다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/dto/RoutineEditRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/routine/dto/RoutineEditRequest.java
@@ -1,0 +1,26 @@
+package ds.project.orino.planner.google.routine.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 루틴 시리즈/인스턴스 편집 요청. 편집 대상 범위(scope)와 무관하게 새 내용을 전체 재기술한다.
+ *
+ * <p>{@code instance} 범위에서는 {@code recurrence}가 무시된다(단일 occurrence 예외이므로).
+ *
+ * @param allDay     종일 여부
+ * @param start      종일이면 날짜, 아니면 datetime. following은 새 시리즈 시작(보통 instanceDate)
+ * @param end        종일이면 포함 마지막 날짜, 아니면 종료 datetime
+ * @param recurrence 반복 규칙(all/following에서 사용)
+ * @param memo       메모(Google description, null 가능)
+ */
+public record RoutineEditRequest(
+        @NotBlank String title,
+        boolean allDay,
+        @NotNull String start,
+        @NotNull String end,
+        @NotNull @Valid RoutineRecurrence recurrence,
+        String memo
+) {
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RoutineSeriesControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/routine/RoutineSeriesControllerTest.java
@@ -1,0 +1,297 @@
+package ds.project.orino.planner.google.routine;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.domain.planner.routine.entity.RoutineCheck;
+import ds.project.orino.domain.planner.routine.repository.RoutineCheckRepository;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RoutineSeriesControllerTest extends ApiTestSupport {
+
+    private static final String EMPTY_ITEMS = "{\"items\":[]}";
+    private static final String HABIT_MASTER = """
+            {"id":"r-habit-1","summary":"운동하기","start":{"date":"2026-06-20"},"end":{"date":"2026-06-21"},
+             "recurrence":["RRULE:FREQ=DAILY"],
+             "extendedProperties":{"private":{"orinoRoutine":"1","orinoRoutineType":"habit"}}}""";
+    /** PATCH 응답(편집 반영된 마스터/인스턴스). */
+    private static final String EDITED = """
+            {"id":"r-habit-1","summary":"운동하기(아침)","start":{"date":"2026-06-20"},"end":{"date":"2026-06-21"},
+             "recurrence":["RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"],
+             "extendedProperties":{"private":{"orinoRoutine":"1","orinoRoutineType":"habit"}}}""";
+    /** POST 응답(following 분할로 생성된 새 시리즈, 새 id). */
+    private static final String FORKED = """
+            {"id":"r-new-1","summary":"운동하기(아침)","start":{"date":"2026-06-20"},"end":{"date":"2026-06-21"},
+             "recurrence":["RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"],
+             "extendedProperties":{"private":{"orinoRoutine":"1","orinoRoutineType":"habit",
+               "orinoRoutineSplitOf":"r-habit-1@2026-06-20"}}}""";
+    /** GET .../instances 응답. */
+    private static final String INSTANCES = """
+            {"items":[{"id":"r-habit-1_20260620","summary":"운동하기","recurringEventId":"r-habit-1",
+             "start":{"date":"2026-06-20"},"end":{"date":"2026-06-21"},
+             "extendedProperties":{"private":{"orinoRoutine":"1","orinoRoutineType":"habit"}}}]}""";
+
+    private static final String EDIT_BODY = """
+            {"title":"운동하기(아침)","allDay":true,"start":"2026-06-20","end":"2026-06-20",
+             "recurrence":{"freq":"WEEKLY","byDay":["MO","WE","FR"]}}""";
+
+    private static final HttpServer EVENTS_STUB = createStub();
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private GoogleAccountRepository googleAccountRepository;
+    @Autowired
+    private GoogleAccessTokenRepository accessTokenRepository;
+    @Autowired
+    private RoutineCheckRepository routineCheckRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Long memberId;
+    private String authHeader;
+
+    @DynamicPropertySource
+    static void googleProperties(DynamicPropertyRegistry registry) {
+        String base = "http://127.0.0.1:" + EVENTS_STUB.getAddress().getPort();
+        registry.add("planner.google.client-id", () -> "test-client-id");
+        registry.add("planner.google.client-secret", () -> "test-client-secret");
+        registry.add("planner.google.oauth.calendar-api-base-url", () -> base);
+    }
+
+    @AfterAll
+    static void stopStub() {
+        EVENTS_STUB.stop(0);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberId = memberRepository.save(MemberFixture.create()).getId();
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    private void connectGoogle() {
+        googleAccountRepository.save(new GoogleAccount(
+                memberId, "refresh", "scope", "me@gmail.com", "primary", "@default"));
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+    }
+
+    private void seedCheck(String recurringEventId, LocalDate date) {
+        routineCheckRepository.save(new RoutineCheck(memberId, recurringEventId, date));
+    }
+
+    private boolean hasCheck(String recurringEventId, LocalDate date) {
+        return routineCheckRepository.existsByMemberIdAndRecurringEventIdAndInstanceDate(
+                memberId, recurringEventId, date);
+    }
+
+    private ResultActions editRoutine(String scope, String instanceDate) throws Exception {
+        var req = patch("/api/planner/routines/{id}", "r-habit-1")
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(EDIT_BODY)
+                .param("scope", scope);
+        if (instanceDate != null) {
+            req = req.param("instanceDate", instanceDate);
+        }
+        return mockMvc.perform(req);
+    }
+
+    private ResultActions deleteRoutine(String scope, String instanceDate) throws Exception {
+        var req = delete("/api/planner/routines/{id}", "r-habit-1")
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .param("scope", scope);
+        if (instanceDate != null) {
+            req = req.param("instanceDate", instanceDate);
+        }
+        return mockMvc.perform(req);
+    }
+
+    // ---------- EDIT ----------
+
+    @Test
+    @DisplayName("scope=all 편집 - 마스터를 수정하고 같은 시리즈 id로 요약을 반환한다")
+    void editAll() throws Exception {
+        connectGoogle();
+
+        editRoutine("all", null)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recurringEventId").value("r-habit-1"))
+                .andExpect(jsonPath("$.data.type").value("habit"))
+                .andExpect(jsonPath("$.data.title").value("운동하기(아침)"))
+                .andExpect(jsonPath("$.data.recurrence.freq").value("WEEKLY"))
+                .andExpect(jsonPath("$.data.recurrenceText").value("매주 월·수·금"));
+    }
+
+    @Test
+    @DisplayName("scope=instance 편집 - 인스턴스를 수정하고 마스터 id로 요약을 반환한다")
+    void editInstance() throws Exception {
+        connectGoogle();
+
+        editRoutine("instance", "2026-06-20")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recurringEventId").value("r-habit-1"))
+                .andExpect(jsonPath("$.data.title").value("운동하기(아침)"));
+    }
+
+    @Test
+    @DisplayName("scope=following 편집 - 분할 후 새 id 반환 + 체크가 경계로 분리된다")
+    void editFollowing() throws Exception {
+        connectGoogle();
+        seedCheck("r-habit-1", LocalDate.of(2026, 6, 15)); // 분할 전 → 유지
+        seedCheck("r-habit-1", LocalDate.of(2026, 6, 25)); // 분할 후 → 이관
+
+        editRoutine("following", "2026-06-20")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recurringEventId").value("r-new-1"));
+
+        assertThat(hasCheck("r-habit-1", LocalDate.of(2026, 6, 15))).isTrue();
+        assertThat(hasCheck("r-habit-1", LocalDate.of(2026, 6, 25))).isFalse();
+        assertThat(hasCheck("r-new-1", LocalDate.of(2026, 6, 25))).isTrue();
+    }
+
+    @Test
+    @DisplayName("following 편집인데 instanceDate가 없으면 400")
+    void edit_followingNoInstanceDate() throws Exception {
+        connectGoogle();
+
+        editRoutine("following", null).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("미연동이면 409(PLN-ERR-003)")
+    void edit_notConnected() throws Exception {
+        editRoutine("all", null)
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PLN-ERR-003"));
+    }
+
+    // ---------- DELETE ----------
+
+    @Test
+    @DisplayName("scope=all 삭제 - 마스터 삭제 + 시리즈 체크 전부 정리")
+    void deleteAll() throws Exception {
+        connectGoogle();
+        seedCheck("r-habit-1", LocalDate.of(2026, 6, 15));
+        seedCheck("r-habit-1", LocalDate.of(2026, 6, 25));
+
+        deleteRoutine("all", null).andExpect(status().isOk());
+
+        assertThat(hasCheck("r-habit-1", LocalDate.of(2026, 6, 15))).isFalse();
+        assertThat(hasCheck("r-habit-1", LocalDate.of(2026, 6, 25))).isFalse();
+    }
+
+    @Test
+    @DisplayName("scope=instance 삭제 - 해당 날짜 체크만 정리")
+    void deleteInstance() throws Exception {
+        connectGoogle();
+        seedCheck("r-habit-1", LocalDate.of(2026, 6, 20));
+        seedCheck("r-habit-1", LocalDate.of(2026, 6, 21));
+
+        deleteRoutine("instance", "2026-06-20").andExpect(status().isOk());
+
+        assertThat(hasCheck("r-habit-1", LocalDate.of(2026, 6, 20))).isFalse();
+        assertThat(hasCheck("r-habit-1", LocalDate.of(2026, 6, 21))).isTrue();
+    }
+
+    @Test
+    @DisplayName("scope=following 삭제 - instanceDate 이상 체크 정리(이전은 유지)")
+    void deleteFollowing() throws Exception {
+        connectGoogle();
+        seedCheck("r-habit-1", LocalDate.of(2026, 6, 15));
+        seedCheck("r-habit-1", LocalDate.of(2026, 6, 25));
+
+        deleteRoutine("following", "2026-06-20").andExpect(status().isOk());
+
+        assertThat(hasCheck("r-habit-1", LocalDate.of(2026, 6, 15))).isTrue();
+        assertThat(hasCheck("r-habit-1", LocalDate.of(2026, 6, 25))).isFalse();
+    }
+
+    @Test
+    @DisplayName("알 수 없는 scope면 400")
+    void delete_unknownScope() throws Exception {
+        connectGoogle();
+
+        deleteRoutine("bogus", null).andExpect(status().isBadRequest());
+    }
+
+    private static HttpServer createStub() {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/calendar/v3/calendars/primary/events", RoutineSeriesControllerTest::handle);
+            server.start();
+            return server;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void handle(HttpExchange exchange) throws IOException {
+        String path = exchange.getRequestURI().getPath();
+        String method = exchange.getRequestMethod();
+        String suffix = path.substring(path.indexOf("/events") + "/events".length());
+
+        if (suffix.isEmpty() || suffix.equals("/")) {
+            // base: POST=forked 시리즈 생성, GET=마스터 목록(findForkedSeries→없음)
+            respond(exchange, 200, "POST".equals(method) ? FORKED : EMPTY_ITEMS);
+            return;
+        }
+        String rest = suffix.startsWith("/") ? suffix.substring(1) : suffix;
+        if (rest.endsWith("/instances")) {
+            respond(exchange, 200, INSTANCES);
+            return;
+        }
+        // single id
+        switch (method) {
+            case "DELETE" -> respondNoBody(exchange);
+            case "PATCH" -> respond(exchange, 200, EDITED);
+            default -> respond(exchange, "r-habit-1".equals(rest) ? 200 : 404,
+                    "r-habit-1".equals(rest) ? HABIT_MASTER : "{\"error\":\"notFound\"}");
+        }
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    private static void respondNoBody(HttpExchange exchange) throws IOException {
+        exchange.sendResponseHeaders(204, -1);
+        exchange.close();
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/routine/repository/RoutineCheckRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/routine/repository/RoutineCheckRepository.java
@@ -2,6 +2,9 @@ package ds.project.orino.domain.planner.routine.repository;
 
 import ds.project.orino.domain.planner.routine.entity.RoutineCheck;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -21,4 +24,24 @@ public interface RoutineCheckRepository extends JpaRepository<RoutineCheck, Long
     /** 통합 피드 done 조인용 batch 로드: [from, to] 구간의 완료 행을 한 번에 가져온다(N+1 회피). */
     List<RoutineCheck> findByMemberIdAndInstanceDateBetween(
             Long memberId, LocalDate from, LocalDate to);
+
+    /** 시리즈 전체 삭제(scope=all)용 체크 정리. */
+    void deleteByMemberIdAndRecurringEventId(Long memberId, String recurringEventId);
+
+    /** 이후 모두(scope=following) 삭제용: instanceDate 이상 체크 정리. */
+    void deleteByMemberIdAndRecurringEventIdAndInstanceDateGreaterThanEqual(
+            Long memberId, String recurringEventId, LocalDate instanceDate);
+
+    /**
+     * following 편집 분할 시 체크 재키잉: {@code instanceDate} 이상 행을 새 시리즈 id로 이관한다.
+     * 이미 이관된 행(oldId에 없음)에 대해서는 no-op이라 재시도에 멱등하다.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("update RoutineCheck c set c.recurringEventId = :newId "
+            + "where c.memberId = :memberId and c.recurringEventId = :oldId "
+            + "and c.instanceDate >= :instanceDate")
+    int migrateFollowing(@Param("memberId") Long memberId,
+                         @Param("oldId") String oldId,
+                         @Param("newId") String newId,
+                         @Param("instanceDate") LocalDate instanceDate);
 }


### PR DESCRIPTION
## 이슈
closes #580

## 작업 내용
- **`PATCH` / `DELETE /api/planner/routines/{eventId}?scope=all|following|instance`**
  - `following`/`instance`는 `instanceDate`(YYYY-MM-DD) 필요 — 없으면 400
  - 알 수 없는 scope → 400, 미연동 → 409(PLN-ERR-003), 없는 시리즈 → 404
- **scope별 Google 매핑**
  - `all`: 마스터 `events.patch` / `events.delete`
  - `instance`: 인스턴스 id 해석(`events.instances`) 후 예외 patch / cancelled delete
  - `following`: ①마스터 RRULE `UNTIL`=분할 전날 절단 → ②새 시리즈 `events.insert`(태그 복사). 응답에 **새 `recurringEventId`**
- **following 2-step 멱등·실패 보정** — 새 시리즈에 분할 마커(`orinoRoutineSplitOf={oldId}@{date}`)를 기록하고, ②전에 `findForkedSeries`로 기존 fork를 찾아 재실행 시 중복 생성을 막음
- **`routine_check` 정리/이관**
  - delete: all=시리즈 전체 / instance=해당일 / following=`>= instanceDate`
  - following **edit**=`>= instanceDate` 행을 새 id로 이관(`migrateFollowing`, 멱등) → 과거(old id)/이후(new id) 자연 분리
- **클라이언트 확장** — `patchEventRecurrence`(UNTIL 절단), `insertForkedSeries`, `findForkedSeries`(마커 복구), `toRoutineWriteBody` privateProps 일반화
- `RoutineScope` enum, `RoutineEditRequest` DTO, 쓰기 후 `google:cal-cache:*` 무효화

## 검증
- `./gradlew :orino-domain-rdb:test :orino-app-api:test`(routine/calendar, MockMvc+TestContainers) ✅
- `./gradlew checkstyleMain checkstyleTest`(app-api, domain-rdb) ✅
- 통합 테스트: all/following/instance 편집·삭제 각 결과 / following 분할 후 **새 id + 체크 경계 분리·이관** / 미연동 409 / instanceDate 누락·알 수 없는 scope 400