### PR TITLE
feat : 주간 계획표 다중 선택 삭제 (선택 모드 토글)

### DIFF
--- a/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.test.tsx
@@ -236,4 +236,116 @@ describe("WeeklyPlan", () => {
       ).not.toBeInTheDocument(),
     );
   });
+
+  it("선택 모드에서 여러 블록을 골라 한 번에 삭제한다", async () => {
+    mockPlan([
+      {
+        id: 1,
+        dayOfWeek: 1,
+        startTime: "08:00",
+        endTime: "09:00",
+        label: "기상",
+        color: "violet",
+      },
+      {
+        id: 2,
+        dayOfWeek: 2,
+        startTime: "10:00",
+        endTime: "11:00",
+        label: "공부",
+        color: "sky",
+      },
+      {
+        id: 3,
+        dayOfWeek: 3,
+        startTime: "12:00",
+        endTime: "13:00",
+        label: "점심",
+        color: "amber",
+      },
+    ]);
+    let putBody: { blocks: { label: string }[] } | null = null;
+    server.use(
+      http.put(`${API_BASE}/planner/plan`, async ({ request }) => {
+        putBody = (await request.json()) as { blocks: { label: string }[] };
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            blocks: putBody.blocks.map((b, i) => ({ id: i + 10, ...b })),
+          },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithRouter(<WeeklyPlan />);
+
+    // 선택 모드 진입
+    await user.click(await screen.findByRole("button", { name: "선택" }));
+
+    // 기상·점심 두 블록 체크(공부는 남긴다)
+    await user.click(screen.getByRole("button", { name: "기상 08:00~09:00" }));
+    await user.click(screen.getByRole("button", { name: "점심 12:00~13:00" }));
+
+    // 체크 상태·개수 반영
+    expect(
+      screen.getByRole("button", { name: "기상 08:00~09:00" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText("2개 선택")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "삭제" }));
+
+    // 선택한 두 블록만 제거되고 1회 전량 교체 저장
+    await waitFor(() => expect(putBody).not.toBeNull());
+    expect(putBody!.blocks).toHaveLength(1);
+    expect(putBody!.blocks[0].label).toBe("공부");
+
+    // 남은 블록은 유지, 선택 모드는 해제되어 [선택] 버튼 복귀
+    expect(
+      screen.getByRole("button", { name: "공부 10:00~11:00" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "기상 08:00~09:00" }),
+    ).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: "선택" }),
+    ).toBeInTheDocument();
+  });
+
+  it("선택 모드를 취소하면 삭제 없이 편집 모드로 복귀한다", async () => {
+    mockPlan([
+      {
+        id: 1,
+        dayOfWeek: 2,
+        startTime: "10:00",
+        endTime: "11:00",
+        label: "공부",
+        color: "sky",
+      },
+    ]);
+    const user = userEvent.setup();
+    renderWithRouter(<WeeklyPlan />);
+
+    await user.click(await screen.findByRole("button", { name: "선택" }));
+    await user.click(screen.getByRole("button", { name: "공부 10:00~11:00" }));
+    await user.click(screen.getByRole("button", { name: "취소" }));
+
+    // 블록 유지 + 클릭 시 다시 편집 모달이 열린다(선택 모드 해제 확인)
+    expect(
+      screen.getByRole("button", { name: "공부 10:00~11:00" }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "공부 10:00~11:00" }));
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("블록이 없으면 [선택] 버튼을 노출하지 않는다", async () => {
+    mockPlan([]);
+    renderWithRouter(<WeeklyPlan />);
+    expect(
+      await screen.findByRole("button", { name: "추가" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "선택" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/fe/src/features/planner/components/plan/WeeklyPlan.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.tsx
@@ -1,4 +1,4 @@
-import { Plus } from "lucide-react";
+import { ListChecks, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { PageHeader } from "@/components/PageHeader";
@@ -48,6 +48,9 @@ export function WeeklyPlan() {
   const [editing, setEditing] = useState<EditableBlock | null>(null);
   const [creating, setCreating] = useState(false);
   const [mobileDay, setMobileDay] = useState(new Date().getDay());
+  // 다중 선택 삭제용. selecting=선택 모드, selectedKeys=체크된 블록 key.
+  const [selecting, setSelecting] = useState(false);
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     if (data) setBlocks(toEditable(data));
@@ -75,6 +78,28 @@ export function WeeklyPlan() {
     setEditing(null);
   };
 
+  const exitSelecting = () => {
+    setSelecting(false);
+    setSelectedKeys(new Set());
+  };
+
+  // 선택 모드에서 블록 클릭 → 체크 토글.
+  const toggleSelect = (block: EditableBlock) => {
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(block.key)) next.delete(block.key);
+      else next.add(block.key);
+      return next;
+    });
+  };
+
+  // 체크된 블록을 한 번에 제거하고 1회만 전량 교체 저장한다.
+  const handleDeleteSelected = () => {
+    if (selectedKeys.size === 0) return;
+    persist(blocks.filter((b) => !selectedKeys.has(b.key)));
+    exitSelecting();
+  };
+
   const days = narrow ? [mobileDay] : ALL_DAYS;
 
   return (
@@ -83,10 +108,46 @@ export function WeeklyPlan() {
         title="주간 계획표"
         description={save.isPending ? "저장 중…" : undefined}
         actions={
-          <Button variant="outline" size="sm" onClick={() => setCreating(true)}>
-            <Plus className="size-4" />
-            추가
-          </Button>
+          selecting ? (
+            <>
+              <span className="text-muted-foreground text-sm">
+                {selectedKeys.size}개 선택
+              </span>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleDeleteSelected}
+                disabled={selectedKeys.size === 0}
+              >
+                <Trash2 className="size-4" />
+                삭제
+              </Button>
+              <Button variant="outline" size="sm" onClick={exitSelecting}>
+                취소
+              </Button>
+            </>
+          ) : (
+            <>
+              {blocks.length > 0 && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setSelecting(true)}
+                >
+                  <ListChecks className="size-4" />
+                  선택
+                </Button>
+              )}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setCreating(true)}
+              >
+                <Plus className="size-4" />
+                추가
+              </Button>
+            </>
+          )
         }
       />
 
@@ -119,7 +180,14 @@ export function WeeklyPlan() {
           주간 계획표를 불러오지 못했습니다.
         </FieldError>
       ) : (
-        <WeeklyPlanGrid blocks={blocks} days={days} onSelect={setEditing} />
+        <WeeklyPlanGrid
+          blocks={blocks}
+          days={days}
+          onSelect={setEditing}
+          selecting={selecting}
+          selectedKeys={selectedKeys}
+          onToggleSelect={toggleSelect}
+        />
       )}
 
       <PlanBlockCreate

--- a/fe/src/features/planner/components/plan/WeeklyPlanGrid.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlanGrid.tsx
@@ -1,3 +1,5 @@
+import { Check } from "lucide-react";
+
 import { cn } from "@/lib/utils";
 
 import { blockColorClass } from "./planColors";
@@ -18,8 +20,14 @@ interface WeeklyPlanGridProps {
   blocks: EditableBlock[];
   /** 표시할 요일 인덱스(데스크탑 0~6, 모바일 단일). */
   days: number[];
-  /** 블록 클릭 → 편집. */
+  /** 블록 클릭 → 편집(선택 모드가 아닐 때). */
   onSelect: (block: EditableBlock) => void;
+  /** 선택 모드: 블록 클릭이 편집 대신 체크 토글로 동작한다. */
+  selecting?: boolean;
+  /** 선택 모드에서 체크된 블록 key 집합. */
+  selectedKeys?: ReadonlySet<string>;
+  /** 선택 모드에서 블록 클릭 시 선택 토글. */
+  onToggleSelect?: (block: EditableBlock) => void;
 }
 
 /** 일~토 × 시간축 그리드. 표시 + 블록 클릭 편집(생성은 상단 [+ 추가] 버튼). */
@@ -27,6 +35,9 @@ export function WeeklyPlanGrid({
   blocks,
   days,
   onSelect,
+  selecting = false,
+  selectedKeys,
+  onToggleSelect,
 }: WeeklyPlanGridProps) {
   return (
     <div className="overflow-x-auto">
@@ -76,30 +87,46 @@ export function WeeklyPlanGrid({
             ))}
 
             {/* 블록 */}
-            {layoutDay(blocks.filter((b) => b.dayOfWeek === day)).map((b) => (
-              <button
-                key={b.key}
-                type="button"
-                aria-label={`${b.label || "(라벨 없음)"} ${b.startTime}~${b.endTime}`}
-                onClick={() => onSelect(b)}
-                className={cn(
-                  // border-background로 인접(같은 색) 블록 사이에 seam을 만든다
-                  "border-background absolute overflow-hidden rounded border px-1 py-0.5 text-left text-[11px] leading-tight text-white shadow-sm",
-                  blockColorClass(b.color),
-                )}
-                style={{
-                  top: topRatio(b.startTime) * COLUMN_HEIGHT,
-                  height: heightRatio(b.startTime, b.endTime) * COLUMN_HEIGHT,
-                  left: `${b.left * 100}%`,
-                  width: `${b.width * 100}%`,
-                }}
-              >
-                <span className="block font-semibold">
-                  {b.startTime}–{b.endTime}
-                </span>
-                <span className="block truncate">{b.label}</span>
-              </button>
-            ))}
+            {layoutDay(blocks.filter((b) => b.dayOfWeek === day)).map((b) => {
+              const selected = selecting && !!selectedKeys?.has(b.key);
+              return (
+                <button
+                  key={b.key}
+                  type="button"
+                  aria-label={`${b.label || "(라벨 없음)"} ${b.startTime}~${b.endTime}`}
+                  aria-pressed={selecting ? selected : undefined}
+                  onClick={() =>
+                    selecting ? onToggleSelect?.(b) : onSelect(b)
+                  }
+                  className={cn(
+                    // border-background로 인접(같은 색) 블록 사이에 seam을 만든다
+                    "border-background absolute overflow-hidden rounded border px-1 py-0.5 text-left text-[11px] leading-tight text-white shadow-sm",
+                    blockColorClass(b.color),
+                    // 선택 모드: 체크된 블록은 링으로 강조, 나머지는 흐리게
+                    selecting &&
+                      (selected
+                        ? "ring-primary ring-offset-background ring-2 ring-offset-1"
+                        : "opacity-60"),
+                  )}
+                  style={{
+                    top: topRatio(b.startTime) * COLUMN_HEIGHT,
+                    height: heightRatio(b.startTime, b.endTime) * COLUMN_HEIGHT,
+                    left: `${b.left * 100}%`,
+                    width: `${b.width * 100}%`,
+                  }}
+                >
+                  {selected && (
+                    <span className="bg-primary text-primary-foreground absolute top-0.5 right-0.5 flex size-4 items-center justify-center rounded-full">
+                      <Check className="size-3" strokeWidth={3} />
+                    </span>
+                  )}
+                  <span className="block font-semibold">
+                    {b.startTime}–{b.endTime}
+                  </span>
+                  <span className="block truncate">{b.label}</span>
+                </button>
+              );
+            })}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## 이슈
closes #710

## 작업 내용
주간 계획표에서 블록을 지우려면 블록마다 편집 모달을 열고 삭제해야 해서, 여러 개를 지울 때 반복 클릭이 번거로웠다. **선택 모드**를 추가해 여러 블록을 한 번에 삭제할 수 있게 했다.

전량 교체 저장(PUT) 구조라 **BE 변경 없이 FE만** 수정했다.

- 헤더에 `[선택]` 토글 버튼 추가 — 켜면 블록 클릭이 편집 대신 **체크 토글**로 동작
- 선택된 블록은 **링 + 체크 배지**로 강조, 미선택 블록은 흐리게 표시 (`aria-pressed`로 상태 노출)
- `선택 개수` 노출 + `[삭제]`로 체크된 블록을 **한 번에 제거 → 1회만 전량 교체 저장**
- `[취소]` 시 편집 모드로 복귀, 블록이 없으면 `[선택]` 버튼 숨김
- 기존 단일 클릭=편집 동작은 선택 모드가 꺼져 있을 때 그대로 유지

## 테스트
- `WeeklyPlan.test.tsx`에 통합 테스트 3종 추가: 다중 선택 후 일괄 삭제(PUT 1회·잔여 블록 검증), 취소 후 편집 복귀, 빈 상태 `[선택]` 미노출
- FE: vitest 11개 통과, eslint·tsc·prettier clean