### PR TITLE
feat : Routine 습관 체크 UI + 오늘의 루틴 섹션 (R3 FE)

### DIFF
--- a/fe/src/features/planner/api/feed.ts
+++ b/fe/src/features/planner/api/feed.ts
@@ -1,5 +1,12 @@
 import { client } from "@/shared/api";
 
+/** 루틴 인스턴스 주석. 루틴이 아니면 null. habit done은 routine_check 조인 결과. */
+export interface RoutineMeta {
+  type: "habit" | "schedule";
+  recurringEventId: string;
+  done: boolean;
+}
+
 export interface PlannerEvent {
   id: string;
   title: string | null;
@@ -10,6 +17,7 @@ export interface PlannerEvent {
   location: string | null;
   recurring: boolean;
   source: "google";
+  routine?: RoutineMeta | null;
 }
 
 export interface PlannerTask {

--- a/fe/src/features/planner/api/routines.ts
+++ b/fe/src/features/planner/api/routines.ts
@@ -98,3 +98,22 @@ export async function deleteRoutine(
     params: { scope, instanceDate },
   });
 }
+
+export interface RoutineCheckResult {
+  recurringEventId: string;
+  date: string;
+  done: boolean;
+}
+
+/** 습관 완료 체크 토글. done=true upsert / false delete. */
+export async function checkRoutine(
+  recurringEventId: string,
+  date: string,
+  done: boolean,
+): Promise<RoutineCheckResult> {
+  const { data } = await client.post<ApiEnvelope<RoutineCheckResult>>(
+    `/planner/routines/${recurringEventId}/check`,
+    { date, done },
+  );
+  return data.data;
+}

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
@@ -21,12 +21,14 @@ import {
   useUpdateEvent,
 } from "../../hooks/useEventMutations";
 import { usePlannerCalendar } from "../../hooks/usePlannerCalendar";
+import { useRoutineCheck } from "../../hooks/useRoutineCheck";
 import {
   useCreateTask,
   useDeleteTask,
   useUpdateTask,
 } from "../../hooks/useTaskMutations";
 import { weekDays } from "../../weekLayout";
+import { TodayRoutines } from "../routine/TodayRoutines";
 import { EventFormDialog } from "./EventFormDialog";
 import { PlannerCalendarCell } from "./PlannerCalendarCell";
 import { PlannerCalendarLegend } from "./PlannerCalendarLegend";
@@ -91,6 +93,8 @@ export function PlannerCalendar() {
     if (dialog?.mode !== "edit") return;
     deleteEvent.mutate(dialog.event.id, { onSuccess: () => setDialog(null) });
   };
+
+  const routineCheck = useRoutineCheck();
 
   const [taskDialogOpen, setTaskDialogOpen] = useState(false);
   const createTask = useCreateTask();
@@ -188,6 +192,8 @@ export function PlannerCalendar() {
 
       <PlannerConnectionBanner feed={data} />
 
+      <TodayRoutines />
+
       <PlannerCalendarLegend />
 
       {view !== "month" ? (
@@ -279,6 +285,14 @@ export function PlannerCalendar() {
                   })
                 }
                 onTaskDelete={(task) => deleteTask.mutate(task.id)}
+                onRoutineCheck={(event) =>
+                  event.routine &&
+                  routineCheck.mutate({
+                    recurringEventId: event.routine.recurringEventId,
+                    date: event.start.slice(0, 10),
+                    done: !event.routine.done,
+                  })
+                }
               />
             </CardContent>
           </Card>

--- a/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { Trash2 } from "lucide-react";
+import { Repeat, Trash2 } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 
 import type { PlannerEvent, PlannerReview, PlannerTask } from "../../api/feed";
 import { eventTimeLabel } from "../../calendar";
+import { RoutineCheckCircle } from "../routine/RoutineCheckCircle";
 
 interface Props {
   isoDate: string;
@@ -17,6 +18,7 @@ interface Props {
   onEventClick?: (event: PlannerEvent) => void;
   onTaskToggle?: (task: PlannerTask) => void;
   onTaskDelete?: (task: PlannerTask) => void;
+  onRoutineCheck?: (event: PlannerEvent) => void;
 }
 
 function formatHeading(isoDate: string): string {
@@ -32,6 +34,7 @@ export function PlannerDayDetailPanel({
   onEventClick,
   onTaskToggle,
   onTaskDelete,
+  onRoutineCheck,
 }: Props) {
   const isEmpty = events.length + tasks.length + reviews.length === 0;
 
@@ -56,29 +59,56 @@ export function PlannerDayDetailPanel({
                 일정 ({events.length})
               </h3>
               <ul className="flex flex-col gap-1.5">
-                {events.map((event) => (
-                  <li key={event.id}>
-                    <button
-                      type="button"
-                      onClick={() => onEventClick?.(event)}
-                      className="border-border bg-card hover:bg-muted/50 flex w-full items-start gap-2 rounded-md border p-2 text-left text-sm transition-colors"
+                {events.map((event) => {
+                  const isHabit = event.routine?.type === "habit";
+                  const isSchedule = event.routine?.type === "schedule";
+                  const done = event.routine?.done ?? false;
+                  return (
+                    <li
+                      key={event.id}
+                      className="border-border bg-card flex items-center gap-2 rounded-md border p-2 text-sm"
                     >
-                      <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
-                        {eventTimeLabel(event)}
-                      </span>
-                      <div className="flex min-w-0 flex-1 flex-col">
-                        <span className="truncate">
-                          {event.title ?? "(제목 없음)"}
+                      {isHabit && (
+                        <RoutineCheckCircle
+                          checked={done}
+                          label={`${event.title ?? "(제목 없음)"} 완료 토글`}
+                          onToggle={() => onRoutineCheck?.(event)}
+                        />
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => onEventClick?.(event)}
+                        className="hover:bg-muted/50 flex min-w-0 flex-1 items-start gap-2 rounded-sm text-left transition-colors"
+                      >
+                        <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+                          {eventTimeLabel(event)}
                         </span>
-                        {event.location && (
-                          <span className="text-muted-foreground truncate text-xs">
-                            {event.location}
+                        <div className="flex min-w-0 flex-1 flex-col">
+                          <span
+                            className={cn(
+                              "flex items-center gap-1 truncate",
+                              done &&
+                                "text-muted-foreground line-through opacity-70",
+                            )}
+                          >
+                            {isSchedule && (
+                              <Repeat
+                                className="size-3.5 shrink-0"
+                                aria-label="반복 일정"
+                              />
+                            )}
+                            {event.title ?? "(제목 없음)"}
                           </span>
-                        )}
-                      </div>
-                    </button>
-                  </li>
-                ))}
+                          {event.location && (
+                            <span className="text-muted-foreground truncate text-xs">
+                              {event.location}
+                            </span>
+                          )}
+                        </div>
+                      </button>
+                    </li>
+                  );
+                })}
               </ul>
             </section>
           )}

--- a/fe/src/features/planner/components/routine/RoutineCheckCircle.tsx
+++ b/fe/src/features/planner/components/routine/RoutineCheckCircle.tsx
@@ -1,0 +1,45 @@
+import { Circle, CircleCheckBig } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface Props {
+  checked: boolean;
+  label: string;
+  onToggle: () => void;
+  disabled?: boolean;
+}
+
+/**
+ * 습관 완료 체크 동그라미(○/●). 색 외에 기호(빈 원/체크 원)로 상태를 구분하고,
+ * role=checkbox + aria-checked로 노출한다. native button이라 포커스·Enter 토글이 기본 동작한다.
+ */
+export function RoutineCheckCircle({
+  checked,
+  label,
+  onToggle,
+  disabled,
+}: Props) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={onToggle}
+      className={cn(
+        "shrink-0 rounded-full transition-colors",
+        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+        checked
+          ? "text-primary"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {checked ? (
+        <CircleCheckBig className="size-5" />
+      ) : (
+        <Circle className="size-5" />
+      )}
+    </button>
+  );
+}

--- a/fe/src/features/planner/components/routine/TodayRoutines.test.tsx
+++ b/fe/src/features/planner/components/routine/TodayRoutines.test.tsx
@@ -1,0 +1,118 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { useToastStore } from "@/shared/lib/toast";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { TodayRoutines } from "./TodayRoutines";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function todayIso(): string {
+  const d = new Date();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${m}-${day}`;
+}
+
+function feed(done: boolean) {
+  return {
+    code: "OK",
+    data: {
+      from: todayIso(),
+      to: todayIso(),
+      googleConnected: true,
+      partial: false,
+      errors: [],
+      events: [
+        {
+          id: "r-habit-1_today",
+          title: "운동하기",
+          allDay: true,
+          start: todayIso(),
+          end: null,
+          location: null,
+          recurring: true,
+          source: "google",
+          routine: { type: "habit", recurringEventId: "r-habit-1", done },
+        },
+      ],
+      tasks: [],
+      reviews: [],
+    },
+  };
+}
+
+/** GET은 mutable checked 상태를 반영하고, POST가 그 상태를 갱신한다(낙관적→재검증 일관성). */
+function installStatefulHandlers(checkStatus = 200) {
+  let checked = false;
+  server.use(
+    http.get(`${API_BASE}/planner/calendar`, () =>
+      HttpResponse.json(feed(checked)),
+    ),
+    http.post(
+      `${API_BASE}/planner/routines/r-habit-1/check`,
+      async ({ request }) => {
+        if (checkStatus !== 200) {
+          return HttpResponse.json({ code: "ERR" }, { status: checkStatus });
+        }
+        const body = (await request.json()) as { done: boolean };
+        checked = body.done;
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            recurringEventId: "r-habit-1",
+            date: todayIso(),
+            done: checked,
+          },
+        });
+      },
+    ),
+  );
+}
+
+describe("TodayRoutines", () => {
+  it("체크 토글을 낙관적으로 반영한다 (0/1 → 1/1)", async () => {
+    installStatefulHandlers();
+    renderWithRouter(<TodayRoutines />);
+
+    const circle = await screen.findByRole("checkbox", {
+      name: "운동하기 완료 토글",
+    });
+    expect(circle).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByText("0/1")).toBeInTheDocument();
+
+    await userEvent.click(circle);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("checkbox", { name: "운동하기 완료 토글" }),
+      ).toHaveAttribute("aria-checked", "true"),
+    );
+    expect(screen.getByText("1/1")).toBeInTheDocument();
+  });
+
+  it("실패하면 롤백하고 에러 토스트를 띄운다", async () => {
+    installStatefulHandlers(500);
+    renderWithRouter(<TodayRoutines />);
+
+    const circle = await screen.findByRole("checkbox", {
+      name: "운동하기 완료 토글",
+    });
+    await userEvent.click(circle);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("checkbox", { name: "운동하기 완료 토글" }),
+      ).toHaveAttribute("aria-checked", "false"),
+    );
+    await waitFor(() =>
+      expect(
+        useToastStore.getState().toasts.some((t) => t.variant === "error"),
+      ).toBe(true),
+    );
+  });
+});

--- a/fe/src/features/planner/components/routine/TodayRoutines.tsx
+++ b/fe/src/features/planner/components/routine/TodayRoutines.tsx
@@ -1,0 +1,99 @@
+import { Repeat } from "lucide-react";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { startOfDay, toIsoDate } from "@/features/review/calendar";
+import { cn } from "@/lib/utils";
+
+import type { PlannerEvent } from "../../api/feed";
+import { eventTimeLabel } from "../../calendar";
+import { usePlannerCalendar } from "../../hooks/usePlannerCalendar";
+import { useRoutineCheck } from "../../hooks/useRoutineCheck";
+import { RoutineCheckCircle } from "./RoutineCheckCircle";
+
+/** 오늘의 루틴 체크리스트. 습관은 체크 토글(낙관적), 고정 일정은 🔁 읽기 전용. */
+export function TodayRoutines() {
+  const todayIso = toIsoDate(startOfDay(new Date()));
+  const { data } = usePlannerCalendar(todayIso, todayIso);
+  const check = useRoutineCheck();
+
+  const routineEvents = (data?.events ?? []).filter(
+    (
+      e,
+    ): e is PlannerEvent & { routine: NonNullable<PlannerEvent["routine"]> } =>
+      e.routine != null,
+  );
+  const habits = routineEvents.filter((e) => e.routine.type === "habit");
+  const schedules = routineEvents.filter((e) => e.routine.type === "schedule");
+
+  if (routineEvents.length === 0) return null;
+
+  const doneCount = habits.filter((h) => h.routine.done).length;
+
+  const toggle = (event: (typeof habits)[number]) =>
+    check.mutate({
+      recurringEventId: event.routine.recurringEventId,
+      date: todayIso,
+      done: !event.routine.done,
+    });
+
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold">오늘의 루틴</h2>
+          {habits.length > 0 && (
+            <span
+              className="text-muted-foreground text-sm tabular-nums"
+              aria-label={`완료 ${doneCount} / 전체 ${habits.length}`}
+            >
+              {doneCount}/{habits.length}
+            </span>
+          )}
+        </div>
+
+        {habits.length > 0 && (
+          <ul className="flex flex-col gap-1.5">
+            {habits.map((event) => (
+              <li key={event.id} className="flex items-center gap-2.5">
+                <RoutineCheckCircle
+                  checked={event.routine.done}
+                  label={`${event.title ?? "(제목 없음)"} 완료 토글`}
+                  disabled={check.isPending}
+                  onToggle={() => toggle(event)}
+                />
+                <span
+                  className={cn(
+                    "min-w-0 flex-1 truncate text-sm",
+                    event.routine.done &&
+                      "text-muted-foreground line-through opacity-70",
+                  )}
+                >
+                  {event.title ?? "(제목 없음)"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {schedules.length > 0 && (
+          <ul className="flex flex-col gap-1.5">
+            {schedules.map((event) => (
+              <li
+                key={event.id}
+                className="text-muted-foreground flex items-center gap-2.5 text-sm"
+              >
+                <Repeat className="size-4 shrink-0" aria-label="반복 일정" />
+                <span className="shrink-0 tabular-nums">
+                  {eventTimeLabel(event)}
+                </span>
+                <span className="min-w-0 flex-1 truncate">
+                  {event.title ?? "(제목 없음)"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/fe/src/features/planner/hooks/useRoutineCheck.ts
+++ b/fe/src/features/planner/hooks/useRoutineCheck.ts
@@ -1,0 +1,67 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { toast } from "@/shared/lib/toast";
+
+import type { PlannerCalendarFeed, PlannerEvent } from "../api/feed";
+import { checkRoutine } from "../api/routines";
+import { plannerKeys } from "../queryKeys";
+
+interface CheckVars {
+  recurringEventId: string;
+  /** 인스턴스 날짜 "2026-06-20" */
+  date: string;
+  done: boolean;
+}
+
+function matches(event: PlannerEvent, vars: CheckVars): boolean {
+  return (
+    event.routine?.recurringEventId === vars.recurringEventId &&
+    event.start.slice(0, 10) === vars.date
+  );
+}
+
+function applyDone(
+  feed: PlannerCalendarFeed,
+  vars: CheckVars,
+): PlannerCalendarFeed {
+  return {
+    ...feed,
+    events: feed.events.map((event) =>
+      matches(event, vars) && event.routine
+        ? { ...event, routine: { ...event.routine, done: vars.done } }
+        : event,
+    ),
+  };
+}
+
+/**
+ * 습관 완료 체크 토글(낙관적). 모든 캘린더 피드 캐시에서 해당 인스턴스 done을 즉시 뒤집고,
+ * 실패 시 스냅샷으로 롤백 + 토스트한다. 성공/실패와 무관하게 마지막에 재검증한다.
+ */
+export function useRoutineCheck() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ recurringEventId, date, done }: CheckVars) =>
+      checkRoutine(recurringEventId, date, done),
+    onMutate: async (vars) => {
+      await queryClient.cancelQueries({ queryKey: plannerKeys.all });
+      const snapshots = queryClient.getQueriesData<PlannerCalendarFeed>({
+        queryKey: plannerKeys.all,
+      });
+      queryClient.setQueriesData<PlannerCalendarFeed>(
+        { queryKey: plannerKeys.all },
+        (feed) => (feed ? applyDone(feed, vars) : feed),
+      );
+      return { snapshots };
+    },
+    onError: (_error, _vars, context) => {
+      context?.snapshots.forEach(([key, data]) =>
+        queryClient.setQueryData(key, data),
+      );
+      toast("체크 변경에 실패했습니다.", "error");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: plannerKeys.all });
+    },
+  });
+}


### PR DESCRIPTION
## 이슈
closes #579

## 작업 내용
- **통합 피드 타입** — `PlannerEvent`에 `routine`(type/recurringEventId/done) 추가
- **체크 토글 + 낙관적 갱신** — `checkRoutine` API, `useRoutineCheck`
  - 모든 캘린더 피드 캐시에서 해당 인스턴스 `done`을 즉시 뒤집고, 실패 시 스냅샷 롤백 + 토스트, settle 시 재검증
- **`RoutineCheckCircle`** — ○/● 체크 동그라미
  - `role=checkbox` + `aria-checked`, native button이라 포커스·**Enter 토글** 기본 지원, **색 외에 기호(○/●)·취소선** 병행
- **`TodayRoutines`** — "오늘의 루틴" 체크리스트(완료/전체 카운트), 캘린더 **상단 배치(모바일 우선)**
  - 습관=체크 토글, 고정 일정=🔁 읽기 전용
- **일 상세 패널** — 습관 인스턴스 ○/● 체크 + 일정 🔁 표시, 완료 시 취소선

## 검증
- `npm test`(RTL + MSW): 체크 **낙관적 갱신(0/1→1/1)** + **실패 롤백·에러 토스트**
- `npm run lint` / `format:check` / `tsc --noEmit` ✅
- 전체 165 테스트 통과(캘린더 회귀 포함)