### PR TITLE
feat : Day Plan DP0 — 스키마 + 플랜 CRUD/펼침 API

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/DayPlanController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/DayPlanController.java
@@ -1,0 +1,72 @@
+package ds.project.orino.planner.dayplan;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.dayplan.dto.DayPlanListResponse;
+import ds.project.orino.planner.dayplan.dto.DayPlanRequest;
+import ds.project.orino.planner.dayplan.dto.DayPlanResponse;
+import ds.project.orino.planner.dayplan.dto.PlanInstancesResponse;
+import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+/** 데일리 플랜 CRUD + 배경 레이어 펼침. Google 무관. */
+@RestController
+@RequestMapping("/api/planner/plans")
+public class DayPlanController {
+
+    private final DayPlanService dayPlanService;
+
+    public DayPlanController(DayPlanService dayPlanService) {
+        this.dayPlanService = dayPlanService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<DayPlanResponse>> create(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody DayPlanRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(dayPlanService.create(memberId, request)));
+    }
+
+    @GetMapping
+    public ApiResponse<DayPlanListResponse> list(@AuthenticationPrincipal Long memberId) {
+        return ApiResponse.success(dayPlanService.list(memberId));
+    }
+
+    @GetMapping("/instances")
+    public ApiResponse<PlanInstancesResponse> instances(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return ApiResponse.success(dayPlanService.instances(memberId, from, to));
+    }
+
+    @PatchMapping("/{planId}")
+    public ApiResponse<DayPlanResponse> update(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long planId,
+            @Valid @RequestBody DayPlanRequest request) {
+        return ApiResponse.success(dayPlanService.update(memberId, planId, request));
+    }
+
+    @DeleteMapping("/{planId}")
+    public ApiResponse<Void> delete(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long planId) {
+        dayPlanService.delete(memberId, planId);
+        return ApiResponse.success();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/DayPlanRecurrenceMapper.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/DayPlanRecurrenceMapper.java
@@ -1,0 +1,90 @@
+package ds.project.orino.planner.dayplan;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.dayplan.entity.DayPlan;
+import ds.project.orino.domain.planner.dayplan.entity.DayPlanFreq;
+import ds.project.orino.planner.dayplan.dto.DayPlanRecurrence;
+import ds.project.orino.planner.google.recurrence.RecurrenceFreq;
+import ds.project.orino.planner.google.recurrence.RecurrenceRule;
+import ds.project.orino.planner.google.recurrence.RecurrenceWeekday;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 플랜 반복 규칙 매핑 — DTO/엔티티 컬럼 ↔ {@link RecurrenceRule}(앱 계층 VO, 검증·한글요약·펼침 공용).
+ * 엔티티는 {@code orino-domain-rdb}라 RecurrenceRule을 직접 못 들고, 컬럼(freq enum + CSV)으로 저장한다.
+ */
+@Component
+public class DayPlanRecurrenceMapper {
+
+    /** 요청 DTO → RecurrenceRule(생성자에서 interval·byMonthDay 검증). 잘못된 값은 PLN-ERR-002. */
+    public RecurrenceRule toRule(DayPlanRecurrence dto) {
+        try {
+            RecurrenceFreq freq = RecurrenceFreq.valueOf(dto.freq().trim().toUpperCase());
+            List<RecurrenceWeekday> byDay = dto.byDay() == null ? List.of()
+                    : dto.byDay().stream().map(RecurrenceWeekday::fromCode).toList();
+            List<Integer> byMonthDay = dto.byMonthDay() == null ? List.of() : dto.byMonthDay();
+            return new RecurrenceRule(freq, dto.interval(), byDay, byMonthDay, dto.until());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.ROUTINE_INVALID_RULE);
+        }
+    }
+
+    /** 엔티티 컬럼 → RecurrenceRule. */
+    public RecurrenceRule toRule(DayPlan plan) {
+        RecurrenceFreq freq = RecurrenceFreq.valueOf(plan.getFreq().name());
+        return new RecurrenceRule(
+                freq, plan.getIntervalVal(),
+                parseWeekdays(plan.getByDay()), parseInts(plan.getByMonthDay()), plan.getUntil());
+    }
+
+    /** RecurrenceRule → 응답 DTO(정규화된 값 그대로). */
+    public DayPlanRecurrence toDto(RecurrenceRule rule, LocalDate startsOn) {
+        return new DayPlanRecurrence(
+                rule.freq().name(),
+                rule.interval(),
+                rule.byDay().isEmpty() ? null : rule.byDay().stream().map(Enum::name).toList(),
+                rule.byMonthDay().isEmpty() ? null : List.copyOf(rule.byMonthDay()),
+                startsOn,
+                rule.until());
+    }
+
+    /** WEEKLY일 때만 요일 CSV, 그 외 null. */
+    public String byDayColumn(RecurrenceRule rule) {
+        if (rule.freq() != RecurrenceFreq.WEEKLY || rule.byDay().isEmpty()) {
+            return null;
+        }
+        return rule.byDay().stream().map(Enum::name).collect(Collectors.joining(","));
+    }
+
+    /** MONTHLY일 때만 일자 CSV, 그 외 null. */
+    public String byMonthDayColumn(RecurrenceRule rule) {
+        if (rule.freq() != RecurrenceFreq.MONTHLY || rule.byMonthDay().isEmpty()) {
+            return null;
+        }
+        return rule.byMonthDay().stream().map(String::valueOf).collect(Collectors.joining(","));
+    }
+
+    public DayPlanFreq freqColumn(RecurrenceRule rule) {
+        return DayPlanFreq.valueOf(rule.freq().name());
+    }
+
+    private List<RecurrenceWeekday> parseWeekdays(String csv) {
+        if (csv == null || csv.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(csv.split(",")).map(RecurrenceWeekday::fromCode).toList();
+    }
+
+    private List<Integer> parseInts(String csv) {
+        if (csv == null || csv.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(csv.split(",")).map(String::trim).map(Integer::valueOf).toList();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/DayPlanService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/DayPlanService.java
@@ -1,0 +1,182 @@
+package ds.project.orino.planner.dayplan;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.dayplan.entity.DayPlan;
+import ds.project.orino.domain.planner.dayplan.entity.DayPlanBlock;
+import ds.project.orino.domain.planner.dayplan.repository.DayPlanRepository;
+import ds.project.orino.planner.dayplan.dto.DayPlanBlockRequest;
+import ds.project.orino.planner.dayplan.dto.DayPlanBlockResponse;
+import ds.project.orino.planner.dayplan.dto.DayPlanListResponse;
+import ds.project.orino.planner.dayplan.dto.DayPlanRequest;
+import ds.project.orino.planner.dayplan.dto.DayPlanResponse;
+import ds.project.orino.planner.dayplan.dto.PlanInstancesResponse;
+import ds.project.orino.planner.google.recurrence.RecurrenceRule;
+import ds.project.orino.planner.google.routine.RecurrenceTextFormatter;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 데일리 플랜 CRUD + 펼침. orino가 진실(Google 무관). 블록은 declarative 전량 교체(id 기준 upsert/삭제),
+ * 반복 규칙은 {@link DayPlanRecurrenceMapper}로 컬럼 ↔ RecurrenceRule 매핑한다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class DayPlanService {
+
+    private final DayPlanRepository dayPlanRepository;
+    private final DayPlanRecurrenceMapper recurrenceMapper;
+
+    public DayPlanService(DayPlanRepository dayPlanRepository, DayPlanRecurrenceMapper recurrenceMapper) {
+        this.dayPlanRepository = dayPlanRepository;
+        this.recurrenceMapper = recurrenceMapper;
+    }
+
+    @Transactional
+    public DayPlanResponse create(Long memberId, DayPlanRequest request) {
+        RecurrenceRule rule = recurrenceMapper.toRule(request.recurrence());
+        validateBlocks(request.blocks());
+
+        DayPlan plan = new DayPlan(
+                memberId, request.name(), request.color(),
+                recurrenceMapper.freqColumn(rule), rule.effectiveInterval(),
+                recurrenceMapper.byDayColumn(rule), recurrenceMapper.byMonthDayColumn(rule),
+                request.recurrence().startsOn(), rule.until());
+        applyBlocks(plan, request.blocks());
+
+        dayPlanRepository.saveAndFlush(plan);
+        return toResponse(plan);
+    }
+
+    @Transactional
+    public DayPlanResponse update(Long memberId, Long planId, DayPlanRequest request) {
+        DayPlan plan = getOwned(memberId, planId);
+        RecurrenceRule rule = recurrenceMapper.toRule(request.recurrence());
+        validateBlocks(request.blocks());
+
+        plan.updateMeta(
+                request.name(), request.color(),
+                recurrenceMapper.freqColumn(rule), rule.effectiveInterval(),
+                recurrenceMapper.byDayColumn(rule), recurrenceMapper.byMonthDayColumn(rule),
+                request.recurrence().startsOn(), rule.until());
+        applyBlocks(plan, request.blocks());
+
+        dayPlanRepository.flush();
+        return toResponse(plan);
+    }
+
+    @Transactional
+    public void delete(Long memberId, Long planId) {
+        dayPlanRepository.delete(getOwned(memberId, planId));
+    }
+
+    public DayPlanListResponse list(Long memberId) {
+        List<DayPlanResponse> plans = dayPlanRepository.findAllByMemberIdOrderByIdAsc(memberId).stream()
+                .map(this::toResponse)
+                .toList();
+        return new DayPlanListResponse(plans);
+    }
+
+    /** [from, to] 구간을 활성 플랜으로 펼쳐 날짜별 블록을 만든다(배경 레이어). 블록 없는 날짜는 생략. */
+    public PlanInstancesResponse instances(Long memberId, LocalDate from, LocalDate to) {
+        if (to.isBefore(from)) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        Map<LocalDate, List<PlanInstancesResponse.Block>> byDate = new TreeMap<>();
+        for (DayPlan plan : dayPlanRepository.findAllByMemberIdAndEnabledTrue(memberId)) {
+            RecurrenceRule rule = recurrenceMapper.toRule(plan);
+            List<DayPlanBlock> blocks = sortedBlocks(plan);
+            for (LocalDate date : PlanExpander.occurrences(rule, plan.getStartsOn(), from, to)) {
+                List<PlanInstancesResponse.Block> dayBlocks =
+                        byDate.computeIfAbsent(date, d -> new ArrayList<>());
+                for (DayPlanBlock block : blocks) {
+                    dayBlocks.add(new PlanInstancesResponse.Block(
+                            plan.getId(), plan.getName(), plan.getColor(),
+                            block.getStartTime(), block.getEndTime(), block.getLabel()));
+                }
+            }
+        }
+        List<PlanInstancesResponse.Day> days = byDate.entrySet().stream()
+                .map(e -> new PlanInstancesResponse.Day(e.getKey(), e.getValue()))
+                .toList();
+        return new PlanInstancesResponse(days);
+    }
+
+    private DayPlan getOwned(Long memberId, Long planId) {
+        return dayPlanRepository.findByIdAndMemberId(planId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    /** 시간 역전(end<=start)·범위 블록 간 겹침을 검증한다. 위반 시 PLN-ERR-002. */
+    private void validateBlocks(List<DayPlanBlockRequest> blocks) {
+        for (DayPlanBlockRequest block : blocks) {
+            if (block.endTime() != null && !block.endTime().isAfter(block.startTime())) {
+                throw new CustomException(ErrorCode.ROUTINE_INVALID_RULE);
+            }
+        }
+        List<DayPlanBlockRequest> ranges = blocks.stream()
+                .filter(b -> b.endTime() != null)
+                .sorted(Comparator.comparing(DayPlanBlockRequest::startTime))
+                .toList();
+        for (int i = 1; i < ranges.size(); i++) {
+            if (ranges.get(i).startTime().isBefore(ranges.get(i - 1).endTime())) {
+                throw new CustomException(ErrorCode.ROUTINE_INVALID_RULE);
+            }
+        }
+    }
+
+    /** declarative 교체: 시작시각 순으로 sort_order를 재부여하고, id 기준 수정/신규/삭제한다. */
+    private void applyBlocks(DayPlan plan, List<DayPlanBlockRequest> requests) {
+        Map<Long, DayPlanBlock> existing = plan.getBlocks().stream()
+                .filter(block -> block.getId() != null)
+                .collect(Collectors.toMap(DayPlanBlock::getId, Function.identity()));
+        List<DayPlanBlockRequest> sorted = requests.stream()
+                .sorted(Comparator.comparing(DayPlanBlockRequest::startTime))
+                .toList();
+
+        Set<Long> kept = new HashSet<>();
+        int order = 0;
+        for (DayPlanBlockRequest request : sorted) {
+            if (request.id() != null && existing.containsKey(request.id())) {
+                existing.get(request.id()).update(
+                        request.startTime(), request.endTime(), request.label(), request.chime(), order);
+                kept.add(request.id());
+            } else {
+                plan.addBlock(new DayPlanBlock(
+                        plan, request.startTime(), request.endTime(),
+                        request.label(), request.chime(), order));
+            }
+            order++;
+        }
+        plan.getBlocks().removeIf(block -> block.getId() != null && !kept.contains(block.getId()));
+    }
+
+    private DayPlanResponse toResponse(DayPlan plan) {
+        RecurrenceRule rule = recurrenceMapper.toRule(plan);
+        List<DayPlanBlockResponse> blocks = sortedBlocks(plan).stream()
+                .map(DayPlanBlockResponse::of)
+                .toList();
+        return new DayPlanResponse(
+                plan.getId(), plan.getName(), plan.getColor(), plan.isEnabled(),
+                recurrenceMapper.toDto(rule, plan.getStartsOn()),
+                RecurrenceTextFormatter.toKorean(rule),
+                blocks);
+    }
+
+    private List<DayPlanBlock> sortedBlocks(DayPlan plan) {
+        return plan.getBlocks().stream()
+                .sorted(Comparator.comparingInt(DayPlanBlock::getSortOrder))
+                .toList();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/PlanExpander.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/PlanExpander.java
@@ -1,0 +1,82 @@
+package ds.project.orino.planner.dayplan;
+
+import ds.project.orino.planner.google.recurrence.RecurrenceRule;
+import ds.project.orino.planner.google.recurrence.RecurrenceWeekday;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 플랜 반복 규칙을 로컬에서 [from, to] 날짜로 펼친다(Google 무관). Routine과 달리 orino가 진실이라
+ * Google API 펼침을 못 쓰므로 직접 매칭한다. Phase 1: DAILY/WEEKLY/MONTHLY + interval + byDay/byMonthDay,
+ * {@code startsOn}(DTSTART)·{@code until}(포함) 경계.
+ */
+public final class PlanExpander {
+
+    private PlanExpander() {
+    }
+
+    /**
+     * {@code [from, to]}(양끝 포함) 구간에서 규칙에 맞는 발생일 목록을 오름차순으로 반환한다.
+     * {@code startsOn} 이전과 {@code rule.until} 이후는 제외한다.
+     */
+    public static List<LocalDate> occurrences(RecurrenceRule rule, LocalDate startsOn,
+                                              LocalDate from, LocalDate to) {
+        LocalDate rangeStart = from.isBefore(startsOn) ? startsOn : from;
+        LocalDate rangeEnd = (rule.until() != null && rule.until().isBefore(to)) ? rule.until() : to;
+        if (rangeStart.isAfter(rangeEnd)) {
+            return List.of();
+        }
+
+        List<LocalDate> result = new ArrayList<>();
+        for (LocalDate date = rangeStart; !date.isAfter(rangeEnd); date = date.plusDays(1)) {
+            if (matches(rule, startsOn, date)) {
+                result.add(date);
+            }
+        }
+        return result;
+    }
+
+    private static boolean matches(RecurrenceRule rule, LocalDate startsOn, LocalDate date) {
+        int interval = rule.effectiveInterval();
+        return switch (rule.freq()) {
+            case DAILY -> ChronoUnit.DAYS.between(startsOn, date) % interval == 0;
+            case WEEKLY -> matchesWeekly(rule, startsOn, date, interval);
+            case MONTHLY -> matchesMonthly(rule, startsOn, date, interval);
+        };
+    }
+
+    private static boolean matchesWeekly(RecurrenceRule rule, LocalDate startsOn,
+                                         LocalDate date, int interval) {
+        Set<DayOfWeek> days = rule.byDay().isEmpty()
+                ? Set.of(startsOn.getDayOfWeek())
+                : rule.byDay().stream().map(RecurrenceWeekday::toDayOfWeek)
+                        .collect(Collectors.toSet());
+        if (!days.contains(date.getDayOfWeek())) {
+            return false;
+        }
+        LocalDate startWeek = startsOn.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate dateWeek = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        return ChronoUnit.WEEKS.between(startWeek, dateWeek) % interval == 0;
+    }
+
+    private static boolean matchesMonthly(RecurrenceRule rule, LocalDate startsOn,
+                                          LocalDate date, int interval) {
+        Set<Integer> monthDays = rule.byMonthDay().isEmpty()
+                ? Set.of(startsOn.getDayOfMonth())
+                : new HashSet<>(rule.byMonthDay());
+        if (!monthDays.contains(date.getDayOfMonth())) {
+            return false;
+        }
+        long months = ChronoUnit.MONTHS.between(
+                startsOn.withDayOfMonth(1), date.withDayOfMonth(1));
+        return months % interval == 0;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanBlockRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanBlockRequest.java
@@ -1,0 +1,26 @@
+package ds.project.orino.planner.dayplan.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalTime;
+
+/**
+ * 타임박스 블록 요청. 시간은 사용자 로컬 벽시계 "HH:mm".
+ *
+ * @param id        기존 블록 id(있으면 수정, 없으면 신규). PATCH의 declarative 교체에서 사용
+ * @param startTime 시작(필수)
+ * @param endTime   종료(null이면 시점 블록)
+ * @param chime     알람 여부(true면 미러 ON 시 보조 캘린더에 푸시 — DP3)
+ */
+public record DayPlanBlockRequest(
+        Long id,
+        @NotNull @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+        LocalTime startTime,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+        LocalTime endTime,
+        @NotBlank String label,
+        boolean chime
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanBlockResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanBlockResponse.java
@@ -1,0 +1,21 @@
+package ds.project.orino.planner.dayplan.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import ds.project.orino.domain.planner.dayplan.entity.DayPlanBlock;
+
+import java.time.LocalTime;
+
+public record DayPlanBlockResponse(
+        Long id,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm") LocalTime startTime,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm") LocalTime endTime,
+        String label,
+        boolean chime
+) {
+
+    public static DayPlanBlockResponse of(DayPlanBlock block) {
+        return new DayPlanBlockResponse(
+                block.getId(), block.getStartTime(), block.getEndTime(),
+                block.getLabel(), block.isChime());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanListResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanListResponse.java
@@ -1,0 +1,8 @@
+package ds.project.orino.planner.dayplan.dto;
+
+import java.util.List;
+
+public record DayPlanListResponse(
+        List<DayPlanResponse> plans
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanRecurrence.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanRecurrence.java
@@ -1,0 +1,27 @@
+package ds.project.orino.planner.dayplan.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 플랜 반복 규칙(요청·응답 공용). RRULE 문자열이 아니라 구조화된 형태.
+ *
+ * @param freq       DAILY|WEEKLY|MONTHLY (필수)
+ * @param interval   반복 간격 N(null=1)
+ * @param byDay      WEEKLY 요일 코드 목록 ["MO".."SU"] (그 외 freq면 무시)
+ * @param byMonthDay MONTHLY 일자 목록 [1..31] (그 외 freq면 무시)
+ * @param startsOn   첫 적용일(DTSTART, 필수)
+ * @param until      종료일(포함). null=무한
+ */
+public record DayPlanRecurrence(
+        @NotBlank String freq,
+        Integer interval,
+        List<String> byDay,
+        List<Integer> byMonthDay,
+        @NotNull LocalDate startsOn,
+        LocalDate until
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanRequest.java
@@ -1,0 +1,18 @@
+package ds.project.orino.planner.dayplan.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+/**
+ * 플랜 생성/수정 요청. {@code blocks}는 최종 상태(declarative) — id 있으면 수정, 없으면 신규, 누락은 삭제.
+ */
+public record DayPlanRequest(
+        @NotBlank String name,
+        String color,
+        @NotNull @Valid DayPlanRecurrence recurrence,
+        @NotNull @Valid List<DayPlanBlockRequest> blocks
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanResponse.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.dayplan.dto;
+
+import java.util.List;
+
+/** 플랜 상세(생성/수정/조회 공용). */
+public record DayPlanResponse(
+        Long id,
+        String name,
+        String color,
+        boolean enabled,
+        DayPlanRecurrence recurrence,
+        String recurrenceText,
+        List<DayPlanBlockResponse> blocks
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/PlanInstancesResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/PlanInstancesResponse.java
@@ -1,0 +1,32 @@
+package ds.project.orino.planner.dayplan.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+/**
+ * 플랜 펼침(배경 레이어용). 날짜별로 해당일에 발생하는 모든 활성 플랜의 블록을 담는다.
+ * 블록 없는 날짜는 응답에서 생략한다(omission).
+ */
+public record PlanInstancesResponse(
+        List<Day> days
+) {
+
+    public record Day(
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") LocalDate date,
+            List<Block> blocks
+    ) {
+    }
+
+    public record Block(
+            Long planId,
+            String planName,
+            String color,
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm") LocalTime startTime,
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm") LocalTime endTime,
+            String label
+    ) {
+    }
+}

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/028-create-day-plan.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/028-create-day-plan.yaml
@@ -1,0 +1,149 @@
+databaseChangeLog:
+  - changeSet:
+      id: 028-create-day-plan
+      author: wcorn
+      comment: |
+        데일리 플랜(Day Plan) — orino가 진실인 "반복되는 하루 템플릿" (#608).
+        day_plan(반복 규칙은 컬럼으로 분해) 1:N day_plan_block(타임박스). Google 무관.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: day_plan
+      changes:
+        - createTable:
+            tableName: day_plan
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_day_plan_member
+                    references: member(id)
+                    deleteCascade: true
+              - column:
+                  name: name
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: color
+                  type: VARCHAR(20)
+              - column:
+                  name: freq
+                  type: VARCHAR(10)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: interval_val
+                  type: INT
+                  defaultValueNumeric: 1
+                  constraints:
+                    nullable: false
+              - column:
+                  name: by_day
+                  type: VARCHAR(40)
+              - column:
+                  name: by_month_day
+                  type: VARCHAR(80)
+              - column:
+                  name: starts_on
+                  type: DATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: until
+                  type: DATE
+              - column:
+                  name: enabled
+                  type: BIT(1)
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: day_plan
+            indexName: idx_day_plan_member_enabled
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: enabled
+        - createTable:
+            tableName: day_plan_block
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: plan_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_day_plan_block_plan
+                    references: day_plan(id)
+                    deleteCascade: true
+              - column:
+                  name: start_time
+                  type: TIME
+                  constraints:
+                    nullable: false
+              - column:
+                  name: end_time
+                  type: TIME
+              - column:
+                  name: label
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: chime
+                  type: BIT(1)
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: sort_order
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: day_plan_block
+            indexName: idx_day_plan_block_plan_sort
+            columns:
+              - column:
+                  name: plan_id
+              - column:
+                  name: sort_order

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -53,3 +53,5 @@ databaseChangeLog:
       file: db/changelog/changes/026-add-google-account-review-mirror.yaml
   - include:
       file: db/changelog/changes/027-create-review-calendar-mirror.yaml
+  - include:
+      file: db/changelog/changes/028-create-day-plan.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dayplan/DayPlanControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dayplan/DayPlanControllerTest.java
@@ -1,0 +1,225 @@
+package ds.project.orino.planner.dayplan;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.dayplan.repository.DayPlanRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class DayPlanControllerTest extends ApiTestSupport {
+
+    private static final String WEEKDAY_PLAN = """
+            {
+              "name": "평일 공부",
+              "color": "violet",
+              "recurrence": {
+                "freq": "WEEKLY", "interval": 1,
+                "byDay": ["MO","TU","WE","TH","FR"], "byMonthDay": null,
+                "startsOn": "2026-06-22", "until": null
+              },
+              "blocks": [
+                { "startTime": "10:00", "endTime": "12:00", "label": "개인 프로젝트", "chime": false },
+                { "startTime": "08:00", "endTime": null,    "label": "기상",        "chime": true }
+              ]
+            }""";
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DayPlanRepository dayPlanRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    @Test
+    @DisplayName("POST - 플랜을 생성하고 201 + 블록(시작시각 정렬)·recurrenceText를 반환한다")
+    void create() throws Exception {
+        mockMvc.perform(createPlan(WEEKDAY_PLAN))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.id").exists())
+                .andExpect(jsonPath("$.data.name").value("평일 공부"))
+                .andExpect(jsonPath("$.data.enabled").value(true))
+                .andExpect(jsonPath("$.data.recurrenceText").value("매주 월·화·수·목·금"))
+                .andExpect(jsonPath("$.data.blocks", hasSize(2)))
+                // 시작시각 순으로 정렬된다(08:00이 먼저)
+                .andExpect(jsonPath("$.data.blocks[0].startTime").value("08:00"))
+                .andExpect(jsonPath("$.data.blocks[0].endTime").doesNotExist())
+                .andExpect(jsonPath("$.data.blocks[0].label").value("기상"))
+                .andExpect(jsonPath("$.data.blocks[1].startTime").value("10:00"))
+                .andExpect(jsonPath("$.data.blocks[1].endTime").value("12:00"));
+    }
+
+    @Test
+    @DisplayName("GET - 플랜 목록을 반환한다")
+    void list() throws Exception {
+        mockMvc.perform(createPlan(WEEKDAY_PLAN)).andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/planner/plans").header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.plans", hasSize(1)))
+                .andExpect(jsonPath("$.data.plans[0].name").value("평일 공부"));
+    }
+
+    @Test
+    @DisplayName("GET instances - 활성 플랜을 구간 펼침해 날짜별 블록을 준다(주말 생략)")
+    void instances() throws Exception {
+        mockMvc.perform(createPlan(WEEKDAY_PLAN)).andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/planner/plans/instances")
+                        .param("from", "2026-06-22").param("to", "2026-06-28")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                // 월~금 5일 (토·일 생략)
+                .andExpect(jsonPath("$.data.days", hasSize(5)))
+                .andExpect(jsonPath("$.data.days[0].date").value("2026-06-22"))
+                .andExpect(jsonPath("$.data.days[0].blocks", hasSize(2)))
+                .andExpect(jsonPath("$.data.days[0].blocks[0].planName").value("평일 공부"))
+                .andExpect(jsonPath("$.data.days[0].blocks[0].startTime").value("08:00"))
+                .andExpect(jsonPath("$.data.days[4].date").value("2026-06-26"));
+    }
+
+    @Test
+    @DisplayName("PATCH - declarative 블록 교체(수정+신규, 누락 삭제)하고 id를 보존한다")
+    void update() throws Exception {
+        String body = mockMvc.perform(createPlan(WEEKDAY_PLAN))
+                .andReturn().getResponse().getContentAsString();
+        long planId = ((Number) JsonPath.read(body, "$.data.id")).longValue();
+        // blocks[0]=기상(08:00), blocks[1]=개인 프로젝트(10:00)
+        long wakeBlockId = ((Number) JsonPath.read(body, "$.data.blocks[0].id")).longValue();
+
+        String patch = """
+                {
+                  "name": "평일 공부",
+                  "color": "violet",
+                  "recurrence": {
+                    "freq": "WEEKLY", "byDay": ["MO","WE","FR"],
+                    "startsOn": "2026-06-22", "until": "2026-12-31"
+                  },
+                  "blocks": [
+                    { "id": %d, "startTime": "07:30", "endTime": null, "label": "기상(수정)", "chime": true },
+                    {           "startTime": "09:00", "endTime": "12:00", "label": "운동+공부", "chime": false }
+                  ]
+                }""".formatted(wakeBlockId);
+
+        mockMvc.perform(patch("/api/planner/plans/{id}", planId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON).content(patch))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recurrenceText").value("매주 월·수·금"))
+                .andExpect(jsonPath("$.data.recurrence.until").value("2026-12-31"))
+                .andExpect(jsonPath("$.data.blocks", hasSize(2)))
+                // 수정된 기상 블록은 id 보존 + 새 시각/라벨
+                .andExpect(jsonPath("$.data.blocks[0].id").value((int) wakeBlockId))
+                .andExpect(jsonPath("$.data.blocks[0].startTime").value("07:30"))
+                .andExpect(jsonPath("$.data.blocks[0].label").value("기상(수정)"))
+                .andExpect(jsonPath("$.data.blocks[1].label").value("운동+공부"));
+    }
+
+    @Test
+    @DisplayName("DELETE - 플랜을 삭제한다")
+    void deletePlan() throws Exception {
+        String body = mockMvc.perform(createPlan(WEEKDAY_PLAN))
+                .andReturn().getResponse().getContentAsString();
+        long planId = ((Number) JsonPath.read(body, "$.data.id")).longValue();
+
+        mockMvc.perform(delete("/api/planner/plans/{id}", planId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+
+        assertThat(dayPlanRepository.findById(planId)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("POST - 블록 시간 역전(end<=start)이면 400 PLN-ERR-002")
+    void create_blockTimeReversed_400() throws Exception {
+        String invalid = """
+                { "name": "x", "recurrence": { "freq": "DAILY", "startsOn": "2026-06-22" },
+                  "blocks": [ { "startTime": "12:00", "endTime": "10:00", "label": "역전", "chime": false } ] }""";
+
+        mockMvc.perform(createPlan(invalid))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("PLN-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("POST - 범위 블록이 겹치면 400 PLN-ERR-002")
+    void create_blocksOverlap_400() throws Exception {
+        String invalid = """
+                { "name": "x", "recurrence": { "freq": "DAILY", "startsOn": "2026-06-22" },
+                  "blocks": [
+                    { "startTime": "10:00", "endTime": "12:00", "label": "a", "chime": false },
+                    { "startTime": "11:00", "endTime": "13:00", "label": "b", "chime": false }
+                  ] }""";
+
+        mockMvc.perform(createPlan(invalid))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("PLN-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("POST - 잘못된 freq면 400 PLN-ERR-002")
+    void create_invalidFreq_400() throws Exception {
+        String invalid = """
+                { "name": "x", "recurrence": { "freq": "YEARLY", "startsOn": "2026-06-22" }, "blocks": [] }""";
+
+        mockMvc.perform(createPlan(invalid))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("PLN-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("PATCH - 존재하지 않는 플랜이면 404")
+    void update_notFound_404() throws Exception {
+        mockMvc.perform(patch("/api/planner/plans/{id}", 999999)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON).content(WEEKDAY_PLAN))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("DELETE - 타인 플랜이면 404")
+    void delete_otherMember_404() throws Exception {
+        Member other = memberRepository.save(MemberFixture.create("other", "password"));
+        var plan = dayPlanRepository.save(new ds.project.orino.domain.planner.dayplan.entity.DayPlan(
+                other.getId(), "남의 플랜", null,
+                ds.project.orino.domain.planner.dayplan.entity.DayPlanFreq.DAILY, 1,
+                null, null, java.time.LocalDate.of(2026, 6, 22), null));
+
+        mockMvc.perform(delete("/api/planner/plans/{id}", plan.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNotFound());
+    }
+
+    private org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder createPlan(String body) {
+        return post("/api/planner/plans")
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dayplan/PlanExpanderTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dayplan/PlanExpanderTest.java
@@ -1,0 +1,94 @@
+package ds.project.orino.planner.dayplan;
+
+import ds.project.orino.planner.google.recurrence.RecurrenceRule;
+import ds.project.orino.planner.google.recurrence.RecurrenceWeekday;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("PlanExpander — 로컬 반복 펼침")
+class PlanExpanderTest {
+
+    private static final LocalDate MON = LocalDate.of(2026, 6, 22); // 월요일
+
+    @Test
+    @DisplayName("DAILY interval=1은 구간 전 날짜를 포함한다")
+    void dailyEveryDay() {
+        List<LocalDate> dates = PlanExpander.occurrences(
+                RecurrenceRule.daily(null), MON, MON, MON.plusDays(3));
+
+        assertThat(dates).containsExactly(
+                MON, MON.plusDays(1), MON.plusDays(2), MON.plusDays(3));
+    }
+
+    @Test
+    @DisplayName("DAILY interval=3은 startsOn 기준 3일 간격만 포함한다")
+    void dailyEvery3Days() {
+        List<LocalDate> dates = PlanExpander.occurrences(
+                RecurrenceRule.everyNDays(3, null), MON, MON, MON.plusDays(7));
+
+        assertThat(dates).containsExactly(MON, MON.plusDays(3), MON.plusDays(6));
+    }
+
+    @Test
+    @DisplayName("WEEKLY 월·수·금만 포함한다")
+    void weeklyByDay() {
+        RecurrenceRule rule = RecurrenceRule.weekly(
+                List.of(RecurrenceWeekday.MO, RecurrenceWeekday.WE, RecurrenceWeekday.FR), null);
+
+        List<LocalDate> dates = PlanExpander.occurrences(rule, MON, MON, MON.plusDays(6));
+
+        assertThat(dates).containsExactly(MON, MON.plusDays(2), MON.plusDays(4)); // 월,수,금
+    }
+
+    @Test
+    @DisplayName("WEEKLY interval=2는 격주만 포함한다")
+    void weeklyBiweekly() {
+        RecurrenceRule rule = new RecurrenceRule(
+                ds.project.orino.planner.google.recurrence.RecurrenceFreq.WEEKLY,
+                2, List.of(RecurrenceWeekday.MO), List.of(), null);
+
+        List<LocalDate> dates = PlanExpander.occurrences(rule, MON, MON, MON.plusWeeks(3));
+
+        assertThat(dates).containsExactly(MON, MON.plusWeeks(2));
+    }
+
+    @Test
+    @DisplayName("MONTHLY 1·15일만 포함한다")
+    void monthlyByMonthDay() {
+        LocalDate start = LocalDate.of(2026, 6, 1);
+        RecurrenceRule rule = RecurrenceRule.monthly(List.of(1, 15), null);
+
+        List<LocalDate> dates = PlanExpander.occurrences(
+                rule, start, start, LocalDate.of(2026, 7, 31));
+
+        assertThat(dates).containsExactly(
+                LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 15),
+                LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 15));
+    }
+
+    @Test
+    @DisplayName("startsOn 이전과 until 이후는 제외한다")
+    void respectsBounds() {
+        RecurrenceRule rule = RecurrenceRule.daily(MON.plusDays(2)); // until = 수요일
+
+        List<LocalDate> dates = PlanExpander.occurrences(
+                rule, MON, MON.minusDays(3), MON.plusDays(10));
+
+        // startsOn(월)~until(수)만
+        assertThat(dates).containsExactly(MON, MON.plusDays(1), MON.plusDays(2));
+    }
+
+    @Test
+    @DisplayName("구간이 startsOn보다 모두 이전이면 비어 있다")
+    void emptyWhenRangeBeforeStart() {
+        List<LocalDate> dates = PlanExpander.occurrences(
+                RecurrenceRule.daily(null), MON, MON.minusDays(10), MON.minusDays(1));
+
+        assertThat(dates).isEmpty();
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
@@ -8,6 +8,8 @@ public class DbCleaner {
 
     private static final String[] TABLES_IN_FK_ORDER = {
             "holiday",
+            "day_plan_block",
+            "day_plan",
             "routine_check",
             "review_calendar_mirror",
             "review_schedule",

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dayplan/entity/DayPlan.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dayplan/entity/DayPlan.java
@@ -1,0 +1,166 @@
+package ds.project.orino.domain.planner.dayplan.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 데일리 플랜 — "반복되는 하루 템플릿". orino가 진실(Google 무관).
+ *
+ * <p>반복 규칙은 RRULE 문자열이 아니라 컬럼으로 분해 저장한다({@code freq/interval_val/by_day/by_month_day/
+ * starts_on/until}). {@code by_day}는 CSV(예: "MO,WE,FR"), {@code by_month_day}는 CSV(예: "1,15").
+ * 블록은 declarative 전량 교체(요청이 최종 상태)로 관리하며 cascade·orphanRemoval로 동기화한다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "day_plan")
+public class DayPlan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 20)
+    private String color;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private DayPlanFreq freq;
+
+    @Column(name = "interval_val", nullable = false)
+    private int intervalVal;
+
+    /** WEEKLY 요일 CSV(예: "MO,WE,FR"). 비-WEEKLY면 null. */
+    @Column(name = "by_day", length = 40)
+    private String byDay;
+
+    /** MONTHLY 일자 CSV(예: "1,15"). 비-MONTHLY면 null. */
+    @Column(name = "by_month_day", length = 80)
+    private String byMonthDay;
+
+    @Column(name = "starts_on", nullable = false)
+    private LocalDate startsOn;
+
+    @Column
+    private LocalDate until;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+
+    @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sortOrder ASC")
+    private List<DayPlanBlock> blocks = new ArrayList<>();
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected DayPlan() {
+    }
+
+    public DayPlan(Long memberId, String name, String color, DayPlanFreq freq, int intervalVal,
+                   String byDay, String byMonthDay, LocalDate startsOn, LocalDate until) {
+        this.memberId = memberId;
+        this.name = name;
+        this.color = color;
+        this.freq = freq;
+        this.intervalVal = intervalVal;
+        this.byDay = byDay;
+        this.byMonthDay = byMonthDay;
+        this.startsOn = startsOn;
+        this.until = until;
+        this.enabled = true;
+    }
+
+    /** 플랜 메타(이름·색·반복 규칙)를 갱신한다. 블록은 별도 교체. */
+    public void updateMeta(String name, String color, DayPlanFreq freq, int intervalVal,
+                           String byDay, String byMonthDay, LocalDate startsOn, LocalDate until) {
+        this.name = name;
+        this.color = color;
+        this.freq = freq;
+        this.intervalVal = intervalVal;
+        this.byDay = byDay;
+        this.byMonthDay = byMonthDay;
+        this.startsOn = startsOn;
+        this.until = until;
+    }
+
+    public void addBlock(DayPlanBlock block) {
+        blocks.add(block);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public DayPlanFreq getFreq() {
+        return freq;
+    }
+
+    public int getIntervalVal() {
+        return intervalVal;
+    }
+
+    public String getByDay() {
+        return byDay;
+    }
+
+    public String getByMonthDay() {
+        return byMonthDay;
+    }
+
+    public LocalDate getStartsOn() {
+        return startsOn;
+    }
+
+    public LocalDate getUntil() {
+        return until;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public List<DayPlanBlock> getBlocks() {
+        return blocks;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dayplan/entity/DayPlanBlock.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dayplan/entity/DayPlanBlock.java
@@ -1,0 +1,108 @@
+package ds.project.orino.domain.planner.dayplan.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.time.LocalTime;
+
+/**
+ * 플랜 타임박스 블록. 하루 중 한 구간(또는 시점)을 나타낸다.
+ * {@code endTime}이 null이면 시점 블록(예: 기상 알람).
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "day_plan_block")
+public class DayPlanBlock {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private DayPlan plan;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time")
+    private LocalTime endTime;
+
+    @Column(nullable = false, length = 100)
+    private String label;
+
+    @Column(nullable = false)
+    private boolean chime;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected DayPlanBlock() {
+    }
+
+    public DayPlanBlock(DayPlan plan, LocalTime startTime, LocalTime endTime,
+                        String label, boolean chime, int sortOrder) {
+        this.plan = plan;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.label = label;
+        this.chime = chime;
+        this.sortOrder = sortOrder;
+    }
+
+    public void update(LocalTime startTime, LocalTime endTime, String label, boolean chime, int sortOrder) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.label = label;
+        this.chime = chime;
+        this.sortOrder = sortOrder;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public DayPlan getPlan() {
+        return plan;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public boolean isChime() {
+        return chime;
+    }
+
+    public int getSortOrder() {
+        return sortOrder;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dayplan/entity/DayPlanFreq.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dayplan/entity/DayPlanFreq.java
@@ -1,0 +1,8 @@
+package ds.project.orino.domain.planner.dayplan.entity;
+
+/** 플랜 반복 주기. 앱 계층 RecurrenceFreq와 이름이 일치한다(상호 매핑). */
+public enum DayPlanFreq {
+    DAILY,
+    WEEKLY,
+    MONTHLY
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dayplan/repository/DayPlanRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dayplan/repository/DayPlanRepository.java
@@ -1,0 +1,17 @@
+package ds.project.orino.domain.planner.dayplan.repository;
+
+import ds.project.orino.domain.planner.dayplan.entity.DayPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DayPlanRepository extends JpaRepository<DayPlan, Long> {
+
+    List<DayPlan> findAllByMemberIdOrderByIdAsc(Long memberId);
+
+    Optional<DayPlan> findByIdAndMemberId(Long id, Long memberId);
+
+    /** 펼침(instances)용 — 활성 플랜만. */
+    List<DayPlan> findAllByMemberIdAndEnabledTrue(Long memberId);
+}


### PR DESCRIPTION
## 이슈
closes #608

## 작업 내용
데일리 플랜(Day Plan) 모듈의 기반(DP0, Epic #607). orino가 진실인 "반복되는 하루 템플릿" 도메인 + CRUD + 배경 레이어용 펼침 API. **Google 무관**(미러는 DP3).

- **Liquibase 028**: `day_plan`(반복 규칙을 컬럼으로 분해: freq/interval_val/by_day/by_month_day/starts_on/until) 1:N `day_plan_block`(start_time/end_time TIME, chime, sort_order)
- **엔티티**: `DayPlan`(1:N, cascade ALL·orphanRemoval) · `DayPlanBlock` · `DayPlanFreq`(도메인 enum), `DayPlanRepository`
- **DayPlanService**: 플랜·블록 CRUD — 블록은 **declarative 전량 교체**(id 있으면 수정·없으면 신규·누락은 삭제, 시작시각 순 sort_order 재부여). 반복 규칙은 `DayPlanRecurrenceMapper`로 컬럼 ↔ `RecurrenceRule`(Routine 엔진 재사용) 매핑
- **PlanExpander**: 활성 플랜 반복을 `[from,to]` 로컬 펼침(DAILY/WEEKLY/MONTHLY + interval·byDay·byMonthDay·startsOn·until). Routine은 Google이 펼치지만 플랜은 orino 진실이라 직접 매칭
- **DayPlanController**: `GET/POST/PATCH/DELETE /api/planner/plans`, `GET /api/planner/plans/instances?from&to`
- **검증**: 블록 시간 역전(end≤start)·범위 블록 겹침·잘못된 반복 규칙 → **400 PLN-ERR-002**, 타 사용자/없는 플랜 → 404. `recurrenceText`(한글 요약) 제공

## 설계 대비 메모
- `day_plan_block.google_event_id` + `google_account`의 plan mirror 컬럼은 **Google 의존이라 DP0(Google 무관)에서 제외**, 차임 미러(DP3)에서 추가합니다.
- 펼침 응답은 블록 없는 날짜를 생략(omission)합니다.

## 테스트
- `PlanExpanderTest`(단위): DAILY/WEEKLY(byDay·격주)/MONTHLY, startsOn·until 경계
- `DayPlanControllerTest`(MockMvc+TestContainers): 생성·목록·펼침(주말 생략)·declarative PATCH(id 보존)·삭제·검증(시간역전/겹침/freq)·404
- 전체 `:orino-domain-rdb:test`·`:orino-app-api:test`·checkstyle 통과

## 다음
- DP1(#609, FE): 플랜 관리 화면+편집 폼 / DP2(#610, FE): 타임라인 배경 레이어 / DP3(#611): 차임 미러