### PR TITLE
feat : 복습 미러 RM2 — 토글 API + 백필 + status 확장

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/GoogleOAuthService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/GoogleOAuthService.java
@@ -121,7 +121,8 @@ public class GoogleOAuthService {
                 .map(account -> GoogleStatusResponse.connected(
                         account.getGoogleEmail(),
                         splitScopes(account.getScopes()),
-                        account.getConnectedAt()))
+                        account.getConnectedAt(),
+                        account.isReviewMirrorEnabled()))
                 .orElseGet(GoogleStatusResponse::disconnected);
     }
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/dto/GoogleStatusResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/oauth/dto/GoogleStatusResponse.java
@@ -4,20 +4,24 @@ import java.time.Instant;
 import java.util.List;
 
 /**
- * Google 연동 상태. 미연동(또는 revoked)이면 connected=false, 나머지 필드는 null.
+ * Google 연동 상태. 미연동(또는 revoked)이면 connected=false, 나머지 필드는 null/false.
+ *
+ * @param reviewMirrorEnabled 복습 → 보조 캘린더 미러 on/off (미연동이면 false)
  */
 public record GoogleStatusResponse(
         boolean connected,
         String googleEmail,
         List<String> scopes,
-        Instant connectedAt
+        Instant connectedAt,
+        boolean reviewMirrorEnabled
 ) {
 
     public static GoogleStatusResponse disconnected() {
-        return new GoogleStatusResponse(false, null, null, null);
+        return new GoogleStatusResponse(false, null, null, null, false);
     }
 
-    public static GoogleStatusResponse connected(String googleEmail, List<String> scopes, Instant connectedAt) {
-        return new GoogleStatusResponse(true, googleEmail, scopes, connectedAt);
+    public static GoogleStatusResponse connected(String googleEmail, List<String> scopes,
+                                                 Instant connectedAt, boolean reviewMirrorEnabled) {
+        return new GoogleStatusResponse(true, googleEmail, scopes, connectedAt, reviewMirrorEnabled);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
@@ -1,11 +1,15 @@
 package ds.project.orino.planner.review.controller;
 
 import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.core.time.UserTimeZone;
 import ds.project.orino.planner.review.dto.CalendarReviewsResponse;
 import ds.project.orino.planner.review.dto.ReviewCompletionRequest;
 import ds.project.orino.planner.review.dto.ReviewCompletionResponse;
+import ds.project.orino.planner.review.dto.ReviewMirrorStatusResponse;
+import ds.project.orino.planner.review.dto.ReviewMirrorToggleRequest;
 import ds.project.orino.planner.review.dto.TodayReviewsResponse;
 import ds.project.orino.planner.review.service.ReviewCompletionService;
+import ds.project.orino.planner.review.service.ReviewMirrorService;
 import ds.project.orino.planner.review.service.ReviewQueryService;
 import jakarta.validation.Valid;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -13,12 +17,14 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 
 @RestController
 @RequestMapping("/api/planner/reviews")
@@ -26,11 +32,14 @@ public class ReviewController {
 
     private final ReviewCompletionService reviewCompletionService;
     private final ReviewQueryService reviewQueryService;
+    private final ReviewMirrorService reviewMirrorService;
 
     public ReviewController(ReviewCompletionService reviewCompletionService,
-                            ReviewQueryService reviewQueryService) {
+                            ReviewQueryService reviewQueryService,
+                            ReviewMirrorService reviewMirrorService) {
         this.reviewCompletionService = reviewCompletionService;
         this.reviewQueryService = reviewQueryService;
+        this.reviewMirrorService = reviewMirrorService;
     }
 
     @GetMapping("/today")
@@ -52,5 +61,17 @@ public class ReviewController {
             @PathVariable Long id,
             @Valid @RequestBody ReviewCompletionRequest request) {
         return ApiResponse.success(reviewCompletionService.complete(memberId, id, request));
+    }
+
+    /** 복습 → 보조 캘린더 미러 on/off. ON이면 보조 캘린더 보장 + 전 PENDING 백필, OFF면 미러 정리. 미연동 409. */
+    @PutMapping("/mirror")
+    public ApiResponse<ReviewMirrorStatusResponse> toggleMirror(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody ReviewMirrorToggleRequest request) {
+        ZoneId zone = UserTimeZone.get();
+        ReviewMirrorStatusResponse result = request.enabled()
+                ? reviewMirrorService.enableMirror(memberId, zone)
+                : reviewMirrorService.disableMirror(memberId);
+        return ApiResponse.success(result);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewMirrorStatusResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewMirrorStatusResponse.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.review.dto;
+
+/**
+ * 복습 미러 토글 결과. {@code reviewCalendarId}는 보조 캘린더("orino 복습") ID로, OFF여도 보존되어 빠른 재-enable에 쓰인다.
+ */
+public record ReviewMirrorStatusResponse(
+        boolean enabled,
+        String reviewCalendarId
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewMirrorToggleRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewMirrorToggleRequest.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.review.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/** 복습 미러 on/off 토글 요청. */
+public record ReviewMirrorToggleRequest(
+        @NotNull(message = "enabled는 필수입니다.")
+        Boolean enabled
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewMirrorService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewMirrorService.java
@@ -14,6 +14,7 @@ import ds.project.orino.domain.planner.review.entity.ReviewStatus;
 import ds.project.orino.domain.planner.review.repository.ReviewCalendarMirrorRepository;
 import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
 import ds.project.orino.planner.google.client.GoogleCalendarClient;
+import ds.project.orino.planner.review.dto.ReviewMirrorStatusResponse;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -51,6 +52,8 @@ public class ReviewMirrorService {
     private static final String CALENDAR_SUMMARY_PREFIX = "복습 ";
     private static final String CALENDAR_SUMMARY_SUFFIX = "개";
     private static final String NO_MATERIAL_LABEL = "(자료 없음)";
+    /** 보조 캘린더 제목. */
+    private static final String SECONDARY_CALENDAR_SUMMARY = "orino 복습";
 
     private final GoogleAccountRepository googleAccountRepository;
     private final ReviewScheduleRepository reviewScheduleRepository;
@@ -78,6 +81,62 @@ public class ReviewMirrorService {
         this.calendarClient = calendarClient;
         this.clock = clock;
         this.self = self;
+    }
+
+    /**
+     * 미러를 켠다. 보조 캘린더가 없으면 생성·저장하고(enabled 커밋), 모든 PENDING 복습 날짜를 백필 reconcile한다.
+     * 미연동(또는 revoked)이면 {@link ErrorCode#GOOGLE_NOT_CONNECTED}(409).
+     *
+     * <p>활성화 커밋을 백필보다 먼저 끝내야 reconcileDate(REQUIRES_NEW)가 enabled=true를 본다.
+     */
+    public ReviewMirrorStatusResponse enableMirror(Long memberId, ZoneId zone) {
+        String calendarId = self.activateMirror(memberId);
+        backfill(memberId, zone);
+        return new ReviewMirrorStatusResponse(true, calendarId);
+    }
+
+    /** 미러를 끈다. mirror 이벤트·행을 모두 정리하고 enabled=0으로 둔다(빈 보조 캘린더는 보존). 미연동이면 409. */
+    @Transactional
+    public ReviewMirrorStatusResponse disableMirror(Long memberId) {
+        GoogleAccount account = requireConnected(memberId);
+        String calendarId = account.getReviewCalendarId();
+        if (calendarId != null) {
+            for (ReviewCalendarMirror mirror : mirrorRepository.findAllByMemberId(memberId)) {
+                deleteEventQuietly(memberId, calendarId, mirror.getGoogleEventId());
+            }
+            mirrorRepository.deleteByMemberId(memberId);
+        }
+        account.disableReviewMirror();
+        googleAccountRepository.save(account);
+        return new ReviewMirrorStatusResponse(false, calendarId);
+    }
+
+    /** 보조 캘린더를 보장(없으면 생성)하고 enabled=true로 만든 뒤 calendarId를 반환한다(독립 트랜잭션으로 커밋). */
+    @Transactional
+    public String activateMirror(Long memberId) {
+        GoogleAccount account = requireConnected(memberId);
+        String calendarId = account.getReviewCalendarId();
+        if (calendarId == null) {
+            calendarId = calendarClient.createSecondaryCalendar(memberId, SECONDARY_CALENDAR_SUMMARY);
+        }
+        account.enableReviewMirror(calendarId);
+        googleAccountRepository.save(account);
+        return calendarId;
+    }
+
+    /** 모든 PENDING 복습의 dueDate(04:00 롤오버 날짜)를 멱등 reconcile한다(이미 커밋된 enabled 계정 기준). */
+    private void backfill(Long memberId, ZoneId zone) {
+        Set<LocalDate> dueDates = reviewScheduleRepository
+                .findAllByMemberIdAndStatus(memberId, ReviewStatus.PENDING).stream()
+                .map(review -> review.getScheduledAt().atZone(zone).toLocalDate())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        dueDates.forEach(date -> self.reconcileDate(memberId, date, zone));
+    }
+
+    private GoogleAccount requireConnected(Long memberId) {
+        return googleAccountRepository.findByMemberId(memberId)
+                .filter(account -> !account.isRevoked())
+                .orElseThrow(() -> new CustomException(ErrorCode.GOOGLE_NOT_CONNECTED));
     }
 
     /**

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/oauth/GoogleOAuthControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/oauth/GoogleOAuthControllerTest.java
@@ -166,7 +166,23 @@ class GoogleOAuthControllerTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.connected").value(true))
                 .andExpect(jsonPath("$.data.googleEmail").value("me@gmail.com"))
                 .andExpect(jsonPath("$.data.scopes.length()").value(2))
-                .andExpect(jsonPath("$.data.connectedAt").exists());
+                .andExpect(jsonPath("$.data.connectedAt").exists())
+                .andExpect(jsonPath("$.data.reviewMirrorEnabled").value(false));
+    }
+
+    @Test
+    @DisplayName("GET /status - 복습 미러가 켜져 있으면 reviewMirrorEnabled=true")
+    void status_reviewMirrorEnabled() throws Exception {
+        GoogleAccount account = new GoogleAccount(
+                memberId, "refresh", "scope", "me@gmail.com", "primary", "@default");
+        account.enableReviewMirror("c_review@group.calendar.google.com");
+        accountRepository.save(account);
+
+        mockMvc.perform(get("/api/planner/google/status")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.connected").value(true))
+                .andExpect(jsonPath("$.data.reviewMirrorEnabled").value(true));
     }
 
     @Test

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/mirror/ReviewMirrorToggleIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/mirror/ReviewMirrorToggleIntegrationTest.java
@@ -1,0 +1,245 @@
+package ds.project.orino.planner.review.mirror;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
+import ds.project.orino.domain.planner.google.entity.GoogleAccount;
+import ds.project.orino.domain.planner.google.repository.GoogleAccountRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.ReviewCalendarMirror;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.repository.ReviewCalendarMirrorRepository;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.redis.planner.google.GoogleAccessTokenRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.math.BigDecimal;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 복습 미러 토글 API(RM2) 통합 테스트(MockMvc + TestContainers + Google 스텁).
+ * PUT /api/planner/reviews/mirror 의 ON(보조 캘린더 생성 + 백필) / OFF(정리) / 미연동(409)을 검증한다.
+ */
+class ReviewMirrorToggleIntegrationTest extends ApiTestSupport {
+
+    private static final BigDecimal EF = new BigDecimal("2.50");
+
+    private static final HttpServer CALENDAR_STUB = createStub();
+    private static final List<CapturedRequest> REQUESTS = new ArrayList<>();
+    private static final AtomicInteger EVENT_SEQ = new AtomicInteger();
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+    @Autowired
+    private FlashcardRepository flashcardRepository;
+    @Autowired
+    private ReviewScheduleRepository reviewScheduleRepository;
+    @Autowired
+    private ReviewCalendarMirrorRepository mirrorRepository;
+    @Autowired
+    private GoogleAccountRepository googleAccountRepository;
+    @Autowired
+    private GoogleAccessTokenRepository accessTokenRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+    @Autowired
+    private Clock clock;
+
+    private Long memberId;
+    private Long materialId;
+    private String authHeader;
+    private LocalDate today;
+
+    @DynamicPropertySource
+    static void googleProperties(DynamicPropertyRegistry registry) {
+        String base = "http://127.0.0.1:" + CALENDAR_STUB.getAddress().getPort();
+        registry.add("planner.google.client-id", () -> "test-client-id");
+        registry.add("planner.google.client-secret", () -> "test-client-secret");
+        registry.add("planner.google.oauth.calendar-api-base-url", () -> base);
+    }
+
+    @AfterAll
+    static void stopStub() {
+        CALENDAR_STUB.stop(0);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        REQUESTS.clear();
+        EVENT_SEQ.set(0);
+        dbCleaner.clean();
+        Member member = memberRepository.save(MemberFixture.create());
+        memberId = member.getId();
+        materialId = studyMaterialRepository.save(
+                new StudyMaterial(memberId, "수학", MaterialType.BOOK)).getId();
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        today = clock.instant().atZone(TEST_ZONE).toLocalDate();
+    }
+
+    @Test
+    @DisplayName("ON - 미연동이면 409 PLN-ERR-003")
+    void enable_notConnected_returns_409() throws Exception {
+        toggle(true)
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PLN-ERR-003"));
+    }
+
+    @Test
+    @DisplayName("ON - 보조 캘린더를 생성하고 PENDING 전 날짜를 백필해 묶음을 만든다")
+    void enable_creates_calendar_and_backfills() throws Exception {
+        connectGoogle(null, false); // 보조 캘린더 없음, 미러 OFF
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+        seedPendingReview(today.plusDays(1)); // 카드1
+        seedPendingReview(today.plusDays(3)); // 카드2
+
+        toggle(true)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.enabled").value(true))
+                .andExpect(jsonPath("$.data.reviewCalendarId").value("review-cal-new"));
+
+        // 보조 캘린더 생성(calendars.insert) 1회
+        assertThat(REQUESTS).anyMatch(r -> r.method.equals("POST") && r.path.equals("/calendar/v3/calendars"));
+        // 두 날짜 백필 → 묶음 행 2개
+        assertThat(mirrorRepository.findAllByMemberId(memberId)).hasSize(2);
+        assertThat(mirrorRepository.findByMemberIdAndDueDate(memberId, today.plusDays(1))).isPresent();
+        assertThat(mirrorRepository.findByMemberIdAndDueDate(memberId, today.plusDays(3))).isPresent();
+        // 계정 enabled + calendarId 저장
+        GoogleAccount account = googleAccountRepository.findByMemberId(memberId).orElseThrow();
+        assertThat(account.isReviewMirrorEnabled()).isTrue();
+        assertThat(account.getReviewCalendarId()).isEqualTo("review-cal-new");
+    }
+
+    @Test
+    @DisplayName("OFF - mirror 이벤트·행을 정리하고 enabled=0, 보조 캘린더 ID는 보존한다")
+    void disable_cleans_up_keeps_calendar() throws Exception {
+        connectGoogle("review-cal", true); // 미러 ON, 보조 캘린더 보유
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+        mirrorRepository.save(new ReviewCalendarMirror(
+                memberId, today.plusDays(1), "evt-1", 1, clock.instant()));
+        mirrorRepository.save(new ReviewCalendarMirror(
+                memberId, today.plusDays(2), "evt-2", 1, clock.instant()));
+
+        toggle(false)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.enabled").value(false))
+                .andExpect(jsonPath("$.data.reviewCalendarId").value("review-cal"));
+
+        // Google 이벤트 2건 삭제
+        assertThat(REQUESTS).filteredOn(r -> r.method.equals("DELETE")).hasSize(2);
+        // 매핑 전부 정리
+        assertThat(mirrorRepository.findAllByMemberId(memberId)).isEmpty();
+        // 계정 비활성 + calendarId 보존
+        GoogleAccount account = googleAccountRepository.findByMemberId(memberId).orElseThrow();
+        assertThat(account.isReviewMirrorEnabled()).isFalse();
+        assertThat(account.getReviewCalendarId()).isEqualTo("review-cal");
+    }
+
+    private void connectGoogle(String reviewCalendarId, boolean mirrorEnabled) {
+        GoogleAccount account = new GoogleAccount(
+                memberId, "refresh", "scope", "me@gmail.com", "primary", "@default");
+        if (mirrorEnabled) {
+            account.enableReviewMirror(reviewCalendarId);
+        } else if (reviewCalendarId != null) {
+            account.enableReviewMirror(reviewCalendarId);
+            account.disableReviewMirror();
+        }
+        googleAccountRepository.save(account);
+    }
+
+    private void seedPendingReview(LocalDate dueDate) {
+        Flashcard card = flashcardRepository.save(new Flashcard(memberId, materialId, "Q", "A"));
+        reviewScheduleRepository.save(new ReviewSchedule(
+                memberId, card.getId(), 1, atTestZone(dueDate.atTime(4, 0)), 1, EF));
+    }
+
+    private org.springframework.test.web.servlet.ResultActions toggle(boolean enabled) throws Exception {
+        return mockMvc.perform(put("/api/planner/reviews/mirror")
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"enabled\":" + enabled + "}"));
+    }
+
+    private static HttpServer createStub() {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/calendar/v3/calendars", ReviewMirrorToggleIntegrationTest::handle);
+            server.start();
+            return server;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void handle(HttpExchange exchange) throws IOException {
+        String method = exchange.getRequestMethod();
+        String path = exchange.getRequestURI().getPath();
+        String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+        REQUESTS.add(new CapturedRequest(method, path, body));
+
+        if ("DELETE".equals(method)) {
+            respond(exchange, 204, null);
+            return;
+        }
+        if ("POST".equals(method) && path.equals("/calendar/v3/calendars")) {
+            respond(exchange, 200, "{\"id\":\"review-cal-new\"}"); // calendars.insert
+            return;
+        }
+        if ("POST".equals(method)) {
+            respond(exchange, 200, "{\"id\":\"evt-" + EVENT_SEQ.incrementAndGet() + "\"}"); // event insert
+            return;
+        }
+        String eventId = path.substring(path.lastIndexOf('/') + 1);
+        respond(exchange, 200, "{\"id\":\"" + eventId + "\"}"); // PATCH
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        if (body == null) {
+            exchange.sendResponseHeaders(status, -1);
+            exchange.close();
+            return;
+        }
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    private record CapturedRequest(String method, String path, String body) {
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
@@ -28,4 +28,7 @@ public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, 
      */
     List<ReviewSchedule> findAllByMemberIdAndStatusAndScheduledAt(
             Long memberId, ReviewStatus status, Instant scheduledAt);
+
+    /** 미러 enable 백필용 — 멤버의 모든 PENDING 복습(과거·미래 포함). */
+    List<ReviewSchedule> findAllByMemberIdAndStatus(Long memberId, ReviewStatus status);
 }


### PR DESCRIPTION
## 이슈
closes #586

## 작업 내용
복습 → 보조 캘린더 미러링(Epic #583)의 사용자 토글 API(RM2). RM0/RM1(머지됨) 위에서 동작합니다.

- **`PUT /api/planner/reviews/mirror` `{enabled}`**
  - **ON**: 보조 캘린더("orino 복습")가 없으면 `calendars.insert`로 생성·저장 → `enabled=1` 커밋 → **모든 PENDING 복습 날짜 백필 reconcile**(묶음 종일 이벤트 생성). 미연동(또는 revoked)이면 **409 PLN-ERR-003**
  - **OFF**: mirror 이벤트·행을 **전부 정리** + `enabled=0`. 빈 보조 캘린더는 보존(빠른 재-enable)
  - 응답: `{enabled, reviewCalendarId}`
- **백필 트랜잭션 순서**: 활성화(enabled=true)를 별도 트랜잭션으로 **먼저 커밋**해야 `reconcileDate`(REQUIRES_NEW)가 enabled를 보고 동작 → `enableMirror`는 `activateMirror`(커밋) 후 백필
- **`GET /api/planner/google/status`** 응답에 **`reviewMirrorEnabled`** 필드 추가
- `ReviewScheduleRepository.findAllByMemberIdAndStatus`(백필용) 추가

## 테스트
- `ReviewMirrorToggleIntegrationTest` (MockMvc + TestContainers + Google 스텁)
  - ON → `calendars.insert` 호출 + 전 PENDING 날짜 백필로 묶음 행 생성, 계정 enabled/calendarId 저장
  - OFF → Google 이벤트 삭제 + 매핑 정리 + enabled=0, calendarId 보존
  - 미연동 → 409 PLN-ERR-003
- `GoogleOAuthControllerTest` — status에 `reviewMirrorEnabled` 케이스 보강
- 전체 `:orino-domain-rdb:test`·`:orino-app-api:test`·checkstyle 통과

## 다음
- RM3(#587, FE): 설정 토글 UI / RM4(#588): 마무리·문서