### PR TITLE
fix : alloy message 축약 동작 복구 (Helm tpl이 River 템플릿 평가 회피)

### DIFF
--- a/infra/helm/alloy/values.yaml
+++ b/infra/helm/alloy/values.yaml
@@ -148,6 +148,9 @@ alloy:
           // 나머지 고유 식별자는 structured metadata로 부착한다.
           // 라벨이 아니라 스트림 카디널리티를 늘리지 않으면서도,
           // Grafana 로그 패널에서 컬럼/필터로 바로 쓰고 `| json` 파싱이 불필요.
+          // 식별 필드 + 예외 스택은 structured metadata로 보존한다(라벨 아님 →
+          // 스트림 카디널리티 무관). 본문을 message로 줄여도 stack_trace는
+          // 로그 디테일에서 그대로 조회된다.
           stage.structured_metadata {
             values = {
               logger      = "",
@@ -155,19 +158,16 @@ alloy:
               user_id     = "",
               trace_id    = "",
               thread_name = "",
+              stack_trace = "",
             }
           }
 
-          // BE JSON 로그는 본문을 message(+stack_trace)로 축약한다.
-          // 장황한 raw JSON 대신 사람이 읽는 message만 저장하고, 식별 필드는
-          // 위 structured metadata로 보존한다. message가 추출된 경우에만
-          // 교체하고, FE nginx 등 plain text는 원본 라인(.Entry)을 유지한다.
-          stage.template {
-            source   = "log_line"
-            template = "{{ if .message }}{{ .message }}{{ if .stack_trace }}\n{{ .stack_trace }}{{ end }}{{ else }}{{ .Entry }}{{ end }}"
-          }
+          // BE JSON 로그는 본문을 message만 남긴다. message가 추출된 경우
+          // (JSON 파싱 성공)에만 본문을 교체하고, FE nginx 등 plain text는
+          // message 키가 없어 stage.output이 no-op 처리되어 원본 라인을 유지한다.
+          // Go template 표현식은 alloy 차트의 Helm tpl 렌더와 충돌하므로 쓰지 않는다.
           stage.output {
-            source = "log_line"
+            source = "message"
           }
 
           forward_to = [loki.write.default.receiver]


### PR DESCRIPTION
## 이슈
closes #631

## 작업 내용

#629(BE 로그 message 축약)가 **Helm tpl 충돌로 미동작**하던 것을 복구한다.

### 원인
alloy 차트가 `configMap.content`를 Helm `tpl`로 렌더링 → #629의 `stage.template` River `{{ if .message }}...` 가 Helm 단계에서 평가되어 `template = ""`로 비워짐 → 본문 축약 무효(BE 여전히 raw JSON). 파드 내 로드된 config에서 `template = ""` 확인.

### 변경 (`infra/helm/alloy/values.yaml`)
- `{{ }}`를 쓰는 `stage.template` **제거**.
- **`stage.output { source = "message" }`** 로 전환:
  - BE: `message` 추출됨 → 본문 = message
  - FE/redis/istio: `message` 키 없음 → output **no-op** → 원본 라인 유지
- `stack_trace`를 `stage.structured_metadata`에 추가 → 본문 축약 후에도 스택은 로그 디테일에서 조회.

### 검증
- `{{ }}` 완전 제거 → **helm template 렌더 성공**(이전엔 tpl 에러).
- **alloy 실증**(파드에서 `alloy run`으로 5종 샘플 처리):
  | 입력 | 결과 |
  |------|------|
  | nginx/redis/istio(탭) | 원본 유지 (no-op) |
  | BE message | message로 축약 |
  | BE message+stack | 본문 message + stack_trace 메타데이터 보존 |
- plain text 빈 줄 깨짐 없음 확인.

### 머지 후 후속
- [ ] sync → alloy reload/재시작 → 실클러스터 BE 로그 message 축약 + plain 원본 유지 최종 확인