### PR TITLE
feat : Tabs 컴포넌트 — base-ui 래핑 (P5 #3)

### DIFF
--- a/fe/src/components/ui/tabs.test.tsx
+++ b/fe/src/components/ui/tabs.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";
+
+describe("Tabs", () => {
+  it("tablist/tab/tabpanel을 렌더하고 활성 탭에 data-selected가 붙는다", () => {
+    render(
+      <Tabs defaultValue="a">
+        <TabsList>
+          <TabsTrigger value="a">탭 A</TabsTrigger>
+          <TabsTrigger value="b">탭 B</TabsTrigger>
+        </TabsList>
+        <TabsContent value="a">내용 A</TabsContent>
+        <TabsContent value="b">내용 B</TabsContent>
+      </Tabs>,
+    );
+
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(2);
+    // 기본 활성 탭(a)에 base-ui의 활성 상태 속성(data-active) + aria-selected
+    expect(screen.getByText("탭 A")).toHaveAttribute("data-active");
+    expect(screen.getByText("탭 A")).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("내용 A")).toBeInTheDocument();
+  });
+});

--- a/fe/src/components/ui/tabs.tsx
+++ b/fe/src/components/ui/tabs.tsx
@@ -1,0 +1,65 @@
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/** base-ui Tabs 래핑 — 시맨틱: Tabs(Root) / TabsList / TabsTrigger(Tab) / TabsContent(Panel). */
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-1",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Tab>) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[active]:bg-background data-[active]:text-foreground focus-visible:ring-ring/50 inline-flex h-7 flex-1 items-center justify-center gap-1.5 rounded-md px-2.5 text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Panel>) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsContent, TabsList, TabsTrigger };


### PR DESCRIPTION
## 이슈
closes #690 (연관 #684)

## 작업 내용
DS 리팩터 P5 세 번째. `@base-ui/react` Tabs 프리미티브 래핑(우리 다른 컴포넌트와 동일 방식).
- **`Tabs`**(Root) / **`TabsList`** / **`TabsTrigger`**(Tab) / **`TabsContent`**(Panel), data-slot 패턴
- 활성 강조는 base-ui의 **`data-[active]`** 훅 사용(렌더 DOM으로 확인 — `data-selected` 아님). `data-[active]:bg-background text-foreground`
- 포커스 `focus-visible:ring-ring/50`(--ring), 리스트 `bg-muted`, 트리거 `text-muted-foreground` — 중립 토큰만

## 테스트
- `tabs.test.tsx`: tablist/tab/tabpanel 렌더 + 활성 탭의 `data-active`·`aria-selected` 검증
- 전체 FE 212 통과, eslint·format·build 통과

## 다음
P5: Tooltip → Alert