### PR TITLE
chore : 로그 대시보드 가독성 개선 (probe 노이즈 제거·로그 패널 전체 폭)

### DIFF
--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/logs-overview.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/logs-overview.json
@@ -130,7 +130,7 @@
       "type": "table",
       "title": "로거별 에러 Top 15",
       "datasource": { "type": "loki", "uid": "loki" },
-      "gridPos": { "x": 0, "y": 12, "w": 8, "h": 12 },
+      "gridPos": { "x": 0, "y": 12, "w": 24, "h": 8 },
       "options": { "showHeader": true },
       "fieldConfig": { "defaults": {}, "overrides": [] },
       "targets": [
@@ -142,20 +142,20 @@
       "type": "logs",
       "title": "로그 (level=$level, search=$search)",
       "datasource": { "type": "loki", "uid": "loki" },
-      "gridPos": { "x": 8, "y": 12, "w": 16, "h": 12 },
+      "gridPos": { "x": 0, "y": 20, "w": 24, "h": 16 },
       "options": {
         "showTime": true,
         "showLabels": false,
-        "showCommonLabels": false,
+        "showCommonLabels": true,
         "wrapLogMessage": true,
         "prettifyLogMessage": true,
         "enableLogDetails": true,
-        "dedupStrategy": "none",
+        "dedupStrategy": "signature",
         "sortOrder": "Descending"
       },
       "targets": [
         { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "range",
-          "expr": "{namespace=~\"$namespace\", service_name=~\"$service_name\", level=~\"$level\"} |~ \"(?i)$search\"" }
+          "expr": "{namespace=~\"$namespace\", service_name=~\"$service_name\", level=~\"$level\"} != \"kube-probe\" |~ \"(?i)$search\"" }
       ]
     }
   ]


### PR DESCRIPTION
## 이슈
closes #625

## 작업 내용

`orino-logs` 대시보드 로그 패널의 가독성을 개선한다.

### 변경 (`logs-overview.json`)
- **노이즈 제거**: 로그 패널 쿼리에 `!= "kube-probe"` 추가. fe nginx 헬스체크(liveness/readiness) 200 로그가 fe 로그의 ~98%를 차지해 실제 트래픽을 가렸음.
- **중복/가독성**: `dedupStrategy` `none` → `signature`, `showCommonLabels: true`(어느 서비스인지 상단 표시).
- **레이아웃**: "로거별 에러 Top 15"를 전체 폭 위로(w8→w24, h8), 로그 패널을 그 아래 전체 폭(x8/w16 → x0/w24, h16)으로 재배치 → 로그 한 줄을 통째로 사용.

### 검증
- `helm template` 렌더 + 임베드 JSON 파싱 OK, 패널 gridPos 겹침 없음(stat=0 / 레벨별=4 / 로거별=12 / 로그=20).
- Loki 실측(최근 15분, fe): 전체 **245줄 → kube-probe 제외 5줄**(실제 트래픽만).