### PR TITLE
feat : Alert 컴포넌트 — status 토큰 소비 (P5 #5 마지막)

### DIFF
--- a/fe/src/components/ui/alert.test.tsx
+++ b/fe/src/components/ui/alert.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Alert, AlertDescription, AlertTitle } from "./alert";
+
+describe("Alert", () => {
+  it("role=alert로 제목·설명을 렌더한다", () => {
+    render(
+      <Alert>
+        <AlertTitle>안내</AlertTitle>
+        <AlertDescription>변경 사항이 저장되었습니다.</AlertDescription>
+      </Alert>,
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("안내")).toBeInTheDocument();
+    expect(screen.getByText("변경 사항이 저장되었습니다.")).toBeInTheDocument();
+  });
+
+  it("상태 variant는 해당 status 토큰을 쓴다", () => {
+    render(
+      <Alert variant="warning">
+        <AlertTitle>주의</AlertTitle>
+      </Alert>,
+    );
+    expect(screen.getByRole("alert")).toHaveClass(
+      "border-warning/30",
+      "bg-warning/10",
+    );
+  });
+});

--- a/fe/src/components/ui/alert.tsx
+++ b/fe/src/components/ui/alert.tsx
@@ -1,0 +1,73 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[1.25rem_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-card text-card-foreground border-border [&>svg]:text-foreground",
+        info: "border-info/30 bg-info/10 text-foreground [&>svg]:text-info",
+        success:
+          "border-success/30 bg-success/10 text-foreground [&>svg]:text-success",
+        warning:
+          "border-warning/30 bg-warning/10 text-foreground [&>svg]:text-warning",
+        destructive:
+          "border-destructive/30 bg-destructive/10 text-foreground [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+/** 인라인 알림. 상태색은 시맨틱 토큰만(info/success/warning/destructive). 아이콘은 svg 자식으로. */
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      role="alert"
+      data-slot="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 font-medium tracking-tight whitespace-nowrap",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground col-start-2 text-sm [&_p]:leading-relaxed",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertDescription, AlertTitle };


### PR DESCRIPTION
## 이슈
closes #694 (연관 #684)

## 작업 내용
DS 리팩터 **P5 마지막** 컴포넌트. 인라인 알림.
- **`Alert`** / **`AlertTitle`** / **`AlertDescription`**, `variant: default|info|success|warning|destructive`
- 소프트 톤(`border-{status}/30 bg-{status}/10`, 아이콘 `[&>svg]:text-{status}`, 본문 foreground/muted) — `PlannerConnectionBanner`와 일관
- **info/success/warning/destructive status 토큰을 실제 소비** → P2 "토큰만 있고 소비처 없음" 약속 완결(Badge+Alert가 status 전부 소비)
- 아이콘은 svg 자식, grid로 아이콘+제목/설명 정렬(shadcn 패턴)

## 테스트
- `alert.test.tsx`: role=alert 렌더 + 상태 variant 토큰 검증
- 전체 FE 215 통과(55파일), 컴파일 CSS에 bg-info/success/warning/destructive 생성 확인, eslint·format·build 통과

## P5 완료
Badge·Table·Tabs·Tooltip·Alert 5종 — 네비/데이터/피드백 공백 메움