### PR TITLE
feat : 월 뷰 날짜 칸 일정을 라인(점+시작시각+제목)으로 (FE)

### DIFF
--- a/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
@@ -94,7 +94,8 @@ describe("PlannerCalendar", () => {
 
     expect(screen.getByLabelText("불러오는 중")).toBeInTheDocument();
 
-    expect(await screen.findByText("회의")).toBeInTheDocument();
+    // 월 셀과 그날 상세 양쪽에 제목이 나타날 수 있다(최소 1개).
+    expect((await screen.findAllByText("회의")).length).toBeGreaterThan(0);
     expect(screen.getByText("이펙티브 자바")).toBeInTheDocument();
     expect(screen.getByText("Q1")).toBeInTheDocument();
     expect(

--- a/fe/src/features/planner/components/calendar/PlannerCalendarCell.test.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendarCell.test.tsx
@@ -28,7 +28,7 @@ const baseProps = {
   onSelect: () => {},
   tasks: [],
   reviews: [],
-} as const;
+};
 
 describe("PlannerCalendarCell 일정 라인", () => {
   it("시간 일정은 시작 시각 + 제목, 종일은 제목만 보여준다", () => {

--- a/fe/src/features/planner/components/calendar/PlannerCalendarCell.test.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendarCell.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { PlannerEvent } from "../../api/feed";
+import { PlannerCalendarCell } from "./PlannerCalendarCell";
+
+function event(partial: Partial<PlannerEvent>): PlannerEvent {
+  return {
+    id: "e",
+    title: "일정",
+    allDay: false,
+    start: "2026-06-10T09:00:00",
+    end: "2026-06-10T10:00:00",
+    location: null,
+    recurring: false,
+    source: "google",
+    ...partial,
+  };
+}
+
+const baseProps = {
+  date: new Date(2026, 5, 10),
+  isoDate: "2026-06-10",
+  inMonth: true,
+  isToday: false,
+  isSelected: false,
+  today: new Date(2026, 5, 10),
+  onSelect: () => {},
+  tasks: [],
+  reviews: [],
+} as const;
+
+describe("PlannerCalendarCell 일정 라인", () => {
+  it("시간 일정은 시작 시각 + 제목, 종일은 제목만 보여준다", () => {
+    render(
+      <PlannerCalendarCell
+        {...baseProps}
+        events={[
+          event({ id: "t", title: "회의", start: "2026-06-10T14:00:00" }),
+          event({ id: "a", title: "여행", allDay: true, start: "2026-06-10" }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("14:00")).toBeInTheDocument();
+    expect(screen.getByText("회의")).toBeInTheDocument();
+    expect(screen.getByText("여행")).toBeInTheDocument();
+    // 종일은 시각 표기 없음(14:00만 존재)
+    expect(screen.queryByText("종일")).not.toBeInTheDocument();
+  });
+
+  it("3개를 넘으면 +N개로 접는다", () => {
+    render(
+      <PlannerCalendarCell
+        {...baseProps}
+        events={Array.from({ length: 5 }, (_, i) =>
+          event({
+            id: `e${i}`,
+            title: `일정${i}`,
+            start: `2026-06-10T0${i}:00:00`,
+          }),
+        )}
+      />,
+    );
+
+    expect(screen.getByText("+2개")).toBeInTheDocument();
+  });
+});

--- a/fe/src/features/planner/components/calendar/PlannerCalendarCell.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendarCell.tsx
@@ -5,7 +5,11 @@ import {
 import { cn } from "@/lib/utils";
 
 import type { PlannerEvent, PlannerReview, PlannerTask } from "../../api/feed";
-import { classifyFeedReview } from "../../calendar";
+import {
+  classifyFeedReview,
+  eventTimeLabel,
+  sortDayEvents,
+} from "../../calendar";
 import { EVENT_DOT, TASK_DOT } from "./sourceStyles";
 
 interface Props {
@@ -21,7 +25,12 @@ interface Props {
   onSelect: (isoDate: string) => void;
 }
 
-const MAX_DOTS = 5;
+/** 셀에 한 줄로 보여줄 최대 항목 수. 초과분은 "+N개"로 접는다. */
+const MAX_LINES = 3;
+
+function Dot({ className }: { className: string }) {
+  return <span className={cn("size-1.5 shrink-0 rounded-full", className)} />;
+}
 
 export function PlannerCalendarCell({
   date,
@@ -35,18 +44,59 @@ export function PlannerCalendarCell({
   today,
   onSelect,
 }: Props) {
-  const reviewDots = BUCKET_ORDER.flatMap((bucket) =>
-    reviews
-      .filter((r) => classifyFeedReview(r, today) === bucket)
-      .map(() => BUCKET_DOT[bucket]),
-  );
-  const dots = [
-    ...events.map(() => EVENT_DOT),
-    ...tasks.map(() => TASK_DOT),
-    ...reviewDots,
+  const reviewDot =
+    BUCKET_ORDER.map((bucket) =>
+      reviews.some((r) => classifyFeedReview(r, today) === bucket)
+        ? BUCKET_DOT[bucket]
+        : null,
+    ).find(Boolean) ?? BUCKET_DOT[BUCKET_ORDER[0]];
+
+  // 점 + (시작 시각) + 제목 한 줄. 일정 → 할 일 → 복습(묶음) 순.
+  const lines = [
+    ...sortDayEvents(events).map((event) => (
+      <span
+        key={`e-${event.id}`}
+        className="flex items-center gap-1 text-[10px] leading-tight"
+      >
+        <Dot className={EVENT_DOT} />
+        {!event.allDay && (
+          <span className="text-muted-foreground shrink-0 tabular-nums">
+            {eventTimeLabel(event)}
+          </span>
+        )}
+        <span className="truncate">{event.title ?? "(제목 없음)"}</span>
+      </span>
+    )),
+    ...tasks.map((task) => (
+      <span
+        key={`t-${task.id}`}
+        className="flex items-center gap-1 text-[10px] leading-tight"
+      >
+        <Dot className={TASK_DOT} />
+        <span
+          className={cn(
+            "truncate",
+            task.completed && "line-through opacity-60",
+          )}
+        >
+          {task.title}
+        </span>
+      </span>
+    )),
+    ...(reviews.length > 0
+      ? [
+          <span
+            key="reviews"
+            className="flex items-center gap-1 text-[10px] leading-tight"
+          >
+            <Dot className={reviewDot} />
+            <span className="truncate">복습 {reviews.length}</span>
+          </span>,
+        ]
+      : []),
   ];
-  const shown = dots.slice(0, MAX_DOTS);
-  const overflow = dots.length - shown.length;
+  const shown = lines.slice(0, MAX_LINES);
+  const hidden = lines.length - shown.length;
   const total = events.length + tasks.length + reviews.length;
 
   return (
@@ -61,7 +111,7 @@ export function PlannerCalendarCell({
       aria-pressed={isSelected}
       onClick={() => onSelect(isoDate)}
       className={cn(
-        "flex min-h-20 flex-col gap-1 rounded-md border p-1.5 text-left transition-colors sm:min-h-24 lg:min-h-28",
+        "flex min-h-20 flex-col gap-0.5 rounded-md border p-1.5 text-left transition-colors sm:min-h-24 lg:min-h-28",
         inMonth ? "bg-card" : "bg-muted/30 text-muted-foreground",
         isToday ? "border-primary" : "border-border",
         isSelected && "ring-primary ring-2",
@@ -75,18 +125,12 @@ export function PlannerCalendarCell({
       >
         {date.getDate()}
       </span>
-      {shown.length > 0 && (
-        <span className="flex flex-wrap items-center gap-0.5">
-          {shown.map((dot, i) => (
-            <span key={i} className={cn("size-1.5 rounded-full", dot)} />
-          ))}
-          {overflow > 0 && (
-            <span className="text-muted-foreground text-[10px]">
-              +{overflow}
-            </span>
-          )}
-        </span>
-      )}
+      <span className="flex min-w-0 flex-col gap-0.5">
+        {shown}
+        {hidden > 0 && (
+          <span className="text-muted-foreground text-[10px]">+{hidden}개</span>
+        )}
+      </span>
     </button>
   );
 }


### PR DESCRIPTION
## 이슈
closes #603

## 작업 내용
월 뷰 날짜 칸의 일정이 **점**으로만 보이던 것을 Google Calendar 월 뷰처럼 **한 줄 라인**으로 바꿨습니다.

- 일정마다 **[점 + 시작 시각 + 제목]** 한 줄(종일은 시각 없이 제목)
- 시간 일정은 **시작 시각 오름차순** 정렬, 표기 순서는 일정 → 할 일 → 복습(묶음)
- 칸당 **최대 3줄** 표기, 초과분은 **"+N개"**로 접음
- 셀 `aria-label`(일정/할일/복습 카운트)은 그대로 유지

## 검증
- 셀 렌더 테스트: 시간 일정(시작 시각+제목) / 종일(제목만) / "+N개" 접힘
- 월 뷰 제목이 셀+상세 양쪽에 나타나는 점 반영해 기존 테스트 단언 보정
- `lint` / `format:check` / `tsc` ✅, 전체 179 테스트 통과

> ⚠️ 칸 높이·줄 수(현재 3줄)·폰트 크기 같은 시각 디테일은 브라우저 확인 후 조정 가능합니다(특히 모바일 좁은 칸).