### PR TITLE
feat : 브랜드 차별화 3장치 — 키네틱 궤도 + i-점 워드마크 + 락

### DIFF
--- a/fe/.design-sync/conventions.md
+++ b/fe/.design-sync/conventions.md
@@ -40,7 +40,10 @@ React + Tailwind CSS v4 component library (shadcn/ui 스타일). 컴포넌트는
 - **상태/피드백**: 빈 상태 `<EmptyState>`, 로딩 `<LoadingText>`, 인라인 알림 `<Alert variant="info|success|warning|destructive"><AlertTitle/><AlertDescription/></Alert>`(아이콘은 svg 자식), 라벨 칩 `<Badge variant="default|secondary|success|warning|info|destructive|outline">`
 - **데이터/내비**: `<Table>`+`<TableHeader/TableBody/TableRow/TableHead/TableCell>`(상태 칸엔 Badge 조합), `<Tabs defaultValue><TabsList><TabsTrigger value/></TabsList><TabsContent value/></Tabs>`, `<Tooltip><TooltipTrigger/><TooltipContent/></Tooltip>`
 - **상태색 규칙**: 성공/주의/정보/실패는 `success|warning|info|destructive` 시맨틱 토큰만 쓴다(임의 green/amber/red 금지). 일요일·공휴일 빨강 같은 캘린더 도메인 색은 예외
-- **브랜드(로고)**: `<Logo tone="primary|mono|inverse" size showWordmark/>`(심볼+워드마크), 심볼만은 `<BrandMark size tone/>`. 색은 토큰만(`--foreground` 링·`--brand` 점, inverse만 흰색). 좌표는 브랜드 확정본 — 임의 변경 금지. **클리어스페이스=링 두께(x) 사방**, **디지털 최소 16px**(탭), UI 아이콘 24px+. 어두운 배경엔 `tone="inverse"`
+- **브랜드(로고)**: `<Logo tone="primary|mono|inverse" size showWordmark animated/>`(락업), 심볼만 `<BrandMark size tone animated/>`, 워드마크만 `<Wordmark size tone/>`. 색은 토큰만(`--foreground` 링·`--brand` 점, inverse만 흰색). 좌표는 브랜드 확정본 — 임의 변경 금지. **클리어스페이스=링 두께(x) 사방**, **디지털 최소 16px**(탭), 24px+. 어두운 배경엔 `tone="inverse"`
+  - **장치 1 — 궤도 i-점 워드마크**: 모든 공식 워드마크는 점 없는 `ı`(U+0131) 위에 궤도 퍼플 점을 얹은 `<Wordmark>`/`<Logo>`를 쓴다(마크·글자를 한 시스템으로 묶음).
+  - **장치 2 — 키네틱 궤도(모션)**: 스플래시·로딩·대기에서만 `animated`(3.4s linear 무한, `prefers-reduced-motion`이면 자동 정지). 그 외 UI는 정적 마크. 비-React 스플래시는 `/symbol-kinetic.svg`(온다크 `-white`).
+  - **장치 3 — 컬러·케이스·점 락(불변)**: 색은 퍼플 `#8837ED`(+잉크/화이트 모노)만 — 레드·임의색 금지. 표기는 항상 소문자 `orino` — 대문자/첫자대문자 금지. 점은 궤도 퍼플 점(심볼·i 공통) — 제거·타색·타형 금지.
 
 ## 출처(읽어야 할 곳)
 

--- a/fe/.design-sync/previews/BrandMark.tsx
+++ b/fe/.design-sync/previews/BrandMark.tsx
@@ -6,6 +6,7 @@ export function Sizes() {
       <BrandMark size={16} />
       <BrandMark size={24} />
       <BrandMark size={40} />
+      <BrandMark size={40} animated />
       <BrandMark size={40} tone="mono" />
       <div style={{ background: "#0B0B0C", padding: 12, borderRadius: 8 }}>
         <BrandMark size={40} tone="inverse" />

--- a/fe/.design-sync/previews/Logo.tsx
+++ b/fe/.design-sync/previews/Logo.tsx
@@ -4,6 +4,7 @@ export function Variants() {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
       <Logo />
+      <Logo animated />
       <Logo tone="mono" />
       <div
         style={{

--- a/fe/.design-sync/previews/Wordmark.tsx
+++ b/fe/.design-sync/previews/Wordmark.tsx
@@ -1,0 +1,14 @@
+import { Wordmark } from "orino-fe";
+
+export function Sizes() {
+  return (
+    <div style={{ display: "flex", alignItems: "baseline", gap: 20 }}>
+      <Wordmark size={20} />
+      <Wordmark size={28} />
+      <Wordmark size={40} />
+      <div style={{ background: "#0B0B0C", padding: 12, borderRadius: 8 }}>
+        <Wordmark size={28} tone="inverse" />
+      </div>
+    </div>
+  );
+}

--- a/fe/public/brand/symbol-kinetic-white.svg
+++ b/fe/public/brand/symbol-kinetic-white.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <defs><mask id="notch"><rect width="100" height="100" fill="#fff"/>
+    <circle r="12.90" fill="#000"><animateMotion dur="3.4s" repeatCount="indefinite"
+      path="M 49.14 24.20 A 26.66 26.66 0 1 1 49.14 77.52 A 26.66 26.66 0 1 1 49.14 24.20"/></circle>
+  </mask></defs>
+  <circle cx="49.14" cy="50.86" r="26.66" fill="none" stroke="#ffffff" stroke-width="9.46" mask="url(#notch)"/>
+  <circle r="10.32" fill="#ffffff"><animateMotion dur="3.4s" repeatCount="indefinite"
+    path="M 49.14 24.20 A 26.66 26.66 0 1 1 49.14 77.52 A 26.66 26.66 0 1 1 49.14 24.20"/></circle>
+</svg>

--- a/fe/public/brand/symbol-kinetic.svg
+++ b/fe/public/brand/symbol-kinetic.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <defs><mask id="notch"><rect width="100" height="100" fill="#fff"/>
+    <circle r="12.90" fill="#000"><animateMotion dur="3.4s" repeatCount="indefinite"
+      path="M 49.14 24.20 A 26.66 26.66 0 1 1 49.14 77.52 A 26.66 26.66 0 1 1 49.14 24.20"/></circle>
+  </mask></defs>
+  <circle cx="49.14" cy="50.86" r="26.66" fill="none" stroke="#0B0B0C" stroke-width="9.46" mask="url(#notch)"/>
+  <circle r="10.32" fill="#8837ED"><animateMotion dur="3.4s" repeatCount="indefinite"
+    path="M 49.14 24.20 A 26.66 26.66 0 1 1 49.14 77.52 A 26.66 26.66 0 1 1 49.14 24.20"/></circle>
+</svg>

--- a/fe/public/symbol-kinetic-white.svg
+++ b/fe/public/symbol-kinetic-white.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <defs><mask id="notch"><rect width="100" height="100" fill="#fff"/>
+    <circle r="12.90" fill="#000"><animateMotion dur="3.4s" repeatCount="indefinite"
+      path="M 49.14 24.20 A 26.66 26.66 0 1 1 49.14 77.52 A 26.66 26.66 0 1 1 49.14 24.20"/></circle>
+  </mask></defs>
+  <circle cx="49.14" cy="50.86" r="26.66" fill="none" stroke="#ffffff" stroke-width="9.46" mask="url(#notch)"/>
+  <circle r="10.32" fill="#ffffff"><animateMotion dur="3.4s" repeatCount="indefinite"
+    path="M 49.14 24.20 A 26.66 26.66 0 1 1 49.14 77.52 A 26.66 26.66 0 1 1 49.14 24.20"/></circle>
+</svg>

--- a/fe/public/symbol-kinetic.svg
+++ b/fe/public/symbol-kinetic.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <defs><mask id="notch"><rect width="100" height="100" fill="#fff"/>
+    <circle r="12.90" fill="#000"><animateMotion dur="3.4s" repeatCount="indefinite"
+      path="M 49.14 24.20 A 26.66 26.66 0 1 1 49.14 77.52 A 26.66 26.66 0 1 1 49.14 24.20"/></circle>
+  </mask></defs>
+  <circle cx="49.14" cy="50.86" r="26.66" fill="none" stroke="#0B0B0C" stroke-width="9.46" mask="url(#notch)"/>
+  <circle r="10.32" fill="#8837ED"><animateMotion dur="3.4s" repeatCount="indefinite"
+    path="M 49.14 24.20 A 26.66 26.66 0 1 1 49.14 77.52 A 26.66 26.66 0 1 1 49.14 24.20"/></circle>
+</svg>

--- a/fe/src/app/layout/AppLayout.test.tsx
+++ b/fe/src/app/layout/AppLayout.test.tsx
@@ -72,7 +72,10 @@ describe("AppLayout", () => {
     mockTodayReviews(0);
     renderLayout();
     await waitFor(() => {
-      expect(screen.getByText("orino")).toBeInTheDocument();
+      // Logo는 심볼+워드마크(둘 다 aria-label="orino"); 워드마크 텍스트는 분할됨
+      expect(
+        screen.getAllByRole("img", { name: "orino" }).length,
+      ).toBeGreaterThan(0);
     });
     expect(
       screen.getByRole("button", { name: /로그아웃/ }),

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 
+import { BrandMark } from "@/components/brand/Logo";
 import { LoadingText } from "@/components/ui/loading-text";
 
 import { PrivateRoute } from "../features/auth/components/PrivateRoute";
@@ -34,7 +35,12 @@ const WeeklyPlanPage = lazy(importWeeklyPlan);
 const MemoPage = lazy(importMemo);
 
 function RouteFallback() {
-  return <LoadingText className="p-6" />;
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 p-10">
+      <BrandMark size={40} animated />
+      <LoadingText />
+    </div>
+  );
 }
 
 export function AppRouter() {

--- a/fe/src/components/brand/Logo.test.tsx
+++ b/fe/src/components/brand/Logo.test.tsx
@@ -1,30 +1,45 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { BrandMark, Logo } from "./Logo";
+import { BrandMark, Logo, Wordmark } from "./Logo";
 
 describe("BrandMark", () => {
   it("aria-label=orino인 svg를 렌더한다", () => {
     render(<BrandMark />);
     expect(screen.getByRole("img", { name: "orino" })).toBeInTheDocument();
   });
+
+  it("animated여도 정상 렌더한다", () => {
+    render(<BrandMark animated />);
+    expect(screen.getByRole("img", { name: "orino" })).toBeInTheDocument();
+  });
+});
+
+describe("Wordmark", () => {
+  it("aria-label=orino + dotless ı를 포함한 소문자 표기", () => {
+    render(<Wordmark />);
+    const wm = screen.getByRole("img", { name: "orino" });
+    expect(wm).toBeInTheDocument();
+    // 가시 텍스트는 점 없는 ı(U+0131) — "orıno"
+    expect(wm).toHaveTextContent("orıno");
+  });
+
+  it("tone=inverse면 흰색", () => {
+    render(<Wordmark tone="inverse" />);
+    expect(screen.getByRole("img", { name: "orino" })).toHaveClass(
+      "text-white",
+    );
+  });
 });
 
 describe("Logo", () => {
-  it("기본은 심볼 + 워드마크(orino)", () => {
+  it("기본은 심볼 + 워드마크(둘 다 orino)", () => {
     render(<Logo />);
-    expect(screen.getByRole("img", { name: "orino" })).toBeInTheDocument();
-    expect(screen.getByText("orino")).toBeInTheDocument();
+    expect(screen.getAllByRole("img", { name: "orino" })).toHaveLength(2);
   });
 
-  it("showWordmark=false면 워드마크를 렌더하지 않는다", () => {
+  it("showWordmark=false면 심볼만", () => {
     render(<Logo showWordmark={false} />);
-    expect(screen.queryByText("orino")).not.toBeInTheDocument();
-    expect(screen.getByRole("img", { name: "orino" })).toBeInTheDocument();
-  });
-
-  it("tone=inverse면 워드마크가 흰색", () => {
-    render(<Logo tone="inverse" />);
-    expect(screen.getByText("orino")).toHaveClass("text-white");
+    expect(screen.getAllByRole("img", { name: "orino" })).toHaveLength(1);
   });
 });

--- a/fe/src/components/brand/Logo.tsx
+++ b/fe/src/components/brand/Logo.tsx
@@ -16,17 +16,50 @@ const DOT: Record<LogoTone, string> = {
   inverse: "#ffffff",
 };
 
-/** orino 심볼(2a Orbit) — 궤도 틈은 마스크로 관통해 배경색과 무관하게 유지된다. 좌표는 브랜드 확정본. */
+function useReducedMotion() {
+  const [reduced, setReduced] = React.useState(false);
+  React.useEffect(() => {
+    // matchMedia가 없는 환경(SSR·테스트)에서는 애니메이션을 켠 채로 둔다.
+    if (typeof window.matchMedia !== "function") return;
+    const m = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const on = () => setReduced(m.matches);
+    on();
+    m.addEventListener("change", on);
+    return () => m.removeEventListener("change", on);
+  }, []);
+  return reduced;
+}
+
+/**
+ * orino 심볼(2a Orbit). 궤도 틈은 마스크로 관통해 배경색과 무관하게 유지된다. 좌표는 브랜드 확정본.
+ * - animated=false: 정적(우상단 틈에 점이 쉼) — 파비콘/기본
+ * - animated=true : 키네틱(점이 링을 돌고 틈이 함께 이동) — 스플래시/로딩(장치 2).
+ *   prefers-reduced-motion이면 자동 정지(상단에 점이 쉼).
+ */
 export function BrandMark({
   size = 24,
   tone = "primary",
+  animated = false,
   className,
 }: {
   size?: number;
   tone?: LogoTone;
+  animated?: boolean;
   className?: string;
 }) {
   const id = React.useId();
+  const reduce = useReducedMotion();
+  const spin: React.CSSProperties | undefined =
+    animated && !reduce
+      ? {
+          transformOrigin: "49.14px 50.86px",
+          animation: "orino-orbit 3.4s linear infinite",
+        }
+      : undefined;
+
+  // 정적: 우상단 고정 틈+점 / 키네틱: 상단(12시)에서 시작해 회전 그룹으로 돈다.
+  const dotCx = animated ? "49.14" : "72.27";
+  const dotCy = animated ? "24.2" : "27.73";
   return (
     <svg
       width={size}
@@ -39,7 +72,9 @@ export function BrandMark({
     >
       <mask id={id}>
         <rect width="100" height="100" fill="#fff" />
-        <circle cx="72.27" cy="27.73" r="12.9" fill="#000" />
+        <g style={spin}>
+          <circle cx={dotCx} cy={dotCy} r="12.9" fill="#000" />
+        </g>
       </mask>
       <circle
         cx="49.14"
@@ -50,37 +85,77 @@ export function BrandMark({
         strokeWidth="9.46"
         mask={`url(#${id})`}
       />
-      <circle cx="72.27" cy="27.73" r="10.32" fill={DOT[tone]} />
+      <g style={spin}>
+        <circle cx={dotCx} cy={dotCy} r="10.32" fill={DOT[tone]} />
+      </g>
     </svg>
   );
 }
 
-/** 심볼 + 워드마크. 앱바·헤더 등에 사용. showWordmark=false면 심볼만. */
+/**
+ * 워드마크(장치 1: 궤도 i-점). i는 점 없는 ı(U+0131), 그 위에 심볼의 궤도 점과 같은
+ * 퍼플·원형 점을 얹어 마크와 글자를 하나의 시스템으로 묶는다. 항상 소문자.
+ */
+export function Wordmark({
+  size = 26,
+  tone = "primary",
+  className,
+}: {
+  size?: number;
+  tone?: LogoTone;
+  className?: string;
+}) {
+  const dotColor = tone === "inverse" ? "#ffffff" : "var(--brand)";
+  return (
+    <span
+      role="img"
+      aria-label="orino"
+      className={cn(
+        "font-bold tracking-tight",
+        tone === "inverse" ? "text-white" : "text-foreground",
+        className,
+      )}
+      style={{ fontSize: size, lineHeight: 1 }}
+    >
+      or
+      <span style={{ position: "relative" }} aria-hidden>
+        {"ı"}
+        <span
+          style={{
+            position: "absolute",
+            left: "50%",
+            top: "0.03em",
+            transform: "translateX(-50%)",
+            width: "0.22em",
+            height: "0.22em",
+            borderRadius: "50%",
+            background: dotColor,
+          }}
+        />
+      </span>
+      no
+    </span>
+  );
+}
+
+/** 락업(심볼 + i-점 워드마크). 앱바·헤더 등에 사용. animated면 심볼이 키네틱. */
 export function Logo({
   size = 28,
   tone = "primary",
   showWordmark = true,
+  animated = false,
   className,
 }: {
   size?: number;
   tone?: LogoTone;
   showWordmark?: boolean;
+  animated?: boolean;
   className?: string;
 }) {
   return (
     <span className={cn("inline-flex items-center gap-2.5", className)}>
-      <BrandMark size={size} tone={tone} />
-      {showWordmark && (
-        <span
-          className={cn(
-            "font-bold tracking-tight",
-            tone === "inverse" ? "text-white" : "text-foreground",
-          )}
-          style={{ fontSize: size * 0.95, lineHeight: 1 }}
-        >
-          orino
-        </span>
-      )}
+      <BrandMark size={size} tone={tone} animated={animated} />
+      {showWordmark && <Wordmark size={size * 0.95} tone={tone} />}
     </span>
   );
 }

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -226,3 +226,10 @@
 .tiptap.resize-cursor {
   cursor: col-resize;
 }
+
+/* 브랜드 키네틱 궤도(장치 2) — BrandMark animated에서 점/틈 그룹을 회전. */
+@keyframes orino-orbit {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## 이슈
closes #729 (로고 #717 · 개정 #723 후속)

## 배경
brand 3 지시서 — O'Reilly와 벌리는 **차별화 3장치 정식 채택**. 정적 좌표는 brand 2와 동일(변경 없음), 모션·워드마크·락을 추가.

## 변경
- **장치 1 — 궤도 i-점 워드마크** `<Wordmark>`: 점 없는 `ı`(U+0131) 위에 심볼과 같은 궤도 퍼플 점. `<Logo>`가 이 워드마크를 사용(마크·글자를 한 시스템으로). `role="img" aria-label="orino"`
- **장치 2 — 키네틱 궤도**: `<BrandMark animated>`(점이 링을 돌고 틈이 함께 이동) + `@keyframes orino-orbit`(3.4s linear 무한). `prefers-reduced-motion`이면 자동 정지 — `matchMedia` 가드로 SSR/테스트 안전. **로딩(RouteFallback)에 배선**. 비-React 스플래시용 `public/symbol-kinetic(-white).svg`(SMIL 정본 — 디자이너 export는 모션 누락이라 §4-4로 대체)
- **장치 3 — 컬러·케이스·점 락**: conventions에 퍼플만/소문자 orino/궤도 퍼플 점 3대 불변 규칙 명문화
- 정적 파비콘은 brand 2와 바이트 동일 → 변경 없음. 전체 킷 `public/brand/`에 키네틱 포함 갱신

## 영향/검증
- Wordmark 텍스트가 분할(`orıno`)되어 `AppLayout.test`·`Logo.test`를 접근성 이름(`getByRole("img",{name:"orino"})`) 기준으로 갱신
- Logo 6 + 전체 236 테스트 통과, eslint·format·tsc·build 클린. dist에 키네틱 SVG·파비콘·킷 14종 확인

## 비고
- 패널 Logo/BrandMark/Wordmark 카드(키네틱·i-점)는 다음 재싱크에 반영