### PR TITLE
feat : ad-hoc 색을 상태 토큰으로 (복습 평점·연동 배너)

### DIFF
--- a/fe/src/features/planner/components/calendar/PlannerConnectionBanner.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerConnectionBanner.tsx
@@ -49,10 +49,10 @@ function Banner({ message, action }: BannerProps) {
   return (
     <div
       role="alert"
-      className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm dark:border-amber-900/60 dark:bg-amber-950/40"
+      className="border-warning/40 bg-warning/10 flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3 text-sm"
     >
-      <span className="flex items-center gap-2 text-amber-700 dark:text-amber-300">
-        <AlertTriangle className="size-4" />
+      <span className="flex items-center gap-2">
+        <AlertTriangle className="text-warning size-4" />
         {message}
       </span>
       {action && (

--- a/fe/src/features/review/components/ReviewCard.tsx
+++ b/fe/src/features/review/components/ReviewCard.tsx
@@ -28,14 +28,14 @@ const RATING_BUTTONS: RatingButton[] = [
     key: "1",
     // AGAIN은 당일 10분 뒤 재복습 (일 단위 아님)
     previewLabel: () => "10분",
-    textClass: "text-red-500",
+    textClass: "text-destructive",
   },
   {
     rating: "HARD",
     label: "Hard",
     key: "2",
     previewLabel: (r) => `${r.preview.hard}d`,
-    textClass: "text-orange-500",
+    textClass: "text-warning",
   },
   {
     rating: "GOOD",
@@ -49,7 +49,7 @@ const RATING_BUTTONS: RatingButton[] = [
     label: "Easy",
     key: "4",
     previewLabel: (r) => `${r.preview.easy}d`,
-    textClass: "text-green-500",
+    textClass: "text-success",
   },
 ];
 


### PR DESCRIPTION
## 이슈
closes #682 (연관 #680/#681 브랜드 토큰)

## 작업 내용
#681에서 추가한 status 토큰으로 ad-hoc 색 리터럴 교체:
- **복습 평점**(ReviewCard): Again `text-red-500`→`text-destructive`, Hard `text-orange-500`→`text-warning`, Easy `text-green-500`→`text-success` (Good은 `text-primary`=브랜드 유지)
- **연동 경고 배너**(PlannerConnectionBanner): `amber-*` 스케일 → warning 토큰 — `border-warning/40 bg-warning/10`, 아이콘 `text-warning`, 본문은 `foreground`(가독성·다크 자동 대응)

## 유지(도메인 컨벤션, status 아님)
- 공휴일/일요일 빨강(캘린더), 이벤트 블록 파랑, 카테고리 점 팔레트(sourceStyles/bucketStyles/planColors)

## 테스트
- 전체 FE 207 통과, format·eslint·tsc·build 통과. text-warning/success/bg-warning 유틸 컴파일 확인