### PR TITLE
feat : 페이지 헤더 공통 PageHeader로 통일

### DIFF
--- a/fe/src/components/PageHeader.test.tsx
+++ b/fe/src/components/PageHeader.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PageHeader } from "./PageHeader";
+
+describe("PageHeader", () => {
+  it("제목을 text-xl h1로 렌더한다", () => {
+    render(<PageHeader title="학습 자료" />);
+    const heading = screen.getByRole("heading", { name: "학습 자료" });
+    expect(heading.tagName).toBe("H1");
+    expect(heading).toHaveClass("text-xl", "font-semibold");
+  });
+
+  it("설명과 우측 액션 슬롯을 함께 렌더한다", () => {
+    render(
+      <PageHeader
+        title="주간 계획표"
+        description="변경 시 자동 저장됩니다"
+        actions={<button>추가</button>}
+      />,
+    );
+    expect(screen.getByText("변경 시 자동 저장됩니다")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "추가" })).toBeInTheDocument();
+  });
+
+  it("설명/액션이 없으면 해당 요소를 렌더하지 않는다", () => {
+    render(<PageHeader title="연동 설정" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/fe/src/components/PageHeader.tsx
+++ b/fe/src/components/PageHeader.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface PageHeaderProps {
+  /** 페이지 제목. */
+  title: ReactNode;
+  /** 제목 아래 보조 설명(선택). */
+  description?: ReactNode;
+  /** 우측 정렬 액션 슬롯(버튼 등, 선택). */
+  actions?: ReactNode;
+  className?: string;
+}
+
+/**
+ * 페이지 상단 헤더 — 모든 페이지가 동일한 제목 크기(text-xl)·여백·정렬을 쓰도록 통일한다.
+ * 우측 액션과 보조 설명은 선택 슬롯.
+ */
+export function PageHeader({
+  title,
+  description,
+  actions,
+  className,
+}: PageHeaderProps) {
+  return (
+    <header
+      className={cn("flex items-center justify-between gap-3", className)}
+    >
+      <div className="min-w-0">
+        <h1 className="text-xl font-semibold">{title}</h1>
+        {description && (
+          <p className="text-muted-foreground mt-0.5 text-sm">{description}</p>
+        )}
+      </div>
+      {actions && (
+        <div className="flex shrink-0 items-center gap-2">{actions}</div>
+      )}
+    </header>
+  );
+}

--- a/fe/src/features/planner/components/plan/WeeklyPlan.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.tsx
@@ -1,6 +1,7 @@
 import { Plus } from "lucide-react";
 import { useEffect, useState } from "react";
 
+import { PageHeader } from "@/components/PageHeader";
 import { Button } from "@/components/ui/button";
 import { LoadingText } from "@/components/ui/loading-text";
 import { cn } from "@/lib/utils";
@@ -76,19 +77,17 @@ export function WeeklyPlan() {
   const days = narrow ? [mobileDay] : ALL_DAYS;
 
   return (
-    <div className="flex flex-col gap-3 p-4">
-      <header className="flex items-center justify-between gap-3">
-        <div>
-          <h1 className="text-lg font-semibold">주간 계획표</h1>
-          <p className="text-muted-foreground text-xs">
-            {save.isPending ? "저장 중…" : "변경 시 자동 저장됩니다"}
-          </p>
-        </div>
-        <Button variant="outline" size="sm" onClick={() => setCreating(true)}>
-          <Plus className="size-4" />
-          추가
-        </Button>
-      </header>
+    <div className="flex flex-col gap-6">
+      <PageHeader
+        title="주간 계획표"
+        description={save.isPending ? "저장 중…" : "변경 시 자동 저장됩니다"}
+        actions={
+          <Button variant="outline" size="sm" onClick={() => setCreating(true)}>
+            <Plus className="size-4" />
+            추가
+          </Button>
+        }
+      />
 
       {narrow && (
         <div className="flex gap-1" role="tablist" aria-label="요일 선택">

--- a/fe/src/pages/HomePage.tsx
+++ b/fe/src/pages/HomePage.tsx
@@ -1,7 +1,9 @@
+import { PageHeader } from "@/components/PageHeader";
+
 export function HomePage() {
   return (
     <div className="flex flex-col gap-6">
-      <h1 className="text-xl font-semibold">안녕하세요 👋</h1>
+      <PageHeader title="안녕하세요 👋" />
       <p className="text-muted-foreground text-sm">
         Study Planner v2 준비 중이에요. 곧 새 기능으로 만나요.
       </p>

--- a/fe/src/pages/planner/MaterialListPage.tsx
+++ b/fe/src/pages/planner/MaterialListPage.tsx
@@ -2,6 +2,7 @@ import { Plus } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { PageHeader } from "@/components/PageHeader";
 import { Button } from "@/components/ui/button";
 import { LoadingText } from "@/components/ui/loading-text";
 import { AddMaterialDialog } from "@/features/material/components/AddMaterialDialog";
@@ -20,12 +21,14 @@ export function MaterialListPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between gap-3">
-        <h1 className="text-xl font-semibold">학습 자료</h1>
-        <Button onClick={() => setDialogOpen(true)}>
-          <Plus className="size-4" /> 자료 추가
-        </Button>
-      </div>
+      <PageHeader
+        title="학습 자료"
+        actions={
+          <Button onClick={() => setDialogOpen(true)}>
+            <Plus className="size-4" /> 자료 추가
+          </Button>
+        }
+      />
 
       {isLoading ? (
         <LoadingText />

--- a/fe/src/pages/planner/PlannerSettingsPage.tsx
+++ b/fe/src/pages/planner/PlannerSettingsPage.tsx
@@ -1,9 +1,10 @@
+import { PageHeader } from "@/components/PageHeader";
 import { GoogleConnectionCard } from "@/features/google/components/GoogleConnectionCard";
 
 export function PlannerSettingsPage() {
   return (
     <div className="flex flex-col gap-6">
-      <h1 className="text-xl font-semibold">연동 설정</h1>
+      <PageHeader title="연동 설정" />
       <div className="max-w-md">
         <GoogleConnectionCard />
       </div>

--- a/fe/src/pages/planner/RoutinesPage.tsx
+++ b/fe/src/pages/planner/RoutinesPage.tsx
@@ -1,6 +1,7 @@
 import { Plus } from "lucide-react";
 import { useState } from "react";
 
+import { PageHeader } from "@/components/PageHeader";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { LoadingText } from "@/components/ui/loading-text";
@@ -122,12 +123,14 @@ export function RoutinesPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between gap-3">
-        <h1 className="text-xl font-semibold">루틴</h1>
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="size-4" /> 새 루틴
-        </Button>
-      </div>
+      <PageHeader
+        title="루틴"
+        actions={
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="size-4" /> 새 루틴
+          </Button>
+        }
+      />
 
       {status.isLoading ? (
         <LoadingText />


### PR DESCRIPTION
## 이슈
closes #669

## 문제
각 페이지가 `<h1>`을 제각각 작성해 제목 크기·여백·정렬이 달랐다. 공통 헤더 컴포넌트가 없었음.
- 주간계획표만 `text-lg`(나머지는 `text-xl`)
- 주간계획표는 레이아웃 `<main className="p-6">` 위에 **자체 `p-4`를 더해 이중 패딩** + 바깥 간격 `gap-3`(다른 페이지는 `gap-6`)

## 해결
- 공통 **`PageHeader`** 컴포넌트 도입: `text-xl font-semibold` 제목 + 우측 `actions` 슬롯 + `description` 슬롯
- 적용: Home(안녕하세요)·학습 자료·주간 계획표·루틴·연동 설정
- 주간 계획표: 제목 크기 통일, **자체 `p-4` 제거**(레이아웃 p-6과 정렬), 바깥 간격 `gap-6`으로 통일
- 캘린더 월 헤더(`< 2026년 6월 >`)는 prev/next 네비 컨트롤이라 구조 유지(폰트는 이미 `text-xl`)

## 테스트
- `PageHeader.test.tsx`: 제목 h1(text-xl)·설명·액션 슬롯·빈 슬롯 미렌더
- 기존 페이지 테스트(제목 heading) 유지, 전체 FE 203 통과, lint·tsc·build 통과