### PR TITLE
feat : 복습 미러 RM1 — reconcileDate 단방향 동기화 + 복습 훅

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/service/FlashcardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/service/FlashcardService.java
@@ -13,6 +13,7 @@ import ds.project.orino.planner.flashcard.dto.FlashcardCreateResponse;
 import ds.project.orino.planner.flashcard.dto.FlashcardResponse;
 import ds.project.orino.planner.flashcard.dto.FlashcardUpdateRequest;
 import ds.project.orino.planner.review.dto.ReviewScheduleView;
+import ds.project.orino.planner.review.service.ReviewMirrorService;
 import ds.project.orino.core.time.UserTimeZone;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,15 +32,18 @@ public class FlashcardService {
     private final FlashcardRepository flashcardRepository;
     private final ReviewScheduleRepository reviewScheduleRepository;
     private final StudyMaterialRepository studyMaterialRepository;
+    private final ReviewMirrorService reviewMirrorService;
     private final Clock clock;
 
     public FlashcardService(FlashcardRepository flashcardRepository,
                             ReviewScheduleRepository reviewScheduleRepository,
                             StudyMaterialRepository studyMaterialRepository,
+                            ReviewMirrorService reviewMirrorService,
                             Clock clock) {
         this.flashcardRepository = flashcardRepository;
         this.reviewScheduleRepository = reviewScheduleRepository;
         this.studyMaterialRepository = studyMaterialRepository;
+        this.reviewMirrorService = reviewMirrorService;
         this.clock = clock;
     }
 
@@ -70,6 +74,10 @@ public class FlashcardService {
         LocalDate today = clock.instant().atZone(zone).toLocalDate();
         ReviewSchedule firstReview = reviewScheduleRepository.save(
                 ReviewSchedule.firstReview(memberId, saved.getId(), today, zone));
+
+        // 첫 복습 dueDate를 보조 캘린더에 미러(커밋 후, 미러 활성 시에만)
+        reviewMirrorService.reconcileAfterCommit(memberId,
+                List.of(firstReview.getScheduledAt().atZone(zone).toLocalDate()), zone);
 
         return new FlashcardCreateResponse(
                 FlashcardResponse.withoutReview(saved),

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
@@ -340,10 +340,12 @@ public class GoogleCalendarClient {
 
     /**
      * 보조 캘린더에 하루짜리 종일 이벤트를 생성하고 생성된 eventId를 반환한다. 알림은 계정 기본(useDefault).
+     * {@code description}은 자료별 묶음 설명(null 가능).
      */
-    public String insertAllDayEvent(Long memberId, String calendarId, String summary, LocalDate date) {
+    public String insertAllDayEvent(Long memberId, String calendarId, String summary,
+                                    String description, LocalDate date) {
         URI uri = eventsBuilder(calendarId).build().toUri();
-        GoogleEventWriteBody body = allDayBody(summary, date);
+        GoogleEventWriteBody body = allDayBody(summary, description, date);
         GoogleEventItem item = tokenProvider.executeWithRetry(memberId, accessToken ->
                 googleRestClient.post()
                         .uri(uri)
@@ -356,11 +358,12 @@ public class GoogleCalendarClient {
     }
 
     /**
-     * 보조 캘린더 종일 이벤트의 제목만 patch한다(복습 개수 변동 반영). 없는 id면 404(RESOURCE_NOT_FOUND).
+     * 보조 캘린더 종일 이벤트의 제목·설명을 patch한다(복습 개수/자료 변동 반영). 없는 id면 404(RESOURCE_NOT_FOUND).
      */
-    public void patchEventSummary(Long memberId, String calendarId, String eventId, String summary) {
+    public void patchAllDayEvent(Long memberId, String calendarId, String eventId,
+                                 String summary, String description) {
         URI uri = eventUri(calendarId, eventId);
-        GoogleEventWriteBody body = new GoogleEventWriteBody(summary, null, null, null, null);
+        GoogleEventWriteBody body = new GoogleEventWriteBody(summary, null, description, null, null);
         tokenProvider.executeWithRetry(memberId, accessToken ->
                 googleRestClient.patch()
                         .uri(uri)
@@ -372,11 +375,11 @@ public class GoogleCalendarClient {
     }
 
     /** 하루짜리 종일 이벤트 바디(useDefault 알림). Google 종일 종료는 배타적이라 end=date+1일. */
-    private GoogleEventWriteBody allDayBody(String summary, LocalDate date) {
+    private GoogleEventWriteBody allDayBody(String summary, String description, LocalDate date) {
         GoogleEventTime start = new GoogleEventTime(null, date.toString(), null);
         GoogleEventTime end = new GoogleEventTime(null, date.plusDays(1).toString(), null);
         return new GoogleEventWriteBody(
-                summary, null, null, start, end, null, null, GoogleReminders.defaults());
+                summary, null, description, start, end, null, null, GoogleReminders.defaults());
     }
 
     private GoogleEventWriteBody toWriteBody(EventRequest request, ZoneId zone) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCompletionService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCompletionService.java
@@ -16,16 +16,21 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.List;
 
 @Service
 public class ReviewCompletionService {
 
     private final ReviewScheduleRepository reviewScheduleRepository;
+    private final ReviewMirrorService reviewMirrorService;
     private final Clock clock;
 
-    public ReviewCompletionService(ReviewScheduleRepository reviewScheduleRepository, Clock clock) {
+    public ReviewCompletionService(ReviewScheduleRepository reviewScheduleRepository,
+                                   ReviewMirrorService reviewMirrorService, Clock clock) {
         this.reviewScheduleRepository = reviewScheduleRepository;
+        this.reviewMirrorService = reviewMirrorService;
         this.clock = clock;
     }
 
@@ -52,6 +57,12 @@ public class ReviewCompletionService {
         ReviewSchedule next = reviewScheduleRepository.save(new ReviewSchedule(
                 memberId, current.getFlashcardId(), newSequence,
                 scheduledAt, computed.intervalDays(), computed.easeFactor()));
+
+        // 완료된 dueDate(감소)와 다음 dueDate(증가) 묶음을 모두 재동기화(커밋 후, 미러 활성 시에만).
+        // AGAIN은 04:00 정각이 아니어서 reconcile 집계에서 자연히 제외된다.
+        LocalDate completedDate = current.getScheduledAt().atZone(zone).toLocalDate();
+        LocalDate nextDate = next.getScheduledAt().atZone(zone).toLocalDate();
+        reviewMirrorService.reconcileAfterCommit(memberId, List.of(completedDate, nextDate), zone);
 
         return new ReviewCompletionResponse(
                 CompletedReviewView.of(current),

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewMirrorService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewMirrorService.java
@@ -1,0 +1,207 @@
+package ds.project.orino.planner.review.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.ReviewCalendarMirror;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+import ds.project.orino.domain.planner.review.repository.ReviewCalendarMirrorRepository;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.planner.google.client.GoogleCalendarClient;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 복습 → 보조 캘린더("orino 복습") 단방향 미러. orino가 진실, Google은 투영.
+ *
+ * <p>이벤트 기반 멱등 reconcile: dueDate(04:00 롤오버)당 PENDING 복습을 "복습 N개" 종일 묶음 이벤트 1개로
+ * upsert하고, 0이면 삭제한다. AGAIN(now+10분)은 04:00 정각이 아니라 자연히 제외된다. 항상 DB 진실 기준
+ * 재계산하므로 Google에서 사용자가 이벤트를 지워도(404) 재생성으로 self-heal한다.
+ *
+ * <p>미러는 핵심 복습 동작의 부수효과이므로, 호출부 트랜잭션 <b>커밋 후</b>({@link #reconcileAfterCommit})
+ * 실행한다 — Google 장애가 복습 생성/완료를 롤백시키지 않게 한다(드리프트는 다음 reconcile가 치유).
+ */
+@Service
+public class ReviewMirrorService {
+
+    private static final String CALENDAR_SUMMARY_PREFIX = "복습 ";
+    private static final String CALENDAR_SUMMARY_SUFFIX = "개";
+    private static final String NO_MATERIAL_LABEL = "(자료 없음)";
+
+    private final GoogleAccountRepository googleAccountRepository;
+    private final ReviewScheduleRepository reviewScheduleRepository;
+    private final ReviewCalendarMirrorRepository mirrorRepository;
+    private final FlashcardRepository flashcardRepository;
+    private final StudyMaterialRepository studyMaterialRepository;
+    private final GoogleCalendarClient calendarClient;
+    private final Clock clock;
+    /** 커밋 후/프록시 경유 호출로 {@link #reconcileDate}의 {@code REQUIRES_NEW} 트랜잭션을 적용하기 위한 self 참조. */
+    private final ReviewMirrorService self;
+
+    public ReviewMirrorService(GoogleAccountRepository googleAccountRepository,
+                               ReviewScheduleRepository reviewScheduleRepository,
+                               ReviewCalendarMirrorRepository mirrorRepository,
+                               FlashcardRepository flashcardRepository,
+                               StudyMaterialRepository studyMaterialRepository,
+                               GoogleCalendarClient calendarClient,
+                               Clock clock,
+                               @Lazy ReviewMirrorService self) {
+        this.googleAccountRepository = googleAccountRepository;
+        this.reviewScheduleRepository = reviewScheduleRepository;
+        this.mirrorRepository = mirrorRepository;
+        this.flashcardRepository = flashcardRepository;
+        this.studyMaterialRepository = studyMaterialRepository;
+        this.calendarClient = calendarClient;
+        this.clock = clock;
+        this.self = self;
+    }
+
+    /**
+     * 주어진 dueDate들을 현재 트랜잭션 커밋 후 reconcile하도록 등록한다. 활성 트랜잭션이 없으면 즉시 실행한다.
+     * 중복 날짜는 한 번만 처리한다.
+     */
+    public void reconcileAfterCommit(Long memberId, Collection<LocalDate> dueDates, ZoneId zone) {
+        Set<LocalDate> dates = new LinkedHashSet<>(dueDates);
+        if (dates.isEmpty()) {
+            return;
+        }
+        // self 프록시 경유 호출이라야 reconcileDate의 REQUIRES_NEW 트랜잭션이 적용된다(직접 호출 시 self-invocation으로 무시됨).
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    dates.forEach(date -> self.reconcileDate(memberId, date, zone));
+                }
+            });
+        } else {
+            dates.forEach(date -> self.reconcileDate(memberId, date, zone));
+        }
+    }
+
+    /**
+     * dueDate 묶음을 보조 캘린더와 동기화한다(멱등). 미러 비활성이거나 미연동이면 no-op.
+     * N&gt;0이면 "복습 N개" 종일 이벤트를 upsert(없으면 insert, 있으면 patch, Google 404면 재생성),
+     * N=0이면 이벤트·매핑을 삭제한다.
+     *
+     * <p>{@code REQUIRES_NEW} — 커밋 후(afterCommit) 호출 시 완료 중인 트랜잭션에 합류해 쓰기가 유실되지 않도록
+     * 항상 새 트랜잭션에서 실행한다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void reconcileDate(Long memberId, LocalDate dueDate, ZoneId zone) {
+        GoogleAccount account = googleAccountRepository.findByMemberId(memberId).orElse(null);
+        if (account == null || account.isRevoked()
+                || !account.isReviewMirrorEnabled() || account.getReviewCalendarId() == null) {
+            return;
+        }
+        String calendarId = account.getReviewCalendarId();
+
+        Instant rollover = dueDate.atTime(ReviewSchedule.ROLLOVER_HOUR, 0).atZone(zone).toInstant();
+        List<ReviewSchedule> pending = reviewScheduleRepository
+                .findAllByMemberIdAndStatusAndScheduledAt(memberId, ReviewStatus.PENDING, rollover);
+        Optional<ReviewCalendarMirror> existing = mirrorRepository.findByMemberIdAndDueDate(memberId, dueDate);
+
+        if (pending.isEmpty()) {
+            existing.ifPresent(mirror -> {
+                deleteEventQuietly(memberId, calendarId, mirror.getGoogleEventId());
+                mirrorRepository.delete(mirror);
+            });
+            return;
+        }
+
+        int count = pending.size();
+        String summary = CALENDAR_SUMMARY_PREFIX + count + CALENDAR_SUMMARY_SUFFIX;
+        String description = buildDescription(pending);
+        Instant now = clock.instant();
+
+        if (existing.isPresent()) {
+            ReviewCalendarMirror mirror = existing.get();
+            String eventId = patchOrRecreate(
+                    memberId, calendarId, mirror.getGoogleEventId(), summary, description, dueDate);
+            mirror.sync(eventId, count, now);
+            mirrorRepository.save(mirror);
+        } else {
+            String eventId = calendarClient.insertAllDayEvent(
+                    memberId, calendarId, summary, description, dueDate);
+            mirrorRepository.save(new ReviewCalendarMirror(memberId, dueDate, eventId, count, now));
+        }
+    }
+
+    /** patch를 시도하고, Google에서 이벤트가 지워졌으면(404) 재생성해 새 eventId를 반환한다(self-heal). */
+    private String patchOrRecreate(Long memberId, String calendarId, String eventId,
+                                   String summary, String description, LocalDate dueDate) {
+        try {
+            calendarClient.patchAllDayEvent(memberId, calendarId, eventId, summary, description);
+            return eventId;
+        } catch (CustomException e) {
+            if (e.getErrorCode() == ErrorCode.RESOURCE_NOT_FOUND) {
+                return calendarClient.insertAllDayEvent(memberId, calendarId, summary, description, dueDate);
+            }
+            throw e;
+        }
+    }
+
+    /** 이벤트 삭제 — 이미 Google에 없으면(404) 무시한다. */
+    private void deleteEventQuietly(Long memberId, String calendarId, String eventId) {
+        try {
+            calendarClient.deleteEvent(memberId, calendarId, eventId);
+        } catch (CustomException e) {
+            if (e.getErrorCode() != ErrorCode.RESOURCE_NOT_FOUND) {
+                throw e;
+            }
+        }
+    }
+
+    /** 자료 제목별 복습 개수 설명("제목: N개" 줄 목록). 링크 필드는 아직 데이터 모델에 없어 제외. */
+    private String buildDescription(List<ReviewSchedule> pending) {
+        List<Long> cardIds = pending.stream()
+                .map(ReviewSchedule::getFlashcardId).distinct().toList();
+        Map<Long, Flashcard> cardById = flashcardRepository.findAllByIdIn(cardIds).stream()
+                .collect(Collectors.toMap(Flashcard::getId, Function.identity()));
+        List<Long> materialIds = cardById.values().stream()
+                .map(Flashcard::getMaterialId).distinct().toList();
+        Map<Long, StudyMaterial> materialById = studyMaterialRepository.findAllByIdIn(materialIds).stream()
+                .collect(Collectors.toMap(StudyMaterial::getId, Function.identity()));
+
+        Map<String, Integer> countByTitle = new TreeMap<>();
+        for (ReviewSchedule review : pending) {
+            countByTitle.merge(materialTitle(review, cardById, materialById), 1, Integer::sum);
+        }
+        return countByTitle.entrySet().stream()
+                .map(e -> e.getKey() + ": " + e.getValue() + CALENDAR_SUMMARY_SUFFIX)
+                .collect(Collectors.joining("\n"));
+    }
+
+    private String materialTitle(ReviewSchedule review,
+                                 Map<Long, Flashcard> cardById, Map<Long, StudyMaterial> materialById) {
+        Flashcard card = cardById.get(review.getFlashcardId());
+        if (card == null) {
+            return NO_MATERIAL_LABEL;
+        }
+        StudyMaterial material = materialById.get(card.getMaterialId());
+        return material == null ? NO_MATERIAL_LABEL : material.getTitle();
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/client/GoogleCalendarClientTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/client/GoogleCalendarClientTest.java
@@ -87,18 +87,19 @@ class GoogleCalendarClientTest {
     }
 
     @Test
-    @DisplayName("insertAllDayEvent는 종일(date) 이벤트 + useDefault 알림으로 생성하고 eventId를 반환한다")
+    @DisplayName("insertAllDayEvent는 종일(date) 이벤트 + 설명 + useDefault 알림으로 생성하고 eventId를 반환한다")
     void insertAllDayEvent() {
         nextResponse = "{\"id\":\"evt-1\"}";
 
         String eventId = client.insertAllDayEvent(
-                MEMBER_ID, CALENDAR_ID, "복습 2개", LocalDate.of(2026, 6, 20));
+                MEMBER_ID, CALENDAR_ID, "복습 2개", "수학: 2개", LocalDate.of(2026, 6, 20));
 
         assertThat(eventId).isEqualTo("evt-1");
         CapturedRequest req = last();
         assertThat(req.method).isEqualTo("POST");
         assertThat(req.path).isEqualTo("/calendar/v3/calendars/" + CALENDAR_ID + "/events");
         assertThat(req.body).contains("\"summary\":\"복습 2개\"");
+        assertThat(req.body).contains("\"description\":\"수학: 2개\"");
         // 종일은 date(시간 없음), Google 종료는 배타적 → end=date+1일
         assertThat(req.body).contains("\"start\":{\"date\":\"2026-06-20\"}");
         assertThat(req.body).contains("\"end\":{\"date\":\"2026-06-21\"}");
@@ -109,16 +110,17 @@ class GoogleCalendarClientTest {
     }
 
     @Test
-    @DisplayName("patchEventSummary는 제목만 patch한다(start/end 미포함)")
-    void patchEventSummary() {
+    @DisplayName("patchAllDayEvent는 제목·설명만 patch한다(start/end 미포함)")
+    void patchAllDayEvent() {
         nextResponse = "{\"id\":\"evt-1\",\"summary\":\"복습 3개\"}";
 
-        client.patchEventSummary(MEMBER_ID, CALENDAR_ID, "evt-1", "복습 3개");
+        client.patchAllDayEvent(MEMBER_ID, CALENDAR_ID, "evt-1", "복습 3개", "수학: 3개");
 
         CapturedRequest req = last();
         assertThat(req.method).isEqualTo("PATCH");
         assertThat(req.path).isEqualTo("/calendar/v3/calendars/" + CALENDAR_ID + "/events/evt-1");
         assertThat(req.body).contains("\"summary\":\"복습 3개\"");
+        assertThat(req.body).contains("\"description\":\"수학: 3개\"");
         assertThat(req.body).doesNotContain("start");
         assertThat(req.body).doesNotContain("end");
     }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/mirror/ReviewMirrorIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/mirror/ReviewMirrorIntegrationTest.java
@@ -1,0 +1,288 @@
+package ds.project.orino.planner.review.mirror;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.ReviewCalendarMirror;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.repository.ReviewCalendarMirrorRepository;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 복습 → 보조 캘린더 미러 RM1 통합 테스트(MockMvc + TestContainers + Google 스텁).
+ * 플래시카드 생성/복습 완료 훅 → reconcile(커밋 후)가 보조 캘린더에 묶음 종일 이벤트를 upsert/삭제하는지 검증한다.
+ */
+class ReviewMirrorIntegrationTest extends ApiTestSupport {
+
+    private static final String CALENDAR_ID = "review-cal";
+
+    private static final HttpServer CALENDAR_STUB = createStub();
+    private static final List<CapturedRequest> REQUESTS = new ArrayList<>();
+    private static final Set<String> NOT_FOUND_EVENT_IDS = ConcurrentHashMap.newKeySet();
+    private static final AtomicInteger EVENT_SEQ = new AtomicInteger();
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+    @Autowired
+    private ReviewScheduleRepository reviewScheduleRepository;
+    @Autowired
+    private ReviewCalendarMirrorRepository mirrorRepository;
+    @Autowired
+    private GoogleAccountRepository googleAccountRepository;
+    @Autowired
+    private GoogleAccessTokenRepository accessTokenRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+    @Autowired
+    private Clock clock;
+
+    private Long memberId;
+    private Long materialId;
+    private String authHeader;
+    private LocalDate today;
+
+    @DynamicPropertySource
+    static void googleProperties(DynamicPropertyRegistry registry) {
+        String base = "http://127.0.0.1:" + CALENDAR_STUB.getAddress().getPort();
+        registry.add("planner.google.client-id", () -> "test-client-id");
+        registry.add("planner.google.client-secret", () -> "test-client-secret");
+        registry.add("planner.google.oauth.calendar-api-base-url", () -> base);
+    }
+
+    @AfterAll
+    static void stopStub() {
+        CALENDAR_STUB.stop(0);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        REQUESTS.clear();
+        NOT_FOUND_EVENT_IDS.clear();
+        EVENT_SEQ.set(0);
+        dbCleaner.clean();
+
+        Member member = memberRepository.save(MemberFixture.create());
+        memberId = member.getId();
+        materialId = studyMaterialRepository.save(
+                new StudyMaterial(memberId, "수학", MaterialType.BOOK)).getId();
+
+        GoogleAccount account = new GoogleAccount(
+                memberId, "refresh", "scope", "me@gmail.com", "primary", "@default");
+        account.enableReviewMirror(CALENDAR_ID);
+        googleAccountRepository.save(account);
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        today = clock.instant().atZone(TEST_ZONE).toLocalDate();
+    }
+
+    @Test
+    @DisplayName("플래시카드 생성 → 첫 복습 dueDate에 '복습 1개' 종일 이벤트를 insert하고 매핑을 저장한다")
+    void create_inserts_bundle() throws Exception {
+        createCard("Q1");
+
+        LocalDate dueDate = today.plusDays(1);
+        ReviewCalendarMirror mirror =
+                mirrorRepository.findByMemberIdAndDueDate(memberId, dueDate).orElseThrow();
+        assertThat(mirror.getPendingCount()).isEqualTo(1);
+        assertThat(mirror.getGoogleEventId()).isEqualTo("evt-1");
+
+        CapturedRequest insert = last();
+        assertThat(insert.method).isEqualTo("POST");
+        assertThat(insert.path).isEqualTo("/calendar/v3/calendars/" + CALENDAR_ID + "/events");
+        assertThat(insert.body).contains("\"summary\":\"복습 1개\"");
+        assertThat(insert.body).contains("\"수학: 1개\"");
+        assertThat(insert.body).contains("\"start\":{\"date\":\"" + dueDate + "\"}");
+    }
+
+    @Test
+    @DisplayName("같은 날 두 번째 카드 → 기존 이벤트를 '복습 2개'로 patch하고 count를 갱신한다")
+    void second_card_patches_bundle() throws Exception {
+        createCard("Q1");
+        createCard("Q2");
+
+        LocalDate dueDate = today.plusDays(1);
+        ReviewCalendarMirror mirror =
+                mirrorRepository.findByMemberIdAndDueDate(memberId, dueDate).orElseThrow();
+        assertThat(mirror.getPendingCount()).isEqualTo(2);
+        assertThat(mirror.getGoogleEventId()).isEqualTo("evt-1");
+
+        CapturedRequest patch = last();
+        assertThat(patch.method).isEqualTo("PATCH");
+        assertThat(patch.path).isEqualTo("/calendar/v3/calendars/" + CALENDAR_ID + "/events/evt-1");
+        assertThat(patch.body).contains("\"summary\":\"복습 2개\"");
+        assertThat(patch.body).contains("\"수학: 2개\"");
+    }
+
+    @Test
+    @DisplayName("GOOD 완료 → 완료 dueDate 묶음을 삭제하고 다음 dueDate에 새 묶음을 insert한다")
+    void good_completion_deletes_old_and_inserts_new() throws Exception {
+        createCard("Q1");
+        Long reviewId = onlyReviewId();
+
+        complete(reviewId, "GOOD");
+
+        // 완료된 dueDate(today+1) 묶음은 N=0 → 삭제
+        assertThat(mirrorRepository.findByMemberIdAndDueDate(memberId, today.plusDays(1))).isEmpty();
+        // 다음 복습(GOOD: interval 6) dueDate(today+6) 묶음은 새로 insert
+        ReviewCalendarMirror next =
+                mirrorRepository.findByMemberIdAndDueDate(memberId, today.plusDays(6)).orElseThrow();
+        assertThat(next.getPendingCount()).isEqualTo(1);
+        assertThat(next.getGoogleEventId()).isEqualTo("evt-2");
+
+        assertThat(REQUESTS).anyMatch(r -> r.method.equals("DELETE")
+                && r.path.endsWith("/events/evt-1"));
+    }
+
+    @Test
+    @DisplayName("AGAIN 완료 → 당일 +10분 재복습은 04:00 묶음에서 제외되어 미러되지 않는다")
+    void again_completion_excludes_relearn() throws Exception {
+        createCard("Q1");
+        Long reviewId = onlyReviewId();
+
+        complete(reviewId, "AGAIN");
+
+        // 완료된 today+1 묶음은 삭제, AGAIN(today, +10분)은 미러 없음 → 멤버 미러 0건
+        assertThat(mirrorRepository.findAllByMemberId(memberId)).isEmpty();
+        assertThat(mirrorRepository.findByMemberIdAndDueDate(memberId, today)).isEmpty();
+        // 다음 복습은 PENDING으로 존재하지만(2건), 04:00 정각이 아니라 묶음에 안 잡힌다
+        assertThat(reviewScheduleRepository.findAll()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("self-heal: Google에서 이벤트가 사라지면(404) patch 실패 후 재생성하고 새 eventId로 매핑을 갱신한다")
+    void self_heal_recreates_on_404() throws Exception {
+        createCard("Q1"); // evt-1 매핑 생성
+        NOT_FOUND_EVENT_IDS.add("evt-1"); // 사용자가 Google에서 삭제했다고 가정
+
+        createCard("Q2"); // reconcile → patch evt-1(404) → 재생성 evt-2
+
+        ReviewCalendarMirror mirror =
+                mirrorRepository.findByMemberIdAndDueDate(memberId, today.plusDays(1)).orElseThrow();
+        assertThat(mirror.getPendingCount()).isEqualTo(2);
+        assertThat(mirror.getGoogleEventId()).isEqualTo("evt-2");
+
+        assertThat(REQUESTS).anyMatch(r -> r.method.equals("PATCH") && r.path.endsWith("/events/evt-1"));
+        CapturedRequest recreate = last();
+        assertThat(recreate.method).isEqualTo("POST");
+        assertThat(recreate.path).isEqualTo("/calendar/v3/calendars/" + CALENDAR_ID + "/events");
+        assertThat(recreate.body).contains("\"summary\":\"복습 2개\"");
+    }
+
+    private void createCard(String front) throws Exception {
+        mockMvc.perform(post("/api/planner/materials/{id}/flashcards", materialId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"front\":\"" + front + "\",\"back\":\"A\"}"))
+                .andExpect(status().isCreated());
+    }
+
+    private void complete(Long reviewId, String rating) throws Exception {
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", reviewId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rating\":\"" + rating + "\"}"))
+                .andExpect(status().isOk());
+    }
+
+    private Long onlyReviewId() {
+        List<ReviewSchedule> all = reviewScheduleRepository.findAll();
+        assertThat(all).hasSize(1);
+        return all.get(0).getId();
+    }
+
+    private CapturedRequest last() {
+        return REQUESTS.get(REQUESTS.size() - 1);
+    }
+
+    private static HttpServer createStub() {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/calendar/v3/calendars", ReviewMirrorIntegrationTest::handle);
+            server.start();
+            return server;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void handle(HttpExchange exchange) throws IOException {
+        String method = exchange.getRequestMethod();
+        String path = exchange.getRequestURI().getPath();
+        String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+        REQUESTS.add(new CapturedRequest(method, path, body));
+
+        String eventId = path.substring(path.lastIndexOf('/') + 1);
+        boolean isCollection = path.endsWith("/events");
+        if (!isCollection && NOT_FOUND_EVENT_IDS.contains(eventId)) {
+            respond(exchange, 404, "{\"error\":\"notFound\"}");
+            return;
+        }
+        if ("DELETE".equals(method)) {
+            respond(exchange, 204, null);
+            return;
+        }
+        if (isCollection && "POST".equals(method)) {
+            respond(exchange, 200, "{\"id\":\"evt-" + EVENT_SEQ.incrementAndGet() + "\"}");
+            return;
+        }
+        respond(exchange, 200, "{\"id\":\"" + eventId + "\"}"); // PATCH
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        if (body == null) {
+            exchange.sendResponseHeaders(status, -1);
+            exchange.close();
+            return;
+        }
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    private record CapturedRequest(String method, String path, String body) {
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
@@ -9,6 +9,7 @@ public class DbCleaner {
     private static final String[] TABLES_IN_FK_ORDER = {
             "holiday",
             "routine_check",
+            "review_calendar_mirror",
             "review_schedule",
             "flashcard",
             "note",

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
@@ -21,4 +21,11 @@ public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, 
 
     List<ReviewSchedule> findAllByMemberIdAndScheduledAtBetweenOrderByScheduledAtAscIdAsc(
             Long memberId, Instant from, Instant to);
+
+    /**
+     * dueDate 묶음 미러용 — 정확히 해당 04:00 롤오버 시각에 예약된 복습만 조회한다.
+     * AGAIN(now+10분, 분 단위)은 이 시각과 일치하지 않아 자연히 제외된다.
+     */
+    List<ReviewSchedule> findAllByMemberIdAndStatusAndScheduledAt(
+            Long memberId, ReviewStatus status, Instant scheduledAt);
 }


### PR DESCRIPTION
## 이슈
closes #585

## 작업 내용
복습 → Google 보조 캘린더("orino 복습") 단방향 미러링의 이벤트 기반 동기화 핵심(Epic #583, RM1).

- **`ReviewMirrorService.reconcileDate(memberId, dueDate, zone)`** — 멱등 reconcile
  - dueDate(04:00 롤오버)당 PENDING 복습을 **"복습 N개" 종일 묶음 이벤트 1개**로 upsert
  - N>0: 매핑 없으면 insert, 있으면 patch / **N=0: Google 이벤트·매핑 삭제**
  - **AGAIN 제외**: AGAIN은 `now+10분`(분 단위)이라 04:00 정각 묶음 집계에 안 잡힘 (정확매칭 쿼리)
  - **self-heal**: Google 404(사용자 삭제)면 재생성, 항상 DB 진실 기준 재계산
  - **자료 제목별 설명**("제목: N개"). 링크는 데이터 모델에 URL 필드가 없어 제외(후속 과제)
- **트랜잭션**: 호출부 커밋 후(`afterCommit`) `REQUIRES_NEW`로 실행 → Google 장애가 복습 생성/완료를 롤백하지 않음(드리프트는 다음 reconcile가 치유)
- **훅 연결** (`review_mirror_enabled`일 때만 동작)
  - 플래시카드 생성 → 첫 복습 dueDate reconcile
  - 복습 완료 → 완료 dueDate(감소) + 다음 dueDate(증가) 2건 reconcile
- **클라이언트**: `insertAllDayEvent`/`patchAllDayEvent`에 description 지원

## 테스트
- `ReviewMirrorIntegrationTest` (MockMvc + TestContainers + Google 스텁)
  - 생성→insert("복습 1개"), 같은 날 2장→patch("복습 2개")
  - GOOD 완료→완료 dueDate 삭제 + 다음 dueDate insert
  - AGAIN 완료→당일 +10분 재복습 묶음 제외
  - self-heal→patch 404 후 재생성, 새 eventId로 매핑 갱신
- `GoogleCalendarClientTest` — description 직렬화 검증 보강
- 전체 `:orino-domain-rdb:test`·`:orino-app-api:test`·checkstyle 통과

