### PR TITLE
feat : Routine 생성 폼 모달 (R1 FE)

### DIFF
--- a/fe/src/features/planner/api/routines.ts
+++ b/fe/src/features/planner/api/routines.ts
@@ -1,0 +1,53 @@
+import { client } from "@/shared/api";
+
+export type RoutineType = "habit" | "schedule";
+export type RoutineFreq = "DAILY" | "WEEKLY" | "MONTHLY";
+export type Weekday = "MO" | "TU" | "WE" | "TH" | "FR" | "SA" | "SU";
+
+export interface RoutineRecurrence {
+  freq: RoutineFreq;
+  interval?: number | null;
+  byDay?: Weekday[] | null;
+  byMonthDay?: number[] | null;
+  /** 종료일(포함) "2026-12-31". 없으면 무한 반복 */
+  until?: string | null;
+}
+
+export interface RoutineCreateRequest {
+  type: RoutineType;
+  title: string;
+  allDay: boolean;
+  /** 종일이면 "2026-06-20", 시간 루틴이면 로컬 "2026-06-20T07:00:00" */
+  start: string;
+  end: string;
+  recurrence: RoutineRecurrence;
+  memo: string | null;
+  color: string | null;
+}
+
+export interface RoutineSeriesSummary {
+  recurringEventId: string;
+  type: RoutineType;
+  title: string;
+  allDay: boolean;
+  start: string;
+  end?: string | null;
+  recurrence: RoutineRecurrence;
+  recurrenceText: string;
+  color?: string | null;
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export async function createRoutine(
+  request: RoutineCreateRequest,
+): Promise<RoutineSeriesSummary> {
+  const { data } = await client.post<ApiEnvelope<RoutineSeriesSummary>>(
+    "/planner/routines",
+    request,
+  );
+  return data.data;
+}

--- a/fe/src/features/planner/components/routine/RoutineFormDialog.test.tsx
+++ b/fe/src/features/planner/components/routine/RoutineFormDialog.test.tsx
@@ -1,0 +1,144 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithRouter } from "@/test/render";
+
+import { RoutineFormDialog } from "./RoutineFormDialog";
+
+const baseProps = {
+  open: true,
+  onOpenChange: () => {},
+  googleConnected: true,
+  defaultDate: "2026-06-20",
+} as const;
+
+describe("RoutineFormDialog", () => {
+  it("습관: 종일 매일 루틴 생성 payload", async () => {
+    const onSubmit = vi.fn();
+    renderWithRouter(<RoutineFormDialog {...baseProps} onSubmit={onSubmit} />);
+
+    await userEvent.type(screen.getByLabelText("제목"), "운동하기");
+    await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      type: "habit",
+      title: "운동하기",
+      allDay: true,
+      start: "2026-06-20",
+      end: "2026-06-20",
+      recurrence: { freq: "DAILY", until: null },
+      memo: null,
+      color: null,
+    });
+  });
+
+  it("일정: 고정 일정으로 바꾸면 시간 입력이 나오고 datetime payload", async () => {
+    const onSubmit = vi.fn();
+    renderWithRouter(<RoutineFormDialog {...baseProps} onSubmit={onSubmit} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "고정 일정" }));
+    await userEvent.type(screen.getByLabelText("제목"), "스탠드업");
+    await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "schedule",
+        allDay: false,
+        start: "2026-06-20T10:00:00",
+        end: "2026-06-20T11:00:00",
+      }),
+    );
+  });
+
+  it("주간: 선택 요일이 byDay로 매핑된다", async () => {
+    const onSubmit = vi.fn();
+    renderWithRouter(<RoutineFormDialog {...baseProps} onSubmit={onSubmit} />);
+
+    await userEvent.type(screen.getByLabelText("제목"), "운동하기");
+    await userEvent.click(screen.getByRole("button", { name: "주간" }));
+    await userEvent.click(screen.getByRole("button", { name: "월" }));
+    await userEvent.click(screen.getByRole("button", { name: "수" }));
+    await userEvent.click(screen.getByRole("button", { name: "금" }));
+    await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recurrence: { freq: "WEEKLY", byDay: ["MO", "WE", "FR"], until: null },
+      }),
+    );
+  });
+
+  it("매월: 추가한 일자가 byMonthDay로 매핑된다", async () => {
+    const onSubmit = vi.fn();
+    renderWithRouter(<RoutineFormDialog {...baseProps} onSubmit={onSubmit} />);
+
+    await userEvent.type(screen.getByLabelText("제목"), "정산");
+    await userEvent.click(screen.getByRole("button", { name: "매월" }));
+    await userEvent.type(screen.getByLabelText("일자 입력"), "15");
+    await userEvent.click(screen.getByRole("button", { name: "추가" }));
+    await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recurrence: { freq: "MONTHLY", byMonthDay: [15], until: null },
+      }),
+    );
+  });
+
+  it("N일 간격: interval로 매핑된다", async () => {
+    const onSubmit = vi.fn();
+    renderWithRouter(<RoutineFormDialog {...baseProps} onSubmit={onSubmit} />);
+
+    await userEvent.type(screen.getByLabelText("제목"), "물주기");
+    await userEvent.click(screen.getByRole("button", { name: "N일 간격" }));
+    await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recurrence: { freq: "DAILY", interval: 3, until: null },
+      }),
+    );
+  });
+
+  it("주간인데 요일이 없으면 저장이 비활성화된다", async () => {
+    renderWithRouter(<RoutineFormDialog {...baseProps} onSubmit={() => {}} />);
+
+    await userEvent.type(screen.getByLabelText("제목"), "운동하기");
+    await userEvent.click(screen.getByRole("button", { name: "주간" }));
+
+    expect(screen.getByRole("button", { name: "저장" })).toBeDisabled();
+  });
+
+  it("실시간 미리보기 라인이 갱신된다", async () => {
+    renderWithRouter(<RoutineFormDialog {...baseProps} onSubmit={() => {}} />);
+
+    expect(screen.getByTestId("routine-preview")).toHaveTextContent(
+      "매일 · 2026-06-20부터",
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "주간" }));
+    await userEvent.click(screen.getByRole("button", { name: "월" }));
+    await userEvent.click(screen.getByRole("button", { name: "금" }));
+
+    expect(screen.getByTestId("routine-preview")).toHaveTextContent(
+      "매주 월·금 · 2026-06-20부터",
+    );
+  });
+
+  it("미연동이면 연결 CTA를 보여주고 폼은 없다", () => {
+    renderWithRouter(
+      <RoutineFormDialog
+        {...baseProps}
+        googleConnected={false}
+        onSubmit={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Google 연결이 필요합니다.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Google 연결" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("제목")).not.toBeInTheDocument();
+  });
+});

--- a/fe/src/features/planner/components/routine/RoutineFormDialog.tsx
+++ b/fe/src/features/planner/components/routine/RoutineFormDialog.tsx
@@ -1,0 +1,421 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { useEffect, useId, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { DialogFooter } from "@/components/ui/dialog-footer";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { Textarea } from "@/components/ui/textarea";
+import { GoogleConnectButton } from "@/features/google/components/GoogleConnectButton";
+
+import type {
+  RoutineCreateRequest,
+  RoutineRecurrence,
+  RoutineType,
+  Weekday,
+} from "../../api/routines";
+import {
+  recurrencePreview,
+  WEEKDAY_KO,
+  WEEKDAYS,
+} from "../../routineRecurrence";
+
+/** 반복 세그먼트. NDAY는 freq=DAILY + interval=N으로 매핑된다. */
+type Segment = "DAILY" | "WEEKLY" | "MONTHLY" | "NDAY";
+
+const SEGMENTS: { value: Segment; label: string }[] = [
+  { value: "DAILY", label: "매일" },
+  { value: "WEEKLY", label: "주간" },
+  { value: "MONTHLY", label: "매월" },
+  { value: "NDAY", label: "N일 간격" },
+];
+
+interface FormState {
+  type: RoutineType;
+  title: string;
+  allDay: boolean;
+  startDate: string;
+  startTime: string;
+  endTime: string;
+  segment: Segment;
+  interval: number;
+  byDay: Weekday[];
+  byMonthDay: number[];
+  noEnd: boolean;
+  untilDate: string;
+  memo: string;
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  googleConnected: boolean;
+  /** 생성 시 기본 시작일(YYYY-MM-DD) */
+  defaultDate: string;
+  pending?: boolean;
+  onSubmit: (values: RoutineCreateRequest) => void;
+}
+
+function initialState(type: RoutineType, defaultDate: string): FormState {
+  return {
+    type,
+    title: "",
+    allDay: type === "habit",
+    startDate: defaultDate,
+    startTime: "10:00",
+    endTime: "11:00",
+    segment: "DAILY",
+    interval: 3,
+    byDay: [],
+    byMonthDay: [],
+    noEnd: true,
+    untilDate: "",
+    memo: "",
+  };
+}
+
+function buildRecurrence(form: FormState): RoutineRecurrence {
+  const until = form.noEnd ? null : form.untilDate || null;
+  switch (form.segment) {
+    case "DAILY":
+      return { freq: "DAILY", until };
+    case "NDAY":
+      return { freq: "DAILY", interval: form.interval, until };
+    case "WEEKLY":
+      return { freq: "WEEKLY", byDay: form.byDay, until };
+    case "MONTHLY":
+      return { freq: "MONTHLY", byMonthDay: form.byMonthDay, until };
+  }
+}
+
+export function RoutineFormDialog({
+  open,
+  onOpenChange,
+  googleConnected,
+  defaultDate,
+  pending = false,
+  onSubmit,
+}: Props) {
+  const titleId = useId();
+  const [form, setForm] = useState<FormState>(() =>
+    initialState("habit", defaultDate),
+  );
+  const [monthDayInput, setMonthDayInput] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setForm(initialState("habit", defaultDate));
+      setMonthDayInput("");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  const setType = (type: RoutineType) =>
+    setForm((prev) => ({ ...prev, type, allDay: type === "habit" }));
+
+  const toggleWeekday = (day: Weekday) =>
+    setForm((prev) => ({
+      ...prev,
+      byDay: prev.byDay.includes(day)
+        ? prev.byDay.filter((d) => d !== day)
+        : [...prev.byDay, day].sort(
+            (a, b) => WEEKDAYS.indexOf(a) - WEEKDAYS.indexOf(b),
+          ),
+    }));
+
+  const addMonthDay = (day: number) => {
+    if (!Number.isInteger(day) || day < 1 || day > 31) return;
+    setForm((prev) =>
+      prev.byMonthDay.includes(day)
+        ? prev
+        : {
+            ...prev,
+            byMonthDay: [...prev.byMonthDay, day].sort((a, b) => a - b),
+          },
+    );
+    setMonthDayInput("");
+  };
+
+  const removeMonthDay = (day: number) =>
+    set(
+      "byMonthDay",
+      form.byMonthDay.filter((d) => d !== day),
+    );
+
+  const recurrence = buildRecurrence(form);
+  const start = form.allDay
+    ? form.startDate
+    : `${form.startDate}T${form.startTime}:00`;
+  const end = form.allDay
+    ? form.startDate
+    : `${form.startDate}T${form.endTime}:00`;
+
+  const recurrenceValid =
+    (form.segment !== "WEEKLY" || form.byDay.length > 0) &&
+    (form.segment !== "MONTHLY" || form.byMonthDay.length > 0) &&
+    (form.segment !== "NDAY" || form.interval >= 1);
+  const valid =
+    form.title.trim().length > 0 &&
+    !!form.startDate &&
+    recurrenceValid &&
+    (form.noEnd || (!!form.untilDate && form.untilDate >= form.startDate)) &&
+    (form.allDay || form.endTime > form.startTime);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!valid || pending) return;
+    onSubmit({
+      type: form.type,
+      title: form.title.trim(),
+      allDay: form.allDay,
+      start,
+      end,
+      recurrence,
+      memo: form.memo.trim() || null,
+      color: null,
+    });
+  };
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange} className="max-w-md">
+      <Dialog.Title className="text-base font-semibold">새 루틴</Dialog.Title>
+
+      {!googleConnected ? (
+        <div className="mt-4 flex flex-col gap-4">
+          <p className="text-muted-foreground text-sm">
+            Google 연결이 필요합니다.
+          </p>
+          <DialogFooter className="mt-0">
+            <Dialog.Close
+              render={
+                <Button variant="ghost" type="button">
+                  닫기
+                </Button>
+              }
+            />
+            <GoogleConnectButton />
+          </DialogFooter>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3">
+          <FormField label="종류">
+            <div className="flex gap-2">
+              {(
+                [
+                  { value: "habit", label: "습관(체크형)" },
+                  { value: "schedule", label: "고정 일정" },
+                ] as const
+              ).map((opt) => (
+                <Button
+                  key={opt.value}
+                  type="button"
+                  variant={form.type === opt.value ? "default" : "outline"}
+                  aria-pressed={form.type === opt.value}
+                  onClick={() => setType(opt.value)}
+                >
+                  {opt.label}
+                </Button>
+              ))}
+            </div>
+          </FormField>
+
+          <FormField label="제목" htmlFor={titleId}>
+            <Input
+              id={titleId}
+              value={form.title}
+              onChange={(e) => set("title", e.target.value)}
+              placeholder="운동하기"
+              autoFocus
+            />
+          </FormField>
+
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={form.allDay}
+              onChange={(e) => set("allDay", e.target.checked)}
+            />
+            종일
+          </label>
+
+          {!form.allDay && (
+            <FormField label="시간">
+              <div className="flex items-center gap-2">
+                <Input
+                  type="time"
+                  aria-label="시작 시간"
+                  value={form.startTime}
+                  onChange={(e) => set("startTime", e.target.value)}
+                />
+                <span className="text-muted-foreground">~</span>
+                <Input
+                  type="time"
+                  aria-label="종료 시간"
+                  value={form.endTime}
+                  onChange={(e) => set("endTime", e.target.value)}
+                />
+              </div>
+            </FormField>
+          )}
+
+          <FormField label="반복">
+            <div className="flex flex-wrap gap-2">
+              {SEGMENTS.map((seg) => (
+                <Button
+                  key={seg.value}
+                  type="button"
+                  size="sm"
+                  variant={form.segment === seg.value ? "default" : "outline"}
+                  aria-pressed={form.segment === seg.value}
+                  onClick={() => set("segment", seg.value)}
+                >
+                  {seg.label}
+                </Button>
+              ))}
+            </div>
+          </FormField>
+
+          {form.segment === "WEEKLY" && (
+            <FormField label="요일">
+              <div className="flex gap-1">
+                {WEEKDAYS.map((day) => (
+                  <Button
+                    key={day}
+                    type="button"
+                    size="sm"
+                    className="flex-1 px-0"
+                    variant={form.byDay.includes(day) ? "default" : "outline"}
+                    aria-pressed={form.byDay.includes(day)}
+                    aria-label={WEEKDAY_KO[day]}
+                    onClick={() => toggleWeekday(day)}
+                  >
+                    {WEEKDAY_KO[day]}
+                  </Button>
+                ))}
+              </div>
+            </FormField>
+          )}
+
+          {form.segment === "MONTHLY" && (
+            <FormField label="일자">
+              <div className="flex flex-col gap-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Input
+                    type="number"
+                    min={1}
+                    max={31}
+                    aria-label="일자 입력"
+                    className="w-20"
+                    value={monthDayInput}
+                    onChange={(e) => setMonthDayInput(e.target.value)}
+                  />
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => addMonthDay(Number(monthDayInput))}
+                  >
+                    추가
+                  </Button>
+                </div>
+                {form.byMonthDay.length > 0 && (
+                  <div className="flex flex-wrap gap-1">
+                    {form.byMonthDay.map((day) => (
+                      <Button
+                        key={day}
+                        type="button"
+                        size="sm"
+                        variant="secondary"
+                        aria-label={`${day}일 제거`}
+                        onClick={() => removeMonthDay(day)}
+                      >
+                        {day}일 ✕
+                      </Button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </FormField>
+          )}
+
+          {form.segment === "NDAY" && (
+            <FormField label="간격">
+              <div className="flex items-center gap-2">
+                <Input
+                  type="number"
+                  min={1}
+                  aria-label="간격 일수"
+                  className="w-20"
+                  value={form.interval}
+                  onChange={(e) => set("interval", Number(e.target.value))}
+                />
+                <span className="text-muted-foreground text-sm">일마다</span>
+              </div>
+            </FormField>
+          )}
+
+          <FormField label="시작">
+            <Input
+              type="date"
+              aria-label="시작 날짜"
+              value={form.startDate}
+              onChange={(e) => set("startDate", e.target.value)}
+            />
+          </FormField>
+
+          <FormField label="종료">
+            <div className="flex items-center gap-2">
+              <label className="flex items-center gap-2 text-sm">
+                <Checkbox
+                  checked={form.noEnd}
+                  onChange={(e) => set("noEnd", e.target.checked)}
+                />
+                없음
+              </label>
+              {!form.noEnd && (
+                <Input
+                  type="date"
+                  aria-label="종료 날짜"
+                  value={form.untilDate}
+                  onChange={(e) => set("untilDate", e.target.value)}
+                />
+              )}
+            </div>
+          </FormField>
+
+          <FormField label="메모 (선택)">
+            <Textarea
+              rows={2}
+              value={form.memo}
+              onChange={(e) => set("memo", e.target.value)}
+            />
+          </FormField>
+
+          <p
+            className="text-muted-foreground text-sm"
+            data-testid="routine-preview"
+          >
+            {recurrencePreview(recurrence, form.startDate)}
+          </p>
+
+          <DialogFooter className="mt-1">
+            <Dialog.Close
+              render={
+                <Button variant="ghost" type="button" disabled={pending}>
+                  취소
+                </Button>
+              }
+            />
+            <Button type="submit" disabled={!valid || pending}>
+              {pending ? "저장 중..." : "저장"}
+            </Button>
+          </DialogFooter>
+        </form>
+      )}
+    </Modal>
+  );
+}

--- a/fe/src/features/planner/hooks/useRoutineMutations.test.tsx
+++ b/fe/src/features/planner/hooks/useRoutineMutations.test.tsx
@@ -1,0 +1,77 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { RoutineFormDialog } from "@/features/planner/components/routine/RoutineFormDialog";
+import { useToastStore } from "@/shared/lib/toast";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { useCreateRoutine } from "./useRoutineMutations";
+
+const ROUTINES_URL = "https://api.orino.dev/api/planner/routines";
+
+function Harness() {
+  const mutation = useCreateRoutine();
+  return (
+    <RoutineFormDialog
+      open
+      onOpenChange={() => {}}
+      googleConnected
+      defaultDate="2026-06-20"
+      pending={mutation.isPending}
+      onSubmit={(values) => mutation.mutate(values)}
+    />
+  );
+}
+
+describe("useCreateRoutine (RTL + MSW)", () => {
+  it("주간 습관 생성 시 POST 본문을 보내고 성공 토스트를 띄운다", async () => {
+    let captured: unknown;
+    server.use(
+      http.post(ROUTINES_URL, async ({ request }) => {
+        captured = await request.json();
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            recurringEventId: "r-1",
+            type: "habit",
+            title: "운동하기",
+            allDay: true,
+            start: "2026-06-20",
+            recurrence: { freq: "WEEKLY", byDay: ["MO", "WE", "FR"] },
+            recurrenceText: "매주 월·수·금",
+          },
+        });
+      }),
+    );
+
+    renderWithRouter(<Harness />);
+
+    await userEvent.type(screen.getByLabelText("제목"), "운동하기");
+    await userEvent.click(screen.getByRole("button", { name: "주간" }));
+    await userEvent.click(screen.getByRole("button", { name: "월" }));
+    await userEvent.click(screen.getByRole("button", { name: "수" }));
+    await userEvent.click(screen.getByRole("button", { name: "금" }));
+    await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() => expect(captured).toBeDefined());
+    expect(captured).toEqual({
+      type: "habit",
+      title: "운동하기",
+      allDay: true,
+      start: "2026-06-20",
+      end: "2026-06-20",
+      recurrence: { freq: "WEEKLY", byDay: ["MO", "WE", "FR"], until: null },
+      memo: null,
+      color: null,
+    });
+
+    await waitFor(() =>
+      expect(
+        useToastStore.getState().toasts.some((t) => t.variant === "success"),
+      ).toBe(true),
+    );
+  });
+});

--- a/fe/src/features/planner/hooks/useRoutineMutations.ts
+++ b/fe/src/features/planner/hooks/useRoutineMutations.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { toast } from "@/shared/lib/toast";
+
+import { createRoutine } from "../api/routines";
+import { plannerKeys, routineKeys } from "../queryKeys";
+
+/**
+ * 루틴 생성 후 시리즈 목록과 통합 피드를 invalidate해 갱신한다(서버가 캐시를 무효화하므로 재조회로 최신화).
+ */
+export function useCreateRoutine() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createRoutine,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: routineKeys.all });
+      queryClient.invalidateQueries({ queryKey: plannerKeys.all });
+      toast("루틴을 저장했습니다.", "success");
+    },
+    onError: () => toast("루틴 저장에 실패했습니다.", "error"),
+  });
+}

--- a/fe/src/features/planner/queryKeys.ts
+++ b/fe/src/features/planner/queryKeys.ts
@@ -3,3 +3,8 @@ export const plannerKeys = {
   calendar: (from: string, to: string) =>
     ["planner", "calendar", from, to] as const,
 };
+
+export const routineKeys = {
+  all: ["routine"] as const,
+  list: () => ["routine", "list"] as const,
+};

--- a/fe/src/features/planner/routineRecurrence.test.ts
+++ b/fe/src/features/planner/routineRecurrence.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { recurrencePreview, recurrenceText } from "./routineRecurrence";
+
+describe("recurrenceText", () => {
+  it("매일 / N일마다", () => {
+    expect(recurrenceText({ freq: "DAILY" })).toBe("매일");
+    expect(recurrenceText({ freq: "DAILY", interval: 3 })).toBe("3일마다");
+  });
+
+  it("매주 요일 / N주마다", () => {
+    expect(recurrenceText({ freq: "WEEKLY", byDay: ["MO", "WE", "FR"] })).toBe(
+      "매주 월·수·금",
+    );
+    expect(recurrenceText({ freq: "WEEKLY", interval: 2, byDay: ["TU"] })).toBe(
+      "2주마다 화",
+    );
+  });
+
+  it("매월 일자 / N개월마다", () => {
+    expect(recurrenceText({ freq: "MONTHLY", byMonthDay: [1, 15] })).toBe(
+      "매월 1·15일",
+    );
+    expect(
+      recurrenceText({ freq: "MONTHLY", interval: 3, byMonthDay: [1] }),
+    ).toBe("3개월마다 1일");
+  });
+});
+
+describe("recurrencePreview", () => {
+  it("시작일과 종료일을 덧붙인다", () => {
+    expect(
+      recurrencePreview(
+        { freq: "WEEKLY", byDay: ["MO", "WE", "FR"] },
+        "2026-06-20",
+      ),
+    ).toBe("매주 월·수·금 · 2026-06-20부터");
+
+    expect(
+      recurrencePreview({ freq: "DAILY", until: "2026-12-31" }, "2026-06-20"),
+    ).toBe("매일 · 2026-06-20부터 ~ 2026-12-31까지");
+  });
+});

--- a/fe/src/features/planner/routineRecurrence.ts
+++ b/fe/src/features/planner/routineRecurrence.ts
@@ -1,0 +1,48 @@
+import type { RoutineRecurrence, Weekday } from "./api/routines";
+
+/** 요일 표시 순서(월~일). */
+export const WEEKDAYS: Weekday[] = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"];
+
+export const WEEKDAY_KO: Record<Weekday, string> = {
+  MO: "월",
+  TU: "화",
+  WE: "수",
+  TH: "목",
+  FR: "금",
+  SA: "토",
+  SU: "일",
+};
+
+/** 반복 규칙을 한국어 표시 문구로 변환한다(예: "매주 월·수·금", "3일마다", "매월 1·15일"). */
+export function recurrenceText(recurrence: RoutineRecurrence): string {
+  const interval =
+    recurrence.interval && recurrence.interval > 1 ? recurrence.interval : 1;
+
+  switch (recurrence.freq) {
+    case "DAILY":
+      return interval === 1 ? "매일" : `${interval}일마다`;
+    case "WEEKLY": {
+      const prefix = interval === 1 ? "매주" : `${interval}주마다`;
+      const days = (recurrence.byDay ?? []).map((d) => WEEKDAY_KO[d]).join("·");
+      return days ? `${prefix} ${days}` : prefix;
+    }
+    case "MONTHLY": {
+      const prefix = interval === 1 ? "매월" : `${interval}개월마다`;
+      const days = recurrence.byMonthDay ?? [];
+      return days.length ? `${prefix} ${days.join("·")}일` : prefix;
+    }
+  }
+}
+
+/** 폼 미리보기 라인: "매주 월·수·금 · 2026-06-20부터 ~ 2026-12-31까지". */
+export function recurrencePreview(
+  recurrence: RoutineRecurrence,
+  startDate: string,
+): string {
+  const parts = [recurrenceText(recurrence)];
+  if (startDate) {
+    const until = recurrence.until ? ` ~ ${recurrence.until}까지` : "";
+    parts.push(`${startDate}부터${until}`);
+  }
+  return parts.join(" · ");
+}


### PR DESCRIPTION
## 이슈
closes #575

## 작업 내용
- **`RoutineFormDialog`** — 새 루틴 생성 모달 ([UI Design §2](https://github.com/wcorn/orino/wiki/Routine-UI-Design))
  - 종류 토글(습관/일정 — 습관은 종일 기본 on, 일정은 시간 입력 노출)
  - 종일 토글 / 시간 입력(시작~종료)
  - 반복 세그먼트: 매일 · 주간 · 매월 · N일 간격
    - 주간: 요일 멀티토글(월~일 한 줄)
    - 매월: 일자 멀티입력(추가/제거 칩)
    - N일: 간격 입력
  - 시작일 / 종료(없음 토글 + 날짜)
  - **실시간 한글 미리보기 라인**("매주 월·수·금 · 2026-06-20부터")
  - 유효성: 주간 요일·매월 일자 최소 1개, N일 간격 ≥1, 종료일 ≥ 시작일, 시간 일정은 종료 > 시작
  - 미연동 시 "Google 연결이 필요합니다" + 연결 CTA
- **API/훅** — `api/routines.ts`(`POST /planner/routines`), `useCreateRoutine`(성공 토스트 + 시리즈/피드 invalidate)
- **`routineRecurrence`** — 한글 요약/미리보기 포매터(BE `RecurrenceTextFormatter`와 동일 규칙)

## 검증
- `npm test`(RTL): 습관/일정/주간/매월/N일 **payload 검증**, 미리보기 갱신, 주간 요일 미선택 시 저장 비활성, 미연동 CTA
- RTL + MSW: 주간 습관 생성 플로우 → `POST /planner/routines` 본문 검증 + 성공 토스트
- 단위 테스트: 한글 요약/미리보기 포매터
- `npm run lint` / `format:check` / `tsc --noEmit` ✅, planner 전체 43 테스트 통과