### PR TITLE
feat : redis·mysql Prometheus exporter 추가

### DIFF
--- a/infra/helm/mysql/templates/exporter-user-job.yaml
+++ b/infra/helm/mysql/templates/exporter-user-job.yaml
@@ -1,0 +1,44 @@
+# exporter 전용 DB 유저(최소 권한: PROCESS, REPLICATION CLIENT, SELECT)를 생성한다.
+# 기존 PVC라 initdb.d가 안 돌므로 ArgoCD PostSync hook Job으로 멱등 생성한다.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mysql-exporter-user
+  namespace: orino
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: create-exporter-user
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          command: ["sh", "-c"]
+          args:
+            - |
+              until mysqladmin ping -h mysql -uroot -p"$MYSQL_ROOT_PASSWORD" --silent; do
+                echo "waiting for mysql..."; sleep 3
+              done
+              mysql -h mysql -uroot -p"$MYSQL_ROOT_PASSWORD" <<SQL
+              CREATE USER IF NOT EXISTS 'exporter'@'%' IDENTIFIED BY '$EXPORTER_PASSWORD' WITH MAX_USER_CONNECTIONS 3;
+              ALTER USER 'exporter'@'%' IDENTIFIED BY '$EXPORTER_PASSWORD';
+              GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'%';
+              FLUSH PRIVILEGES;
+              SQL
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-secret
+                  key: MYSQL_ROOT_PASSWORD
+            - name: EXPORTER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-exporter-secret
+                  key: password

--- a/infra/helm/mysql/templates/sealedsecret-exporter.yaml
+++ b/infra/helm/mysql/templates/sealedsecret-exporter.yaml
@@ -1,0 +1,13 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: mysql-exporter-secret
+  namespace: orino
+spec:
+  encryptedData:
+    password: AgBft1ya/v1gTsdW1JAG+8Z7FFCgXhYLwEvZsifTVzcjJXXr/gAXbY7SLUbQGbfGtbulK+WUA74SO80OxOmhmychJGHH9cH0jEgZybjKrPesGslHYR7TawoEJR9XSjln7EMvQVBf+PPQwO8pHK28UBIjsa6DyRFMcM2Rr+3IkWXCyVxa1+2sG2agThRDfVcdayh7g4FHPh+aEoRqpJjulxfe/BeUPG95/Hj/e0Wblo7BekBinwzQJR78gYznKR6AESyQwVCz2FrZmIvRrxe4BaZGSrpo27JnJeEvh6EYiwAA/I29pOe3Whw++WOZAH38XDC1lHLNkh+N8TCTcaR32mpqwjzROVMGM16Wni5X7ZiplWwLYHdqaMQYq97torpR4Hi3YtgKZr294CWH4oLJ/ql/WL1rGoB3Jdcl6l5VrgJr/E+eIDn3d9NohcfNFEP9lygHyPSBmbsOER988O1OHUbiJotHM3Sr0IglrBdMl9QbHHwaF+DgbVvIrhL0lVt62kXIUD2+p6PjqQpjXZKMAEKCRBNpeWNr7me29CJVh2LlNfdj6Yeeh06CwUjpOq+F50Zjt9KZz7na+vAigh9BQBdLUAPxgvhDKSRM/cpBA9jIa1Jq5brjpIY2Ib6Bn734i8I3tbd6pbEYU5FkG6W6ZCsRKXLbJ3Z799d+UlPrjrmc0iC9AZA7aDqezGp9jgo3/uPtWUK11XT3SxCTBSQuI1ubxTgWEg==
+  template:
+    metadata:
+      name: mysql-exporter-secret
+      namespace: orino
+    type: Opaque

--- a/infra/helm/mysql/templates/service.yaml
+++ b/infra/helm/mysql/templates/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: mysql
+  labels:
+    app: mysql
 spec:
   type: NodePort
   selector:
@@ -12,3 +14,21 @@ spec:
       port: 3306
       targetPort: 3306
       nodePort: 30306
+---
+# metrics는 내부 전용(ClusterIP). ServiceMonitor가 pod endpoints(9104)를
+# 클러스터 내부에서 스크랩하므로 NodePort 외부 노출이 불필요하다.
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-metrics
+  labels:
+    app: mysql
+    component: metrics
+spec:
+  type: ClusterIP
+  selector:
+    app: mysql
+  ports:
+    - name: metrics
+      port: 9104
+      targetPort: 9104

--- a/infra/helm/mysql/templates/servicemonitor.yaml
+++ b/infra/helm/mysql/templates/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mysql
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+      component: metrics
+  endpoints:
+    - port: metrics
+      interval: 30s

--- a/infra/helm/mysql/templates/statefulset.yaml
+++ b/infra/helm/mysql/templates/statefulset.yaml
@@ -45,6 +45,29 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+        # mysqld_exporter 사이드카 — exporter 전용 유저(최소 권한)로 localhost 접속.
+        # metrics(9104)는 mysql-metrics(ClusterIP) + ServiceMonitor로 내부 수집.
+        - name: mysqld-exporter
+          image: prom/mysqld-exporter:v0.16.0
+          args:
+            - "--mysqld.address=localhost:3306"
+            - "--mysqld.username=exporter"
+          env:
+            - name: MYSQLD_EXPORTER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-exporter-secret
+                  key: password
+          ports:
+            - containerPort: 9104
+              name: metrics
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
       volumes:
         - name: mysql-data
           persistentVolumeClaim:

--- a/infra/helm/redis/templates/deployment.yaml
+++ b/infra/helm/redis/templates/deployment.yaml
@@ -33,3 +33,17 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 3
+        # redis_exporter 사이드카 — Prometheus가 metrics(9121)를 스크랩한다.
+        - name: redis-exporter
+          image: oliver006/redis_exporter:v1.66.0
+          args: ["--redis.addr=redis://localhost:6379"]
+          ports:
+            - containerPort: 9121
+              name: metrics
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi

--- a/infra/helm/redis/templates/service.yaml
+++ b/infra/helm/redis/templates/service.yaml
@@ -2,11 +2,32 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis
+  labels:
+    app: redis
 spec:
   type: NodePort
   selector:
     app: redis
   ports:
-    - port: 6379
+    - name: redis
+      port: 6379
       targetPort: 6379
       nodePort: 30379
+---
+# metrics는 내부 전용(ClusterIP). ServiceMonitor가 pod endpoints(9121)를
+# 클러스터 내부에서 스크랩하므로 NodePort 외부 노출이 불필요하다.
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-metrics
+  labels:
+    app: redis
+    component: metrics
+spec:
+  type: ClusterIP
+  selector:
+    app: redis
+  ports:
+    - name: metrics
+      port: 9121
+      targetPort: 9121

--- a/infra/helm/redis/templates/servicemonitor.yaml
+++ b/infra/helm/redis/templates/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: redis
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: redis
+      component: metrics
+  endpoints:
+    - port: metrics
+      interval: 30s


### PR DESCRIPTION
## 이슈
ref #660 (대시보드는 메트릭 확인 후 후속 PR)

## 작업 내용
redis·mysql 메트릭 수집을 위한 exporter를 추가한다. (대시보드는 exporter 배포·메트릭 검증 후 별도 PR)

### redis
- `redis_exporter:v1.66.0` 사이드카(9121).
- `redis`(NodePort 6379) / `redis-metrics`(ClusterIP 9121) service 분리 — metrics는 내부 전용.
- ServiceMonitor(`component: metrics` 셀렉터).

### mysql
- `mysqld_exporter:v0.16.0` 사이드카(9104), exporter 전용 유저로 localhost 접속.
- exporter 유저(최소 권한 `PROCESS, REPLICATION CLIENT, SELECT`)를 **ArgoCD PostSync Job**으로 멱등 생성(기존 PVC라 initdb.d 불가), 자격은 SealedSecret(`mysql-exporter-secret`).
- `mysql`(NodePort 3306) / `mysql-metrics`(ClusterIP 9104) 분리 + ServiceMonitor.

### 설계 포인트 (NodePort/FQDN 질문 관련)
ServiceMonitor는 Prometheus가 **pod endpoints를 클러스터 내부에서 직접 스크랩**하므로 metrics에 NodePort(외부 노출)·FQDN이 불필요 → metrics는 ClusterIP 내부 전용.

### 검증
- redis·mysql helm 렌더 OK (사이드카·service 분리·SM·Job·SealedSecret).

### 머지 후
- [ ] 배포 후 `up{job=~"redis|mysql"}` 메트릭 수집 확인 (Job으로 mysql exporter 유저 생성됨)
- [ ] 메트릭 기반 대시보드 3종(node/redis/mysql) 후속 PR