### PR TITLE
refactor : 토큰 SSOT 정리 — brand=primary 별칭 + 고아 토큰 제거 (P1·P2)

### DIFF
--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -17,19 +17,6 @@
     "Segoe UI Symbol", sans-serif;
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
@@ -89,24 +76,11 @@
   --info-foreground: oklch(0.99 0 0);
   --border: oklch(0.925 0 0);
   --input: oklch(0.925 0 0);
-  /* 포커스 링도 브랜드 — 대비 + 정체성. */
-  --ring: oklch(0.55 0.22 297.5);
-  --brand: oklch(0.55 0.25 297.5);
-  --brand-foreground: oklch(1 0 0);
-  --chart-1: oklch(0.55 0.25 297.5);
-  --chart-2: oklch(0.65 0.18 297.5);
-  --chart-3: oklch(0.75 0.12 297.5);
-  --chart-4: oklch(0.85 0.06 297.5);
-  --chart-5: oklch(0.93 0.02 297.5);
+  /* 포커스 링·브랜드는 primary를 단일 진실원천으로 별칭(같은 의미=같은 값). */
+  --ring: var(--primary);
+  --brand: var(--primary);
+  --brand-foreground: var(--primary-foreground);
   --radius: 0.5rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.12 0 0);
-  --sidebar-primary: oklch(0.55 0.22 297.5);
-  --sidebar-primary-foreground: oklch(0.99 0 0);
-  --sidebar-accent: oklch(0.95 0.03 297.5);
-  --sidebar-accent-foreground: oklch(0.3 0.12 297.5);
-  --sidebar-border: oklch(0.925 0 0);
-  --sidebar-ring: oklch(0.55 0.22 297.5);
 }
 
 .dark {
@@ -118,6 +92,9 @@
   --popover-foreground: oklch(0.94 0 0);
   --primary: oklch(0.58 0.22 297.5);
   --primary-foreground: oklch(0.99 0 0);
+  --ring: var(--primary);
+  --brand: var(--primary);
+  --brand-foreground: var(--primary-foreground);
   --secondary: oklch(0.22 0 0);
   --secondary-foreground: oklch(0.94 0 0);
   --muted: oklch(0.19 0 0);
@@ -133,22 +110,6 @@
   --info-foreground: oklch(0.13 0 0);
   --border: oklch(0.22 0 0);
   --input: oklch(0.22 0 0);
-  --ring: oklch(0.58 0.22 297.5);
-  --brand: oklch(0.68 0.22 297.5);
-  --brand-foreground: oklch(1 0 0);
-  --chart-1: oklch(0.68 0.22 297.5);
-  --chart-2: oklch(0.58 0.16 297.5);
-  --chart-3: oklch(0.48 0.1 297.5);
-  --chart-4: oklch(0.38 0.06 297.5);
-  --chart-5: oklch(0.28 0.02 297.5);
-  --sidebar: oklch(0.145 0 0);
-  --sidebar-foreground: oklch(0.94 0 0);
-  --sidebar-primary: oklch(0.58 0.22 297.5);
-  --sidebar-primary-foreground: oklch(0.99 0 0);
-  --sidebar-accent: oklch(0.26 0.05 297.5);
-  --sidebar-accent-foreground: oklch(0.92 0.03 297.5);
-  --sidebar-border: oklch(0.22 0 0);
-  --sidebar-ring: oklch(0.58 0.22 297.5);
 }
 
 @layer base {


### PR DESCRIPTION
## 이슈
closes #684

## 배경
DS 리팩터 지시서 P1·P2 — "토큰은 풀시스템을 약속하는데 컴포넌트는 폼+다이얼로그 키트" 격차 정리의 첫 단계.

## P1 — brand/primary SSOT 통합
- `--brand`(어디서도 소비 안 되던 고아, 채도만 미세히 달랐음)를 **`--primary`의 `var()` 별칭**으로. `--brand-foreground`도 `var(--primary-foreground)`
- `--ring`도 `var(--primary)`로 통일(이미 동일 값이던 리터럴 → SSOT)
- 완료 기준 충족: 라이트/다크 양쪽 `--brand`==`--primary` 픽셀 동일

## P2 — 토큰↔컴포넌트 정합
- 소비 컴포넌트가 없는 **`--sidebar-*`(8개)·`--chart-*`(5개)** 토큰 + `@theme` 매핑 제거
  - 앱 `Sidebar.tsx`는 일반 토큰(`bg-primary` 등)만 사용 → 안전 확인
- **`--success`/`--warning`/`--info`는 유지** — P5에서 Badge/Alert가 소비(약속 실현). 30일 룰 적용

## 영향
- 컴포넌트 렌더 변화 없음(제거·별칭화한 토큰 전부 미사용) → design-sync 재싱크 불필요
- 전체 FE 207 통과, format·build 통과

## 다음
P3(다이얼로그 API 정리)·P4(타이포 토큰)·P5(Badge→Table→Tabs→Tooltip→Alert) 각각 별 PR