### PR TITLE
fix : 앱 로그 대시보드 service_name 기반 정비 (FE 로그 JSON parse 해소)

### DIFF
--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/logs-overview.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/logs-overview.json
@@ -23,11 +23,11 @@
         "current": { "text": "orino", "value": "orino" }
       },
       {
-        "name": "app",
-        "label": "App",
+        "name": "service_name",
+        "label": "Service",
         "type": "query",
         "datasource": { "type": "loki", "uid": "loki" },
-        "query": "label_values({namespace=~\"$namespace\"}, app)",
+        "query": "label_values({namespace=~\"$namespace\"}, service_name)",
         "refresh": 2,
         "multi": true,
         "includeAll": true,
@@ -41,7 +41,7 @@
         "query": "error,warn,info,debug,trace",
         "multi": true,
         "includeAll": true,
-        "allValue": ".+",
+        "allValue": ".*",
         "current": { "text": "All", "value": "$__all" }
       },
       {
@@ -63,7 +63,7 @@
       "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "red" }, "unit": "short" } },
       "targets": [
         { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "instant",
-          "expr": "sum(count_over_time({namespace=~\"$namespace\", app=~\"$app\", level=\"error\"}[$__range]))" }
+          "expr": "sum(count_over_time({namespace=~\"$namespace\", service_name=~\"$service_name\", level=\"error\"}[$__range]))" }
       ]
     },
     {
@@ -75,7 +75,7 @@
       "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "orange" }, "unit": "short" } },
       "targets": [
         { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "instant",
-          "expr": "sum(count_over_time({namespace=~\"$namespace\", app=~\"$app\", level=\"warn\"}[$__range]))" }
+          "expr": "sum(count_over_time({namespace=~\"$namespace\", service_name=~\"$service_name\", level=\"warn\"}[$__range]))" }
       ]
     },
     {
@@ -87,7 +87,7 @@
       "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "green" }, "unit": "short" } },
       "targets": [
         { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "instant",
-          "expr": "sum(count_over_time({namespace=~\"$namespace\", app=~\"$app\", level=\"info\"}[$__range]))" }
+          "expr": "sum(count_over_time({namespace=~\"$namespace\", service_name=~\"$service_name\", level=\"info\"}[$__range]))" }
       ]
     },
     {
@@ -99,7 +99,7 @@
       "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "blue" }, "unit": "short" } },
       "targets": [
         { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "instant",
-          "expr": "sum(count_over_time({namespace=~\"$namespace\", app=~\"$app\"}[$__range]))" }
+          "expr": "sum(count_over_time({namespace=~\"$namespace\", service_name=~\"$service_name\"}[$__range]))" }
       ]
     },
     {
@@ -123,7 +123,7 @@
       "targets": [
         { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "range",
           "legendFormat": "{{level}}",
-          "expr": "sum by (level) (count_over_time({namespace=~\"$namespace\", app=~\"$app\"}[$__auto]))" }
+          "expr": "sum by (level) (count_over_time({namespace=~\"$namespace\", service_name=~\"$service_name\"}[$__auto]))" }
       ]
     },
     {
@@ -135,7 +135,7 @@
       "fieldConfig": { "defaults": {}, "overrides": [] },
       "targets": [
         { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "instant", "format": "table",
-          "expr": "topk(15, sum by (logger) (count_over_time({namespace=~\"$namespace\", app=~\"$app\", level=\"error\"} | logger != \"\" [$__range])))" }
+          "expr": "topk(15, sum by (logger) (count_over_time({namespace=~\"$namespace\", service_name=~\"$service_name\", level=\"error\"} | logger != \"\" [$__range])))" }
       ]
     },
     {
@@ -155,7 +155,7 @@
       },
       "targets": [
         { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "range",
-          "expr": "{namespace=~\"$namespace\", app=~\"$app\", level=~\"$level\"} |~ \"(?i)$search\"" }
+          "expr": "{namespace=~\"$namespace\", service_name=~\"$service_name\", level=~\"$level\"} |~ \"(?i)$search\"" }
       ]
     }
   ]


### PR DESCRIPTION
## 이슈
closes #615

## 작업 내용

Grafana **Application Logs**(`uid: app-logs`, UI 수동 생성) 대시보드의 앱 로그 패널에서 발생하던 `json parse 에러`(JSONParserErr)를, 코드로 관리되는 표준 `orino-logs` 대시보드로 일원화하여 해소한다.

### 원인
- 수동 `app-logs` 대시보드가 `{namespace="orino"} | json` 으로 orino 네임스페이스 전체에 `| json`을 적용 → **FE nginx access log(plain text)** 에서 JSON 파싱 실패.
- 추가로, alloy relabel이 `app` 라벨을 `app.kubernetes.io/name`에서 가져오는데 fe/be 파드엔 해당 라벨이 없어 `app` 라벨이 비어 있었고, 그 탓에 표준 `orino-logs` 대시보드(`app` 변수 기반)에서도 fe/be 로그가 누락되고 있었음.

### 변경 (`logs-overview.json`)
- `app` 변수/필터 → **`service_name`** 으로 전환 (Loki가 모든 워크로드에 자동 부여 → fe/be/redis 누락 없음, `| json` 불필요)
- `level` 변수 `allValue` `.+` → **`.*`** (level 라벨이 없는 nginx access log도 "All"에서 포함)

### 검증
- `helm dependency build` 후 `helm template` 렌더링 → ConfigMap/대시보드 JSON 파싱 정상
- Loki 실측:
  - `service_name` 값에 fe·be·redis 포함 확인
  - `{service_name="fe", level=~".*"}` → fe 로그 **노출됨** / `level=~".+"`(기존) → fe **0건**(누락 재현)
  - `{service_name="be", level=~".*"}` → be 로그 정상

### 머지 후 후속 (런타임)
- [ ] Grafana에서 수동 생성된 `app-logs` 대시보드 삭제 (JSON 백업 후) — GitOps 일원화 마무리