### PR TITLE
feat : 메모 모듈 BE 재착륙 — memo 테이블 + 트리 CRUD API (M0)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/memo/controller/MemoController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/memo/controller/MemoController.java
@@ -1,0 +1,69 @@
+package ds.project.orino.memo.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.memo.dto.MemoCreateRequest;
+import ds.project.orino.memo.dto.MemoDetailResponse;
+import ds.project.orino.memo.dto.MemoTreeResponse;
+import ds.project.orino.memo.dto.MemoUpdateRequest;
+import ds.project.orino.memo.dto.MemoUpdateResponse;
+import ds.project.orino.memo.service.MemoService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/memos")
+public class MemoController {
+
+    private final MemoService memoService;
+
+    public MemoController(MemoService memoService) {
+        this.memoService = memoService;
+    }
+
+    @GetMapping
+    public ApiResponse<MemoTreeResponse> tree(
+            @AuthenticationPrincipal Long memberId) {
+        return ApiResponse.success(memoService.findTree(memberId));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<MemoDetailResponse>> create(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody MemoCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(memoService.create(memberId, request)));
+    }
+
+    @GetMapping("/{memoId}")
+    public ApiResponse<MemoDetailResponse> detail(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long memoId) {
+        return ApiResponse.success(memoService.findOne(memberId, memoId));
+    }
+
+    @PatchMapping("/{memoId}")
+    public ApiResponse<MemoUpdateResponse> update(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long memoId,
+            @Valid @RequestBody MemoUpdateRequest request) {
+        return ApiResponse.success(memoService.update(memberId, memoId, request));
+    }
+
+    @DeleteMapping("/{memoId}")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long memoId) {
+        memoService.delete(memberId, memoId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/memo/dto/MemoCreateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/memo/dto/MemoCreateRequest.java
@@ -1,0 +1,11 @@
+package ds.project.orino.memo.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record MemoCreateRequest(
+        Long parentId,
+
+        @Size(min = 1, max = 200, message = "title은 1~200자여야 합니다.")
+        String title
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/memo/dto/MemoDetailResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/memo/dto/MemoDetailResponse.java
@@ -1,0 +1,33 @@
+package ds.project.orino.memo.dto;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.memo.entity.Memo;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.time.Instant;
+
+public record MemoDetailResponse(
+        Long id,
+        Long parentId,
+        String title,
+        int sortOrder,
+        JsonNode content,
+        Instant updatedAt
+) {
+    private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+    public static MemoDetailResponse of(Memo memo) {
+        JsonNode parsed;
+        try {
+            parsed = MAPPER.readTree(memo.getContent());
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, e);
+        }
+        return new MemoDetailResponse(
+                memo.getId(), memo.getParentId(),
+                memo.getTitle(), memo.getSortOrder(), parsed, memo.getUpdatedAt());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/memo/dto/MemoTreeNode.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/memo/dto/MemoTreeNode.java
@@ -1,0 +1,12 @@
+package ds.project.orino.memo.dto;
+
+import java.util.List;
+
+public record MemoTreeNode(
+        Long id,
+        String title,
+        Long parentId,
+        int sortOrder,
+        List<MemoTreeNode> children
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/memo/dto/MemoTreeResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/memo/dto/MemoTreeResponse.java
@@ -1,0 +1,6 @@
+package ds.project.orino.memo.dto;
+
+import java.util.List;
+
+public record MemoTreeResponse(List<MemoTreeNode> memos) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/memo/dto/MemoUpdateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/memo/dto/MemoUpdateRequest.java
@@ -1,0 +1,16 @@
+package ds.project.orino.memo.dto;
+
+import jakarta.validation.constraints.Size;
+import tools.jackson.databind.JsonNode;
+
+public record MemoUpdateRequest(
+        @Size(min = 1, max = 200, message = "title은 1~200자여야 합니다.")
+        String title,
+
+        JsonNode content,
+
+        Long parentId,
+
+        Integer sortOrder
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/memo/dto/MemoUpdateResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/memo/dto/MemoUpdateResponse.java
@@ -1,0 +1,19 @@
+package ds.project.orino.memo.dto;
+
+import ds.project.orino.domain.memo.entity.Memo;
+
+import java.time.Instant;
+
+public record MemoUpdateResponse(
+        Long id,
+        Long parentId,
+        String title,
+        int sortOrder,
+        Instant updatedAt
+) {
+    public static MemoUpdateResponse of(Memo memo) {
+        return new MemoUpdateResponse(
+                memo.getId(), memo.getParentId(),
+                memo.getTitle(), memo.getSortOrder(), memo.getUpdatedAt());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/memo/service/MemoService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/memo/service/MemoService.java
@@ -1,0 +1,169 @@
+package ds.project.orino.memo.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.memo.entity.Memo;
+import ds.project.orino.domain.memo.repository.MemoRepository;
+import ds.project.orino.memo.dto.MemoCreateRequest;
+import ds.project.orino.memo.dto.MemoDetailResponse;
+import ds.project.orino.memo.dto.MemoTreeNode;
+import ds.project.orino.memo.dto.MemoTreeResponse;
+import ds.project.orino.memo.dto.MemoUpdateRequest;
+import ds.project.orino.memo.dto.MemoUpdateResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+@Transactional(readOnly = true)
+public class MemoService {
+
+    static final int MAX_CONTENT_BYTES = 1024 * 1024;
+    private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+    private final MemoRepository memoRepository;
+
+    public MemoService(MemoRepository memoRepository) {
+        this.memoRepository = memoRepository;
+    }
+
+    public MemoTreeResponse findTree(Long memberId) {
+        List<Memo> memos = memoRepository.findAllByMemberIdOrderBySortOrderAscIdAsc(memberId);
+        return new MemoTreeResponse(buildTree(memos));
+    }
+
+    public MemoDetailResponse findOne(Long memberId, Long memoId) {
+        return MemoDetailResponse.of(getOwnedMemo(memberId, memoId));
+    }
+
+    @Transactional
+    public MemoDetailResponse create(Long memberId, MemoCreateRequest request) {
+        Long parentId = request.parentId();
+        if (parentId != null) {
+            getOwnedMemo(memberId, parentId);
+        }
+
+        int sortOrder = memoRepository.findMaxSortOrder(memberId, parentId) + 1;
+        Memo saved = memoRepository.save(
+                new Memo(memberId, parentId, request.title(), sortOrder));
+        return MemoDetailResponse.of(saved);
+    }
+
+    @Transactional
+    public MemoUpdateResponse update(Long memberId, Long memoId, MemoUpdateRequest request) {
+        if (request.title() == null && request.content() == null
+                && request.parentId() == null && request.sortOrder() == null) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+
+        Memo memo = getOwnedMemo(memberId, memoId);
+
+        if (request.content() != null) {
+            String serialized = serialize(request.content());
+            if (serialized.getBytes(StandardCharsets.UTF_8).length > MAX_CONTENT_BYTES) {
+                throw new CustomException(ErrorCode.INVALID_REQUEST);
+            }
+            memo.updateContent(serialized);
+        }
+        if (request.title() != null) {
+            memo.updateTitle(request.title());
+        }
+        if (request.parentId() != null) {
+            moveTo(memberId, memo, request.parentId());
+        }
+        if (request.sortOrder() != null) {
+            memo.updateSortOrder(request.sortOrder());
+        }
+
+        return MemoUpdateResponse.of(memo);
+    }
+
+    @Transactional
+    public void delete(Long memberId, Long memoId) {
+        Memo memo = getOwnedMemo(memberId, memoId);
+        memoRepository.delete(memo);
+    }
+
+    private void moveTo(Long memberId, Memo memo, Long newParentId) {
+        if (newParentId.equals(memo.getId())) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        getOwnedMemo(memberId, newParentId);
+        if (isDescendant(memberId, memo.getId(), newParentId)) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        memo.updateParent(newParentId);
+    }
+
+    /**
+     * candidateId가 rootId의 서브트리(자손) 안에 있으면 true.
+     */
+    private boolean isDescendant(Long memberId, Long rootId, Long candidateId) {
+        List<Memo> all = memoRepository.findAllByMemberIdOrderBySortOrderAscIdAsc(memberId);
+        Map<Long, List<Long>> childrenByParent = new HashMap<>();
+        for (Memo m : all) {
+            childrenByParent
+                    .computeIfAbsent(m.getParentId(), k -> new ArrayList<>())
+                    .add(m.getId());
+        }
+        Set<Long> visited = new HashSet<>();
+        List<Long> stack = new ArrayList<>(childrenByParent.getOrDefault(rootId, List.of()));
+        while (!stack.isEmpty()) {
+            Long cur = stack.remove(stack.size() - 1);
+            if (!visited.add(cur)) {
+                continue;
+            }
+            if (cur.equals(candidateId)) {
+                return true;
+            }
+            stack.addAll(childrenByParent.getOrDefault(cur, List.of()));
+        }
+        return false;
+    }
+
+    private List<MemoTreeNode> buildTree(List<Memo> memos) {
+        Map<Long, List<Memo>> childrenByParent = new HashMap<>();
+        for (Memo m : memos) {
+            childrenByParent
+                    .computeIfAbsent(m.getParentId(), k -> new ArrayList<>())
+                    .add(m);
+        }
+        return toNodes(childrenByParent.get(null), childrenByParent);
+    }
+
+    private List<MemoTreeNode> toNodes(List<Memo> level, Map<Long, List<Memo>> childrenByParent) {
+        if (level == null) {
+            return List.of();
+        }
+        List<MemoTreeNode> nodes = new ArrayList<>(level.size());
+        for (Memo m : level) {
+            nodes.add(new MemoTreeNode(
+                    m.getId(), m.getTitle(), m.getParentId(), m.getSortOrder(),
+                    toNodes(childrenByParent.get(m.getId()), childrenByParent)));
+        }
+        return nodes;
+    }
+
+    private Memo getOwnedMemo(Long memberId, Long memoId) {
+        return memoRepository.findByIdAndMemberId(memoId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    private static String serialize(JsonNode content) {
+        try {
+            return MAPPER.writeValueAsString(content);
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST, e);
+        }
+    }
+}

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/031-create-memo.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/031-create-memo.yaml
@@ -1,0 +1,84 @@
+databaseChangeLog:
+  - changeSet:
+      id: 031-create-memo
+      author: wcorn
+      comment: |
+        독립 메모장(Memo) 모듈용 memo 테이블 (#719).
+        노트(note) 트리 스키마를 material_id 없이 미러링한다.
+        Notion 스타일 트리: parent_id self-ref(자식 CASCADE), sort_order 형제 정렬.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: memo
+      changes:
+        - createTable:
+            tableName: memo
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_memo_member
+                    references: member(id)
+              - column:
+                  name: parent_id
+                  type: BIGINT
+                  constraints:
+                    nullable: true
+              - column:
+                  name: title
+                  type: VARCHAR(200)
+                  defaultValue: 제목 없음
+                  constraints:
+                    nullable: false
+              - column:
+                  name: sort_order
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: content
+                  type: JSON
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+
+        # 트리 조회용 인덱스 (member_id prefix → 멤버별 트리 + 형제 정렬)
+        - createIndex:
+            tableName: memo
+            indexName: idx_memo_member_parent_sort
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: parent_id
+              - column:
+                  name: sort_order
+
+        # parent_id self-ref FK (부모 삭제 시 자손 CASCADE). 테이블 생성 후 추가.
+        - addForeignKeyConstraint:
+            constraintName: fk_memo_parent
+            baseTableName: memo
+            baseColumnNames: parent_id
+            referencedTableName: memo
+            referencedColumnNames: id
+            onDelete: CASCADE

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -59,3 +59,5 @@ databaseChangeLog:
       file: db/changelog/changes/029-reshape-day-plan.yaml
   - include:
       file: db/changelog/changes/030-day-plan-block-minutes.yaml
+  - include:
+      file: db/changelog/changes/031-create-memo.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/memo/controller/MemoControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/memo/controller/MemoControllerTest.java
@@ -1,0 +1,298 @@
+package ds.project.orino.memo.controller;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.memo.entity.Memo;
+import ds.project.orino.domain.memo.repository.MemoRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MemoControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MemoRepository memoRepository;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private Member member;
+    private Member otherMember;
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        member = memberRepository.save(MemberFixture.create());
+        otherMember = memberRepository.save(MemberFixture.create("other", "password"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    private Memo root(String title, int sortOrder) {
+        return memoRepository.save(new Memo(member.getId(), null, title, sortOrder));
+    }
+
+    private Memo child(Long parentId, String title, int sortOrder) {
+        return memoRepository.save(new Memo(member.getId(), parentId, title, sortOrder));
+    }
+
+    @Test
+    @DisplayName("GET memos - 메모가 없으면 빈 트리")
+    void tree_empty() throws Exception {
+        mockMvc.perform(get("/api/memos")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memos", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("GET memos - 중첩 트리를 sortOrder 순으로 조립한다 (content 제외)")
+    void tree_nested() throws Exception {
+        Memo r1 = root("메모1", 0);
+        Memo r2 = root("메모2", 1);
+        Memo c1 = child(r1.getId(), "1-1", 0);
+        child(c1.getId(), "1-1-1", 0);
+
+        mockMvc.perform(get("/api/memos")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memos", hasSize(2)))
+                .andExpect(jsonPath("$.data.memos[0].id").value(r1.getId()))
+                .andExpect(jsonPath("$.data.memos[0].title").value("메모1"))
+                .andExpect(jsonPath("$.data.memos[0].children", hasSize(1)))
+                .andExpect(jsonPath("$.data.memos[0].children[0].id").value(c1.getId()))
+                .andExpect(jsonPath("$.data.memos[0].children[0].children", hasSize(1)))
+                .andExpect(jsonPath("$.data.memos[0].children[0].children[0].title").value("1-1-1"))
+                .andExpect(jsonPath("$.data.memos[1].id").value(r2.getId()))
+                .andExpect(jsonPath("$.data.memos[0].content").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET memos - 타인 메모는 트리에 포함되지 않는다")
+    void tree_excludes_other_member() throws Exception {
+        root("내 메모", 0);
+        memoRepository.save(new Memo(otherMember.getId(), null, "남의 메모", 0));
+
+        mockMvc.perform(get("/api/memos")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memos", hasSize(1)))
+                .andExpect(jsonPath("$.data.memos[0].title").value("내 메모"));
+    }
+
+    @Test
+    @DisplayName("POST memos - 루트 메모 생성 (parentId null, sortOrder=같은 부모 max+1)")
+    void create_root() throws Exception {
+        root("기존 루트", 0);
+
+        mockMvc.perform(post("/api/memos")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "새 루트"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.title").value("새 루트"))
+                .andExpect(jsonPath("$.data.parentId").doesNotExist())
+                .andExpect(jsonPath("$.data.sortOrder").value(1))
+                .andExpect(jsonPath("$.data.content.type").value("doc"))
+                .andExpect(jsonPath("$.data.content.content").isArray());
+    }
+
+    @Test
+    @DisplayName("POST memos - title 생략 시 기본 제목, 하위 메모 생성")
+    void create_child_default_title() throws Exception {
+        Memo parent = root("부모", 0);
+
+        mockMvc.perform(post("/api/memos")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"parentId": %d}
+                                """.formatted(parent.getId())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.parentId").value(parent.getId()))
+                .andExpect(jsonPath("$.data.title").value("제목 없음"))
+                .andExpect(jsonPath("$.data.sortOrder").value(0));
+    }
+
+    @Test
+    @DisplayName("POST memos - 타인 메모를 부모로 지정하면 404")
+    void create_with_others_parent_404() throws Exception {
+        Memo othersMemo = memoRepository.save(
+                new Memo(otherMember.getId(), null, "남의 메모", 0));
+
+        mockMvc.perform(post("/api/memos")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"parentId": %d}
+                                """.formatted(othersMemo.getId())))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+    }
+
+    @Test
+    @DisplayName("GET memo/{id} - 단건 content 포함 조회")
+    void detail_with_content() throws Exception {
+        Memo memo = root("메모", 0);
+
+        mockMvc.perform(get("/api/memos/{id}", memo.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(memo.getId()))
+                .andExpect(jsonPath("$.data.title").value("메모"))
+                .andExpect(jsonPath("$.data.content.type").value("doc"));
+    }
+
+    @Test
+    @DisplayName("GET memo/{id} - 타인 메모 조회 시 404")
+    void detail_other_member_404() throws Exception {
+        Memo othersMemo = memoRepository.save(
+                new Memo(otherMember.getId(), null, "남의 메모", 0));
+
+        mockMvc.perform(get("/api/memos/{id}", othersMemo.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SP-ERR-001"));
+    }
+
+    @Test
+    @DisplayName("PATCH memo - title/content 부분 수정")
+    void update_title_content() throws Exception {
+        Memo memo = root("원래 제목", 0);
+
+        mockMvc.perform(patch("/api/memos/{id}", memo.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "바뀐 제목",
+                                 "content": {"type":"doc","content":[
+                                   {"type":"paragraph","content":[{"type":"text","text":"내용"}]}]}}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("바뀐 제목"));
+
+        mockMvc.perform(get("/api/memos/{id}", memo.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.content.content[0].content[0].text").value("내용"));
+    }
+
+    @Test
+    @DisplayName("PATCH memo - 본문이 모두 null이면 400")
+    void update_empty_400() throws Exception {
+        Memo memo = root("메모", 0);
+
+        mockMvc.perform(patch("/api/memos/{id}", memo.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PATCH memo - parentId 이동 (정상)")
+    void update_move_parent() throws Exception {
+        Memo a = root("A", 0);
+        Memo b = root("B", 1);
+
+        mockMvc.perform(patch("/api/memos/{id}", b.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"parentId": %d}
+                                """.formatted(a.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.parentId").value(a.getId()));
+    }
+
+    @Test
+    @DisplayName("PATCH memo - 자기 자신을 부모로 지정하면 400")
+    void update_self_parent_400() throws Exception {
+        Memo memo = root("메모", 0);
+
+        mockMvc.perform(patch("/api/memos/{id}", memo.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"parentId": %d}
+                                """.formatted(memo.getId())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("PATCH memo - 자손을 부모로 지정하면 사이클이라 400")
+    void update_descendant_parent_cycle_400() throws Exception {
+        Memo a = root("A", 0);
+        Memo b = child(a.getId(), "B", 0);
+        Memo c = child(b.getId(), "C", 0);
+
+        // A를 C(자손)의 자식으로 이동 → 사이클
+        mockMvc.perform(patch("/api/memos/{id}", a.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"parentId": %d}
+                                """.formatted(c.getId())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("DELETE memo - 서브트리가 cascade 삭제된다")
+    void delete_subtree_cascade() throws Exception {
+        Memo a = root("A", 0);
+        Memo b = child(a.getId(), "B", 0);
+        Memo c = child(b.getId(), "C", 0);
+        Memo sibling = root("형제", 1);
+
+        mockMvc.perform(delete("/api/memos/{id}", a.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNoContent());
+
+        assertThat(memoCount(a.getId())).isZero();
+        assertThat(memoCount(b.getId())).isZero();
+        assertThat(memoCount(c.getId())).isZero();
+        assertThat(memoCount(sibling.getId())).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("DELETE memo - 타인 메모 삭제 시 404")
+    void delete_other_member_404() throws Exception {
+        Memo othersMemo = memoRepository.save(
+                new Memo(otherMember.getId(), null, "남의 메모", 0));
+
+        mockMvc.perform(delete("/api/memos/{id}", othersMemo.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNotFound());
+    }
+
+    private Integer memoCount(Long id) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM memo WHERE id = ?", Integer.class, id);
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/memo/entity/Memo.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/memo/entity/Memo.java
@@ -1,0 +1,120 @@
+package ds.project.orino.domain.memo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "memo")
+public class Memo {
+
+    public static final String DEFAULT_CONTENT = "{\"type\":\"doc\",\"content\":[]}";
+    public static final String DEFAULT_TITLE = "제목 없음";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "parent_id")
+    private Long parentId;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @Column(nullable = false, columnDefinition = "JSON")
+    private String content;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected Memo() {
+    }
+
+    /**
+     * 멤버의 루트 메모(빈 doc)를 만든다. parentId=null, 기본 제목, sortOrder=0.
+     */
+    public Memo(Long memberId) {
+        this(memberId, null, DEFAULT_TITLE, 0, DEFAULT_CONTENT);
+    }
+
+    public Memo(Long memberId, Long parentId, String title, int sortOrder) {
+        this(memberId, parentId, title, sortOrder, DEFAULT_CONTENT);
+    }
+
+    public Memo(Long memberId, Long parentId, String title, int sortOrder, String content) {
+        this.memberId = memberId;
+        this.parentId = parentId;
+        this.title = (title == null || title.isBlank()) ? DEFAULT_TITLE : title;
+        this.sortOrder = sortOrder;
+        this.content = content;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateParent(Long parentId) {
+        this.parentId = parentId;
+    }
+
+    public void updateSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Long getParentId() {
+        return parentId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Integer getSortOrder() {
+        return sortOrder;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/memo/repository/MemoRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/memo/repository/MemoRepository.java
@@ -1,0 +1,25 @@
+package ds.project.orino.domain.memo.repository;
+
+import ds.project.orino.domain.memo.entity.Memo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemoRepository extends JpaRepository<Memo, Long> {
+
+    List<Memo> findAllByMemberIdOrderBySortOrderAscIdAsc(Long memberId);
+
+    Optional<Memo> findByIdAndMemberId(Long id, Long memberId);
+
+    @Query("""
+            SELECT COALESCE(MAX(m.sortOrder), -1)
+            FROM Memo m
+            WHERE m.memberId = :memberId
+              AND (:parentId IS NULL AND m.parentId IS NULL
+                   OR m.parentId = :parentId)
+            """)
+    int findMaxSortOrder(@Param("memberId") Long memberId, @Param("parentId") Long parentId);
+}


### PR DESCRIPTION
## 이슈
closes #719

## 배경 — 재착륙(re-land)
기존 PR #724는 브랜치 `feat/memo-be-tree-crud`가 **다른 작업(브랜드 에셋)으로 force-push된 뒤 머지**되어, 라벨만 "메모 BE"로 남고 실제로는 memo 코드가 main에 **0줄** 들어갔습니다. (main 트리에 `Memo.java`/`MemoService`/`031-create-memo` 없음) 검증한 memo BE 커밋을 최신 main 위에 **그대로 재적용**해 다시 올립니다.

## 작업 내용
메모(Memo) 독립 메모장 모듈 **M0(BE)**. 노트(`planner.note`) 구조를 **`material_id` 없이** 미러링. (Epic #718)

- `domain.memo` — `Memo` 엔티티 + `MemoRepository` (member 기준 트리, `parent_id` self-ref, `sort_order`)
- `memo` API (`/api/memos`) — `GET` 트리(본문 제외) · `POST` 생성(sortOrder=형제 max+1, 빈 doc) · `GET/PATCH/DELETE {id}`
  - 자기·자손을 부모로 → **400**, 없음·타인 소유 → **404**, content **1MB** 제한
- Liquibase `031-create-memo.yaml` — member FK, parent self-FK(ON DELETE CASCADE), 인덱스 `(member_id, parent_id, sort_order)`

## 설계 대비 결정
- envelope·HTTP 시맨틱은 실제 노트 미러링(DELETE `204`, 트리 래퍼 `memos`)
- 잘못된/타인 `parentId`는 **404**(메모엔 자료 개념 없음)

## 테스트
- MockMvc + TestContainers 통합 **15종**(트리·생성·단건·PATCH·DELETE 엣지) — 최신 main 위에서 통과
- `:orino-app-api:test` + checkstyle 통과, 실제 MySQL 8.4.4에서 liquibase 031 적용 실증