### PR TITLE
refactor : 색 스와치·Google 연결 안내 공통화 (P1a)

### DIFF
--- a/fe/src/features/google/components/GoogleRequiredState.tsx
+++ b/fe/src/features/google/components/GoogleRequiredState.tsx
@@ -1,0 +1,36 @@
+import { Dialog } from "@base-ui/react/dialog";
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { DialogFooter } from "@/components/ui/dialog-footer";
+
+import { GoogleConnectButton } from "./GoogleConnectButton";
+
+interface GoogleRequiredStateProps {
+  /** 안내 문구(기본: "Google 연결이 필요합니다."). */
+  message?: ReactNode;
+}
+
+/**
+ * 다이얼로그에서 Google 미연동 시 보여주는 본문 — 안내 문구 + 닫기/연결 푸터.
+ * 일정·할 일·루틴 폼이 동일하게 사용한다.
+ */
+export function GoogleRequiredState({
+  message = "Google 연결이 필요합니다.",
+}: GoogleRequiredStateProps) {
+  return (
+    <div className="mt-4 flex flex-col gap-4">
+      <p className="text-muted-foreground text-sm">{message}</p>
+      <DialogFooter className="mt-0">
+        <Dialog.Close
+          render={
+            <Button variant="ghost" type="button">
+              닫기
+            </Button>
+          }
+        />
+        <GoogleConnectButton />
+      </DialogFooter>
+    </div>
+  );
+}

--- a/fe/src/features/planner/components/calendar/EventFormDialog.tsx
+++ b/fe/src/features/planner/components/calendar/EventFormDialog.tsx
@@ -8,7 +8,7 @@ import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
 import { Textarea } from "@/components/ui/textarea";
-import { GoogleConnectButton } from "@/features/google/components/GoogleConnectButton";
+import { GoogleRequiredState } from "@/features/google/components/GoogleRequiredState";
 
 import type { EventWriteRequest } from "../../api/events";
 import type { PlannerEvent } from "../../api/feed";
@@ -134,21 +134,7 @@ export function EventFormDialog({
       </Dialog.Title>
 
       {!googleConnected ? (
-        <div className="mt-4 flex flex-col gap-4">
-          <p className="text-muted-foreground text-sm">
-            Google 연결이 필요합니다.
-          </p>
-          <DialogFooter className="mt-0">
-            <Dialog.Close
-              render={
-                <Button variant="ghost" type="button">
-                  닫기
-                </Button>
-              }
-            />
-            <GoogleConnectButton />
-          </DialogFooter>
-        </div>
+        <GoogleRequiredState />
       ) : (
         <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3">
           <FormField label="제목" htmlFor={titleId}>

--- a/fe/src/features/planner/components/calendar/TaskFormDialog.tsx
+++ b/fe/src/features/planner/components/calendar/TaskFormDialog.tsx
@@ -6,7 +6,7 @@ import { DialogFooter } from "@/components/ui/dialog-footer";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
-import { GoogleConnectButton } from "@/features/google/components/GoogleConnectButton";
+import { GoogleRequiredState } from "@/features/google/components/GoogleRequiredState";
 
 import type { TaskCreateRequest } from "../../api/tasks";
 
@@ -56,21 +56,7 @@ export function TaskFormDialog({
       </Dialog.Title>
 
       {!googleConnected ? (
-        <div className="mt-4 flex flex-col gap-4">
-          <p className="text-muted-foreground text-sm">
-            Google 연결이 필요합니다.
-          </p>
-          <DialogFooter className="mt-0">
-            <Dialog.Close
-              render={
-                <Button variant="ghost" type="button">
-                  닫기
-                </Button>
-              }
-            />
-            <GoogleConnectButton />
-          </DialogFooter>
-        </div>
+        <GoogleRequiredState />
       ) : (
         <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3">
           <FormField label="제목" htmlFor={titleId}>

--- a/fe/src/features/planner/components/plan/ColorSwatchSelector.test.tsx
+++ b/fe/src/features/planner/components/plan/ColorSwatchSelector.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ColorSwatchSelector } from "./ColorSwatchSelector";
+
+describe("ColorSwatchSelector", () => {
+  it("선택된 색만 aria-pressed=true로 표시한다", () => {
+    render(<ColorSwatchSelector value="sky" onChange={() => {}} />);
+    expect(screen.getByRole("button", { name: "하늘" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "보라" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("클릭하면 색 키로 onChange를 호출한다", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<ColorSwatchSelector value="violet" onChange={onChange} />);
+    await user.click(screen.getByRole("button", { name: "초록" }));
+    expect(onChange).toHaveBeenCalledWith("emerald");
+  });
+});

--- a/fe/src/features/planner/components/plan/ColorSwatchSelector.tsx
+++ b/fe/src/features/planner/components/plan/ColorSwatchSelector.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@/lib/utils";
+
+import { PLAN_COLORS } from "./planColors";
+
+interface ColorSwatchSelectorProps {
+  /** 선택된 색 키(null이면 미선택). */
+  value: string | null;
+  onChange: (key: string) => void;
+  /** 그룹 라벨 연결용 id(FormField labelId). */
+  labelledBy?: string;
+}
+
+/** 주간 계획표 색 선택 스와치 묶음. 생성/편집 폼에서 공용. */
+export function ColorSwatchSelector({
+  value,
+  onChange,
+  labelledBy,
+}: ColorSwatchSelectorProps) {
+  return (
+    <div className="flex gap-2" role="group" aria-labelledby={labelledBy}>
+      {PLAN_COLORS.map((c) => (
+        <button
+          key={c.key}
+          type="button"
+          aria-label={c.label}
+          aria-pressed={value === c.key}
+          onClick={() => onChange(c.key)}
+          className={cn(
+            "size-6 rounded-full ring-offset-2 transition",
+            c.swatch,
+            value === c.key
+              ? "ring-ring ring-2"
+              : "opacity-70 hover:opacity-100",
+          )}
+        />
+      ))}
+    </div>
+  );
+}

--- a/fe/src/features/planner/components/plan/PlanBlockCreate.tsx
+++ b/fe/src/features/planner/components/plan/PlanBlockCreate.tsx
@@ -8,7 +8,8 @@ import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
 import { cn } from "@/lib/utils";
 
-import { DEFAULT_COLOR, PLAN_COLORS } from "./planColors";
+import { ColorSwatchSelector } from "./ColorSwatchSelector";
+import { DEFAULT_COLOR } from "./planColors";
 import {
   createBlocks,
   DAY_LABELS,
@@ -150,28 +151,11 @@ export function PlanBlockCreate({
         </label>
 
         <FormField label="색" labelId="create-color">
-          <div
-            className="flex gap-2"
-            role="group"
-            aria-labelledby="create-color"
-          >
-            {PLAN_COLORS.map((c) => (
-              <button
-                key={c.key}
-                type="button"
-                aria-label={c.label}
-                aria-pressed={color === c.key}
-                onClick={() => setColor(c.key)}
-                className={cn(
-                  "size-6 rounded-full ring-offset-2 transition",
-                  c.swatch,
-                  color === c.key
-                    ? "ring-ring ring-2"
-                    : "opacity-70 hover:opacity-100",
-                )}
-              />
-            ))}
-          </div>
+          <ColorSwatchSelector
+            value={color}
+            onChange={setColor}
+            labelledBy="create-color"
+          />
         </FormField>
       </div>
 

--- a/fe/src/features/planner/components/plan/PlanBlockEditor.tsx
+++ b/fe/src/features/planner/components/plan/PlanBlockEditor.tsx
@@ -7,9 +7,8 @@ import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
 import { Select, type SelectOption } from "@/components/ui/select";
-import { cn } from "@/lib/utils";
 
-import { PLAN_COLORS } from "./planColors";
+import { ColorSwatchSelector } from "./ColorSwatchSelector";
 import { DAY_LABELS, type EditableBlock, isReversed } from "./planGrid";
 
 const DAY_OPTIONS: SelectOption<string>[] = DAY_LABELS.map((label, i) => ({
@@ -119,28 +118,11 @@ export function PlanBlockEditor({
         </label>
 
         <FormField label="색" labelId="block-color">
-          <div
-            className="flex gap-2"
-            role="group"
-            aria-labelledby="block-color"
-          >
-            {PLAN_COLORS.map((c) => (
-              <button
-                key={c.key}
-                type="button"
-                aria-label={c.label}
-                aria-pressed={draft.color === c.key}
-                onClick={() => setDraft({ ...draft, color: c.key })}
-                className={cn(
-                  "size-6 rounded-full ring-offset-2 transition",
-                  c.swatch,
-                  draft.color === c.key
-                    ? "ring-ring ring-2"
-                    : "opacity-70 hover:opacity-100",
-                )}
-              />
-            ))}
-          </div>
+          <ColorSwatchSelector
+            value={draft.color}
+            onChange={(key) => setDraft({ ...draft, color: key })}
+            labelledBy="block-color"
+          />
         </FormField>
       </div>
 

--- a/fe/src/features/planner/components/routine/RoutineFormDialog.tsx
+++ b/fe/src/features/planner/components/routine/RoutineFormDialog.tsx
@@ -8,7 +8,7 @@ import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
 import { Textarea } from "@/components/ui/textarea";
-import { GoogleConnectButton } from "@/features/google/components/GoogleConnectButton";
+import { GoogleRequiredState } from "@/features/google/components/GoogleRequiredState";
 
 import type {
   RoutineCreateRequest,
@@ -221,21 +221,7 @@ export function RoutineFormDialog({
       </Dialog.Title>
 
       {!googleConnected ? (
-        <div className="mt-4 flex flex-col gap-4">
-          <p className="text-muted-foreground text-sm">
-            Google 연결이 필요합니다.
-          </p>
-          <DialogFooter className="mt-0">
-            <Dialog.Close
-              render={
-                <Button variant="ghost" type="button">
-                  닫기
-                </Button>
-              }
-            />
-            <GoogleConnectButton />
-          </DialogFooter>
-        </div>
+        <GoogleRequiredState />
       ) : (
         <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3">
           <FormField label="종류">


### PR DESCRIPTION
## 이슈
연관 #671 (컴포넌트 공통화 — 전수조사 기반, 단계별 PR 중 **P1a**)

## 배경
FE 전수조사 결과, 공통 라이브러리는 탄탄하나 피처에 동일 마크업 중복이 다수. 그 중 **완전 동일한 두 패턴**을 먼저 추출(동작 변화 없음).

## 작업 내용
- **`ColorSwatchSelector`**: `PlanBlockCreate`·`PlanBlockEditor`의 동일한 색 스와치 버튼 묶음을 공통화 (`value`/`onChange`/`labelledBy`)
- **`GoogleRequiredState`**: `EventFormDialog`·`TaskFormDialog`·`RoutineFormDialog`의 동일한 "Google 연결이 필요합니다" 본문(안내 + 닫기/연결 푸터)을 공통화

## 테스트
- `ColorSwatchSelector.test.tsx`(선택 표시·onChange). Google 안내 분기는 기존 다이얼로그 테스트가 그대로 커버
- 전체 FE 202 통과, eslint·tsc·build 통과

## 다음 단계
- P1b: `DayOfWeekSelector`, `TimeRangeInput`, `DialogFormFooter`(변형 있어 분리)
- P2: `SectionHeader`·헤더 마무리·에러/빈 상태 정규화 / P3: 표시 행·뱃지