### PR TITLE
feat : 주간 계획표 자동 저장 + 시간 눈금 간격 정리

### DIFF
--- a/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { Toaster } from "@/components/Toaster";
 import { useToastStore } from "@/shared/lib/toast";
 import { server } from "@/test/mocks/server";
 import { renderWithRouter } from "@/test/render";
@@ -92,9 +91,6 @@ describe("WeeklyPlan", () => {
     expect(
       await screen.findAllByRole("button", { name: "공부 09:00~10:00" }),
     ).toHaveLength(2);
-    expect(
-      screen.getByText("저장되지 않은 변경이 있습니다"),
-    ).toBeInTheDocument();
   });
 
   it("추가를 취소하면 블록이 생성되지 않는다", async () => {
@@ -113,12 +109,9 @@ describe("WeeklyPlan", () => {
     expect(
       screen.queryByRole("button", { name: /09:00~10:00/ }),
     ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText("저장되지 않은 변경이 있습니다"),
-    ).not.toBeInTheDocument();
   });
 
-  it("저장은 PUT으로 전량 교체하고 성공 토스트를 띄운다", async () => {
+  it("추가하면 [저장] 버튼 없이 즉시 PUT으로 전량 교체된다(자동 저장)", async () => {
     mockPlan([
       {
         id: 1,
@@ -146,29 +139,20 @@ describe("WeeklyPlan", () => {
     );
 
     const user = userEvent.setup();
-    renderWithRouter(
-      <>
-        <WeeklyPlan />
-        <Toaster />
-      </>,
-    );
+    renderWithRouter(<WeeklyPlan />);
 
-    // 토요일에 블록 추가로 dirty
     await user.click(await screen.findByRole("button", { name: "추가" }));
     const dialog = await screen.findByRole("dialog");
     await user.click(within(dialog).getByRole("checkbox", { name: "토" }));
     await user.type(within(dialog).getByLabelText("라벨"), "운동");
     await user.click(within(dialog).getByRole("button", { name: "추가" }));
 
-    await user.click(screen.getByRole("button", { name: "저장" }));
-
-    await waitFor(() =>
-      expect(
-        screen.getByText("주간 계획표를 저장했습니다."),
-      ).toBeInTheDocument(),
-    );
-    expect(putBody).not.toBeNull();
+    // 별도 [저장] 버튼 없이 PUT이 자동 발생
+    await waitFor(() => expect(putBody).not.toBeNull());
     expect(putBody!.blocks).toHaveLength(2); // 기존 1 + 신규 1, 전량 교체
+    expect(
+      screen.queryByRole("button", { name: "저장" }),
+    ).not.toBeInTheDocument();
   });
 
   it("블록 편집에서 종료가 시작보다 빠르면 적용을 막는다", async () => {

--- a/fe/src/features/planner/components/plan/WeeklyPlan.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.tsx
@@ -43,39 +43,34 @@ export function WeeklyPlan() {
   const narrow = useIsNarrow();
 
   const [blocks, setBlocks] = useState<EditableBlock[]>([]);
-  const [dirty, setDirty] = useState(false);
   const [editing, setEditing] = useState<EditableBlock | null>(null);
   const [creating, setCreating] = useState(false);
   const [mobileDay, setMobileDay] = useState(new Date().getDay());
 
   useEffect(() => {
-    if (data) {
-      setBlocks(toEditable(data));
-      setDirty(false);
-    }
+    if (data) setBlocks(toEditable(data));
   }, [data]);
+
+  // 변경을 로컬에 즉시 반영하고 전량 교체로 자동 저장한다(저장 버튼 없음).
+  const persist = (next: EditableBlock[]) => {
+    setBlocks(next);
+    save.mutate(toInput(next));
+  };
 
   // + 버튼 생성: 선택한 여러 요일에 블록을 한 번에 추가.
   const handleCreate = (created: EditableBlock[]) => {
-    setBlocks((prev) => [...prev, ...created]);
-    setDirty(true);
+    persist([...blocks, ...created]);
     setCreating(false);
   };
 
   const handleSaveBlock = (updated: EditableBlock) => {
-    setBlocks((prev) => prev.map((b) => (b.key === updated.key ? updated : b)));
-    setDirty(true);
+    persist(blocks.map((b) => (b.key === updated.key ? updated : b)));
     setEditing(null);
   };
 
   const handleDeleteBlock = (key: string) => {
-    setBlocks((prev) => prev.filter((b) => b.key !== key));
-    setDirty(true);
+    persist(blocks.filter((b) => b.key !== key));
     setEditing(null);
-  };
-
-  const handleSaveAll = () => {
-    save.mutate(toInput(blocks), { onSuccess: () => setDirty(false) });
   };
 
   const days = narrow ? [mobileDay] : ALL_DAYS;
@@ -85,25 +80,14 @@ export function WeeklyPlan() {
       <header className="flex items-center justify-between gap-3">
         <div>
           <h1 className="text-lg font-semibold">주간 계획표</h1>
-          {dirty && (
-            <p className="text-muted-foreground text-xs">
-              저장되지 않은 변경이 있습니다
-            </p>
-          )}
+          <p className="text-muted-foreground text-xs">
+            {save.isPending ? "저장 중…" : "변경 시 자동 저장됩니다"}
+          </p>
         </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={() => setCreating(true)}>
-            <Plus className="size-4" />
-            추가
-          </Button>
-          <Button
-            size="sm"
-            onClick={handleSaveAll}
-            disabled={!dirty || save.isPending}
-          >
-            {save.isPending ? "저장 중…" : "저장"}
-          </Button>
-        </div>
+        <Button variant="outline" size="sm" onClick={() => setCreating(true)}>
+          <Plus className="size-4" />
+          추가
+        </Button>
       </header>
 
       {narrow && (

--- a/fe/src/features/planner/components/plan/WeeklyPlanGrid.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlanGrid.tsx
@@ -46,20 +46,12 @@ export function WeeklyPlanGrid({
           </div>
         ))}
 
-        {/* 시간 눈금 거터(00:00~24:00) */}
+        {/* 시간 눈금 거터(00:00~24:00). 모든 라벨을 자기 격자선 바로 아래에 균일 정렬. */}
         <div className="relative" style={{ height: COLUMN_HEIGHT }}>
           {HOUR_TICKS.map((hour) => (
             <div
               key={hour}
-              className={cn(
-                "text-muted-foreground absolute right-1 text-[10px]",
-                // 처음/끝은 잘리지 않게 위·아래 끝에 맞춰 정렬
-                hour === 0
-                  ? ""
-                  : hour === 24
-                    ? "-translate-y-full"
-                    : "-translate-y-1/2",
-              )}
+              className="text-muted-foreground absolute right-1 pt-0.5 text-[10px] leading-none"
               style={{ top: hour * HOUR_PX }}
             >
               {`${String(hour).padStart(2, "0")}:00`}

--- a/fe/src/features/planner/hooks/useWeeklyPlan.ts
+++ b/fe/src/features/planner/hooks/useWeeklyPlan.ts
@@ -17,14 +17,16 @@ export function useWeeklyPlan() {
   });
 }
 
-/** 주간 템플릿 전량 교체 저장. 성공 시 캐시를 갱신하고 토스트를 띄운다. */
+/**
+ * 주간 템플릿 전량 교체 저장(자동 저장). 성공 시 캐시를 서버 응답으로 갱신한다.
+ * 변경마다 호출되므로 성공 토스트는 띄우지 않고(소음 방지), 실패만 토스트로 알린다.
+ */
 export function useSaveWeeklyPlan() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (blocks: WeeklyPlanBlockInput[]) => saveWeeklyPlan(blocks),
     onSuccess: (blocks) => {
       queryClient.setQueryData(plannerKeys.weeklyPlan(), blocks);
-      toast("주간 계획표를 저장했습니다.", "success");
     },
     onError: () => {
       toast("저장에 실패했습니다. 다시 시도해 주세요.", "error");

--- a/fe/src/test/mocks/handlers.ts
+++ b/fe/src/test/mocks/handlers.ts
@@ -55,6 +55,16 @@ export const handlers = [
     return HttpResponse.json({ code: "OK", data: { blocks: [] } });
   }),
 
+  // 기본값: 자동 저장(전량 교체) — 요청 블록에 id를 붙여 그대로 반환.
+  http.put(`${API_BASE}/planner/plan`, async ({ request }) => {
+    const body = (await request.json()) as { blocks: unknown[] };
+    const blocks = (body.blocks ?? []).map((b, i) => ({
+      id: i + 1,
+      ...(b as object),
+    }));
+    return HttpResponse.json({ code: "OK", data: { blocks } });
+  }),
+
   // 기본값: 공휴일 없음. 공휴일 표시 검증 테스트는 server.use로 덮어쓴다.
   http.get(`${API_BASE}/planner/holidays`, () => {
     return HttpResponse.json({ code: "OK", data: [] });


### PR DESCRIPTION
## 이슈
closes #665

## 작업 내용
1. **자동 저장**: [저장] 버튼/미저장 표시 제거. 블록 **추가·수정·삭제 시 즉시** `PUT /planner/plan`으로 전량 교체 저장. 저장 중 표시("저장 중…"), 실패 토스트(성공 토스트는 변경마다 떠 소음이라 제거)
2. **시간 눈금 간격**: 00:00~24:00 라벨을 모두 자기 격자선 바로 아래로 **균일 정렬** — #655에서 00:00/24:00만 다르게 정렬해 1~23시와 간격이 어긋나던 문제 해소

## 테스트
- `WeeklyPlan.test.tsx`: 추가 시 [저장] 버튼 없이 PUT 자동 발생 검증, 멀티 요일 생성·취소·편집·삭제·모바일
- 기본 PUT 핸들러 추가, 전체 FE 198 통과, prettier·eslint·tsc·build 통과

## 비고
- 자동 저장은 낙관적 반영 + 성공 시 서버 응답으로 캐시 갱신. 실패 시 토스트로 알림