### PR TITLE
refactor : 시작/종료 시간+자정 입력 공통화 (P1b)

### DIFF
--- a/fe/src/features/planner/components/plan/PlanBlockCreate.tsx
+++ b/fe/src/features/planner/components/plan/PlanBlockCreate.tsx
@@ -16,6 +16,7 @@ import {
   type EditableBlock,
   isReversed,
 } from "./planGrid";
+import { TimeRangeFields } from "./TimeRangeFields";
 
 interface PlanBlockCreateProps {
   open: boolean;
@@ -117,38 +118,14 @@ export function PlanBlockCreate({
           />
         </FormField>
 
-        <div className="flex gap-3">
-          <FormField label="시작" htmlFor="create-start" className="flex-1">
-            <Input
-              id="create-start"
-              type="time"
-              value={startTime}
-              onChange={(e) => setStartTime(e.target.value)}
-            />
-          </FormField>
-          <FormField
-            label="종료"
-            htmlFor="create-end"
-            className="flex-1"
-            error={reversed ? "종료가 시작보다 늦어야 합니다." : undefined}
-          >
-            <Input
-              id="create-end"
-              type="time"
-              value={endTime === "24:00" ? "" : endTime}
-              disabled={endTime === "24:00"}
-              onChange={(e) => setEndTime(e.target.value)}
-            />
-          </FormField>
-        </div>
-
-        <label className="flex items-center gap-1.5 text-xs">
-          <Checkbox
-            checked={endTime === "24:00"}
-            onChange={(e) => setEndTime(e.target.checked ? "24:00" : "23:00")}
-          />
-          종료를 자정(24:00)으로
-        </label>
+        <TimeRangeFields
+          startTime={startTime}
+          endTime={endTime}
+          onStartChange={setStartTime}
+          onEndChange={setEndTime}
+          reversed={reversed}
+          idPrefix="create"
+        />
 
         <FormField label="색" labelId="create-color">
           <ColorSwatchSelector

--- a/fe/src/features/planner/components/plan/PlanBlockEditor.tsx
+++ b/fe/src/features/planner/components/plan/PlanBlockEditor.tsx
@@ -2,7 +2,6 @@ import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
@@ -10,6 +9,7 @@ import { Select, type SelectOption } from "@/components/ui/select";
 
 import { ColorSwatchSelector } from "./ColorSwatchSelector";
 import { DAY_LABELS, type EditableBlock, isReversed } from "./planGrid";
+import { TimeRangeFields } from "./TimeRangeFields";
 
 const DAY_OPTIONS: SelectOption<string>[] = DAY_LABELS.map((label, i) => ({
   value: String(i),
@@ -77,45 +77,14 @@ export function PlanBlockEditor({
           />
         </FormField>
 
-        <div className="flex gap-3">
-          <FormField label="시작" htmlFor="block-start" className="flex-1">
-            <Input
-              id="block-start"
-              type="time"
-              value={draft.startTime}
-              onChange={(e) =>
-                setDraft({ ...draft, startTime: e.target.value })
-              }
-            />
-          </FormField>
-          <FormField
-            label="종료"
-            htmlFor="block-end"
-            className="flex-1"
-            error={reversed ? "종료가 시작보다 늦어야 합니다." : undefined}
-          >
-            <Input
-              id="block-end"
-              type="time"
-              value={draft.endTime === "24:00" ? "" : draft.endTime}
-              disabled={draft.endTime === "24:00"}
-              onChange={(e) => setDraft({ ...draft, endTime: e.target.value })}
-            />
-          </FormField>
-        </div>
-
-        <label className="flex items-center gap-1.5 text-xs">
-          <Checkbox
-            checked={draft.endTime === "24:00"}
-            onChange={(e) =>
-              setDraft({
-                ...draft,
-                endTime: e.target.checked ? "24:00" : "23:00",
-              })
-            }
-          />
-          종료를 자정(24:00)으로
-        </label>
+        <TimeRangeFields
+          startTime={draft.startTime}
+          endTime={draft.endTime}
+          onStartChange={(v) => setDraft({ ...draft, startTime: v })}
+          onEndChange={(v) => setDraft({ ...draft, endTime: v })}
+          reversed={reversed}
+          idPrefix="block"
+        />
 
         <FormField label="색" labelId="block-color">
           <ColorSwatchSelector

--- a/fe/src/features/planner/components/plan/TimeRangeFields.tsx
+++ b/fe/src/features/planner/components/plan/TimeRangeFields.tsx
@@ -1,0 +1,69 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+
+interface TimeRangeFieldsProps {
+  startTime: string;
+  endTime: string;
+  onStartChange: (value: string) => void;
+  onEndChange: (value: string) => void;
+  /** 종료 ≤ 시작이면 true → 종료에 인라인 에러 표시. */
+  reversed: boolean;
+  /** input id 접두사(예: "create" → create-start/create-end). */
+  idPrefix: string;
+}
+
+/**
+ * 시작/종료 시간 입력 + "자정(24:00)으로" 체크박스. 생성·편집 폼 공용.
+ * 자정 체크 시 종료=24:00, 시간 입력은 비활성(자정은 native time input으로 못 고름).
+ */
+export function TimeRangeFields({
+  startTime,
+  endTime,
+  onStartChange,
+  onEndChange,
+  reversed,
+  idPrefix,
+}: TimeRangeFieldsProps) {
+  const midnight = endTime === "24:00";
+  return (
+    <>
+      <div className="flex gap-3">
+        <FormField
+          label="시작"
+          htmlFor={`${idPrefix}-start`}
+          className="flex-1"
+        >
+          <Input
+            id={`${idPrefix}-start`}
+            type="time"
+            value={startTime}
+            onChange={(e) => onStartChange(e.target.value)}
+          />
+        </FormField>
+        <FormField
+          label="종료"
+          htmlFor={`${idPrefix}-end`}
+          className="flex-1"
+          error={reversed ? "종료가 시작보다 늦어야 합니다." : undefined}
+        >
+          <Input
+            id={`${idPrefix}-end`}
+            type="time"
+            value={midnight ? "" : endTime}
+            disabled={midnight}
+            onChange={(e) => onEndChange(e.target.value)}
+          />
+        </FormField>
+      </div>
+
+      <label className="flex items-center gap-1.5 text-xs">
+        <Checkbox
+          checked={midnight}
+          onChange={(e) => onEndChange(e.target.checked ? "24:00" : "23:00")}
+        />
+        종료를 자정(24:00)으로
+      </label>
+    </>
+  );
+}


### PR DESCRIPTION
## 이슈
연관 #671 (컴포넌트 공통화 — **P1b**)

## 작업 내용
- **`TimeRangeFields`**: `PlanBlockCreate`·`PlanBlockEditor`에 동일하게 중복되던 **시작/종료 시간 입력 + "자정(24:00)으로" 체크박스** 블록을 공통 컴포넌트로 추출 (동작 변화 없음)
  - props: `startTime`/`endTime`/`onStartChange`/`onEndChange`/`reversed`/`idPrefix`

## 테스트
- 기존 폼 테스트가 그대로 커버: `PlanBlockCreate.test`(자정 24:00 생성/해제), `WeeklyPlan.test`(편집 역전 차단)
- 전체 FE 205 통과, eslint·tsc·build 통과

## 범위 결정
- **요일 선택기 통합 보류**: 3곳이 의미·동작이 서로 다름(생성=멀티 체크박스 / 주간계획표=단일선택 tablist / 루틴=멀티 버튼) → 억지 통합은 회귀 위험만 커 제외
- **`DialogFormFooter`(P1c)로 분리**: 폼 `submit` vs `onClick`, 삭제/연결 변형이 있어 다이얼로그 6종을 별도 PR에서 신중히 처리