### PR TITLE
refactor : 다이얼로그 폼 푸터 공통화 (P1c)

### DIFF
--- a/fe/src/components/ui/dialog-form-footer.tsx
+++ b/fe/src/components/ui/dialog-form-footer.tsx
@@ -1,0 +1,62 @@
+import { Dialog } from "@base-ui/react/dialog";
+
+import { Button } from "@/components/ui/button";
+import { DialogFooter } from "@/components/ui/dialog-footer";
+import { cn } from "@/lib/utils";
+
+interface DialogFormFooterProps {
+  /** 제출 버튼 라벨. */
+  submitLabel: string;
+  /** 제출 진행 중 라벨(예: "저장 중..."). */
+  pendingLabel: string;
+  /** 진행 중 여부 — 라벨 전환 + 취소/삭제 비활성. */
+  pending: boolean;
+  /** 제출 비활성 조건(호출부에서 `!valid || pending` 등 전체 식을 전달). */
+  submitDisabled?: boolean;
+  /** 있으면 왼쪽에 삭제 버튼(빨강) + 양끝 정렬. */
+  onDelete?: () => void;
+  deleteLabel?: string;
+  cancelLabel?: string;
+}
+
+/**
+ * 폼 다이얼로그 하단 액션 — 취소(Dialog.Close) + 제출(type=submit), 선택적 삭제(왼쪽).
+ * `<form>` 안에서 사용한다(제출은 form submit).
+ */
+export function DialogFormFooter({
+  submitLabel,
+  pendingLabel,
+  pending,
+  submitDisabled,
+  onDelete,
+  deleteLabel = "삭제",
+  cancelLabel = "취소",
+}: DialogFormFooterProps) {
+  return (
+    <DialogFooter className={cn("mt-1", onDelete && "justify-between")}>
+      {onDelete && (
+        <Button
+          type="button"
+          variant="ghost"
+          className="text-destructive"
+          disabled={pending}
+          onClick={onDelete}
+        >
+          {deleteLabel}
+        </Button>
+      )}
+      <div className="flex gap-2">
+        <Dialog.Close
+          render={
+            <Button variant="ghost" type="button" disabled={pending}>
+              {cancelLabel}
+            </Button>
+          }
+        />
+        <Button type="submit" disabled={submitDisabled}>
+          {pending ? pendingLabel : submitLabel}
+        </Button>
+      </div>
+    </DialogFooter>
+  );
+}

--- a/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
+++ b/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
@@ -1,8 +1,7 @@
 import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
-import { Button } from "@/components/ui/button";
-import { DialogFooter } from "@/components/ui/dialog-footer";
+import { DialogFormFooter } from "@/components/ui/dialog-form-footer";
 import { FieldError } from "@/components/ui/field-error";
 import { FormField } from "@/components/ui/form-field";
 import { Modal } from "@/components/ui/modal";
@@ -90,33 +89,13 @@ export function FlashcardFormDialog({
 
         {errorMessage && <FieldError>{errorMessage}</FieldError>}
 
-        <DialogFooter className="mt-1 justify-between">
-          {mode === "edit" && onDelete ? (
-            <Button
-              type="button"
-              variant="ghost"
-              className="text-destructive"
-              disabled={pending}
-              onClick={onDelete}
-            >
-              삭제
-            </Button>
-          ) : (
-            <span />
-          )}
-          <div className="flex gap-2">
-            <Dialog.Close
-              render={
-                <Button variant="ghost" type="button" disabled={pending}>
-                  취소
-                </Button>
-              }
-            />
-            <Button type="submit" disabled={!valid || !dirty || pending}>
-              {pending ? "저장 중..." : "저장"}
-            </Button>
-          </div>
-        </DialogFooter>
+        <DialogFormFooter
+          submitLabel="저장"
+          pendingLabel="저장 중..."
+          pending={pending}
+          submitDisabled={!valid || !dirty || pending}
+          onDelete={mode === "edit" ? onDelete : undefined}
+        />
       </form>
     </Modal>
   );

--- a/fe/src/features/material/components/AddMaterialDialog.tsx
+++ b/fe/src/features/material/components/AddMaterialDialog.tsx
@@ -1,8 +1,7 @@
 import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
-import { Button } from "@/components/ui/button";
-import { DialogFooter } from "@/components/ui/dialog-footer";
+import { DialogFormFooter } from "@/components/ui/dialog-form-footer";
 import { FieldError } from "@/components/ui/field-error";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
@@ -92,22 +91,12 @@ export function AddMaterialDialog({ open, onOpenChange, onCreated }: Props) {
           </FieldError>
         )}
 
-        <DialogFooter className="mt-1">
-          <Dialog.Close
-            render={
-              <Button
-                variant="ghost"
-                type="button"
-                disabled={mutation.isPending}
-              >
-                취소
-              </Button>
-            }
-          />
-          <Button type="submit" disabled={!titleValid || mutation.isPending}>
-            {mutation.isPending ? "추가 중..." : "추가"}
-          </Button>
-        </DialogFooter>
+        <DialogFormFooter
+          submitLabel="추가"
+          pendingLabel="추가 중..."
+          pending={mutation.isPending}
+          submitDisabled={!titleValid || mutation.isPending}
+        />
       </form>
     </Modal>
   );

--- a/fe/src/features/material/components/EditMaterialDialog.tsx
+++ b/fe/src/features/material/components/EditMaterialDialog.tsx
@@ -1,8 +1,7 @@
 import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
-import { Button } from "@/components/ui/button";
-import { DialogFooter } from "@/components/ui/dialog-footer";
+import { DialogFormFooter } from "@/components/ui/dialog-form-footer";
 import { FieldError } from "@/components/ui/field-error";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
@@ -83,25 +82,12 @@ export function EditMaterialDialog({ material, open, onOpenChange }: Props) {
           <FieldError>저장에 실패했어요. 잠시 후 다시 시도해주세요.</FieldError>
         )}
 
-        <DialogFooter className="mt-1">
-          <Dialog.Close
-            render={
-              <Button
-                variant="ghost"
-                type="button"
-                disabled={mutation.isPending}
-              >
-                취소
-              </Button>
-            }
-          />
-          <Button
-            type="submit"
-            disabled={!titleValid || !dirty || mutation.isPending}
-          >
-            {mutation.isPending ? "저장 중..." : "저장"}
-          </Button>
-        </DialogFooter>
+        <DialogFormFooter
+          submitLabel="저장"
+          pendingLabel="저장 중..."
+          pending={mutation.isPending}
+          submitDisabled={!titleValid || !dirty || mutation.isPending}
+        />
       </form>
     </Modal>
   );

--- a/fe/src/features/planner/components/calendar/EventFormDialog.tsx
+++ b/fe/src/features/planner/components/calendar/EventFormDialog.tsx
@@ -1,9 +1,8 @@
 import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
-import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { DialogFooter } from "@/components/ui/dialog-footer";
+import { DialogFormFooter } from "@/components/ui/dialog-form-footer";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
@@ -207,33 +206,13 @@ export function EventFormDialog({
             />
           </FormField>
 
-          <DialogFooter className="mt-1 justify-between">
-            {mode === "edit" && onDelete ? (
-              <Button
-                type="button"
-                variant="ghost"
-                className="text-destructive"
-                disabled={pending}
-                onClick={onDelete}
-              >
-                삭제
-              </Button>
-            ) : (
-              <span />
-            )}
-            <div className="flex gap-2">
-              <Dialog.Close
-                render={
-                  <Button variant="ghost" type="button" disabled={pending}>
-                    취소
-                  </Button>
-                }
-              />
-              <Button type="submit" disabled={!valid || pending}>
-                {pending ? "저장 중..." : "저장"}
-              </Button>
-            </div>
-          </DialogFooter>
+          <DialogFormFooter
+            submitLabel="저장"
+            pendingLabel="저장 중..."
+            pending={pending}
+            submitDisabled={!valid || pending}
+            onDelete={mode === "edit" ? onDelete : undefined}
+          />
         </form>
       )}
     </Modal>

--- a/fe/src/features/planner/components/calendar/TaskFormDialog.tsx
+++ b/fe/src/features/planner/components/calendar/TaskFormDialog.tsx
@@ -1,8 +1,7 @@
 import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
-import { Button } from "@/components/ui/button";
-import { DialogFooter } from "@/components/ui/dialog-footer";
+import { DialogFormFooter } from "@/components/ui/dialog-form-footer";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
@@ -76,18 +75,12 @@ export function TaskFormDialog({
             />
           </FormField>
 
-          <DialogFooter className="mt-1">
-            <Dialog.Close
-              render={
-                <Button variant="ghost" type="button" disabled={pending}>
-                  취소
-                </Button>
-              }
-            />
-            <Button type="submit" disabled={!valid || pending}>
-              {pending ? "저장 중..." : "저장"}
-            </Button>
-          </DialogFooter>
+          <DialogFormFooter
+            submitLabel="저장"
+            pendingLabel="저장 중..."
+            pending={pending}
+            submitDisabled={!valid || pending}
+          />
         </form>
       )}
     </Modal>

--- a/fe/src/features/planner/components/routine/RoutineFormDialog.tsx
+++ b/fe/src/features/planner/components/routine/RoutineFormDialog.tsx
@@ -3,7 +3,7 @@ import { useEffect, useId, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { DialogFooter } from "@/components/ui/dialog-footer";
+import { DialogFormFooter } from "@/components/ui/dialog-form-footer";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
@@ -424,18 +424,12 @@ export function RoutineFormDialog({
             {recurrencePreview(recurrence, form.startDate)}
           </p>
 
-          <DialogFooter className="mt-1">
-            <Dialog.Close
-              render={
-                <Button variant="ghost" type="button" disabled={pending}>
-                  취소
-                </Button>
-              }
-            />
-            <Button type="submit" disabled={!valid || pending}>
-              {pending ? "저장 중..." : "저장"}
-            </Button>
-          </DialogFooter>
+          <DialogFormFooter
+            submitLabel="저장"
+            pendingLabel="저장 중..."
+            pending={pending}
+            submitDisabled={!valid || pending}
+          />
         </form>
       )}
     </Modal>


### PR DESCRIPTION
## 이슈
연관 #671 (컴포넌트 공통화 — **P1c**)

## 작업 내용
- **`DialogFormFooter`**: 폼 다이얼로그 하단 액션(취소 `Dialog.Close` + 제출 `type=submit` + 선택적 삭제) 푸터를 공통화
  - props: `submitLabel`/`pendingLabel`/`pending`/`submitDisabled`/`onDelete`(있으면 왼쪽 빨강 삭제 + 양끝 정렬)
- **적용 6종**(동작 변화 없음): `EventFormDialog`·`TaskFormDialog`·`RoutineFormDialog`·`FlashcardFormDialog`·`AddMaterialDialog`·`EditMaterialDialog`
- 사용처에서 불필요해진 `Button` 임포트 정리

## 테스트
- 6개 다이얼로그의 기존 테스트(취소/저장/추가/삭제 버튼)가 그대로 통과 → 푸터 동작 보존 검증
- 전체 FE 207 통과, eslint·tsc·build 통과

## 비고
- `PlanBlockCreate`/`PlanBlockEditor`는 `<form>`이 아니라 onClick 제출이라 이 푸터(폼 submit) 대상에서 제외