### PR TITLE
feat : 주간 계획표 — [+ 추가] 버튼 + 여러 요일 동시 선택, 블록 구분·컴팩트

### DIFF
--- a/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -88,6 +88,46 @@ describe("WeeklyPlan", () => {
     expect(
       screen.getByText("저장되지 않은 변경이 있습니다"),
     ).toBeInTheDocument();
+  });
+
+  it("세로 드래그로 구간 블록을 만든다(스냅 단위)", async () => {
+    mockPlan([]);
+    const user = userEvent.setup();
+    // 컬럼 높이를 1440px로 고정 → 1px = 1분
+    const originalRect = Element.prototype.getBoundingClientRect;
+    Element.prototype.getBoundingClientRect = () =>
+      ({
+        top: 0,
+        left: 0,
+        right: 100,
+        bottom: 1440,
+        width: 100,
+        height: 1440,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      }) as DOMRect;
+    try {
+      renderWithRouter(<WeeklyPlan />);
+
+      // 수요일 컬럼 = "수요일 0시 추가" 칸의 부모
+      const column = (await screen.findByLabelText("수요일 0시 추가"))
+        .parentElement as HTMLElement;
+      // 09:00(540) → 11:30(690) 드래그
+      fireEvent.pointerDown(column, { clientY: 540, pointerId: 1 });
+      fireEvent.pointerMove(column, { clientY: 690, pointerId: 1 });
+      fireEvent.pointerUp(column, { clientY: 690, pointerId: 1 });
+
+      const dialog = await screen.findByRole("dialog");
+      await user.type(within(dialog).getByLabelText("라벨"), "공부");
+      await user.click(within(dialog).getByRole("button", { name: "적용" }));
+
+      expect(
+        await screen.findByRole("button", { name: "공부 09:00~11:30" }),
+      ).toBeInTheDocument();
+    } finally {
+      Element.prototype.getBoundingClientRect = originalRect;
+    }
   });
 
   it("편집을 취소하면 블록이 추가되지 않고 누적되지 않는다", async () => {

--- a/fe/src/features/planner/components/plan/WeeklyPlan.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.tsx
@@ -9,6 +9,8 @@ import { PlanBlockEditor } from "./PlanBlockEditor";
 import {
   DAY_LABELS,
   type EditableBlock,
+  SNAP_OPTIONS,
+  type SnapMinutes,
   toEditable,
   toInput,
 } from "./planGrid";
@@ -44,6 +46,7 @@ export function WeeklyPlan() {
   const [dirty, setDirty] = useState(false);
   const [editing, setEditing] = useState<EditableBlock | null>(null);
   const [mobileDay, setMobileDay] = useState(new Date().getDay());
+  const [snapMinutes, setSnapMinutes] = useState<SnapMinutes>(30);
 
   useEffect(() => {
     if (data) {
@@ -92,13 +95,37 @@ export function WeeklyPlan() {
             </p>
           )}
         </div>
-        <Button
-          size="sm"
-          onClick={handleSaveAll}
-          disabled={!dirty || save.isPending}
-        >
-          {save.isPending ? "저장 중…" : "저장"}
-        </Button>
+        <div className="flex items-center gap-2">
+          <div
+            className="flex overflow-hidden rounded-md border"
+            role="group"
+            aria-label="스냅 단위"
+          >
+            {SNAP_OPTIONS.map((min) => (
+              <button
+                key={min}
+                type="button"
+                aria-pressed={snapMinutes === min}
+                onClick={() => setSnapMinutes(min)}
+                className={cn(
+                  "px-2 py-1 text-xs font-medium",
+                  snapMinutes === min
+                    ? "bg-primary text-primary-foreground"
+                    : "text-foreground/70 hover:bg-muted",
+                )}
+              >
+                {min}분
+              </button>
+            ))}
+          </div>
+          <Button
+            size="sm"
+            onClick={handleSaveAll}
+            disabled={!dirty || save.isPending}
+          >
+            {save.isPending ? "저장 중…" : "저장"}
+          </Button>
+        </div>
       </header>
 
       {narrow && (
@@ -139,6 +166,7 @@ export function WeeklyPlan() {
           <WeeklyPlanGrid
             blocks={blocks}
             days={days}
+            snapMinutes={snapMinutes}
             onCreate={handleCreate}
             onSelect={setEditing}
           />

--- a/fe/src/features/planner/components/plan/WeeklyPlanGrid.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlanGrid.tsx
@@ -1,68 +1,110 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
-import { blockColorClass, DEFAULT_COLOR } from "./planColors";
+import { blockColorClass } from "./planColors";
 import {
+  blockAtHour,
+  blockFromRange,
   DAY_LABELS,
   DAY_LABELS_LONG,
   type EditableBlock,
   heightRatio,
   HOUR_PX,
   layoutDay,
-  MAX_MINUTE,
-  minutesToTime,
-  nextKey,
   topRatio,
+  yToMinutes,
 } from "./planGrid";
 
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 const COLUMN_HEIGHT = 24 * HOUR_PX;
+const DAY_MINUTES = 24 * 60;
 
 interface WeeklyPlanGridProps {
   blocks: EditableBlock[];
   /** 표시할 요일 인덱스(데스크탑 0~6, 모바일 단일). */
   days: number[];
-  /** 빈 영역 클릭/드래그로 새 블록 생성. */
+  /** 드래그/클릭 생성 스냅 단위(분). */
+  snapMinutes: number;
+  /** 빈 영역 클릭(1시간)/드래그(구간)로 새 블록 생성. */
   onCreate: (block: EditableBlock) => void;
   /** 블록 클릭 → 편집. */
   onSelect: (block: EditableBlock) => void;
 }
 
-/** 일~토 × 시간축 그리드. 시간 칸 클릭=1시간 생성, 세로 드래그=구간 생성, 블록 클릭=편집. */
+interface Draft {
+  day: number;
+  startMin: number;
+  endMin: number;
+}
+
+/** 일~토 × 시간축 그리드. 빈 영역 세로 드래그=구간 생성(연속·스냅), 칸 클릭=1시간, 블록 클릭=편집. */
 export function WeeklyPlanGrid({
   blocks,
   days,
+  snapMinutes,
   onCreate,
   onSelect,
 }: WeeklyPlanGridProps) {
-  const dragRef = useRef<{ day: number; start: number; end: number } | null>(
-    null,
-  );
+  const dragRef = useRef<{
+    day: number;
+    startMin: number;
+    moved: boolean;
+  } | null>(null);
+  const suppressClickRef = useRef(false);
+  const [draft, setDraft] = useState<Draft | null>(null);
 
-  const startDrag = (day: number, hour: number) => {
-    dragRef.current = { day, start: hour, end: hour };
+  const minuteAt = (e: React.PointerEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    return yToMinutes(e.clientY - rect.top, rect.height, snapMinutes);
   };
-  const extendDrag = (day: number, hour: number) => {
-    if (dragRef.current && dragRef.current.day === day) {
-      dragRef.current.end = hour;
+
+  const handlePointerDown = (
+    day: number,
+    e: React.PointerEvent<HTMLDivElement>,
+  ) => {
+    // 블록 위에서 시작한 포인터는 편집(클릭)이므로 드래그 생성 시작 안 함
+    if ((e.target as HTMLElement).closest("[data-plan-block]")) return;
+    const startMin = minuteAt(e);
+    dragRef.current = { day, startMin, moved: false };
+    setDraft({ day, startMin, endMin: startMin });
+    if (e.currentTarget.setPointerCapture) {
+      e.currentTarget.setPointerCapture(e.pointerId);
     }
   };
-  const endDrag = () => {
+
+  const handlePointerMove = (
+    day: number,
+    e: React.PointerEvent<HTMLDivElement>,
+  ) => {
+    const drag = dragRef.current;
+    if (!drag || drag.day !== day) return;
+    const endMin = minuteAt(e);
+    if (Math.abs(endMin - drag.startMin) >= snapMinutes) drag.moved = true;
+    setDraft({ day, startMin: drag.startMin, endMin });
+  };
+
+  const handlePointerUp = (
+    day: number,
+    e: React.PointerEvent<HTMLDivElement>,
+  ) => {
     const drag = dragRef.current;
     dragRef.current = null;
-    if (!drag) return;
-    const lo = Math.min(drag.start, drag.end);
-    const hi = Math.max(drag.start, drag.end);
-    onCreate({
-      key: nextKey(),
-      id: null,
-      dayOfWeek: drag.day,
-      startTime: minutesToTime(lo * 60),
-      endTime: minutesToTime(Math.min((hi + 1) * 60, MAX_MINUTE)),
-      label: "",
-      color: DEFAULT_COLOR,
-    });
+    setDraft(null);
+    if (!drag || drag.day !== day) return;
+    suppressClickRef.current = drag.moved;
+    if (drag.moved) {
+      onCreate(blockFromRange(day, drag.startMin, minuteAt(e), snapMinutes));
+    }
+  };
+
+  const handleHourClick = (day: number, hour: number) => {
+    // 드래그로 생성한 경우 뒤따르는 click은 무시(중복 방지)
+    if (suppressClickRef.current) {
+      suppressClickRef.current = false;
+      return;
+    }
+    onCreate(blockAtHour(day, hour));
   };
 
   return (
@@ -70,10 +112,9 @@ export function WeeklyPlanGrid({
       <div
         className="grid min-w-fit"
         style={{
-          gridTemplateColumns: `3rem repeat(${days.length}, minmax(6rem, 1fr))`,
+          gridTemplateColumns: `3rem repeat(${days.length}, minmax(5rem, 1fr))`,
         }}
       >
-        {/* 헤더: 빈 코너 + 요일 */}
         <div className="border-border bg-background sticky top-0 z-10 border-b" />
         {days.map((day) => (
           <div
@@ -101,11 +142,13 @@ export function WeeklyPlanGrid({
         {days.map((day) => (
           <div
             key={day}
-            className="border-border relative border-l"
+            className="border-border relative touch-none border-l"
             style={{ height: COLUMN_HEIGHT }}
-            onPointerUp={endDrag}
+            onPointerDown={(e) => handlePointerDown(day, e)}
+            onPointerMove={(e) => handlePointerMove(day, e)}
+            onPointerUp={(e) => handlePointerUp(day, e)}
           >
-            {/* 시간 칸(생성용) */}
+            {/* 시간 칸(클릭=1시간 생성) */}
             {HOURS.map((hour) => (
               <button
                 key={hour}
@@ -113,20 +156,36 @@ export function WeeklyPlanGrid({
                 aria-label={`${DAY_LABELS_LONG[day]} ${hour}시 추가`}
                 className="border-border/40 hover:bg-muted/40 absolute inset-x-0 border-t"
                 style={{ top: hour * HOUR_PX, height: HOUR_PX }}
-                onPointerDown={() => startDrag(day, hour)}
-                onPointerEnter={() => extendDrag(day, hour)}
+                onClick={() => handleHourClick(day, hour)}
               />
             ))}
+
+            {/* 드래그 미리보기 */}
+            {draft && draft.day === day && (
+              <div
+                className="bg-primary/30 border-primary pointer-events-none absolute inset-x-0 rounded border"
+                style={{
+                  top:
+                    (Math.min(draft.startMin, draft.endMin) / DAY_MINUTES) *
+                    COLUMN_HEIGHT,
+                  height:
+                    (Math.abs(draft.endMin - draft.startMin) / DAY_MINUTES) *
+                    COLUMN_HEIGHT,
+                }}
+              />
+            )}
 
             {/* 블록 */}
             {layoutDay(blocks.filter((b) => b.dayOfWeek === day)).map((b) => (
               <button
                 key={b.key}
                 type="button"
+                data-plan-block
                 aria-label={`${b.label || "(라벨 없음)"} ${b.startTime}~${b.endTime}`}
                 onClick={() => onSelect(b)}
                 className={cn(
-                  "absolute overflow-hidden rounded px-1 py-0.5 text-left text-[11px] leading-tight text-white shadow-sm",
+                  // border-background로 인접(같은 색) 블록 사이에 seam을 만든다
+                  "border-background absolute overflow-hidden rounded border px-1 py-0.5 text-left text-[11px] leading-tight text-white shadow-sm",
                   blockColorClass(b.color),
                 )}
                 style={{
@@ -136,7 +195,10 @@ export function WeeklyPlanGrid({
                   width: `${b.width * 100}%`,
                 }}
               >
-                <span className="font-semibold">{b.startTime}</span> {b.label}
+                <span className="block font-semibold">
+                  {b.startTime}–{b.endTime}
+                </span>
+                <span className="block truncate">{b.label}</span>
               </button>
             ))}
           </div>

--- a/fe/src/features/planner/components/plan/planGrid.test.ts
+++ b/fe/src/features/planner/components/plan/planGrid.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   blockAtHour,
+  blockFromRange,
   type EditableBlock,
   isReversed,
   layoutDay,
@@ -9,6 +10,7 @@ import {
   nextKey,
   snap,
   timeToMinutes,
+  yToMinutes,
 } from "./planGrid";
 
 function block(start: string, end: string): EditableBlock {
@@ -36,6 +38,30 @@ describe("planGrid", () => {
     expect(snap(46)).toBe(60);
     expect(snap(74)).toBe(60);
     expect(snap(75)).toBe(90); // 정확히 중간은 올림
+  });
+
+  it("snap은 step 단위(60/15/5)로 스냅한다", () => {
+    expect(snap(40, 60)).toBe(60);
+    expect(snap(40, 15)).toBe(45);
+    expect(snap(42, 5)).toBe(40);
+  });
+
+  it("yToMinutes는 픽셀→분을 step 단위로 스냅(height=1440이면 1px=1분)", () => {
+    expect(yToMinutes(545, 1440, 30)).toBe(540); // 09:00
+    expect(yToMinutes(550, 1440, 15)).toBe(555); // 09:15
+    expect(yToMinutes(542, 1440, 5)).toBe(540);
+  });
+
+  it("blockFromRange는 역방향 보정·최소 한 칸 보장", () => {
+    expect(blockFromRange(1, 600, 540, 30)).toMatchObject({
+      startTime: "09:00",
+      endTime: "10:00",
+    });
+    // 같은 지점(클릭)은 최소 step 길이
+    expect(blockFromRange(1, 540, 540, 30)).toMatchObject({
+      startTime: "09:00",
+      endTime: "09:30",
+    });
   });
 
   it("isReversed는 종료<=시작이면 true", () => {

--- a/fe/src/features/planner/components/plan/planGrid.ts
+++ b/fe/src/features/planner/components/plan/planGrid.ts
@@ -15,9 +15,12 @@ export const DAY_LABELS_LONG = [
   "토요일",
 ];
 
-export const HOUR_PX = 44;
+export const HOUR_PX = 32; // 더 컴팩트하게(0~24 더 한눈에)
 export const DAY_MINUTES = 24 * 60;
 export const SNAP_MINUTES = 30;
+/** 사용자가 고를 수 있는 스냅 단위(분). */
+export const SNAP_OPTIONS = [60, 30, 15, 5] as const;
+export type SnapMinutes = (typeof SNAP_OPTIONS)[number];
 export const MAX_MINUTE = DAY_MINUTES - 1; // 23:59
 
 /** 클라이언트 편집용 블록. 저장 전(id=null)·저장 후(id) 모두 표현하며 React key로 {@link EditableBlock.key} 사용. */
@@ -76,10 +79,36 @@ export function heightRatio(startTime: string, endTime: string): number {
   return (timeToMinutes(endTime) - timeToMinutes(startTime)) / DAY_MINUTES;
 }
 
-/** 그리드 세로 픽셀 → 스냅된 분(0..1440). 드래그/클릭 위치 계산용. */
-export function yToMinutes(y: number, heightPx: number): number {
+/** 그리드 세로 픽셀 → 스냅된 분(0..1440). 드래그/클릭 위치 계산용(step 단위 스냅). */
+export function yToMinutes(
+  y: number,
+  heightPx: number,
+  step: number = SNAP_MINUTES,
+): number {
   const ratio = heightPx <= 0 ? 0 : Math.max(0, Math.min(1, y / heightPx));
-  return snap(Math.round(ratio * DAY_MINUTES));
+  return snap(Math.round(ratio * DAY_MINUTES), step);
+}
+
+/** 드래그 구간(분) → 블록. 최소 한 칸(step) 보장하고 23:59로 클램프. */
+export function blockFromRange(
+  dayOfWeek: number,
+  startMin: number,
+  endMin: number,
+  step: number = SNAP_MINUTES,
+  color: string | null = DEFAULT_COLOR,
+): EditableBlock {
+  const lo = Math.min(startMin, endMin);
+  const hi = Math.max(startMin, endMin);
+  const end = Math.min(Math.max(hi, lo + step), MAX_MINUTE);
+  return {
+    key: nextKey(),
+    id: null,
+    dayOfWeek,
+    startTime: minutesToTime(lo),
+    endTime: minutesToTime(end),
+    label: "",
+    color,
+  };
 }
 
 /** 특정 요일·시(hour)에 1시간 기본 블록 생성(마지막 시간대는 23:59까지). */


### PR DESCRIPTION
## 이슈
closes #642

## 작업 내용
주간 계획표 그리드 UX 개선(WP1 #636 후속). **사용자 피드백으로 방향 전환**: 드래그 생성은 제거하고, 캘린더처럼 **우상단 [+ 추가] 버튼 + 폼**으로 생성한다. 추가 시 **여러 요일을 동시에 선택**해 같은 블록을 한 번에 만들 수 있다.

- **드래그 제거**: 드래그/스냅 단위/시간 칸 클릭 생성 제거 → 그리드는 **표시 + 블록 클릭 편집**만
- **[+ 추가] 버튼**(우상단) → `PlanBlockCreate` 모달
  - **요일 복수 선택(일~토)** + 라벨 + 시작/종료(**분 단위 자유 입력**) + 색
  - 선택한 요일마다 블록 생성. 요일 미선택/시간 역전/빈 라벨이면 [추가] 비활성
- **블록 구분 유지**: 테두리(seam) + 시간·라벨 항상 표시(같은 색 연속도 구분)
- **컴팩트 유지**: 시간당 높이 32px로 0~24 더 한눈에
- 블록 클릭 → 편집 모달(요일·라벨·색·시간·삭제), 시간 역전 차단

## 메모
- 분 단위 정밀도는 생성/편집 **폼의 시간 입력**이 담당(드래그 스냅 불필요)
- 기존 "드래그·스냅" 접근은 사용자 요청으로 폐기, 본 PR이 최종 설계

## 테스트
- `planGrid.test.ts`: `createBlocks`(여러 요일 동일 블록)·시간 변환·역전·겹침 레이아웃
- `WeeklyPlan.test.tsx`: [+ 추가] 멀티 요일 생성·추가 취소 누적 방지·전량 교체 저장·편집 역전 차단·삭제·모바일 1일 뷰
- 전체 FE 테스트(198) 통과, prettier·eslint·tsc·build 통과