### PR TITLE
chore : FE nginx 접근 로그 JSON화 (BE와 포맷 통일·가독성)

### DIFF
--- a/fe/nginx.conf
+++ b/fe/nginx.conf
@@ -1,7 +1,26 @@
+# 접근 로그를 JSON으로 — alloy가 message만 추출해 BE 로그와 동일하게 본문을
+# 축약하고, 식별 필드(client_ip·user_agent)는 structured metadata로 보존한다.
+# (conf.d/*.conf는 http 컨텍스트에 include되므로 여기서 log_format·map 정의 가능)
+map $status $fe_log_level {
+    ~^[23] info;
+    ~^4    warn;
+    ~^5    error;
+    default info;
+}
+log_format app_json escape=json
+    '{'
+        '"message":"$request_method $request_uri $status $body_bytes_sent",'
+        '"level":"$fe_log_level",'
+        '"client_ip":"$http_x_forwarded_for",'
+        '"user_agent":"$http_user_agent"'
+    '}';
+
 server {
     listen 80;
     root /usr/share/nginx/html;
     index index.html;
+
+    access_log /var/log/nginx/access.log app_json;
 
     # 해시 파일명 asset(JS/CSS/이미지 등): 내용이 바뀌면 파일명도 바뀌므로 불변·장기 캐시.
     # 없는 파일은 index.html로 폴백하지 않고 404 → 옛 해시 요청 시 text/html(MIME 에러) 방지.

--- a/infra/helm/alloy/values.yaml
+++ b/infra/helm/alloy/values.yaml
@@ -135,6 +135,8 @@ alloy:
               thread_name = "thread_name",
               message     = "message",
               stack_trace = "stack_trace",
+              client_ip   = "client_ip",
+              user_agent  = "user_agent",
             }
           }
 
@@ -159,6 +161,8 @@ alloy:
               trace_id    = "",
               thread_name = "",
               stack_trace = "",
+              client_ip   = "",
+              user_agent  = "",
             }
           }
 


### PR DESCRIPTION
## 이슈
closes #634

## 작업 내용

FE nginx 접근 로그를 JSON으로 바꿔 BE 로그와 포맷을 통일하고 가독성을 개선한다.

### 변경
- **`fe/nginx.conf`**: JSON `log_format`(`app_json`) + status→level `map` 추가, server에 `access_log ... app_json`.
  - `message = "$request_method $request_uri $status $body_bytes_sent"`
  - 날짜(Grafana가 표시)·무의미한 `127.0.0.6`(envoy 내부 IP) 제거, 실제 client는 `$http_x_forwarded_for`.
  - (conf.d/*.conf는 http 컨텍스트 include라 log_format·map 정의 가능)
- **`infra/helm/alloy/values.yaml`**: `client_ip`/`user_agent`를 stage.json 추출 + structured_metadata 보존.

### Before → After
```
127.0.0.6 - - [27/Jun/2026:08:21:48 +0000] "GET /assets/MaterialDetailPage-C8zjeMMJ.js HTTP/1.1" 200 42926 "-" "Mozilla/5.0 ..." "10.244.139.64"
→
GET /assets/MaterialDetailPage-C8zjeMMJ.js 200 42926
```
- 기존 alloy(message 추출→stage.output)가 BE와 동일하게 본문 축약. client_ip·user_agent는 메타데이터로 보존.

### 검증
- nginx 문법: `docker run nginx:alpine nginx -t` → syntax ok.
- nginx 실제 출력: `{"message":"GET /assets/test.js 404 153","level":"warn","client_ip":"10.244.139.64","user_agent":"..."}` — **404→warn** level 매핑·XFF·UA 정상.
- alloy helm 렌더 OK.
- alloy 실증(`alloy run`): fe JSON → 본문 `GET /assets/... 200 42926` 축약 + client_ip/user_agent structured metadata 보존 확인.

### 머지 후 후속
- [ ] FE 이미지 빌드·배포(argocd-image-updater) + alloy sync 후 실로그 확인