### PR TITLE
feat : Routine 관리 화면 (R2 FE)

### DIFF
--- a/fe/src/app/layout/Sidebar.tsx
+++ b/fe/src/app/layout/Sidebar.tsx
@@ -1,4 +1,11 @@
-import { BookOpen, Calendar, CheckSquare, Home, Settings } from "lucide-react";
+import {
+  BookOpen,
+  Calendar,
+  CheckSquare,
+  Home,
+  Repeat,
+  Settings,
+} from "lucide-react";
 import { NavLink } from "react-router-dom";
 
 import { useTodayReviews } from "@/features/review/hooks/useTodayReviews";
@@ -15,6 +22,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/planner/materials", label: "학습 자료", icon: BookOpen },
   { to: "/planner/reviews/today", label: "오늘 복습", icon: CheckSquare },
   { to: "/planner/calendar", label: "캘린더", icon: Calendar },
+  { to: "/planner/routines", label: "루틴", icon: Repeat },
   { to: "/planner/settings", label: "연동 설정", icon: Settings },
 ];
 

--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -24,6 +24,10 @@ export const importPlannerSettings = () =>
   import("../pages/planner/PlannerSettingsPage").then((m) => ({
     default: m.PlannerSettingsPage,
   }));
+export const importRoutines = () =>
+  import("../pages/planner/RoutinesPage").then((m) => ({
+    default: m.RoutinesPage,
+  }));
 
 /**
  * 로그인 후 idle 시간에 페이지 청크를 미리 받아둔다.

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -15,6 +15,7 @@ import {
   importMaterialList,
   importPlannerCalendar,
   importPlannerSettings,
+  importRoutines,
   importTodayReviews,
 } from "./routeImports";
 
@@ -26,6 +27,7 @@ const MaterialDetailPage = lazy(importMaterialDetail);
 const TodayReviewsPage = lazy(importTodayReviews);
 const PlannerCalendarPage = lazy(importPlannerCalendar);
 const PlannerSettingsPage = lazy(importPlannerSettings);
+const RoutinesPage = lazy(importRoutines);
 
 function RouteFallback() {
   return <LoadingText className="p-6" />;
@@ -77,6 +79,14 @@ export function AppRouter() {
             element={
               <Suspense fallback={<RouteFallback />}>
                 <PlannerCalendarPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/planner/routines"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <RoutinesPage />
               </Suspense>
             }
           />

--- a/fe/src/features/planner/api/routines.ts
+++ b/fe/src/features/planner/api/routines.ts
@@ -37,9 +37,29 @@ export interface RoutineSeriesSummary {
   color?: string | null;
 }
 
+/** 편집/삭제 적용 범위. following/instance는 instanceDate가 필요하다. */
+export type RoutineScope = "all" | "following" | "instance";
+
+export interface RoutineEditRequest {
+  title: string;
+  allDay: boolean;
+  start: string;
+  end: string;
+  recurrence: RoutineRecurrence;
+  memo: string | null;
+}
+
 interface ApiEnvelope<T> {
   code: string;
   data: T;
+}
+
+export async function listRoutines(): Promise<RoutineSeriesSummary[]> {
+  const { data } =
+    await client.get<ApiEnvelope<{ routines: RoutineSeriesSummary[] }>>(
+      "/planner/routines",
+    );
+  return data.data.routines;
 }
 
 export async function createRoutine(
@@ -50,4 +70,31 @@ export async function createRoutine(
     request,
   );
   return data.data;
+}
+
+interface ScopeParams {
+  scope: RoutineScope;
+  instanceDate?: string;
+}
+
+export async function updateRoutine(
+  eventId: string,
+  request: RoutineEditRequest,
+  { scope, instanceDate }: ScopeParams,
+): Promise<RoutineSeriesSummary> {
+  const { data } = await client.patch<ApiEnvelope<RoutineSeriesSummary>>(
+    `/planner/routines/${eventId}`,
+    request,
+    { params: { scope, instanceDate } },
+  );
+  return data.data;
+}
+
+export async function deleteRoutine(
+  eventId: string,
+  { scope, instanceDate }: ScopeParams,
+): Promise<void> {
+  await client.delete(`/planner/routines/${eventId}`, {
+    params: { scope, instanceDate },
+  });
 }

--- a/fe/src/features/planner/components/routine/RoutineFormDialog.tsx
+++ b/fe/src/features/planner/components/routine/RoutineFormDialog.tsx
@@ -13,6 +13,7 @@ import { GoogleConnectButton } from "@/features/google/components/GoogleConnectB
 import type {
   RoutineCreateRequest,
   RoutineRecurrence,
+  RoutineSeriesSummary,
   RoutineType,
   Weekday,
 } from "../../api/routines";
@@ -54,6 +55,8 @@ interface Props {
   googleConnected: boolean;
   /** 생성 시 기본 시작일(YYYY-MM-DD) */
   defaultDate: string;
+  /** 편집 대상 시리즈. 있으면 편집 모드(폼 prefill, 종류 변경 불가). */
+  series?: RoutineSeriesSummary;
   pending?: boolean;
   onSubmit: (values: RoutineCreateRequest) => void;
 }
@@ -72,6 +75,32 @@ function initialState(type: RoutineType, defaultDate: string): FormState {
     byMonthDay: [],
     noEnd: true,
     untilDate: "",
+    memo: "",
+  };
+}
+
+/** 시리즈 요약(파싱된 recurrence 포함)을 폼 상태로 역매핑한다(편집 prefill). */
+function stateFromSeries(series: RoutineSeriesSummary): FormState {
+  const r = series.recurrence;
+  const interval = r.interval ?? 1;
+  let segment: Segment = "DAILY";
+  if (r.freq === "WEEKLY") segment = "WEEKLY";
+  else if (r.freq === "MONTHLY") segment = "MONTHLY";
+  else if (interval > 1) segment = "NDAY";
+
+  return {
+    type: series.type,
+    title: series.title,
+    allDay: series.allDay,
+    startDate: series.start.slice(0, 10),
+    startTime: series.allDay ? "10:00" : series.start.slice(11, 16) || "10:00",
+    endTime: series.end ? series.end.slice(11, 16) || "11:00" : "11:00",
+    segment,
+    interval: interval > 1 ? interval : 3,
+    byDay: r.byDay ?? [],
+    byMonthDay: r.byMonthDay ?? [],
+    noEnd: !r.until,
+    untilDate: r.until ?? "",
     memo: "",
   };
 }
@@ -95,18 +124,22 @@ export function RoutineFormDialog({
   onOpenChange,
   googleConnected,
   defaultDate,
+  series,
   pending = false,
   onSubmit,
 }: Props) {
+  const editing = !!series;
   const titleId = useId();
   const [form, setForm] = useState<FormState>(() =>
-    initialState("habit", defaultDate),
+    series ? stateFromSeries(series) : initialState("habit", defaultDate),
   );
   const [monthDayInput, setMonthDayInput] = useState("");
 
   useEffect(() => {
     if (open) {
-      setForm(initialState("habit", defaultDate));
+      setForm(
+        series ? stateFromSeries(series) : initialState("habit", defaultDate),
+      );
       setMonthDayInput("");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -183,7 +216,9 @@ export function RoutineFormDialog({
 
   return (
     <Modal open={open} onOpenChange={onOpenChange} className="max-w-md">
-      <Dialog.Title className="text-base font-semibold">새 루틴</Dialog.Title>
+      <Dialog.Title className="text-base font-semibold">
+        {editing ? "루틴 편집" : "새 루틴"}
+      </Dialog.Title>
 
       {!googleConnected ? (
         <div className="mt-4 flex flex-col gap-4">
@@ -216,6 +251,7 @@ export function RoutineFormDialog({
                   type="button"
                   variant={form.type === opt.value ? "default" : "outline"}
                   aria-pressed={form.type === opt.value}
+                  disabled={editing}
                   onClick={() => setType(opt.value)}
                 >
                   {opt.label}

--- a/fe/src/features/planner/components/routine/RoutineListItem.tsx
+++ b/fe/src/features/planner/components/routine/RoutineListItem.tsx
@@ -1,0 +1,43 @@
+import { CircleDashed, MoreVertical, Repeat } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Menu, MenuItem } from "@/components/ui/menu";
+
+import type { RoutineSeriesSummary } from "../../api/routines";
+
+interface Props {
+  series: RoutineSeriesSummary;
+  onEdit: (series: RoutineSeriesSummary) => void;
+  onDelete: (series: RoutineSeriesSummary) => void;
+}
+
+/** 루틴 시리즈 한 행: 종류 아이콘 + 제목 + 반복 요약 + ⋯(수정/삭제). */
+export function RoutineListItem({ series, onEdit, onDelete }: Props) {
+  const Icon = series.type === "habit" ? CircleDashed : Repeat;
+
+  return (
+    <li className="flex items-center gap-3 rounded-lg border px-3 py-2.5">
+      <Icon className="text-muted-foreground size-4 shrink-0" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{series.title}</p>
+        <p className="text-muted-foreground text-xs">{series.recurrenceText}</p>
+      </div>
+      <Menu
+        trigger={
+          <Button
+            size="icon-sm"
+            variant="ghost"
+            aria-label={`${series.title} 메뉴`}
+          >
+            <MoreVertical className="size-4" />
+          </Button>
+        }
+      >
+        <MenuItem onClick={() => onEdit(series)}>수정</MenuItem>
+        <MenuItem variant="destructive" onClick={() => onDelete(series)}>
+          삭제
+        </MenuItem>
+      </Menu>
+    </li>
+  );
+}

--- a/fe/src/features/planner/hooks/useRoutineList.ts
+++ b/fe/src/features/planner/hooks/useRoutineList.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { listRoutines } from "../api/routines";
+import { routineKeys } from "../queryKeys";
+
+/** 루틴 시리즈 목록 조회. 미연동(409)이면 에러로 떨어지므로 호출부가 연동 상태로 분기한다. */
+export function useRoutineList(enabled = true) {
+  return useQuery({
+    queryKey: routineKeys.list(),
+    queryFn: listRoutines,
+    enabled,
+    staleTime: 30 * 1000,
+    retry: false,
+  });
+}

--- a/fe/src/features/planner/hooks/useRoutineMutations.ts
+++ b/fe/src/features/planner/hooks/useRoutineMutations.ts
@@ -2,21 +2,71 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { toast } from "@/shared/lib/toast";
 
-import { createRoutine } from "../api/routines";
+import {
+  createRoutine,
+  deleteRoutine,
+  type RoutineEditRequest,
+  type RoutineScope,
+  updateRoutine,
+} from "../api/routines";
 import { plannerKeys, routineKeys } from "../queryKeys";
 
-/**
- * 루틴 생성 후 시리즈 목록과 통합 피드를 invalidate해 갱신한다(서버가 캐시를 무효화하므로 재조회로 최신화).
- */
+/** 루틴 시리즈 목록과 통합 피드를 함께 무효화한다(서버가 캐시를 무효화하므로 재조회로 최신화). */
+function invalidateRoutines(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: routineKeys.all });
+  queryClient.invalidateQueries({ queryKey: plannerKeys.all });
+}
+
 export function useCreateRoutine() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: createRoutine,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: routineKeys.all });
-      queryClient.invalidateQueries({ queryKey: plannerKeys.all });
+      invalidateRoutines(queryClient);
       toast("루틴을 저장했습니다.", "success");
     },
     onError: () => toast("루틴 저장에 실패했습니다.", "error"),
+  });
+}
+
+export function useUpdateRoutine() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      eventId,
+      request,
+      scope,
+      instanceDate,
+    }: {
+      eventId: string;
+      request: RoutineEditRequest;
+      scope: RoutineScope;
+      instanceDate?: string;
+    }) => updateRoutine(eventId, request, { scope, instanceDate }),
+    onSuccess: () => {
+      invalidateRoutines(queryClient);
+      toast("루틴을 수정했습니다.", "success");
+    },
+    onError: () => toast("루틴 수정에 실패했습니다.", "error"),
+  });
+}
+
+export function useDeleteRoutine() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      eventId,
+      scope,
+      instanceDate,
+    }: {
+      eventId: string;
+      scope: RoutineScope;
+      instanceDate?: string;
+    }) => deleteRoutine(eventId, { scope, instanceDate }),
+    onSuccess: () => {
+      invalidateRoutines(queryClient);
+      toast("루틴을 삭제했습니다.", "success");
+    },
+    onError: () => toast("루틴 삭제에 실패했습니다.", "error"),
   });
 }

--- a/fe/src/pages/planner/RoutinesPage.test.tsx
+++ b/fe/src/pages/planner/RoutinesPage.test.tsx
@@ -1,0 +1,109 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { RoutinesPage } from "./RoutinesPage";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function connectedStatus() {
+  server.use(
+    http.get(`${API_BASE}/planner/google/status`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          connected: true,
+          googleEmail: "me@gmail.com",
+          scopes: "calendar",
+          connectedAt: "2026-06-01T00:00:00Z",
+        },
+      }),
+    ),
+  );
+}
+
+function routinesResponse(routines: unknown[]) {
+  server.use(
+    http.get(`${API_BASE}/planner/routines`, () =>
+      HttpResponse.json({ code: "OK", data: { routines } }),
+    ),
+  );
+}
+
+const HABIT = {
+  recurringEventId: "r-habit-1",
+  type: "habit",
+  title: "운동하기",
+  allDay: true,
+  start: "2026-06-20",
+  recurrence: { freq: "WEEKLY", byDay: ["MO", "WE", "FR"] },
+  recurrenceText: "매주 월·수·금",
+};
+const SCHEDULE = {
+  recurringEventId: "r-sched-1",
+  type: "schedule",
+  title: "스탠드업",
+  allDay: false,
+  start: "2026-06-20T09:00:00",
+  end: "2026-06-20T09:15:00",
+  recurrence: { freq: "DAILY" },
+  recurrenceText: "매일",
+};
+
+describe("RoutinesPage", () => {
+  it("종류별 그룹으로 시리즈를 렌더한다", async () => {
+    connectedStatus();
+    routinesResponse([HABIT, SCHEDULE]);
+
+    renderWithRouter(<RoutinesPage />);
+
+    expect(await screen.findByText("운동하기")).toBeInTheDocument();
+    expect(screen.getByText("매주 월·수·금")).toBeInTheDocument();
+    expect(screen.getByText("스탠드업")).toBeInTheDocument();
+    expect(screen.getByText("습관")).toBeInTheDocument();
+    expect(screen.getByText("고정 일정")).toBeInTheDocument();
+  });
+
+  it("루틴이 없으면 빈 상태를 보여준다", async () => {
+    connectedStatus();
+    routinesResponse([]);
+
+    renderWithRouter(<RoutinesPage />);
+
+    expect(
+      await screen.findByText("아직 루틴이 없습니다."),
+    ).toBeInTheDocument();
+  });
+
+  it("⋯ 메뉴에서 수정/삭제 진입점을 보여준다", async () => {
+    connectedStatus();
+    routinesResponse([HABIT]);
+
+    renderWithRouter(<RoutinesPage />);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "운동하기 메뉴" }),
+    );
+
+    expect(
+      await screen.findByRole("menuitem", { name: "수정" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "삭제" })).toBeInTheDocument();
+  });
+
+  it("미연동이면 연결 CTA를 보여준다", async () => {
+    // 기본 핸들러가 connected:false를 반환한다.
+    renderWithRouter(<RoutinesPage />);
+
+    expect(
+      await screen.findByText("Google 연결이 필요합니다."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Google 연결" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/fe/src/pages/planner/RoutinesPage.tsx
+++ b/fe/src/pages/planner/RoutinesPage.tsx
@@ -1,0 +1,204 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { Plus } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { DialogFooter } from "@/components/ui/dialog-footer";
+import { EmptyState } from "@/components/ui/empty-state";
+import { LoadingText } from "@/components/ui/loading-text";
+import { Modal } from "@/components/ui/modal";
+import { GoogleConnectButton } from "@/features/google/components/GoogleConnectButton";
+import { useGoogleStatus } from "@/features/google/hooks/useGoogleStatus";
+import type {
+  RoutineCreateRequest,
+  RoutineSeriesSummary,
+} from "@/features/planner/api/routines";
+import { RoutineFormDialog } from "@/features/planner/components/routine/RoutineFormDialog";
+import { RoutineListItem } from "@/features/planner/components/routine/RoutineListItem";
+import { useRoutineList } from "@/features/planner/hooks/useRoutineList";
+import {
+  useCreateRoutine,
+  useDeleteRoutine,
+  useUpdateRoutine,
+} from "@/features/planner/hooks/useRoutineMutations";
+
+function localToday(): string {
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${now.getFullYear()}-${month}-${day}`;
+}
+
+interface SectionProps {
+  title: string;
+  series: RoutineSeriesSummary[];
+  onEdit: (s: RoutineSeriesSummary) => void;
+  onDelete: (s: RoutineSeriesSummary) => void;
+}
+
+function RoutineSection({ title, series, onEdit, onDelete }: SectionProps) {
+  if (series.length === 0) return null;
+  return (
+    <section className="flex flex-col gap-2">
+      <h2 className="text-muted-foreground text-xs font-semibold">{title}</h2>
+      <ul className="flex flex-col gap-2">
+        {series.map((s) => (
+          <RoutineListItem
+            key={s.recurringEventId}
+            series={s}
+            onEdit={onEdit}
+            onDelete={onDelete}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export function RoutinesPage() {
+  const status = useGoogleStatus();
+  const connected = status.data?.connected ?? false;
+  const list = useRoutineList(connected);
+
+  const createRoutine = useCreateRoutine();
+  const updateRoutine = useUpdateRoutine();
+  const deleteRoutine = useDeleteRoutine();
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<RoutineSeriesSummary | null>(
+    null,
+  );
+  const [deleteTarget, setDeleteTarget] = useState<RoutineSeriesSummary | null>(
+    null,
+  );
+
+  const handleCreate = (values: RoutineCreateRequest) =>
+    createRoutine.mutate(values, { onSuccess: () => setCreateOpen(false) });
+
+  const handleUpdate = (values: RoutineCreateRequest) => {
+    if (!editTarget) return;
+    // scope=all 고정(전체 시리즈). 범위 선택 다이얼로그는 R4(#581)에서 추가.
+    const { type: _type, color: _color, ...request } = values;
+    void _type;
+    void _color;
+    updateRoutine.mutate(
+      { eventId: editTarget.recurringEventId, request, scope: "all" },
+      { onSuccess: () => setEditTarget(null) },
+    );
+  };
+
+  const confirmDelete = () => {
+    if (!deleteTarget) return;
+    deleteRoutine.mutate(
+      { eventId: deleteTarget.recurringEventId, scope: "all" },
+      { onSuccess: () => setDeleteTarget(null) },
+    );
+  };
+
+  const routines = list.data ?? [];
+  const habits = routines.filter((r) => r.type === "habit");
+  const schedules = routines.filter((r) => r.type === "schedule");
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold">루틴</h1>
+        <Button onClick={() => setCreateOpen(true)}>
+          <Plus className="size-4" /> 새 루틴
+        </Button>
+      </div>
+
+      {status.isLoading ? (
+        <LoadingText />
+      ) : !connected ? (
+        <EmptyState>
+          <p className="text-muted-foreground text-sm">
+            Google 연결이 필요합니다.
+          </p>
+          <GoogleConnectButton />
+        </EmptyState>
+      ) : list.isLoading ? (
+        <LoadingText />
+      ) : list.isError ? (
+        <EmptyState>
+          <p className="text-muted-foreground text-sm">
+            루틴을 불러오지 못했습니다.
+          </p>
+          <Button variant="outline" onClick={() => list.refetch()}>
+            다시 시도
+          </Button>
+        </EmptyState>
+      ) : routines.length === 0 ? (
+        <EmptyState>
+          <p className="text-muted-foreground text-sm">아직 루틴이 없습니다.</p>
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="size-4" /> 새 루틴
+          </Button>
+        </EmptyState>
+      ) : (
+        <div className="flex flex-col gap-5">
+          <RoutineSection
+            title="습관"
+            series={habits}
+            onEdit={setEditTarget}
+            onDelete={setDeleteTarget}
+          />
+          <RoutineSection
+            title="고정 일정"
+            series={schedules}
+            onEdit={setEditTarget}
+            onDelete={setDeleteTarget}
+          />
+        </div>
+      )}
+
+      <RoutineFormDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        googleConnected={connected}
+        defaultDate={localToday()}
+        pending={createRoutine.isPending}
+        onSubmit={handleCreate}
+      />
+
+      <RoutineFormDialog
+        open={!!editTarget}
+        onOpenChange={(open) => !open && setEditTarget(null)}
+        googleConnected={connected}
+        defaultDate={localToday()}
+        series={editTarget ?? undefined}
+        pending={updateRoutine.isPending}
+        onSubmit={handleUpdate}
+      />
+
+      <Modal
+        open={!!deleteTarget}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+        className="max-w-sm"
+      >
+        <Dialog.Title className="text-base font-semibold">
+          루틴 삭제
+        </Dialog.Title>
+        <p className="text-muted-foreground mt-2 text-sm">
+          ‘{deleteTarget?.title}’ 루틴을 삭제할까요?
+        </p>
+        <DialogFooter>
+          <Dialog.Close
+            render={
+              <Button variant="ghost" type="button">
+                취소
+              </Button>
+            }
+          />
+          <Button
+            variant="destructive"
+            onClick={confirmDelete}
+            disabled={deleteRoutine.isPending}
+          >
+            삭제
+          </Button>
+        </DialogFooter>
+      </Modal>
+    </div>
+  );
+}


### PR DESCRIPTION
## 이슈
closes #577

## 작업 내용
- **`/planner/routines` 라우트** + 사이드바 진입점("루틴", Repeat 아이콘)
- **`RoutinesPage`** — 종류별 그룹 관리 화면 ([UI Design §4](https://github.com/wcorn/orino/wiki/Routine-UI-Design))
  - 습관 / 고정 일정 섹션, 각 행: 종류 아이콘 + 제목 + `recurrenceText` + ⋯ 메뉴(수정/삭제)
  - **새 루틴** 생성(`RoutineFormDialog`), **수정**(폼 prefill — 종류 변경 불가), **삭제**(확인 모달)
  - `EmptyState`(아직 루틴이 없습니다) · 미연동 CTA · 로딩/에러(재시도) — 공유 컴포넌트 재사용
- **API/훅** — `listRoutines`·`updateRoutine`·`deleteRoutine`(scope 파라미터), `useRoutineList`, `useUpdate/DeleteRoutine`
- `RoutineFormDialog`에 편집 prefill 추가(시리즈 요약 → 폼 역매핑)

> 편집/삭제는 현재 **`scope=all`(전체 시리즈) 고정**입니다. 범위 선택(all/following/instance) 다이얼로그는 **R4(#581)**에서 이 mutation 위에 얹습니다.

## 검증
- `npm test`: 그룹 목록 렌더 / 빈 상태 / ⋯ 메뉴 수정·삭제 진입 / 미연동 CTA (RTL + MSW)
- `npm run lint` / `format:check` / `tsc --noEmit` ✅
- 전체 163 테스트 통과(라우터·사이드바 회귀 포함)