### PR TITLE
chore : design-sync 입력 파일 추가 (claude.ai/design 동기화 재현용)

### DIFF
--- a/fe/.design-sync/NOTES.md
+++ b/fe/.design-sync/NOTES.md
@@ -1,0 +1,31 @@
+# design-sync NOTES (orino-fe)
+
+이 리포는 **퍼블리시되는 라이브러리가 아니라 Vite 앱**이다. 디자인 시스템은 `src/components/ui` + `src/components`(앱 레벨)에 있고, 토큰은 `src/index.css`(Tailwind v4 `@theme`)에 있다.
+
+## 빌드/엔트리 (synth-entry)
+
+- 라이브러리 dist 엔트리가 없어 **synth-entry 모드**로 `src/components`에서 직접 번들한다(`cfg.srcDir = "src/components"`).
+- 컨버터는 `node_modules/orino-fe/package.json`을 읽으려 한다(앱은 self-install 안 됨). 해결: `node_modules/orino-fe`를 리포로 심링크.
+  - **주의**: 이 워크트리의 `node_modules`는 메인 리포(`/Users/dongseok/Documents/GitHub/orino/fe/node_modules`)로의 심링크다. 그래서 `ln -sfn .. node_modules/orino-fe`는 메인 리포 fe를 가리켜 버린다. 반드시 **절대경로**로:
+    `ln -sfn /Users/dongseok/Documents/GitHub/orino/.claude/worktrees/be-fe/fe node_modules/orino-fe`
+- `@/*` 별칭은 esbuild가 자동 tsconfig 탐지로 해석한다(cfg.tsconfig는 "outside workspace root"로 skip되지만 동작에는 무관).
+
+## 토큰/폰트 (Tailwind v4)
+
+- 컴포넌트는 Tailwind 유틸리티로 스타일링되므로 **컴파일된 CSS**가 필요하다. `cfg.cssEntry`는 `npm run build` 산출물 `dist/assets/index-*.css`(컴파일된 Tailwind, 토큰 :root + 유틸 포함).
+- Pretendard는 `cfg.extraFonts`로 `dist/assets/PretendardVariable-*.woff2`를 싣는다.
+
+## Known render warns (정상 — 새 경고 아님)
+
+- `[FONT_MISSING]` "Pretendard"(정적), "Apple SD Gothic Neo"(시스템) — 폴백 패밀리. **Pretendard Variable는 실린다**. 대체 폴백 허용.
+- thin(2): `Menu`(닫힌 트리거 상태 — 여는 건 인터랙션), 짧은 단일-룩 컴포넌트. 정상.
+
+## 플로어 카드(의도적 — 정적 프리뷰 부적합)
+
+- `DialogPopup`, `DialogFormFooter`, `MenuItem`, `Toaster` — 포털/Dialog 컨텍스트/스토어 상태에 의존해 정적 카드로 의미있게 렌더 불가. 기능 번들에는 모두 포함됨(import 가능). 추후 부모 조합으로 작성 가능.
+
+## Re-sync 위험(다음 실행이 주의할 것)
+
+- **해시 경로 취약**: `cfg.cssEntry`와 `cfg.extraFonts`가 content-hash된 파일명(`index-CUGrMVGd.css`, `PretendardVariable-CJuje-Rk.woff2`)을 가리킨다. `npm run build` 때마다 해시가 바뀌므로, 재동기화 시 **먼저 `npm run build` → config의 두 해시 경로를 새 파일명으로 갱신**해야 한다.
+- **심링크 재생성 필요**: `node_modules/orino-fe` 심링크는 gitignore(node_modules)라 클론마다 위 절대경로로 다시 만들어야 한다.
+- **워크트리/메인 node_modules 공유**: 위 "주의" 참고.

--- a/fe/.design-sync/config.json
+++ b/fe/.design-sync/config.json
@@ -1,0 +1,11 @@
+{
+  "projectId": "00735845-fe68-4ca7-a7c9-b0ae7c92e8b4",
+  "shape": "package",
+  "pkg": "orino-fe",
+  "globalName": "OrinoUI",
+  "srcDir": "src/components",
+  "tsconfig": "tsconfig.app.json",
+  "cssEntry": "dist/assets/index-CUGrMVGd.css",
+  "extraFonts": ["dist/assets/PretendardVariable-CJuje-Rk.woff2"],
+  "readmeHeader": ".design-sync/conventions.md"
+}

--- a/fe/.design-sync/conventions.md
+++ b/fe/.design-sync/conventions.md
@@ -1,0 +1,61 @@
+# orino Design System
+
+React + Tailwind CSS v4 component library (shadcn/ui 스타일). 컴포넌트는 내부적으로 Tailwind 유틸리티 + 시맨틱 OKLCH 토큰으로 스타일링되어 있고, 레이아웃 글루는 같은 Tailwind 유틸리티 어휘로 작성한다.
+
+## 셋업
+
+- **별도 Provider/래퍼는 필요 없다.** 디자인 토큰은 `:root`(다크모드는 `.dark`)의 CSS 변수로 정의되며 `styles.css`로 실린다 — `styles.css`만 로드되면 된다.
+- **다크모드**: 루트 요소에 `dark` 클래스를 추가하면 토큰 값이 전환된다.
+- **폰트**: Pretendard Variable(한글 우선). 미로드 시 시스템 폰트로 폴백.
+- 클래스 병합 헬퍼는 내부적으로 `cn()`(clsx + tailwind-merge)를 쓴다 — 소비 측에서는 그냥 `className`에 Tailwind 유틸리티를 넘기면 된다.
+
+## 스타일 idiom — Tailwind v4 유틸리티 + 시맨틱 토큰
+
+레이아웃은 DS 토큰을 참조하는 Tailwind 유틸리티 클래스로 작성한다(임의 hex 색상 금지, 토큰 사용):
+
+- 표면: `bg-background`, `bg-card`, `bg-muted`, `bg-popover`
+- 텍스트: `text-foreground`, `text-muted-foreground`, `text-primary`, `text-destructive`
+- 강조: `bg-primary text-primary-foreground`, `bg-secondary`, `bg-destructive text-destructive-foreground`
+- 테두리/링: `border border-border`, `ring-ring`
+- 반경: `rounded-md`, `rounded-lg`(`--radius` 기반)
+- 브랜드 색: 토큰 `--brand`(보라 `oklch(0.55 0.25 297.5)`) — 유틸리티가 필요하면 `text-[var(--brand)]` / `bg-[var(--brand)]`로 사용
+- 간격·타이포는 표준 Tailwind 스케일: `gap-3`, `p-4`, `text-sm`, `font-semibold`
+
+## 컴포넌트 사용
+
+- **버튼**: `<Button variant="default|secondary|outline|ghost|destructive|link" size="sm|default|lg">`
+- **폼**: 컨트롤을 `<FormField label htmlFor error>`로 감싼다. 컨트롤은 `<Input>` · `<Textarea>` · `<Select value onValueChange options={[{value,label}]}>` · `<Checkbox>` · `<Switch checked onCheckedChange>`. 오류 문구는 `<FieldError>`
+- **카드**: `<Card>` 안에 `<CardHeader><CardTitle/><CardDescription/><CardAction/></CardHeader>` · `<CardContent>` · `<CardFooter>`로 조합
+- **오버레이**: `<Modal open onOpenChange>`, `<ConfirmDialog title description confirmLabel onConfirm/>`, `<Menu trigger={<Button/>}><MenuItem/></Menu>`. 다이얼로그 푸터는 `<DialogFooter>` / `<DialogFormFooter submitLabel pending onDelete>`
+- **헤더**: 페이지 제목은 `<PageHeader title description actions/>`, 섹션 제목은 `<SectionHeader size="sm|md" level={2|3}>`
+- **상태**: 빈 상태 `<EmptyState>`, 로딩 `<LoadingText>`
+
+## 출처(읽어야 할 곳)
+
+- 토큰·유틸리티 정의: 번들의 `styles.css`와 그 `@import` 클로저(`_ds_bundle.css` — 토큰 `:root` 블록 + Tailwind 레이어)
+- 컴포넌트별 API·예시: 각 컴포넌트의 `.d.ts` · `.prompt.md`
+
+## 예시
+
+```tsx
+import {
+  Button,
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "orino-fe";
+
+<Card className="max-w-sm">
+  <CardHeader>
+    <CardTitle>복습 카드</CardTitle>
+  </CardHeader>
+  <CardContent className="text-muted-foreground text-sm">
+    오늘 복습할 카드 8장
+  </CardContent>
+  <CardFooter>
+    <Button size="sm">복습 시작</Button>
+  </CardFooter>
+</Card>;
+```

--- a/fe/.design-sync/previews/Button.tsx
+++ b/fe/.design-sync/previews/Button.tsx
@@ -1,0 +1,30 @@
+import { Button } from "orino-fe";
+
+export function Variants() {
+  return (
+    <div
+      style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}
+    >
+      <Button>기본</Button>
+      <Button variant="secondary">보조</Button>
+      <Button variant="outline">아웃라인</Button>
+      <Button variant="ghost">고스트</Button>
+      <Button variant="destructive">삭제</Button>
+      <Button variant="link">링크</Button>
+    </div>
+  );
+}
+
+export function Sizes() {
+  return (
+    <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+      <Button size="sm">작게</Button>
+      <Button>기본</Button>
+      <Button size="lg">크게</Button>
+    </div>
+  );
+}
+
+export function Disabled() {
+  return <Button disabled>비활성</Button>;
+}

--- a/fe/.design-sync/previews/Card.tsx
+++ b/fe/.design-sync/previews/Card.tsx
@@ -1,0 +1,32 @@
+import {
+  Button,
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "orino-fe";
+
+export function Default() {
+  return (
+    <Card style={{ maxWidth: 360 }}>
+      <CardHeader>
+        <CardTitle>학습 자료</CardTitle>
+        <CardDescription>이번 주 복습 카드 12장</CardDescription>
+        <CardAction>
+          <Button size="sm" variant="ghost">
+            관리
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        오늘 복습할 항목을 확인하고 바로 시작할 수 있어요.
+      </CardContent>
+      <CardFooter>
+        <Button size="sm">복습 시작</Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/fe/.design-sync/previews/CardAction.tsx
+++ b/fe/.design-sync/previews/CardAction.tsx
@@ -1,0 +1,22 @@
+import {
+  Button,
+  Card,
+  CardAction,
+  CardHeader,
+  CardTitle,
+} from "orino-fe";
+
+export function Default() {
+  return (
+    <Card style={{ maxWidth: 360 }}>
+      <CardHeader>
+        <CardTitle>알림 설정</CardTitle>
+        <CardAction>
+          <Button size="sm" variant="outline">
+            관리
+          </Button>
+        </CardAction>
+      </CardHeader>
+    </Card>
+  );
+}

--- a/fe/.design-sync/previews/CardContent.tsx
+++ b/fe/.design-sync/previews/CardContent.tsx
@@ -1,0 +1,14 @@
+import { Card, CardContent, CardHeader, CardTitle } from "orino-fe";
+
+export function Default() {
+  return (
+    <Card style={{ maxWidth: 360 }}>
+      <CardHeader>
+        <CardTitle>오늘의 루틴</CardTitle>
+      </CardHeader>
+      <CardContent>
+        아침 스트레칭 · 영어 단어 30개 · 알고리즘 1문제
+      </CardContent>
+    </Card>
+  );
+}

--- a/fe/.design-sync/previews/CardDescription.tsx
+++ b/fe/.design-sync/previews/CardDescription.tsx
@@ -1,0 +1,14 @@
+import { Card, CardDescription, CardHeader, CardTitle } from "orino-fe";
+
+export function Default() {
+  return (
+    <Card style={{ maxWidth: 360 }}>
+      <CardHeader>
+        <CardTitle>복습 카드</CardTitle>
+        <CardDescription>
+          오늘 복습할 카드 8장이 준비되어 있어요.
+        </CardDescription>
+      </CardHeader>
+    </Card>
+  );
+}

--- a/fe/.design-sync/previews/CardFooter.tsx
+++ b/fe/.design-sync/previews/CardFooter.tsx
@@ -1,0 +1,25 @@
+import {
+  Button,
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "orino-fe";
+
+export function Default() {
+  return (
+    <Card style={{ maxWidth: 360 }}>
+      <CardHeader>
+        <CardTitle>복습 시작</CardTitle>
+      </CardHeader>
+      <CardContent>오늘 복습할 카드 8장</CardContent>
+      <CardFooter style={{ gap: 8 }}>
+        <Button size="sm">시작</Button>
+        <Button size="sm" variant="outline">
+          나중에
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/fe/.design-sync/previews/CardHeader.tsx
+++ b/fe/.design-sync/previews/CardHeader.tsx
@@ -1,0 +1,24 @@
+import {
+  Button,
+  Card,
+  CardAction,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "orino-fe";
+
+export function Default() {
+  return (
+    <Card style={{ maxWidth: 360 }}>
+      <CardHeader>
+        <CardTitle>주간 계획표</CardTitle>
+        <CardDescription>이번 주 일정 12건</CardDescription>
+        <CardAction>
+          <Button size="sm" variant="ghost">
+            편집
+          </Button>
+        </CardAction>
+      </CardHeader>
+    </Card>
+  );
+}

--- a/fe/.design-sync/previews/CardTitle.tsx
+++ b/fe/.design-sync/previews/CardTitle.tsx
@@ -1,0 +1,11 @@
+import { Card, CardHeader, CardTitle } from "orino-fe";
+
+export function Default() {
+  return (
+    <Card style={{ maxWidth: 360 }}>
+      <CardHeader>
+        <CardTitle>학습 자료</CardTitle>
+      </CardHeader>
+    </Card>
+  );
+}

--- a/fe/.design-sync/previews/Checkbox.tsx
+++ b/fe/.design-sync/previews/Checkbox.tsx
@@ -1,0 +1,27 @@
+import { Checkbox } from "orino-fe";
+
+export function States() {
+  return (
+    <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+      <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
+        <Checkbox defaultChecked />
+        선택됨
+      </label>
+      <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
+        <Checkbox />
+        선택 안 함
+      </label>
+      <label
+        style={{
+          display: "flex",
+          gap: 6,
+          alignItems: "center",
+          opacity: 0.5,
+        }}
+      >
+        <Checkbox disabled />
+        비활성
+      </label>
+    </div>
+  );
+}

--- a/fe/.design-sync/previews/ConfirmDialog.tsx
+++ b/fe/.design-sync/previews/ConfirmDialog.tsx
@@ -1,0 +1,15 @@
+import { ConfirmDialog } from "orino-fe";
+
+export function Default() {
+  return (
+    <ConfirmDialog
+      open
+      onOpenChange={() => {}}
+      title="자료를 삭제할까요?"
+      description="자료·노트·카드가 모두 삭제됩니다. 되돌릴 수 없어요."
+      confirmLabel="삭제"
+      destructive
+      onConfirm={() => {}}
+    />
+  );
+}

--- a/fe/.design-sync/previews/DialogFooter.tsx
+++ b/fe/.design-sync/previews/DialogFooter.tsx
@@ -1,0 +1,32 @@
+import { Button, DialogFooter } from "orino-fe";
+
+export function Default() {
+  return (
+    <div style={{ width: 360 }}>
+      <DialogFooter>
+        <Button variant="ghost" size="sm">
+          취소
+        </Button>
+        <Button size="sm">저장</Button>
+      </DialogFooter>
+    </div>
+  );
+}
+
+export function WithDelete() {
+  return (
+    <div style={{ width: 360 }}>
+      <DialogFooter className="justify-between">
+        <Button variant="ghost" size="sm" className="text-destructive">
+          삭제
+        </Button>
+        <div style={{ display: "flex", gap: 8 }}>
+          <Button variant="ghost" size="sm">
+            취소
+          </Button>
+          <Button size="sm">저장</Button>
+        </div>
+      </DialogFooter>
+    </div>
+  );
+}

--- a/fe/.design-sync/previews/EmptyState.tsx
+++ b/fe/.design-sync/previews/EmptyState.tsx
@@ -1,0 +1,10 @@
+import { Button, EmptyState } from "orino-fe";
+
+export function Default() {
+  return (
+    <EmptyState className="min-h-[200px]">
+      <p className="text-muted-foreground text-sm">아직 등록된 학습 자료가 없습니다.</p>
+      <Button size="sm">자료 추가</Button>
+    </EmptyState>
+  );
+}

--- a/fe/.design-sync/previews/FieldError.tsx
+++ b/fe/.design-sync/previews/FieldError.tsx
@@ -1,0 +1,5 @@
+import { FieldError } from "orino-fe";
+
+export function Default() {
+  return <FieldError>종료가 시작보다 늦어야 합니다.</FieldError>;
+}

--- a/fe/.design-sync/previews/FormField.tsx
+++ b/fe/.design-sync/previews/FormField.tsx
@@ -1,0 +1,21 @@
+import { FormField, Input } from "orino-fe";
+
+export function Default() {
+  return (
+    <div style={{ width: 320 }}>
+      <FormField label="제목" htmlFor="ff-title">
+        <Input id="ff-title" defaultValue="자료구조 정리" />
+      </FormField>
+    </div>
+  );
+}
+
+export function WithError() {
+  return (
+    <div style={{ width: 320 }}>
+      <FormField label="라벨" htmlFor="ff-label" error="라벨을 입력해 주세요.">
+        <Input id="ff-label" placeholder="예: 개인 프로젝트" />
+      </FormField>
+    </div>
+  );
+}

--- a/fe/.design-sync/previews/Input.tsx
+++ b/fe/.design-sync/previews/Input.tsx
@@ -1,0 +1,17 @@
+import { FormField, Input } from "orino-fe";
+
+export function Default() {
+  return <Input placeholder="이름을 입력하세요" defaultValue="홍길동" />;
+}
+
+export function Disabled() {
+  return <Input placeholder="비활성 입력" disabled />;
+}
+
+export function WithLabel() {
+  return (
+    <FormField label="이메일" htmlFor="email-preview">
+      <Input id="email-preview" type="email" placeholder="you@example.com" />
+    </FormField>
+  );
+}

--- a/fe/.design-sync/previews/Label.tsx
+++ b/fe/.design-sync/previews/Label.tsx
@@ -1,0 +1,10 @@
+import { Input, Label } from "orino-fe";
+
+export function Default() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6, width: 280 }}>
+      <Label htmlFor="label-name">이름</Label>
+      <Input id="label-name" placeholder="이름을 입력하세요" />
+    </div>
+  );
+}

--- a/fe/.design-sync/previews/LoadingText.tsx
+++ b/fe/.design-sync/previews/LoadingText.tsx
@@ -1,0 +1,9 @@
+import { LoadingText } from "orino-fe";
+
+export function Default() {
+  return <LoadingText />;
+}
+
+export function CustomMessage() {
+  return <LoadingText>복습 카드를 불러오는 중…</LoadingText>;
+}

--- a/fe/.design-sync/previews/Menu.tsx
+++ b/fe/.design-sync/previews/Menu.tsx
@@ -1,0 +1,16 @@
+import { Button, Menu, MenuItem } from "orino-fe";
+
+export function Default() {
+  return (
+    <Menu
+      trigger={
+        <Button variant="outline" size="sm">
+          메뉴 열기
+        </Button>
+      }
+    >
+      <MenuItem>편집</MenuItem>
+      <MenuItem variant="destructive">삭제</MenuItem>
+    </Menu>
+  );
+}

--- a/fe/.design-sync/previews/Modal.tsx
+++ b/fe/.design-sync/previews/Modal.tsx
@@ -1,0 +1,18 @@
+import { Button, Modal } from "orino-fe";
+
+export function Default() {
+  return (
+    <Modal open onOpenChange={() => {}} className="max-w-sm">
+      <h2 className="text-base font-semibold">블록 편집</h2>
+      <p className="text-muted-foreground mt-2 text-sm">
+        시간과 라벨을 수정하세요.
+      </p>
+      <div className="mt-4 flex justify-end gap-2">
+        <Button variant="ghost" size="sm">
+          취소
+        </Button>
+        <Button size="sm">저장</Button>
+      </div>
+    </Modal>
+  );
+}

--- a/fe/.design-sync/previews/PageHeader.tsx
+++ b/fe/.design-sync/previews/PageHeader.tsx
@@ -1,0 +1,20 @@
+import { Button, PageHeader } from "orino-fe";
+
+export function Default() {
+  return (
+    <div style={{ width: 480 }}>
+      <PageHeader
+        title="학습 자료"
+        actions={<Button size="sm">자료 추가</Button>}
+      />
+    </div>
+  );
+}
+
+export function WithDescription() {
+  return (
+    <div style={{ width: 480 }}>
+      <PageHeader title="주간 계획표" description="변경 시 자동 저장됩니다" />
+    </div>
+  );
+}

--- a/fe/.design-sync/previews/SectionHeader.tsx
+++ b/fe/.design-sync/previews/SectionHeader.tsx
@@ -1,0 +1,12 @@
+import { SectionHeader } from "orino-fe";
+
+export function Sizes() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <SectionHeader>오늘의 루틴</SectionHeader>
+      <SectionHeader size="sm" level={3}>
+        일정 (3)
+      </SectionHeader>
+    </div>
+  );
+}

--- a/fe/.design-sync/previews/Select.tsx
+++ b/fe/.design-sync/previews/Select.tsx
@@ -1,0 +1,20 @@
+import { Select } from "orino-fe";
+
+const DAYS = [
+  { value: "mon", label: "월요일" },
+  { value: "tue", label: "화요일" },
+  { value: "wed", label: "수요일" },
+];
+
+export function Default() {
+  return (
+    <div style={{ width: 200 }}>
+      <Select
+        value="wed"
+        onValueChange={() => {}}
+        options={DAYS}
+        ariaLabelledby="day-select"
+      />
+    </div>
+  );
+}

--- a/fe/.design-sync/previews/Switch.tsx
+++ b/fe/.design-sync/previews/Switch.tsx
@@ -1,0 +1,11 @@
+import { Switch } from "orino-fe";
+
+export function On() {
+  return <Switch checked aria-label="알림 켜짐" onCheckedChange={() => {}} />;
+}
+
+export function Off() {
+  return (
+    <Switch checked={false} aria-label="알림 꺼짐" onCheckedChange={() => {}} />
+  );
+}

--- a/fe/.design-sync/previews/Textarea.tsx
+++ b/fe/.design-sync/previews/Textarea.tsx
@@ -1,0 +1,20 @@
+import { Textarea } from "orino-fe";
+
+export function Default() {
+  return (
+    <div style={{ width: 320 }}>
+      <Textarea
+        defaultValue={"오늘 공부한 내용을 정리해 보세요.\n- 자료구조 1장\n- 알고리즘 복습"}
+        rows={4}
+      />
+    </div>
+  );
+}
+
+export function Placeholder() {
+  return (
+    <div style={{ width: 320 }}>
+      <Textarea placeholder="메모를 입력하세요" rows={3} />
+    </div>
+  );
+}

--- a/fe/.gitignore
+++ b/fe/.gitignore
@@ -8,3 +8,8 @@ dist-ssr
 # Playwright
 test-results/
 playwright-report/
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules

--- a/fe/.prettierignore
+++ b/fe/.prettierignore
@@ -4,3 +4,6 @@ coverage
 test-results
 playwright-report
 package-lock.json
+.design-sync
+.ds-sync
+ds-bundle

--- a/fe/eslint.config.js
+++ b/fe/eslint.config.js
@@ -7,7 +7,7 @@ import tseslint from "typescript-eslint";
 import prettier from "eslint-config-prettier";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", ".design-sync", ".ds-sync", "ds-bundle"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],


### PR DESCRIPTION
## 이슈
closes #678

## 작업 내용
`/design-sync`로 orino 디자인 시스템(28개 컴포넌트)을 claude.ai/design에 동기화했다. 다음 재동기화가 빠르고 재현 가능하도록 입력 파일을 커밋한다(산출물 `.ds-sync/`·`ds-bundle/`·`.cache`는 gitignore).

- **`fe/.design-sync/config.json`** — synth-entry(`srcDir=src/components`)·`cssEntry`(컴파일된 Tailwind)·`extraFonts`(Pretendard) 설정
- **`fe/.design-sync/conventions.md`** — 디자인 에이전트용 사용 규약(README 헤더로 stitching)
- **`fe/.design-sync/NOTES.md`** — 앱(라이브러리 아님) 특수성 + 재동기화 위험(content-hash 경로·심링크)
- **`fe/.design-sync/previews/`** — 24개 컴포넌트 리치 프리뷰(.tsx)
- **`.gitignore`** — 동기화 산출물 제외

## 비고
- 코드 변경 없음(동기화 입력 파일만). 결과 프로젝트: claude.ai/design "orino Design System"