### PR TITLE
chore : design-sync 재싱크 — P3/P4 패널 반영

### DIFF
--- a/fe/.design-sync/config.json
+++ b/fe/.design-sync/config.json
@@ -5,7 +5,7 @@
   "globalName": "OrinoUI",
   "srcDir": "src/components",
   "tsconfig": "tsconfig.app.json",
-  "cssEntry": "dist/assets/index-DvBX7uA8.css",
+  "cssEntry": "dist/assets/index-BnJavGAO.css",
   "extraFonts": [
     "dist/assets/PretendardVariable-CJuje-Rk.woff2"
   ],


### PR DESCRIPTION
## 이슈
closes #702

## 작업 내용
P3·P4를 claude.ai/design 패널에 재동기화한 결과.
- **패널 48→45종**: 다이얼로그 내부 3종(`DialogPopup`/`DialogFooter`/`DialogFormFooter`)을 패널에서 제거(P3 `componentSrcMap`). Modal/ConfirmDialog가 단일 진입점으로 정리됨
- **타이포 재렌더**: PageHeader(text-title 24)·SectionHeader(heading/caption)·Card(heading 18)를 P4 위계 강화 스케일로 재캡처·재채점(전 good). SectionHeader sm muted 색 유지 확인(tailwind-merge 수정 실렌더 검증)
- **config.json**: cssEntry 해시 갱신(content-hash라 빌드마다 변경 — NOTES 참조)

## 결과
- 원격 45종 확인, self-check(`_ds_manifest.json`) 재생성, anchor 갱신
- 코드 변경 없음(design-sync 입력만)

🏁 이 PR로 DS 리팩터 P1–P5 + 패널 반영까지 전부 마무리