### PR TITLE
chore : design-sync 재싱크 입력 — P5 신규 컴포넌트 프리뷰

### DIFF
--- a/fe/.design-sync/config.json
+++ b/fe/.design-sync/config.json
@@ -5,7 +5,9 @@
   "globalName": "OrinoUI",
   "srcDir": "src/components",
   "tsconfig": "tsconfig.app.json",
-  "cssEntry": "dist/assets/index-CUGrMVGd.css",
-  "extraFonts": ["dist/assets/PretendardVariable-CJuje-Rk.woff2"],
+  "cssEntry": "dist/assets/index-DvBX7uA8.css",
+  "extraFonts": [
+    "dist/assets/PretendardVariable-CJuje-Rk.woff2"
+  ],
   "readmeHeader": ".design-sync/conventions.md"
 }

--- a/fe/.design-sync/conventions.md
+++ b/fe/.design-sync/conventions.md
@@ -28,7 +28,9 @@ React + Tailwind CSS v4 component library (shadcn/ui 스타일). 컴포넌트는
 - **카드**: `<Card>` 안에 `<CardHeader><CardTitle/><CardDescription/><CardAction/></CardHeader>` · `<CardContent>` · `<CardFooter>`로 조합
 - **오버레이**: `<Modal open onOpenChange>`, `<ConfirmDialog title description confirmLabel onConfirm/>`, `<Menu trigger={<Button/>}><MenuItem/></Menu>`. 다이얼로그 푸터는 `<DialogFooter>` / `<DialogFormFooter submitLabel pending onDelete>`
 - **헤더**: 페이지 제목은 `<PageHeader title description actions/>`, 섹션 제목은 `<SectionHeader size="sm|md" level={2|3}>`
-- **상태**: 빈 상태 `<EmptyState>`, 로딩 `<LoadingText>`
+- **상태/피드백**: 빈 상태 `<EmptyState>`, 로딩 `<LoadingText>`, 인라인 알림 `<Alert variant="info|success|warning|destructive"><AlertTitle/><AlertDescription/></Alert>`(아이콘은 svg 자식), 라벨 칩 `<Badge variant="default|secondary|success|warning|info|destructive|outline">`
+- **데이터/내비**: `<Table>`+`<TableHeader/TableBody/TableRow/TableHead/TableCell>`(상태 칸엔 Badge 조합), `<Tabs defaultValue><TabsList><TabsTrigger value/></TabsList><TabsContent value/></Tabs>`, `<Tooltip><TooltipTrigger/><TooltipContent/></Tooltip>`
+- **상태색 규칙**: 성공/주의/정보/실패는 `success|warning|info|destructive` 시맨틱 토큰만 쓴다(임의 green/amber/red 금지). 일요일·공휴일 빨강 같은 캘린더 도메인 색은 예외
 
 ## 출처(읽어야 할 곳)
 

--- a/fe/.design-sync/previews/Alert.tsx
+++ b/fe/.design-sync/previews/Alert.tsx
@@ -1,0 +1,31 @@
+import { AlertTriangle, CheckCircle2, Info, XCircle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "orino-fe";
+
+export function Variants() {
+  return (
+    <div
+      style={{ display: "flex", flexDirection: "column", gap: 12, width: 440 }}
+    >
+      <Alert variant="info">
+        <Info />
+        <AlertTitle>안내</AlertTitle>
+        <AlertDescription>다음 복습은 내일입니다.</AlertDescription>
+      </Alert>
+      <Alert variant="success">
+        <CheckCircle2 />
+        <AlertTitle>완료</AlertTitle>
+        <AlertDescription>변경 사항이 저장되었습니다.</AlertDescription>
+      </Alert>
+      <Alert variant="warning">
+        <AlertTriangle />
+        <AlertTitle>주의</AlertTitle>
+        <AlertDescription>마감이 1시간 남았습니다.</AlertDescription>
+      </Alert>
+      <Alert variant="destructive">
+        <XCircle />
+        <AlertTitle>실패</AlertTitle>
+        <AlertDescription>저장에 실패했습니다.</AlertDescription>
+      </Alert>
+    </div>
+  );
+}

--- a/fe/.design-sync/previews/Badge.tsx
+++ b/fe/.design-sync/previews/Badge.tsx
@@ -1,0 +1,15 @@
+import { Badge } from "orino-fe";
+
+export function Variants() {
+  return (
+    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+      <Badge>기본</Badge>
+      <Badge variant="secondary">보조</Badge>
+      <Badge variant="success">완료</Badge>
+      <Badge variant="warning">주의</Badge>
+      <Badge variant="info">정보</Badge>
+      <Badge variant="destructive">실패</Badge>
+      <Badge variant="outline">아웃라인</Badge>
+    </div>
+  );
+}

--- a/fe/.design-sync/previews/Table.tsx
+++ b/fe/.design-sync/previews/Table.tsx
@@ -1,0 +1,48 @@
+import {
+  Badge,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "orino-fe";
+
+export function Default() {
+  return (
+    <div style={{ width: 480 }}>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>과목</TableHead>
+            <TableHead>카드</TableHead>
+            <TableHead>상태</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>자료구조</TableCell>
+            <TableCell>12장</TableCell>
+            <TableCell>
+              <Badge variant="success">완료</Badge>
+            </TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>알고리즘</TableCell>
+            <TableCell>8장</TableCell>
+            <TableCell>
+              <Badge variant="warning">진행</Badge>
+            </TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>운영체제</TableCell>
+            <TableCell>5장</TableCell>
+            <TableCell>
+              <Badge variant="info">예정</Badge>
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/fe/.design-sync/previews/TableCaption.tsx
+++ b/fe/.design-sync/previews/TableCaption.tsx
@@ -1,0 +1,23 @@
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableRow,
+} from "orino-fe";
+
+export function Default() {
+  return (
+    <div style={{ width: 360 }}>
+      <Table>
+        <TableCaption>최근 7일 복습 현황</TableCaption>
+        <TableBody>
+          <TableRow>
+            <TableCell>자료구조</TableCell>
+            <TableCell>12장</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/fe/.design-sync/previews/TableCell.tsx
+++ b/fe/.design-sync/previews/TableCell.tsx
@@ -1,0 +1,20 @@
+import { Table, TableBody, TableCell, TableRow } from "orino-fe";
+
+export function Default() {
+  return (
+    <div style={{ width: 360 }}>
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell>자료구조</TableCell>
+            <TableCell>12장</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>알고리즘</TableCell>
+            <TableCell>8장</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/fe/.design-sync/previews/TableHead.tsx
+++ b/fe/.design-sync/previews/TableHead.tsx
@@ -1,0 +1,17 @@
+import { Table, TableHead, TableHeader, TableRow } from "orino-fe";
+
+export function Default() {
+  return (
+    <div style={{ width: 360 }}>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>과목</TableHead>
+            <TableHead>카드</TableHead>
+            <TableHead>상태</TableHead>
+          </TableRow>
+        </TableHeader>
+      </Table>
+    </div>
+  );
+}

--- a/fe/.design-sync/previews/Tabs.tsx
+++ b/fe/.design-sync/previews/Tabs.tsx
@@ -1,0 +1,20 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "orino-fe";
+
+export function Default() {
+  return (
+    <div style={{ width: 400 }}>
+      <Tabs defaultValue="overview">
+        <TabsList>
+          <TabsTrigger value="overview">개요</TabsTrigger>
+          <TabsTrigger value="cards">카드</TabsTrigger>
+          <TabsTrigger value="stats">통계</TabsTrigger>
+        </TabsList>
+        <TabsContent value="overview">
+          이번 주 복습 12건, 완료율 75%.
+        </TabsContent>
+        <TabsContent value="cards">복습할 카드 목록입니다.</TabsContent>
+        <TabsContent value="stats">주간 통계입니다.</TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/fe/.design-sync/previews/Tooltip.tsx
+++ b/fe/.design-sync/previews/Tooltip.tsx
@@ -1,0 +1,12 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "orino-fe";
+
+export function Default() {
+  return (
+    <div style={{ padding: 48 }}>
+      <Tooltip defaultOpen>
+        <TooltipTrigger>도움말</TooltipTrigger>
+        <TooltipContent>마감 기준 시각입니다</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}


### PR DESCRIPTION
## 이슈
closes #696

## 작업 내용
P5 컴포넌트 5종(Badge·Table·Tabs·Tooltip·Alert)을 claude.ai/design 패널에 **리치 프리뷰**로 반영하고 재동기화한 입력 파일.
- **previews/**: Badge(7 variant)·Table(상태 Badge 조합)·Tabs(활성 강조)·Tooltip(popover)·Alert(4 상태+아이콘) + Table 서브 Head/Cell/Caption
- **conventions.md**: 데이터/내비/피드백 컴포넌트 + "상태색은 시맨틱 토큰만" 규칙 추가
- **config.json**: cssEntry 해시 갱신(content-hash라 빌드마다 변경 — NOTES의 재동기화 위험 참조)

## 결과 (claude.ai/design)
- 패널 **48개 컴포넌트**로 재싱크 완료 — 보라 정체성 + 상태색 + 신규 5종, 전 프리뷰 graded good, 렌더 48/48 클린, self-check 처리 확인
- 디자인 에이전트가 이제 신규 컴포넌트(Badge/Table/Tabs/Tooltip/Alert)로도 디자인 가능

## 비고
- 코드 변경 없음(design-sync 입력만). 컴포넌트 자체는 #687/#689/#691/#693/#695에서 머지됨