### PR TITLE
test : 주간 계획표 WP2 마무리 — 엣지 테스트 보강

### DIFF
--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dayplan/DayPlanControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dayplan/DayPlanControllerTest.java
@@ -1,5 +1,6 @@
 package ds.project.orino.planner.dayplan;
 
+import com.jayway.jsonpath.JsonPath;
 import ds.project.orino.domain.member.repository.MemberRepository;
 import ds.project.orino.domain.planner.dayplan.repository.DayPlanBlockRepository;
 import ds.project.orino.support.ApiTestSupport;
@@ -90,6 +91,25 @@ class DayPlanControllerTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.blocks[0].label").value("회의"));
 
         assertThat(blockRepository.findAllByMemberId(memberId)).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("PUT - 같은 내용 2회 전량 교체는 멱등(중복 누적 없이 동일 블록, 새 id)")
+    void put_idempotent() throws Exception {
+        String first = mockMvc.perform(putBlocks(WEEKLY_BLOCKS))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.blocks", hasSize(3)))
+                .andReturn().getResponse().getContentAsString();
+        long firstWakeId = ((Number) JsonPath.read(first, "$.data.blocks[0].id")).longValue();
+
+        mockMvc.perform(putBlocks(WEEKLY_BLOCKS))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.blocks", hasSize(3)))
+                .andExpect(jsonPath("$.data.blocks[0].label").value("기상"))
+                // 전량 교체라 새 row → id가 바뀐다(누적 아님)
+                .andExpect(jsonPath("$.data.blocks[0].id").value(org.hamcrest.Matchers.not((int) firstWakeId)));
+
+        assertThat(blockRepository.findAllByMemberId(memberId)).hasSize(3); // 6 아님
     }
 
     @Test

--- a/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { Toaster } from "@/components/Toaster";
 import { useToastStore } from "@/shared/lib/toast";
@@ -20,9 +20,29 @@ function mockPlan(blocks: unknown[]) {
   );
 }
 
+/** 모바일(좁은 폭) matchMedia로 위장. 기본(데스크탑)은 jsdom에 matchMedia가 없어 자동. */
+function setNarrowViewport() {
+  window.matchMedia = ((query: string) => ({
+    matches: query.includes("767"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
 describe("WeeklyPlan", () => {
+  const originalMatchMedia = window.matchMedia;
+
   beforeEach(() => {
     useToastStore.setState({ toasts: [] });
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
   });
 
   it("기존 블록을 로드해 그리드에 렌더한다", async () => {
@@ -149,6 +169,35 @@ describe("WeeklyPlan", () => {
       within(dialog).getByText("종료가 시작보다 늦어야 합니다."),
     ).toBeInTheDocument();
     expect(within(dialog).getByRole("button", { name: "적용" })).toBeDisabled();
+  });
+
+  it("모바일에서는 요일 탭으로 1일 뷰를 전환한다", async () => {
+    setNarrowViewport();
+    mockPlan([
+      {
+        id: 1,
+        dayOfWeek: 2,
+        startTime: "10:00",
+        endTime: "11:00",
+        label: "공부",
+        color: "sky",
+      },
+    ]);
+    const user = userEvent.setup();
+    renderWithRouter(<WeeklyPlan />);
+
+    const tablist = await screen.findByRole("tablist", { name: "요일 선택" });
+    // 화요일 탭 → 공부 블록 보임
+    await user.click(within(tablist).getByRole("tab", { name: "화" }));
+    expect(
+      await screen.findByRole("button", { name: "공부 10:00~11:00" }),
+    ).toBeInTheDocument();
+
+    // 수요일 탭으로 전환하면 화요일 블록은 사라진다(1일 뷰)
+    await user.click(within(tablist).getByRole("tab", { name: "수" }));
+    expect(
+      screen.queryByRole("button", { name: "공부 10:00~11:00" }),
+    ).not.toBeInTheDocument();
   });
 
   it("블록을 삭제한다", async () => {


### PR DESCRIPTION
## 이슈
closes #613

## 작업 내용
주간 계획표(Weekly Plan) **마무리**(Epic #607). 구현은 WP0(#633, BE)·WP1(#636, FE)에서 끝났고, 본 PR은 부족했던 엣지 케이스 테스트를 보강하고 Wiki를 정합 갱신한다.

- **BE 엣지**: `PUT /api/planner/plan` **전량 교체 멱등** 테스트 — 같은 내용 2회 저장 시 동일 블록(새 id), 행 중복 누적 없음(3개 유지)
- **FE 엣지**: **모바일 1일 뷰** — `matchMedia` 위장으로 좁은 폭에서 요일 탭 노출, 탭 클릭으로 보이는 요일 전환(다른 요일 블록 미표시) 검증

> 이미 WP0/WP1에서 검증된 것(BE: dayOfWeek 범위·end>start·label 공백 / FE: 역전 차단·겹침 렌더·전량 교체 저장)은 중복 추가하지 않음.

## Wiki
- Day-Plan 설계 문서 6종 상태를 **"구현 완료 (WP0 #633 · WP1 #636)"** 로 갱신
- UI 설계에 구현 노트 추가(편집은 인라인 팝오버 대신 **모달**, 드래그 생성·30분 스냅, 명시적 저장, 모바일 1일 뷰)

## 남은 항목 (코드 외)
- **로컬 E2E**(bootRun + 브라우저: 블록 생성→저장→새로고침 유지)는 실브라우저가 필요해 개발자 직접 확인 영역입니다.

## 테스트
- `:orino-app-api:test`(DayPlanControllerTest 멱등 포함)·checkstyle 통과
- FE `WeeklyPlan.test.tsx`(7) 포함 전체 통과, prettier·eslint·tsc 통과