### PR TITLE
feat : 메모 FE — /memo 트리 사이드바 + 에디터 + 자동 저장 (M1)

### DIFF
--- a/fe/src/app/layout/Sidebar.tsx
+++ b/fe/src/app/layout/Sidebar.tsx
@@ -3,6 +3,7 @@ import {
   Calendar,
   CalendarRange,
   CheckSquare,
+  FileText,
   Home,
   Repeat,
   Settings,
@@ -21,6 +22,7 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
   { to: "/home", label: "홈", icon: Home },
   { to: "/planner/materials", label: "학습 자료", icon: BookOpen },
+  { to: "/memo", label: "메모", icon: FileText },
   { to: "/planner/reviews/today", label: "오늘 복습", icon: CheckSquare },
   { to: "/planner/calendar", label: "캘린더", icon: Calendar },
   { to: "/planner/plan", label: "주간 계획표", icon: CalendarRange },

--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -32,6 +32,8 @@ export const importWeeklyPlan = () =>
   import("../pages/planner/WeeklyPlanPage").then((m) => ({
     default: m.WeeklyPlanPage,
   }));
+export const importMemo = () =>
+  import("../pages/MemoPage").then((m) => ({ default: m.MemoPage }));
 
 /**
  * 로그인 후 idle 시간에 페이지 청크를 미리 받아둔다.
@@ -49,6 +51,7 @@ export function prefetchRoutes() {
     void importTodayReviews().catch(ignore);
     void importPlannerCalendar().catch(ignore);
     void importHome().catch(ignore);
+    void importMemo().catch(ignore);
   };
   if (typeof requestIdleCallback === "function") {
     requestIdleCallback(run);

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -13,6 +13,7 @@ import {
   importHome,
   importMaterialDetail,
   importMaterialList,
+  importMemo,
   importPlannerCalendar,
   importPlannerSettings,
   importRoutines,
@@ -30,6 +31,7 @@ const PlannerCalendarPage = lazy(importPlannerCalendar);
 const PlannerSettingsPage = lazy(importPlannerSettings);
 const RoutinesPage = lazy(importRoutines);
 const WeeklyPlanPage = lazy(importWeeklyPlan);
+const MemoPage = lazy(importMemo);
 
 function RouteFallback() {
   return <LoadingText className="p-6" />;
@@ -105,6 +107,14 @@ export function AppRouter() {
             element={
               <Suspense fallback={<RouteFallback />}>
                 <PlannerSettingsPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/memo"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <MemoPage />
               </Suspense>
             }
           />

--- a/fe/src/features/memo/api/memos.ts
+++ b/fe/src/features/memo/api/memos.ts
@@ -1,0 +1,90 @@
+import { client } from "@/shared/api";
+
+export interface MemoContent {
+  type: string;
+  content?: unknown[];
+  [key: string]: unknown;
+}
+
+export interface MemoTreeNode {
+  id: number;
+  title: string;
+  parentId: number | null;
+  sortOrder: number;
+  children: MemoTreeNode[];
+}
+
+export interface MemoTreeResponse {
+  memos: MemoTreeNode[];
+}
+
+export interface MemoDetail {
+  id: number;
+  parentId: number | null;
+  title: string;
+  sortOrder: number;
+  content: MemoContent;
+  updatedAt: string;
+}
+
+export interface MemoUpdateResponse {
+  id: number;
+  parentId: number | null;
+  title: string;
+  sortOrder: number;
+  updatedAt: string;
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export async function fetchMemoTree(): Promise<MemoTreeNode[]> {
+  const { data } = await client.get<ApiEnvelope<MemoTreeResponse>>("/memos");
+  return data.data.memos;
+}
+
+export async function fetchMemo(memoId: number): Promise<MemoDetail> {
+  const { data } = await client.get<ApiEnvelope<MemoDetail>>(
+    `/memos/${memoId}`,
+  );
+  return data.data;
+}
+
+export interface MemoCreateRequest {
+  parentId?: number | null;
+  title?: string;
+}
+
+export async function createMemo(
+  request: MemoCreateRequest,
+): Promise<MemoDetail> {
+  const { data } = await client.post<ApiEnvelope<MemoDetail>>(
+    "/memos",
+    request,
+  );
+  return data.data;
+}
+
+export interface MemoUpdateRequest {
+  title?: string;
+  content?: MemoContent;
+  parentId?: number | null;
+  sortOrder?: number;
+}
+
+export async function updateMemo(
+  memoId: number,
+  request: MemoUpdateRequest,
+): Promise<MemoUpdateResponse> {
+  const { data } = await client.patch<ApiEnvelope<MemoUpdateResponse>>(
+    `/memos/${memoId}`,
+    request,
+  );
+  return data.data;
+}
+
+export async function deleteMemo(memoId: number): Promise<void> {
+  await client.delete(`/memos/${memoId}`);
+}

--- a/fe/src/features/memo/components/MemoEditor.tsx
+++ b/fe/src/features/memo/components/MemoEditor.tsx
@@ -1,0 +1,162 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { DragHandle } from "@tiptap/extension-drag-handle-react";
+import Image from "@tiptap/extension-image";
+import Placeholder from "@tiptap/extension-placeholder";
+import { TableKit } from "@tiptap/extension-table";
+import TaskItem from "@tiptap/extension-task-item";
+import TaskList from "@tiptap/extension-task-list";
+import { EditorContent, type JSONContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { GripVertical } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+// 노트의 에디터 UI 프리미티브를 재사용한다(도구모음·저장상태·이미지 업로드).
+// childPage(인라인 하위 페이지)는 메모 v1에서 제외한다(트리 사이드바로만 하위 생성).
+import { EditorToolbar } from "@/features/note/components/EditorToolbar";
+import { SaveStatusIndicator } from "@/features/note/components/SaveStatusIndicator";
+import {
+  extractImageFiles,
+  uploadAndInsertImage,
+} from "@/features/note/editor/imageUpload";
+
+import type { MemoContent, MemoDetail } from "../api/memos";
+import { useAutoSaveMemo } from "../hooks/useAutoSaveMemo";
+import { memoKeys } from "../queryKeys";
+
+interface Props {
+  memo: MemoDetail;
+}
+
+export function MemoEditor({ memo }: Props) {
+  const queryClient = useQueryClient();
+  const { status, savedAt, schedule, flush, retry } = useAutoSaveMemo(memo.id, {
+    onSaved: (patch) => {
+      // 저장된 값을 detail 캐시에 반영해 메모 재진입 시 최신 내용이 보이게 한다.
+      // (자동저장 응답엔 content가 없으므로 보낸 patch를 직접 머지)
+      queryClient.setQueryData<MemoDetail>(memoKeys.detail(memo.id), (old) =>
+        old ? { ...old, ...patch } : old,
+      );
+      // 제목 저장 시 사이드바 트리 라벨도 갱신
+      if (patch.title !== undefined) {
+        queryClient.invalidateQueries({ queryKey: memoKeys.tree() });
+      }
+    },
+  });
+
+  const [title, setTitle] = useState(memo.title);
+  // editorProps 핸들러(handlePaste/handleDrop)는 생성 시점 클로저라 editor를
+  // 직접 못 잡으므로 ref로 우회한다.
+  const editorRef = useRef<ReturnType<typeof useEditor>>(null);
+
+  const editor = useEditor(
+    {
+      extensions: [
+        StarterKit,
+        TaskList,
+        TaskItem.configure({ nested: true }),
+        TableKit.configure({ table: { resizable: true } }),
+        Image.configure({ inline: false }),
+        Placeholder.configure({
+          placeholder: "내용을 입력하세요...",
+        }),
+      ],
+      content: memo.content as JSONContent,
+      editorProps: {
+        attributes: {
+          class:
+            "prose prose-sm dark:prose-invert max-w-none min-h-[40svh] focus:outline-none py-4 pr-4 pl-10",
+          "aria-label": "메모 본문",
+        },
+        // 클립보드 붙여넣기로 이미지 업로드
+        handlePaste: (_view, event) => {
+          const files = extractImageFiles(event.clipboardData);
+          if (files.length === 0) return false;
+          event.preventDefault();
+          files.forEach((file) => {
+            if (editorRef.current)
+              void uploadAndInsertImage(editorRef.current, file);
+          });
+          return true;
+        },
+        // 드래그앤드롭으로 이미지 업로드
+        handleDrop: (_view, event) => {
+          const files = extractImageFiles(
+            (event as DragEvent).dataTransfer ?? null,
+          );
+          if (files.length === 0) return false;
+          event.preventDefault();
+          files.forEach((file) => {
+            if (editorRef.current)
+              void uploadAndInsertImage(editorRef.current, file);
+          });
+          return true;
+        },
+      },
+      onUpdate: ({ editor }) => {
+        schedule({ content: editor.getJSON() as MemoContent });
+      },
+    },
+    [memo.id],
+  );
+  editorRef.current = editor;
+
+  // 메모 전환은 부모의 key={memo.id} 리마운트로 처리되므로 setContent를
+  // 수동 호출하지 않는다. (editor 재생성마다 setContent가 캐시의 옛 content로
+  // onUpdate를 발화해 방금 쓴 내용을 빈 doc으로 덮어쓰던 버그 회피)
+
+  useEffect(() => {
+    return () => {
+      flush();
+    };
+  }, [flush]);
+
+  const handleTitleChange = (next: string) => {
+    setTitle(next);
+    schedule({ title: next });
+  };
+
+  return (
+    // min-w-0: 부모(md:flex-row) flex 자식의 기본 min-width:auto 때문에
+    // 넓은 표가 들어오면 에디터가 부모를 넘어 페이지 전체가 늘어난다.
+    <div className="flex min-w-0 flex-col gap-3">
+      <div className="flex items-center gap-3">
+        <Input
+          value={title}
+          onChange={(e) => handleTitleChange(e.target.value)}
+          aria-label="메모 제목"
+          placeholder="제목 없음"
+          className="border-none px-0 text-lg font-semibold shadow-none focus-visible:ring-0"
+        />
+        {/* 상태가 나타났다 사라질 때 제목 Input 폭이 밀리지 않게 슬롯 폭을 예약한다. */}
+        <div className="flex min-w-[7rem] shrink-0 justify-end">
+          <SaveStatusIndicator
+            status={status}
+            savedAt={savedAt}
+            onRetry={retry}
+          />
+        </div>
+      </div>
+
+      <div className="border-border bg-card overflow-hidden rounded-md border">
+        <EditorToolbar editor={editor} />
+        {editor && (
+          <DragHandle
+            editor={editor}
+            nested={{ edgeDetection: "none" }}
+            className="z-10"
+          >
+            <button
+              type="button"
+              aria-label="블록 이동"
+              className="text-muted-foreground hover:bg-muted flex size-6 cursor-grab items-center justify-center rounded transition-colors active:cursor-grabbing"
+            >
+              <GripVertical className="size-4" />
+            </button>
+          </DragHandle>
+        )}
+        <EditorContent editor={editor} className="relative" />
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/memo/components/MemoTreeSidebar.tsx
+++ b/fe/src/features/memo/components/MemoTreeSidebar.tsx
@@ -1,0 +1,170 @@
+import {
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  MoreHorizontal,
+  Plus,
+  Trash2,
+} from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Menu, MenuItem } from "@/components/ui/menu";
+import { cn } from "@/lib/utils";
+
+import type { MemoTreeNode } from "../api/memos";
+
+interface Props {
+  tree: MemoTreeNode[];
+  activeMemoId: number | null;
+  onSelect: (memoId: number) => void;
+  onAddRoot: () => void;
+  onAddChild: (parentId: number) => void;
+  onRequestDelete: (node: MemoTreeNode) => void;
+  addPending?: boolean;
+}
+
+export function MemoTreeSidebar({
+  tree,
+  activeMemoId,
+  onSelect,
+  onAddRoot,
+  onAddChild,
+  onRequestDelete,
+  addPending,
+}: Props) {
+  return (
+    <nav
+      aria-label="메모 목록"
+      className="flex w-full flex-col gap-1 md:w-56 md:shrink-0"
+    >
+      <div className="flex items-center justify-between px-1">
+        <span className="text-muted-foreground text-xs font-medium">메모</span>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="새 메모"
+          disabled={addPending}
+          onClick={onAddRoot}
+        >
+          <Plus className="size-4" />
+        </Button>
+      </div>
+      {tree.length === 0 ? (
+        <p className="text-muted-foreground px-2 py-1 text-xs">
+          아직 메모가 없습니다
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-0.5">
+          {tree.map((node) => (
+            <MemoTreeItem
+              key={node.id}
+              node={node}
+              depth={0}
+              activeMemoId={activeMemoId}
+              onSelect={onSelect}
+              onAddChild={onAddChild}
+              onRequestDelete={onRequestDelete}
+            />
+          ))}
+        </ul>
+      )}
+    </nav>
+  );
+}
+
+interface ItemProps {
+  node: MemoTreeNode;
+  depth: number;
+  activeMemoId: number | null;
+  onSelect: (memoId: number) => void;
+  onAddChild: (parentId: number) => void;
+  onRequestDelete: (node: MemoTreeNode) => void;
+}
+
+function MemoTreeItem({
+  node,
+  depth,
+  activeMemoId,
+  onSelect,
+  onAddChild,
+  onRequestDelete,
+}: ItemProps) {
+  const [expanded, setExpanded] = useState(true);
+  const hasChildren = node.children.length > 0;
+  const isActive = node.id === activeMemoId;
+
+  return (
+    <li>
+      <div
+        className={cn(
+          "group/memo flex items-center gap-0.5 rounded-md pr-1 text-sm",
+          isActive
+            ? "bg-primary/10 text-primary"
+            : "text-foreground/80 hover:bg-muted",
+        )}
+        style={{ paddingLeft: `${depth * 0.75}rem` }}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            aria-label={expanded ? "접기" : "펼치기"}
+            onClick={() => setExpanded((v) => !v)}
+            className="hover:bg-muted-foreground/10 flex size-5 shrink-0 items-center justify-center rounded"
+          >
+            {expanded ? (
+              <ChevronDown className="size-3.5" />
+            ) : (
+              <ChevronRight className="size-3.5" />
+            )}
+          </button>
+        ) : (
+          <span className="size-5 shrink-0" />
+        )}
+        <button
+          type="button"
+          onClick={() => onSelect(node.id)}
+          className="flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left"
+        >
+          <FileText className="size-3.5 shrink-0 opacity-60" />
+          <span className="truncate">{node.title}</span>
+        </button>
+
+        <Menu
+          trigger={
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label={`${node.title} 메뉴`}
+              className="size-6 shrink-0 opacity-0 group-hover/memo:opacity-100 data-[popup-open]:opacity-100"
+            >
+              <MoreHorizontal className="size-3.5" />
+            </Button>
+          }
+        >
+          <MenuItem onClick={() => onAddChild(node.id)}>
+            <Plus className="size-3.5" /> 하위 추가
+          </MenuItem>
+          <MenuItem variant="destructive" onClick={() => onRequestDelete(node)}>
+            <Trash2 className="size-3.5" /> 삭제
+          </MenuItem>
+        </Menu>
+      </div>
+      {hasChildren && expanded && (
+        <ul className="flex flex-col gap-0.5">
+          {node.children.map((child) => (
+            <MemoTreeItem
+              key={child.id}
+              node={child}
+              depth={depth + 1}
+              activeMemoId={activeMemoId}
+              onSelect={onSelect}
+              onAddChild={onAddChild}
+              onRequestDelete={onRequestDelete}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}

--- a/fe/src/features/memo/components/MemoWorkspace.test.tsx
+++ b/fe/src/features/memo/components/MemoWorkspace.test.tsx
@@ -1,0 +1,211 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { MemoWorkspace } from "./MemoWorkspace";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function renderWorkspace(initialEntries = ["/memo"]) {
+  return renderWithRouter(
+    <Providers>
+      <Routes>
+        <Route path="/memo" element={<MemoWorkspace />} />
+      </Routes>
+    </Providers>,
+    { initialEntries },
+  );
+}
+
+interface TreeNode {
+  id: number;
+  title: string;
+  parentId: number | null;
+  sortOrder: number;
+  children: TreeNode[];
+}
+
+function mockTree(memos: TreeNode[]) {
+  server.use(
+    http.get(`${API_BASE}/memos`, () =>
+      HttpResponse.json({ code: "OK", data: { memos } }),
+    ),
+  );
+}
+
+function mockMemoDetail(
+  id: number,
+  content: unknown = { type: "doc", content: [] },
+  title = "메모",
+) {
+  server.use(
+    http.get(`${API_BASE}/memos/${id}`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          id,
+          parentId: null,
+          title,
+          sortOrder: 0,
+          content,
+          updatedAt: "2026-07-04T10:00:00",
+        },
+      }),
+    ),
+  );
+}
+
+describe("MemoWorkspace", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+  });
+
+  it("메모가 없으면 빈 상태와 [첫 메모 만들기]를 표시한다", async () => {
+    mockTree([]);
+    renderWorkspace();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 메모가 없습니다.")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: /첫 메모 만들기/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("[첫 메모 만들기] → POST 후 새 메모가 선택되어 에디터가 열린다", async () => {
+    mockTree([]);
+    server.use(
+      http.post(`${API_BASE}/memos`, () =>
+        HttpResponse.json(
+          {
+            code: "OK",
+            data: {
+              id: 50,
+              parentId: null,
+              title: "제목 없음",
+              sortOrder: 0,
+              content: { type: "doc", content: [] },
+              updatedAt: "2026-07-04T10:00:00",
+            },
+          },
+          { status: 201 },
+        ),
+      ),
+    );
+    mockMemoDetail(50, { type: "doc", content: [] }, "제목 없음");
+
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 메모가 없습니다.")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /첫 메모 만들기/ }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("메모 제목")).toBeInTheDocument();
+    });
+  });
+
+  it("트리의 메모를 클릭하면 해당 메모 에디터가 열린다 (첫 루트는 자동 선택)", async () => {
+    mockTree([
+      { id: 1, title: "메모1", parentId: null, sortOrder: 0, children: [] },
+      { id: 2, title: "메모2", parentId: null, sortOrder: 1, children: [] },
+    ]);
+    mockMemoDetail(1, { type: "doc", content: [] }, "메모1");
+    mockMemoDetail(2, { type: "doc", content: [] }, "메모2");
+
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("메모 제목")).toHaveValue("메모1");
+    });
+
+    await user.click(screen.getByRole("button", { name: "메모2" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("메모 제목")).toHaveValue("메모2");
+    });
+  });
+
+  it("노드 메뉴의 [하위 추가]로 parentId를 담아 POST하고 새 하위 메모가 선택된다", async () => {
+    mockTree([
+      { id: 1, title: "부모", parentId: null, sortOrder: 0, children: [] },
+    ]);
+    mockMemoDetail(1, { type: "doc", content: [] }, "부모");
+    let postedParentId: number | null | undefined;
+    server.use(
+      http.post(`${API_BASE}/memos`, async ({ request }) => {
+        const body = (await request.json()) as { parentId: number | null };
+        postedParentId = body.parentId;
+        return HttpResponse.json(
+          {
+            code: "OK",
+            data: {
+              id: 77,
+              parentId: body.parentId,
+              title: "제목 없음",
+              sortOrder: 0,
+              content: { type: "doc", content: [] },
+              updatedAt: "2026-07-04T10:00:00",
+            },
+          },
+          { status: 201 },
+        );
+      }),
+    );
+    mockMemoDetail(77, { type: "doc", content: [] }, "제목 없음");
+
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("메모 제목")).toHaveValue("부모");
+    });
+
+    await user.click(screen.getByRole("button", { name: "부모 메뉴" }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: /하위 추가/ }),
+    );
+
+    await waitFor(() => {
+      expect(postedParentId).toBe(1);
+    });
+  });
+
+  it("메모 삭제는 확인 후 DELETE를 호출한다", async () => {
+    mockTree([
+      { id: 7, title: "지울 메모", parentId: null, sortOrder: 0, children: [] },
+    ]);
+    mockMemoDetail(7, { type: "doc", content: [] }, "지울 메모");
+    let deleted = false;
+    server.use(
+      http.delete(`${API_BASE}/memos/7`, () => {
+        deleted = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("메모 제목")).toHaveValue("지울 메모");
+    });
+
+    await user.click(screen.getByRole("button", { name: "지울 메모 메뉴" }));
+    await user.click(await screen.findByRole("menuitem", { name: /삭제/ }));
+    // 확인 다이얼로그의 삭제 버튼
+    await user.click(await screen.findByRole("button", { name: "삭제" }));
+
+    await waitFor(() => expect(deleted).toBe(true));
+  });
+});

--- a/fe/src/features/memo/components/MemoWorkspace.tsx
+++ b/fe/src/features/memo/components/MemoWorkspace.tsx
@@ -1,0 +1,179 @@
+import { ArrowLeft, Plus } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { PageHeader } from "@/components/PageHeader";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { FieldError } from "@/components/ui/field-error";
+import { LoadingText } from "@/components/ui/loading-text";
+
+import type { MemoTreeNode } from "../api/memos";
+import { useMemoDetail } from "../hooks/useMemoDetail";
+import { useCreateMemo, useDeleteMemo } from "../hooks/useMemoMutations";
+import { useMemoTree } from "../hooks/useMemoTree";
+import { MemoEditor } from "./MemoEditor";
+import { MemoTreeSidebar } from "./MemoTreeSidebar";
+
+function collectSubtreeIds(node: MemoTreeNode): number[] {
+  return [node.id, ...node.children.flatMap(collectSubtreeIds)];
+}
+
+function countDescendants(node: MemoTreeNode): number {
+  return node.children.reduce(
+    (sum, child) => sum + 1 + countDescendants(child),
+    0,
+  );
+}
+
+/** 독립 메모장 본체. 좌측 트리 사이드바 + 우측 Tiptap 에디터 2-pane. */
+export function MemoWorkspace() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const memoParam = searchParams.get("memo");
+  const activeMemoId = memoParam ? Number(memoParam) : null;
+
+  const treeQuery = useMemoTree();
+  const detailQuery = useMemoDetail(activeMemoId);
+  const createMemo = useCreateMemo();
+  const deleteMemo = useDeleteMemo();
+  const [pendingDelete, setPendingDelete] = useState<MemoTreeNode | null>(null);
+
+  const setActiveMemo = (memoId: number | null) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (memoId == null) {
+          next.delete("memo");
+        } else {
+          next.set("memo", String(memoId));
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  };
+
+  const tree = treeQuery.data ?? [];
+
+  // 메모가 있는데 아무것도 선택 안 됐으면 첫 루트 자동 선택
+  useEffect(() => {
+    if (activeMemoId == null && tree.length > 0) {
+      setActiveMemo(tree[0].id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeMemoId, tree]);
+
+  const handleAddRoot = () => {
+    if (createMemo.isPending) return;
+    createMemo.mutate(
+      { parentId: null, title: "제목 없음" },
+      { onSuccess: (created) => setActiveMemo(created.id) },
+    );
+  };
+
+  const handleAddChild = (parentId: number) => {
+    if (createMemo.isPending) return;
+    createMemo.mutate(
+      { parentId, title: "제목 없음" },
+      { onSuccess: (created) => setActiveMemo(created.id) },
+    );
+  };
+
+  const handleConfirmDelete = () => {
+    if (!pendingDelete || deleteMemo.isPending) return;
+    const removedIds = new Set(collectSubtreeIds(pendingDelete));
+    deleteMemo.mutate(pendingDelete.id, {
+      onSuccess: () => {
+        // 삭제된 서브트리에 활성 메모가 포함됐으면 선택 해제
+        // (남은 루트가 있으면 useEffect가 자동 선택)
+        if (activeMemoId != null && removedIds.has(activeMemoId)) {
+          setActiveMemo(null);
+        }
+        setPendingDelete(null);
+      },
+      onError: () => setPendingDelete(null),
+    });
+  };
+
+  const showEditorOnMobile = activeMemoId != null;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <PageHeader title="메모" />
+
+      {treeQuery.isLoading ? (
+        <LoadingText />
+      ) : treeQuery.isError ? (
+        <FieldError>메모를 불러오지 못했어요.</FieldError>
+      ) : tree.length === 0 && activeMemoId == null ? (
+        <EmptyState>
+          <p className="text-muted-foreground text-sm">아직 메모가 없습니다.</p>
+          <Button onClick={handleAddRoot} disabled={createMemo.isPending}>
+            <Plus className="size-4" /> 첫 메모 만들기
+          </Button>
+        </EmptyState>
+      ) : (
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:gap-6">
+          {/* 모바일: 메모 선택 시 트리 숨김(드릴다운) */}
+          <div className={showEditorOnMobile ? "hidden md:block" : "block"}>
+            <MemoTreeSidebar
+              tree={tree}
+              activeMemoId={activeMemoId}
+              onSelect={setActiveMemo}
+              onAddRoot={handleAddRoot}
+              onAddChild={handleAddChild}
+              onRequestDelete={setPendingDelete}
+              addPending={createMemo.isPending}
+            />
+          </div>
+
+          <div
+            className={
+              "min-w-0 flex-1 " +
+              (showEditorOnMobile ? "block" : "hidden md:block")
+            }
+          >
+            <Button
+              variant="ghost"
+              size="sm"
+              className="mb-2 md:hidden"
+              onClick={() => setActiveMemo(null)}
+            >
+              <ArrowLeft className="size-4" /> 메모 목록
+            </Button>
+
+            {activeMemoId == null ? (
+              <p className="text-muted-foreground hidden text-sm md:block">
+                왼쪽에서 메모를 선택하거나 새로 만드세요.
+              </p>
+            ) : detailQuery.isLoading ? (
+              <LoadingText />
+            ) : detailQuery.isError || !detailQuery.data ? (
+              <FieldError>메모를 불러오지 못했어요.</FieldError>
+            ) : (
+              <MemoEditor key={detailQuery.data.id} memo={detailQuery.data} />
+            )}
+          </div>
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+        title="메모를 삭제할까요?"
+        description={
+          pendingDelete && countDescendants(pendingDelete) > 0
+            ? `하위 메모 ${countDescendants(pendingDelete)}개도 함께 삭제됩니다. 되돌릴 수 없어요.`
+            : "이 메모가 삭제됩니다. 되돌릴 수 없어요."
+        }
+        confirmLabel="삭제"
+        destructive
+        onConfirm={handleConfirmDelete}
+        pending={deleteMemo.isPending}
+      />
+    </div>
+  );
+}

--- a/fe/src/features/memo/hooks/useAutoSaveMemo.test.ts
+++ b/fe/src/features/memo/hooks/useAutoSaveMemo.test.ts
@@ -1,0 +1,118 @@
+import { act, renderHook } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { server } from "@/test/mocks/server";
+
+import { useAutoSaveMemo } from "./useAutoSaveMemo";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function ok() {
+  return HttpResponse.json({
+    code: "OK",
+    data: {
+      id: 1,
+      parentId: null,
+      title: "t",
+      sortOrder: 0,
+      updatedAt: "2026-07-04T10:30:00",
+    },
+  });
+}
+
+describe("useAutoSaveMemo", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("schedule 후 2초 debounce되어 PATCH를 호출하고 saved로 전환된다", async () => {
+    const calls: unknown[] = [];
+    server.use(
+      http.patch(`${API_BASE}/memos/:id`, async ({ request }) => {
+        calls.push(await request.json());
+        return ok();
+      }),
+    );
+
+    const { result } = renderHook(() => useAutoSaveMemo(1));
+    expect(result.current.status).toBe("idle");
+
+    act(() => {
+      result.current.schedule({ content: { type: "doc", content: [] } });
+    });
+    expect(result.current.status).toBe("idle");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ content: { type: "doc", content: [] } });
+    expect(result.current.status).toBe("saved");
+  });
+
+  it("같은 창의 title/content schedule은 병합되어 1회 PATCH", async () => {
+    let count = 0;
+    let lastBody: { title?: string; content?: unknown } | null = null;
+    server.use(
+      http.patch(`${API_BASE}/memos/:id`, async ({ request }) => {
+        count++;
+        lastBody = (await request.json()) as typeof lastBody;
+        return ok();
+      }),
+    );
+
+    const { result } = renderHook(() => useAutoSaveMemo(1));
+    act(() => {
+      result.current.schedule({ title: "새 제목" });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    act(() => {
+      result.current.schedule({ content: { type: "doc", content: [] } });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(count).toBe(1);
+    expect(lastBody).toEqual({
+      title: "새 제목",
+      content: { type: "doc", content: [] },
+    });
+  });
+
+  it("실패하면 error → retry로 재전송하여 saved", async () => {
+    let failed = false;
+    server.use(
+      http.patch(`${API_BASE}/memos/:id`, async () => {
+        if (!failed) {
+          failed = true;
+          return HttpResponse.json({ code: "ERR" }, { status: 500 });
+        }
+        return ok();
+      }),
+    );
+
+    const { result } = renderHook(() => useAutoSaveMemo(1));
+    act(() => {
+      result.current.schedule({ title: "x" });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(result.current.status).toBe("error");
+
+    await act(async () => {
+      result.current.retry();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.status).toBe("saved");
+  });
+});

--- a/fe/src/features/memo/hooks/useAutoSaveMemo.ts
+++ b/fe/src/features/memo/hooks/useAutoSaveMemo.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { type MemoUpdateRequest, updateMemo } from "../api/memos";
+
+export type SaveStatus = "idle" | "saving" | "saved" | "error";
+
+interface UseAutoSaveMemoOptions {
+  /** 저장 성공 시 호출. 방금 반영된 patch를 전달 (예: title 변경 시 트리 invalidate). */
+  onSaved?: (patch: MemoUpdateRequest) => void;
+}
+
+interface UseAutoSaveMemoResult {
+  status: SaveStatus;
+  savedAt: Date | null;
+  schedule: (patch: MemoUpdateRequest) => void;
+  flush: () => void;
+  retry: () => void;
+}
+
+const DEBOUNCE_MS = 2000;
+
+/**
+ * memoId의 메모에 대해 title/content 부분 변경을 2초 debounce로 PATCH.
+ * 같은 debounce 창의 여러 schedule은 병합되어 1회 호출된다.
+ * (노트 useAutoSaveNote를 material 종속 없이 미러링)
+ */
+export function useAutoSaveMemo(
+  memoId: number | null,
+  options: UseAutoSaveMemoOptions = {},
+): UseAutoSaveMemoResult {
+  const [status, setStatus] = useState<SaveStatus>("idle");
+  const [savedAt, setSavedAt] = useState<Date | null>(null);
+  const pendingRef = useRef<MemoUpdateRequest | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastFailedRef = useRef<MemoUpdateRequest | null>(null);
+  const memoIdRef = useRef(memoId);
+  memoIdRef.current = memoId;
+  const onSavedRef = useRef(options.onSaved);
+  onSavedRef.current = options.onSaved;
+
+  const save = useCallback(async (patch: MemoUpdateRequest) => {
+    const id = memoIdRef.current;
+    if (id == null) return;
+    setStatus("saving");
+    try {
+      const res = await updateMemo(id, patch);
+      setSavedAt(new Date(res.updatedAt));
+      setStatus("saved");
+      lastFailedRef.current = null;
+      onSavedRef.current?.(patch);
+    } catch {
+      lastFailedRef.current = patch;
+      setStatus("error");
+    }
+  }, []);
+
+  const fire = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    const pending = pendingRef.current;
+    pendingRef.current = null;
+    if (pending) {
+      void save(pending);
+    }
+  }, [save]);
+
+  const schedule = useCallback(
+    (patch: MemoUpdateRequest) => {
+      pendingRef.current = { ...pendingRef.current, ...patch };
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+      timerRef.current = setTimeout(fire, DEBOUNCE_MS);
+    },
+    [fire],
+  );
+
+  const flush = useCallback(() => {
+    fire();
+  }, [fire]);
+
+  const retry = useCallback(() => {
+    const failed = lastFailedRef.current;
+    if (failed) {
+      void save(failed);
+    }
+  }, [save]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  return { status, savedAt, schedule, flush, retry };
+}

--- a/fe/src/features/memo/hooks/useMemoDetail.ts
+++ b/fe/src/features/memo/hooks/useMemoDetail.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchMemo } from "../api/memos";
+import { memoKeys } from "../queryKeys";
+
+export function useMemoDetail(memoId: number | null) {
+  return useQuery({
+    queryKey: memoKeys.detail(memoId ?? 0),
+    queryFn: () => fetchMemo(memoId as number),
+    enabled: memoId !== null,
+    staleTime: Infinity,
+  });
+}

--- a/fe/src/features/memo/hooks/useMemoMutations.ts
+++ b/fe/src/features/memo/hooks/useMemoMutations.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  createMemo,
+  deleteMemo,
+  type MemoCreateRequest,
+  type MemoDetail,
+} from "../api/memos";
+import { memoKeys } from "../queryKeys";
+
+export function useCreateMemo() {
+  const queryClient = useQueryClient();
+  return useMutation<MemoDetail, Error, MemoCreateRequest>({
+    mutationFn: createMemo,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: memoKeys.tree() });
+    },
+  });
+}
+
+export function useDeleteMemo() {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, number>({
+    mutationFn: deleteMemo,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: memoKeys.tree() });
+    },
+  });
+}

--- a/fe/src/features/memo/hooks/useMemoTree.ts
+++ b/fe/src/features/memo/hooks/useMemoTree.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchMemoTree } from "../api/memos";
+import { memoKeys } from "../queryKeys";
+
+export function useMemoTree() {
+  return useQuery({
+    queryKey: memoKeys.tree(),
+    queryFn: fetchMemoTree,
+  });
+}

--- a/fe/src/features/memo/queryKeys.ts
+++ b/fe/src/features/memo/queryKeys.ts
@@ -1,0 +1,5 @@
+export const memoKeys = {
+  all: ["memos"] as const,
+  tree: () => ["memos", "tree"] as const,
+  detail: (memoId: number) => ["memos", "detail", memoId] as const,
+};

--- a/fe/src/pages/MemoPage.tsx
+++ b/fe/src/pages/MemoPage.tsx
@@ -1,0 +1,5 @@
+import { MemoWorkspace } from "@/features/memo/components/MemoWorkspace";
+
+export function MemoPage() {
+  return <MemoWorkspace />;
+}


### PR DESCRIPTION
## 이슈
closes #720

## 작업 내용
메모(Memo) 독립 메모장 **M1(FE)**. `/memo` 페이지 — 좌측 트리 사이드바 + 우측 Tiptap 에디터 2-pane. (Epic #718 · 선행 M0 #719 완료)

### features/memo
- `api/memos.ts` — fetchMemoTree/fetchMemo/createMemo/updateMemo/deleteMemo (`/api/memos`, envelope 언랩)
- 훅 — `useMemoTree` / `useMemoDetail`(staleTime∞) / `useCreateMemo`·`useDeleteMemo`(tree invalidate) / `useAutoSaveMemo`(2초 debounce·병합·재시도)
- `MemoTreeSidebar` — 재귀 트리, [+ 새 메모], 노드 메뉴 [하위 추가]/[삭제], 활성 하이라이트
- `MemoEditor` — Tiptap 에디터. **노트의 `EditorToolbar`·`SaveStatusIndicator`·`imageUpload`를 재사용**하고 childPage(인라인 하위 페이지)는 v1 제외. 저장 상태는 고정폭 슬롯(레이아웃 밀림 방지)
- `MemoWorkspace` — PageHeader + 2-pane, 첫 루트 자동선택, 모바일 드릴다운, 빈상태·로딩·에러
- 라우트 `/memo`(lazy+prefetch) + Sidebar "메모" 메뉴

### 재사용 전략 (설계 결정)
설계의 "에디터 엔진 재사용"은 **노트의 표준 하위 컴포넌트(도구모음·저장상태·이미지 업로드)를 그대로 공유**하고, childPage 기계장치만 없는 얇은 MemoEditor로 구현했다. NoteEditor 자체를 데이터-agnostic으로 승격하는 전면 리팩터링은 노트 회귀 위험이 커서, #721이 선택 항목으로 미뤄둔 방향과 맞춰 이번엔 하지 않았다. 이미지 업로드는 M1에서 노트 엔드포인트를 재사용(네임스페이스 결정은 #721).

## 테스트
- 통합(RTL+MSW): 빈상태 / 생성→에디터 / 트리 선택(자동선택) / 하위 추가(parentId POST) / 삭제(확인→DELETE)
- 훅: 자동저장 2초 debounce·필드 병합·실패→재시도
- 전체 234개 통과, tsc·eslint·prettier·production build 통과

## 확인 안 된 것 (후속)
- **실제 브라우저 해피패스**: dev 프록시가 로컬 BE(`localhost:8080`)를 향하는데 로컬 BE 스택이 미기동이고 인증 토큰이 비영속이라 이번엔 미실행. 통합 테스트(실제 컴포넌트+네트워크 MSW)+빌드로 대체 검증. memo API 배포 또는 로컬 스택 기동 시 브라우저 확인 가능.