### PR TITLE
chore : 로그 패널을 table로 전환 (서비스 식별·가독성)

### DIFF
--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/logs-overview.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/logs-overview.json
@@ -139,23 +139,47 @@
       ]
     },
     {
-      "type": "logs",
-      "title": "로그 (level=$level, search=$search)",
+      "type": "table",
+      "title": "로그 (service=$service_name, level=$level, search=$search)",
       "datasource": { "type": "loki", "uid": "loki" },
       "gridPos": { "x": 0, "y": 20, "w": 24, "h": 16 },
+      "description": "service·level·message를 컬럼으로 분리해 어느 서비스 로그인지 한눈에 보이게 한다. Time 컬럼이 따로 있어 본문 타임스탬프와 중복되지 않는다. 헤더로 정렬·필터 가능.",
       "options": {
-        "showTime": true,
-        "showLabels": false,
-        "showCommonLabels": true,
-        "wrapLogMessage": true,
-        "prettifyLogMessage": true,
-        "enableLogDetails": true,
-        "dedupStrategy": "signature",
-        "sortOrder": "Descending"
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": { "show": false },
+        "sortBy": [ { "displayName": "Time", "desc": true } ]
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "filterable": true, "align": "left", "cellOptions": { "type": "auto", "wrapText": true } }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Time" }, "properties": [ { "id": "custom.width", "value": 175 } ] },
+          { "matcher": { "id": "byName", "options": "service" }, "properties": [ { "id": "custom.width", "value": 140 } ] },
+          { "matcher": { "id": "byName", "options": "level" }, "properties": [
+            { "id": "custom.width", "value": 75 },
+            { "id": "custom.cellOptions", "value": { "type": "color-text" } },
+            { "id": "mappings", "value": [ { "type": "value", "options": {
+              "error": { "color": "red", "index": 0 },
+              "warn":  { "color": "orange", "index": 1 },
+              "info":  { "color": "green", "index": 2 },
+              "debug": { "color": "blue", "index": 3 }
+            } } ] }
+          ] }
+        ]
       },
       "targets": [
-        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "range",
+        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "range", "maxLines": 1000,
           "expr": "{namespace=~\"$namespace\", service_name=~\"$service_name\", level=~\"$level\"} != \"kube-probe\" |~ \"(?i)$search\"" }
+      ],
+      "transformations": [
+        { "id": "extractFields", "options": { "source": "labels" } },
+        { "id": "filterFieldsByName", "options": { "include": { "names": ["Time", "service_name", "level", "Line"] } } },
+        { "id": "organize", "options": {
+            "indexByName": { "Time": 0, "service_name": 1, "level": 2, "Line": 3 },
+            "renameByName": { "Line": "message", "service_name": "service" }
+        } }
       ]
     }
   ]


### PR DESCRIPTION
## 이슈
closes #652

## 작업 내용

멀티 서비스 로그 가독성 — 조사(Grafana/Loki best practice) 기반으로 로그 패널을 **logs → table**로 전환한다.

### 조사 근거
- logs 패널 `displayedFields`는 본문을 **대체**해 "본문+서비스 동시 표시"가 약함 ([discussion #38290](https://github.com/grafana/grafana/discussions/38290) → table 권장).
- **멀티 서비스 + 필드 표시엔 table 패널**이 권장 ([6 ways to improve log dashboards](https://grafana.com/blog/2023/05/18/6-easy-ways-to-improve-your-log-dashboards-with-grafana-and-grafana-loki/)).
- 대시보드는 단일 + template variable이 표준(분리는 안티패턴) → service_name 변수 유지.

### 변경 (`logs-overview.json`)
- 로그 패널 `logs` → `table`: **Time \| service \| level \| message** 컬럼.
  - `extractFields`(labels) → service_name·level 컬럼화, `filterFieldsByName`+`organize`로 4개 컬럼 정리·rename.
  - level 색상(error/warn/info), 헤더 정렬·필터, message wrap.
- Time 컬럼 분리 → 본문 ts 중복 완화.

### 검증
- JSON 유효 + helm 렌더 OK.
- ⚠️ transformation은 Grafana 클라이언트 렌더라 **배포 후 화면 확인 필요**.

### 머지 후
- [ ] Grafana에서 service/level/message 컬럼 정상 표시 확인 (extractFields 동작)
- [ ] 필요시 transformation 조정
- [ ] (후속) redis 등 본문 ts 남은 로그 alloy 정리