### PR TITLE
test : 복습 미러 RM4 마무리 — 엣지 케이스 통합 테스트

### DIFF
--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/mirror/ReviewMirrorIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/mirror/ReviewMirrorIntegrationTest.java
@@ -117,6 +117,19 @@ class ReviewMirrorIntegrationTest extends ApiTestSupport {
     }
 
     @Test
+    @DisplayName("연동 만료(revoked) 중에는 미러를 건너뛴다 — 매핑·Google 호출 없음")
+    void revoked_account_skips_mirror() throws Exception {
+        GoogleAccount account = googleAccountRepository.findByMemberId(memberId).orElseThrow();
+        account.markRevoked(); // 미러는 켜져 있으나 토큰이 무효화된 상태
+        googleAccountRepository.save(account);
+
+        createCard("Q1");
+
+        assertThat(mirrorRepository.findAllByMemberId(memberId)).isEmpty();
+        assertThat(REQUESTS).isEmpty();
+    }
+
+    @Test
     @DisplayName("플래시카드 생성 → 첫 복습 dueDate에 '복습 1개' 종일 이벤트를 insert하고 매핑을 저장한다")
     void create_inserts_bundle() throws Exception {
         createCard("Q1");

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/mirror/ReviewMirrorToggleIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/mirror/ReviewMirrorToggleIntegrationTest.java
@@ -168,6 +168,60 @@ class ReviewMirrorToggleIntegrationTest extends ApiTestSupport {
         assertThat(account.getReviewCalendarId()).isEqualTo("review-cal");
     }
 
+    @Test
+    @DisplayName("ON - 오버듀(지난 날) PENDING도 백필해 묶음을 유지한다")
+    void enable_backfills_overdue() throws Exception {
+        connectGoogle(null, false);
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+        seedPendingReview(today.minusDays(2)); // 지난 날인데 아직 PENDING(오버듀)
+
+        toggle(true).andExpect(status().isOk());
+
+        assertThat(mirrorRepository.findByMemberIdAndDueDate(memberId, today.minusDays(2)))
+                .isPresent();
+    }
+
+    @Test
+    @DisplayName("ON - 같은 날 여러 자료는 설명을 자료 제목별로 묶는다")
+    void enable_groups_description_by_material() throws Exception {
+        connectGoogle(null, false);
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+        Long english = studyMaterialRepository.save(
+                new StudyMaterial(memberId, "영어", MaterialType.BOOK)).getId();
+        seedPendingReviewIn(materialId, today.plusDays(1)); // 수학 1개
+        seedPendingReviewIn(english, today.plusDays(1));    // 영어 1개
+
+        toggle(true).andExpect(status().isOk());
+
+        CapturedRequest insert = REQUESTS.stream()
+                .filter(r -> r.method.equals("POST") && r.path.endsWith("/events"))
+                .reduce((first, second) -> second).orElseThrow();
+        assertThat(insert.body).contains("복습 2개");
+        assertThat(insert.body).contains("수학: 1개");
+        assertThat(insert.body).contains("영어: 1개");
+    }
+
+    @Test
+    @DisplayName("OFF→ON - 다시 켜면 백필로 묶음을 재생성한다(보조 캘린더는 재사용)")
+    void disable_then_enable_rebackfills() throws Exception {
+        connectGoogle(null, false);
+        accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
+        seedPendingReview(today.plusDays(1));
+
+        toggle(true).andExpect(status().isOk());
+        assertThat(mirrorRepository.findAllByMemberId(memberId)).hasSize(1);
+
+        toggle(false).andExpect(status().isOk());
+        assertThat(mirrorRepository.findAllByMemberId(memberId)).isEmpty();
+
+        REQUESTS.clear();
+        toggle(true).andExpect(status().isOk());
+        assertThat(mirrorRepository.findByMemberIdAndDueDate(memberId, today.plusDays(1)))
+                .isPresent();
+        // 보조 캘린더는 보존됐으므로 재생성(calendars.insert) 없이 재사용한다
+        assertThat(REQUESTS).noneMatch(r -> r.path.equals("/calendar/v3/calendars"));
+    }
+
     private void connectGoogle(String reviewCalendarId, boolean mirrorEnabled) {
         GoogleAccount account = new GoogleAccount(
                 memberId, "refresh", "scope", "me@gmail.com", "primary", "@default");
@@ -181,7 +235,11 @@ class ReviewMirrorToggleIntegrationTest extends ApiTestSupport {
     }
 
     private void seedPendingReview(LocalDate dueDate) {
-        Flashcard card = flashcardRepository.save(new Flashcard(memberId, materialId, "Q", "A"));
+        seedPendingReviewIn(materialId, dueDate);
+    }
+
+    private void seedPendingReviewIn(Long material, LocalDate dueDate) {
+        Flashcard card = flashcardRepository.save(new Flashcard(memberId, material, "Q", "A"));
         reviewScheduleRepository.save(new ReviewSchedule(
                 memberId, card.getId(), 1, atTestZone(dueDate.atTime(4, 0)), 1, EF));
     }


### PR DESCRIPTION
## 이슈
closes #588

## 작업 내용
복습 → Google 보조 캘린더 미러링(Epic #583)의 마무리(RM4). 구현은 RM0~RM3(머지됨)에서 끝났고, 본 PR은 엣지 케이스 통합 테스트를 보강합니다.

- **오버듀**: 지난 날인데 아직 PENDING인 복습도 백필로 묶음 유지
- **다수 자료 설명**: 같은 날 여러 자료는 설명을 자료 제목별로 묶음(`"복습 2개"` + `수학: 1개` / `영어: 1개`)
- **OFF→ON 재백필**: 다시 켜면 백필로 묶음 재생성, 보조 캘린더는 보존된 ID 재사용(`calendars.insert` 없음)
- **연동 만료(revoked)**: 미러가 켜져 있어도 토큰 무효화 중에는 동기화를 건너뜀(매핑·Google 호출 없음)

## 테스트
- `ReviewMirrorToggleIntegrationTest` +3 (오버듀 백필, 다자료 설명 그룹, OFF→ON 재백필)
- `ReviewMirrorIntegrationTest` +1 (revoked 스킵)
- `:orino-app-api:test`·checkstyle 통과

## 남은 마무리(코드 외)
- **로컬 실기기 검증**: bootRun + 실제 Google 계정으로 보조 캘린더 생성·폰 표시 확인 — OAuth/실기기 필요로 개발자 직접 수행
- **Wiki**: Review-Calendar-Mirror "구현 완료" 갱신(별도 반영)