### PR TITLE
refactor : 캘린더 색 점·카드 행 표면 공통화 (P3)

### DIFF
--- a/fe/src/features/planner/components/calendar/ColorDot.tsx
+++ b/fe/src/features/planner/components/calendar/ColorDot.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib/utils";
+
+interface ColorDotProps {
+  /** 색 클래스(예: EVENT_DOT, BUCKET_DOT[...]). */
+  className?: string;
+  /** xs=셀 점(size-1.5), sm=범례 점(size-2). */
+  size?: "xs" | "sm";
+}
+
+/** 캘린더 소스/버킷 색 점. 셀·범례 공용. */
+export function ColorDot({ className, size = "sm" }: ColorDotProps) {
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded-full",
+        size === "xs" ? "size-1.5" : "size-2",
+        className,
+      )}
+    />
+  );
+}

--- a/fe/src/features/planner/components/calendar/DayTimeline.tsx
+++ b/fe/src/features/planner/components/calendar/DayTimeline.tsx
@@ -7,6 +7,7 @@ import type { PlannerEvent } from "../../api/feed";
 import { eventTimeParts, sortDayEvents } from "../../calendar";
 import { HOURS, layoutDayEvents } from "../../weekLayout";
 import { RoutineCheckCircle } from "../routine/RoutineCheckCircle";
+import { CARD_ROW_SURFACE } from "./rowStyles";
 import { EVENT_DOT } from "./sourceStyles";
 
 const HOUR_PX = 44;
@@ -57,7 +58,10 @@ export function DayTimeline({
             return (
               <li
                 key={event.id}
-                className="border-border bg-card flex items-center gap-2 rounded-md border px-2 py-1.5 text-sm"
+                className={cn(
+                  CARD_ROW_SURFACE,
+                  "flex items-center gap-2 px-2 py-1.5",
+                )}
               >
                 {isHabit ? (
                   <RoutineCheckCircle

--- a/fe/src/features/planner/components/calendar/PlannerCalendarCell.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendarCell.tsx
@@ -10,6 +10,7 @@ import {
   eventTimeLabel,
   sortDayEvents,
 } from "../../calendar";
+import { ColorDot } from "./ColorDot";
 import { EVENT_DOT, TASK_DOT } from "./sourceStyles";
 
 interface Props {
@@ -29,10 +30,6 @@ interface Props {
 
 /** 셀에 한 줄로 보여줄 최대 항목 수. 초과분은 "+N개"로 접는다. */
 const MAX_LINES = 3;
-
-function Dot({ className }: { className: string }) {
-  return <span className={cn("size-1.5 shrink-0 rounded-full", className)} />;
-}
 
 export function PlannerCalendarCell({
   date,
@@ -61,7 +58,7 @@ export function PlannerCalendarCell({
         key={`e-${event.id}`}
         className="flex items-center gap-1 text-[10px] leading-tight"
       >
-        <Dot className={EVENT_DOT} />
+        <ColorDot size="xs" className={EVENT_DOT} />
         {!event.allDay && (
           <span className="text-muted-foreground shrink-0 tabular-nums">
             {eventTimeLabel(event)}
@@ -75,7 +72,7 @@ export function PlannerCalendarCell({
         key={`t-${task.id}`}
         className="flex items-center gap-1 text-[10px] leading-tight"
       >
-        <Dot className={TASK_DOT} />
+        <ColorDot size="xs" className={TASK_DOT} />
         <span
           className={cn(
             "truncate",
@@ -92,7 +89,7 @@ export function PlannerCalendarCell({
             key="reviews"
             className="flex items-center gap-1 text-[10px] leading-tight"
           >
-            <Dot className={reviewDot} />
+            <ColorDot size="xs" className={reviewDot} />
             <span className="truncate">복습 {reviews.length}</span>
           </span>,
         ]

--- a/fe/src/features/planner/components/calendar/PlannerCalendarLegend.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendarLegend.tsx
@@ -3,8 +3,8 @@ import {
   BUCKET_LABEL,
   BUCKET_ORDER,
 } from "@/features/review/components/calendar/bucketStyles";
-import { cn } from "@/lib/utils";
 
+import { ColorDot } from "./ColorDot";
 import { EVENT_DOT, EVENT_LABEL, TASK_DOT, TASK_LABEL } from "./sourceStyles";
 
 const SOURCE_ITEMS = [
@@ -17,13 +17,13 @@ export function PlannerCalendarLegend() {
     <ul className="text-muted-foreground flex flex-wrap gap-x-3 gap-y-1 text-xs">
       {SOURCE_ITEMS.map((item) => (
         <li key={item.label} className="flex items-center gap-1.5">
-          <span className={cn("size-2 rounded-full", item.dot)} />
+          <ColorDot className={item.dot} />
           {item.label}
         </li>
       ))}
       {BUCKET_ORDER.map((bucket) => (
         <li key={bucket} className="flex items-center gap-1.5">
-          <span className={cn("size-2 rounded-full", BUCKET_DOT[bucket])} />
+          <ColorDot className={BUCKET_DOT[bucket]} />
           {BUCKET_LABEL[bucket]}
         </li>
       ))}

--- a/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerDayDetailPanel.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils";
 
 import type { PlannerEvent, PlannerReview, PlannerTask } from "../../api/feed";
 import { DayTimeline } from "./DayTimeline";
+import { CARD_ROW_SURFACE } from "./rowStyles";
 
 interface Props {
   isoDate: string;
@@ -91,7 +92,10 @@ export function PlannerDayDetailPanel({
                 {tasks.map((task) => (
                   <li
                     key={task.id}
-                    className="border-border bg-card flex items-center gap-2 rounded-md border p-2 text-sm"
+                    className={cn(
+                      CARD_ROW_SURFACE,
+                      "flex items-center gap-2 p-2",
+                    )}
                   >
                     <Checkbox
                       checked={task.completed}
@@ -129,7 +133,7 @@ export function PlannerDayDetailPanel({
                 {reviews.map((review) => (
                   <li
                     key={review.id}
-                    className="border-border bg-card flex flex-col rounded-md border p-2 text-sm"
+                    className={cn(CARD_ROW_SURFACE, "flex flex-col p-2")}
                   >
                     <span className="text-muted-foreground truncate text-xs">
                       {review.materialTitle}

--- a/fe/src/features/planner/components/calendar/rowStyles.ts
+++ b/fe/src/features/planner/components/calendar/rowStyles.ts
@@ -1,0 +1,3 @@
+/** 캘린더 일 상세·타임라인의 카드형 행 공통 표면 클래스(테두리+카드 배경+라운드). */
+export const CARD_ROW_SURFACE =
+  "border-border bg-card rounded-md border text-sm";


### PR DESCRIPTION
## 이슈
연관 #671 (컴포넌트 공통화 — **P3** 표시 요소, 마지막 단계)

## 작업 내용
- **`ColorDot`**: 캘린더 셀 점(`size-1.5`)·범례 점(`size-2`)을 `size` 변형(`xs`/`sm`)으로 통합 — `PlannerCalendarCell`·`PlannerCalendarLegend`
- **`CARD_ROW_SURFACE`**: 일 상세·타임라인의 카드형 행(`<li>`)에서 반복되던 표면 클래스(`border-border bg-card rounded-md border text-sm`)를 상수로 추출 — `DayTimeline`·`PlannerDayDetailPanel`(3곳). 행은 `<li>`라 래퍼 컴포넌트 대신 표면 클래스만 공통화(모양 변화 없음)

## 의도적으로 제외(과한 추상화 방지)
전수조사 P3 후보 중 **실제 교차 중복이 아닌** 항목은 추출하지 않음:
- **RatingBadge** — `ReviewCard` 단일 파일 내 색 매핑(다른 곳에서 안 씀)
- **LoadingSkeletonGrid** — `PlannerCalendar` 단일 사용처(추출해도 중복 제거 효과 없음)
- **AlertBanner** — `PlannerConnectionBanner`에 이미 로컬 `Banner`로 공통화돼 있음

## 테스트
- 기존 캘린더 테스트가 셀/범례/일상세 렌더 커버. 전체 FE 207 통과, eslint·tsc·build 통과