### PR TITLE
feat : 주간 계획표 빈 상태 안내 문구 제거

### DIFF
--- a/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
@@ -63,10 +63,13 @@ describe("WeeklyPlan", () => {
     ).toBeInTheDocument();
   });
 
-  it("블록이 없으면 빈 상태 안내를 보여준다", async () => {
+  it("블록이 없어도 그리드를 렌더하고 빈 상태 안내 문구는 없다", async () => {
     mockPlan([]);
     renderWithRouter(<WeeklyPlan />);
-    expect(await screen.findByText(/빈 한 주입니다/)).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: "추가" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/빈 한 주입니다/)).not.toBeInTheDocument();
   });
 
   it("[+ 추가]로 여러 요일에 블록을 한 번에 만든다", async () => {

--- a/fe/src/features/planner/components/plan/WeeklyPlan.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.tsx
@@ -135,14 +135,7 @@ export function WeeklyPlan() {
           주간 계획표를 불러오지 못했습니다.
         </p>
       ) : (
-        <>
-          {blocks.length === 0 && (
-            <p className="text-muted-foreground rounded-md border border-dashed p-4 text-center text-sm">
-              빈 한 주입니다. 오른쪽 위 [+ 추가]로 블록을 추가하세요.
-            </p>
-          )}
-          <WeeklyPlanGrid blocks={blocks} days={days} onSelect={setEditing} />
-        </>
+        <WeeklyPlanGrid blocks={blocks} days={days} onSelect={setEditing} />
       )}
 
       <PlanBlockCreate


### PR DESCRIPTION
## 이슈
closes #650

## 작업 내용
주간 계획표(`/planner/plan`)에서 블록이 없을 때 표시되던 빈 상태 안내 문구
"빈 한 주입니다. 오른쪽 위 [+ 추가]로 블록을 추가하세요."를 제거한다. 블록이 없으면 빈 그리드만 표시.

- WeeklyPlan 빈 상태 안내 `<p>` 제거(빈 그리드 렌더)
- 테스트를 "안내 문구 부재 + 그리드 렌더" 검증으로 갱신

## 테스트
- `WeeklyPlan.test.tsx`(8) 통과, 전체 FE 198 통과, prettier·eslint·tsc·build 통과