### PR TITLE
chore : design-sync 재싱크 — Modal 새 API·PageHeader 36

### DIFF
--- a/fe/.design-sync/config.json
+++ b/fe/.design-sync/config.json
@@ -5,7 +5,7 @@
   "globalName": "OrinoUI",
   "srcDir": "src/components",
   "tsconfig": "tsconfig.app.json",
-  "cssEntry": "dist/assets/index-BnJavGAO.css",
+  "cssEntry": "dist/assets/index-DreHcLBT.css",
   "extraFonts": [
     "dist/assets/PretendardVariable-CJuje-Rk.woff2"
   ],

--- a/fe/.design-sync/previews/Modal.tsx
+++ b/fe/.design-sync/previews/Modal.tsx
@@ -1,18 +1,15 @@
-import { Button, Modal } from "orino-fe";
+import { Modal } from "orino-fe";
 
 export function Default() {
   return (
-    <Modal open onOpenChange={() => {}} className="max-w-sm">
-      <h2 className="text-base font-semibold">블록 편집</h2>
-      <p className="text-muted-foreground mt-2 text-sm">
-        시간과 라벨을 수정하세요.
-      </p>
-      <div className="mt-4 flex justify-end gap-2">
-        <Button variant="ghost" size="sm">
-          취소
-        </Button>
-        <Button size="sm">저장</Button>
-      </div>
+    <Modal
+      open
+      onOpenChange={() => {}}
+      title="블록 편집"
+      description="시간과 라벨을 수정하세요."
+      size="sm"
+    >
+      <Modal.Footer submitLabel="저장" onSubmit={() => {}} />
     </Modal>
   );
 }


### PR DESCRIPTION
## 이슈
closes #708

## 작업 내용
P3·P4를 claude.ai/design 패널에 재동기화.
- **Modal 카드**: 새 API(`title`/`description`/`size` + `Modal.Footer`)로 프리뷰 갱신·재캡처 — 보라 버튼 푸터 + 백드롭 렌더 확인
- **PageHeader 카드**: `text-display`(36) 재캡처 — 표현적 제목
- **ConfirmDialog 카드**: 새 Modal 위 프리셋, destructive 삭제 소프트 레드 재캡처
- config.json cssEntry 해시 갱신

## 결과
- 패널 45종(P3에서 다이얼로그 내부 3종은 #703에서 이미 제거됨) — 동일 셋이라 추가/삭제 없음, 변경 카드만 갱신
- 전 프리뷰 graded good, 렌더 45/45 클린, self-check 재생성, anchor 갱신
- 코드 변경 없음(design-sync 입력만)

🏁 이 PR로 P3·P4 후속 + 패널 동기화까지 코드·패널 완전 일치