### PR TITLE
feat : Badge 컴포넌트 — status 토큰 소비 (P5 #1)

### DIFF
--- a/fe/src/components/ui/badge.test.tsx
+++ b/fe/src/components/ui/badge.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Badge } from "./badge";
+
+describe("Badge", () => {
+  it("기본 variant는 primary 토큰을 쓴다", () => {
+    render(<Badge>완료</Badge>);
+    expect(screen.getByText("완료")).toHaveClass(
+      "bg-primary",
+      "text-primary-foreground",
+    );
+  });
+
+  it("상태 variant는 해당 시맨틱 토큰을 쓴다", () => {
+    render(<Badge variant="success">성공</Badge>);
+    expect(screen.getByText("성공")).toHaveClass(
+      "bg-success",
+      "text-success-foreground",
+    );
+  });
+
+  it("outline variant는 테두리만", () => {
+    render(<Badge variant="outline">기본</Badge>);
+    const badge = screen.getByText("기본");
+    expect(badge).toHaveClass("border-border", "text-foreground");
+    expect(badge).not.toHaveClass("bg-primary");
+  });
+});

--- a/fe/src/components/ui/badge.tsx
+++ b/fe/src/components/ui/badge.tsx
@@ -38,4 +38,4 @@ function Badge({
   );
 }
 
-export { Badge, badgeVariants };
+export { Badge };

--- a/fe/src/components/ui/badge.tsx
+++ b/fe/src/components/ui/badge.tsx
@@ -1,0 +1,41 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex w-fit shrink-0 items-center gap-1 rounded-md border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap [&>svg]:pointer-events-none [&>svg]:size-3",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground",
+        secondary: "bg-secondary text-secondary-foreground",
+        success: "bg-success text-success-foreground",
+        warning: "bg-warning text-warning-foreground",
+        info: "bg-info text-info-foreground",
+        destructive: "bg-destructive text-white",
+        outline: "text-foreground border-border",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+/** 상태·분류 라벨 칩. 색은 시맨틱 토큰만 사용(success/warning/info 소비). */
+function Badge({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return (
+    <span
+      data-slot="badge"
+      className={cn(badgeVariants({ variant, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };


### PR DESCRIPTION
## 이슈
closes #686 (연관 #684 토큰 정리)

## 배경
DS 리팩터 지시서 **P5 커버리지 첫 컴포넌트**. 대시보드/리스트에서 자주 임시로 만들던 상태·분류 칩을 시스템 컴포넌트로. **P2에서 유지한 `--success`/`--warning`/`--info` 토큰을 Badge가 실제 소비** → "토큰만 있고 소비처 없음"의 약속 실현.

## 작업 내용
- **`Badge`** (cva, button.tsx와 동일 패턴): `variant: default|secondary|success|warning|info|destructive|outline`
- 색은 **시맨틱 토큰만** — `bg-{primary|secondary|success|warning|info|destructive}` + `text-*-foreground`. 새 색·간격 발명 없음
- destructive는 `--destructive-foreground` 토큰이 아직 없어 `text-white`(추후 토큰 추가 시 교체)

## 테스트
- `badge.test.tsx`(기본·status·outline variant), 전체 FE 210 통과
- 컴파일 CSS에 `bg-success/warning/info`·`text-success-foreground` 생성 확인(= 토큰 소비)

## 후속
- design-sync 재싱크 시 Badge 자동 발견(새 export) → 패널에 추가
- 다음: Table → Tabs → Tooltip → Alert(P5 순서)