### PR TITLE
feat : 공휴일 표시 — 특일정보 API 일일 동기화 + 캘린더 오버레이

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/OrinoApplication.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/OrinoApplication.java
@@ -3,9 +3,11 @@ package ds.project.orino;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class OrinoApplication {
     public static void main(String[] args) {
         SpringApplication.run(OrinoApplication.class, args);

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/HolidayApiClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/HolidayApiClient.java
@@ -1,0 +1,104 @@
+package ds.project.orino.planner.holiday;
+
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 한국천문연구원 특일정보 {@code getRestDeInfo}(공휴일) 호출 래퍼.
+ *
+ * <p>data.go.kr 응답 특성에 방어적으로 파싱한다: {@code items.item}이 0건이면 빈 문자열,
+ * 1건이면 객체, 2건 이상이면 배열로 내려온다. {@code locdate}(yyyyMMdd int)와 {@code dateName}을 읽는다.
+ */
+@Component
+public class HolidayApiClient {
+
+    private static final DateTimeFormatter LOCDATE = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final RestClient restClient;
+    private final HolidayProperties properties;
+    private final ObjectMapper objectMapper;
+
+    public HolidayApiClient(HolidayProperties properties, ObjectMapper objectMapper) {
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(properties.connectTimeout());
+        factory.setReadTimeout(properties.readTimeout());
+        this.restClient = RestClient.builder().requestFactory(factory).build();
+    }
+
+    /** 한 해의 공휴일(대체·임시 포함)을 조회한다. */
+    public List<HolidayItem> fetchYear(int year) {
+        URI uri = UriComponentsBuilder.fromUriString(properties.baseUrl())
+                .path("/getRestDeInfo")
+                .queryParam("serviceKey", properties.serviceKey())
+                .queryParam("solYear", year)
+                .queryParam("numOfRows", 100)
+                .queryParam("_type", "json")
+                .build()
+                .toUri();
+
+        String body = restClient.get().uri(uri).retrieve().body(String.class);
+        return parse(body);
+    }
+
+    private List<HolidayItem> parse(String body) {
+        if (body == null || body.isBlank()) {
+            return List.of();
+        }
+        JsonNode root;
+        try {
+            root = objectMapper.readTree(body);
+        } catch (JacksonException e) {
+            throw new IllegalStateException("특일정보 응답 파싱 실패: " + truncate(body), e);
+        }
+
+        String resultCode = root.path("response").path("header").path("resultCode").asString("");
+        if (!resultCode.isEmpty() && !"00".equals(resultCode)) {
+            String msg = root.path("response").path("header").path("resultMsg").asString("");
+            throw new IllegalStateException("특일정보 오류 " + resultCode + ": " + msg);
+        }
+
+        JsonNode item = root.path("response").path("body").path("items").path("item");
+        List<HolidayItem> result = new ArrayList<>();
+        if (item.isArray()) {
+            for (JsonNode node : item) {
+                addIfHoliday(result, node);
+            }
+        } else if (item.isObject()) {
+            addIfHoliday(result, item);
+        }
+        return result;
+    }
+
+    private void addIfHoliday(List<HolidayItem> result, JsonNode node) {
+        if (!"Y".equals(node.path("isHoliday").asString("Y"))) {
+            return;
+        }
+        String locdate = node.path("locdate").asString("");
+        String name = node.path("dateName").asString("");
+        if (locdate.isBlank() || name.isBlank()) {
+            return;
+        }
+        result.add(new HolidayItem(LocalDate.parse(locdate, LOCDATE), name));
+    }
+
+    private static String truncate(String s) {
+        return s.length() > 200 ? s.substring(0, 200) : s;
+    }
+
+    /** 특일정보 1건(공휴일 날짜·이름). */
+    public record HolidayItem(LocalDate date, String name) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/HolidayApiClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/HolidayApiClient.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * 한국천문연구원 특일정보 {@code getRestDeInfo}(공휴일) 호출 래퍼.
@@ -24,6 +25,11 @@ import java.util.List;
 public class HolidayApiClient {
 
     private static final DateTimeFormatter LOCDATE = DateTimeFormatter.ofPattern("yyyyMMdd");
+    /**
+     * 특일정보가 {@code isHoliday=Y}로 주지만 실제 관공서 휴무일이 아니라 빨간날에서 제외할 이름.
+     * 제헌절은 2008년부터 공휴일(휴무)이 아니다. (노동절은 근로자 휴일이라 포함 유지)
+     */
+    private static final Set<String> EXCLUDED_NAMES = Set.of("제헌절");
 
     private final RestClient restClient;
     private final HolidayProperties properties;
@@ -88,7 +94,7 @@ public class HolidayApiClient {
         }
         String locdate = node.path("locdate").asString("");
         String name = node.path("dateName").asString("");
-        if (locdate.isBlank() || name.isBlank()) {
+        if (locdate.isBlank() || name.isBlank() || EXCLUDED_NAMES.contains(name)) {
             return;
         }
         result.add(new HolidayItem(LocalDate.parse(locdate, LOCDATE), name));

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/HolidayController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/HolidayController.java
@@ -1,0 +1,33 @@
+package ds.project.orino.planner.holiday;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.holiday.dto.HolidayResponse;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 공휴일 조회 엔드포인트. Google 연동과 무관하게 [from, to] 구간 공휴일을 반환한다.
+ */
+@RestController
+@RequestMapping("/api/planner/holidays")
+public class HolidayController {
+
+    private final HolidayQueryService holidayQueryService;
+
+    public HolidayController(HolidayQueryService holidayQueryService) {
+        this.holidayQueryService = holidayQueryService;
+    }
+
+    @GetMapping
+    public ApiResponse<List<HolidayResponse>> list(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return ApiResponse.success(holidayQueryService.list(from, to));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/HolidayProperties.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/HolidayProperties.java
@@ -1,0 +1,22 @@
+package ds.project.orino.planner.holiday;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * 공휴일 동기화 설정. 한국천문연구원 특일정보 API(공공데이터포털)를 호출한다.
+ *
+ * @param serviceKey   디코딩 일반 인증키(운영=env/SealedSecret). 비어 있으면 동기화를 건너뛴다.
+ * @param baseUrl      특일정보 서비스 base URL
+ * @param syncYears    올해부터 동기화할 연도 수(2 = 올해+내년)
+ */
+@ConfigurationProperties(prefix = "holiday")
+public record HolidayProperties(
+        String serviceKey,
+        String baseUrl,
+        int syncYears,
+        Duration connectTimeout,
+        Duration readTimeout
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/HolidayQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/HolidayQueryService.java
@@ -1,0 +1,27 @@
+package ds.project.orino.planner.holiday;
+
+import ds.project.orino.domain.planner.holiday.repository.HolidayRepository;
+import ds.project.orino.planner.holiday.dto.HolidayResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/** 공휴일 조회. 통합 캘린더 FE 오버레이가 [from, to] 구간으로 가져간다. */
+@Service
+public class HolidayQueryService {
+
+    private final HolidayRepository repository;
+
+    public HolidayQueryService(HolidayRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<HolidayResponse> list(LocalDate from, LocalDate to) {
+        return repository.findByDateBetween(from, to).stream()
+                .map(h -> new HolidayResponse(h.getDate().toString(), h.getName()))
+                .toList();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/HolidayScheduler.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/HolidayScheduler.java
@@ -1,0 +1,42 @@
+package ds.project.orino.planner.holiday;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 공휴일 동기화 트리거: 기동 직후 1회 + 매일 00:00(KST).
+ * 멱등 upsert라 단일/다중 인스턴스 모두 안전하며, 실패해도 앱에 영향을 주지 않는다(로그만).
+ */
+@Component
+public class HolidayScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(HolidayScheduler.class);
+
+    private final HolidaySyncService syncService;
+
+    public HolidayScheduler(HolidaySyncService syncService) {
+        this.syncService = syncService;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onStartup() {
+        runSafely();
+    }
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void daily() {
+        runSafely();
+    }
+
+    private void runSafely() {
+        try {
+            syncService.syncUpcomingYears();
+        } catch (RuntimeException e) {
+            log.warn("holiday sync failed: {}", e.getMessage());
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/HolidaySyncService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/HolidaySyncService.java
@@ -1,0 +1,62 @@
+package ds.project.orino.planner.holiday;
+
+import ds.project.orino.domain.planner.holiday.entity.Holiday;
+import ds.project.orino.domain.planner.holiday.repository.HolidayRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Year;
+import java.time.ZoneId;
+import java.util.List;
+
+/**
+ * 특일정보 API로 공휴일을 가져와 {@code holiday} 테이블에 멱등 upsert한다.
+ * 같은 날짜가 있으면 이름만 갱신(대체공휴일 명칭 변경 등), 없으면 추가한다.
+ */
+@Service
+public class HolidaySyncService {
+
+    private static final Logger log = LoggerFactory.getLogger(HolidaySyncService.class);
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final HolidayApiClient apiClient;
+    private final HolidayRepository repository;
+    private final HolidayProperties properties;
+
+    public HolidaySyncService(HolidayApiClient apiClient,
+                              HolidayRepository repository,
+                              HolidayProperties properties) {
+        this.apiClient = apiClient;
+        this.repository = repository;
+        this.properties = properties;
+    }
+
+    /** 올해부터 syncYears개년을 동기화한다. 인증키 미설정이면 건너뛴다. */
+    public void syncUpcomingYears() {
+        if (properties.serviceKey() == null || properties.serviceKey().isBlank()) {
+            log.info("holiday sync skipped: service key not configured");
+            return;
+        }
+        int start = Year.now(KST).getValue();
+        int years = Math.max(1, properties.syncYears());
+        for (int year = start; year < start + years; year++) {
+            int count = sync(year);
+            log.info("holiday sync {}: {} days", year, count);
+        }
+    }
+
+    /** 한 해를 동기화하고 upsert한 건수를 반환한다. */
+    @Transactional
+    public int sync(int year) {
+        List<HolidayApiClient.HolidayItem> items = apiClient.fetchYear(year);
+        for (HolidayApiClient.HolidayItem item : items) {
+            repository.findByDate(item.date())
+                    .ifPresentOrElse(
+                            existing -> existing.updateName(item.name()),
+                            () -> repository.save(new Holiday(item.date(), item.name())));
+        }
+        return items.size();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/dto/HolidayResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/holiday/dto/HolidayResponse.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.holiday.dto;
+
+/**
+ * 공휴일 응답 1건.
+ *
+ * @param date 공휴일 날짜("2026-06-06")
+ * @param name 공휴일 이름("현충일")
+ */
+public record HolidayResponse(String date, String name) {
+}

--- a/be/orino-app-api/src/main/resources/application.yml
+++ b/be/orino-app-api/src/main/resources/application.yml
@@ -56,6 +56,16 @@ planner:
       # 콜백 후 리다이렉트할 FE base URL (local Vite 3000, prod orino.dev)
       frontend-url: ${FRONTEND_URL:http://localhost:3000}
 
+# 공휴일(한국천문연구원 특일정보, 공공데이터포털 data 15012690) 동기화.
+# service-key는 디코딩 일반 인증키. 운영=SealedSecret→env, 로컬=.secrets/.env. 매일 00:00(KST) job이 DB 갱신.
+holiday:
+  service-key: ${HOLIDAY_SERVICE_KEY:}
+  base-url: ${HOLIDAY_API_BASE_URL:https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService}
+  # 동기화 대상 연도 수(올해부터 N개년). 2 = 올해+내년.
+  sync-years: ${HOLIDAY_SYNC_YEARS:2}
+  connect-timeout: ${HOLIDAY_CONNECT_TIMEOUT:5s}
+  read-timeout: ${HOLIDAY_READ_TIMEOUT:10s}
+
 management:
   tracing:
     sampling:

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/025-create-holiday.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/025-create-holiday.yaml
@@ -1,0 +1,42 @@
+databaseChangeLog:
+  - changeSet:
+      id: 025-create-holiday
+      author: wcorn
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: holiday
+      changes:
+        - createTable:
+            tableName: holiday
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: holiday_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uk_holiday_date
+              - column:
+                  name: name
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -47,3 +47,5 @@ databaseChangeLog:
       file: db/changelog/changes/023-create-google-account.yaml
   - include:
       file: db/changelog/changes/024-create-routine-check.yaml
+  - include:
+      file: db/changelog/changes/025-create-holiday.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/holiday/HolidayControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/holiday/HolidayControllerTest.java
@@ -1,0 +1,150 @@
+package ds.project.orino.planner.holiday;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.holiday.repository.HolidayRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class HolidayControllerTest extends ApiTestSupport {
+
+    private static final String ARRAY_BODY = """
+            {"response":{"header":{"resultCode":"00","resultMsg":"NORMAL SERVICE."},
+             "body":{"items":{"item":[
+               {"dateKind":"01","dateName":"지방선거일","isHoliday":"Y","locdate":20260603},
+               {"dateKind":"01","dateName":"현충일","isHoliday":"Y","locdate":20260606}
+             ]},"numOfRows":100,"pageNo":1,"totalCount":2}}}""";
+    private static final String SINGLE_BODY = """
+            {"response":{"header":{"resultCode":"00","resultMsg":"NORMAL SERVICE."},
+             "body":{"items":{"item":
+               {"dateKind":"01","dateName":"신정","isHoliday":"Y","locdate":20260101}
+             },"numOfRows":100,"pageNo":1,"totalCount":1}}}""";
+    private static final String EMPTY_BODY = """
+            {"response":{"header":{"resultCode":"00","resultMsg":"NORMAL SERVICE."},
+             "body":{"items":"","numOfRows":100,"pageNo":1,"totalCount":0}}}""";
+
+    private static volatile String responseBody = ARRAY_BODY;
+    private static final HttpServer STUB = createStub();
+
+    @Autowired
+    private HolidaySyncService holidaySyncService;
+    @Autowired
+    private HolidayRepository holidayRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+
+    @DynamicPropertySource
+    static void holidayProperties(DynamicPropertyRegistry registry) {
+        String base = "http://127.0.0.1:" + STUB.getAddress().getPort();
+        registry.add("holiday.base-url", () -> base);
+        registry.add("holiday.service-key", () -> "test-key");
+        registry.add("holiday.sync-years", () -> "1");
+    }
+
+    @AfterAll
+    static void stopStub() {
+        STUB.stop(0);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        responseBody = ARRAY_BODY;
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    @Test
+    @DisplayName("동기화 후 구간 조회 시 공휴일을 날짜·이름으로 반환한다")
+    void syncThenList() throws Exception {
+        holidaySyncService.sync(2026);
+
+        mockMvc.perform(get("/api/planner/holidays")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .param("from", "2026-06-01")
+                        .param("to", "2026-06-30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].date").value("2026-06-03"))
+                .andExpect(jsonPath("$.data[0].name").value("지방선거일"))
+                .andExpect(jsonPath("$.data[1].date").value("2026-06-06"))
+                .andExpect(jsonPath("$.data[1].name").value("현충일"));
+    }
+
+    @Test
+    @DisplayName("items가 단일 객체로 와도 파싱한다")
+    void singleObjectItem() {
+        responseBody = SINGLE_BODY;
+
+        int count = holidaySyncService.sync(2026);
+
+        assertThat(count).isEqualTo(1);
+        assertThat(holidayRepository.findByDate(java.time.LocalDate.of(2026, 1, 1)))
+                .isPresent();
+    }
+
+    @Test
+    @DisplayName("공휴일이 0건(빈 문자열)이어도 오류 없이 처리한다")
+    void emptyItems() {
+        responseBody = EMPTY_BODY;
+
+        int count = holidaySyncService.sync(2026);
+
+        assertThat(count).isZero();
+    }
+
+    @Test
+    @DisplayName("같은 날짜 재동기화는 멱등(중복 생성 없음)")
+    void idempotentSync() {
+        holidaySyncService.sync(2026);
+        holidaySyncService.sync(2026);
+
+        assertThat(holidayRepository.findAll()).hasSize(2);
+    }
+
+    private static HttpServer createStub() {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/getRestDeInfo", exchange -> respond(exchange, responseBody));
+            server.start();
+            return server;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void respond(HttpExchange exchange, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/holiday/HolidayControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/holiday/HolidayControllerTest.java
@@ -120,6 +120,25 @@ class HolidayControllerTest extends ApiTestSupport {
     }
 
     @Test
+    @DisplayName("제헌절은 isHoliday=Y여도 빨간날에서 제외한다")
+    void excludesConstitutionDay() {
+        responseBody = """
+                {"response":{"header":{"resultCode":"00","resultMsg":"NORMAL SERVICE."},
+                 "body":{"items":{"item":[
+                   {"dateKind":"01","dateName":"제헌절","isHoliday":"Y","locdate":20260717},
+                   {"dateKind":"01","dateName":"광복절","isHoliday":"Y","locdate":20260815}
+                 ]},"numOfRows":100,"pageNo":1,"totalCount":2}}}""";
+
+        int count = holidaySyncService.sync(2026);
+
+        assertThat(count).isEqualTo(1);
+        assertThat(holidayRepository.findByDate(java.time.LocalDate.of(2026, 7, 17)))
+                .isEmpty();
+        assertThat(holidayRepository.findByDate(java.time.LocalDate.of(2026, 8, 15)))
+                .isPresent();
+    }
+
+    @Test
     @DisplayName("같은 날짜 재동기화는 멱등(중복 생성 없음)")
     void idempotentSync() {
         holidaySyncService.sync(2026);

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 public class DbCleaner {
 
     private static final String[] TABLES_IN_FK_ORDER = {
+            "holiday",
             "routine_check",
             "review_schedule",
             "flashcard",

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/holiday/entity/Holiday.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/holiday/entity/Holiday.java
@@ -1,0 +1,69 @@
+package ds.project.orino.domain.planner.holiday.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * 대한민국 공휴일(관공서 공휴일) 1일 = 1행. 한국천문연구원 특일정보 API 동기화 결과 캐시.
+ *
+ * <p>FE 빨간날 오버레이용 표시 데이터. 매일 동기화 job이 대체·임시공휴일 변경을 upsert로 반영한다.
+ */
+@Entity
+@Table(name = "holiday")
+@EntityListeners(AuditingEntityListener.class)
+public class Holiday {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "holiday_date", nullable = false, unique = true)
+    private LocalDate date;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected Holiday() {
+    }
+
+    public Holiday(LocalDate date, String name) {
+        this.date = date;
+        this.name = name;
+    }
+
+    /** 이름 변경(대체공휴일 명칭 변경 등 동기화 갱신용). */
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/holiday/repository/HolidayRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/holiday/repository/HolidayRepository.java
@@ -1,0 +1,15 @@
+package ds.project.orino.domain.planner.holiday.repository;
+
+import ds.project.orino.domain.planner.holiday.entity.Holiday;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface HolidayRepository extends JpaRepository<Holiday, Long> {
+
+    List<Holiday> findByDateBetween(LocalDate from, LocalDate to);
+
+    Optional<Holiday> findByDate(LocalDate date);
+}

--- a/fe/src/features/planner/api/holidays.ts
+++ b/fe/src/features/planner/api/holidays.ts
@@ -1,0 +1,25 @@
+import { client } from "@/shared/api";
+
+export interface Holiday {
+  /** "2026-06-06" */
+  date: string;
+  /** "현충일" */
+  name: string;
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+/** [from, to] 구간 공휴일. BE가 한국천문연구원 특일정보 API로 동기화한 값을 반환한다. */
+export async function fetchHolidays(
+  from: string,
+  to: string,
+): Promise<Holiday[]> {
+  const { data } = await client.get<ApiEnvelope<Holiday[]>>(
+    "/planner/holidays",
+    { params: { from, to } },
+  );
+  return data.data;
+}

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
@@ -20,6 +20,7 @@ import {
   useDeleteEvent,
   useUpdateEvent,
 } from "../../hooks/useEventMutations";
+import { useHolidays } from "../../hooks/useHolidays";
 import { usePlannerCalendar } from "../../hooks/usePlannerCalendar";
 import { useRoutineCheck } from "../../hooks/useRoutineCheck";
 import {
@@ -64,10 +65,15 @@ export function PlannerCalendar() {
   const to = toIsoDate(days[days.length - 1]);
 
   const { data, isLoading } = usePlannerCalendar(from, to);
+  const { data: holidays } = useHolidays(from, to);
 
   const eventsMap = useMemo(() => eventsByDate(data?.events ?? []), [data]);
   const tasksMap = useMemo(() => tasksByDate(data?.tasks ?? []), [data]);
   const reviewsMap = useMemo(() => reviewsByDate(data?.reviews ?? []), [data]);
+  const holidayMap = useMemo(
+    () => new Map((holidays ?? []).map((h) => [h.date, h.name])),
+    [holidays],
+  );
 
   const googleConnected = data?.googleConnected ?? false;
 
@@ -261,6 +267,7 @@ export function PlannerCalendar() {
                         tasks={tasksMap.get(iso) ?? []}
                         reviews={reviewsMap.get(iso) ?? []}
                         today={today}
+                        holidayName={holidayMap.get(iso)}
                         onSelect={setSelected}
                       />
                     );
@@ -277,6 +284,7 @@ export function PlannerCalendar() {
                 events={eventsMap.get(selected) ?? []}
                 tasks={tasksMap.get(selected) ?? []}
                 reviews={reviewsMap.get(selected) ?? []}
+                holidayName={holidayMap.get(selected)}
                 onEventClick={(event) => setDialog({ mode: "edit", event })}
                 onTaskToggle={(task) =>
                   updateTask.mutate({

--- a/fe/src/features/planner/components/calendar/PlannerCalendarCell.test.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendarCell.test.tsx
@@ -65,4 +65,13 @@ describe("PlannerCalendarCell 일정 라인", () => {
 
     expect(screen.getByText("+2개")).toBeInTheDocument();
   });
+
+  it("공휴일이면 이름을 표시하고 aria-label에 포함한다", () => {
+    render(
+      <PlannerCalendarCell {...baseProps} events={[]} holidayName="현충일" />,
+    );
+
+    expect(screen.getByText("현충일")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /현충일/ })).toBeInTheDocument();
+  });
 });

--- a/fe/src/features/planner/components/calendar/PlannerCalendarCell.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendarCell.tsx
@@ -22,6 +22,8 @@ interface Props {
   tasks: PlannerTask[];
   reviews: PlannerReview[];
   today: Date;
+  /** 공휴일이면 이름(빨간날 표시). 아니면 undefined. */
+  holidayName?: string;
   onSelect: (isoDate: string) => void;
 }
 
@@ -42,6 +44,7 @@ export function PlannerCalendarCell({
   tasks,
   reviews,
   today,
+  holidayName,
   onSelect,
 }: Props) {
   const reviewDot =
@@ -98,12 +101,14 @@ export function PlannerCalendarCell({
   const shown = lines.slice(0, MAX_LINES);
   const hidden = lines.length - shown.length;
   const total = events.length + tasks.length + reviews.length;
+  const holiday = holidayName;
 
   return (
     <button
       type="button"
       aria-label={
         `${isoDate}` +
+        (holiday ? ` ${holiday}` : "") +
         (total > 0
           ? ` 일정 ${events.length} 할일 ${tasks.length} 복습 ${reviews.length}`
           : "")
@@ -120,12 +125,18 @@ export function PlannerCalendarCell({
       <span
         className={cn(
           "text-xs font-medium",
+          holiday && "text-red-500",
           isToday && "text-primary font-semibold",
         )}
       >
         {date.getDate()}
       </span>
       <span className="flex min-w-0 flex-col gap-0.5">
+        {holiday && (
+          <span className="truncate text-[10px] leading-tight text-red-500">
+            {holiday}
+          </span>
+        )}
         {shown}
         {hidden > 0 && (
           <span className="text-muted-foreground text-[10px]">+{hidden}개</span>

--- a/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
@@ -14,6 +14,7 @@ interface Props {
   events: PlannerEvent[];
   tasks: PlannerTask[];
   reviews: PlannerReview[];
+  holidayName?: string;
   onEventClick?: (event: PlannerEvent) => void;
   onTaskToggle?: (task: PlannerTask) => void;
   onTaskDelete?: (task: PlannerTask) => void;
@@ -31,6 +32,7 @@ export function PlannerDayDetailPanel({
   events,
   tasks,
   reviews,
+  holidayName,
   onEventClick,
   onTaskToggle,
   onTaskDelete,
@@ -42,7 +44,14 @@ export function PlannerDayDetailPanel({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-base font-medium">{formatHeading(isoDate)}</h2>
+        <h2 className="text-base font-medium">
+          {formatHeading(isoDate)}
+          {holidayName && (
+            <span className="ml-2 text-sm font-normal text-red-500">
+              {holidayName}
+            </span>
+          )}
+        </h2>
         {reviews.length > 0 && (
           <Link to="/planner/reviews/today">
             <Button size="sm">오늘 복습 하러가기</Button>

--- a/fe/src/features/planner/hooks/useHolidays.test.tsx
+++ b/fe/src/features/planner/hooks/useHolidays.test.tsx
@@ -1,0 +1,50 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import { server } from "@/test/mocks/server";
+
+import { useHolidays } from "./useHolidays";
+
+const HOLIDAYS_URL = "https://api.orino.dev/api/planner/holidays";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useHolidays", () => {
+  it("구간 공휴일을 조회한다", async () => {
+    server.use(
+      http.get(HOLIDAYS_URL, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get("from")).toBe("2026-06-01");
+        expect(url.searchParams.get("to")).toBe("2026-06-30");
+        return HttpResponse.json({
+          code: "OK",
+          data: [
+            { date: "2026-06-03", name: "지방선거일" },
+            { date: "2026-06-06", name: "현충일" },
+          ],
+        });
+      }),
+    );
+
+    const { result } = renderHook(
+      () => useHolidays("2026-06-01", "2026-06-30"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([
+      { date: "2026-06-03", name: "지방선거일" },
+      { date: "2026-06-06", name: "현충일" },
+    ]);
+  });
+});

--- a/fe/src/features/planner/hooks/useHolidays.ts
+++ b/fe/src/features/planner/hooks/useHolidays.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchHolidays } from "../api/holidays";
+import { holidayKeys } from "../queryKeys";
+
+/** [from, to] 구간 공휴일 조회. 거의 변하지 않으므로 1시간 staleTime. */
+export function useHolidays(from: string, to: string) {
+  return useQuery({
+    queryKey: holidayKeys.range(from, to),
+    queryFn: () => fetchHolidays(from, to),
+    staleTime: 60 * 60 * 1000,
+  });
+}

--- a/fe/src/features/planner/queryKeys.ts
+++ b/fe/src/features/planner/queryKeys.ts
@@ -8,3 +8,8 @@ export const routineKeys = {
   all: ["routine"] as const,
   list: () => ["routine", "list"] as const,
 };
+
+export const holidayKeys = {
+  all: ["holiday"] as const,
+  range: (from: string, to: string) => ["holiday", from, to] as const,
+};

--- a/fe/src/test/mocks/handlers.ts
+++ b/fe/src/test/mocks/handlers.ts
@@ -48,4 +48,9 @@ export const handlers = [
       },
     });
   }),
+
+  // 기본값: 공휴일 없음. 공휴일 표시 검증 테스트는 server.use로 덮어쓴다.
+  http.get(`${API_BASE}/planner/holidays`, () => {
+    return HttpResponse.json({ code: "OK", data: [] });
+  }),
 ];


### PR DESCRIPTION
## 이슈
closes #605

> ⚠️ #604(월 셀 라인) 위에 스택된 PR입니다. **#604 먼저 머지**하면 이 PR diff가 공휴일 변경분만 남습니다.

## 작업 내용
대한민국 공휴일을 빨간날로 표시. 임시·대체공휴일 변경을 자동 반영하기 위해 **하드코딩 대신 BE가 매일 동기화**.

### BE
- **`holiday` 테이블**(Liquibase 025) + `Holiday` 엔티티/리포지토리
- **`HolidayApiClient`** — 한국천문연구원 특일정보 `getRestDeInfo`(JSON). data.go.kr 응답 특성(0건=빈 문자열, 1건=객체, 2건+=배열) 방어 파싱
- **`HolidaySyncService`** — 연도별 멱등 upsert(같은 날짜 이름만 갱신) / **`HolidayScheduler`** — 기동 직후 + **매일 00:00(KST)** (`@EnableScheduling`, 멱등이라 락 없이 안전, 실패해도 앱 무영향)
- **`GET /api/planner/holidays?from&to`** — Google 연동과 무관(미연동이어도 표시)
- 인증키는 `application.yml holiday.service-key`(env/SealedSecret), 로컬은 `.secrets`(gitignore)

### FE
- `api/holidays` + `useHolidays` 훅
- 월 셀: **빨간 날짜 + 공휴일명**(점/라인과 함께), 일 상세 헤더: 공휴일명
- 정적 하드코딩 테이블 제거 → BE 조회로 전환

### 문서
- 위키 결정 기록: 공휴일=BE 특일정보 동기화 오버레이, 멀티캘린더 비목표와 무관([Planner-Open-Items §4.4](https://github.com/wcorn/orino/wiki/Planner-Open-Items))

## 검증
- BE: `:orino-app-api:test`(특일정보 스텁 — 배열/단일/빈/멱등) + checkstyle ✅
- FE: `npm run build`/`lint`/`format:check` + 전체 181 테스트 ✅ (셀 빨간날, `useHolidays` MSW)

> ⚠️ **운영 인증키 활성화 대기**: data.go.kr 발급 키가 아직 게이트웨이 401(활용신청 승인/반영 대기). 활성화되면 기동·일일 job이 자동으로 `holiday` 테이블을 채웁니다. 코드/스키마/스텁 테스트는 완료. 활성화 후 `GET /api/planner/holidays`로 스모크 확인 권장.