### PR TITLE
refactor : 다이얼로그 API 정리 — Modal.Footer/FormFooter (P3)

### DIFF
--- a/fe/.design-sync/config.json
+++ b/fe/.design-sync/config.json
@@ -9,5 +9,10 @@
   "extraFonts": [
     "dist/assets/PretendardVariable-CJuje-Rk.woff2"
   ],
-  "readmeHeader": ".design-sync/conventions.md"
+  "readmeHeader": ".design-sync/conventions.md",
+  "componentSrcMap": {
+    "DialogPopup": null,
+    "DialogFooter": null,
+    "DialogFormFooter": null
+  }
 }

--- a/fe/.design-sync/conventions.md
+++ b/fe/.design-sync/conventions.md
@@ -26,7 +26,7 @@ React + Tailwind CSS v4 component library (shadcn/ui 스타일). 컴포넌트는
 - **버튼**: `<Button variant="default|secondary|outline|ghost|destructive|link" size="sm|default|lg">`
 - **폼**: 컨트롤을 `<FormField label htmlFor error>`로 감싼다. 컨트롤은 `<Input>` · `<Textarea>` · `<Select value onValueChange options={[{value,label}]}>` · `<Checkbox>` · `<Switch checked onCheckedChange>`. 오류 문구는 `<FieldError>`
 - **카드**: `<Card>` 안에 `<CardHeader><CardTitle/><CardDescription/><CardAction/></CardHeader>` · `<CardContent>` · `<CardFooter>`로 조합
-- **오버레이**: `<Modal open onOpenChange>`, `<ConfirmDialog title description confirmLabel onConfirm/>`, `<Menu trigger={<Button/>}><MenuItem/></Menu>`. 다이얼로그 푸터는 `<DialogFooter>` / `<DialogFormFooter submitLabel pending onDelete>`
+- **오버레이**: `<Modal open onOpenChange>` 안에 본문 + 푸터. 푸터는 Modal 서브컴포넌트로 — `<Modal.Footer>`(자유 구성), `<Modal.FormFooter submitLabel pending onDelete/>`(폼 제출). 확인은 프리셋 `<ConfirmDialog title description confirmLabel destructive onConfirm/>`. 메뉴는 `<Menu trigger={<Button/>}><MenuItem/></Menu>`. (DialogPopup/DialogFooter/DialogFormFooter는 내부 구현 — 직접 쓰지 않는다)
 - **헤더**: 페이지 제목은 `<PageHeader title description actions/>`, 섹션 제목은 `<SectionHeader size="sm|md" level={2|3}>`
 - **상태/피드백**: 빈 상태 `<EmptyState>`, 로딩 `<LoadingText>`, 인라인 알림 `<Alert variant="info|success|warning|destructive"><AlertTitle/><AlertDescription/></Alert>`(아이콘은 svg 자식), 라벨 칩 `<Badge variant="default|secondary|success|warning|info|destructive|outline">`
 - **데이터/내비**: `<Table>`+`<TableHeader/TableBody/TableRow/TableHead/TableCell>`(상태 칸엔 Badge 조합), `<Tabs defaultValue><TabsList><TabsTrigger value/></TabsList><TabsContent value/></Tabs>`, `<Tooltip><TooltipTrigger/><TooltipContent/></Tooltip>`

--- a/fe/src/components/ConfirmDialog.tsx
+++ b/fe/src/components/ConfirmDialog.tsx
@@ -2,7 +2,6 @@ import { Dialog } from "@base-ui/react/dialog";
 import { type ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
-import { DialogFooter } from "@/components/ui/dialog-footer";
 import { Modal } from "@/components/ui/modal";
 
 interface ConfirmDialogProps {
@@ -36,7 +35,7 @@ export function ConfirmDialog({
           {description}
         </Dialog.Description>
       )}
-      <DialogFooter>
+      <Modal.Footer>
         <Dialog.Close
           render={
             <Button variant="ghost" type="button" disabled={pending}>
@@ -52,7 +51,7 @@ export function ConfirmDialog({
         >
           {pending ? "처리 중..." : confirmLabel}
         </Button>
-      </DialogFooter>
+      </Modal.Footer>
     </Modal>
   );
 }

--- a/fe/src/components/ui/modal.tsx
+++ b/fe/src/components/ui/modal.tsx
@@ -1,6 +1,8 @@
 import { Dialog } from "@base-ui/react/dialog";
 import type { ReactNode } from "react";
 
+import { DialogFooter } from "./dialog-footer";
+import { DialogFormFooter } from "./dialog-form-footer";
 import { DialogPopup } from "./dialog-popup";
 
 const BACKDROP_CLASS =
@@ -18,7 +20,7 @@ interface ModalProps {
  * 표준 모달 골격: Root + Portal + Backdrop + DialogPopup을 한 번에 캡슐화한다.
  * 내부에서 base-ui의 Dialog.Title / Dialog.Close 등을 children으로 그대로 사용한다.
  */
-function Modal({ open, onOpenChange, className, children }: ModalProps) {
+function ModalRoot({ open, onOpenChange, className, children }: ModalProps) {
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
@@ -28,5 +30,16 @@ function Modal({ open, onOpenChange, className, children }: ModalProps) {
     </Dialog.Root>
   );
 }
+
+/**
+ * 모달의 단일 진입점. 푸터는 서브컴포넌트로 노출한다:
+ * - `<Modal.Footer>` — 취소/확인 등 자유 구성 푸터
+ * - `<Modal.FormFooter submitLabel pending onDelete>` — 폼 제출 푸터(취소+제출+삭제)
+ * DialogPopup/DialogFooter/DialogFormFooter는 내부 구현이며 직접 import 대신 위를 쓴다.
+ */
+const Modal = Object.assign(ModalRoot, {
+  Footer: DialogFooter,
+  FormFooter: DialogFormFooter,
+});
 
 export { Modal };

--- a/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
+++ b/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
@@ -1,7 +1,6 @@
 import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
-import { DialogFormFooter } from "@/components/ui/dialog-form-footer";
 import { FieldError } from "@/components/ui/field-error";
 import { FormField } from "@/components/ui/form-field";
 import { Modal } from "@/components/ui/modal";
@@ -89,7 +88,7 @@ export function FlashcardFormDialog({
 
         {errorMessage && <FieldError>{errorMessage}</FieldError>}
 
-        <DialogFormFooter
+        <Modal.FormFooter
           submitLabel="저장"
           pendingLabel="저장 중..."
           pending={pending}

--- a/fe/src/features/google/components/GoogleRequiredState.tsx
+++ b/fe/src/features/google/components/GoogleRequiredState.tsx
@@ -2,7 +2,7 @@ import { Dialog } from "@base-ui/react/dialog";
 import type { ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
-import { DialogFooter } from "@/components/ui/dialog-footer";
+import { Modal } from "@/components/ui/modal";
 
 import { GoogleConnectButton } from "./GoogleConnectButton";
 
@@ -21,7 +21,7 @@ export function GoogleRequiredState({
   return (
     <div className="mt-4 flex flex-col gap-4">
       <p className="text-muted-foreground text-sm">{message}</p>
-      <DialogFooter className="mt-0">
+      <Modal.Footer className="mt-0">
         <Dialog.Close
           render={
             <Button variant="ghost" type="button">
@@ -30,7 +30,7 @@ export function GoogleRequiredState({
           }
         />
         <GoogleConnectButton />
-      </DialogFooter>
+      </Modal.Footer>
     </div>
   );
 }

--- a/fe/src/features/material/components/AddMaterialDialog.tsx
+++ b/fe/src/features/material/components/AddMaterialDialog.tsx
@@ -1,7 +1,6 @@
 import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
-import { DialogFormFooter } from "@/components/ui/dialog-form-footer";
 import { FieldError } from "@/components/ui/field-error";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
@@ -91,7 +90,7 @@ export function AddMaterialDialog({ open, onOpenChange, onCreated }: Props) {
           </FieldError>
         )}
 
-        <DialogFormFooter
+        <Modal.FormFooter
           submitLabel="추가"
           pendingLabel="추가 중..."
           pending={mutation.isPending}

--- a/fe/src/features/material/components/EditMaterialDialog.tsx
+++ b/fe/src/features/material/components/EditMaterialDialog.tsx
@@ -1,7 +1,6 @@
 import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
-import { DialogFormFooter } from "@/components/ui/dialog-form-footer";
 import { FieldError } from "@/components/ui/field-error";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
@@ -82,7 +81,7 @@ export function EditMaterialDialog({ material, open, onOpenChange }: Props) {
           <FieldError>저장에 실패했어요. 잠시 후 다시 시도해주세요.</FieldError>
         )}
 
-        <DialogFormFooter
+        <Modal.FormFooter
           submitLabel="저장"
           pendingLabel="저장 중..."
           pending={mutation.isPending}

--- a/fe/src/features/planner/components/calendar/EventFormDialog.tsx
+++ b/fe/src/features/planner/components/calendar/EventFormDialog.tsx
@@ -2,7 +2,6 @@ import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
 import { Checkbox } from "@/components/ui/checkbox";
-import { DialogFormFooter } from "@/components/ui/dialog-form-footer";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
@@ -206,7 +205,7 @@ export function EventFormDialog({
             />
           </FormField>
 
-          <DialogFormFooter
+          <Modal.FormFooter
             submitLabel="저장"
             pendingLabel="저장 중..."
             pending={pending}

--- a/fe/src/features/planner/components/calendar/TaskFormDialog.tsx
+++ b/fe/src/features/planner/components/calendar/TaskFormDialog.tsx
@@ -1,7 +1,6 @@
 import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useId, useState } from "react";
 
-import { DialogFormFooter } from "@/components/ui/dialog-form-footer";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
@@ -75,7 +74,7 @@ export function TaskFormDialog({
             />
           </FormField>
 
-          <DialogFormFooter
+          <Modal.FormFooter
             submitLabel="저장"
             pendingLabel="저장 중..."
             pending={pending}

--- a/fe/src/features/planner/components/routine/RoutineFormDialog.tsx
+++ b/fe/src/features/planner/components/routine/RoutineFormDialog.tsx
@@ -3,7 +3,6 @@ import { useEffect, useId, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { DialogFormFooter } from "@/components/ui/dialog-form-footer";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
@@ -424,7 +423,7 @@ export function RoutineFormDialog({
             {recurrencePreview(recurrence, form.startDate)}
           </p>
 
-          <DialogFormFooter
+          <Modal.FormFooter
             submitLabel="저장"
             pendingLabel="저장 중..."
             pending={pending}

--- a/fe/src/features/planner/components/routine/RoutineScopeDialog.tsx
+++ b/fe/src/features/planner/components/routine/RoutineScopeDialog.tsx
@@ -2,7 +2,6 @@ import { Dialog } from "@base-ui/react/dialog";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { DialogFooter } from "@/components/ui/dialog-footer";
 import { Modal } from "@/components/ui/modal";
 
 import type { RoutineScope } from "../../api/routines";
@@ -80,7 +79,7 @@ export function RoutineScopeDialog({
         })}
       </fieldset>
 
-      <DialogFooter>
+      <Modal.Footer>
         <Dialog.Close
           render={
             <Button variant="ghost" type="button" disabled={pending}>
@@ -96,7 +95,7 @@ export function RoutineScopeDialog({
         >
           확인
         </Button>
-      </DialogFooter>
+      </Modal.Footer>
     </Modal>
   );
 }


### PR DESCRIPTION
## 이슈
closes #698

## 배경
DS 리팩터 P3 — "Modal/DialogPopup/ConfirmDialog/DialogFooter/DialogFormFooter 5개가 겹쳐 모달 조합법이 불명확." 진입점을 Modal로 단일화하고 푸터를 서브컴포넌트로 노출.

## 변경
- **`Modal.Footer`**(=DialogFooter) · **`Modal.FormFooter`**(=DialogFormFooter) 서브컴포넌트 부착(`Object.assign`)
  - `<Modal>...<Modal.FormFooter submitLabel pending onDelete/></Modal>` 처럼 self-contained
- **소비처 마이그레이션**(직접 import 제거):
  - 폼 다이얼로그 6종(Event·Task·Routine·Flashcard·Add/EditMaterial): `DialogFormFooter` → `Modal.FormFooter`
  - `ConfirmDialog`·`RoutineScopeDialog`·`GoogleRequiredState`: `DialogFooter` → `Modal.Footer`
- `DialogPopup`/`DialogFooter`/`DialogFormFooter`는 이제 **전부 내부 구현**(Modal만 사용). 직접 import 0
- **design-sync**: `componentSrcMap`으로 위 3개를 패널 컴포넌트 목록에서 제외(다음 재싱크 반영) + conventions에 Modal.Footer/FormFooter 규약

## 영향
- **동작 변화 없음** — Modal.Footer/FormFooter는 같은 컴포넌트의 별칭이라 푸터 렌더 동일. 다이얼로그 테스트(취소/저장/삭제) 전부 통과
- 전체 FE 215 통과, eslint·format·tsc·build 통과

## 남음
P4(타이포 스케일 토큰)