### PR TITLE
feat : 주간 계획표 24:00(자정) 종료 지원 — 시간 분 단위 저장

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/DayPlanService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/DayPlanService.java
@@ -36,7 +36,7 @@ public class DayPlanService {
     public DayPlanResponse getWeeklyPlan(Long memberId) {
         List<DayPlanBlockResponse> blocks = blockRepository.findAllByMemberId(memberId).stream()
                 .sorted(Comparator.comparingInt(DayPlanBlock::getDayOfWeek)
-                        .thenComparing(DayPlanBlock::getStartTime))
+                        .thenComparingInt(DayPlanBlock::getStartMinute))
                 .map(DayPlanBlockResponse::of)
                 .toList();
         return new DayPlanResponse(blocks);
@@ -45,41 +45,61 @@ public class DayPlanService {
     /** 주간 템플릿 전량 교체. 기존 블록을 모두 지우고 요청 블록으로 대체한다(요일 내 시작시각 순 sort_order). */
     @Transactional
     public DayPlanResponse replace(Long memberId, DayPlanRequest request) {
-        validate(request.blocks());
+        List<ParsedBlock> parsed = request.blocks().stream()
+                .map(this::parseAndValidate)
+                .toList();
 
         blockRepository.deleteByMemberId(memberId);
         blockRepository.flush();
-        blockRepository.saveAll(buildBlocks(memberId, request.blocks()));
+        blockRepository.saveAll(buildBlocks(memberId, parsed));
 
         return getWeeklyPlan(memberId);
     }
 
-    /** 요일 범위·시간 역전·라벨 공백 검증. 위반 시 400 PLN-ERR-002. 같은 요일 겹침은 허용(약한 검증). */
-    private void validate(List<DayPlanBlockRequest> blocks) {
-        for (DayPlanBlockRequest block : blocks) {
-            boolean invalid = block.dayOfWeek() < MIN_DAY_OF_WEEK || block.dayOfWeek() > MAX_DAY_OF_WEEK
-                    || block.label() == null || block.label().isBlank()
-                    || !block.endTime().isAfter(block.startTime());
-            if (invalid) {
-                throw new CustomException(ErrorCode.ROUTINE_INVALID_RULE);
-            }
-        }
+    /** 검증 통과한 블록(분 단위). */
+    private record ParsedBlock(int dayOfWeek, int startMinute, int endMinute, String label, String color) {
     }
 
-    private List<DayPlanBlock> buildBlocks(Long memberId, List<DayPlanBlockRequest> requests) {
-        List<DayPlanBlockRequest> sorted = requests.stream()
-                .sorted(Comparator.comparingInt(DayPlanBlockRequest::dayOfWeek)
-                        .thenComparing(DayPlanBlockRequest::startTime))
+    /**
+     * 시각 파싱 + 요일 범위·시간 역전·라벨 공백 검증. 위반 시 400 PLN-ERR-002.
+     * start 0~1439, end 1~1440(1440=자정), end&gt;start. 같은 요일 겹침은 허용(약한 검증).
+     */
+    private ParsedBlock parseAndValidate(DayPlanBlockRequest block) {
+        int startMinute;
+        int endMinute;
+        try {
+            startMinute = WeeklyPlanTime.toMinutes(block.startTime());
+            endMinute = WeeklyPlanTime.toMinutes(block.endTime());
+        } catch (RuntimeException e) {
+            throw new CustomException(ErrorCode.ROUTINE_INVALID_RULE);
+        }
+
+        boolean invalid = block.dayOfWeek() < MIN_DAY_OF_WEEK || block.dayOfWeek() > MAX_DAY_OF_WEEK
+                || block.label() == null || block.label().isBlank()
+                || startMinute < 0 || startMinute >= WeeklyPlanTime.DAY_MINUTES
+                || endMinute < 1 || endMinute > WeeklyPlanTime.DAY_MINUTES
+                || endMinute <= startMinute;
+        if (invalid) {
+            throw new CustomException(ErrorCode.ROUTINE_INVALID_RULE);
+        }
+        return new ParsedBlock(
+                block.dayOfWeek(), startMinute, endMinute, block.label().trim(), block.color());
+    }
+
+    private List<DayPlanBlock> buildBlocks(Long memberId, List<ParsedBlock> parsed) {
+        List<ParsedBlock> sorted = parsed.stream()
+                .sorted(Comparator.comparingInt(ParsedBlock::dayOfWeek)
+                        .thenComparingInt(ParsedBlock::startMinute))
                 .toList();
 
         Map<Integer, Integer> nextOrderByDay = new HashMap<>();
         List<DayPlanBlock> blocks = new ArrayList<>();
-        for (DayPlanBlockRequest request : sorted) {
-            int order = nextOrderByDay.getOrDefault(request.dayOfWeek(), 0);
-            nextOrderByDay.put(request.dayOfWeek(), order + 1);
+        for (ParsedBlock block : sorted) {
+            int order = nextOrderByDay.getOrDefault(block.dayOfWeek(), 0);
+            nextOrderByDay.put(block.dayOfWeek(), order + 1);
             blocks.add(new DayPlanBlock(
-                    memberId, request.dayOfWeek(), request.startTime(), request.endTime(),
-                    request.label().trim(), request.color(), order));
+                    memberId, block.dayOfWeek(), block.startMinute(), block.endMinute(),
+                    block.label(), block.color(), order));
         }
         return blocks;
     }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/WeeklyPlanTime.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/WeeklyPlanTime.java
@@ -1,0 +1,32 @@
+package ds.project.orino.planner.dayplan;
+
+/** 주간 계획표 시간 변환: API "HH:mm" 문자열 ↔ 자정 기준 분(0~1440, 1440="24:00"). */
+public final class WeeklyPlanTime {
+
+    public static final int DAY_MINUTES = 24 * 60; // 1440
+
+    private WeeklyPlanTime() {
+    }
+
+    /** "HH:mm" → 분(0~1440). 형식이 잘못되면 {@link IllegalArgumentException}. */
+    public static int toMinutes(String hhmm) {
+        if (hhmm == null) {
+            throw new IllegalArgumentException("시간이 비어있습니다");
+        }
+        String[] parts = hhmm.trim().split(":");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("HH:mm 형식이 아닙니다: " + hhmm);
+        }
+        int hour = Integer.parseInt(parts[0]);
+        int minute = Integer.parseInt(parts[1]);
+        if (hour < 0 || minute < 0 || minute > 59) {
+            throw new IllegalArgumentException("유효하지 않은 시각: " + hhmm);
+        }
+        return hour * 60 + minute;
+    }
+
+    /** 분(0~1440) → "HH:mm"(1440="24:00"). */
+    public static String toHhmm(int minutes) {
+        return String.format("%02d:%02d", minutes / 60, minutes % 60);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanBlockRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanBlockRequest.java
@@ -1,20 +1,17 @@
 package ds.project.orino.planner.dayplan.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import jakarta.validation.constraints.NotNull;
-
-import java.time.LocalTime;
+import jakarta.validation.constraints.NotBlank;
 
 /**
- * 주간 블록 요청. 시간은 사용자 로컬 벽시계 "HH:mm". 의미 검증(요일 범위·end&gt;start·label 비어있음)은
- * 서비스에서 PLN-ERR-002로 처리한다.
+ * 주간 블록 요청. 시간은 사용자 로컬 벽시계 "HH:mm"(종료는 "24:00"=자정 허용).
+ * 의미 검증(요일 범위·시각 파싱·end&gt;start·label 비어있음)은 서비스에서 PLN-ERR-002로 처리한다.
  *
  * @param dayOfWeek 요일 0=일 … 6=토
  */
 public record DayPlanBlockRequest(
         int dayOfWeek,
-        @NotNull @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm") LocalTime startTime,
-        @NotNull @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm") LocalTime endTime,
+        @NotBlank String startTime,
+        @NotBlank String endTime,
         String label,
         String color
 ) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanBlockResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dayplan/dto/DayPlanBlockResponse.java
@@ -1,22 +1,25 @@
 package ds.project.orino.planner.dayplan.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import ds.project.orino.domain.planner.dayplan.entity.DayPlanBlock;
+import ds.project.orino.planner.dayplan.WeeklyPlanTime;
 
-import java.time.LocalTime;
-
+/** 주간 블록 응답. 시간은 "HH:mm"(종료 "24:00"=자정). */
 public record DayPlanBlockResponse(
         Long id,
         int dayOfWeek,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm") LocalTime startTime,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm") LocalTime endTime,
+        String startTime,
+        String endTime,
         String label,
         String color
 ) {
 
     public static DayPlanBlockResponse of(DayPlanBlock block) {
         return new DayPlanBlockResponse(
-                block.getId(), block.getDayOfWeek(), block.getStartTime(), block.getEndTime(),
-                block.getLabel(), block.getColor());
+                block.getId(),
+                block.getDayOfWeek(),
+                WeeklyPlanTime.toHhmm(block.getStartMinute()),
+                WeeklyPlanTime.toHhmm(block.getEndMinute()),
+                block.getLabel(),
+                block.getColor());
     }
 }

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/030-day-plan-block-minutes.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/030-day-plan-block-minutes.yaml
@@ -1,0 +1,42 @@
+databaseChangeLog:
+  - changeSet:
+      id: 030-day-plan-block-minutes
+      author: wcorn
+      comment: |
+        주간 계획표 블록 시간을 분(0~1440) 정수로 전환(#667). LocalTime(TIME, 최대 23:59)으로는
+        자정(24:00) 종료를 표현 못 해 start_time/end_time(TIME)을 start_minute/end_minute(INT)로
+        바꾼다. 기존 데이터는 TIME_TO_SEC로 분 변환해 보존한다.
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: day_plan_block
+            columnName: start_time
+      changes:
+        - addColumn:
+            tableName: day_plan_block
+            columns:
+              - column:
+                  name: start_minute
+                  type: INT
+              - column:
+                  name: end_minute
+                  type: INT
+        - sql:
+            sql: >
+              UPDATE day_plan_block
+              SET start_minute = TIME_TO_SEC(start_time) DIV 60,
+                  end_minute = TIME_TO_SEC(end_time) DIV 60
+        - addNotNullConstraint:
+            tableName: day_plan_block
+            columnName: start_minute
+            columnDataType: INT
+        - addNotNullConstraint:
+            tableName: day_plan_block
+            columnName: end_minute
+            columnDataType: INT
+        - dropColumn:
+            tableName: day_plan_block
+            columnName: start_time
+        - dropColumn:
+            tableName: day_plan_block
+            columnName: end_time

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -57,3 +57,5 @@ databaseChangeLog:
       file: db/changelog/changes/028-create-day-plan.yaml
   - include:
       file: db/changelog/changes/029-reshape-day-plan.yaml
+  - include:
+      file: db/changelog/changes/030-day-plan-block-minutes.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dayplan/DayPlanControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dayplan/DayPlanControllerTest.java
@@ -125,6 +125,38 @@ class DayPlanControllerTest extends ApiTestSupport {
     }
 
     @Test
+    @DisplayName("PUT - 종료 24:00(자정)을 허용하고 분 단위로 저장한다")
+    void put_allowsMidnightEnd() throws Exception {
+        String body = """
+                { "blocks": [
+                  { "dayOfWeek": 1, "startTime": "22:00", "endTime": "24:00", "label": "마감", "color": null }
+                ] }""";
+
+        mockMvc.perform(putBlocks(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.blocks", hasSize(1)))
+                .andExpect(jsonPath("$.data.blocks[0].startTime").value("22:00"))
+                .andExpect(jsonPath("$.data.blocks[0].endTime").value("24:00"));
+
+        assertThat(blockRepository.findAllByMemberId(memberId))
+                .singleElement()
+                .satisfies(b -> {
+                    assertThat(b.getStartMinute()).isEqualTo(1320);
+                    assertThat(b.getEndMinute()).isEqualTo(1440);
+                });
+    }
+
+    @Test
+    @DisplayName("PUT - 종료가 24:00을 넘으면(25:00) 400 PLN-ERR-002")
+    void put_endBeyondMidnight_400() throws Exception {
+        String invalid = """
+                { "blocks": [ { "dayOfWeek": 1, "startTime": "22:00", "endTime": "25:00", "label": "초과" } ] }""";
+        mockMvc.perform(putBlocks(invalid))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("PLN-ERR-002"));
+    }
+
+    @Test
     @DisplayName("PUT - 시간 역전(end<=start)이면 400 PLN-ERR-002")
     void put_timeReversed_400() throws Exception {
         String invalid = """

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dayplan/entity/DayPlanBlock.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dayplan/entity/DayPlanBlock.java
@@ -14,11 +14,13 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.Instant;
-import java.time.LocalTime;
 
 /**
  * 주간 계획표의 시간 블록(한 칸). 멤버당 모든 블록의 집합이 곧 "단일 주간 템플릿"이다.
  * wrapper 엔티티 없이 {@code member_id}를 직접 보유하고 요일·구간만 가진다(반복·차임·미러 없음).
+ *
+ * <p>시간은 자정 기준 분(0~1440)으로 저장한다. {@code endMinute=1440}은 자정(24:00) 종료를 뜻한다
+ * (LocalTime/TIME으로는 표현 불가해 분 정수로 둔다).
  */
 @Entity
 @EntityListeners(AuditingEntityListener.class)
@@ -37,12 +39,13 @@ public class DayPlanBlock {
     @Column(name = "day_of_week", nullable = false)
     private int dayOfWeek;
 
-    @Column(name = "start_time", nullable = false)
-    private LocalTime startTime;
+    /** 시작(자정 기준 분, 0~1439). */
+    @Column(name = "start_minute", nullable = false)
+    private int startMinute;
 
-    /** 종료(벽시계). 항상 {@code > startTime}(구간 블록, 자정 넘김 불가). */
-    @Column(name = "end_time", nullable = false)
-    private LocalTime endTime;
+    /** 종료(자정 기준 분, 1~1440). 항상 {@code > startMinute}. 1440=자정(24:00). */
+    @Column(name = "end_minute", nullable = false)
+    private int endMinute;
 
     @Column(nullable = false, length = 100)
     private String label;
@@ -64,12 +67,12 @@ public class DayPlanBlock {
     protected DayPlanBlock() {
     }
 
-    public DayPlanBlock(Long memberId, int dayOfWeek, LocalTime startTime, LocalTime endTime,
+    public DayPlanBlock(Long memberId, int dayOfWeek, int startMinute, int endMinute,
                         String label, String color, int sortOrder) {
         this.memberId = memberId;
         this.dayOfWeek = dayOfWeek;
-        this.startTime = startTime;
-        this.endTime = endTime;
+        this.startMinute = startMinute;
+        this.endMinute = endMinute;
         this.label = label;
         this.color = color;
         this.sortOrder = sortOrder;
@@ -87,12 +90,12 @@ public class DayPlanBlock {
         return dayOfWeek;
     }
 
-    public LocalTime getStartTime() {
-        return startTime;
+    public int getStartMinute() {
+        return startMinute;
     }
 
-    public LocalTime getEndTime() {
-        return endTime;
+    public int getEndMinute() {
+        return endMinute;
     }
 
     public String getLabel() {

--- a/fe/src/features/planner/components/plan/PlanBlockCreate.test.tsx
+++ b/fe/src/features/planner/components/plan/PlanBlockCreate.test.tsx
@@ -1,0 +1,56 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithRouter } from "@/test/render";
+
+import { PlanBlockCreate } from "./PlanBlockCreate";
+
+describe("PlanBlockCreate", () => {
+  it("'자정(24:00)' 체크 시 종료 24:00 블록을 만든다", async () => {
+    const onCreate = vi.fn();
+    const user = userEvent.setup();
+    renderWithRouter(
+      <PlanBlockCreate open onCreate={onCreate} onClose={() => {}} />,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    await user.click(within(dialog).getByRole("checkbox", { name: "월" }));
+    await user.type(within(dialog).getByLabelText("라벨"), "마감");
+    await user.click(
+      within(dialog).getByRole("checkbox", { name: "종료를 자정(24:00)으로" }),
+    );
+    await user.click(within(dialog).getByRole("button", { name: "추가" }));
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    const blocks = onCreate.mock.calls[0][0];
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      dayOfWeek: 1,
+      startTime: "09:00",
+      endTime: "24:00",
+      label: "마감",
+    });
+  });
+
+  it("자정 체크를 해제하면 24:00이 아닌 종료로 되돌아간다", async () => {
+    const onCreate = vi.fn();
+    const user = userEvent.setup();
+    renderWithRouter(
+      <PlanBlockCreate open onCreate={onCreate} onClose={() => {}} />,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    const midnight = within(dialog).getByRole("checkbox", {
+      name: "종료를 자정(24:00)으로",
+    });
+    await user.click(midnight); // on → 24:00
+    await user.click(midnight); // off → 24:00 아님
+
+    await user.click(within(dialog).getByRole("checkbox", { name: "월" }));
+    await user.type(within(dialog).getByLabelText("라벨"), "공부");
+    await user.click(within(dialog).getByRole("button", { name: "추가" }));
+
+    expect(onCreate.mock.calls[0][0][0].endTime).not.toBe("24:00");
+  });
+});

--- a/fe/src/features/planner/components/plan/PlanBlockCreate.tsx
+++ b/fe/src/features/planner/components/plan/PlanBlockCreate.tsx
@@ -134,11 +134,20 @@ export function PlanBlockCreate({
             <Input
               id="create-end"
               type="time"
-              value={endTime}
+              value={endTime === "24:00" ? "" : endTime}
+              disabled={endTime === "24:00"}
               onChange={(e) => setEndTime(e.target.value)}
             />
           </FormField>
         </div>
+
+        <label className="flex items-center gap-1.5 text-xs">
+          <Checkbox
+            checked={endTime === "24:00"}
+            onChange={(e) => setEndTime(e.target.checked ? "24:00" : "23:00")}
+          />
+          종료를 자정(24:00)으로
+        </label>
 
         <FormField label="색" labelId="create-color">
           <div

--- a/fe/src/features/planner/components/plan/PlanBlockEditor.tsx
+++ b/fe/src/features/planner/components/plan/PlanBlockEditor.tsx
@@ -2,6 +2,7 @@ import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
@@ -97,11 +98,25 @@ export function PlanBlockEditor({
             <Input
               id="block-end"
               type="time"
-              value={draft.endTime}
+              value={draft.endTime === "24:00" ? "" : draft.endTime}
+              disabled={draft.endTime === "24:00"}
               onChange={(e) => setDraft({ ...draft, endTime: e.target.value })}
             />
           </FormField>
         </div>
+
+        <label className="flex items-center gap-1.5 text-xs">
+          <Checkbox
+            checked={draft.endTime === "24:00"}
+            onChange={(e) =>
+              setDraft({
+                ...draft,
+                endTime: e.target.checked ? "24:00" : "23:00",
+              })
+            }
+          />
+          종료를 자정(24:00)으로
+        </label>
 
         <FormField label="색" labelId="block-color">
           <div

--- a/fe/src/features/planner/components/plan/planGrid.test.ts
+++ b/fe/src/features/planner/components/plan/planGrid.test.ts
@@ -25,9 +25,11 @@ function block(start: string, end: string): EditableBlock {
 describe("planGrid", () => {
   it("timeToMinutes / minutesToTime 왕복", () => {
     expect(timeToMinutes("08:30")).toBe(510);
+    expect(timeToMinutes("24:00")).toBe(1440);
     expect(minutesToTime(510)).toBe("08:30");
     expect(minutesToTime(0)).toBe("00:00");
-    expect(minutesToTime(1500)).toBe("23:59"); // 클램프
+    expect(minutesToTime(1440)).toBe("24:00"); // 자정
+    expect(minutesToTime(1500)).toBe("24:00"); // 1440으로 클램프
   });
 
   it("isReversed는 종료<=시작이면 true", () => {

--- a/fe/src/features/planner/components/plan/planGrid.ts
+++ b/fe/src/features/planner/components/plan/planGrid.ts
@@ -48,9 +48,9 @@ export function timeToMinutes(time: string): number {
   return h * 60 + m;
 }
 
-/** 분 → "HH:mm"(0..1439로 클램프). */
+/** 분 → "HH:mm"(0..1440로 클램프, 1440="24:00"). */
 export function minutesToTime(minutes: number): string {
-  const clamped = Math.max(0, Math.min(MAX_MINUTE, Math.round(minutes)));
+  const clamped = Math.max(0, Math.min(DAY_MINUTES, Math.round(minutes)));
   const h = Math.floor(clamped / 60);
   const m = clamped % 60;
   return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;


### PR DESCRIPTION
## 이슈
closes #667

## 문제
블록 종료를 **24:00(자정)** 으로 지정할 수 없었다. 입력은 `<input type="time">`(최대 23:59)이고 백엔드가 `LocalTime`(TIME, 최대 23:59:59)이라 자정 끝을 표현 못 함. 그리드엔 24:00 눈금이 보이는데 그 지점까지 닿는 블록은 못 만드는 모순.

## 해결 — 시간을 분(0~1440) 정수로 저장
**BE**
- Liquibase 030: `day_plan_block` `start_time`/`end_time`(TIME) → `start_minute`/`end_minute`(INT). 기존 데이터는 `TIME_TO_SEC`로 분 변환해 **보존**
- 엔티티 `int startMinute/endMinute`(1440=자정), `WeeklyPlanTime`(HH:mm↔분)
- DTO 시간은 `String`("24:00" 허용), 서비스가 파싱·검증: start 0~1439, end 1~1440, end>start → 위반 400 PLN-ERR-002
- API는 기존처럼 `"HH:mm"`(종료만 `"24:00"` 추가 허용) — 다른 시간 표현은 그대로

**FE**
- 생성/편집 폼에 **"종료를 자정(24:00)으로"** 체크박스(체크 시 종료=24:00, 시간 입력 비활성). 그리드는 24:00까지 채워 렌더
- `minutesToTime` 1440="24:00" 지원

## 테스트
- BE: 종료 24:00 허용·분 저장(1440), 25:00 거부, 기존 검증 유지. 마이그레이션 028→030 적용 확인
- FE: `PlanBlockCreate.test.tsx`(자정 체크→24:00 생성/해제 복귀), planGrid 변환, 전체 200 통과
- BE checkstyle·app-api test·FE lint/tsc/build 통과

## 비고
- 자동 저장(#666)과 파일 겹침 없음(WeeklyPlan/Grid/handlers 미수정) — 독립 머지 가능