### PR TITLE
chore : fe nginx kube-probe 헬스체크 access log 미수집

### DIFF
--- a/fe/default.conf
+++ b/fe/default.conf
@@ -15,12 +15,21 @@ log_format app_json escape=json
         '"user_agent":"$http_user_agent"'
     '}';
 
+# kube-probe(readiness/liveness) 헬스체크 요청은 access log를 남기지 않는다.
+# 단순 노이즈이고, probe 실패는 pod readiness·k8s 이벤트로 관측한다.
+# (본문 message 축약으로 대시보드의 "kube-probe" 문자열 필터가 무효화되므로
+#  소스에서 아예 로깅하지 않는 것이 근본적이다 — 수집·저장·표시 전 단계 제거)
+map $http_user_agent $loggable {
+    ~*kube-probe 0;
+    default      1;
+}
+
 server {
     listen 80;
     root /usr/share/nginx/html;
     index index.html;
 
-    access_log /var/log/nginx/access.log app_json;
+    access_log /var/log/nginx/access.log app_json if=$loggable;
 
     # 해시 파일명 asset(JS/CSS/이미지 등): 내용이 바뀌면 파일명도 바뀌므로 불변·장기 캐시.
     # 없는 파일은 index.html로 폴백하지 않고 404 → 옛 해시 요청 시 text/html(MIME 에러) 방지.


### PR DESCRIPTION
## 이슈
closes #658

## 작업 내용

fe 로그의 `GET / 200 680`(kube-probe 헬스체크) 노이즈를 **소스(nginx)에서 미수집**으로 제거한다.

### 배경
nginx JSON + alloy message 축약으로 본문에서 'kube-probe'가 빠지고(user_agent는 structured metadata로 이동) 대시보드의 `!= "kube-probe"` 필터가 무효화 → probe 로그 재노출.

### 변경 (`fe/default.conf`)
- `map $http_user_agent $loggable` (kube-probe → 0).
- `access_log ... app_json if=$loggable` → probe 요청 access log 미기록.

### 근거
best practice는 헬스체크를 **소스에서 아예 로깅하지 않는 것** — 수집·저장·표시 전 단계의 노이즈를 없애므로 대시보드 필터보다 근본적. probe 실패는 pod readiness·k8s 이벤트로 관측.

### 검증
- `docker run nginx -t` OK.
- 실측: kube-probe UA 2건 → 로그 미기록, 일반 UA 1건만 기록.

### 머지 후
- [ ] FE 빌드·배포 후 fe probe 로그(GET / 200 680) 사라짐 확인