### PR TITLE
feat : Tooltip 컴포넌트 — base-ui 래핑 (P5 #4)

### DIFF
--- a/fe/src/components/ui/tooltip.test.tsx
+++ b/fe/src/components/ui/tooltip.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
+
+describe("Tooltip", () => {
+  it("열리면 popover 토큰으로 content를 렌더한다", () => {
+    render(
+      <Tooltip defaultOpen>
+        <TooltipTrigger>도움말</TooltipTrigger>
+        <TooltipContent>마감 기준 시각입니다</TooltipContent>
+      </Tooltip>,
+    );
+
+    expect(screen.getByText("도움말")).toBeInTheDocument();
+    const content = screen.getByText("마감 기준 시각입니다");
+    expect(content).toHaveClass("bg-popover", "text-popover-foreground");
+  });
+});

--- a/fe/src/components/ui/tooltip.tsx
+++ b/fe/src/components/ui/tooltip.tsx
@@ -1,0 +1,49 @@
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/** base-ui Tooltip 래핑. content는 popover 토큰 사용. */
+function TooltipProvider(
+  props: React.ComponentProps<typeof TooltipPrimitive.Provider>,
+) {
+  return <TooltipPrimitive.Provider data-slot="tooltip-provider" {...props} />;
+}
+
+function Tooltip(props: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger(
+  props: React.ComponentProps<typeof TooltipPrimitive.Trigger>,
+) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 6,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Popup> & {
+  sideOffset?: number;
+}) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner sideOffset={sideOffset}>
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "bg-popover text-popover-foreground z-50 w-fit rounded-md border px-2.5 py-1 text-xs shadow-md",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };


### PR DESCRIPTION
## 이슈
closes #692 (연관 #684)

## 작업 내용
DS 리팩터 P5 네 번째. `@base-ui/react` Tooltip 래핑.
- **`Tooltip`**(Root) / **`TooltipTrigger`** / **`TooltipContent`**(Portal+Positioner+Popup) / **`TooltipProvider`**
- content는 **`bg-popover text-popover-foreground`**(P5.4 지시) + border·shadow, data-slot 패턴

## 테스트
- `tooltip.test.tsx`: `defaultOpen`으로 강제 노출 → content가 popover 토큰으로 렌더되는지 검증
- 전체 FE 212 통과, eslint·format·build 통과

## 다음
P5 마지막: **Alert** (status 토큰 소비: info|success|warning|destructive)