### PR TITLE
test : Routine 마무리 — 엣지·문서 마감 (R5)

### DIFF
--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/recurrence/RecurrenceRuleFactoryTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/recurrence/RecurrenceRuleFactoryTest.java
@@ -57,6 +57,15 @@ class RecurrenceRuleFactoryTest {
         }
 
         @Test
+        @DisplayName("매월 31일은 BYMONTHDAY=31로 그대로 출력한다 (31일 없는 달은 Google이 건너뜀)")
+        void monthlyDay31() {
+            RecurrenceRule rule = RecurrenceRule.monthly(List.of(31), null);
+
+            assertThat(RecurrenceRuleFactory.toRRule(rule, SEOUL))
+                    .isEqualTo("RRULE:FREQ=MONTHLY;BYMONTHDAY=31");
+        }
+
+        @Test
         @DisplayName("UNTIL은 사용자 TZ 마지막날 23:59:59를 UTC로 변환한다 (KST → -9h)")
         void untilUtcSeoul() {
             RecurrenceRule rule = RecurrenceRule.daily(LocalDate.of(2026, 12, 31));
@@ -114,6 +123,10 @@ class RecurrenceRuleFactoryTest {
             RecurrenceRule monthly = RecurrenceRuleFactory.parse(
                     "RRULE:FREQ=MONTHLY;BYMONTHDAY=1,15", SEOUL);
             assertThat(monthly.byMonthDay()).containsExactly(1, 15);
+
+            RecurrenceRule day31 = RecurrenceRuleFactory.parse(
+                    "RRULE:FREQ=MONTHLY;BYMONTHDAY=31", SEOUL);
+            assertThat(day31.byMonthDay()).containsExactly(31);
         }
 
         @Test

--- a/fe/src/features/planner/routineRecurrence.test.ts
+++ b/fe/src/features/planner/routineRecurrence.test.ts
@@ -24,6 +24,21 @@ describe("recurrenceText", () => {
     expect(
       recurrenceText({ freq: "MONTHLY", interval: 3, byMonthDay: [1] }),
     ).toBe("3개월마다 1일");
+    // 31일 없는 달은 Google이 건너뛰지만 표시 문구는 그대로 31일
+    expect(recurrenceText({ freq: "MONTHLY", byMonthDay: [31] })).toBe(
+      "매월 31일",
+    );
+  });
+
+  it("요일/일자가 비면 접두사만, 매주 7요일 전체도 처리", () => {
+    expect(recurrenceText({ freq: "WEEKLY", byDay: [] })).toBe("매주");
+    expect(recurrenceText({ freq: "MONTHLY", byMonthDay: [] })).toBe("매월");
+    expect(
+      recurrenceText({
+        freq: "WEEKLY",
+        byDay: ["MO", "TU", "WE", "TH", "FR", "SA", "SU"],
+      }),
+    ).toBe("매주 월·화·수·목·금·토·일");
   });
 });
 
@@ -39,5 +54,9 @@ describe("recurrencePreview", () => {
     expect(
       recurrencePreview({ freq: "DAILY", until: "2026-12-31" }, "2026-06-20"),
     ).toBe("매일 · 2026-06-20부터 ~ 2026-12-31까지");
+  });
+
+  it("시작일이 없으면 반복 문구만 보여준다", () => {
+    expect(recurrencePreview({ freq: "DAILY" }, "")).toBe("매일");
   });
 });


### PR DESCRIPTION
## 이슈
closes #582

## 작업 내용 (출시 전 품질 마감)
- **엣지 케이스 테스트 보강**
  - BE `RecurrenceRuleFactory`: 매월 **31일**(`BYMONTHDAY=31`) 빌드/역파싱 — 31일 없는 달은 Google이 건너뜀
  - FE `routineRecurrence`: 매월 31일 / 빈 요일·일자(접두사만) / 매주 7요일 전체 / 시작일 없는 미리보기
  - 기존: UNTIL 경계(KST/EST 롤오버), 미연동(409)·만료(401)는 R0~R4에서 커버
- **Wiki 문서 마감** (별도 wiki repo push 완료)
  - 6개 Routine 문서에 `✅ 구현 완료 — R0~R5` 상태 배너 추가
  - API-Spec의 미정 코드(`PLN-ERR-006`) 안내를 실제 구현(`PLN-ERR-002`가 반복 규칙/scope/날짜 오류 포괄)으로 정정
- **반응형/상태 점검**
  - 모달은 공유 `DialogPopup`(전폭−여백 + max-height 스크롤)으로 모바일 대응, 요일 토글은 `flex-1` 7칸 한 줄. 앱 전역 영향이 큰 바텀시트 리팩터는 디자인 시스템 결정 사항이라 본 PR 범위에서 제외
  - 빈/오류/미연동 상태는 관리 화면·오늘의 루틴·폼에서 공유 컴포넌트(EmptyState·CTA)로 일관 처리됨(R2/R3)

## 검증
- BE `:orino-app-api:test`(recurrence) + `checkstyleTest` ✅
- FE `npm test`(routineRecurrence) / `lint` / `tsc` / **`npm run build`(프로덕션 번들)** ✅

> ⚠️ 로컬 직접 동작 확인(`bootRun` + 브라우저 OAuth 플로우)은 Google 실연동이 필요해 자동화 범위 밖입니다 — 머지 전 개발자 수동 확인을 권장합니다.