### PR TITLE
feat : 타이포 P4 마무리 — PageHeader text-display(36) + 스케일 표

### DIFF
--- a/fe/.design-sync/conventions.md
+++ b/fe/.design-sync/conventions.md
@@ -19,7 +19,16 @@ React + Tailwind CSS v4 component library (shadcn/ui 스타일). 컴포넌트는
 - 테두리/링: `border border-border`, `ring-ring`
 - 반경: `rounded-md`, `rounded-lg`(`--radius` 기반)
 - 브랜드 색: 토큰 `--brand`(보라 `oklch(0.55 0.25 297.5)`) — 유틸리티가 필요하면 `text-[var(--brand)]` / `bg-[var(--brand)]`로 사용
-- 간격은 표준 Tailwind 스케일(`gap-3`, `p-4`). 타이포는 시맨틱 스케일 토큰을 쓴다: `text-title`(페이지 제목 24) · `text-heading`(섹션/카드 제목 18) · `text-body`(15) · `text-label`(14) · `text-caption`(보조 12), `text-display`(32)는 히어로용. 색과 함께 쓸 때도 `cn("text-muted-foreground text-caption")`처럼 안전(폰트크기 그룹 등록됨)
+- 간격은 표준 Tailwind 스케일(`gap-3`, `p-4`). 타이포는 raw `text-2xl` 대신 시맨틱 스케일 토큰을 쓴다. 색과 함께 써도 `cn("text-muted-foreground text-caption")`처럼 안전(폰트크기 그룹 등록됨):
+
+  | 토큰 | 크기 | 용도 |
+  |---|---|---|
+  | `text-display` | 36 (2.25rem) | 페이지 제목 — `PageHeader` |
+  | `text-title` | 24 (1.5rem) | 큰 섹션 제목 |
+  | `text-heading` | 18 (1.125rem) | 섹션/카드/모달 제목 — `SectionHeader`(md)·`CardTitle`·`Modal` 제목 |
+  | `text-body` | 15 (0.9375rem) | 본문 |
+  | `text-label` | 14 (0.875rem) | 폼 라벨·보조 — `Modal` 설명 |
+  | `text-caption` | 12 (0.75rem) | 캡션·메타 — `SectionHeader`(sm) |
 
 ## 컴포넌트 사용
 

--- a/fe/src/components/PageHeader.test.tsx
+++ b/fe/src/components/PageHeader.test.tsx
@@ -4,11 +4,11 @@ import { describe, expect, it } from "vitest";
 import { PageHeader } from "./PageHeader";
 
 describe("PageHeader", () => {
-  it("제목을 text-title h1로 렌더한다", () => {
+  it("제목을 text-display h1로 렌더한다", () => {
     render(<PageHeader title="학습 자료" />);
     const heading = screen.getByRole("heading", { name: "학습 자료" });
     expect(heading.tagName).toBe("H1");
-    expect(heading).toHaveClass("text-title", "font-semibold");
+    expect(heading).toHaveClass("text-display", "font-semibold");
   });
 
   it("설명과 우측 액션 슬롯을 함께 렌더한다", () => {

--- a/fe/src/components/PageHeader.tsx
+++ b/fe/src/components/PageHeader.tsx
@@ -13,7 +13,7 @@ interface PageHeaderProps {
 }
 
 /**
- * 페이지 상단 헤더 — 모든 페이지가 동일한 제목 크기(text-title 토큰)·여백·정렬을 쓰도록 통일한다.
+ * 페이지 상단 헤더 — 모든 페이지가 동일한 제목 크기(text-display 토큰)·여백·정렬을 쓰도록 통일한다.
  * 우측 액션과 보조 설명은 선택 슬롯.
  */
 export function PageHeader({
@@ -27,7 +27,7 @@ export function PageHeader({
       className={cn("flex items-center justify-between gap-3", className)}
     >
       <div className="min-w-0">
-        <h1 className="text-title font-semibold">{title}</h1>
+        <h1 className="text-display font-semibold">{title}</h1>
         {description && (
           <p className="text-muted-foreground mt-0.5 text-sm">{description}</p>
         )}

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -16,7 +16,7 @@
     "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji",
     "Segoe UI Symbol", sans-serif;
   /* 타이포 스케일 토큰 — 컴포넌트가 text-xl 등 하드코딩 대신 참조(text-title 등 유틸 생성). */
-  --text-display: 2rem;
+  --text-display: 2.25rem;
   --text-display--line-height: 1.15;
   --text-title: 1.5rem;
   --text-title--line-height: 1.2;


### PR DESCRIPTION
## 이슈
closes #706

## 배경
DS 후속 지시서 P4 마무리. 타이포 토큰 도입·컴포넌트 참조는 이미 #701에서 머지됨. 이 PR은 지시서와의 차이 두 가지만 반영.

## 변경
- **PageHeader 제목 = `text-display`(36px)**: `--text-display` 2rem→2.25rem(36)으로 올리고 PageHeader가 `text-title`(24)→`text-display`(36) 참조. (지시서 스펙 "PageHeader 제목 = text-display". 직전 '약간 키움'에서 24였던 것을 사용자 확인 후 36으로 확정)
- **README/conventions 타이포 스케일 표** 추가(토큰·크기·용도 — 지시서 완료 기준)

## 영향
- 전 페이지 제목이 24→36px로 커져 표현적. 그 외 타이포(섹션/카드/본문)는 #701 그대로
- 215 테스트 통과, eslint·format·tsc·build 클린

## 비고
- font-weight-* 토큰은 Tailwind 기본(font-medium/semibold 등)과 중복이라 제외(사용자 확인)
- 패널 PageHeader 카드 갱신은 다음 재싱크에 반영