### PR TITLE
feat : Routine 편집/삭제 범위 선택 다이얼로그 (R4 FE)

### DIFF
--- a/fe/src/features/planner/components/routine/RoutineScopeDialog.test.tsx
+++ b/fe/src/features/planner/components/routine/RoutineScopeDialog.test.tsx
@@ -1,0 +1,75 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithRouter } from "@/test/render";
+
+import { RoutineScopeDialog } from "./RoutineScopeDialog";
+
+const base = {
+  open: true,
+  onOpenChange: () => {},
+  instanceDate: "2026-06-20",
+} as const;
+
+describe("RoutineScopeDialog", () => {
+  it("기본 scope가 선택되고 인스턴스 날짜를 라벨에 표시한다", () => {
+    renderWithRouter(
+      <RoutineScopeDialog
+        {...base}
+        mode="edit"
+        defaultScope="all"
+        onConfirm={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: "전체 루틴" })).toBeChecked();
+    expect(
+      screen.getByRole("radio", { name: "이 날짜만 (6/20)" }),
+    ).toBeInTheDocument();
+  });
+
+  it("각 scope를 선택해 확인하면 그 값으로 onConfirm을 부른다", async () => {
+    const onConfirm = vi.fn();
+    renderWithRouter(
+      <RoutineScopeDialog
+        {...base}
+        mode="delete"
+        defaultScope="instance"
+        onConfirm={onConfirm}
+      />,
+    );
+
+    // 기본: 이 날짜만 → instance
+    await userEvent.click(screen.getByRole("button", { name: "확인" }));
+    expect(onConfirm).toHaveBeenLastCalledWith("instance");
+
+    await userEvent.click(
+      screen.getByRole("radio", { name: "이 날짜 이후 모두" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "확인" }));
+    expect(onConfirm).toHaveBeenLastCalledWith("following");
+
+    await userEvent.click(screen.getByRole("radio", { name: "전체 루틴" }));
+    await userEvent.click(screen.getByRole("button", { name: "확인" }));
+    expect(onConfirm).toHaveBeenLastCalledWith("all");
+  });
+
+  it("instanceDate가 없으면 날짜 기반 옵션은 비활성화된다", () => {
+    renderWithRouter(
+      <RoutineScopeDialog
+        open
+        onOpenChange={() => {}}
+        mode="edit"
+        defaultScope="all"
+        onConfirm={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: "이 날짜만" })).toBeDisabled();
+    expect(
+      screen.getByRole("radio", { name: "이 날짜 이후 모두" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("radio", { name: "전체 루틴" })).toBeEnabled();
+  });
+});

--- a/fe/src/features/planner/components/routine/RoutineScopeDialog.tsx
+++ b/fe/src/features/planner/components/routine/RoutineScopeDialog.tsx
@@ -1,0 +1,102 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { DialogFooter } from "@/components/ui/dialog-footer";
+import { Modal } from "@/components/ui/modal";
+
+import type { RoutineScope } from "../../api/routines";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "edit" | "delete";
+  /** 인스턴스 기준 날짜(YYYY-MM-DD). 없으면 '이 날짜만/이후 모두'는 비활성. */
+  instanceDate?: string;
+  defaultScope: RoutineScope;
+  pending?: boolean;
+  onConfirm: (scope: RoutineScope) => void;
+}
+
+function shortDate(iso?: string): string {
+  if (!iso) return "";
+  const [, m, d] = iso.split("-");
+  return ` (${Number(m)}/${Number(d)})`;
+}
+
+/** 반복 루틴 수정/삭제 시 적용 범위(이 날짜만 / 이후 모두 / 전체)를 고른다. */
+export function RoutineScopeDialog({
+  open,
+  onOpenChange,
+  mode,
+  instanceDate,
+  defaultScope,
+  pending = false,
+  onConfirm,
+}: Props) {
+  const [scope, setScope] = useState<RoutineScope>(defaultScope);
+
+  useEffect(() => {
+    if (open) setScope(defaultScope);
+  }, [open, defaultScope]);
+
+  const options: { value: RoutineScope; label: string; needsDate: boolean }[] =
+    [
+      {
+        value: "instance",
+        label: `이 날짜만${shortDate(instanceDate)}`,
+        needsDate: true,
+      },
+      { value: "following", label: "이 날짜 이후 모두", needsDate: true },
+      { value: "all", label: "전체 루틴", needsDate: false },
+    ];
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange} className="max-w-sm">
+      <Dialog.Title className="text-base font-semibold">
+        {mode === "edit" ? "이 루틴을 수정" : "이 루틴을 삭제"}
+      </Dialog.Title>
+
+      <fieldset className="mt-4 flex flex-col gap-2">
+        {options.map((opt) => {
+          const disabled = opt.needsDate && !instanceDate;
+          return (
+            <label
+              key={opt.value}
+              className="flex items-center gap-2 text-sm aria-disabled:opacity-50"
+              aria-disabled={disabled}
+            >
+              <input
+                type="radio"
+                name="routine-scope"
+                value={opt.value}
+                checked={scope === opt.value}
+                disabled={disabled}
+                onChange={() => setScope(opt.value)}
+              />
+              {opt.label}
+            </label>
+          );
+        })}
+      </fieldset>
+
+      <DialogFooter>
+        <Dialog.Close
+          render={
+            <Button variant="ghost" type="button" disabled={pending}>
+              취소
+            </Button>
+          }
+        />
+        <Button
+          type="button"
+          variant={mode === "delete" ? "destructive" : "default"}
+          disabled={pending}
+          onClick={() => onConfirm(scope)}
+        >
+          확인
+        </Button>
+      </DialogFooter>
+    </Modal>
+  );
+}

--- a/fe/src/pages/planner/RoutinesPage.test.tsx
+++ b/fe/src/pages/planner/RoutinesPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
@@ -105,5 +105,34 @@ describe("RoutinesPage", () => {
     expect(
       screen.getByRole("button", { name: "Google 연결" }),
     ).toBeInTheDocument();
+  });
+
+  it("삭제: 범위(이후 모두) 선택 시 scope·instanceDate 파라미터로 DELETE한다", async () => {
+    connectedStatus();
+    routinesResponse([HABIT]);
+    let capturedUrl: URL | undefined;
+    server.use(
+      http.delete(`${API_BASE}/planner/routines/r-habit-1`, ({ request }) => {
+        capturedUrl = new URL(request.url);
+        return HttpResponse.json({ code: "OK", data: null });
+      }),
+    );
+
+    renderWithRouter(<RoutinesPage />);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "운동하기 메뉴" }),
+    );
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "삭제" }),
+    );
+    await userEvent.click(
+      await screen.findByRole("radio", { name: "이 날짜 이후 모두" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "확인" }));
+
+    await waitFor(() => expect(capturedUrl).toBeDefined());
+    expect(capturedUrl?.searchParams.get("scope")).toBe("following");
+    expect(capturedUrl?.searchParams.get("instanceDate")).toBe("2026-06-20");
   });
 });

--- a/fe/src/pages/planner/RoutinesPage.tsx
+++ b/fe/src/pages/planner/RoutinesPage.tsx
@@ -1,20 +1,20 @@
-import { Dialog } from "@base-ui/react/dialog";
 import { Plus } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { DialogFooter } from "@/components/ui/dialog-footer";
 import { EmptyState } from "@/components/ui/empty-state";
 import { LoadingText } from "@/components/ui/loading-text";
-import { Modal } from "@/components/ui/modal";
 import { GoogleConnectButton } from "@/features/google/components/GoogleConnectButton";
 import { useGoogleStatus } from "@/features/google/hooks/useGoogleStatus";
 import type {
   RoutineCreateRequest,
+  RoutineEditRequest,
+  RoutineScope,
   RoutineSeriesSummary,
 } from "@/features/planner/api/routines";
 import { RoutineFormDialog } from "@/features/planner/components/routine/RoutineFormDialog";
 import { RoutineListItem } from "@/features/planner/components/routine/RoutineListItem";
+import { RoutineScopeDialog } from "@/features/planner/components/routine/RoutineScopeDialog";
 import { useRoutineList } from "@/features/planner/hooks/useRoutineList";
 import {
   useCreateRoutine,
@@ -68,6 +68,10 @@ export function RoutinesPage() {
   const [editTarget, setEditTarget] = useState<RoutineSeriesSummary | null>(
     null,
   );
+  const [pendingEdit, setPendingEdit] = useState<{
+    series: RoutineSeriesSummary;
+    request: RoutineEditRequest;
+  } | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<RoutineSeriesSummary | null>(
     null,
   );
@@ -75,22 +79,39 @@ export function RoutinesPage() {
   const handleCreate = (values: RoutineCreateRequest) =>
     createRoutine.mutate(values, { onSuccess: () => setCreateOpen(false) });
 
-  const handleUpdate = (values: RoutineCreateRequest) => {
+  // 폼 저장 → 범위 선택 다이얼로그로 넘긴다(종류·색상은 편집 대상이 아님).
+  const handleEditSubmit = (values: RoutineCreateRequest) => {
     if (!editTarget) return;
-    // scope=all 고정(전체 시리즈). 범위 선택 다이얼로그는 R4(#581)에서 추가.
     const { type: _type, color: _color, ...request } = values;
     void _type;
     void _color;
+    setPendingEdit({ series: editTarget, request });
+    setEditTarget(null);
+  };
+
+  const confirmEdit = (scope: RoutineScope) => {
+    if (!pendingEdit) return;
+    const instanceDate = pendingEdit.series.start.slice(0, 10);
     updateRoutine.mutate(
-      { eventId: editTarget.recurringEventId, request, scope: "all" },
-      { onSuccess: () => setEditTarget(null) },
+      {
+        eventId: pendingEdit.series.recurringEventId,
+        request: pendingEdit.request,
+        scope,
+        instanceDate: scope === "all" ? undefined : instanceDate,
+      },
+      { onSuccess: () => setPendingEdit(null) },
     );
   };
 
-  const confirmDelete = () => {
+  const confirmDelete = (scope: RoutineScope) => {
     if (!deleteTarget) return;
+    const instanceDate = deleteTarget.start.slice(0, 10);
     deleteRoutine.mutate(
-      { eventId: deleteTarget.recurringEventId, scope: "all" },
+      {
+        eventId: deleteTarget.recurringEventId,
+        scope,
+        instanceDate: scope === "all" ? undefined : instanceDate,
+      },
       { onSuccess: () => setDeleteTarget(null) },
     );
   };
@@ -168,37 +189,28 @@ export function RoutinesPage() {
         defaultDate={localToday()}
         series={editTarget ?? undefined}
         pending={updateRoutine.isPending}
-        onSubmit={handleUpdate}
+        onSubmit={handleEditSubmit}
       />
 
-      <Modal
+      <RoutineScopeDialog
+        open={!!pendingEdit}
+        onOpenChange={(open) => !open && setPendingEdit(null)}
+        mode="edit"
+        instanceDate={pendingEdit?.series.start.slice(0, 10)}
+        defaultScope="all"
+        pending={updateRoutine.isPending}
+        onConfirm={confirmEdit}
+      />
+
+      <RoutineScopeDialog
         open={!!deleteTarget}
         onOpenChange={(open) => !open && setDeleteTarget(null)}
-        className="max-w-sm"
-      >
-        <Dialog.Title className="text-base font-semibold">
-          루틴 삭제
-        </Dialog.Title>
-        <p className="text-muted-foreground mt-2 text-sm">
-          ‘{deleteTarget?.title}’ 루틴을 삭제할까요?
-        </p>
-        <DialogFooter>
-          <Dialog.Close
-            render={
-              <Button variant="ghost" type="button">
-                취소
-              </Button>
-            }
-          />
-          <Button
-            variant="destructive"
-            onClick={confirmDelete}
-            disabled={deleteRoutine.isPending}
-          >
-            삭제
-          </Button>
-        </DialogFooter>
-      </Modal>
+        mode="delete"
+        instanceDate={deleteTarget?.start.slice(0, 10)}
+        defaultScope="all"
+        pending={deleteRoutine.isPending}
+        onConfirm={confirmDelete}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 이슈
closes #581

## 작업 내용
- **`RoutineScopeDialog`** — 반복 루틴 수정/삭제 범위 선택 ([UI Design §5](https://github.com/wcorn/orino/wiki/Routine-UI-Design))
  - **이 날짜만 (M/D) / 이 날짜 이후 모두 / 전체 루틴** (instance / following / all)
  - 컨텍스트별 기본값: 인스턴스 컨텍스트=이 날짜만, 관리 화면=전체
  - `instanceDate`가 없으면 날짜 기반 옵션 비활성, 수정/삭제 모드별 제목·확인 버튼(삭제는 destructive)
- **관리 화면 연동** — R2에서 `scope=all` 고정이던 자리를 대체
  - 수정: 폼 저장(prefill 역파싱) → 범위 선택 → `PATCH(scope, instanceDate)`
  - 삭제: → 범위 선택 → `DELETE(scope, instanceDate)`
  - 시리즈 `start`를 인스턴스 기준 날짜로 사용해 3개 scope 모두 선택 가능, `scope=all`이면 instanceDate 미전송

## 검증
- `npm test`(RTL + MSW)
  - `RoutineScopeDialog`: 각 scope 선택 → `onConfirm`이 해당 값으로 호출 / 날짜 라벨 / instanceDate 없을 때 비활성
  - `RoutinesPage`: 삭제 **이후 모두** 선택 → `DELETE ...?scope=following&instanceDate=2026-06-20` 쿼리 파라미터 검증
- `npm run lint` / `format:check` / `tsc --noEmit` ✅, 전체 169 테스트 통과