### PR TITLE
fix : 주간 계획표 저장 상태 표기 제거 (레이아웃 밀림 해소)

### DIFF
--- a/fe/src/features/planner/components/plan/WeeklyPlan.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.tsx
@@ -106,7 +106,6 @@ export function WeeklyPlan() {
     <div className="flex flex-col gap-6">
       <PageHeader
         title="주간 계획표"
-        description={save.isPending ? "저장 중…" : undefined}
         actions={
           selecting ? (
             <>


### PR DESCRIPTION
## 이슈
closes #712

## 작업 내용
주간 계획표 저장 시 PageHeader 제목 아래에 `저장 중…` 줄이 잠깐 나타났다 사라지며 헤더가 순간적으로 밀리던 문제를 해결했다.

- `PageHeader`의 `description={save.isPending ? "저장 중…" : undefined}` 제거
- 적용 시 모달이 즉시 닫히는 **낙관적 저장** 구조라 진행 표기는 실질적으로 보이지 않아 불필요
- 저장 실패 피드백은 기존 **토스트**(`저장에 실패했습니다`)로 그대로 유지

## 테스트
- vitest 11개 통과, eslint·tsc·prettier clean