### PR TITLE
feat : node·redis·mysql 모니터링 대시보드 추가

### DIFF
--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/mysql-overview.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/mysql-overview.json
@@ -1,0 +1,101 @@
+{
+  "uid": "mysql-overview",
+  "title": "MySQL",
+  "tags": ["orino", "mysql"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "type": "stat", "title": "MySQL Up",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "options": { "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "mappings": [ { "type": "value", "options": { "1": { "text": "UP", "color": "green" }, "0": { "text": "DOWN", "color": "red" } } } ] } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "mysql_up" } ]
+    },
+    {
+      "type": "stat", "title": "Uptime",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 4, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "s", "color": { "mode": "fixed", "fixedColor": "blue" } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "mysql_global_status_uptime" } ]
+    },
+    {
+      "type": "stat", "title": "연결 수",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 9, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "fixed", "fixedColor": "purple" } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "mysql_global_status_threads_connected" } ]
+    },
+    {
+      "type": "stat", "title": "실행 중 스레드",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 14, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "fixed", "fixedColor": "green" } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "mysql_global_status_threads_running" } ]
+    },
+    {
+      "type": "stat", "title": "Slow Query (5m rate)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 19, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "qps", "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "value": null, "color": "green" }, { "value": 0.1, "color": "orange" } ] } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "rate(mysql_global_status_slow_queries[5m])" } ]
+    },
+    {
+      "type": "timeseries", "title": "초당 쿼리 (QPS)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "qps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "queries",
+          "expr": "rate(mysql_global_status_queries[5m])" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "slow",
+          "expr": "rate(mysql_global_status_slow_queries[5m])" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "연결 (current / max)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "connected",
+          "expr": "mysql_global_status_threads_connected" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "max",
+          "expr": "mysql_global_variables_max_connections" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "InnoDB Buffer Pool",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "data",
+          "expr": "mysql_global_status_innodb_buffer_pool_bytes_data" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "total",
+          "expr": "mysql_global_variables_innodb_buffer_pool_size" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "네트워크 트래픽 (bytes/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "received",
+          "expr": "rate(mysql_global_status_bytes_received[5m])" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "sent",
+          "expr": "rate(mysql_global_status_bytes_sent[5m])" }
+      ]
+    }
+  ]
+}

--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/node-overview.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/node-overview.json
@@ -1,0 +1,101 @@
+{
+  "uid": "node-overview",
+  "title": "Node Exporter",
+  "tags": ["orino", "node"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Node",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(node_uname_info, instance)",
+        "refresh": 2,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".+",
+        "current": { "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries", "title": "CPU 사용률 (%)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}}",
+          "expr": "100 - (avg by(instance) (rate(node_cpu_seconds_total{mode=\"idle\", instance=~\"$instance\"}[5m])) * 100)" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "메모리 사용률 (%)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}}",
+          "expr": "(1 - node_memory_MemAvailable_bytes{instance=~\"$instance\"} / node_memory_MemTotal_bytes{instance=~\"$instance\"}) * 100" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "디스크 사용률 (%)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}} {{mountpoint}}",
+          "expr": "(1 - node_filesystem_avail_bytes{instance=~\"$instance\", fstype!~\"tmpfs|overlay|squashfs|ramfs\"} / node_filesystem_size_bytes{instance=~\"$instance\", fstype!~\"tmpfs|overlay|squashfs|ramfs\"}) * 100" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "Load Average",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "short", "min": 0, "custom": { "drawStyle": "line", "fillOpacity": 0 } } },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}} load1",
+          "expr": "node_load1{instance=~\"$instance\"}" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}} load5",
+          "expr": "node_load5{instance=~\"$instance\"}" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "네트워크 (bps)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "bps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}} rx",
+          "expr": "sum by(instance) (rate(node_network_receive_bytes_total{instance=~\"$instance\", device!~\"lo|veth.*|cali.*|cni.*|flannel.*\"}[5m]) * 8)" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}} tx",
+          "expr": "sum by(instance) (rate(node_network_transmit_bytes_total{instance=~\"$instance\", device!~\"lo|veth.*|cali.*|cni.*|flannel.*\"}[5m]) * 8)" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "디스크 I/O (bytes/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}} read",
+          "expr": "sum by(instance) (rate(node_disk_read_bytes_total{instance=~\"$instance\"}[5m]))" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}} write",
+          "expr": "sum by(instance) (rate(node_disk_written_bytes_total{instance=~\"$instance\"}[5m]))" }
+      ]
+    }
+  ]
+}

--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/redis-overview.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/redis-overview.json
@@ -1,0 +1,98 @@
+{
+  "uid": "redis-overview",
+  "title": "Redis",
+  "tags": ["orino", "redis"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "type": "stat", "title": "Redis Up",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "options": { "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "mappings": [ { "type": "value", "options": { "1": { "text": "UP", "color": "green" }, "0": { "text": "DOWN", "color": "red" } } } ] } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "redis_up" } ]
+    },
+    {
+      "type": "stat", "title": "연결 클라이언트",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 4, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "fixed", "fixedColor": "blue" } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "redis_connected_clients" } ]
+    },
+    {
+      "type": "stat", "title": "전체 키",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 9, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "fixed", "fixedColor": "purple" } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(redis_db_keys)" } ]
+    },
+    {
+      "type": "stat", "title": "메모리 사용",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 14, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "bytes", "color": { "mode": "fixed", "fixedColor": "orange" } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "redis_memory_used_bytes" } ]
+    },
+    {
+      "type": "stat", "title": "Hit Rate",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 19, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "color": { "mode": "fixed", "fixedColor": "green" } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "rate(redis_keyspace_hits_total[5m]) / clamp_min(rate(redis_keyspace_hits_total[5m]) + rate(redis_keyspace_misses_total[5m]), 1)" } ]
+    },
+    {
+      "type": "timeseries", "title": "초당 명령 처리 (ops/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "ops/s",
+        "expr": "rate(redis_commands_processed_total[5m])" } ]
+    },
+    {
+      "type": "timeseries", "title": "메모리 사용 추이",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "used",
+          "expr": "redis_memory_used_bytes" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "maxmemory",
+          "expr": "redis_memory_max_bytes" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "Keyspace hits/misses (rate)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "hits",
+          "expr": "rate(redis_keyspace_hits_total[5m])" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "misses",
+          "expr": "rate(redis_keyspace_misses_total[5m])" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "네트워크 I/O (bytes/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "in",
+          "expr": "rate(redis_net_input_bytes_total[5m])" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "out",
+          "expr": "rate(redis_net_output_bytes_total[5m])" }
+      ]
+    }
+  ]
+}

--- a/infra/helm/kube-prometheus-stack/templates/dashboard-mysql.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/dashboard-mysql.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-mysql-overview
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  mysql-overview.json: |-
+{{ .Files.Get "grafana-dashboards/mysql-overview.json" | indent 4 }}

--- a/infra/helm/kube-prometheus-stack/templates/dashboard-node.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/dashboard-node.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-node-overview
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  node-overview.json: |-
+{{ .Files.Get "grafana-dashboards/node-overview.json" | indent 4 }}

--- a/infra/helm/kube-prometheus-stack/templates/dashboard-redis.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/dashboard-redis.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-redis-overview
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  redis-overview.json: |-
+{{ .Files.Get "grafana-dashboards/redis-overview.json" | indent 4 }}


### PR DESCRIPTION
## 이슈
closes #660 (exporter는 #661에서 선행 완료)

## 작업 내용
exporter(#661) 배포로 메트릭이 수집되는 것을 확인한 뒤, node/redis/mysql 모니터링 대시보드를 추가한다.

### 대시보드 (커스텀 경량 — 기존 SLO·Logs 스타일)
- **node-overview**: CPU·메모리·디스크 사용률, Load, 네트워크, 디스크 I/O (Node 변수로 노드 선택)
- **redis-overview**: Up·연결 클라이언트·전체 키·메모리·Hit Rate(stat), ops/s·메모리 추이·keyspace hits/misses·네트워크 I/O(timeseries)
- **mysql-overview**: Up·Uptime·연결·실행 스레드·Slow Query(stat), QPS·연결(current/max)·InnoDB Buffer Pool·네트워크(timeseries)

### 검증
- 14+10개 패널 메트릭을 Prometheus에서 **전부 존재 확인**(`redis_*`, `mysql_*`, `node_*`).
- JSON 유효 + helm 렌더(ConfigMap 3개) OK.

### 머지 후
- [ ] 배포 후 Grafana에서 3개 대시보드 패널 정상 표시 확인