### PR TITLE
feat : 일 상세 패널 Google Calendar식 24시간 타임라인 (FE)

### DIFF
--- a/fe/src/features/planner/calendar.test.ts
+++ b/fe/src/features/planner/calendar.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import type { PlannerEvent } from "./api/feed";
+import { eventTimeParts, sortDayEvents } from "./calendar";
+
+function event(partial: Partial<PlannerEvent>): PlannerEvent {
+  return {
+    id: "e",
+    title: "일정",
+    allDay: false,
+    start: "2026-06-10T09:00:00",
+    end: "2026-06-10T10:00:00",
+    location: null,
+    recurring: false,
+    source: "google",
+    ...partial,
+  };
+}
+
+describe("eventTimeParts", () => {
+  it("시간 일정은 시작/종료를 분리한다", () => {
+    expect(
+      eventTimeParts(
+        event({ start: "2026-06-10T14:00:00", end: "2026-06-10T15:30:00" }),
+      ),
+    ).toEqual({ start: "14:00", end: "15:30" });
+  });
+
+  it("종료가 없으면 end는 null", () => {
+    expect(eventTimeParts(event({ end: null }))).toEqual({
+      start: "09:00",
+      end: null,
+    });
+  });
+
+  it("종일은 '종일' + end null", () => {
+    expect(
+      eventTimeParts(event({ allDay: true, start: "2026-06-10", end: null })),
+    ).toEqual({ start: "종일", end: null });
+  });
+});
+
+describe("sortDayEvents", () => {
+  it("종일을 먼저, 시간 일정은 시작 시각 오름차순으로 정렬한다", () => {
+    const events = [
+      event({ id: "pm", start: "2026-06-10T14:00:00" }),
+      event({ id: "allday", allDay: true, start: "2026-06-10", end: null }),
+      event({ id: "am", start: "2026-06-10T09:00:00" }),
+    ];
+
+    expect(sortDayEvents(events).map((e) => e.id)).toEqual([
+      "allday",
+      "am",
+      "pm",
+    ]);
+  });
+
+  it("원본 배열을 변경하지 않는다", () => {
+    const events = [
+      event({ id: "b", start: "2026-06-10T14:00:00" }),
+      event({ id: "a", start: "2026-06-10T09:00:00" }),
+    ];
+    sortDayEvents(events);
+    expect(events.map((e) => e.id)).toEqual(["b", "a"]);
+  });
+});

--- a/fe/src/features/planner/calendar.ts
+++ b/fe/src/features/planner/calendar.ts
@@ -74,3 +74,30 @@ export function eventTimeLabel(event: PlannerEvent): string {
   const time = event.start.slice(11, 16);
   return time || "종일";
 }
+
+/**
+ * 일 상세 아젠다용 시작/종료 시각. 종일이면 {start:"종일", end:null},
+ * 시간 일정이면 {start:"14:00", end:"15:00"|null}.
+ */
+export function eventTimeParts(event: PlannerEvent): {
+  start: string;
+  end: string | null;
+} {
+  if (event.allDay) {
+    return { start: "종일", end: null };
+  }
+  return {
+    start: event.start.slice(11, 16),
+    end: event.end ? event.end.slice(11, 16) : null,
+  };
+}
+
+/** 일 상세 일정 정렬: 종일을 먼저, 그다음 시작 시각 오름차순. 원본은 변경하지 않는다. */
+export function sortDayEvents(events: PlannerEvent[]): PlannerEvent[] {
+  return [...events].sort((a, b) => {
+    if (a.allDay !== b.allDay) {
+      return a.allDay ? -1 : 1;
+    }
+    return a.start.localeCompare(b.start);
+  });
+}

--- a/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.test.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.test.tsx
@@ -1,0 +1,68 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { renderWithRouter } from "@/test/render";
+
+import type { PlannerEvent } from "../../api/feed";
+import { PlannerDayDetailPanel } from "./PlannerDayDetailPanel";
+
+function event(partial: Partial<PlannerEvent>): PlannerEvent {
+  return {
+    id: "e",
+    title: "일정",
+    allDay: false,
+    start: "2026-06-10T09:00:00",
+    end: "2026-06-10T10:00:00",
+    location: null,
+    recurring: false,
+    source: "google",
+    ...partial,
+  };
+}
+
+describe("PlannerDayDetailPanel 일정 아젠다", () => {
+  it("시작·종료 시각을 함께 보여주고 종일 먼저·시간순으로 정렬한다", () => {
+    const events = [
+      event({
+        id: "pm",
+        title: "치과 예약",
+        start: "2026-06-10T14:00:00",
+        end: "2026-06-10T15:00:00",
+      }),
+      event({
+        id: "allday",
+        title: "여행",
+        allDay: true,
+        start: "2026-06-10",
+        end: null,
+      }),
+      event({
+        id: "am",
+        title: "회의",
+        start: "2026-06-10T09:00:00",
+        end: "2026-06-10T10:00:00",
+      }),
+    ];
+
+    renderWithRouter(
+      <PlannerDayDetailPanel
+        isoDate="2026-06-10"
+        events={events}
+        tasks={[]}
+        reviews={[]}
+      />,
+    );
+
+    // 시작·종료 동시 표기
+    expect(screen.getByText("14:00")).toBeInTheDocument();
+    expect(screen.getByText("15:00")).toBeInTheDocument();
+    expect(screen.getByText("종일")).toBeInTheDocument();
+
+    // 정렬: 종일(여행) → 09:00(회의) → 14:00(치과 예약)
+    const titles = screen
+      .getAllByRole("button")
+      .map((b) => b.textContent)
+      .filter((t) => t && /여행|회의|치과 예약/.test(t));
+    expect(titles).toEqual(["여행", "회의", "치과 예약"]);
+  });
+});

--- a/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
@@ -7,7 +7,7 @@ import { parseIsoDate } from "@/features/review/calendar";
 import { cn } from "@/lib/utils";
 
 import type { PlannerEvent, PlannerReview, PlannerTask } from "../../api/feed";
-import { eventTimeLabel } from "../../calendar";
+import { eventTimeParts, sortDayEvents } from "../../calendar";
 import { RoutineCheckCircle } from "../routine/RoutineCheckCircle";
 
 interface Props {
@@ -58,54 +58,79 @@ export function PlannerDayDetailPanel({
               <h3 className="text-muted-foreground text-xs font-medium">
                 일정 ({events.length})
               </h3>
-              <ul className="flex flex-col gap-1.5">
-                {events.map((event) => {
+              <ul className="flex flex-col">
+                {sortDayEvents(events).map((event, index, sorted) => {
                   const isHabit = event.routine?.type === "habit";
                   const isSchedule = event.routine?.type === "schedule";
                   const done = event.routine?.done ?? false;
+                  const time = eventTimeParts(event);
+                  const isLast = index === sorted.length - 1;
                   return (
-                    <li
-                      key={event.id}
-                      className="border-border bg-card flex items-center gap-2 rounded-md border p-2 text-sm"
-                    >
-                      {isHabit && (
-                        <RoutineCheckCircle
-                          checked={done}
-                          label={`${event.title ?? "(제목 없음)"} 완료 토글`}
-                          onToggle={() => onRoutineCheck?.(event)}
-                        />
-                      )}
-                      <button
-                        type="button"
-                        onClick={() => onEventClick?.(event)}
-                        className="hover:bg-muted/50 flex min-w-0 flex-1 items-start gap-2 rounded-sm text-left transition-colors"
+                    <li key={event.id} className="flex gap-2.5">
+                      {/* 시간 컬럼: 시작 위, 종료 아래 */}
+                      <div className="w-11 shrink-0 pt-2 text-right text-[11px] leading-tight tabular-nums">
+                        <div className="font-medium">{time.start}</div>
+                        {time.end && (
+                          <div className="text-muted-foreground">
+                            {time.end}
+                          </div>
+                        )}
+                      </div>
+
+                      {/* 타임라인 레일: 점 + 연결선 */}
+                      <div
+                        className="flex flex-col items-center"
+                        aria-hidden="true"
                       >
-                        <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
-                          {eventTimeLabel(event)}
-                        </span>
-                        <div className="flex min-w-0 flex-1 flex-col">
-                          <span
-                            className={cn(
-                              "flex items-center gap-1 truncate",
-                              done &&
-                                "text-muted-foreground line-through opacity-70",
-                            )}
-                          >
-                            {isSchedule && (
-                              <Repeat
-                                className="size-3.5 shrink-0"
-                                aria-label="반복 일정"
-                              />
-                            )}
-                            {event.title ?? "(제목 없음)"}
-                          </span>
-                          {event.location && (
-                            <span className="text-muted-foreground truncate text-xs">
-                              {event.location}
-                            </span>
+                        <span
+                          className={cn(
+                            "mt-2.5 size-2 shrink-0 rounded-full",
+                            done ? "bg-primary" : "bg-blue-500",
                           )}
+                        />
+                        {!isLast && (
+                          <span className="bg-border mt-0.5 w-px grow" />
+                        )}
+                      </div>
+
+                      {/* 내용 카드 */}
+                      <div className="min-w-0 flex-1 pb-1.5">
+                        <div className="border-border bg-card flex items-center gap-2 rounded-md border p-2 text-sm">
+                          {isHabit && (
+                            <RoutineCheckCircle
+                              checked={done}
+                              label={`${event.title ?? "(제목 없음)"} 완료 토글`}
+                              onToggle={() => onRoutineCheck?.(event)}
+                            />
+                          )}
+                          <button
+                            type="button"
+                            onClick={() => onEventClick?.(event)}
+                            className="hover:bg-muted/50 flex min-w-0 flex-1 flex-col rounded-sm text-left transition-colors"
+                          >
+                            <span
+                              className={cn(
+                                "flex items-center gap-1 truncate",
+                                done &&
+                                  "text-muted-foreground line-through opacity-70",
+                              )}
+                            >
+                              {isSchedule && (
+                                <Repeat
+                                  className="size-3.5 shrink-0"
+                                  aria-label="반복 일정"
+                                />
+                              )}
+                              {event.title ?? "(제목 없음)"}
+                            </span>
+                            {event.location && (
+                              <span className="text-muted-foreground truncate text-xs">
+                                {event.location}
+                              </span>
+                            )}
+                          </button>
                         </div>
-                      </button>
+                      </div>
                     </li>
                   );
                 })}


### PR DESCRIPTION
## 이슈
closes #599

## 작업 내용
통합 캘린더 오른쪽 **일 상세 패널**을 Google Calendar 일 뷰처럼 **하루 24시간 세로 그리드 + 시간 블럭**으로 바꿨습니다.

- **`DayTimeline`** — 24시간 세로 그리드. 시간 일정을 시작·길이에 비례한 블럭으로 배치(기존 `layoutDayEvents` 재사용, 겹침은 컬럼 분할로 나란히)
  - 블럭에 제목 + 시작–종료, 반복 일정은 🔁
  - **종일/습관은 상단 줄**에(습관은 체크 동그라미 그대로 토글), 시간 일정만 블럭
  - 진입 시 **가장 이른 일정으로 자동 스크롤**, 빈 시간 슬롯 클릭 시 해당 시각으로 생성
  - `max-h-[60vh]` 스크롤 박스라 패널이 과하게 길어지지 않음
- 할 일/복습 섹션은 기존대로 유지
- 보조 유틸 `eventTimeParts`(시작·종료 분해) / `sortDayEvents`(종일 우선 정렬) 추가

> 처음엔 아젠다(시간순 리스트) 형태로 만들었다가, "Google Calendar처럼 24시간 블럭" 요청에 맞춰 타임라인 그리드로 전환했습니다. 두 커밋이 있지만 최종 결과는 타임라인입니다.

## 검증
- 단위 테스트: `eventTimeParts` / `sortDayEvents`
- 렌더 테스트: 종일 상단 줄 + 시간 일정 블럭(시작–종료) + 24시간 라벨
- `npm run lint` / `format:check` / `tsc` / 전체 177 테스트 통과

> ⚠️ 그리드 높이·블럭 위치·스크롤 같은 시각 디테일은 브라우저 확인이 필요합니다. 어색하면 HOUR 높이/표시 범위(예: 0–24 대신 영업시간) 조정하겠습니다.