### PR TITLE
fix : 조건부 상태·에러 표기 레이아웃 밀림 전수 정리

### DIFF
--- a/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
+++ b/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useId, useState } from "react";
 
-import { FieldError } from "@/components/ui/field-error";
 import { FormField } from "@/components/ui/form-field";
 import { Modal } from "@/components/ui/modal";
 import { Textarea } from "@/components/ui/textarea";
@@ -15,7 +14,6 @@ interface Props {
   initialFront?: string;
   initialBack?: string;
   pending?: boolean;
-  errorMessage?: string;
   onSubmit: (values: { front: string; back: string }) => void;
   onDelete?: () => void;
 }
@@ -27,7 +25,6 @@ export function FlashcardFormDialog({
   initialFront = "",
   initialBack = "",
   pending = false,
-  errorMessage,
   onSubmit,
   onDelete,
 }: Props) {
@@ -84,8 +81,6 @@ export function FlashcardFormDialog({
           onChange={setBack}
           max={MAX_LEN}
         />
-
-        {errorMessage && <FieldError>{errorMessage}</FieldError>}
 
         <Modal.Footer
           submitLabel="저장"

--- a/fe/src/features/flashcard/components/FlashcardListTab.test.tsx
+++ b/fe/src/features/flashcard/components/FlashcardListTab.test.tsx
@@ -162,6 +162,34 @@ describe("FlashcardListTab", () => {
     expect(await screen.findByText(/카드가 추가되었어요/)).toBeInTheDocument();
   });
 
+  it("카드 생성 실패 시 인라인 에러 대신 토스트로 알린다", async () => {
+    mockListEmpty();
+    server.use(
+      http.post(`${API_BASE}/planner/materials/1/flashcards`, () =>
+        HttpResponse.json(
+          { code: "ERR", message: "server error" },
+          { status: 500 },
+        ),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 카드가 없습니다.")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /첫 카드 추가/ }));
+    await user.type(await screen.findByLabelText("앞면 (질문)"), "Q");
+    await user.type(screen.getByLabelText("뒷면 (답)"), "A");
+    await user.click(screen.getByRole("button", { name: "저장" }));
+
+    // 다이얼로그 내부에 밀림을 유발하는 인라인 에러 없이 토스트로만 알린다
+    expect(
+      await screen.findByText(/카드 추가에 실패했어요/),
+    ).toBeInTheDocument();
+  });
+
   it("[편집] 후 [삭제] 클릭 시 확인 → DELETE 호출", async () => {
     mockListWith([
       {

--- a/fe/src/features/flashcard/components/FlashcardListTab.tsx
+++ b/fe/src/features/flashcard/components/FlashcardListTab.tsx
@@ -36,6 +36,8 @@ export function FlashcardListTab({ materialId }: Props) {
         setCreateOpen(false);
         toast("카드가 추가되었어요. 첫 복습은 내일.", "success");
       },
+      onError: () =>
+        toast("카드 추가에 실패했어요. 잠시 후 다시 시도해주세요.", "error"),
     });
   };
 
@@ -43,6 +45,8 @@ export function FlashcardListTab({ materialId }: Props) {
     if (!editing) return;
     updateMutation.mutate(values, {
       onSuccess: () => setEditing(null),
+      onError: () =>
+        toast("저장에 실패했어요. 잠시 후 다시 시도해주세요.", "error"),
     });
   };
 
@@ -100,11 +104,6 @@ export function FlashcardListTab({ materialId }: Props) {
           if (!o) createMutation.reset();
         }}
         pending={createMutation.isPending}
-        errorMessage={
-          createMutation.isError
-            ? "카드 추가에 실패했어요. 잠시 후 다시 시도해주세요."
-            : undefined
-        }
         onSubmit={handleCreate}
       />
 
@@ -120,11 +119,6 @@ export function FlashcardListTab({ materialId }: Props) {
         initialFront={editing?.front}
         initialBack={editing?.back}
         pending={updateMutation.isPending}
-        errorMessage={
-          updateMutation.isError
-            ? "저장에 실패했어요. 잠시 후 다시 시도해주세요."
-            : undefined
-        }
         onSubmit={handleUpdate}
         onDelete={() => setDeleteConfirmOpen(true)}
       />

--- a/fe/src/features/google/components/GoogleConnectionCard.tsx
+++ b/fe/src/features/google/components/GoogleConnectionCard.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { LoadingText } from "@/components/ui/loading-text";
 import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
 
 import { useDisconnectGoogle } from "../hooks/useDisconnectGoogle";
 import { useGoogleStatus } from "../hooks/useGoogleStatus";
@@ -55,11 +56,16 @@ export function GoogleConnectionCard() {
                 </p>
               </div>
               <div className="flex shrink-0 items-center gap-2">
-                {mirror.isPending && (
-                  <span className="text-muted-foreground text-xs">
-                    {status.reviewMirrorEnabled ? "끄는 중…" : "켜는 중…"}
-                  </span>
-                )}
+                {/* 토글 중 표기는 항상 렌더하고 opacity로만 숨겨, 나타날 때 Switch가 밀리지 않게 공간을 예약한다. */}
+                <span
+                  aria-hidden={!mirror.isPending}
+                  className={cn(
+                    "text-muted-foreground text-xs transition-opacity",
+                    !mirror.isPending && "opacity-0",
+                  )}
+                >
+                  {status.reviewMirrorEnabled ? "끄는 중…" : "켜는 중…"}
+                </span>
                 <Switch
                   checked={status.reviewMirrorEnabled}
                   disabled={mirror.isPending}

--- a/fe/src/features/material/components/AddMaterialDialog.tsx
+++ b/fe/src/features/material/components/AddMaterialDialog.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useId, useState } from "react";
 
-import { FieldError } from "@/components/ui/field-error";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
 import { Select, type SelectOption } from "@/components/ui/select";
+import { toast } from "@/shared/lib/toast";
 
 import type { MaterialType } from "../api/materials";
 import { useCreateMaterial } from "../hooks/useCreateMaterial";
@@ -52,6 +52,11 @@ export function AddMaterialDialog({ open, onOpenChange, onCreated }: Props) {
           onOpenChange(false);
           onCreated?.(data.material.id);
         },
+        onError: () =>
+          toast(
+            "자료를 추가하지 못했어요. 잠시 후 다시 시도해주세요.",
+            "error",
+          ),
       },
     );
   };
@@ -83,12 +88,6 @@ export function AddMaterialDialog({ open, onOpenChange, onCreated }: Props) {
             ariaLabelledby={typeLabelId}
           />
         </FormField>
-
-        {mutation.isError && (
-          <FieldError>
-            자료를 추가하지 못했어요. 잠시 후 다시 시도해주세요.
-          </FieldError>
-        )}
 
         <Modal.Footer
           submitLabel="추가"

--- a/fe/src/features/material/components/EditMaterialDialog.tsx
+++ b/fe/src/features/material/components/EditMaterialDialog.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useId, useState } from "react";
 
-import { FieldError } from "@/components/ui/field-error";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
 import { Select, type SelectOption } from "@/components/ui/select";
+import { toast } from "@/shared/lib/toast";
 
 import type { Material, MaterialStatus } from "../api/materials";
 import { useUpdateMaterial } from "../hooks/useUpdateMaterial";
@@ -48,7 +48,11 @@ export function EditMaterialDialog({ material, open, onOpenChange }: Props) {
         title: trimmed !== material.title ? trimmed : undefined,
         status: status !== material.status ? status : undefined,
       },
-      { onSuccess: () => onOpenChange(false) },
+      {
+        onSuccess: () => onOpenChange(false),
+        onError: () =>
+          toast("저장에 실패했어요. 잠시 후 다시 시도해주세요.", "error"),
+      },
     );
   };
 
@@ -73,10 +77,6 @@ export function EditMaterialDialog({ material, open, onOpenChange }: Props) {
             ariaLabelledby={statusLabelId}
           />
         </FormField>
-
-        {mutation.isError && (
-          <FieldError>저장에 실패했어요. 잠시 후 다시 시도해주세요.</FieldError>
-        )}
 
         <Modal.Footer
           submitLabel="저장"

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -180,11 +180,14 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
           placeholder="제목 없음"
           className="border-none px-0 text-lg font-semibold shadow-none focus-visible:ring-0"
         />
-        <SaveStatusIndicator
-          status={status}
-          savedAt={savedAt}
-          onRetry={retry}
-        />
+        {/* 상태가 나타났다 사라질 때 제목 Input 폭이 밀리지 않게 슬롯 폭을 예약한다. */}
+        <div className="flex min-w-[7rem] shrink-0 justify-end">
+          <SaveStatusIndicator
+            status={status}
+            savedAt={savedAt}
+            onRetry={retry}
+          />
+        </div>
       </div>
 
       <div className="border-border bg-card overflow-hidden rounded-md border">


### PR DESCRIPTION
## 이슈
closes #714

## 작업 내용
`저장 중…`(주간 계획표, #713)과 **같은 유형** — "짧게 나타났다 사라지는 조건부 상태/에러 표기가 flow에 요소를 추가해 주변을 밀어내는" 문제를 FE 전체에서 전수 조사해 정리했다.

### 상태 표기 (공간 예약)
- **GoogleConnectionCard**: 토글 중 `켜는 중…/끄는 중…`를 조건부 렌더 대신 **항상 렌더 + `opacity`로만 숨김**(+`aria-hidden`). 나타날 때 우측 Switch가 좌우로 튀지 않게 공간을 예약.
- **NoteEditor**: 저장 상태 표기(`SaveStatusIndicator`)를 **`min-w` 슬롯**으로 감싸 제목 Input 폭이 저장 상태에 따라 밀리지 않게 고정.

### 폼 제출 에러 (토스트 전환)
- **AddMaterialDialog · EditMaterialDialog · FlashcardFormDialog**: 모달 안 인라인 제출 에러(`{isError && <FieldError>}`)가 나타나며 푸터를 밀고 다이얼로그가 리센터되던 문제 → **토스트로 전환**. 밀림·빈 여백 없이, 앱의 저장 실패 토스트 관례(`useSaveWeeklyPlan` 등)와 일치.

## 조사 범위 메모 (제외 항목)
콘텐츠·빈상태(TodayRoutines 목록·`N/M` 카운터), 버튼 라벨 스왑(`pendingLabel`, `해제 중…`), 페이지 로딩 스켈레톤은 성격이 달라 제외.

## 테스트
- 카드 생성 실패 시 인라인 에러 대신 토스트로 알리는 테스트 추가
- 전체 219개 통과, eslint·tsc·prettier clean