### PR TITLE
feat : 노드 하드웨어 모니터링 — CPU 온도·팬 RPM 대시보드 + 고온 알림

### DIFF
--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/mysql-overview.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/mysql-overview.json
@@ -1,0 +1,101 @@
+{
+  "uid": "mysql-overview",
+  "title": "MySQL",
+  "tags": ["orino", "mysql"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "type": "stat", "title": "MySQL Up",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "options": { "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "mappings": [ { "type": "value", "options": { "1": { "text": "UP", "color": "green" }, "0": { "text": "DOWN", "color": "red" } } } ] } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "mysql_up" } ]
+    },
+    {
+      "type": "stat", "title": "Uptime",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 4, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "s", "color": { "mode": "fixed", "fixedColor": "blue" } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "mysql_global_status_uptime" } ]
+    },
+    {
+      "type": "stat", "title": "연결 수",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 9, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "fixed", "fixedColor": "purple" } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "mysql_global_status_threads_connected" } ]
+    },
+    {
+      "type": "stat", "title": "실행 중 스레드",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 14, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "fixed", "fixedColor": "green" } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "mysql_global_status_threads_running" } ]
+    },
+    {
+      "type": "stat", "title": "Slow Query (5m rate)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 19, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "qps", "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "value": null, "color": "green" }, { "value": 0.1, "color": "orange" } ] } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "rate(mysql_global_status_slow_queries[5m])" } ]
+    },
+    {
+      "type": "timeseries", "title": "초당 쿼리 (QPS)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "qps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "queries",
+          "expr": "rate(mysql_global_status_queries[5m])" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "slow",
+          "expr": "rate(mysql_global_status_slow_queries[5m])" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "연결 (current / max)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "connected",
+          "expr": "mysql_global_status_threads_connected" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "max",
+          "expr": "mysql_global_variables_max_connections" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "InnoDB Buffer Pool",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "data",
+          "expr": "mysql_global_status_innodb_buffer_pool_bytes_data" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "total",
+          "expr": "mysql_global_variables_innodb_buffer_pool_size" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "네트워크 트래픽 (bytes/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "received",
+          "expr": "rate(mysql_global_status_bytes_received[5m])" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "sent",
+          "expr": "rate(mysql_global_status_bytes_sent[5m])" }
+      ]
+    }
+  ]
+}

--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/node-hardware.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/node-hardware.json
@@ -1,0 +1,207 @@
+{
+  "uid": "node-hardware",
+  "title": "Node Hardware",
+  "tags": ["orino", "node", "hardware"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "CPU 온도 (k10temp)",
+      "description": "AMD Ryzen Tctl 센서. 스로틀링은 보통 ~95°C. warning 85 / critical 90.",
+      "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "max by (instance) (node_hwmon_temp_celsius * on (instance, chip) group_left node_hwmon_chip_names{chip_name=\"k10temp\"}) * on (instance) group_left(nodename) node_uname_info",
+          "legendFormat": "{{nodename}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "decimals": 1,
+          "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 80},
+              {"color": "red", "value": 90}
+            ]
+          }
+        }
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["last", "max"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "팬 속도 (RPM)",
+      "description": "asus_nb_wmi fan1/fan2. 온도에 따라 팬이 오르내리는 패턴(팬 펌핑) 확인.",
+      "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "node_hwmon_fan_rpm * on (instance) group_left(nodename) node_uname_info",
+          "legendFormat": "{{nodename}} {{sensor}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rotrpm",
+          "decimals": 0,
+          "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10}
+        }
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["last", "max"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "GPU · NVMe 온도",
+      "description": "내장 GPU(amdgpu edge)와 NVMe SSD 온도.",
+      "gridPos": {"x": 0, "y": 8, "w": 12, "h": 8},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "node_hwmon_temp_celsius * on (instance, chip) group_left node_hwmon_chip_names{chip_name=\"amdgpu\"} * on (instance) group_left(nodename) node_uname_info",
+          "legendFormat": "{{nodename}} GPU",
+          "refId": "A"
+        },
+        {
+          "expr": "max by (instance) (node_hwmon_temp_celsius * on (instance, chip) group_left node_hwmon_chip_names{chip_name=\"nvme\"}) * on (instance) group_left(nodename) node_uname_info",
+          "legendFormat": "{{nodename}} NVMe",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "decimals": 1,
+          "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 70},
+              {"color": "red", "value": 85}
+            ]
+          }
+        }
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["last", "max"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "전원 · 배터리",
+      "description": "AC 연결(1=연결) 및 배터리 잔량(%). 정전 시 AC0가 0으로 떨어진다.",
+      "gridPos": {"x": 12, "y": 8, "w": 12, "h": 8},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "node_power_supply_online{power_supply=~\"AC.*\"} * 100 * on (instance) group_left(nodename) node_uname_info",
+          "legendFormat": "{{nodename}} AC 연결(%)",
+          "refId": "A"
+        },
+        {
+          "expr": "node_power_supply_capacity{power_supply=~\"BAT.*\"} * on (instance) group_left(nodename) node_uname_info",
+          "legendFormat": "{{nodename}} 배터리(%)",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "decimals": 0,
+          "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 5}
+        }
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["last"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 5,
+      "type": "table",
+      "title": "노드 버전 정보 (OS · 커널 · kubelet · containerd)",
+      "description": "kube_node_info 기반. 노드별 OS·커널·런타임·kubelet 버전.",
+      "gridPos": {"x": 0, "y": 16, "w": 24, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "kube_node_info",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "container": true,
+              "endpoint": true,
+              "instance": true,
+              "job": true,
+              "namespace": true,
+              "pod": true,
+              "service": true,
+              "provider_id": true,
+              "pod_cidr": true,
+              "system_uuid": true,
+              "kubeproxy_version": true
+            },
+            "renameByName": {
+              "node": "노드",
+              "internal_ip": "IP",
+              "os_image": "OS",
+              "kernel_version": "커널",
+              "kubelet_version": "kubelet",
+              "container_runtime_version": "런타임"
+            },
+            "indexByName": {
+              "node": 0,
+              "internal_ip": 1,
+              "os_image": 2,
+              "kernel_version": 3,
+              "kubelet_version": 4,
+              "container_runtime_version": 5
+            }
+          }
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm"
+      }
+    }
+  ]
+}

--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/node-overview.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/node-overview.json
@@ -1,0 +1,101 @@
+{
+  "uid": "node-overview",
+  "title": "Node Exporter",
+  "tags": ["orino", "node"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Node",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(node_uname_info, instance)",
+        "refresh": 2,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".+",
+        "current": { "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries", "title": "CPU 사용률 (%)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}}",
+          "expr": "100 - (avg by(instance) (rate(node_cpu_seconds_total{mode=\"idle\", instance=~\"$instance\"}[5m])) * 100)" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "메모리 사용률 (%)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}}",
+          "expr": "(1 - node_memory_MemAvailable_bytes{instance=~\"$instance\"} / node_memory_MemTotal_bytes{instance=~\"$instance\"}) * 100" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "디스크 사용률 (%)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100, "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}} {{mountpoint}}",
+          "expr": "(1 - node_filesystem_avail_bytes{instance=~\"$instance\", fstype!~\"tmpfs|overlay|squashfs|ramfs\"} / node_filesystem_size_bytes{instance=~\"$instance\", fstype!~\"tmpfs|overlay|squashfs|ramfs\"}) * 100" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "Load Average",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "short", "min": 0, "custom": { "drawStyle": "line", "fillOpacity": 0 } } },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}} load1",
+          "expr": "node_load1{instance=~\"$instance\"}" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}} load5",
+          "expr": "node_load5{instance=~\"$instance\"}" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "네트워크 (bps)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "bps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}} rx",
+          "expr": "sum by(instance) (rate(node_network_receive_bytes_total{instance=~\"$instance\", device!~\"lo|veth.*|cali.*|cni.*|flannel.*\"}[5m]) * 8)" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}} tx",
+          "expr": "sum by(instance) (rate(node_network_transmit_bytes_total{instance=~\"$instance\", device!~\"lo|veth.*|cali.*|cni.*|flannel.*\"}[5m]) * 8)" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "디스크 I/O (bytes/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}} read",
+          "expr": "sum by(instance) (rate(node_disk_read_bytes_total{instance=~\"$instance\"}[5m]))" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "{{instance}} write",
+          "expr": "sum by(instance) (rate(node_disk_written_bytes_total{instance=~\"$instance\"}[5m]))" }
+      ]
+    }
+  ]
+}

--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/redis-overview.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/redis-overview.json
@@ -1,0 +1,98 @@
+{
+  "uid": "redis-overview",
+  "title": "Redis",
+  "tags": ["orino", "redis"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "type": "stat", "title": "Redis Up",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "options": { "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "mappings": [ { "type": "value", "options": { "1": { "text": "UP", "color": "green" }, "0": { "text": "DOWN", "color": "red" } } } ] } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "redis_up" } ]
+    },
+    {
+      "type": "stat", "title": "연결 클라이언트",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 4, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "fixed", "fixedColor": "blue" } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "redis_connected_clients" } ]
+    },
+    {
+      "type": "stat", "title": "전체 키",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 9, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "fixed", "fixedColor": "purple" } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(redis_db_keys)" } ]
+    },
+    {
+      "type": "stat", "title": "메모리 사용",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 14, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "bytes", "color": { "mode": "fixed", "fixedColor": "orange" } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "redis_memory_used_bytes" } ]
+    },
+    {
+      "type": "stat", "title": "Hit Rate",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 19, "y": 0, "w": 5, "h": 4 },
+      "options": { "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "color": { "mode": "fixed", "fixedColor": "green" } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "rate(redis_keyspace_hits_total[5m]) / clamp_min(rate(redis_keyspace_hits_total[5m]) + rate(redis_keyspace_misses_total[5m]), 1)" } ]
+    },
+    {
+      "type": "timeseries", "title": "초당 명령 처리 (ops/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "ops/s",
+        "expr": "rate(redis_commands_processed_total[5m])" } ]
+    },
+    {
+      "type": "timeseries", "title": "메모리 사용 추이",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "used",
+          "expr": "redis_memory_used_bytes" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "maxmemory",
+          "expr": "redis_memory_max_bytes" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "Keyspace hits/misses (rate)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "hits",
+          "expr": "rate(redis_keyspace_hits_total[5m])" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "misses",
+          "expr": "rate(redis_keyspace_misses_total[5m])" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "네트워크 I/O (bytes/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "in",
+          "expr": "rate(redis_net_input_bytes_total[5m])" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "prometheus" }, "legendFormat": "out",
+          "expr": "rate(redis_net_output_bytes_total[5m])" }
+      ]
+    }
+  ]
+}

--- a/infra/helm/kube-prometheus-stack/templates/dashboard-mysql.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/dashboard-mysql.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-mysql-overview
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  mysql-overview.json: |-
+{{ .Files.Get "grafana-dashboards/mysql-overview.json" | indent 4 }}

--- a/infra/helm/kube-prometheus-stack/templates/dashboard-node-hardware.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/dashboard-node-hardware.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-node-hardware
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  node-hardware.json: |-
+{{ .Files.Get "grafana-dashboards/node-hardware.json" | indent 4 }}

--- a/infra/helm/kube-prometheus-stack/templates/dashboard-node.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/dashboard-node.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-node-overview
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  node-overview.json: |-
+{{ .Files.Get "grafana-dashboards/node-overview.json" | indent 4 }}

--- a/infra/helm/kube-prometheus-stack/templates/dashboard-redis.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/dashboard-redis.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-redis-overview
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  redis-overview.json: |-
+{{ .Files.Get "grafana-dashboards/redis-overview.json" | indent 4 }}

--- a/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
@@ -100,6 +100,34 @@ spec:
             summary: "노드 {{ "{{" }} $labels.instance {{ "}}" }} 디스크 사용률 높음"
             description: "디스크 사용률이 85% 초과 (현재: {{ "{{" }} $value | printf \"%.1f\" {{ "}}" }}%)"
 
+        # CPU 온도 — k10temp(AMD Ryzen) 센서로 한정. chip_name으로 join해 칩 경로 하드코딩을 피한다.
+        # AMD Tctl 스로틀링은 보통 ~95°C 이상 → warning 85 / critical 90 으로 여유를 둔다.
+        - alert: NodeHighTemperature
+          expr: |
+            max by (instance) (
+              node_hwmon_temp_celsius
+              * on (instance, chip) group_left node_hwmon_chip_names{chip_name="k10temp"}
+            ) > 85
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "노드 {{ "{{" }} $labels.instance {{ "}}" }} CPU 온도 높음"
+            description: "CPU 온도가 5분간 85°C 초과 (현재: {{ "{{" }} $value | printf \"%.1f\" {{ "}}" }}°C) — 쿨링/통풍 점검"
+
+        - alert: NodeCriticalTemperature
+          expr: |
+            max by (instance) (
+              node_hwmon_temp_celsius
+              * on (instance, chip) group_left node_hwmon_chip_names{chip_name="k10temp"}
+            ) > 90
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "노드 {{ "{{" }} $labels.instance {{ "}}" }} CPU 온도 위험"
+            description: "CPU 온도가 2분간 90°C 초과 (현재: {{ "{{" }} $value | printf \"%.1f\" {{ "}}" }}°C) — 스로틀링 임박, 즉시 조치"
+
     - name: longhorn-alerts
       rules:
         - alert: LonghornBackupFailed


### PR DESCRIPTION
## 이슈
closes #663

## 작업 내용
node-exporter가 이미 수집 중이던 노드 하드웨어 메트릭이 대시보드·알림 없이 방치돼 있어, PromQL로 직접 쳐야만 보이던 상태를 개선한다.

### PrometheusRule (node-alerts 그룹)
- `NodeHighTemperature` — CPU 85°C 초과 5분 지속 시 warning
- `NodeCriticalTemperature` — CPU 90°C 초과 2분 지속 시 critical (스로틀링 ~95°C 전 경고)
- `k10temp`(AMD Ryzen Tctl) 칩을 `chip_name` join으로 한정 → 칩 PCI 경로 하드코딩 회피

### Grafana 대시보드 `node-hardware`
- CPU 온도(k10temp), 팬 속도(asus_nb_wmi fan1/fan2), GPU·NVMe 온도, 전원·배터리
- OS·커널·kubelet·containerd 버전 인포 테이블 (`kube_node_info`)
- `instance`(IP) 를 `node_uname_info` 로 join 해 `nodename`(note1/note2) 표기

### 검증
- `python -m json.tool` 대시보드 JSON 유효성 OK
- `helm template` 렌더링 정상 (exit 0, 알림·ConfigMap 정상 생성)
- 운영 Prometheus 대상 PromQL 실측 검증: note1 57.9°C/3100rpm, note2 67.1°C/3300~3500rpm, 전원·배터리·버전 인포 모두 정상 반환