### PR TITLE
fix : 청크 로드 실패 시 자동 새로고침 (배포 중 stale 탭 404 흡수)

### DIFF
--- a/fe/src/main.tsx
+++ b/fe/src/main.tsx
@@ -5,10 +5,12 @@ import { createRoot } from "react-dom/client";
 
 import App from "./app/App.tsx";
 import { initFaro } from "./shared/faro/init";
+import { installChunkReloadHandler } from "./shared/lib/chunkReload";
 import { initTheme } from "./shared/lib/theme";
 
 initFaro();
 initTheme();
+installChunkReloadHandler();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/fe/src/shared/lib/chunkReload.test.ts
+++ b/fe/src/shared/lib/chunkReload.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { reloadOnChunkError } from "./chunkReload";
+
+describe("reloadOnChunkError", () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it("첫 청크 실패엔 새로고침한다", () => {
+    const reload = vi.fn();
+    expect(reloadOnChunkError(1000, reload)).toBe(true);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("쿨다운(10s) 내 재실패는 루프 방지로 스킵한다", () => {
+    const reload = vi.fn();
+    reloadOnChunkError(1000, reload);
+    expect(reloadOnChunkError(5000, reload)).toBe(false);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("쿨다운 경과 후엔 다시 새로고침한다(다음 배포 대응)", () => {
+    const reload = vi.fn();
+    reloadOnChunkError(1000, reload);
+    expect(reloadOnChunkError(20000, reload)).toBe(true);
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+});

--- a/fe/src/shared/lib/chunkReload.ts
+++ b/fe/src/shared/lib/chunkReload.ts
@@ -1,0 +1,36 @@
+const KEY = "vite:preloadError:lastReload";
+const COOLDOWN_MS = 10_000;
+
+/**
+ * 청크(dynamic import) 로드 실패 시 1회 새로고침으로 흡수한다.
+ * 대개 새 배포로 옛 해시 청크가 교체·삭제된 stale 탭이 원인 — 새로고침하면 새 index+청크를 받는다.
+ * 단, 쿨다운(10s) 내 재실패면 진짜 404(깨진 배포)로 보고 무한 리로드를 막기 위해 스킵한다
+ * (이 경우 ErrorBoundary가 에러 화면을 보여준다). 테스트를 위해 now/reload를 주입할 수 있다.
+ */
+export function reloadOnChunkError(
+  now: number = Date.now(),
+  reload: () => void = () => window.location.reload(),
+): boolean {
+  let last = 0;
+  try {
+    last = Number(sessionStorage.getItem(KEY) ?? 0);
+  } catch {
+    // sessionStorage 접근 불가(프라이빗 모드 등)는 무시하고 리로드를 시도한다
+  }
+  // last>0(실제 리로드 이력)일 때만 쿨다운 적용 — 첫 실패는 항상 새로고침한다.
+  if (last > 0 && now - last < COOLDOWN_MS) return false;
+  try {
+    sessionStorage.setItem(KEY, String(now));
+  } catch {
+    // 저장 실패는 무시 — 리로드 자체는 진행한다
+  }
+  reload();
+  return true;
+}
+
+/** Vite가 dynamic import 청크 로드에 실패하면 발생시키는 vite:preloadError를 잡아 새로고침한다. */
+export function installChunkReloadHandler(): void {
+  window.addEventListener("vite:preloadError", () => {
+    reloadOnChunkError();
+  });
+}


### PR DESCRIPTION
## 이슈
closes #725

## 배경
브랜드 PR 머지 후 orino.dev에서 다수 청크 404 관측(`Failed to fetch dynamically imported module`, WeeklyPlanPage·field-error·modal 등). curl 확인 결과 **현재는 전부 200으로 정상** — 즉 배포 진행 중 window에서, `index.html`(no-cache)이 새 버전을 가리키는데 `/assets/` 해시 청크가 아직 안 올라온/옛 청크가 삭제된 찰나에 lazy import가 실패한 것.

SPA 배포의 고전 문제(앱을 열어둔 탭이 새 배포 후 옛 해시 청크를 요청)라 **클라 회복력**을 추가한다.

## 변경
- **`vite:preloadError` 핸들러**(`installChunkReloadHandler`, main.tsx 배선): 청크 로드 실패 시 `reloadOnChunkError`로 **1회 새로고침** → 새 index+청크를 받아 흡수
- **쿨다운 10s**: 새로고침 직후 또 실패하면(진짜 404/깨진 배포) 무한 리로드를 막기 위해 스킵 → 기존 ErrorBoundary가 에러 화면 처리. `last>0`일 때만 쿨다운 적용(첫 실패는 항상 리로드)
- `reloadOnChunkError(now, reload)`로 now/reload 주입 가능 → 단위 테스트 3케이스

## 검증
- chunkReload 3 + 전체 226 테스트 통과, eslint·format·tsc·build 클린

## 비고
- 배포 비원자성(index.html이 청크보다 먼저 갱신) 자체는 인프라(nginx/GitOps) 영역 — 필요 시 별도로 옛 청크 유예 삭제/원자적 스왑 검토 가능. 이 PR은 사용자 체감 즉시 해소용 FE 회복력.