### PR TITLE
refactor : SectionHeader 도입 + 에러/빈 상태 정규화 (P2)

### DIFF
--- a/fe/src/components/ui/section-header.test.tsx
+++ b/fe/src/components/ui/section-header.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SectionHeader } from "./section-header";
+
+describe("SectionHeader", () => {
+  it("기본은 h2(text-base font-semibold)", () => {
+    render(<SectionHeader>오늘의 루틴</SectionHeader>);
+    const heading = screen.getByRole("heading", {
+      name: "오늘의 루틴",
+      level: 2,
+    });
+    expect(heading).toHaveClass("text-base", "font-semibold");
+  });
+
+  it("size=sm·level=3은 h3(text-xs font-medium muted)", () => {
+    render(
+      <SectionHeader size="sm" level={3}>
+        일정 (3)
+      </SectionHeader>,
+    );
+    const heading = screen.getByRole("heading", { name: "일정 (3)", level: 3 });
+    expect(heading).toHaveClass(
+      "text-xs",
+      "font-medium",
+      "text-muted-foreground",
+    );
+  });
+});

--- a/fe/src/components/ui/section-header.tsx
+++ b/fe/src/components/ui/section-header.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface SectionHeaderProps {
+  children: ReactNode;
+  /** md=섹션 제목(text-base 진하게), sm=하위 묶음 제목(text-xs 흐리게). */
+  size?: "sm" | "md";
+  /** 제목 계층(h2/h3). */
+  level?: 2 | 3;
+  className?: string;
+}
+
+/** 페이지 내부 섹션/하위 묶음 제목. h1 페이지 제목은 PageHeader를 쓴다. */
+export function SectionHeader({
+  children,
+  size = "md",
+  level = 2,
+  className,
+}: SectionHeaderProps) {
+  const Tag = level === 3 ? "h3" : "h2";
+  return (
+    <Tag
+      className={cn(
+        size === "sm"
+          ? "text-muted-foreground text-xs font-medium"
+          : "text-base font-semibold",
+        className,
+      )}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
@@ -3,6 +3,8 @@ import { Link } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { EmptyState } from "@/components/ui/empty-state";
+import { SectionHeader } from "@/components/ui/section-header";
 import { parseIsoDate } from "@/features/review/calendar";
 import { cn } from "@/lib/utils";
 
@@ -44,14 +46,14 @@ export function PlannerDayDetailPanel({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-base font-medium">
+        <SectionHeader>
           {formatHeading(isoDate)}
           {holidayName && (
             <span className="ml-2 text-sm font-normal text-red-500">
               {holidayName}
             </span>
           )}
-        </h2>
+        </SectionHeader>
         {reviews.length > 0 && (
           <Link to="/planner/reviews/today">
             <Button size="sm">오늘 복습 하러가기</Button>
@@ -60,14 +62,16 @@ export function PlannerDayDetailPanel({
       </div>
 
       {isEmpty ? (
-        <p className="text-muted-foreground text-sm">이 날 일정이 없어요.</p>
+        <EmptyState className="min-h-[20svh]">
+          <p className="text-muted-foreground text-sm">이 날 일정이 없어요.</p>
+        </EmptyState>
       ) : (
         <div className="flex flex-col gap-4">
           {events.length > 0 && (
             <section className="flex flex-col gap-2">
-              <h3 className="text-muted-foreground text-xs font-medium">
+              <SectionHeader size="sm" level={3}>
                 일정 ({events.length})
-              </h3>
+              </SectionHeader>
               <DayTimeline
                 isoDate={isoDate}
                 events={events}
@@ -80,9 +84,9 @@ export function PlannerDayDetailPanel({
 
           {tasks.length > 0 && (
             <section className="flex flex-col gap-2">
-              <h3 className="text-muted-foreground text-xs font-medium">
+              <SectionHeader size="sm" level={3}>
                 할 일 ({tasks.length})
-              </h3>
+              </SectionHeader>
               <ul className="flex flex-col gap-1.5">
                 {tasks.map((task) => (
                   <li
@@ -118,9 +122,9 @@ export function PlannerDayDetailPanel({
 
           {reviews.length > 0 && (
             <section className="flex flex-col gap-2">
-              <h3 className="text-muted-foreground text-xs font-medium">
+              <SectionHeader size="sm" level={3}>
                 복습 (읽기 전용)
-              </h3>
+              </SectionHeader>
               <ul className="flex flex-col gap-1.5">
                 {reviews.map((review) => (
                   <li

--- a/fe/src/features/planner/components/plan/WeeklyPlan.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 
 import { PageHeader } from "@/components/PageHeader";
 import { Button } from "@/components/ui/button";
+import { FieldError } from "@/components/ui/field-error";
 import { LoadingText } from "@/components/ui/loading-text";
 import { cn } from "@/lib/utils";
 
@@ -114,9 +115,9 @@ export function WeeklyPlan() {
       {isLoading ? (
         <LoadingText className="p-6" />
       ) : isError ? (
-        <p className="text-destructive p-6 text-sm">
+        <FieldError className="p-6">
           주간 계획표를 불러오지 못했습니다.
-        </p>
+        </FieldError>
       ) : (
         <WeeklyPlanGrid blocks={blocks} days={days} onSelect={setEditing} />
       )}

--- a/fe/src/features/planner/components/routine/TodayRoutines.tsx
+++ b/fe/src/features/planner/components/routine/TodayRoutines.tsx
@@ -1,6 +1,7 @@
 import { Repeat } from "lucide-react";
 
 import { Card, CardContent } from "@/components/ui/card";
+import { SectionHeader } from "@/components/ui/section-header";
 import { startOfDay, toIsoDate } from "@/features/review/calendar";
 import { cn } from "@/lib/utils";
 
@@ -40,7 +41,7 @@ export function TodayRoutines() {
     <Card>
       <CardContent className="flex flex-col gap-3">
         <div className="flex items-center justify-between">
-          <h2 className="text-base font-semibold">오늘의 루틴</h2>
+          <SectionHeader>오늘의 루틴</SectionHeader>
           {habits.length > 0 && (
             <span
               className="text-muted-foreground text-sm tabular-nums"

--- a/fe/src/pages/planner/RoutinesPage.tsx
+++ b/fe/src/pages/planner/RoutinesPage.tsx
@@ -5,6 +5,7 @@ import { PageHeader } from "@/components/PageHeader";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { LoadingText } from "@/components/ui/loading-text";
+import { SectionHeader } from "@/components/ui/section-header";
 import { GoogleConnectButton } from "@/features/google/components/GoogleConnectButton";
 import { useGoogleStatus } from "@/features/google/hooks/useGoogleStatus";
 import type {
@@ -41,7 +42,7 @@ function RoutineSection({ title, series, onEdit, onDelete }: SectionProps) {
   if (series.length === 0) return null;
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="text-muted-foreground text-xs font-semibold">{title}</h2>
+      <SectionHeader size="sm">{title}</SectionHeader>
       <ul className="flex flex-col gap-2">
         {series.map((s) => (
           <RoutineListItem


### PR DESCRIPTION
## 이슈
연관 #671 (컴포넌트 공통화 — **P2** 헤더·섹션·상태 일관화)

## 작업 내용
- **`SectionHeader`**(`size: sm|md`, `level: 2|3`) 신설 — 페이지 내부 섹션/하위 묶음 제목 통일(h1 페이지 제목은 `PageHeader`):
  - `TodayRoutines` "오늘의 루틴", `PlannerDayDetailPanel` 날짜·일정/할일/복습 소제목, `RoutinesPage` 습관/고정 일정 → 제각각이던 `text-xs/base`·`semibold/medium`를 일관화
- **에러 정규화**: `WeeklyPlan` 로드 실패의 ad-hoc `<p className="text-destructive">` → 공통 **`FieldError`**(다른 페이지와 동일)
- **빈 상태 정규화**: `PlannerDayDetailPanel`의 맨 `<p>` "이 날 일정이 없어요." → **`EmptyState`**(min-h-20svh)

## 범위 결정(유지)
- **캘린더 월 헤더**(`< 2026년 6월 >`)·**MaterialHeader**: 이미 `text-xl font-semibold`(=PageHeader h1)이고 구조가 다름(prev/next 네비, 아이콘+메뉴) → 통합보다 유지
- **RoutinesPage 로드 에러**: "다시 시도" 버튼이 있는 의도된 리치 에러라 유지

## 테스트
- `section-header.test.tsx`(size/level 렌더). 기존 페이지·패널 테스트가 교체 부분 커버
- 전체 FE 207 통과, eslint·tsc·build 통과