### PR TITLE
chore : fe nginx error_log를 warn 레벨로 (notice 노이즈 제거)

### DIFF
--- a/fe/Dockerfile
+++ b/fe/Dockerfile
@@ -11,5 +11,7 @@ FROM nginx:alpine
 ARG CACHEBUST=unknown
 RUN echo "cachebust ${CACHEBUST}" && apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+# nginx.conf=메인(error_log warn), default.conf=server(+access log JSON)
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/fe/default.conf
+++ b/fe/default.conf
@@ -1,0 +1,43 @@
+# 접근 로그를 JSON으로 — alloy가 message만 추출해 BE 로그와 동일하게 본문을
+# 축약하고, 식별 필드(client_ip·user_agent)는 structured metadata로 보존한다.
+# (conf.d/*.conf는 http 컨텍스트에 include되므로 여기서 log_format·map 정의 가능)
+map $status $fe_log_level {
+    ~^[23] info;
+    ~^4    warn;
+    ~^5    error;
+    default info;
+}
+log_format app_json escape=json
+    '{'
+        '"message":"$request_method $request_uri $status $body_bytes_sent",'
+        '"level":"$fe_log_level",'
+        '"client_ip":"$http_x_forwarded_for",'
+        '"user_agent":"$http_user_agent"'
+    '}';
+
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    access_log /var/log/nginx/access.log app_json;
+
+    # 해시 파일명 asset(JS/CSS/이미지 등): 내용이 바뀌면 파일명도 바뀌므로 불변·장기 캐시.
+    # 없는 파일은 index.html로 폴백하지 않고 404 → 옛 해시 요청 시 text/html(MIME 에러) 방지.
+    location /assets/ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
+    # SPA 라우팅: 그 외 경로는 index.html로
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # index.html은 절대 캐시하지 않는다.
+    # (배포마다 새 asset 해시를 가리켜야 하는데, 캐시되면 옛 해시를 요청해 깨진다)
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        expires off;
+    }
+}

--- a/fe/nginx.conf
+++ b/fe/nginx.conf
@@ -1,43 +1,23 @@
-# 접근 로그를 JSON으로 — alloy가 message만 추출해 BE 로그와 동일하게 본문을
-# 축약하고, 식별 필드(client_ip·user_agent)는 structured metadata로 보존한다.
-# (conf.d/*.conf는 http 컨텍스트에 include되므로 여기서 log_format·map 정의 가능)
-map $status $fe_log_level {
-    ~^[23] info;
-    ~^4    warn;
-    ~^5    error;
-    default info;
+# nginx 메인 설정. nginx:alpine 기본값을 기준으로 error_log 레벨만 조정한다.
+# (server 블록과 access log(app_json)는 conf.d/default.conf에서 관리)
+user  nginx;
+worker_processes  auto;
+
+# 기본 notice → warn: worker 종료/시작·signal 수신 등 정상 동작까지 stderr
+# 노이즈로 남기던 것을 줄이고, 실제 경고·에러(warn/error/crit)만 남긴다.
+error_log  /var/log/nginx/error.log warn;
+pid        /run/nginx.pid;
+
+events {
+    worker_connections  1024;
 }
-log_format app_json escape=json
-    '{'
-        '"message":"$request_method $request_uri $status $body_bytes_sent",'
-        '"level":"$fe_log_level",'
-        '"client_ip":"$http_x_forwarded_for",'
-        '"user_agent":"$http_user_agent"'
-    '}';
 
-server {
-    listen 80;
-    root /usr/share/nginx/html;
-    index index.html;
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
 
-    access_log /var/log/nginx/access.log app_json;
+    sendfile           on;
+    keepalive_timeout  65;
 
-    # 해시 파일명 asset(JS/CSS/이미지 등): 내용이 바뀌면 파일명도 바뀌므로 불변·장기 캐시.
-    # 없는 파일은 index.html로 폴백하지 않고 404 → 옛 해시 요청 시 text/html(MIME 에러) 방지.
-    location /assets/ {
-        try_files $uri =404;
-        add_header Cache-Control "public, max-age=31536000, immutable" always;
-    }
-
-    # SPA 라우팅: 그 외 경로는 index.html로
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-
-    # index.html은 절대 캐시하지 않는다.
-    # (배포마다 새 asset 해시를 가리켜야 하는데, 캐시되면 옛 해시를 요청해 깨진다)
-    location = /index.html {
-        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
-        expires off;
-    }
+    include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
## 이슈
closes #646

## 작업 내용

fe nginx **error log**(stderr)의 `notice` 노이즈를 제거한다. sed in-place 대신 **메인 nginx.conf를 레포에서 선언적으로 관리(COPY)** — silent fail 방지.

### 변경 (`fe/`)
- `nginx.conf` = 메인 설정 (nginx:alpine 기본 기준, `error_log ... warn`).
- `default.conf` = server 블록 + access log JSON (기존 nginx.conf에서 이동).
- `Dockerfile`: `COPY nginx.conf /etc/nginx/nginx.conf` + `COPY default.conf /etc/nginx/conf.d/default.conf`.

### Before → After (fe stderr)
```
2026/06/27 09:25:28 [notice] 1#1: worker process exited / signal received  ← 제거
```
warn/error/crit만 남음. (access log는 stdout JSON으로 별개 정리됨)

### 검증
- `docker run nginx -t` → syntax ok, `error_log ... warn` 확인.

### 머지 후
- [ ] FE 빌드·배포 후 fe stderr notice 사라짐 확인