### PR TITLE
feat : 복습 미러 RM0 — 보조 캘린더·종일 클라이언트 확장 + 스키마

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -19,8 +19,8 @@ subprojects {
         }
     }
 
-    ext['jackson-2-bom.version'] = '2.21.2'
-    ext['jackson-bom.version'] = '3.1.2'
+    ext['jackson-2-bom.version'] = '2.21.4'
+    ext['jackson-bom.version'] = '3.1.4'
     ext['netty.version'] = '4.2.15.Final'
     ext['spring-security.version'] = '7.0.5'
     ext['tomcat.version'] = '11.0.22'

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleCalendarResource.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleCalendarResource.java
@@ -1,0 +1,11 @@
+package ds.project.orino.planner.google.calendar.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/** Google Calendar calendars.insert 응답(필요한 필드만). */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GoogleCalendarResource(
+        String id,
+        String summary
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleCalendarWriteBody.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleCalendarWriteBody.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.google.calendar.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/** Google Calendar calendars.insert 요청 바디(보조 캘린더 생성). */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record GoogleCalendarWriteBody(
+        String summary
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventWriteBody.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventWriteBody.java
@@ -9,6 +9,7 @@ import java.util.List;
  *
  * @param recurrence         RRULE 문자열 목록(예: {@code ["RRULE:FREQ=WEEKLY;BYDAY=MO,WE"]}). null이면 단일 일정
  * @param extendedProperties orino 태깅용 확장 속성(루틴 식별). null이면 미설정
+ * @param reminders          알림 설정. null이면 미설정(미러 종일 이벤트는 {@code useDefault=true})
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record GoogleEventWriteBody(
@@ -18,17 +19,37 @@ public record GoogleEventWriteBody(
         GoogleEventTime start,
         GoogleEventTime end,
         List<String> recurrence,
-        GoogleExtendedProperties extendedProperties
+        GoogleExtendedProperties extendedProperties,
+        GoogleReminders reminders
 ) {
 
     /** 반복·태깅 없는 단일 일정 바디. */
     public GoogleEventWriteBody(String summary, String location, String description,
                                GoogleEventTime start, GoogleEventTime end) {
-        this(summary, location, description, start, end, null, null);
+        this(summary, location, description, start, end, null, null, null);
+    }
+
+    /** 반복(recurrence)·태깅(extendedProperties)까지 지정하는 루틴 바디. */
+    public GoogleEventWriteBody(String summary, String location, String description,
+                               GoogleEventTime start, GoogleEventTime end,
+                               List<String> recurrence, GoogleExtendedProperties extendedProperties) {
+        this(summary, location, description, start, end, recurrence, extendedProperties, null);
     }
 
     /** 시간 일정이면 dateTime+timeZone, 종일이면 date. */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record GoogleEventTime(String dateTime, String date, String timeZone) {
+    }
+
+    /**
+     * 이벤트 알림 설정. {@code useDefault=true}면 Google 계정 기본 알림을 따른다(overrides 미지정).
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record GoogleReminders(Boolean useDefault) {
+
+        /** 계정 기본 알림을 따르는 reminders({@code useDefault=true}). */
+        public static GoogleReminders defaults() {
+            return new GoogleReminders(true);
+        }
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
@@ -1,8 +1,11 @@
 package ds.project.orino.planner.google.client;
 
 import ds.project.orino.planner.google.calendar.dto.EventRequest;
+import ds.project.orino.planner.google.calendar.dto.GoogleCalendarResource;
+import ds.project.orino.planner.google.calendar.dto.GoogleCalendarWriteBody;
 import ds.project.orino.planner.google.calendar.dto.GoogleEventWriteBody;
 import ds.project.orino.planner.google.calendar.dto.GoogleEventWriteBody.GoogleEventTime;
+import ds.project.orino.planner.google.calendar.dto.GoogleEventWriteBody.GoogleReminders;
 import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse;
 import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventDateTime;
 import ds.project.orino.planner.google.calendar.dto.GoogleEventsResponse.GoogleEventItem;
@@ -44,7 +47,7 @@ public class GoogleCalendarClient {
     /** 사용자 TZ 로컬 datetime 포맷(오프셋 없이 "2026-06-10T14:00:00"). */
     private static final DateTimeFormatter LOCAL_DATETIME =
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
-    private static final String PRIMARY_CALENDAR_PATH = "/calendar/v3/calendars/primary/events";
+    private static final String PRIMARY_CALENDAR_ID = "primary";
 
     private final GoogleTokenProvider tokenProvider;
     private final RestClient googleRestClient;
@@ -60,8 +63,7 @@ public class GoogleCalendarClient {
 
     /** [timeMin, timeMax) 구간의 primary 캘린더 일정을 조회해 사용자 시간대로 정규화한다. */
     public List<PlannerEvent> listEvents(Long memberId, Instant timeMin, Instant timeMax, ZoneId zone) {
-        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
-                .path(PRIMARY_CALENDAR_PATH)
+        URI uri = eventsBuilder(PRIMARY_CALENDAR_ID)
                 .queryParam("timeMin", timeMin.toString())
                 .queryParam("timeMax", timeMax.toString())
                 .queryParam("singleEvents", "true")
@@ -101,10 +103,7 @@ public class GoogleCalendarClient {
 
     /** 일정 생성. 생성된 이벤트를 정규화해 반환한다. */
     public PlannerEvent insertEvent(Long memberId, EventRequest request, ZoneId zone) {
-        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
-                .path(PRIMARY_CALENDAR_PATH)
-                .build()
-                .toUri();
+        URI uri = eventsBuilder(PRIMARY_CALENDAR_ID).build().toUri();
 
         GoogleEventWriteBody body = toWriteBody(request, zone);
         GoogleEventItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
@@ -139,10 +138,7 @@ public class GoogleCalendarClient {
      */
     public PlannerEvent insertRoutineEvent(Long memberId, EventRequest request,
                                            RecurrenceRule rule, RoutineType type, ZoneId zone) {
-        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
-                .path(PRIMARY_CALENDAR_PATH)
-                .build()
-                .toUri();
+        URI uri = eventsBuilder(PRIMARY_CALENDAR_ID).build().toUri();
 
         GoogleEventWriteBody body = toRoutineWriteBody(request, rule, RoutineTag.privateProperties(type), zone);
         GoogleEventItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
@@ -201,10 +197,7 @@ public class GoogleCalendarClient {
      */
     public PlannerEvent insertForkedSeries(Long memberId, EventRequest request, RecurrenceRule rule,
                                            RoutineType type, String splitMarker, ZoneId zone) {
-        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
-                .path(PRIMARY_CALENDAR_PATH)
-                .build()
-                .toUri();
+        URI uri = eventsBuilder(PRIMARY_CALENDAR_ID).build().toUri();
 
         GoogleEventWriteBody body =
                 toRoutineWriteBody(request, rule, RoutineTag.splitProperties(type, splitMarker), zone);
@@ -242,8 +235,7 @@ public class GoogleCalendarClient {
      * RRULE 역파싱과 종류 판별을 수행한다.
      */
     public List<GoogleEventItem> listRoutineMasters(Long memberId) {
-        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
-                .path(PRIMARY_CALENDAR_PATH)
+        URI uri = eventsBuilder(PRIMARY_CALENDAR_ID)
                 .queryParam("singleEvents", "false")
                 .queryParam("privateExtendedProperty", RoutineTag.LIST_FILTER)
                 .queryParam("maxResults", "2500")
@@ -269,8 +261,7 @@ public class GoogleCalendarClient {
      */
     public List<PlannerEvent> listInstances(Long memberId, String eventId,
                                             Instant timeMin, Instant timeMax, ZoneId zone) {
-        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
-                .path(PRIMARY_CALENDAR_PATH)
+        URI uri = eventsBuilder(PRIMARY_CALENDAR_ID)
                 .pathSegment(eventId, "instances")
                 .queryParam("timeMin", timeMin.toString())
                 .queryParam("timeMax", timeMax.toString())
@@ -293,9 +284,14 @@ public class GoogleCalendarClient {
                 .toList();
     }
 
-    /** 일정 삭제. 없는 id면 404(RESOURCE_NOT_FOUND). */
+    /** primary 캘린더 일정 삭제. 없는 id면 404(RESOURCE_NOT_FOUND). */
     public void deleteEvent(Long memberId, String eventId) {
-        URI uri = eventUri(eventId);
+        deleteEvent(memberId, PRIMARY_CALENDAR_ID, eventId);
+    }
+
+    /** 지정 캘린더의 일정 삭제. 없는 id면 404(RESOURCE_NOT_FOUND). */
+    public void deleteEvent(Long memberId, String calendarId, String eventId) {
+        URI uri = eventUri(calendarId, eventId);
         tokenProvider.executeWithRetry(memberId, accessToken -> {
             googleRestClient.delete()
                     .uri(uri)
@@ -306,12 +302,81 @@ public class GoogleCalendarClient {
         });
     }
 
-    private URI eventUri(String eventId) {
+    /** {@code /calendars/{calendarId}/events} 컬렉션 빌더(쓰기/목록 공용). calendarId는 자동 URL 인코딩된다. */
+    private UriComponentsBuilder eventsBuilder(String calendarId) {
         return UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
-                .path(PRIMARY_CALENDAR_PATH)
-                .pathSegment(eventId)
+                .pathSegment("calendar", "v3", "calendars", calendarId, "events");
+    }
+
+    private URI eventUri(String eventId) {
+        return eventUri(PRIMARY_CALENDAR_ID, eventId);
+    }
+
+    private URI eventUri(String calendarId, String eventId) {
+        return eventsBuilder(calendarId).pathSegment(eventId).build().toUri();
+    }
+
+    // ── 복습 미러: 보조 캘린더 + 종일 이벤트 ──
+
+    /**
+     * 보조 캘린더("orino 복습")를 생성하고 그 calendarId를 반환한다. 미러 최초 enable 시 1회 호출한다.
+     */
+    public String createSecondaryCalendar(Long memberId, String summary) {
+        URI uri = UriComponentsBuilder.fromUriString(oauthProperties.calendarApiBaseUrl())
+                .pathSegment("calendar", "v3", "calendars")
                 .build()
                 .toUri();
+        GoogleCalendarWriteBody body = new GoogleCalendarWriteBody(summary);
+        GoogleCalendarResource created = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.post()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(body)
+                        .retrieve()
+                        .body(GoogleCalendarResource.class));
+        return created == null ? null : created.id();
+    }
+
+    /**
+     * 보조 캘린더에 하루짜리 종일 이벤트를 생성하고 생성된 eventId를 반환한다. 알림은 계정 기본(useDefault).
+     */
+    public String insertAllDayEvent(Long memberId, String calendarId, String summary, LocalDate date) {
+        URI uri = eventsBuilder(calendarId).build().toUri();
+        GoogleEventWriteBody body = allDayBody(summary, date);
+        GoogleEventItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.post()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(body)
+                        .retrieve()
+                        .body(GoogleEventItem.class));
+        return item == null ? null : item.id();
+    }
+
+    /**
+     * 보조 캘린더 종일 이벤트의 제목만 patch한다(복습 개수 변동 반영). 없는 id면 404(RESOURCE_NOT_FOUND).
+     */
+    public void patchEventSummary(Long memberId, String calendarId, String eventId, String summary) {
+        URI uri = eventUri(calendarId, eventId);
+        GoogleEventWriteBody body = new GoogleEventWriteBody(summary, null, null, null, null);
+        tokenProvider.executeWithRetry(memberId, accessToken ->
+                googleRestClient.patch()
+                        .uri(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(body)
+                        .retrieve()
+                        .body(GoogleEventItem.class));
+    }
+
+    /** 하루짜리 종일 이벤트 바디(useDefault 알림). Google 종일 종료는 배타적이라 end=date+1일. */
+    private GoogleEventWriteBody allDayBody(String summary, LocalDate date) {
+        GoogleEventTime start = new GoogleEventTime(null, date.toString(), null);
+        GoogleEventTime end = new GoogleEventTime(null, date.plusDays(1).toString(), null);
+        return new GoogleEventWriteBody(
+                summary, null, null, start, end, null, null, GoogleReminders.defaults());
     }
 
     private GoogleEventWriteBody toWriteBody(EventRequest request, ZoneId zone) {

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/026-add-google-account-review-mirror.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/026-add-google-account-review-mirror.yaml
@@ -1,0 +1,29 @@
+databaseChangeLog:
+  - changeSet:
+      id: 026-add-google-account-review-mirror
+      author: wcorn
+      comment: |
+        복습 → 보조 캘린더 단방향 미러 토글 상태 (#584).
+        review_calendar_id: 최초 enable 시 생성한 "orino 복습" 보조 캘린더 ID(이후 재사용).
+        review_mirror_enabled: 미러 on/off 토글.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: google_account
+                columnName: review_mirror_enabled
+      changes:
+        - addColumn:
+            tableName: google_account
+            columns:
+              - column:
+                  name: review_calendar_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: review_mirror_enabled
+                  type: BIT(1)
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/027-create-review-calendar-mirror.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/027-create-review-calendar-mirror.yaml
@@ -1,0 +1,65 @@
+databaseChangeLog:
+  - changeSet:
+      id: 027-create-review-calendar-mirror
+      author: wcorn
+      comment: |
+        복습 묶음 ↔ Google 보조 캘린더 종일 이벤트 매핑 (#584).
+        dueDate당 "복습 N개" 종일 이벤트 1개. UNIQUE(member_id, due_date)로 멱등 upsert.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: review_calendar_mirror
+      changes:
+        - createTable:
+            tableName: review_calendar_mirror
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_review_calendar_mirror_member
+                    references: member(id)
+                    deleteCascade: true
+              - column:
+                  name: due_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: google_event_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: pending_count
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: synced_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: review_calendar_mirror
+            columnNames: member_id, due_date
+            constraintName: uk_review_calendar_mirror_member_date

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -49,3 +49,7 @@ databaseChangeLog:
       file: db/changelog/changes/024-create-routine-check.yaml
   - include:
       file: db/changelog/changes/025-create-holiday.yaml
+  - include:
+      file: db/changelog/changes/026-add-google-account-review-mirror.yaml
+  - include:
+      file: db/changelog/changes/027-create-review-calendar-mirror.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/client/GoogleCalendarClientTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/client/GoogleCalendarClientTest.java
@@ -1,0 +1,160 @@
+package ds.project.orino.planner.google.client;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.planner.google.config.GoogleApiConfig;
+import ds.project.orino.planner.google.config.GoogleApiProperties;
+import ds.project.orino.planner.google.config.GoogleOAuthProperties;
+import ds.project.orino.planner.google.token.GoogleTokenProvider;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("GoogleCalendarClient — 보조 캘린더 종일 미러")
+class GoogleCalendarClientTest {
+
+    private static final Long MEMBER_ID = 7L;
+    private static final String CALENDAR_ID = "orino-review-cal";
+
+    private HttpServer server;
+    private GoogleCalendarClient client;
+    private final List<CapturedRequest> requests = new ArrayList<>();
+    private volatile String nextResponse = "{}";
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() throws IOException {
+        requests.clear();
+        nextResponse = "{}";
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/calendar/v3/calendars", this::handle);
+        server.start();
+        String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+
+        GoogleApiProperties apiProps = new GoogleApiProperties(
+                "cid", "secret", "http://localhost/cb",
+                List.of("scope"), Duration.ofSeconds(2), Duration.ofSeconds(5),
+                2, Duration.ofMillis(1));
+        RestClient restClient = new GoogleApiConfig().googleRestClient(apiProps, new SimpleMeterRegistry());
+        GoogleOAuthProperties oauthProps = new GoogleOAuthProperties(
+                null, null, null, baseUrl, null, null);
+
+        // 토큰 공급은 검증 대상이 아니므로, 콜백을 더미 토큰으로 그대로 실행한다.
+        GoogleTokenProvider tokenProvider = mock(GoogleTokenProvider.class);
+        when(tokenProvider.executeWithRetry(any(), any())).thenAnswer(inv -> {
+            Function<String, Object> call = inv.getArgument(1);
+            return call.apply("test-token");
+        });
+
+        client = new GoogleCalendarClient(tokenProvider, restClient, oauthProps);
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    @DisplayName("createSecondaryCalendar는 calendars.insert로 보조 캘린더를 만들고 id를 반환한다")
+    void createSecondaryCalendar() {
+        nextResponse = "{\"id\":\"cal-new@group.calendar.google.com\",\"summary\":\"orino 복습\"}";
+
+        String calendarId = client.createSecondaryCalendar(MEMBER_ID, "orino 복습");
+
+        assertThat(calendarId).isEqualTo("cal-new@group.calendar.google.com");
+        CapturedRequest req = last();
+        assertThat(req.method).isEqualTo("POST");
+        assertThat(req.path).isEqualTo("/calendar/v3/calendars");
+        assertThat(req.body).contains("\"summary\":\"orino 복습\"");
+    }
+
+    @Test
+    @DisplayName("insertAllDayEvent는 종일(date) 이벤트 + useDefault 알림으로 생성하고 eventId를 반환한다")
+    void insertAllDayEvent() {
+        nextResponse = "{\"id\":\"evt-1\"}";
+
+        String eventId = client.insertAllDayEvent(
+                MEMBER_ID, CALENDAR_ID, "복습 2개", LocalDate.of(2026, 6, 20));
+
+        assertThat(eventId).isEqualTo("evt-1");
+        CapturedRequest req = last();
+        assertThat(req.method).isEqualTo("POST");
+        assertThat(req.path).isEqualTo("/calendar/v3/calendars/" + CALENDAR_ID + "/events");
+        assertThat(req.body).contains("\"summary\":\"복습 2개\"");
+        // 종일은 date(시간 없음), Google 종료는 배타적 → end=date+1일
+        assertThat(req.body).contains("\"start\":{\"date\":\"2026-06-20\"}");
+        assertThat(req.body).contains("\"end\":{\"date\":\"2026-06-21\"}");
+        assertThat(req.body).contains("\"reminders\":{\"useDefault\":true}");
+        // 시간 일정 필드는 직렬화에서 제외
+        assertThat(req.body).doesNotContain("dateTime");
+        assertThat(req.body).doesNotContain("timeZone");
+    }
+
+    @Test
+    @DisplayName("patchEventSummary는 제목만 patch한다(start/end 미포함)")
+    void patchEventSummary() {
+        nextResponse = "{\"id\":\"evt-1\",\"summary\":\"복습 3개\"}";
+
+        client.patchEventSummary(MEMBER_ID, CALENDAR_ID, "evt-1", "복습 3개");
+
+        CapturedRequest req = last();
+        assertThat(req.method).isEqualTo("PATCH");
+        assertThat(req.path).isEqualTo("/calendar/v3/calendars/" + CALENDAR_ID + "/events/evt-1");
+        assertThat(req.body).contains("\"summary\":\"복습 3개\"");
+        assertThat(req.body).doesNotContain("start");
+        assertThat(req.body).doesNotContain("end");
+    }
+
+    @Test
+    @DisplayName("deleteEvent(calendarId,eventId)는 보조 캘린더의 이벤트를 DELETE한다")
+    void deleteEventOnCalendar() {
+        client.deleteEvent(MEMBER_ID, CALENDAR_ID, "evt-1");
+
+        CapturedRequest req = last();
+        assertThat(req.method).isEqualTo("DELETE");
+        assertThat(req.path).isEqualTo("/calendar/v3/calendars/" + CALENDAR_ID + "/events/evt-1");
+    }
+
+    private CapturedRequest last() {
+        return requests.get(requests.size() - 1);
+    }
+
+    private void handle(HttpExchange exchange) throws IOException {
+        String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+        requests.add(new CapturedRequest(
+                exchange.getRequestMethod(), exchange.getRequestURI().getPath(), body));
+
+        if ("DELETE".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(204, -1);
+            exchange.close();
+            return;
+        }
+        byte[] bytes = nextResponse.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    private record CapturedRequest(String method, String path, String body) {
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/google/entity/GoogleAccount.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/google/entity/GoogleAccount.java
@@ -49,6 +49,14 @@ public class GoogleAccount {
     @Column(name = "task_list_id", length = 255)
     private String taskListId;
 
+    /** 복습 미러용 보조 캘린더("orino 복습") ID. 최초 enable 시 생성·기록 후 재사용. */
+    @Column(name = "review_calendar_id", length = 255)
+    private String reviewCalendarId;
+
+    /** 복습 → 보조 캘린더 단방향 미러 on/off 토글. */
+    @Column(name = "review_mirror_enabled", nullable = false)
+    private boolean reviewMirrorEnabled = false;
+
     @Column(name = "connected_at", nullable = false)
     private Instant connectedAt;
 
@@ -95,6 +103,21 @@ public class GoogleAccount {
         this.revoked = true;
     }
 
+    /**
+     * 복습 미러를 켠다. 보조 캘린더가 새로 생성됐으면 그 ID를 기록하고, 이미 있으면(재-enable) 기존 ID를 유지한다.
+     */
+    public void enableReviewMirror(String reviewCalendarId) {
+        if (reviewCalendarId != null) {
+            this.reviewCalendarId = reviewCalendarId;
+        }
+        this.reviewMirrorEnabled = true;
+    }
+
+    /** 복습 미러를 끈다. 빠른 재-enable을 위해 보조 캘린더 ID는 보존한다. */
+    public void disableReviewMirror() {
+        this.reviewMirrorEnabled = false;
+    }
+
     public Long getId() {
         return id;
     }
@@ -121,6 +144,14 @@ public class GoogleAccount {
 
     public String getTaskListId() {
         return taskListId;
+    }
+
+    public String getReviewCalendarId() {
+        return reviewCalendarId;
+    }
+
+    public boolean isReviewMirrorEnabled() {
+        return reviewMirrorEnabled;
     }
 
     public Instant getConnectedAt() {

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewCalendarMirror.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewCalendarMirror.java
@@ -1,0 +1,111 @@
+package ds.project.orino.domain.planner.review.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * 복습 묶음 ↔ Google 보조 캘린더 종일 이벤트 매핑. dueDate 하루치 PENDING 복습을 "복습 N개" 종일 이벤트
+ * 1개로 단방향 미러한다(orino=진실, Google=투영).
+ *
+ * <p>{@code (member_id, due_date)} UNIQUE로 dueDate당 1 row를 보장해 멱등 upsert의 키가 된다.
+ * {@code google_event_id}는 Google이 삭제됐을 때 self-heal로 재생성되며 갱신될 수 있다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "review_calendar_mirror", uniqueConstraints = @UniqueConstraint(
+        name = "uk_review_calendar_mirror_member_date", columnNames = {"member_id", "due_date"}))
+public class ReviewCalendarMirror {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "due_date", nullable = false)
+    private LocalDate dueDate;
+
+    @Column(name = "google_event_id", nullable = false, length = 255)
+    private String googleEventId;
+
+    @Column(name = "pending_count", nullable = false)
+    private int pendingCount;
+
+    @Column(name = "synced_at", nullable = false)
+    private Instant syncedAt;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected ReviewCalendarMirror() {
+    }
+
+    public ReviewCalendarMirror(Long memberId, LocalDate dueDate, String googleEventId,
+                                int pendingCount, Instant syncedAt) {
+        this.memberId = memberId;
+        this.dueDate = dueDate;
+        this.googleEventId = googleEventId;
+        this.pendingCount = pendingCount;
+        this.syncedAt = syncedAt;
+    }
+
+    /**
+     * 동기화 결과를 반영한다. Google 이벤트가 그대로면 동일 {@code googleEventId}로, self-heal로 재생성됐으면
+     * 새 id로 갱신한다.
+     */
+    public void sync(String googleEventId, int pendingCount, Instant syncedAt) {
+        this.googleEventId = googleEventId;
+        this.pendingCount = pendingCount;
+        this.syncedAt = syncedAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public LocalDate getDueDate() {
+        return dueDate;
+    }
+
+    public String getGoogleEventId() {
+        return googleEventId;
+    }
+
+    public int getPendingCount() {
+        return pendingCount;
+    }
+
+    public Instant getSyncedAt() {
+        return syncedAt;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewCalendarMirrorRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewCalendarMirrorRepository.java
@@ -1,0 +1,19 @@
+package ds.project.orino.domain.planner.review.repository;
+
+import ds.project.orino.domain.planner.review.entity.ReviewCalendarMirror;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface ReviewCalendarMirrorRepository extends JpaRepository<ReviewCalendarMirror, Long> {
+
+    Optional<ReviewCalendarMirror> findByMemberIdAndDueDate(Long memberId, LocalDate dueDate);
+
+    List<ReviewCalendarMirror> findAllByMemberId(Long memberId);
+
+    void deleteByMemberIdAndDueDate(Long memberId, LocalDate dueDate);
+
+    void deleteByMemberId(Long memberId);
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/google/repository/GoogleAccountRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/google/repository/GoogleAccountRepositoryTest.java
@@ -127,6 +127,45 @@ class GoogleAccountRepositoryTest {
     }
 
     @Test
+    @DisplayName("review_mirror_enabled는 기본 false, review_calendar_id는 기본 null")
+    void reviewMirror_defaults() {
+        googleAccountRepository.save(new GoogleAccount(memberId, "t", null, null, null, null));
+
+        GoogleAccount saved = googleAccountRepository.findByMemberId(memberId).orElseThrow();
+        assertThat(saved.isReviewMirrorEnabled()).isFalse();
+        assertThat(saved.getReviewCalendarId()).isNull();
+    }
+
+    @Test
+    @DisplayName("enableReviewMirror는 보조 캘린더 ID를 기록하고 토글을 켠다")
+    void enableReviewMirror() {
+        GoogleAccount account = googleAccountRepository.save(
+                new GoogleAccount(memberId, "t", null, null, null, null));
+
+        account.enableReviewMirror("c_review@group.calendar.google.com");
+        googleAccountRepository.save(account);
+
+        GoogleAccount reloaded = googleAccountRepository.findByMemberId(memberId).orElseThrow();
+        assertThat(reloaded.isReviewMirrorEnabled()).isTrue();
+        assertThat(reloaded.getReviewCalendarId()).isEqualTo("c_review@group.calendar.google.com");
+    }
+
+    @Test
+    @DisplayName("disableReviewMirror는 토글만 끄고 보조 캘린더 ID는 보존한다")
+    void disableReviewMirror_keepsCalendarId() {
+        GoogleAccount account = new GoogleAccount(memberId, "t", null, null, null, null);
+        account.enableReviewMirror("c_review@group.calendar.google.com");
+        googleAccountRepository.save(account);
+
+        account.disableReviewMirror();
+        googleAccountRepository.save(account);
+
+        GoogleAccount reloaded = googleAccountRepository.findByMemberId(memberId).orElseThrow();
+        assertThat(reloaded.isReviewMirrorEnabled()).isFalse();
+        assertThat(reloaded.getReviewCalendarId()).isEqualTo("c_review@group.calendar.google.com");
+    }
+
+    @Test
     @DisplayName("reconnect는 refresh token·메타데이터를 갱신하고 revoked를 해제한다")
     void reconnect() {
         GoogleAccount account = new GoogleAccount(memberId, "old-token", "old-scope", null, null, null);

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/review/repository/ReviewCalendarMirrorRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/review/repository/ReviewCalendarMirrorRepositoryTest.java
@@ -1,0 +1,116 @@
+package ds.project.orino.domain.planner.review.repository;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.review.entity.ReviewCalendarMirror;
+import ds.project.orino.domain.support.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RepositoryTest
+@Transactional
+class ReviewCalendarMirrorRepositoryTest {
+
+    private static final LocalDate DUE_DATE = LocalDate.of(2026, 6, 20);
+    private static final Instant SYNCED_AT = Instant.parse("2026-06-19T01:00:00Z");
+
+    @Autowired
+    private ReviewCalendarMirrorRepository mirrorRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        memberId = memberRepository.save(new Member("mirroruser", "encodedPassword")).getId();
+    }
+
+    @Test
+    @DisplayName("미러를 저장하고 member+dueDate로 조회한다")
+    void save_and_findByMemberIdAndDueDate() {
+        mirrorRepository.save(new ReviewCalendarMirror(memberId, DUE_DATE, "evt-1", 3, SYNCED_AT));
+
+        Optional<ReviewCalendarMirror> found = mirrorRepository.findByMemberIdAndDueDate(memberId, DUE_DATE);
+
+        assertThat(found).isPresent();
+        ReviewCalendarMirror saved = found.get();
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getMemberId()).isEqualTo(memberId);
+        assertThat(saved.getDueDate()).isEqualTo(DUE_DATE);
+        assertThat(saved.getGoogleEventId()).isEqualTo("evt-1");
+        assertThat(saved.getPendingCount()).isEqualTo(3);
+        assertThat(saved.getSyncedAt()).isEqualTo(SYNCED_AT);
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("(member_id, due_date)는 UNIQUE — 같은 키로 두 row를 저장하면 실패한다")
+    void uniqueMemberDueDate() {
+        mirrorRepository.saveAndFlush(new ReviewCalendarMirror(memberId, DUE_DATE, "evt-1", 1, SYNCED_AT));
+
+        assertThatThrownBy(() ->
+                mirrorRepository.saveAndFlush(new ReviewCalendarMirror(memberId, DUE_DATE, "evt-2", 2, SYNCED_AT)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("sync는 googleEventId·pendingCount·syncedAt를 갱신한다(self-heal 포함)")
+    void sync_updatesFields() {
+        ReviewCalendarMirror mirror =
+                mirrorRepository.save(new ReviewCalendarMirror(memberId, DUE_DATE, "evt-1", 3, SYNCED_AT));
+
+        Instant resyncedAt = Instant.parse("2026-06-19T02:00:00Z");
+        mirror.sync("evt-2", 5, resyncedAt);
+        mirrorRepository.saveAndFlush(mirror);
+
+        ReviewCalendarMirror reloaded =
+                mirrorRepository.findByMemberIdAndDueDate(memberId, DUE_DATE).orElseThrow();
+        assertThat(reloaded.getGoogleEventId()).isEqualTo("evt-2");
+        assertThat(reloaded.getPendingCount()).isEqualTo(5);
+        assertThat(reloaded.getSyncedAt()).isEqualTo(resyncedAt);
+    }
+
+    @Test
+    @DisplayName("member의 모든 미러를 조회한다")
+    void findAllByMemberId() {
+        mirrorRepository.save(new ReviewCalendarMirror(memberId, DUE_DATE, "evt-1", 1, SYNCED_AT));
+        mirrorRepository.save(new ReviewCalendarMirror(memberId, DUE_DATE.plusDays(1), "evt-2", 2, SYNCED_AT));
+
+        assertThat(mirrorRepository.findAllByMemberId(memberId)).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("member+dueDate로 미러를 삭제한다(N=0 정리)")
+    void deleteByMemberIdAndDueDate() {
+        mirrorRepository.save(new ReviewCalendarMirror(memberId, DUE_DATE, "evt-1", 1, SYNCED_AT));
+
+        mirrorRepository.deleteByMemberIdAndDueDate(memberId, DUE_DATE);
+
+        assertThat(mirrorRepository.findByMemberIdAndDueDate(memberId, DUE_DATE)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("member의 모든 미러를 삭제한다(disable 정리)")
+    void deleteByMemberId() {
+        mirrorRepository.save(new ReviewCalendarMirror(memberId, DUE_DATE, "evt-1", 1, SYNCED_AT));
+        mirrorRepository.save(new ReviewCalendarMirror(memberId, DUE_DATE.plusDays(1), "evt-2", 2, SYNCED_AT));
+
+        mirrorRepository.deleteByMemberId(memberId);
+
+        assertThat(mirrorRepository.findAllByMemberId(memberId)).isEmpty();
+    }
+}


### PR DESCRIPTION
## 이슈
closes #584

## 작업 내용
복습 → Google 보조 캘린더 단방향 미러링(Epic #583)의 기반(RM0). 보조 캘린더에 종일 묶음 이벤트를 쓰기 위한 클라이언트 확장과 스키마를 추가한다.

- **GoogleCalendarClient**
  - `primary` 하드코딩 제거 → calendarId 파라미터화(기존 메서드는 `primary`로 위임, 동작 동일)
  - `createSecondaryCalendar` — `calendars.insert`로 "orino 복습" 보조 캘린더 생성 후 calendarId 반환
  - `insertAllDayEvent` — 종일(`date`) 이벤트 + `reminders.useDefault` 생성, eventId 반환
  - `patchEventSummary` / `deleteEvent(calendarId, eventId)` — 묶음 제목 갱신·삭제
- **GoogleEventWriteBody** — `reminders(useDefault)` 필드 추가
- **ReviewCalendarMirror** 엔티티 + 리포지토리 — dueDate↔eventId 매핑, `UNIQUE(member_id, due_date)`로 멱등 upsert 키
- **GoogleAccount** — `review_calendar_id`·`review_mirror_enabled` 컬럼 + `enable/disableReviewMirror` 토글
- **Liquibase** — `026`(google_account 컬럼), `027`(review_calendar_mirror 테이블)

## 테스트
- `GoogleCalendarClientTest` — 보조 캘린더 insert/patch/delete + 종일 date 바디 + useDefault 알림 HTTP 검증
- `ReviewCalendarMirrorRepositoryTest` — 저장·조회, `UNIQUE(member_id,due_date)` 위반, sync(self-heal), 삭제
- `GoogleAccountRepositoryTest` — 신규 컬럼 기본값·토글 매핑
- 전체 `:orino-domain-rdb:test` · `:orino-app-api:test` 통과(통합 테스트가 Liquibase 026/027 적용 + Hibernate validate 확인)

## 추가: Jackson 보안 패치 (CI image-scan)
- Trivy가 잡은 jackson-databind HIGH 4건(CVE-2026-54512·CVE-2026-54513) 해소
- BE 핀 버전 bump: `jackson-2-bom 2.21.2→2.21.4`, `jackson-bom 3.1.2→3.1.4`
- RM0와 무관한 저장소 전체(main CD 포함) 실패였으나 본 브랜치에서 함께 처리
