### PR TITLE
feat : 주간 계획표 자동 저장 안내 문구 제거

### DIFF
--- a/fe/src/features/planner/components/plan/WeeklyPlan.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.tsx
@@ -81,7 +81,7 @@ export function WeeklyPlan() {
     <div className="flex flex-col gap-6">
       <PageHeader
         title="주간 계획표"
-        description={save.isPending ? "저장 중…" : "변경 시 자동 저장됩니다"}
+        description={save.isPending ? "저장 중…" : undefined}
         actions={
           <Button variant="outline" size="sm" onClick={() => setCreating(true)}>
             <Plus className="size-4" />


### PR DESCRIPTION
## 작업 내용
주간 계획표 헤더 하단의 "변경 시 자동 저장됩니다" 문구를 제거한다. 저장 진행 중 "저장 중…" 표시는 유지.

## 테스트
- WeeklyPlan 테스트(8) 통과, tsc·prettier·build 통과