### PR TITLE
fix : 주간 계획표 블록 편집 취소 시 빈 블록 누적 해소

### DIFF
--- a/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
@@ -90,6 +90,30 @@ describe("WeeklyPlan", () => {
     ).toBeInTheDocument();
   });
 
+  it("편집을 취소하면 블록이 추가되지 않고 누적되지 않는다", async () => {
+    mockPlan([]);
+    const user = userEvent.setup();
+    renderWithRouter(<WeeklyPlan />);
+
+    // 두 번 생성 시도 후 모두 취소 → 블록 누적 0, 미저장 변경 없음
+    for (let i = 0; i < 2; i++) {
+      await user.click(await screen.findByLabelText("수요일 9시 추가"));
+      const dialog = await screen.findByRole("dialog");
+      await user.click(within(dialog).getByRole("button", { name: "취소" }));
+      await waitFor(() =>
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+      );
+    }
+
+    expect(
+      screen.queryByRole("button", { name: /\(라벨 없음\)/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/빈 한 주입니다/)).toBeInTheDocument();
+    expect(
+      screen.queryByText("저장되지 않은 변경이 있습니다"),
+    ).not.toBeInTheDocument();
+  });
+
   it("저장은 PUT으로 전량 교체하고 성공 토스트를 띄운다", async () => {
     mockPlan([
       {

--- a/fe/src/features/planner/components/plan/WeeklyPlan.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.tsx
@@ -52,14 +52,19 @@ export function WeeklyPlan() {
     }
   }, [data]);
 
+  // 새 블록은 draft로 모달만 연다(아직 grid에 추가하지 않음).
+  // 적용을 눌러야 확정되므로 backdrop/취소로 닫으면 누적되지 않는다.
   const handleCreate = (block: EditableBlock) => {
-    setBlocks((prev) => [...prev, block]);
-    setDirty(true);
     setEditing(block);
   };
 
+  // 적용: 기존 블록이면 교체, draft(미존재)면 추가(확정).
   const handleSaveBlock = (updated: EditableBlock) => {
-    setBlocks((prev) => prev.map((b) => (b.key === updated.key ? updated : b)));
+    setBlocks((prev) =>
+      prev.some((b) => b.key === updated.key)
+        ? prev.map((b) => (b.key === updated.key ? updated : b))
+        : [...prev, updated],
+    );
     setDirty(true);
     setEditing(null);
   };


### PR DESCRIPTION
## 이슈
closes #640

## 문제
주간 계획표(`/planner/plan`)에서 빈 칸을 클릭하면 블록이 생성되며 편집 모달이 뜬다. 모달을 **backdrop(블러된 뒷편) 또는 [취소]** 로 닫아도 (라벨 없는) 블록이 그리드에 남고, 반복하면 **계속 누적**됐다(미저장이라 새로고침하면 사라짐).

## 원인
빈 칸 클릭 시 `handleCreate`가 모달을 열면서 **동시에 블록을 `blocks` 상태에 즉시 추가**했다. backdrop/취소로 닫는 건 저장이 아니라 추가된 블록이 폐기되지 않았다.

## 수정
- **빈 칸 클릭은 draft로 모달만 연다** — `handleCreate`는 `setEditing`만 하고 grid에 추가하지 않음
- **[적용] 시에만 확정** — `handleSaveBlock`을 upsert로(기존 블록이면 교체, draft면 추가)
- 결과: backdrop·취소로 닫으면 누적 없이 폐기되고, 미저장 변경 표시도 생기지 않음

## 테스트
- 회귀 테스트 추가: 2회 생성 시도 후 모두 취소 → 블록 0개·"저장되지 않은 변경" 미표시
- 기존 "칸 클릭→적용→그리드 반영" 테스트는 그대로 통과(적용 시 draft 확정)
- 전체 FE 테스트(199) 통과, prettier·eslint·tsc·build 통과