### PR TITLE
feat : 주간 계획표 — [+ 추가] 버튼 + 여러 요일 동시 선택 (드래그 제거)

### DIFF
--- a/fe/src/features/planner/components/plan/PlanBlockCreate.tsx
+++ b/fe/src/features/planner/components/plan/PlanBlockCreate.tsx
@@ -1,0 +1,179 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { cn } from "@/lib/utils";
+
+import { DEFAULT_COLOR, PLAN_COLORS } from "./planColors";
+import {
+  createBlocks,
+  DAY_LABELS,
+  type EditableBlock,
+  isReversed,
+} from "./planGrid";
+
+interface PlanBlockCreateProps {
+  open: boolean;
+  onCreate: (blocks: EditableBlock[]) => void;
+  onClose: () => void;
+}
+
+/** 블록 추가 모달: 여러 요일을 동시에 선택해 같은 시간/라벨/색의 블록을 한 번에 만든다. */
+export function PlanBlockCreate({
+  open,
+  onCreate,
+  onClose,
+}: PlanBlockCreateProps) {
+  const [days, setDays] = useState<Set<number>>(new Set());
+  const [label, setLabel] = useState("");
+  const [startTime, setStartTime] = useState("09:00");
+  const [endTime, setEndTime] = useState("10:00");
+  const [color, setColor] = useState(DEFAULT_COLOR);
+
+  useEffect(() => {
+    if (open) {
+      setDays(new Set());
+      setLabel("");
+      setStartTime("09:00");
+      setEndTime("10:00");
+      setColor(DEFAULT_COLOR);
+    }
+  }, [open]);
+
+  const reversed = isReversed(startTime, endTime);
+  const labelEmpty = label.trim().length === 0;
+  const noDay = days.size === 0;
+  const invalid = reversed || labelEmpty || noDay;
+
+  const toggleDay = (day: number) =>
+    setDays((prev) => {
+      const next = new Set(prev);
+      if (next.has(day)) next.delete(day);
+      else next.add(day);
+      return next;
+    });
+
+  const handleSubmit = () => {
+    if (invalid) return;
+    const sorted = [...days].sort((a, b) => a - b);
+    onCreate(createBlocks(sorted, startTime, endTime, label, color));
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={(o) => !o && onClose()}
+      className="max-w-sm"
+    >
+      <Dialog.Title className="text-base font-semibold">블록 추가</Dialog.Title>
+
+      <div className="mt-4 flex flex-col gap-3">
+        <FormField
+          label="요일(복수 선택)"
+          labelId="create-days"
+          error={noDay ? "요일을 1개 이상 선택하세요." : undefined}
+        >
+          <div
+            className="flex gap-1.5"
+            role="group"
+            aria-labelledby="create-days"
+          >
+            {DAY_LABELS.map((dayLabel, i) => (
+              <label
+                key={dayLabel}
+                className={cn(
+                  "flex flex-1 cursor-pointer items-center justify-center rounded-md border py-1.5 text-xs font-medium",
+                  days.has(i)
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "text-foreground/70 hover:bg-muted",
+                )}
+              >
+                <Checkbox
+                  className="sr-only"
+                  checked={days.has(i)}
+                  onChange={() => toggleDay(i)}
+                />
+                {dayLabel}
+              </label>
+            ))}
+          </div>
+        </FormField>
+
+        <FormField
+          label="라벨"
+          htmlFor="create-label"
+          error={labelEmpty ? "라벨을 입력해 주세요." : undefined}
+        >
+          <Input
+            id="create-label"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="예: 개인 프로젝트"
+          />
+        </FormField>
+
+        <div className="flex gap-3">
+          <FormField label="시작" htmlFor="create-start" className="flex-1">
+            <Input
+              id="create-start"
+              type="time"
+              value={startTime}
+              onChange={(e) => setStartTime(e.target.value)}
+            />
+          </FormField>
+          <FormField
+            label="종료"
+            htmlFor="create-end"
+            className="flex-1"
+            error={reversed ? "종료가 시작보다 늦어야 합니다." : undefined}
+          >
+            <Input
+              id="create-end"
+              type="time"
+              value={endTime}
+              onChange={(e) => setEndTime(e.target.value)}
+            />
+          </FormField>
+        </div>
+
+        <FormField label="색" labelId="create-color">
+          <div
+            className="flex gap-2"
+            role="group"
+            aria-labelledby="create-color"
+          >
+            {PLAN_COLORS.map((c) => (
+              <button
+                key={c.key}
+                type="button"
+                aria-label={c.label}
+                aria-pressed={color === c.key}
+                onClick={() => setColor(c.key)}
+                className={cn(
+                  "size-6 rounded-full ring-offset-2 transition",
+                  c.swatch,
+                  color === c.key
+                    ? "ring-ring ring-2"
+                    : "opacity-70 hover:opacity-100",
+                )}
+              />
+            ))}
+          </div>
+        </FormField>
+      </div>
+
+      <div className="mt-5 flex justify-end gap-2">
+        <Dialog.Close render={<Button variant="outline" size="sm" />}>
+          취소
+        </Dialog.Close>
+        <Button size="sm" onClick={handleSubmit} disabled={invalid}>
+          추가
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -20,7 +20,6 @@ function mockPlan(blocks: unknown[]) {
   );
 }
 
-/** 모바일(좁은 폭) matchMedia로 위장. 기본(데스크탑)은 jsdom에 matchMedia가 없어 자동. */
 function setNarrowViewport() {
   window.matchMedia = ((query: string) => ({
     matches: query.includes("767"),
@@ -70,85 +69,47 @@ describe("WeeklyPlan", () => {
     expect(await screen.findByText(/빈 한 주입니다/)).toBeInTheDocument();
   });
 
-  it("시간 칸을 눌러 블록을 만들고 편집 후 그리드에 반영한다", async () => {
+  it("[+ 추가]로 여러 요일에 블록을 한 번에 만든다", async () => {
     mockPlan([]);
     const user = userEvent.setup();
     renderWithRouter(<WeeklyPlan />);
 
-    // 수요일(dayOfWeek=3) 9시 칸 → 09:00~10:00 블록 생성 + 편집 모달
-    await user.click(await screen.findByLabelText("수요일 9시 추가"));
-
+    await user.click(await screen.findByRole("button", { name: "추가" }));
     const dialog = await screen.findByRole("dialog");
-    await user.type(within(dialog).getByLabelText("라벨"), "회의");
-    await user.click(within(dialog).getByRole("button", { name: "적용" }));
 
+    // 요일 미선택 → 추가 비활성
+    expect(within(dialog).getByRole("button", { name: "추가" })).toBeDisabled();
+
+    await user.click(within(dialog).getByRole("checkbox", { name: "월" }));
+    await user.click(within(dialog).getByRole("checkbox", { name: "수" }));
+    await user.type(within(dialog).getByLabelText("라벨"), "공부");
+    await user.click(within(dialog).getByRole("button", { name: "추가" }));
+
+    // 월·수 두 블록 생성
     expect(
-      await screen.findByRole("button", { name: "회의 09:00~10:00" }),
-    ).toBeInTheDocument();
+      await screen.findAllByRole("button", { name: "공부 09:00~10:00" }),
+    ).toHaveLength(2);
     expect(
       screen.getByText("저장되지 않은 변경이 있습니다"),
     ).toBeInTheDocument();
   });
 
-  it("세로 드래그로 구간 블록을 만든다(스냅 단위)", async () => {
-    mockPlan([]);
-    const user = userEvent.setup();
-    // 컬럼 높이를 1440px로 고정 → 1px = 1분
-    const originalRect = Element.prototype.getBoundingClientRect;
-    Element.prototype.getBoundingClientRect = () =>
-      ({
-        top: 0,
-        left: 0,
-        right: 100,
-        bottom: 1440,
-        width: 100,
-        height: 1440,
-        x: 0,
-        y: 0,
-        toJSON: () => {},
-      }) as DOMRect;
-    try {
-      renderWithRouter(<WeeklyPlan />);
-
-      // 수요일 컬럼 = "수요일 0시 추가" 칸의 부모
-      const column = (await screen.findByLabelText("수요일 0시 추가"))
-        .parentElement as HTMLElement;
-      // 09:00(540) → 11:30(690) 드래그
-      fireEvent.pointerDown(column, { clientY: 540, pointerId: 1 });
-      fireEvent.pointerMove(column, { clientY: 690, pointerId: 1 });
-      fireEvent.pointerUp(column, { clientY: 690, pointerId: 1 });
-
-      const dialog = await screen.findByRole("dialog");
-      await user.type(within(dialog).getByLabelText("라벨"), "공부");
-      await user.click(within(dialog).getByRole("button", { name: "적용" }));
-
-      expect(
-        await screen.findByRole("button", { name: "공부 09:00~11:30" }),
-      ).toBeInTheDocument();
-    } finally {
-      Element.prototype.getBoundingClientRect = originalRect;
-    }
-  });
-
-  it("편집을 취소하면 블록이 추가되지 않고 누적되지 않는다", async () => {
+  it("추가를 취소하면 블록이 생성되지 않는다", async () => {
     mockPlan([]);
     const user = userEvent.setup();
     renderWithRouter(<WeeklyPlan />);
 
-    // 두 번 생성 시도 후 모두 취소 → 블록 누적 0, 미저장 변경 없음
-    for (let i = 0; i < 2; i++) {
-      await user.click(await screen.findByLabelText("수요일 9시 추가"));
-      const dialog = await screen.findByRole("dialog");
-      await user.click(within(dialog).getByRole("button", { name: "취소" }));
-      await waitFor(() =>
-        expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
-      );
-    }
+    await user.click(await screen.findByRole("button", { name: "추가" }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("checkbox", { name: "월" }));
+    await user.click(within(dialog).getByRole("button", { name: "취소" }));
 
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
     expect(
-      screen.queryByRole("button", { name: /\(라벨 없음\)/ }),
+      screen.queryByRole("button", { name: /09:00~10:00/ }),
     ).not.toBeInTheDocument();
-    expect(screen.getByText(/빈 한 주입니다/)).toBeInTheDocument();
     expect(
       screen.queryByText("저장되지 않은 변경이 있습니다"),
     ).not.toBeInTheDocument();
@@ -189,11 +150,12 @@ describe("WeeklyPlan", () => {
       </>,
     );
 
-    // 블록 추가로 dirty 만들기
-    await user.click(await screen.findByLabelText("토요일 10시 추가"));
+    // 토요일에 블록 추가로 dirty
+    await user.click(await screen.findByRole("button", { name: "추가" }));
     const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("checkbox", { name: "토" }));
     await user.type(within(dialog).getByLabelText("라벨"), "운동");
-    await user.click(within(dialog).getByRole("button", { name: "적용" }));
+    await user.click(within(dialog).getByRole("button", { name: "추가" }));
 
     await user.click(screen.getByRole("button", { name: "저장" }));
 
@@ -224,7 +186,6 @@ describe("WeeklyPlan", () => {
       await screen.findByRole("button", { name: "공부 10:00~11:00" }),
     );
     const dialog = await screen.findByRole("dialog");
-    // 종료를 시작보다 이르게
     const end = within(dialog).getByLabelText("종료");
     await user.clear(end);
     await user.type(end, "09:00");
@@ -251,13 +212,11 @@ describe("WeeklyPlan", () => {
     renderWithRouter(<WeeklyPlan />);
 
     const tablist = await screen.findByRole("tablist", { name: "요일 선택" });
-    // 화요일 탭 → 공부 블록 보임
     await user.click(within(tablist).getByRole("tab", { name: "화" }));
     expect(
       await screen.findByRole("button", { name: "공부 10:00~11:00" }),
     ).toBeInTheDocument();
 
-    // 수요일 탭으로 전환하면 화요일 블록은 사라진다(1일 뷰)
     await user.click(within(tablist).getByRole("tab", { name: "수" }));
     expect(
       screen.queryByRole("button", { name: "공부 10:00~11:00" }),

--- a/fe/src/features/planner/components/plan/WeeklyPlan.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.tsx
@@ -1,3 +1,4 @@
+import { Plus } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -5,12 +6,11 @@ import { LoadingText } from "@/components/ui/loading-text";
 import { cn } from "@/lib/utils";
 
 import { useSaveWeeklyPlan, useWeeklyPlan } from "../../hooks/useWeeklyPlan";
+import { PlanBlockCreate } from "./PlanBlockCreate";
 import { PlanBlockEditor } from "./PlanBlockEditor";
 import {
   DAY_LABELS,
   type EditableBlock,
-  SNAP_OPTIONS,
-  type SnapMinutes,
   toEditable,
   toInput,
 } from "./planGrid";
@@ -45,8 +45,8 @@ export function WeeklyPlan() {
   const [blocks, setBlocks] = useState<EditableBlock[]>([]);
   const [dirty, setDirty] = useState(false);
   const [editing, setEditing] = useState<EditableBlock | null>(null);
+  const [creating, setCreating] = useState(false);
   const [mobileDay, setMobileDay] = useState(new Date().getDay());
-  const [snapMinutes, setSnapMinutes] = useState<SnapMinutes>(30);
 
   useEffect(() => {
     if (data) {
@@ -55,19 +55,15 @@ export function WeeklyPlan() {
     }
   }, [data]);
 
-  // 새 블록은 draft로 모달만 연다(아직 grid에 추가하지 않음).
-  // 적용을 눌러야 확정되므로 backdrop/취소로 닫으면 누적되지 않는다.
-  const handleCreate = (block: EditableBlock) => {
-    setEditing(block);
+  // + 버튼 생성: 선택한 여러 요일에 블록을 한 번에 추가.
+  const handleCreate = (created: EditableBlock[]) => {
+    setBlocks((prev) => [...prev, ...created]);
+    setDirty(true);
+    setCreating(false);
   };
 
-  // 적용: 기존 블록이면 교체, draft(미존재)면 추가(확정).
   const handleSaveBlock = (updated: EditableBlock) => {
-    setBlocks((prev) =>
-      prev.some((b) => b.key === updated.key)
-        ? prev.map((b) => (b.key === updated.key ? updated : b))
-        : [...prev, updated],
-    );
+    setBlocks((prev) => prev.map((b) => (b.key === updated.key ? updated : b)));
     setDirty(true);
     setEditing(null);
   };
@@ -96,28 +92,10 @@ export function WeeklyPlan() {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <div
-            className="flex overflow-hidden rounded-md border"
-            role="group"
-            aria-label="스냅 단위"
-          >
-            {SNAP_OPTIONS.map((min) => (
-              <button
-                key={min}
-                type="button"
-                aria-pressed={snapMinutes === min}
-                onClick={() => setSnapMinutes(min)}
-                className={cn(
-                  "px-2 py-1 text-xs font-medium",
-                  snapMinutes === min
-                    ? "bg-primary text-primary-foreground"
-                    : "text-foreground/70 hover:bg-muted",
-                )}
-              >
-                {min}분
-              </button>
-            ))}
-          </div>
+          <Button variant="outline" size="sm" onClick={() => setCreating(true)}>
+            <Plus className="size-4" />
+            추가
+          </Button>
           <Button
             size="sm"
             onClick={handleSaveAll}
@@ -160,18 +138,18 @@ export function WeeklyPlan() {
         <>
           {blocks.length === 0 && (
             <p className="text-muted-foreground rounded-md border border-dashed p-4 text-center text-sm">
-              빈 한 주입니다. 시간대를 눌러 블록을 추가하세요.
+              빈 한 주입니다. 오른쪽 위 [+ 추가]로 블록을 추가하세요.
             </p>
           )}
-          <WeeklyPlanGrid
-            blocks={blocks}
-            days={days}
-            snapMinutes={snapMinutes}
-            onCreate={handleCreate}
-            onSelect={setEditing}
-          />
+          <WeeklyPlanGrid blocks={blocks} days={days} onSelect={setEditing} />
         </>
       )}
+
+      <PlanBlockCreate
+        open={creating}
+        onCreate={handleCreate}
+        onClose={() => setCreating(false)}
+      />
 
       <PlanBlockEditor
         block={editing}

--- a/fe/src/features/planner/components/plan/WeeklyPlanGrid.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlanGrid.tsx
@@ -1,112 +1,32 @@
-import { useRef, useState } from "react";
-
 import { cn } from "@/lib/utils";
 
 import { blockColorClass } from "./planColors";
 import {
-  blockAtHour,
-  blockFromRange,
   DAY_LABELS,
-  DAY_LABELS_LONG,
   type EditableBlock,
   heightRatio,
   HOUR_PX,
   layoutDay,
   topRatio,
-  yToMinutes,
 } from "./planGrid";
 
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 const COLUMN_HEIGHT = 24 * HOUR_PX;
-const DAY_MINUTES = 24 * 60;
 
 interface WeeklyPlanGridProps {
   blocks: EditableBlock[];
   /** 표시할 요일 인덱스(데스크탑 0~6, 모바일 단일). */
   days: number[];
-  /** 드래그/클릭 생성 스냅 단위(분). */
-  snapMinutes: number;
-  /** 빈 영역 클릭(1시간)/드래그(구간)로 새 블록 생성. */
-  onCreate: (block: EditableBlock) => void;
   /** 블록 클릭 → 편집. */
   onSelect: (block: EditableBlock) => void;
 }
 
-interface Draft {
-  day: number;
-  startMin: number;
-  endMin: number;
-}
-
-/** 일~토 × 시간축 그리드. 빈 영역 세로 드래그=구간 생성(연속·스냅), 칸 클릭=1시간, 블록 클릭=편집. */
+/** 일~토 × 시간축 그리드. 표시 + 블록 클릭 편집(생성은 상단 [+ 추가] 버튼). */
 export function WeeklyPlanGrid({
   blocks,
   days,
-  snapMinutes,
-  onCreate,
   onSelect,
 }: WeeklyPlanGridProps) {
-  const dragRef = useRef<{
-    day: number;
-    startMin: number;
-    moved: boolean;
-  } | null>(null);
-  const suppressClickRef = useRef(false);
-  const [draft, setDraft] = useState<Draft | null>(null);
-
-  const minuteAt = (e: React.PointerEvent<HTMLDivElement>) => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    return yToMinutes(e.clientY - rect.top, rect.height, snapMinutes);
-  };
-
-  const handlePointerDown = (
-    day: number,
-    e: React.PointerEvent<HTMLDivElement>,
-  ) => {
-    // 블록 위에서 시작한 포인터는 편집(클릭)이므로 드래그 생성 시작 안 함
-    if ((e.target as HTMLElement).closest("[data-plan-block]")) return;
-    const startMin = minuteAt(e);
-    dragRef.current = { day, startMin, moved: false };
-    setDraft({ day, startMin, endMin: startMin });
-    if (e.currentTarget.setPointerCapture) {
-      e.currentTarget.setPointerCapture(e.pointerId);
-    }
-  };
-
-  const handlePointerMove = (
-    day: number,
-    e: React.PointerEvent<HTMLDivElement>,
-  ) => {
-    const drag = dragRef.current;
-    if (!drag || drag.day !== day) return;
-    const endMin = minuteAt(e);
-    if (Math.abs(endMin - drag.startMin) >= snapMinutes) drag.moved = true;
-    setDraft({ day, startMin: drag.startMin, endMin });
-  };
-
-  const handlePointerUp = (
-    day: number,
-    e: React.PointerEvent<HTMLDivElement>,
-  ) => {
-    const drag = dragRef.current;
-    dragRef.current = null;
-    setDraft(null);
-    if (!drag || drag.day !== day) return;
-    suppressClickRef.current = drag.moved;
-    if (drag.moved) {
-      onCreate(blockFromRange(day, drag.startMin, minuteAt(e), snapMinutes));
-    }
-  };
-
-  const handleHourClick = (day: number, hour: number) => {
-    // 드래그로 생성한 경우 뒤따르는 click은 무시(중복 방지)
-    if (suppressClickRef.current) {
-      suppressClickRef.current = false;
-      return;
-    }
-    onCreate(blockAtHour(day, hour));
-  };
-
   return (
     <div className="overflow-x-auto">
       <div
@@ -142,45 +62,23 @@ export function WeeklyPlanGrid({
         {days.map((day) => (
           <div
             key={day}
-            className="border-border relative touch-none border-l"
+            className="border-border relative border-l"
             style={{ height: COLUMN_HEIGHT }}
-            onPointerDown={(e) => handlePointerDown(day, e)}
-            onPointerMove={(e) => handlePointerMove(day, e)}
-            onPointerUp={(e) => handlePointerUp(day, e)}
           >
-            {/* 시간 칸(클릭=1시간 생성) */}
+            {/* 시간 격자선 */}
             {HOURS.map((hour) => (
-              <button
+              <div
                 key={hour}
-                type="button"
-                aria-label={`${DAY_LABELS_LONG[day]} ${hour}시 추가`}
-                className="border-border/40 hover:bg-muted/40 absolute inset-x-0 border-t"
-                style={{ top: hour * HOUR_PX, height: HOUR_PX }}
-                onClick={() => handleHourClick(day, hour)}
+                className="border-border/40 absolute inset-x-0 border-t"
+                style={{ top: hour * HOUR_PX }}
               />
             ))}
-
-            {/* 드래그 미리보기 */}
-            {draft && draft.day === day && (
-              <div
-                className="bg-primary/30 border-primary pointer-events-none absolute inset-x-0 rounded border"
-                style={{
-                  top:
-                    (Math.min(draft.startMin, draft.endMin) / DAY_MINUTES) *
-                    COLUMN_HEIGHT,
-                  height:
-                    (Math.abs(draft.endMin - draft.startMin) / DAY_MINUTES) *
-                    COLUMN_HEIGHT,
-                }}
-              />
-            )}
 
             {/* 블록 */}
             {layoutDay(blocks.filter((b) => b.dayOfWeek === day)).map((b) => (
               <button
                 key={b.key}
                 type="button"
-                data-plan-block
                 aria-label={`${b.label || "(라벨 없음)"} ${b.startTime}~${b.endTime}`}
                 onClick={() => onSelect(b)}
                 className={cn(

--- a/fe/src/features/planner/components/plan/planGrid.test.ts
+++ b/fe/src/features/planner/components/plan/planGrid.test.ts
@@ -1,16 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  blockAtHour,
-  blockFromRange,
+  createBlocks,
   type EditableBlock,
   isReversed,
   layoutDay,
   minutesToTime,
   nextKey,
-  snap,
   timeToMinutes,
-  yToMinutes,
 } from "./planGrid";
 
 function block(start: string, end: string): EditableBlock {
@@ -33,53 +30,27 @@ describe("planGrid", () => {
     expect(minutesToTime(1500)).toBe("23:59"); // 클램프
   });
 
-  it("snap은 30분 격자로 반올림", () => {
-    expect(snap(40)).toBe(30);
-    expect(snap(46)).toBe(60);
-    expect(snap(74)).toBe(60);
-    expect(snap(75)).toBe(90); // 정확히 중간은 올림
-  });
-
-  it("snap은 step 단위(60/15/5)로 스냅한다", () => {
-    expect(snap(40, 60)).toBe(60);
-    expect(snap(40, 15)).toBe(45);
-    expect(snap(42, 5)).toBe(40);
-  });
-
-  it("yToMinutes는 픽셀→분을 step 단위로 스냅(height=1440이면 1px=1분)", () => {
-    expect(yToMinutes(545, 1440, 30)).toBe(540); // 09:00
-    expect(yToMinutes(550, 1440, 15)).toBe(555); // 09:15
-    expect(yToMinutes(542, 1440, 5)).toBe(540);
-  });
-
-  it("blockFromRange는 역방향 보정·최소 한 칸 보장", () => {
-    expect(blockFromRange(1, 600, 540, 30)).toMatchObject({
-      startTime: "09:00",
-      endTime: "10:00",
-    });
-    // 같은 지점(클릭)은 최소 step 길이
-    expect(blockFromRange(1, 540, 540, 30)).toMatchObject({
-      startTime: "09:00",
-      endTime: "09:30",
-    });
-  });
-
   it("isReversed는 종료<=시작이면 true", () => {
     expect(isReversed("10:00", "09:00")).toBe(true);
     expect(isReversed("10:00", "10:00")).toBe(true);
     expect(isReversed("09:00", "10:00")).toBe(false);
   });
 
-  it("blockAtHour는 1시간 기본 블록, 23시는 23:59까지", () => {
-    expect(blockAtHour(2, 9)).toMatchObject({
-      dayOfWeek: 2,
-      startTime: "09:00",
-      endTime: "10:00",
+  it("createBlocks는 선택한 여러 요일 각각에 동일 블록을 만든다", () => {
+    const blocks = createBlocks([1, 3, 5], "09:00", "10:30", "공부", "sky");
+    expect(blocks).toHaveLength(3);
+    expect(blocks.map((b) => b.dayOfWeek)).toEqual([1, 3, 5]);
+    blocks.forEach((b) => {
+      expect(b).toMatchObject({
+        startTime: "09:00",
+        endTime: "10:30",
+        label: "공부",
+        color: "sky",
+        id: null,
+      });
     });
-    expect(blockAtHour(2, 23)).toMatchObject({
-      startTime: "23:00",
-      endTime: "23:59",
-    });
+    // 각 블록은 고유 key
+    expect(new Set(blocks.map((b) => b.key)).size).toBe(3);
   });
 
   it("겹치지 않는 블록은 전체 폭(width=1)", () => {

--- a/fe/src/features/planner/components/plan/planGrid.ts
+++ b/fe/src/features/planner/components/plan/planGrid.ts
@@ -2,7 +2,6 @@ import type {
   WeeklyPlanBlock,
   WeeklyPlanBlockInput,
 } from "../../api/weeklyPlan";
-import { DEFAULT_COLOR } from "./planColors";
 
 export const DAY_LABELS = ["일", "월", "화", "수", "목", "금", "토"];
 export const DAY_LABELS_LONG = [
@@ -15,12 +14,8 @@ export const DAY_LABELS_LONG = [
   "토요일",
 ];
 
-export const HOUR_PX = 32; // 더 컴팩트하게(0~24 더 한눈에)
+export const HOUR_PX = 32; // 컴팩트하게(0~24 더 한눈에)
 export const DAY_MINUTES = 24 * 60;
-export const SNAP_MINUTES = 30;
-/** 사용자가 고를 수 있는 스냅 단위(분). */
-export const SNAP_OPTIONS = [60, 30, 15, 5] as const;
-export type SnapMinutes = (typeof SNAP_OPTIONS)[number];
 export const MAX_MINUTE = DAY_MINUTES - 1; // 23:59
 
 /** 클라이언트 편집용 블록. 저장 전(id=null)·저장 후(id) 모두 표현하며 React key로 {@link EditableBlock.key} 사용. */
@@ -61,11 +56,6 @@ export function minutesToTime(minutes: number): string {
   return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
 }
 
-/** 가장 가까운 step(기본 30분) 격자로 스냅. */
-export function snap(minutes: number, step = SNAP_MINUTES): number {
-  return Math.round(minutes / step) * step;
-}
-
 /** 종료 ≤ 시작이면 역전(저장 불가). */
 export function isReversed(startTime: string, endTime: string): boolean {
   return timeToMinutes(endTime) <= timeToMinutes(startTime);
@@ -79,51 +69,23 @@ export function heightRatio(startTime: string, endTime: string): number {
   return (timeToMinutes(endTime) - timeToMinutes(startTime)) / DAY_MINUTES;
 }
 
-/** 그리드 세로 픽셀 → 스냅된 분(0..1440). 드래그/클릭 위치 계산용(step 단위 스냅). */
-export function yToMinutes(
-  y: number,
-  heightPx: number,
-  step: number = SNAP_MINUTES,
-): number {
-  const ratio = heightPx <= 0 ? 0 : Math.max(0, Math.min(1, y / heightPx));
-  return snap(Math.round(ratio * DAY_MINUTES), step);
-}
-
-/** 드래그 구간(분) → 블록. 최소 한 칸(step) 보장하고 23:59로 클램프. */
-export function blockFromRange(
-  dayOfWeek: number,
-  startMin: number,
-  endMin: number,
-  step: number = SNAP_MINUTES,
-  color: string | null = DEFAULT_COLOR,
-): EditableBlock {
-  const lo = Math.min(startMin, endMin);
-  const hi = Math.max(startMin, endMin);
-  const end = Math.min(Math.max(hi, lo + step), MAX_MINUTE);
-  return {
+/** 선택한 여러 요일 각각에 같은 시간/라벨/색의 블록을 만든다(+ 버튼 생성). */
+export function createBlocks(
+  days: number[],
+  startTime: string,
+  endTime: string,
+  label: string,
+  color: string | null,
+): EditableBlock[] {
+  return days.map((dayOfWeek) => ({
     key: nextKey(),
     id: null,
     dayOfWeek,
-    startTime: minutesToTime(lo),
-    endTime: minutesToTime(end),
-    label: "",
+    startTime,
+    endTime,
+    label,
     color,
-  };
-}
-
-/** 특정 요일·시(hour)에 1시간 기본 블록 생성(마지막 시간대는 23:59까지). */
-export function blockAtHour(dayOfWeek: number, hour: number): EditableBlock {
-  const startMin = hour * 60;
-  const endMin = Math.min(startMin + 60, MAX_MINUTE);
-  return {
-    key: nextKey(),
-    id: null,
-    dayOfWeek,
-    startTime: minutesToTime(startMin),
-    endTime: minutesToTime(endMin),
-    label: "",
-    color: DEFAULT_COLOR,
-  };
+  }));
 }
 
 /** 서버 블록 → 편집 블록. */


### PR DESCRIPTION
## 이슈
closes #648

## 작업 내용
주간 계획표 생성 UX 변경(#643 머지 후속). 사용자 피드백으로 **드래그 생성을 제거**하고, 캘린더처럼 **우상단 [+ 추가] 버튼 + 폼**으로 생성한다. 추가 시 **여러 요일을 동시에 선택**해 같은 블록을 한 번에 만든다.

- **드래그 제거**: 드래그/스냅 단위/시간 칸 클릭 생성 제거 → 그리드는 **표시 + 블록 클릭 편집**만 (#643에서 추가됐던 드래그/스냅 롤백)
- **[+ 추가] 버튼**(우상단) → `PlanBlockCreate` 모달
  - **요일 복수 선택(일~토)** + 라벨 + 시작/종료(**분 단위 자유**) + 색
  - 선택한 요일마다 블록 생성. 요일 미선택/시간 역전/빈 라벨이면 [추가] 비활성
- **유지**: 블록 테두리(seam)+시간·라벨 표시(색 구분), 컴팩트(시간당 32px)
- 블록 클릭 → 편집 모달(요일·라벨·색·시간·삭제), 역전 차단

## 메모
- 분 단위 정밀도는 생성/편집 폼의 시간 입력이 담당(드래그 스냅 불필요)
- #643이 이미 머지된 뒤 방향 전환 요청을 받아 별도 PR로 진행(머지된 PR에 추가 커밋 금지 규칙 준수)

## 테스트
- `planGrid.test.ts`: `createBlocks`(여러 요일 동일 블록) 등
- `WeeklyPlan.test.tsx`: [+ 추가] 멀티 요일 생성·추가 취소 누적 방지·전량 교체 저장·편집 역전 차단·삭제·모바일
- 전체 FE 테스트(198) 통과, prettier·eslint·tsc·build 통과