### PR TITLE
chore : istio-proxy 로그 본문 중복 ts·level 제거 (message 축약)

### DIFF
--- a/infra/helm/alloy/values.yaml
+++ b/infra/helm/alloy/values.yaml
@@ -166,6 +166,22 @@ alloy:
             }
           }
 
+          // istio-proxy(사이드카) 로그는 plain text라 자체 ts·level·scope를
+          // 본문에 담는다(예: "2026-...Z\tinfo\txdsproxy\tconnected..."). ts·level을
+          // 떼고 나머지(scope+메시지)를 message로 추출 → Grafana ts/level과 중복
+          // 제거되고 본문이 짧아져 BE/FE와 통일된다. level은 라벨로 승격한다.
+          stage.match {
+            selector = "{container=\"istio-proxy\"}"
+            stage.regex {
+              expression = "^[^\\t]+\\t(?P<level>\\w+)\\t(?P<message>.*)$"
+            }
+            stage.labels {
+              values = {
+                level = "",
+              }
+            }
+          }
+
           // BE JSON 로그는 본문을 message만 남긴다. message가 추출된 경우
           // (JSON 파싱 성공)에만 본문을 교체하고, FE nginx 등 plain text는
           // message 키가 없어 stage.output이 no-op 처리되어 원본 라인을 유지한다.


### PR DESCRIPTION
## 이슈
closes #638

## 작업 내용

istio-proxy(사이드카) 로그가 본문에 자체 ts·level·scope를 담아, Grafana ts/level과 **중복**되고 길어서 **wrap으로 2줄처럼** 보이던 문제를 해결한다.

### 변경 (`infra/helm/alloy/values.yaml`)
- `json_parse`에 `stage.match { selector = "{container=\"istio-proxy\"}" }` 추가.
- `stage.regex`로 `^[^\t]+\t(?P<level>\w+)\t(?P<message>.*)$` 파싱 → ts·level을 떼고 message(scope+내용)만 추출.
- level은 라벨로 승격(warn/error가 대시보드 필터에 반영). 기존 `stage.output { source="message" }`가 본문 축약.

### Before → After
```
2026-06-27 17:36:16.115 info  2026-06-27T08:36:16.115606Z  info  xdsproxy  connected to delta upstream...  id=591
→
xdsproxy  connected to delta upstream...  id=591   (level=info 라벨)
```

### 검증
- helm 렌더 OK.
- alloy 실증(`alloy run`, container 라벨별):
  | container | 결과 | level |
  |---|---|---|
  | istio-proxy | `Aborting proxy` / `xdsproxy connected ... id=591` (ts·level 제거) | warn / info |
  | be | `GET /api/x 200 5ms` (무영향) | INFO |
  | redis | `1:M 27 Jun ... Background saving` (원본 유지) | - |
- be/redis는 selector 미매칭으로 무영향 확인.

### 머지 후 후속
- [ ] sync → alloy 재시작 → istio 로그 message 축약 + be/redis 무영향 실로그 확인