### PR TITLE
feat : alloy 로그 수집을 loki.source.file로 전환 (stage.match 정석 동작)

### DIFF
--- a/infra/helm/alloy/values.yaml
+++ b/infra/helm/alloy/values.yaml
@@ -118,13 +118,28 @@ alloy:
           }
         }
 
-        loki.source.kubernetes "pods" {
-          targets    = discovery.relabel.pods.output
+        // /var/log/pods의 컨테이너 로그 파일을 직접 tail한다(promtail 표준 방식).
+        // loki.source.kubernetes(API tailer)와 달리 discovery.relabel 라벨이
+        // 파이프라인 스트림 라벨로 실려, stage.match selector가 정상 동작한다.
+        local.file_match "pods" {
+          path_targets = discovery.relabel.pods.output
+        }
+
+        loki.source.file "pods" {
+          targets    = local.file_match.pods.targets
           forward_to = [loki.process.json_parse.receiver]
+          // 저장된 position이 없을 때 파일 끝부터 읽는다. 최초 전환·position
+          // 유실 시 과거 로그를 재수집해 Loki retention('too old')을 때리는
+          // 노이즈를 막는다(아래 hostPath position 저장과 함께).
+          tail_from_end = true
         }
 
         // JSON 로그 파싱 (BE prod 로그: LogstashEncoder)
         loki.process "json_parse" {
+          // /var/log/pods 파일은 CRI 포맷("<ts> <stream> <P|F> <log>")이므로
+          // 먼저 stage.cri로 실제 로그 라인을 추출한다(부분 로그 F/P도 합침).
+          stage.cri { }
+
           stage.json {
             expressions = {
               level       = "level",
@@ -200,6 +215,17 @@ alloy:
           }
         }
 
+    # alloy 컴포넌트 상태(loki.source.file의 읽기 position 등)를 노드 hostPath에
+    # 저장해 Pod 재시작에도 위치를 유지한다(로그 누락·중복 방지).
+    storagePath: /var/lib/alloy
+    # /var/log hostPath 마운트(read-only) — loki.source.file이 /var/log/pods의
+    # 컨테이너 로그 파일을 직접 읽는다. position은 alloy-data(hostPath)에 저장.
+    mounts:
+      varlog: true
+      extra:
+        - name: alloy-data
+          mountPath: /var/lib/alloy
+
     # FARO_API_KEY 환경변수 주입 (alloy-faro-secret)
     envFrom:
       - secretRef:
@@ -221,6 +247,12 @@ alloy:
 
   controller:
     type: daemonset
+    volumes:
+      extra:
+        - name: alloy-data
+          hostPath:
+            path: /var/lib/alloy
+            type: DirectoryOrCreate
 
   resources:
     requests:


### PR DESCRIPTION
## 이슈
closes #644

## 작업 내용

istio 로그 정리의 stage.match가 `loki.source.kubernetes`에서 미동작하던 것을, **수집을 `loki.source.file`(promtail 표준)로 전환**해 정석으로 동작시킨다.

### 원인
`loki.source.kubernetes`(API tailer)는 discovery.relabel 라벨(container 등)을 파이프라인 스트림 라벨로 싣지 않아 `stage.match` selector가 매칭 안 됨(실측 — loki.source.file에선 됨).

### 변경 (`infra/helm/alloy/values.yaml`)
- `loki.source.kubernetes` → `local.file_match` + `loki.source.file` (/var/log/pods 직접 tail).
- `mounts.varlog: true` → `/var/log` hostPath(ro) 마운트.
- `stage.cri {}` → 컨테이너 로그 CRI 포맷 파싱.
- `tail_from_end = true` → 최초/position 유실 시 과거 로그 재수집(retention 'too old') 노이즈 방지.
- `storagePath: /var/lib/alloy` + hostPath 볼륨 → position 영구화(재시작 누락·중복 방지).
- istio `stage.match`(container=istio-proxy) 그대로 → 본문 ts·level 제거, message 축약, level 라벨.

### 검증 (배포 전 실증)
- `/var/log` 마운트한 **임시 테스트 파드**로 실제 파이프라인 실증:
  - CRI 파싱 정상, **stage.match 동작 확인** — istio 로그가 `Envoy proxy is ready`(level=info)처럼 ts·level 제거되어 축약됨.
  - metrics-server/prometheus 등은 미매칭(무영향), istio만 level 라벨.
- helm 렌더 OK, alloy fmt 문법 OK.

### ⚠️ 배포 후 필수 검증 (로그 수집 핵심 변경)
- [ ] 전체 네임스페이스 로그 수집 정상(누락 없음) — be/fe/redis/istio/시스템
- [ ] stage.match 동작(istio 축약), CRI 파싱, message 축약
- [ ] 'timestamp too old' 노이즈 없음(tail_from_end)
- [ ] position hostPath 생성 + 재시작 시 이어읽기
- 문제 시 `git revert` + sync로 즉시 롤백

### 참고
- loki.source.file 전환으로 RBAC `pods/log`는 불필요해짐(discovery용 pods get/list/watch는 유지). 권한 축소는 별도 후속.