### PR TITLE
chore : 로그 메타데이터·trace 상세 logs 패널 추가 (table+logs 역할 분담)

### DIFF
--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/logs-overview.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/logs-overview.json
@@ -181,6 +181,27 @@
             "renameByName": { "Line": "message", "service_name": "service" }
         } }
       ]
+    },
+    {
+      "type": "logs",
+      "title": "상세 로그 (라인 클릭 → 메타데이터·trace)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "x": 0, "y": 36, "w": 24, "h": 12 },
+      "description": "위 table에서 본 로그의 상세. 라인을 클릭하면 Structured Metadata(logger·request_id·user_id·trace_id·thread_name·client_ip·user_agent·stack_trace)와 derived field(trace_id → Tempo) 링크가 그룹으로 펼쳐진다. table은 식별·개요, 이 패널은 상세·추적용.",
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "queryType": "range",
+          "expr": "{namespace=~\"$namespace\", service_name=~\"$service_name\", level=~\"$level\"} != \"kube-probe\" |~ \"(?i)$search\"" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 이슈
closes #656

## 작업 내용

#653(table 전환) 후 **structured metadata 펼침·trace 연결이 불가능**해진 것을, 조사 기반 역할 분담으로 보완한다.

### 조사 결론
Grafana에서 단일 패널로 "서비스 식별 + 본문 + 메타데이터 펼침 + trace"를 모두 하는 건 구조적으로 불가능:
| | 식별 | 메타데이터 펼침 | trace |
|---|---|---|---|
| logs | 약함 | **O (enableLogDetails)** | **O (derived field)** |
| table | **O** | X | X |

→ 공식이 가리키는 best practice는 **역할 분담** ([logs in Explore](https://grafana.com/docs/grafana/latest/explore/logs-integration/): 메타데이터는 log details 클릭 펼침 — Indexed Labels/Structured Metadata/Parsed fields 그룹).

### 변경 (`logs-overview.json`)
- table(개요·식별, y20) 아래에 **logs 패널(상세, y36, enableLogDetails)** 추가.
- 라인 클릭 → Structured Metadata(logger·request_id·user_id·trace_id·thread_name·stack_trace·client_ip·user_agent) + derived field(trace_id→Tempo) 펼침.

### 검증
- JSON 유효 + helm 렌더 OK.
- 임시 미리보기 대시보드로 **메타데이터·trace 펼침 동작 확인 완료**(사용자 확인).

### 머지 후
- [ ] 배포 후 정식 대시보드에서 table+logs 동작 확인