### PR TITLE
chore : BE 로그 본문 message 축약 (alloy 파이프라인 정비)

### DIFF
--- a/infra/helm/alloy/values.yaml
+++ b/infra/helm/alloy/values.yaml
@@ -127,11 +127,14 @@ alloy:
         loki.process "json_parse" {
           stage.json {
             expressions = {
-              level      = "level",
-              logger     = "logger_name",
-              request_id = "requestId",
-              user_id    = "userId",
-              trace_id   = "traceId",
+              level       = "level",
+              logger      = "logger_name",
+              request_id  = "requestId",
+              user_id     = "userId",
+              trace_id    = "traceId",
+              thread_name = "thread_name",
+              message     = "message",
+              stack_trace = "stack_trace",
             }
           }
 
@@ -147,11 +150,24 @@ alloy:
           // Grafana 로그 패널에서 컬럼/필터로 바로 쓰고 `| json` 파싱이 불필요.
           stage.structured_metadata {
             values = {
-              logger     = "",
-              request_id = "",
-              user_id    = "",
-              trace_id   = "",
+              logger      = "",
+              request_id  = "",
+              user_id     = "",
+              trace_id    = "",
+              thread_name = "",
             }
+          }
+
+          // BE JSON 로그는 본문을 message(+stack_trace)로 축약한다.
+          // 장황한 raw JSON 대신 사람이 읽는 message만 저장하고, 식별 필드는
+          // 위 structured metadata로 보존한다. message가 추출된 경우에만
+          // 교체하고, FE nginx 등 plain text는 원본 라인(.Entry)을 유지한다.
+          stage.template {
+            source   = "log_line"
+            template = "{{ if .message }}{{ .message }}{{ if .stack_trace }}\n{{ .stack_trace }}{{ end }}{{ else }}{{ .Entry }}{{ end }}"
+          }
+          stage.output {
+            source = "log_line"
           }
 
           forward_to = [loki.write.default.receiver]


### PR DESCRIPTION
## 이슈
closes #628

## 작업 내용

BE(LogstashEncoder) 로그가 Grafana/Loki에서 raw JSON 전체로 보여 장황한 문제를, **수집 단계(alloy)에서 본문을 message로 축약**해 근본 해결한다. 대시보드 쿼리 `| json | line_format` 우회보다 깔끔하고(쿼리 단순), Explore 등 모든 곳에서 일관된다.

### 변경 (`infra/helm/alloy/values.yaml`)
- `stage.json`에 `message`/`stack_trace`/`thread_name` 추출 추가.
- `stage.structured_metadata`에 `thread_name` 추가(보존).
- `stage.template` + `stage.output`로 본문 교체:
  ```
  {{ if .message }}{{ .message }}{{ if .stack_trace }}\n{{ .stack_trace }}{{ end }}{{ else }}{{ .Entry }}{{ end }}
  ```
  - BE: `message`(+예외 시 `stack_trace`)로 축약
  - FE nginx/istio 등 plain text: 원본 라인(`.Entry`) 유지

### 보존
식별 필드(`logger`/`requestId`/`userId`/`traceId`/`thread_name`)는 structured metadata로 그대로 부착 → 필드 손실 없음. `level`은 스트림 라벨.

### 검증
- `helm template` 렌더 OK.
- 클러스터 alloy 바이너리 `alloy fmt`로 River 문법 검증 통과.
- 배포 후 검증 예정: BE message만 표시 + FE/redis 원본 유지(빈 줄 깨짐 없음).

### 머지 후 후속 (런타임)
- [ ] sync → alloy DaemonSet 재시작 후 BE 로그 본문이 message로 축약되는지
- [ ] FE/redis/istio plain text가 원본 그대로인지(`.Entry` fallback 정상)
- [ ] structured metadata(logger/requestId/thread_name 등) 보존 확인