### PR TITLE
chore : Grafana persistence 비활성화 (stale PVC datasource 교착 해소)

### DIFF
--- a/infra/helm/kube-prometheus-stack/values.yaml
+++ b/infra/helm/kube-prometheus-stack/values.yaml
@@ -71,10 +71,12 @@ kube-prometheus-stack:
     service:
       type: NodePort
       nodePort: 30300
+    # persistence 비활성화 — datasource·대시보드·admin을 모두 GitOps
+    # provisioning(코드)으로 관리하므로 PVC는 stale 상태만 보존해 드리프트를
+    # 유발했다(옛 datasource uid가 남아 provisioning reload가 500으로 실패).
+    # stateless로 두면 매 시작 시 코드 기준으로 깨끗하게 재구성된다.
     persistence:
-      enabled: true
-      storageClassName: longhorn
-      size: 5Gi
+      enabled: false
     additionalDataSources:
       - name: Loki
         type: loki


### PR DESCRIPTION
## 이슈
closes #622

## 작업 내용

`datasource not found`의 가장 깊은 뿌리인 **Grafana persistence PVC의 stale 상태**를 제거한다.

### 문제 (PR #620 이후 잔존)
- admin 인증은 정상화됐으나 provisioning reload가 **500** (`data source not found`).
- persistence PVC(longhorn 5Gi)에 85일 전 옛 Loki(uid=`P8E80`, readOnly)가 남아 새 provisioning(uid=`loki`, +Tempo/Thanos)과 충돌. readOnly라 API 삭제도 403.

### 변경
- `grafana.persistence.enabled: false` (stateless).

### 근거
- 이 환경은 datasource·대시보드·admin을 **전부 GitOps provisioning(코드)으로 관리**한다. PVC는 코드와 어긋난 stale만 보존해 반복 드리프트(admin 비번·datasource)의 공통 뿌리였다.
- stateless로 두면 매 시작 시 코드 기준으로 깨끗하게 재구성된다.

### 검증
- `helm template` 렌더: grafana **PVC 미생성** 확인 (storage = emptyDir).

### 머지 후 후속 (런타임)
- [ ] sync → 기존 stale PVC prune 확인
- [ ] Grafana 재시작 → datasource 5개(Loki uid=loki, Tempo, Thanos) 정상 + sidecar reload 200
- [ ] `orino-logs` 대시보드에서 fe/be/redis 로그 정상 표시 확인