### PR TITLE
feat : 복습 미러 RM3 — 설정 토글 UI (FE)

### DIFF
--- a/fe/src/components/ui/switch.tsx
+++ b/fe/src/components/ui/switch.tsx
@@ -1,0 +1,45 @@
+import { cn } from "@/lib/utils";
+
+interface SwitchProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+  id?: string;
+  className?: string;
+  "aria-label"?: string;
+}
+
+/** role="switch" 토글. aria-checked로 상태를 노출한다(접근성·테스트 친화). */
+function Switch({
+  checked,
+  onCheckedChange,
+  disabled,
+  className,
+  ...props
+}: SwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      data-slot="switch"
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        "focus-visible:ring-ring inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+        checked ? "bg-primary" : "bg-input",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        className={cn(
+          "bg-background pointer-events-none block size-4 rounded-full shadow transition-transform",
+          checked ? "translate-x-4" : "translate-x-0.5",
+        )}
+      />
+    </button>
+  );
+}
+
+export { Switch };

--- a/fe/src/features/google/api/googleApi.ts
+++ b/fe/src/features/google/api/googleApi.ts
@@ -5,6 +5,13 @@ export interface GoogleStatus {
   googleEmail: string | null;
   scopes: string[] | null;
   connectedAt: string | null;
+  reviewMirrorEnabled: boolean;
+}
+
+/** 복습 미러 토글 결과. reviewCalendarId는 OFF여도 보존된다(빠른 재-enable). */
+export interface ReviewMirrorStatus {
+  enabled: boolean;
+  reviewCalendarId: string | null;
 }
 
 interface ApiEnvelope<T> {
@@ -31,4 +38,17 @@ export async function fetchGoogleAuthUrl(): Promise<string> {
 /** 연동 해제 (revoke + 삭제). */
 export async function disconnectGoogle(): Promise<void> {
   await client.post("/planner/google/disconnect");
+}
+
+/**
+ * 복습 → 보조 캘린더 미러 on/off. ON이면 서버가 보조 캘린더 보장 + 전체 백필을 수행하므로 응답까지 다소 걸린다.
+ */
+export async function setReviewMirror(
+  enabled: boolean,
+): Promise<ReviewMirrorStatus> {
+  const { data } = await client.put<ApiEnvelope<ReviewMirrorStatus>>(
+    "/planner/reviews/mirror",
+    { enabled },
+  );
+  return data.data;
 }

--- a/fe/src/features/google/components/GoogleConnectionCard.test.tsx
+++ b/fe/src/features/google/components/GoogleConnectionCard.test.tsx
@@ -17,6 +17,7 @@ function mockStatus(data: {
   googleEmail: string | null;
   scopes: string[] | null;
   connectedAt: string | null;
+  reviewMirrorEnabled: boolean;
 }) {
   server.use(
     http.get(`${API_BASE}/planner/google/status`, () =>
@@ -24,6 +25,8 @@ function mockStatus(data: {
     ),
   );
 }
+
+const MIRROR_LABEL = "복습 일정을 Google 캘린더에 표시";
 
 describe("GoogleConnectionCard", () => {
   beforeEach(() => {
@@ -36,6 +39,7 @@ describe("GoogleConnectionCard", () => {
       googleEmail: null,
       scopes: null,
       connectedAt: null,
+      reviewMirrorEnabled: false,
     });
 
     renderWithRouter(<GoogleConnectionCard />);
@@ -44,6 +48,10 @@ describe("GoogleConnectionCard", () => {
     expect(
       screen.getByRole("button", { name: "Google 연결" }),
     ).toBeInTheDocument();
+    // 미연동이면 복습 미러 토글은 노출되지 않는다(연결 선행)
+    expect(
+      screen.queryByRole("switch", { name: MIRROR_LABEL }),
+    ).not.toBeInTheDocument();
   });
 
   it("연동되면 계정/연결일과 해제 버튼을 보여준다", async () => {
@@ -52,6 +60,7 @@ describe("GoogleConnectionCard", () => {
       googleEmail: "me@gmail.com",
       scopes: ["https://www.googleapis.com/auth/calendar"],
       connectedAt: "2026-06-15T10:00:00",
+      reviewMirrorEnabled: false,
     });
 
     renderWithRouter(<GoogleConnectionCard />);
@@ -62,6 +71,108 @@ describe("GoogleConnectionCard", () => {
     expect(
       screen.getByRole("button", { name: "연결 해제" }),
     ).toBeInTheDocument();
+  });
+
+  it("연동되면 복습 미러 토글이 보이고 reviewMirrorEnabled 초기 상태를 반영한다", async () => {
+    mockStatus({
+      connected: true,
+      googleEmail: "me@gmail.com",
+      scopes: ["s"],
+      connectedAt: "2026-06-15T10:00:00",
+      reviewMirrorEnabled: true,
+    });
+
+    renderWithRouter(<GoogleConnectionCard />);
+
+    const toggle = await screen.findByRole("switch", { name: MIRROR_LABEL });
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("토글을 켜면 PUT 호출 후 켜진 상태와 성공 토스트를 반영한다", async () => {
+    let enabled = false;
+    server.use(
+      http.get(`${API_BASE}/planner/google/status`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            connected: true,
+            googleEmail: "me@gmail.com",
+            scopes: ["s"],
+            connectedAt: "2026-06-15T10:00:00",
+            reviewMirrorEnabled: enabled,
+          },
+        }),
+      ),
+      http.put(`${API_BASE}/planner/reviews/mirror`, async ({ request }) => {
+        const body = (await request.json()) as { enabled: boolean };
+        enabled = body.enabled;
+        return HttpResponse.json({
+          code: "OK",
+          data: { enabled, reviewCalendarId: "review-cal" },
+        });
+      }),
+    );
+
+    renderWithRouter(
+      <>
+        <GoogleConnectionCard />
+        <Toaster />
+      </>,
+    );
+
+    const toggle = await screen.findByRole("switch", { name: MIRROR_LABEL });
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    await userEvent.click(toggle);
+
+    expect(
+      await screen.findByText("복습 일정을 Google 캘린더에 표시합니다."),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("switch", { name: MIRROR_LABEL }),
+    ).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("토글 PUT이 실패하면 에러 토스트를 띄우고 상태는 그대로다", async () => {
+    server.use(
+      http.get(`${API_BASE}/planner/google/status`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            connected: true,
+            googleEmail: "me@gmail.com",
+            scopes: ["s"],
+            connectedAt: "2026-06-15T10:00:00",
+            reviewMirrorEnabled: false,
+          },
+        }),
+      ),
+      http.put(`${API_BASE}/planner/reviews/mirror`, () =>
+        HttpResponse.json(
+          { code: "PLN-ERR-003", message: "Google 연동이 필요합니다." },
+          { status: 409 },
+        ),
+      ),
+    );
+
+    renderWithRouter(
+      <>
+        <GoogleConnectionCard />
+        <Toaster />
+      </>,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("switch", { name: MIRROR_LABEL }),
+    );
+
+    expect(
+      await screen.findByText("설정 변경에 실패했습니다. 다시 시도해 주세요."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: MIRROR_LABEL })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
   });
 
   it("연결 해제를 누르면 disconnect 후 미연동 상태로 바뀌고 토스트를 띄운다", async () => {
@@ -76,12 +187,14 @@ describe("GoogleConnectionCard", () => {
                 googleEmail: "me@gmail.com",
                 scopes: ["s"],
                 connectedAt: "2026-06-15T10:00:00",
+                reviewMirrorEnabled: false,
               }
             : {
                 connected: false,
                 googleEmail: null,
                 scopes: null,
                 connectedAt: null,
+                reviewMirrorEnabled: false,
               },
         }),
       ),

--- a/fe/src/features/google/components/GoogleConnectionCard.tsx
+++ b/fe/src/features/google/components/GoogleConnectionCard.tsx
@@ -1,10 +1,14 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { LoadingText } from "@/components/ui/loading-text";
+import { Switch } from "@/components/ui/switch";
 
 import { useDisconnectGoogle } from "../hooks/useDisconnectGoogle";
 import { useGoogleStatus } from "../hooks/useGoogleStatus";
+import { useReviewMirrorToggle } from "../hooks/useReviewMirrorToggle";
 import { GoogleConnectButton } from "./GoogleConnectButton";
+
+const REVIEW_MIRROR_LABEL = "복습 일정을 Google 캘린더에 표시";
 
 function formatDate(iso: string | null): string {
   if (!iso) return "-";
@@ -16,6 +20,7 @@ function formatDate(iso: string | null): string {
 export function GoogleConnectionCard() {
   const { data: status, isLoading } = useGoogleStatus();
   const disconnect = useDisconnectGoogle();
+  const mirror = useReviewMirrorToggle();
 
   return (
     <Card>
@@ -39,6 +44,30 @@ export function GoogleConnectionCard() {
               <dt className="text-muted-foreground">연결일</dt>
               <dd>{formatDate(status.connectedAt)}</dd>
             </dl>
+            <div className="flex items-start justify-between gap-3 border-t pt-3">
+              <div className="flex flex-col gap-0.5">
+                <span className="text-sm font-medium">
+                  {REVIEW_MIRROR_LABEL}
+                </span>
+                <p className="text-muted-foreground text-xs">
+                  복습 일정을 보조 캘린더 &ldquo;orino 복습&rdquo;에 단방향으로
+                  표시합니다. orino가 원본이며 Google에는 사본만 올라갑니다.
+                </p>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                {mirror.isPending && (
+                  <span className="text-muted-foreground text-xs">
+                    {status.reviewMirrorEnabled ? "끄는 중…" : "켜는 중…"}
+                  </span>
+                )}
+                <Switch
+                  checked={status.reviewMirrorEnabled}
+                  disabled={mirror.isPending}
+                  onCheckedChange={(next) => mirror.mutate(next)}
+                  aria-label={REVIEW_MIRROR_LABEL}
+                />
+              </div>
+            </div>
             <div>
               <Button
                 variant="outline"

--- a/fe/src/features/google/hooks/useReviewMirrorToggle.ts
+++ b/fe/src/features/google/hooks/useReviewMirrorToggle.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { toast } from "@/shared/lib/toast";
+
+import { setReviewMirror } from "../api/googleApi";
+import { googleKeys } from "../queryKeys";
+
+/**
+ * 복습 미러 on/off 토글. ON이면 서버가 보조 캘린더 생성 + 백필을 수행하므로 isPending이 그 진행을 덮는다.
+ * 성공 시 status 쿼리를 무효화해 reviewMirrorEnabled를 서버 진실로 갱신한다.
+ */
+export function useReviewMirrorToggle() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (enabled: boolean) => setReviewMirror(enabled),
+    onSuccess: (_result, enabled) => {
+      queryClient.invalidateQueries({ queryKey: googleKeys.status });
+      toast(
+        enabled
+          ? "복습 일정을 Google 캘린더에 표시합니다."
+          : "복습 캘린더 표시를 껐습니다.",
+        "success",
+      );
+    },
+    onError: () => {
+      toast("설정 변경에 실패했습니다. 다시 시도해 주세요.", "error");
+    },
+  });
+}

--- a/fe/src/test/mocks/handlers.ts
+++ b/fe/src/test/mocks/handlers.ts
@@ -45,6 +45,7 @@ export const handlers = [
         googleEmail: null,
         scopes: null,
         connectedAt: null,
+        reviewMirrorEnabled: false,
       },
     });
   }),


### PR DESCRIPTION
## 이슈
closes #587

## 작업 내용
복습 → Google 보조 캘린더 미러링(Epic #583)의 설정 토글 UI(RM3). BE(RM0~RM2, 머지됨)의 `PUT /api/planner/reviews/mirror` + `status.reviewMirrorEnabled`를 연동합니다.

- **Google 연동 카드**에 **"복습 일정을 Google 캘린더에 표시" 토글**(Switch) + 단방향·보조 캘린더("orino 복습") 안내 문구
- `status.reviewMirrorEnabled`로 **초기 상태** 반영, 서버 백필 진행 중 **스피너**("켜는 중…"/"끄는 중…")
- `useReviewMirrorToggle`(useMutation) → `PUT /reviews/mirror`, 성공 시 status 쿼리 무효화 + 성공 토스트
- **미연동 시 토글 미노출**(연결됨 상태에서만 노출 → [Google 연결] 선행 가드), 실패 시 **에러 토스트** + 상태 유지
- `Switch` UI 컴포넌트(`role="switch"`, `aria-checked`) 추가, `GoogleStatus` 타입에 `reviewMirrorEnabled` 추가

## 테스트 (RTL + MSW)
- 토글 ON → PUT 호출 후 켜진 상태 + 성공 토스트 반영
- PUT 실패(409) → 에러 토스트 + 상태 유지
- 연동 시 `reviewMirrorEnabled` 초기 상태 반영
- 미연동 시 토글 미노출
- 전체 FE 테스트(184) 통과, prettier `format:check`·eslint·`tsc -b`·`vite build` 통과

## 다음
- RM4(#588): 복습 미러링 마무리(엣지 테스트·로컬 검증·문서·Engineering Log)