### PR TITLE
feat : Table 컴포넌트 (P5 #2)

### DIFF
--- a/fe/src/components/ui/table.test.tsx
+++ b/fe/src/components/ui/table.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./table";
+
+describe("Table", () => {
+  it("헤더·바디를 렌더하고 중립 토큰을 쓴다", () => {
+    render(
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>이름</TableHead>
+            <TableHead>상태</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>홍길동</TableCell>
+            <TableCell>완료</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>,
+    );
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByText("이름")).toHaveClass("text-muted-foreground");
+    expect(screen.getByText("홍길동")).toBeInTheDocument();
+    // 본문 행은 hover 강조 토큰
+    const rows = screen.getAllByRole("row");
+    expect(rows[rows.length - 1]).toHaveClass("hover:bg-muted/50");
+  });
+});

--- a/fe/src/components/ui/table.tsx
+++ b/fe/src/components/ui/table.tsx
@@ -1,0 +1,117 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/** 가로 스크롤 래퍼 + 테이블. 색은 중립 토큰만(muted/border/foreground). */
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/** 행: hover 강조 + 선택 상태(data-state=selected). zebra가 필요하면 소비처에서
+ *  `[&_tr:nth-child(even)]:bg-muted/30`을 TableBody에 추가. */
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-muted-foreground h-9 px-3 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "px-3 py-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-3 text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+};


### PR DESCRIPTION
## 이슈
closes #688 (연관 #684 토큰 정리)

## 배경
DS 리팩터 P5 두 번째. 대시보드/리스트에서 임시로 짜던 데이터 테이블을 시스템 컴포넌트로.

## 작업 내용
- **`Table`** 컴파운드: `Table`(가로 스크롤 래퍼+table) / `TableHeader` / `TableBody` / `TableFooter` / `TableRow` / `TableHead` / `TableCell` / `TableCaption` (data-slot 패턴)
- 색은 **중립 토큰만**: 헤더 `text-muted-foreground`, 행 hover `bg-muted/50`, 선택 `data-[state=selected]:bg-muted`, 경계 `border-border`, 푸터 `bg-muted/50` — 새 색·간격 발명 없음
- 정렬은 `text-left/align-middle`. **zebra**는 소비처에서 `nth-child` 유틸로 opt-in(주석 안내)

## 테스트
- `table.test.tsx`(헤더/바디 렌더 + 토큰 검증), 전체 FE 211 통과, eslint·format·build 통과

## 다음
P5: Tabs → Tooltip → Alert