### PR TITLE
feat : 주간 계획표 시간 눈금 00:00·24:00 표시

### DIFF
--- a/fe/src/features/planner/components/plan/WeeklyPlanGrid.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlanGrid.tsx
@@ -10,7 +10,8 @@ import {
   topRatio,
 } from "./planGrid";
 
-const HOURS = Array.from({ length: 24 }, (_, i) => i);
+// 0~24시 눈금(처음 00:00 · 끝 24:00 포함).
+const HOUR_TICKS = Array.from({ length: 25 }, (_, i) => i);
 const COLUMN_HEIGHT = 24 * HOUR_PX;
 
 interface WeeklyPlanGridProps {
@@ -45,15 +46,23 @@ export function WeeklyPlanGrid({
           </div>
         ))}
 
-        {/* 시간 눈금 거터 */}
+        {/* 시간 눈금 거터(00:00~24:00) */}
         <div className="relative" style={{ height: COLUMN_HEIGHT }}>
-          {HOURS.map((hour) => (
+          {HOUR_TICKS.map((hour) => (
             <div
               key={hour}
-              className="text-muted-foreground absolute right-1 -translate-y-1/2 text-[10px]"
+              className={cn(
+                "text-muted-foreground absolute right-1 text-[10px]",
+                // 처음/끝은 잘리지 않게 위·아래 끝에 맞춰 정렬
+                hour === 0
+                  ? ""
+                  : hour === 24
+                    ? "-translate-y-full"
+                    : "-translate-y-1/2",
+              )}
               style={{ top: hour * HOUR_PX }}
             >
-              {hour > 0 ? `${String(hour).padStart(2, "0")}:00` : ""}
+              {`${String(hour).padStart(2, "0")}:00`}
             </div>
           ))}
         </div>
@@ -65,8 +74,8 @@ export function WeeklyPlanGrid({
             className="border-border relative border-l"
             style={{ height: COLUMN_HEIGHT }}
           >
-            {/* 시간 격자선 */}
-            {HOURS.map((hour) => (
+            {/* 시간 격자선(0~24, 끝선 포함) */}
+            {HOUR_TICKS.map((hour) => (
               <div
                 key={hour}
                 className="border-border/40 absolute inset-x-0 border-t"


### PR DESCRIPTION
## 이슈
closes #654

## 작업 내용
주간 계획표(`/planner/plan`) 시간 축 눈금에서 맨 위 `00:00`과 맨 아래 `24:00`이 보이지 않던 것을 표시한다.

- 거터 라벨을 **00:00~24:00 전부 표시**(기존엔 hour 0 숨김 + 24:00 없음)
- 처음(00:00)은 위 끝, 끝(24:00)은 아래 끝에 맞춰 잘리지 않게 정렬
- 격자선을 0~24로 확장(바닥 끝선 포함)

## 테스트
- 시각 변경(라벨/격자선). plan 테스트(14)·tsc·prettier·eslint·build 통과