### PR TITLE
feat : 주간 계획표 WP1 — 일~토 시간 그리드 페이지 (FE)

### DIFF
--- a/fe/src/app/layout/Sidebar.tsx
+++ b/fe/src/app/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 import {
   BookOpen,
   Calendar,
+  CalendarRange,
   CheckSquare,
   Home,
   Repeat,
@@ -22,6 +23,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/planner/materials", label: "학습 자료", icon: BookOpen },
   { to: "/planner/reviews/today", label: "오늘 복습", icon: CheckSquare },
   { to: "/planner/calendar", label: "캘린더", icon: Calendar },
+  { to: "/planner/plan", label: "주간 계획표", icon: CalendarRange },
   { to: "/planner/routines", label: "루틴", icon: Repeat },
   { to: "/planner/settings", label: "연동 설정", icon: Settings },
 ];

--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -28,6 +28,10 @@ export const importRoutines = () =>
   import("../pages/planner/RoutinesPage").then((m) => ({
     default: m.RoutinesPage,
   }));
+export const importWeeklyPlan = () =>
+  import("../pages/planner/WeeklyPlanPage").then((m) => ({
+    default: m.WeeklyPlanPage,
+  }));
 
 /**
  * 로그인 후 idle 시간에 페이지 청크를 미리 받아둔다.

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -17,6 +17,7 @@ import {
   importPlannerSettings,
   importRoutines,
   importTodayReviews,
+  importWeeklyPlan,
 } from "./routeImports";
 
 // 로그인 후에만 쓰는 페이지들은 lazy 로드해 초기 번들에서 분리한다.
@@ -28,6 +29,7 @@ const TodayReviewsPage = lazy(importTodayReviews);
 const PlannerCalendarPage = lazy(importPlannerCalendar);
 const PlannerSettingsPage = lazy(importPlannerSettings);
 const RoutinesPage = lazy(importRoutines);
+const WeeklyPlanPage = lazy(importWeeklyPlan);
 
 function RouteFallback() {
   return <LoadingText className="p-6" />;
@@ -87,6 +89,14 @@ export function AppRouter() {
             element={
               <Suspense fallback={<RouteFallback />}>
                 <RoutinesPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/planner/plan"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <WeeklyPlanPage />
               </Suspense>
             }
           />

--- a/fe/src/features/planner/api/weeklyPlan.ts
+++ b/fe/src/features/planner/api/weeklyPlan.ts
@@ -1,0 +1,47 @@
+import { client } from "@/shared/api";
+
+/** 서버 응답 블록(저장 후 id 포함). dayOfWeek 0=일~6=토, 시간은 "HH:mm". */
+export interface WeeklyPlanBlock {
+  id: number;
+  dayOfWeek: number;
+  startTime: string;
+  endTime: string;
+  label: string;
+  color: string | null;
+}
+
+/** 전량 교체 요청 블록(id 불필요). */
+export interface WeeklyPlanBlockInput {
+  dayOfWeek: number;
+  startTime: string;
+  endTime: string;
+  label: string;
+  color: string | null;
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+interface WeeklyPlanData {
+  blocks: WeeklyPlanBlock[];
+}
+
+/** 주간 템플릿 조회. */
+export async function fetchWeeklyPlan(): Promise<WeeklyPlanBlock[]> {
+  const { data } =
+    await client.get<ApiEnvelope<WeeklyPlanData>>("/planner/plan");
+  return data.data.blocks;
+}
+
+/** 주간 템플릿 전량 교체(저장). 반환은 새 id가 부여된 전체 블록. */
+export async function saveWeeklyPlan(
+  blocks: WeeklyPlanBlockInput[],
+): Promise<WeeklyPlanBlock[]> {
+  const { data } = await client.put<ApiEnvelope<WeeklyPlanData>>(
+    "/planner/plan",
+    { blocks },
+  );
+  return data.data.blocks;
+}

--- a/fe/src/features/planner/components/plan/PlanBlockEditor.tsx
+++ b/fe/src/features/planner/components/plan/PlanBlockEditor.tsx
@@ -1,0 +1,156 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { Select, type SelectOption } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+import { PLAN_COLORS } from "./planColors";
+import { DAY_LABELS, type EditableBlock, isReversed } from "./planGrid";
+
+const DAY_OPTIONS: SelectOption<string>[] = DAY_LABELS.map((label, i) => ({
+  value: String(i),
+  label,
+}));
+
+interface PlanBlockEditorProps {
+  block: EditableBlock | null;
+  onSave: (block: EditableBlock) => void;
+  onDelete: (key: string) => void;
+  onClose: () => void;
+}
+
+/** 블록 편집 모달: 요일·라벨·색·시작/종료 수정 + 삭제. 시간 역전이면 저장 차단(인라인 안내). */
+export function PlanBlockEditor({
+  block,
+  onSave,
+  onDelete,
+  onClose,
+}: PlanBlockEditorProps) {
+  const [draft, setDraft] = useState<EditableBlock | null>(block);
+
+  useEffect(() => {
+    setDraft(block);
+  }, [block]);
+
+  if (!draft) return null;
+
+  const reversed = isReversed(draft.startTime, draft.endTime);
+  const labelEmpty = draft.label.trim().length === 0;
+
+  const handleSave = () => {
+    if (reversed || labelEmpty) return;
+    onSave(draft);
+  };
+
+  return (
+    <Modal
+      open={block !== null}
+      onOpenChange={(open) => !open && onClose()}
+      className="max-w-sm"
+    >
+      <Dialog.Title className="text-base font-semibold">블록 편집</Dialog.Title>
+
+      <div className="mt-4 flex flex-col gap-3">
+        <FormField label="요일" labelId="block-day">
+          <Select
+            ariaLabelledby="block-day"
+            value={String(draft.dayOfWeek)}
+            onValueChange={(v) => setDraft({ ...draft, dayOfWeek: Number(v) })}
+            options={DAY_OPTIONS}
+          />
+        </FormField>
+
+        <FormField
+          label="라벨"
+          htmlFor="block-label"
+          error={labelEmpty ? "라벨을 입력해 주세요." : undefined}
+        >
+          <Input
+            id="block-label"
+            value={draft.label}
+            onChange={(e) => setDraft({ ...draft, label: e.target.value })}
+            placeholder="예: 개인 프로젝트"
+          />
+        </FormField>
+
+        <div className="flex gap-3">
+          <FormField label="시작" htmlFor="block-start" className="flex-1">
+            <Input
+              id="block-start"
+              type="time"
+              value={draft.startTime}
+              onChange={(e) =>
+                setDraft({ ...draft, startTime: e.target.value })
+              }
+            />
+          </FormField>
+          <FormField
+            label="종료"
+            htmlFor="block-end"
+            className="flex-1"
+            error={reversed ? "종료가 시작보다 늦어야 합니다." : undefined}
+          >
+            <Input
+              id="block-end"
+              type="time"
+              value={draft.endTime}
+              onChange={(e) => setDraft({ ...draft, endTime: e.target.value })}
+            />
+          </FormField>
+        </div>
+
+        <FormField label="색" labelId="block-color">
+          <div
+            className="flex gap-2"
+            role="group"
+            aria-labelledby="block-color"
+          >
+            {PLAN_COLORS.map((c) => (
+              <button
+                key={c.key}
+                type="button"
+                aria-label={c.label}
+                aria-pressed={draft.color === c.key}
+                onClick={() => setDraft({ ...draft, color: c.key })}
+                className={cn(
+                  "size-6 rounded-full ring-offset-2 transition",
+                  c.swatch,
+                  draft.color === c.key
+                    ? "ring-ring ring-2"
+                    : "opacity-70 hover:opacity-100",
+                )}
+              />
+            ))}
+          </div>
+        </FormField>
+      </div>
+
+      <div className="mt-5 flex items-center justify-between">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-destructive"
+          onClick={() => onDelete(draft.key)}
+        >
+          삭제
+        </Button>
+        <div className="flex gap-2">
+          <Dialog.Close render={<Button variant="outline" size="sm" />}>
+            취소
+          </Dialog.Close>
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={reversed || labelEmpty}
+          >
+            적용
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
@@ -1,0 +1,180 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Toaster } from "@/components/Toaster";
+import { useToastStore } from "@/shared/lib/toast";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { WeeklyPlan } from "./WeeklyPlan";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function mockPlan(blocks: unknown[]) {
+  server.use(
+    http.get(`${API_BASE}/planner/plan`, () =>
+      HttpResponse.json({ code: "OK", data: { blocks } }),
+    ),
+  );
+}
+
+describe("WeeklyPlan", () => {
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [] });
+  });
+
+  it("기존 블록을 로드해 그리드에 렌더한다", async () => {
+    mockPlan([
+      {
+        id: 1,
+        dayOfWeek: 1,
+        startTime: "08:00",
+        endTime: "09:00",
+        label: "기상",
+        color: "violet",
+      },
+    ]);
+
+    renderWithRouter(<WeeklyPlan />);
+
+    expect(
+      await screen.findByRole("button", { name: "기상 08:00~09:00" }),
+    ).toBeInTheDocument();
+  });
+
+  it("블록이 없으면 빈 상태 안내를 보여준다", async () => {
+    mockPlan([]);
+    renderWithRouter(<WeeklyPlan />);
+    expect(await screen.findByText(/빈 한 주입니다/)).toBeInTheDocument();
+  });
+
+  it("시간 칸을 눌러 블록을 만들고 편집 후 그리드에 반영한다", async () => {
+    mockPlan([]);
+    const user = userEvent.setup();
+    renderWithRouter(<WeeklyPlan />);
+
+    // 수요일(dayOfWeek=3) 9시 칸 → 09:00~10:00 블록 생성 + 편집 모달
+    await user.click(await screen.findByLabelText("수요일 9시 추가"));
+
+    const dialog = await screen.findByRole("dialog");
+    await user.type(within(dialog).getByLabelText("라벨"), "회의");
+    await user.click(within(dialog).getByRole("button", { name: "적용" }));
+
+    expect(
+      await screen.findByRole("button", { name: "회의 09:00~10:00" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("저장되지 않은 변경이 있습니다"),
+    ).toBeInTheDocument();
+  });
+
+  it("저장은 PUT으로 전량 교체하고 성공 토스트를 띄운다", async () => {
+    mockPlan([
+      {
+        id: 1,
+        dayOfWeek: 1,
+        startTime: "08:00",
+        endTime: "09:00",
+        label: "기상",
+        color: "violet",
+      },
+    ]);
+    let putBody: { blocks: unknown[] } | null = null;
+    server.use(
+      http.put(`${API_BASE}/planner/plan`, async ({ request }) => {
+        putBody = (await request.json()) as { blocks: unknown[] };
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            blocks: putBody.blocks.map((b, i) => ({
+              id: i + 10,
+              ...(b as object),
+            })),
+          },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithRouter(
+      <>
+        <WeeklyPlan />
+        <Toaster />
+      </>,
+    );
+
+    // 블록 추가로 dirty 만들기
+    await user.click(await screen.findByLabelText("토요일 10시 추가"));
+    const dialog = await screen.findByRole("dialog");
+    await user.type(within(dialog).getByLabelText("라벨"), "운동");
+    await user.click(within(dialog).getByRole("button", { name: "적용" }));
+
+    await user.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("주간 계획표를 저장했습니다."),
+      ).toBeInTheDocument(),
+    );
+    expect(putBody).not.toBeNull();
+    expect(putBody!.blocks).toHaveLength(2); // 기존 1 + 신규 1, 전량 교체
+  });
+
+  it("블록 편집에서 종료가 시작보다 빠르면 적용을 막는다", async () => {
+    mockPlan([
+      {
+        id: 1,
+        dayOfWeek: 2,
+        startTime: "10:00",
+        endTime: "11:00",
+        label: "공부",
+        color: "sky",
+      },
+    ]);
+    const user = userEvent.setup();
+    renderWithRouter(<WeeklyPlan />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "공부 10:00~11:00" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    // 종료를 시작보다 이르게
+    const end = within(dialog).getByLabelText("종료");
+    await user.clear(end);
+    await user.type(end, "09:00");
+
+    expect(
+      within(dialog).getByText("종료가 시작보다 늦어야 합니다."),
+    ).toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: "적용" })).toBeDisabled();
+  });
+
+  it("블록을 삭제한다", async () => {
+    mockPlan([
+      {
+        id: 1,
+        dayOfWeek: 2,
+        startTime: "10:00",
+        endTime: "11:00",
+        label: "공부",
+        color: "sky",
+      },
+    ]);
+    const user = userEvent.setup();
+    renderWithRouter(<WeeklyPlan />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "공부 10:00~11:00" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "삭제" }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "공부 10:00~11:00" }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/fe/src/features/planner/components/plan/WeeklyPlan.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { LoadingText } from "@/components/ui/loading-text";
+import { cn } from "@/lib/utils";
+
+import { useSaveWeeklyPlan, useWeeklyPlan } from "../../hooks/useWeeklyPlan";
+import { PlanBlockEditor } from "./PlanBlockEditor";
+import {
+  DAY_LABELS,
+  type EditableBlock,
+  toEditable,
+  toInput,
+} from "./planGrid";
+import { WeeklyPlanGrid } from "./WeeklyPlanGrid";
+
+const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];
+
+/** 화면 폭이 좁으면(모바일) 1일 뷰로 전환. matchMedia 미지원 환경(테스트)은 데스크탑으로 간주. */
+function useIsNarrow(): boolean {
+  const [narrow, setNarrow] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(max-width: 767px)").matches,
+  );
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const mq = window.matchMedia("(max-width: 767px)");
+    const handler = () => setNarrow(mq.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  return narrow;
+}
+
+/** 주간 계획표 페이지 본체. 서버 주간 템플릿을 로드해 로컬 편집 후 전량 교체로 저장한다. */
+export function WeeklyPlan() {
+  const { data, isLoading, isError } = useWeeklyPlan();
+  const save = useSaveWeeklyPlan();
+  const narrow = useIsNarrow();
+
+  const [blocks, setBlocks] = useState<EditableBlock[]>([]);
+  const [dirty, setDirty] = useState(false);
+  const [editing, setEditing] = useState<EditableBlock | null>(null);
+  const [mobileDay, setMobileDay] = useState(new Date().getDay());
+
+  useEffect(() => {
+    if (data) {
+      setBlocks(toEditable(data));
+      setDirty(false);
+    }
+  }, [data]);
+
+  const handleCreate = (block: EditableBlock) => {
+    setBlocks((prev) => [...prev, block]);
+    setDirty(true);
+    setEditing(block);
+  };
+
+  const handleSaveBlock = (updated: EditableBlock) => {
+    setBlocks((prev) => prev.map((b) => (b.key === updated.key ? updated : b)));
+    setDirty(true);
+    setEditing(null);
+  };
+
+  const handleDeleteBlock = (key: string) => {
+    setBlocks((prev) => prev.filter((b) => b.key !== key));
+    setDirty(true);
+    setEditing(null);
+  };
+
+  const handleSaveAll = () => {
+    save.mutate(toInput(blocks), { onSuccess: () => setDirty(false) });
+  };
+
+  const days = narrow ? [mobileDay] : ALL_DAYS;
+
+  return (
+    <div className="flex flex-col gap-3 p-4">
+      <header className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-lg font-semibold">주간 계획표</h1>
+          {dirty && (
+            <p className="text-muted-foreground text-xs">
+              저장되지 않은 변경이 있습니다
+            </p>
+          )}
+        </div>
+        <Button
+          size="sm"
+          onClick={handleSaveAll}
+          disabled={!dirty || save.isPending}
+        >
+          {save.isPending ? "저장 중…" : "저장"}
+        </Button>
+      </header>
+
+      {narrow && (
+        <div className="flex gap-1" role="tablist" aria-label="요일 선택">
+          {DAY_LABELS.map((label, i) => (
+            <button
+              key={label}
+              type="button"
+              role="tab"
+              aria-selected={mobileDay === i}
+              onClick={() => setMobileDay(i)}
+              className={cn(
+                "flex-1 rounded-md py-1.5 text-sm font-medium",
+                mobileDay === i
+                  ? "bg-primary/10 text-primary"
+                  : "text-foreground/70 hover:bg-muted",
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {isLoading ? (
+        <LoadingText className="p-6" />
+      ) : isError ? (
+        <p className="text-destructive p-6 text-sm">
+          주간 계획표를 불러오지 못했습니다.
+        </p>
+      ) : (
+        <>
+          {blocks.length === 0 && (
+            <p className="text-muted-foreground rounded-md border border-dashed p-4 text-center text-sm">
+              빈 한 주입니다. 시간대를 눌러 블록을 추가하세요.
+            </p>
+          )}
+          <WeeklyPlanGrid
+            blocks={blocks}
+            days={days}
+            onCreate={handleCreate}
+            onSelect={setEditing}
+          />
+        </>
+      )}
+
+      <PlanBlockEditor
+        block={editing}
+        onSave={handleSaveBlock}
+        onDelete={handleDeleteBlock}
+        onClose={() => setEditing(null)}
+      />
+    </div>
+  );
+}

--- a/fe/src/features/planner/components/plan/WeeklyPlanGrid.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlanGrid.tsx
@@ -1,0 +1,147 @@
+import { useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+import { blockColorClass, DEFAULT_COLOR } from "./planColors";
+import {
+  DAY_LABELS,
+  DAY_LABELS_LONG,
+  type EditableBlock,
+  heightRatio,
+  HOUR_PX,
+  layoutDay,
+  MAX_MINUTE,
+  minutesToTime,
+  nextKey,
+  topRatio,
+} from "./planGrid";
+
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+const COLUMN_HEIGHT = 24 * HOUR_PX;
+
+interface WeeklyPlanGridProps {
+  blocks: EditableBlock[];
+  /** 표시할 요일 인덱스(데스크탑 0~6, 모바일 단일). */
+  days: number[];
+  /** 빈 영역 클릭/드래그로 새 블록 생성. */
+  onCreate: (block: EditableBlock) => void;
+  /** 블록 클릭 → 편집. */
+  onSelect: (block: EditableBlock) => void;
+}
+
+/** 일~토 × 시간축 그리드. 시간 칸 클릭=1시간 생성, 세로 드래그=구간 생성, 블록 클릭=편집. */
+export function WeeklyPlanGrid({
+  blocks,
+  days,
+  onCreate,
+  onSelect,
+}: WeeklyPlanGridProps) {
+  const dragRef = useRef<{ day: number; start: number; end: number } | null>(
+    null,
+  );
+
+  const startDrag = (day: number, hour: number) => {
+    dragRef.current = { day, start: hour, end: hour };
+  };
+  const extendDrag = (day: number, hour: number) => {
+    if (dragRef.current && dragRef.current.day === day) {
+      dragRef.current.end = hour;
+    }
+  };
+  const endDrag = () => {
+    const drag = dragRef.current;
+    dragRef.current = null;
+    if (!drag) return;
+    const lo = Math.min(drag.start, drag.end);
+    const hi = Math.max(drag.start, drag.end);
+    onCreate({
+      key: nextKey(),
+      id: null,
+      dayOfWeek: drag.day,
+      startTime: minutesToTime(lo * 60),
+      endTime: minutesToTime(Math.min((hi + 1) * 60, MAX_MINUTE)),
+      label: "",
+      color: DEFAULT_COLOR,
+    });
+  };
+
+  return (
+    <div className="overflow-x-auto">
+      <div
+        className="grid min-w-fit"
+        style={{
+          gridTemplateColumns: `3rem repeat(${days.length}, minmax(6rem, 1fr))`,
+        }}
+      >
+        {/* 헤더: 빈 코너 + 요일 */}
+        <div className="border-border bg-background sticky top-0 z-10 border-b" />
+        {days.map((day) => (
+          <div
+            key={day}
+            className="border-border bg-background sticky top-0 z-10 border-b border-l py-1.5 text-center text-sm font-medium"
+          >
+            {DAY_LABELS[day]}
+          </div>
+        ))}
+
+        {/* 시간 눈금 거터 */}
+        <div className="relative" style={{ height: COLUMN_HEIGHT }}>
+          {HOURS.map((hour) => (
+            <div
+              key={hour}
+              className="text-muted-foreground absolute right-1 -translate-y-1/2 text-[10px]"
+              style={{ top: hour * HOUR_PX }}
+            >
+              {hour > 0 ? `${String(hour).padStart(2, "0")}:00` : ""}
+            </div>
+          ))}
+        </div>
+
+        {/* 요일 컬럼 */}
+        {days.map((day) => (
+          <div
+            key={day}
+            className="border-border relative border-l"
+            style={{ height: COLUMN_HEIGHT }}
+            onPointerUp={endDrag}
+          >
+            {/* 시간 칸(생성용) */}
+            {HOURS.map((hour) => (
+              <button
+                key={hour}
+                type="button"
+                aria-label={`${DAY_LABELS_LONG[day]} ${hour}시 추가`}
+                className="border-border/40 hover:bg-muted/40 absolute inset-x-0 border-t"
+                style={{ top: hour * HOUR_PX, height: HOUR_PX }}
+                onPointerDown={() => startDrag(day, hour)}
+                onPointerEnter={() => extendDrag(day, hour)}
+              />
+            ))}
+
+            {/* 블록 */}
+            {layoutDay(blocks.filter((b) => b.dayOfWeek === day)).map((b) => (
+              <button
+                key={b.key}
+                type="button"
+                aria-label={`${b.label || "(라벨 없음)"} ${b.startTime}~${b.endTime}`}
+                onClick={() => onSelect(b)}
+                className={cn(
+                  "absolute overflow-hidden rounded px-1 py-0.5 text-left text-[11px] leading-tight text-white shadow-sm",
+                  blockColorClass(b.color),
+                )}
+                style={{
+                  top: topRatio(b.startTime) * COLUMN_HEIGHT,
+                  height: heightRatio(b.startTime, b.endTime) * COLUMN_HEIGHT,
+                  left: `${b.left * 100}%`,
+                  width: `${b.width * 100}%`,
+                }}
+              >
+                <span className="font-semibold">{b.startTime}</span> {b.label}
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/planner/components/plan/planColors.ts
+++ b/fe/src/features/planner/components/plan/planColors.ts
@@ -1,0 +1,44 @@
+export interface PlanColor {
+  key: string;
+  label: string;
+  /** 블록 배경 Tailwind 클래스. */
+  block: string;
+  /** 색 선택 스와치 클래스. */
+  swatch: string;
+}
+
+export const PLAN_COLORS: PlanColor[] = [
+  {
+    key: "violet",
+    label: "보라",
+    block: "bg-violet-500",
+    swatch: "bg-violet-500",
+  },
+  { key: "sky", label: "하늘", block: "bg-sky-500", swatch: "bg-sky-500" },
+  {
+    key: "amber",
+    label: "앰버",
+    block: "bg-amber-500",
+    swatch: "bg-amber-500",
+  },
+  {
+    key: "emerald",
+    label: "초록",
+    block: "bg-emerald-500",
+    swatch: "bg-emerald-500",
+  },
+  { key: "rose", label: "분홍", block: "bg-rose-500", swatch: "bg-rose-500" },
+  {
+    key: "slate",
+    label: "회색",
+    block: "bg-slate-500",
+    swatch: "bg-slate-500",
+  },
+];
+
+export const DEFAULT_COLOR = "violet";
+
+/** 색 키 → 블록 배경 클래스(미지정/알 수 없으면 primary). */
+export function blockColorClass(color: string | null): string {
+  return PLAN_COLORS.find((c) => c.key === color)?.block ?? "bg-primary";
+}

--- a/fe/src/features/planner/components/plan/planGrid.test.ts
+++ b/fe/src/features/planner/components/plan/planGrid.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  blockAtHour,
+  type EditableBlock,
+  isReversed,
+  layoutDay,
+  minutesToTime,
+  nextKey,
+  snap,
+  timeToMinutes,
+} from "./planGrid";
+
+function block(start: string, end: string): EditableBlock {
+  return {
+    key: nextKey(),
+    id: null,
+    dayOfWeek: 1,
+    startTime: start,
+    endTime: end,
+    label: "x",
+    color: "violet",
+  };
+}
+
+describe("planGrid", () => {
+  it("timeToMinutes / minutesToTime 왕복", () => {
+    expect(timeToMinutes("08:30")).toBe(510);
+    expect(minutesToTime(510)).toBe("08:30");
+    expect(minutesToTime(0)).toBe("00:00");
+    expect(minutesToTime(1500)).toBe("23:59"); // 클램프
+  });
+
+  it("snap은 30분 격자로 반올림", () => {
+    expect(snap(40)).toBe(30);
+    expect(snap(46)).toBe(60);
+    expect(snap(74)).toBe(60);
+    expect(snap(75)).toBe(90); // 정확히 중간은 올림
+  });
+
+  it("isReversed는 종료<=시작이면 true", () => {
+    expect(isReversed("10:00", "09:00")).toBe(true);
+    expect(isReversed("10:00", "10:00")).toBe(true);
+    expect(isReversed("09:00", "10:00")).toBe(false);
+  });
+
+  it("blockAtHour는 1시간 기본 블록, 23시는 23:59까지", () => {
+    expect(blockAtHour(2, 9)).toMatchObject({
+      dayOfWeek: 2,
+      startTime: "09:00",
+      endTime: "10:00",
+    });
+    expect(blockAtHour(2, 23)).toMatchObject({
+      startTime: "23:00",
+      endTime: "23:59",
+    });
+  });
+
+  it("겹치지 않는 블록은 전체 폭(width=1)", () => {
+    const out = layoutDay([block("08:00", "09:00"), block("10:00", "12:00")]);
+    expect(out).toHaveLength(2);
+    out.forEach((b) => {
+      expect(b.width).toBe(1);
+      expect(b.left).toBe(0);
+    });
+  });
+
+  it("맞닿은 블록(끝=다음 시작)은 겹침 아님 → 전체 폭", () => {
+    const out = layoutDay([block("10:00", "12:00"), block("12:00", "13:00")]);
+    out.forEach((b) => expect(b.width).toBe(1));
+  });
+
+  it("겹치는 두 블록은 반폭으로 나란히", () => {
+    const out = layoutDay([block("10:00", "12:00"), block("11:00", "13:00")]);
+    expect(out).toHaveLength(2);
+    out.forEach((b) => expect(b.width).toBeCloseTo(0.5));
+    expect(out.map((b) => b.left).sort()).toEqual([0, 0.5]);
+  });
+});

--- a/fe/src/features/planner/components/plan/planGrid.ts
+++ b/fe/src/features/planner/components/plan/planGrid.ts
@@ -1,0 +1,173 @@
+import type {
+  WeeklyPlanBlock,
+  WeeklyPlanBlockInput,
+} from "../../api/weeklyPlan";
+import { DEFAULT_COLOR } from "./planColors";
+
+export const DAY_LABELS = ["일", "월", "화", "수", "목", "금", "토"];
+export const DAY_LABELS_LONG = [
+  "일요일",
+  "월요일",
+  "화요일",
+  "수요일",
+  "목요일",
+  "금요일",
+  "토요일",
+];
+
+export const HOUR_PX = 44;
+export const DAY_MINUTES = 24 * 60;
+export const SNAP_MINUTES = 30;
+export const MAX_MINUTE = DAY_MINUTES - 1; // 23:59
+
+/** 클라이언트 편집용 블록. 저장 전(id=null)·저장 후(id) 모두 표현하며 React key로 {@link EditableBlock.key} 사용. */
+export interface EditableBlock {
+  key: string;
+  id: number | null;
+  dayOfWeek: number;
+  startTime: string;
+  endTime: string;
+  label: string;
+  color: string | null;
+}
+
+/** 겹침 분할 렌더용 좌표(left/width는 0..1 비율). */
+export interface LaidOutBlock extends EditableBlock {
+  left: number;
+  width: number;
+}
+
+let keySeq = 0;
+
+export function nextKey(): string {
+  keySeq += 1;
+  return `b-${keySeq}`;
+}
+
+/** "HH:mm" → 자정 기준 분(0..1439). */
+export function timeToMinutes(time: string): number {
+  const [h, m] = time.split(":").map(Number);
+  return h * 60 + m;
+}
+
+/** 분 → "HH:mm"(0..1439로 클램프). */
+export function minutesToTime(minutes: number): string {
+  const clamped = Math.max(0, Math.min(MAX_MINUTE, Math.round(minutes)));
+  const h = Math.floor(clamped / 60);
+  const m = clamped % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+/** 가장 가까운 step(기본 30분) 격자로 스냅. */
+export function snap(minutes: number, step = SNAP_MINUTES): number {
+  return Math.round(minutes / step) * step;
+}
+
+/** 종료 ≤ 시작이면 역전(저장 불가). */
+export function isReversed(startTime: string, endTime: string): boolean {
+  return timeToMinutes(endTime) <= timeToMinutes(startTime);
+}
+
+export function topRatio(startTime: string): number {
+  return timeToMinutes(startTime) / DAY_MINUTES;
+}
+
+export function heightRatio(startTime: string, endTime: string): number {
+  return (timeToMinutes(endTime) - timeToMinutes(startTime)) / DAY_MINUTES;
+}
+
+/** 그리드 세로 픽셀 → 스냅된 분(0..1440). 드래그/클릭 위치 계산용. */
+export function yToMinutes(y: number, heightPx: number): number {
+  const ratio = heightPx <= 0 ? 0 : Math.max(0, Math.min(1, y / heightPx));
+  return snap(Math.round(ratio * DAY_MINUTES));
+}
+
+/** 특정 요일·시(hour)에 1시간 기본 블록 생성(마지막 시간대는 23:59까지). */
+export function blockAtHour(dayOfWeek: number, hour: number): EditableBlock {
+  const startMin = hour * 60;
+  const endMin = Math.min(startMin + 60, MAX_MINUTE);
+  return {
+    key: nextKey(),
+    id: null,
+    dayOfWeek,
+    startTime: minutesToTime(startMin),
+    endTime: minutesToTime(endMin),
+    label: "",
+    color: DEFAULT_COLOR,
+  };
+}
+
+/** 서버 블록 → 편집 블록. */
+export function toEditable(blocks: WeeklyPlanBlock[]): EditableBlock[] {
+  return blocks.map((b) => ({
+    key: nextKey(),
+    id: b.id,
+    dayOfWeek: b.dayOfWeek,
+    startTime: b.startTime,
+    endTime: b.endTime,
+    label: b.label,
+    color: b.color,
+  }));
+}
+
+/** 편집 블록 → 저장 요청(전량 교체). */
+export function toInput(blocks: EditableBlock[]): WeeklyPlanBlockInput[] {
+  return blocks.map((b) => ({
+    dayOfWeek: b.dayOfWeek,
+    startTime: b.startTime,
+    endTime: b.endTime,
+    label: b.label.trim(),
+    color: b.color,
+  }));
+}
+
+/**
+ * 같은 요일 블록들의 겹침을 클러스터 단위로 컬럼 분할한다.
+ * 서로 겹치는 블록 그룹 안에서 left/width(0..1)를 나눠 나란히 렌더한다(맞닿음은 겹침 아님).
+ */
+export function layoutDay(blocks: EditableBlock[]): LaidOutBlock[] {
+  const sorted = [...blocks].sort((a, b) => {
+    const byStart = timeToMinutes(a.startTime) - timeToMinutes(b.startTime);
+    return byStart !== 0
+      ? byStart
+      : timeToMinutes(a.endTime) - timeToMinutes(b.endTime);
+  });
+
+  const result: LaidOutBlock[] = [];
+  let cluster: { block: EditableBlock; col: number }[] = [];
+  let colEnds: number[] = [];
+  let clusterEnd = -1;
+
+  const flush = () => {
+    const cols = colEnds.length || 1;
+    for (const placed of cluster) {
+      result.push({
+        ...placed.block,
+        left: placed.col / cols,
+        width: 1 / cols,
+      });
+    }
+    cluster = [];
+    colEnds = [];
+    clusterEnd = -1;
+  };
+
+  for (const block of sorted) {
+    const start = timeToMinutes(block.startTime);
+    const end = timeToMinutes(block.endTime);
+    if (cluster.length > 0 && start >= clusterEnd) {
+      flush();
+    }
+    let col = colEnds.findIndex((colEnd) => colEnd <= start);
+    if (col === -1) {
+      col = colEnds.length;
+      colEnds.push(end);
+    } else {
+      colEnds[col] = end;
+    }
+    cluster.push({ block, col });
+    clusterEnd = Math.max(clusterEnd, end);
+  }
+  flush();
+  return result;
+}

--- a/fe/src/features/planner/hooks/useWeeklyPlan.ts
+++ b/fe/src/features/planner/hooks/useWeeklyPlan.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { toast } from "@/shared/lib/toast";
+
+import {
+  fetchWeeklyPlan,
+  saveWeeklyPlan,
+  type WeeklyPlanBlockInput,
+} from "../api/weeklyPlan";
+import { plannerKeys } from "../queryKeys";
+
+/** 주간 템플릿 조회. */
+export function useWeeklyPlan() {
+  return useQuery({
+    queryKey: plannerKeys.weeklyPlan(),
+    queryFn: fetchWeeklyPlan,
+  });
+}
+
+/** 주간 템플릿 전량 교체 저장. 성공 시 캐시를 갱신하고 토스트를 띄운다. */
+export function useSaveWeeklyPlan() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (blocks: WeeklyPlanBlockInput[]) => saveWeeklyPlan(blocks),
+    onSuccess: (blocks) => {
+      queryClient.setQueryData(plannerKeys.weeklyPlan(), blocks);
+      toast("주간 계획표를 저장했습니다.", "success");
+    },
+    onError: () => {
+      toast("저장에 실패했습니다. 다시 시도해 주세요.", "error");
+    },
+  });
+}

--- a/fe/src/features/planner/queryKeys.ts
+++ b/fe/src/features/planner/queryKeys.ts
@@ -2,6 +2,7 @@ export const plannerKeys = {
   all: ["planner"] as const,
   calendar: (from: string, to: string) =>
     ["planner", "calendar", from, to] as const,
+  weeklyPlan: () => ["planner", "weeklyPlan"] as const,
 };
 
 export const routineKeys = {

--- a/fe/src/pages/planner/WeeklyPlanPage.tsx
+++ b/fe/src/pages/planner/WeeklyPlanPage.tsx
@@ -1,0 +1,5 @@
+import { WeeklyPlan } from "@/features/planner/components/plan/WeeklyPlan";
+
+export function WeeklyPlanPage() {
+  return <WeeklyPlan />;
+}

--- a/fe/src/test/mocks/handlers.ts
+++ b/fe/src/test/mocks/handlers.ts
@@ -50,6 +50,11 @@ export const handlers = [
     });
   }),
 
+  // 기본값: 빈 주간 계획표. 블록을 검증하는 테스트는 server.use로 덮어쓴다.
+  http.get(`${API_BASE}/planner/plan`, () => {
+    return HttpResponse.json({ code: "OK", data: { blocks: [] } });
+  }),
+
   // 기본값: 공휴일 없음. 공휴일 표시 검증 테스트는 server.use로 덮어쓴다.
   http.get(`${API_BASE}/planner/holidays`, () => {
     return HttpResponse.json({ code: "OK", data: [] });


### PR DESCRIPTION
## 이슈
closes #609

## 작업 내용
재설계된 주간 계획표(Weekly Plan)의 FE 페이지(Epic #607). `/planner/plan` 한 장에서 일~토 × 시간축 그리드로 시간 블록을 직접 만들고 편집한다. WP0(#633)의 `GET`/`PUT /api/planner/plan`에 연동.

- **라우트/네비**: `/planner/plan` 라우트(lazy) + 사이드바 "주간 계획표"
- **WeeklyPlanGrid**: 일~토 × 24시간 그리드. **시간 칸 클릭=1시간 생성**, **세로 드래그=구간 생성**(포인터 이벤트), **블록 클릭=편집**. 같은 요일 겹침은 클러스터 단위로 컬럼 분할 렌더(맞닿음은 겹침 아님)
- **PlanBlockEditor**(모달): 요일·라벨·색·시작/종료 수정 + 삭제. **시간 역전(종료≤시작) 인라인 차단**(적용 비활성)
- **저장**: 명시적 **[저장] 버튼 + "저장되지 않은 변경" 표시**, `PUT` **전량 교체**(react-query, 성공 시 캐시 갱신+토스트). 빈 상태·로딩·저장 실패 토스트
- **모바일**: 1일 뷰 + 요일 탭(matchMedia, 7컬럼 한계 회피)
- **순수 로직 분리**(`planGrid.ts`): 시간↔분 변환·30분 스냅·역전 검증·겹침 레이아웃 → jsdom 의존 없는 단위 테스트

## 테스트
- `planGrid.test.ts`(단위): 시간 변환·스냅(중간값 올림)·역전·겹침 분할(반폭/맞닿음)
- `WeeklyPlan.test.tsx`(RTL+MSW): 로드 렌더·빈 상태·칸 클릭 생성+편집·전량 교체 저장(PUT 본문 검증·토스트)·역전 차단·삭제
- 전체 FE 테스트(197) 통과, prettier·eslint·`tsc -b`·`vite build` 통과

## 다음
- WP2(#613): 마무리(엣지 테스트·로컬 E2E 검증·Wiki 정합)