### PR TITLE
feat : 일 상세 패널 Google Calendar식 24시간 타임라인 그리드 (FE)

### DIFF
--- a/fe/src/features/planner/components/calendar/DayTimeline.tsx
+++ b/fe/src/features/planner/components/calendar/DayTimeline.tsx
@@ -1,0 +1,166 @@
+import { Repeat } from "lucide-react";
+import { useEffect, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+import type { PlannerEvent } from "../../api/feed";
+import { eventTimeParts, sortDayEvents } from "../../calendar";
+import { HOURS, layoutDayEvents } from "../../weekLayout";
+import { RoutineCheckCircle } from "../routine/RoutineCheckCircle";
+import { EVENT_DOT } from "./sourceStyles";
+
+const HOUR_PX = 44;
+const MIN_PER_DAY = 24 * 60;
+
+interface Props {
+  isoDate: string;
+  events: PlannerEvent[];
+  onEventClick?: (event: PlannerEvent) => void;
+  onRoutineCheck?: (event: PlannerEvent) => void;
+  onSlotClick?: (isoDate: string, hour: number) => void;
+}
+
+/**
+ * Google Calendar식 하루 24시간 타임라인. 종일/습관은 상단 줄에, 시간 일정은
+ * 시작·길이에 비례한 블럭으로 시간축에 배치한다(겹침은 컬럼 분할). 진입 시 가장 이른
+ * 일정으로 스크롤한다.
+ */
+export function DayTimeline({
+  isoDate,
+  events,
+  onEventClick,
+  onRoutineCheck,
+  onSlotClick,
+}: Props) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const allDayEvents = sortDayEvents(events).filter((e) => e.allDay);
+  const positioned = layoutDayEvents(events);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const firstMin = positioned.length
+      ? Math.min(...positioned.map((p) => p.top * MIN_PER_DAY))
+      : 8 * 60;
+    el.scrollTop = Math.max(0, (firstMin / 60) * HOUR_PX - HOUR_PX);
+    // 날짜가 바뀔 때만 재스크롤
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isoDate]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {allDayEvents.length > 0 && (
+        <ul className="flex flex-col gap-1">
+          {allDayEvents.map((event) => {
+            const isHabit = event.routine?.type === "habit";
+            const done = event.routine?.done ?? false;
+            return (
+              <li
+                key={event.id}
+                className="border-border bg-card flex items-center gap-2 rounded-md border px-2 py-1.5 text-sm"
+              >
+                {isHabit ? (
+                  <RoutineCheckCircle
+                    checked={done}
+                    label={`${event.title ?? "(제목 없음)"} 완료 토글`}
+                    onToggle={() => onRoutineCheck?.(event)}
+                  />
+                ) : (
+                  <span className="text-muted-foreground shrink-0 text-[10px]">
+                    종일
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={() => onEventClick?.(event)}
+                  className={cn(
+                    "min-w-0 flex-1 truncate text-left",
+                    done && "text-muted-foreground line-through opacity-70",
+                  )}
+                >
+                  {event.title ?? "(제목 없음)"}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div
+        ref={scrollRef}
+        className="relative max-h-[60vh] overflow-y-auto rounded-md border"
+      >
+        <div
+          className="grid"
+          style={{ gridTemplateColumns: "2.75rem minmax(0, 1fr)" }}
+        >
+          {/* 시간 라벨 */}
+          <div>
+            {HOURS.map((h) => (
+              <div
+                key={h}
+                style={{ height: HOUR_PX }}
+                className="text-muted-foreground pr-1.5 text-right text-[10px] tabular-nums"
+              >
+                {h}시
+              </div>
+            ))}
+          </div>
+
+          {/* 시간축 + 블럭 */}
+          <div
+            className="border-border/60 relative border-l"
+            style={{ height: HOUR_PX * 24 }}
+          >
+            {HOURS.map((h) => (
+              <button
+                key={h}
+                type="button"
+                disabled={!onSlotClick}
+                onClick={() => onSlotClick?.(isoDate, h)}
+                style={{ height: HOUR_PX }}
+                aria-label={`${isoDate} ${h}시 일정 추가`}
+                className="border-border/40 enabled:hover:bg-muted/40 block w-full border-t"
+              />
+            ))}
+            {positioned.map((p) => {
+              const time = eventTimeParts(p.event);
+              const isSchedule = p.event.routine?.type === "schedule";
+              return (
+                <button
+                  key={p.event.id}
+                  type="button"
+                  onClick={() => onEventClick?.(p.event)}
+                  style={{
+                    top: `${p.top * 100}%`,
+                    height: `${p.height * 100}%`,
+                    left: `calc(${p.left * 100}% + 2px)`,
+                    width: `calc(${p.width * 100}% - 4px)`,
+                  }}
+                  className={cn(
+                    "absolute flex flex-col overflow-hidden rounded border border-blue-600 px-1.5 py-0.5 text-left text-[11px] leading-tight text-white",
+                    EVENT_DOT,
+                  )}
+                >
+                  <span className="flex items-center gap-1 truncate font-medium">
+                    {isSchedule && (
+                      <Repeat
+                        className="size-3 shrink-0"
+                        aria-label="반복 일정"
+                      />
+                    )}
+                    {p.event.title ?? "(제목 없음)"}
+                  </span>
+                  <span className="truncate tabular-nums opacity-90">
+                    {time.start}
+                    {time.end ? `–${time.end}` : ""}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
@@ -293,6 +293,13 @@ export function PlannerCalendar() {
                     done: !event.routine.done,
                   })
                 }
+                onSlotClick={(isoDate, hour) =>
+                  setDialog({
+                    mode: "create",
+                    date: isoDate,
+                    startTime: `${String(hour).padStart(2, "0")}:00`,
+                  })
+                }
               />
             </CardContent>
           </Card>

--- a/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.test.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.test.tsx
@@ -20,8 +20,8 @@ function event(partial: Partial<PlannerEvent>): PlannerEvent {
   };
 }
 
-describe("PlannerDayDetailPanel 일정 아젠다", () => {
-  it("시작·종료 시각을 함께 보여주고 종일 먼저·시간순으로 정렬한다", () => {
+describe("PlannerDayDetailPanel 일정 타임라인", () => {
+  it("종일은 상단 줄, 시간 일정은 시작·종료가 붙은 블럭으로 보여준다", () => {
     const events = [
       event({
         id: "pm",
@@ -53,16 +53,18 @@ describe("PlannerDayDetailPanel 일정 아젠다", () => {
       />,
     );
 
-    // 시작·종료 동시 표기
-    expect(screen.getByText("14:00")).toBeInTheDocument();
-    expect(screen.getByText("15:00")).toBeInTheDocument();
+    // 종일 일정은 상단 줄
+    expect(screen.getByText("여행")).toBeInTheDocument();
     expect(screen.getByText("종일")).toBeInTheDocument();
 
-    // 정렬: 종일(여행) → 09:00(회의) → 14:00(치과 예약)
-    const titles = screen
-      .getAllByRole("button")
-      .map((b) => b.textContent)
-      .filter((t) => t && /여행|회의|치과 예약/.test(t));
-    expect(titles).toEqual(["여행", "회의", "치과 예약"]);
+    // 시간 일정은 시작–종료가 붙은 블럭
+    expect(screen.getByText("회의")).toBeInTheDocument();
+    expect(screen.getByText(/09:00.10:00/)).toBeInTheDocument();
+    expect(screen.getByText("치과 예약")).toBeInTheDocument();
+    expect(screen.getByText(/14:00.15:00/)).toBeInTheDocument();
+
+    // 24시간 그리드(시간 라벨)
+    expect(screen.getByText("0시")).toBeInTheDocument();
+    expect(screen.getByText("23시")).toBeInTheDocument();
   });
 });

--- a/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { Repeat, Trash2 } from "lucide-react";
+import { Trash2 } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
@@ -7,8 +7,7 @@ import { parseIsoDate } from "@/features/review/calendar";
 import { cn } from "@/lib/utils";
 
 import type { PlannerEvent, PlannerReview, PlannerTask } from "../../api/feed";
-import { eventTimeParts, sortDayEvents } from "../../calendar";
-import { RoutineCheckCircle } from "../routine/RoutineCheckCircle";
+import { DayTimeline } from "./DayTimeline";
 
 interface Props {
   isoDate: string;
@@ -19,6 +18,7 @@ interface Props {
   onTaskToggle?: (task: PlannerTask) => void;
   onTaskDelete?: (task: PlannerTask) => void;
   onRoutineCheck?: (event: PlannerEvent) => void;
+  onSlotClick?: (isoDate: string, hour: number) => void;
 }
 
 function formatHeading(isoDate: string): string {
@@ -35,6 +35,7 @@ export function PlannerDayDetailPanel({
   onTaskToggle,
   onTaskDelete,
   onRoutineCheck,
+  onSlotClick,
 }: Props) {
   const isEmpty = events.length + tasks.length + reviews.length === 0;
 
@@ -58,83 +59,13 @@ export function PlannerDayDetailPanel({
               <h3 className="text-muted-foreground text-xs font-medium">
                 일정 ({events.length})
               </h3>
-              <ul className="flex flex-col">
-                {sortDayEvents(events).map((event, index, sorted) => {
-                  const isHabit = event.routine?.type === "habit";
-                  const isSchedule = event.routine?.type === "schedule";
-                  const done = event.routine?.done ?? false;
-                  const time = eventTimeParts(event);
-                  const isLast = index === sorted.length - 1;
-                  return (
-                    <li key={event.id} className="flex gap-2.5">
-                      {/* 시간 컬럼: 시작 위, 종료 아래 */}
-                      <div className="w-11 shrink-0 pt-2 text-right text-[11px] leading-tight tabular-nums">
-                        <div className="font-medium">{time.start}</div>
-                        {time.end && (
-                          <div className="text-muted-foreground">
-                            {time.end}
-                          </div>
-                        )}
-                      </div>
-
-                      {/* 타임라인 레일: 점 + 연결선 */}
-                      <div
-                        className="flex flex-col items-center"
-                        aria-hidden="true"
-                      >
-                        <span
-                          className={cn(
-                            "mt-2.5 size-2 shrink-0 rounded-full",
-                            done ? "bg-primary" : "bg-blue-500",
-                          )}
-                        />
-                        {!isLast && (
-                          <span className="bg-border mt-0.5 w-px grow" />
-                        )}
-                      </div>
-
-                      {/* 내용 카드 */}
-                      <div className="min-w-0 flex-1 pb-1.5">
-                        <div className="border-border bg-card flex items-center gap-2 rounded-md border p-2 text-sm">
-                          {isHabit && (
-                            <RoutineCheckCircle
-                              checked={done}
-                              label={`${event.title ?? "(제목 없음)"} 완료 토글`}
-                              onToggle={() => onRoutineCheck?.(event)}
-                            />
-                          )}
-                          <button
-                            type="button"
-                            onClick={() => onEventClick?.(event)}
-                            className="hover:bg-muted/50 flex min-w-0 flex-1 flex-col rounded-sm text-left transition-colors"
-                          >
-                            <span
-                              className={cn(
-                                "flex items-center gap-1 truncate",
-                                done &&
-                                  "text-muted-foreground line-through opacity-70",
-                              )}
-                            >
-                              {isSchedule && (
-                                <Repeat
-                                  className="size-3.5 shrink-0"
-                                  aria-label="반복 일정"
-                                />
-                              )}
-                              {event.title ?? "(제목 없음)"}
-                            </span>
-                            {event.location && (
-                              <span className="text-muted-foreground truncate text-xs">
-                                {event.location}
-                              </span>
-                            )}
-                          </button>
-                        </div>
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
+              <DayTimeline
+                isoDate={isoDate}
+                events={events}
+                onEventClick={onEventClick}
+                onRoutineCheck={onRoutineCheck}
+                onSlotClick={onSlotClick}
+              />
             </section>
           )}
 


### PR DESCRIPTION
## 이슈
closes #601

> #600(시간순 아젠다)에 이어, "Google Calendar처럼 24시간 블럭" 요청에 맞춰 아젠다를 **타임라인 그리드**로 전환합니다.

## 작업 내용
- **`DayTimeline`** — 하루 24시간 세로 그리드. 시간 일정을 시작·길이에 비례한 블럭으로 배치(기존 주/일 뷰의 `layoutDayEvents` 재사용, 겹침은 컬럼 분할로 나란히)
  - 블럭에 제목 + 시작–종료, 반복 일정은 🔁
  - **종일/습관은 상단 줄**(습관은 체크 동그라미 그대로 토글), 시간 일정만 블럭
  - 진입 시 **가장 이른 일정으로 자동 스크롤**, 빈 시간 슬롯 클릭 시 해당 시각으로 생성
  - `max-h-[60vh]` 스크롤 박스
- 일 상세 패널의 일정 섹션을 아젠다 리스트 → `DayTimeline`으로 교체, 할 일/복습은 유지

## 검증
- 렌더 테스트: 종일 상단 줄 + 시간 일정 블럭(시작–종료) + 24시간 라벨
- `npm run lint` / `format:check` / `tsc` ✅, 캘린더/패널 테스트 통과

> ⚠️ 그리드 높이·블럭 위치·스크롤 같은 시각 디테일은 브라우저 확인 후 미세 조정이 필요할 수 있습니다(시간당 높이 44px, 표시 범위 0–24시).