### PR TITLE
feat : 메모 트리 드래그 이동·정렬 + 인라인 하위페이지 (M2)

### DIFF
--- a/be/orino-app-api/src/test/java/ds/project/orino/memo/controller/MemoControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/memo/controller/MemoControllerTest.java
@@ -291,6 +291,53 @@ class MemoControllerTest extends ApiTestSupport {
                 .andExpect(status().isNotFound());
     }
 
+    @Test
+    @DisplayName("PATCH memo - sortOrder 변경이 트리 정렬에 반영된다")
+    void reorder_by_sortOrder() throws Exception {
+        Memo a = root("A", 0);
+        Memo b = root("B", 1);
+
+        // A를 뒤로 보냄(sortOrder 5) → 트리는 sortOrder 오름차순이라 [B, A]
+        mockMvc.perform(patch("/api/memos/{id}", a.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"sortOrder\": 5}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sortOrder").value(5));
+
+        mockMvc.perform(get("/api/memos")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memos[0].id").value(b.getId()))
+                .andExpect(jsonPath("$.data.memos[1].id").value(a.getId()));
+    }
+
+    @Test
+    @DisplayName("PATCH memo - parentId·sortOrder 동시 이동이 트리에 반영된다")
+    void move_with_parent_and_sortOrder() throws Exception {
+        Memo parent = root("부모", 0);
+        Memo c1 = child(parent.getId(), "C1", 0);
+        Memo x = root("X", 1);
+
+        // X를 부모의 자식으로 옮기고 정렬을 뒤(5)로 → 자식 순서 [C1(0), X(5)]
+        mockMvc.perform(patch("/api/memos/{id}", x.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"parentId": %d, "sortOrder": 5}
+                                """.formatted(parent.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.parentId").value(parent.getId()))
+                .andExpect(jsonPath("$.data.sortOrder").value(5));
+
+        mockMvc.perform(get("/api/memos")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.memos", hasSize(1)))
+                .andExpect(jsonPath("$.data.memos[0].children", hasSize(2)))
+                .andExpect(jsonPath("$.data.memos[0].children[0].id").value(c1.getId()))
+                .andExpect(jsonPath("$.data.memos[0].children[1].id").value(x.getId()));
+    }
+
     private Integer memoCount(Long id) {
         return jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM memo WHERE id = ?", Integer.class, id);

--- a/fe/src/features/memo/components/MemoEditor.tsx
+++ b/fe/src/features/memo/components/MemoEditor.tsx
@@ -10,11 +10,17 @@ import StarterKit from "@tiptap/starter-kit";
 import { GripVertical } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Input } from "@/components/ui/input";
-// 노트의 에디터 UI 프리미티브를 재사용한다(도구모음·저장상태·이미지 업로드).
-// childPage(인라인 하위 페이지)는 메모 v1에서 제외한다(트리 사이드바로만 하위 생성).
+// 노트의 에디터 엔진을 재사용한다(도구모음·저장상태·이미지 업로드·childPage).
+// childPage는 onOpen/트리를 ChildPageContext로 주입해 메모용으로 동작한다.
 import { EditorToolbar } from "@/features/note/components/EditorToolbar";
 import { SaveStatusIndicator } from "@/features/note/components/SaveStatusIndicator";
+import {
+  ChildPage,
+  collectChildPageIds,
+} from "@/features/note/editor/childPage";
+import { ChildPageContext } from "@/features/note/editor/childPageContext";
 import {
   extractImageFiles,
   uploadAndInsertImage,
@@ -22,13 +28,17 @@ import {
 
 import type { MemoContent, MemoDetail } from "../api/memos";
 import { useAutoSaveMemo } from "../hooks/useAutoSaveMemo";
+import { useCreateMemo, useDeleteMemo } from "../hooks/useMemoMutations";
+import { useMemoTree } from "../hooks/useMemoTree";
 import { memoKeys } from "../queryKeys";
 
 interface Props {
   memo: MemoDetail;
+  /** childPage 블록 클릭 시 자식 메모로 이동 */
+  onOpenMemo: (memoId: number) => void;
 }
 
-export function MemoEditor({ memo }: Props) {
+export function MemoEditor({ memo, onOpenMemo }: Props) {
   const queryClient = useQueryClient();
   const { status, savedAt, schedule, flush, retry } = useAutoSaveMemo(memo.id, {
     onSaved: (patch) => {
@@ -43,10 +53,16 @@ export function MemoEditor({ memo }: Props) {
       }
     },
   });
+  const createMemo = useCreateMemo();
+  const deleteMemo = useDeleteMemo();
+  const { data: memoTree } = useMemoTree();
 
   const [title, setTitle] = useState(memo.title);
-  // editorProps 핸들러(handlePaste/handleDrop)는 생성 시점 클로저라 editor를
-  // 직접 못 잡으므로 ref로 우회한다.
+  const [pendingDelete, setPendingDelete] = useState<number | null>(null);
+  // 본문에 현재 박혀 있는 childPage id 집합 (삭제 diff 기준).
+  // MemoWorkspace가 key={memo.id}로 리마운트하므로 마운트 시점 content로 1회 초기화.
+  const childIdsRef = useRef<Set<number>>(collectChildPageIds(memo.content));
+  // editorProps 핸들러는 생성 시점 클로저라 editor를 못 잡으므로 ref로 우회한다.
   const editorRef = useRef<ReturnType<typeof useEditor>>(null);
 
   const editor = useEditor(
@@ -58,8 +74,9 @@ export function MemoEditor({ memo }: Props) {
         TableKit.configure({ table: { resizable: true } }),
         Image.configure({ inline: false }),
         Placeholder.configure({
-          placeholder: "내용을 입력하세요...",
+          placeholder: "내용을 입력하거나 페이지를 추가하세요...",
         }),
+        ChildPage,
       ],
       content: memo.content as JSONContent,
       editorProps: {
@@ -94,7 +111,9 @@ export function MemoEditor({ memo }: Props) {
         },
       },
       onUpdate: ({ editor }) => {
-        schedule({ content: editor.getJSON() as MemoContent });
+        const json = editor.getJSON() as MemoContent;
+        schedule({ content: json });
+        detectRemovedChildPage(json);
       },
     },
     [memo.id],
@@ -111,9 +130,48 @@ export function MemoEditor({ memo }: Props) {
     };
   }, [flush]);
 
+  const detectRemovedChildPage = (json: MemoContent) => {
+    const current = collectChildPageIds(json);
+    const prev = childIdsRef.current;
+    const removed = [...prev].filter((id) => !current.has(id));
+    childIdsRef.current = current;
+    if (removed.length > 0) {
+      setPendingDelete(removed[0]);
+    }
+  };
+
   const handleTitleChange = (next: string) => {
     setTitle(next);
     schedule({ title: next });
+  };
+
+  const handleInsertPage = () => {
+    if (createMemo.isPending) return;
+    createMemo.mutate(
+      { parentId: memo.id, title: "제목 없음" },
+      {
+        onSuccess: (created) => {
+          editor
+            ?.chain()
+            .focus()
+            .insertChildPage({ noteId: created.id, title: created.title })
+            .run();
+          if (editor) {
+            childIdsRef.current = collectChildPageIds(
+              editor.getJSON() as MemoContent,
+            );
+          }
+        },
+      },
+    );
+  };
+
+  const confirmDelete = () => {
+    if (pendingDelete == null) return;
+    deleteMemo.mutate(pendingDelete, {
+      onSuccess: () => setPendingDelete(null),
+      onError: () => setPendingDelete(null),
+    });
   };
 
   return (
@@ -139,7 +197,11 @@ export function MemoEditor({ memo }: Props) {
       </div>
 
       <div className="border-border bg-card overflow-hidden rounded-md border">
-        <EditorToolbar editor={editor} />
+        <EditorToolbar
+          editor={editor}
+          onInsertPage={handleInsertPage}
+          insertPagePending={createMemo.isPending}
+        />
         {editor && (
           <DragHandle
             editor={editor}
@@ -155,8 +217,25 @@ export function MemoEditor({ memo }: Props) {
             </button>
           </DragHandle>
         )}
-        <EditorContent editor={editor} className="relative" />
+        <ChildPageContext.Provider
+          value={{ onOpen: onOpenMemo, tree: memoTree }}
+        >
+          <EditorContent editor={editor} className="relative" />
+        </ChildPageContext.Provider>
       </div>
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+        title="하위 페이지를 삭제할까요?"
+        description="본문에서 제거한 하위 페이지와 그 안의 모든 내용이 삭제됩니다. 되돌릴 수 없어요."
+        confirmLabel="삭제"
+        destructive
+        onConfirm={confirmDelete}
+        pending={deleteMemo.isPending}
+      />
     </div>
   );
 }

--- a/fe/src/features/memo/components/MemoTreeSidebar.tsx
+++ b/fe/src/features/memo/components/MemoTreeSidebar.tsx
@@ -6,13 +6,14 @@ import {
   Plus,
   Trash2,
 } from "lucide-react";
-import { useState } from "react";
+import { type DragEvent, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Menu, MenuItem } from "@/components/ui/menu";
 import { cn } from "@/lib/utils";
 
 import type { MemoTreeNode } from "../api/memos";
+import { computeMove, type DropPosition } from "../treeMove";
 
 interface Props {
   tree: MemoTreeNode[];
@@ -21,7 +22,14 @@ interface Props {
   onAddRoot: () => void;
   onAddChild: (parentId: number) => void;
   onRequestDelete: (node: MemoTreeNode) => void;
+  /** 드래그 이동/정렬: 드래그한 노드를 대상 기준 위치로 옮긴다. */
+  onMove: (dragId: number, targetId: number, position: DropPosition) => void;
   addPending?: boolean;
+}
+
+interface DropInfo {
+  id: number;
+  pos: DropPosition;
 }
 
 export function MemoTreeSidebar({
@@ -31,8 +39,48 @@ export function MemoTreeSidebar({
   onAddRoot,
   onAddChild,
   onRequestDelete,
+  onMove,
   addPending,
 }: Props) {
+  const [dragId, setDragId] = useState<number | null>(null);
+  const [dropInfo, setDropInfo] = useState<DropInfo | null>(null);
+
+  const handleDragOver = (e: DragEvent, targetId: number) => {
+    if (dragId == null) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const y = e.clientY - rect.top;
+    const pos: DropPosition =
+      y < rect.height / 3
+        ? "before"
+        : y > (rect.height * 2) / 3
+          ? "after"
+          : "inside";
+    // 순환·무변화면 드롭 불가 → 인디케이터 숨김
+    if (computeMove(tree, dragId, targetId, pos)) {
+      e.preventDefault(); // drop 허용
+      e.dataTransfer.dropEffect = "move";
+      if (dropInfo?.id !== targetId || dropInfo?.pos !== pos) {
+        setDropInfo({ id: targetId, pos });
+      }
+    } else if (dropInfo) {
+      setDropInfo(null);
+    }
+  };
+
+  const handleDrop = (e: DragEvent, targetId: number) => {
+    e.preventDefault();
+    if (dragId != null && dropInfo && dropInfo.id === targetId) {
+      onMove(dragId, targetId, dropInfo.pos);
+    }
+    setDragId(null);
+    setDropInfo(null);
+  };
+
+  const handleDragEnd = () => {
+    setDragId(null);
+    setDropInfo(null);
+  };
+
   return (
     <nav
       aria-label="메모 목록"
@@ -62,9 +110,15 @@ export function MemoTreeSidebar({
               node={node}
               depth={0}
               activeMemoId={activeMemoId}
+              dragId={dragId}
+              dropInfo={dropInfo}
               onSelect={onSelect}
               onAddChild={onAddChild}
               onRequestDelete={onRequestDelete}
+              onDragStart={setDragId}
+              onDragOver={handleDragOver}
+              onDrop={handleDrop}
+              onDragEnd={handleDragEnd}
             />
           ))}
         </ul>
@@ -77,31 +131,59 @@ interface ItemProps {
   node: MemoTreeNode;
   depth: number;
   activeMemoId: number | null;
+  dragId: number | null;
+  dropInfo: DropInfo | null;
   onSelect: (memoId: number) => void;
   onAddChild: (parentId: number) => void;
   onRequestDelete: (node: MemoTreeNode) => void;
+  onDragStart: (id: number) => void;
+  onDragOver: (e: DragEvent, targetId: number) => void;
+  onDrop: (e: DragEvent, targetId: number) => void;
+  onDragEnd: () => void;
 }
 
 function MemoTreeItem({
   node,
   depth,
   activeMemoId,
+  dragId,
+  dropInfo,
   onSelect,
   onAddChild,
   onRequestDelete,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
 }: ItemProps) {
   const [expanded, setExpanded] = useState(true);
   const hasChildren = node.children.length > 0;
   const isActive = node.id === activeMemoId;
+  const drop = dropInfo?.id === node.id ? dropInfo.pos : null;
 
   return (
     <li>
       <div
+        draggable
+        onDragStart={(e) => {
+          onDragStart(node.id);
+          e.dataTransfer.effectAllowed = "move";
+          // Firefox는 dataTransfer에 데이터가 있어야 드래그를 시작한다.
+          e.dataTransfer.setData("text/plain", String(node.id));
+        }}
+        onDragOver={(e) => onDragOver(e, node.id)}
+        onDrop={(e) => onDrop(e, node.id)}
+        onDragEnd={onDragEnd}
         className={cn(
           "group/memo flex items-center gap-0.5 rounded-md pr-1 text-sm",
           isActive
             ? "bg-primary/10 text-primary"
             : "text-foreground/80 hover:bg-muted",
+          dragId === node.id && "opacity-50",
+          // 드롭 인디케이터
+          drop === "inside" && "ring-primary bg-primary/15 ring-1",
+          drop === "before" && "border-primary rounded-none border-t-2",
+          drop === "after" && "border-primary rounded-none border-b-2",
         )}
         style={{ paddingLeft: `${depth * 0.75}rem` }}
       >
@@ -158,9 +240,15 @@ function MemoTreeItem({
               node={child}
               depth={depth + 1}
               activeMemoId={activeMemoId}
+              dragId={dragId}
+              dropInfo={dropInfo}
               onSelect={onSelect}
               onAddChild={onAddChild}
               onRequestDelete={onRequestDelete}
+              onDragStart={onDragStart}
+              onDragOver={onDragOver}
+              onDrop={onDrop}
+              onDragEnd={onDragEnd}
             />
           ))}
         </ul>

--- a/fe/src/features/memo/components/MemoWorkspace.test.tsx
+++ b/fe/src/features/memo/components/MemoWorkspace.test.tsx
@@ -208,4 +208,86 @@ describe("MemoWorkspace", () => {
 
     await waitFor(() => expect(deleted).toBe(true));
   });
+
+  it("[페이지] 버튼으로 하위 메모를 만들고 본문에 childPage 블록이 박힌다", async () => {
+    mockTree([
+      { id: 1, title: "부모", parentId: null, sortOrder: 0, children: [] },
+    ]);
+    mockMemoDetail(1, { type: "doc", content: [] }, "부모");
+    let postedParentId: number | null | undefined;
+    server.use(
+      http.post(`${API_BASE}/memos`, async ({ request }) => {
+        const body = (await request.json()) as { parentId: number | null };
+        postedParentId = body.parentId;
+        return HttpResponse.json(
+          {
+            code: "OK",
+            data: {
+              id: 99,
+              parentId: body.parentId,
+              title: "제목 없음",
+              sortOrder: 0,
+              content: { type: "doc", content: [] },
+              updatedAt: "2026-07-05T10:00:00",
+            },
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("메모 제목")).toHaveValue("부모");
+    });
+
+    await user.click(screen.getByRole("button", { name: "하위 페이지 추가" }));
+
+    await waitFor(() => expect(postedParentId).toBe(1));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /하위 페이지 .* 열기/ }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("본문 childPage 블록 클릭 시 자식 메모로 전환된다", async () => {
+    mockTree([
+      {
+        id: 1,
+        title: "부모",
+        parentId: null,
+        sortOrder: 0,
+        children: [
+          { id: 2, title: "자식", parentId: 1, sortOrder: 0, children: [] },
+        ],
+      },
+    ]);
+    mockMemoDetail(
+      1,
+      {
+        type: "doc",
+        content: [{ type: "childPage", attrs: { noteId: 2, title: "자식" } }],
+      },
+      "부모",
+    );
+    mockMemoDetail(2, { type: "doc", content: [] }, "자식");
+
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("메모 제목")).toHaveValue("부모");
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: /하위 페이지 자식 열기/ }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("메모 제목")).toHaveValue("자식");
+    });
+  });
 });

--- a/fe/src/features/memo/components/MemoWorkspace.tsx
+++ b/fe/src/features/memo/components/MemoWorkspace.tsx
@@ -11,8 +11,13 @@ import { LoadingText } from "@/components/ui/loading-text";
 
 import type { MemoTreeNode } from "../api/memos";
 import { useMemoDetail } from "../hooks/useMemoDetail";
-import { useCreateMemo, useDeleteMemo } from "../hooks/useMemoMutations";
+import {
+  useCreateMemo,
+  useDeleteMemo,
+  useMoveMemo,
+} from "../hooks/useMemoMutations";
 import { useMemoTree } from "../hooks/useMemoTree";
+import { computeMove, type DropPosition } from "../treeMove";
 import { MemoEditor } from "./MemoEditor";
 import { MemoTreeSidebar } from "./MemoTreeSidebar";
 
@@ -37,6 +42,7 @@ export function MemoWorkspace() {
   const detailQuery = useMemoDetail(activeMemoId);
   const createMemo = useCreateMemo();
   const deleteMemo = useDeleteMemo();
+  const moveMemo = useMoveMemo();
   const [pendingDelete, setPendingDelete] = useState<MemoTreeNode | null>(null);
 
   const setActiveMemo = (memoId: number | null) => {
@@ -78,6 +84,17 @@ export function MemoWorkspace() {
       { parentId, title: "제목 없음" },
       { onSuccess: (created) => setActiveMemo(created.id) },
     );
+  };
+
+  const handleMove = (
+    dragId: number,
+    targetId: number,
+    position: DropPosition,
+  ) => {
+    if (moveMemo.isPending) return;
+    const plan = computeMove(tree, dragId, targetId, position);
+    if (!plan) return;
+    moveMemo.mutate({ plan, dragId });
   };
 
   const handleConfirmDelete = () => {
@@ -124,6 +141,7 @@ export function MemoWorkspace() {
               onAddRoot={handleAddRoot}
               onAddChild={handleAddChild}
               onRequestDelete={setPendingDelete}
+              onMove={handleMove}
               addPending={createMemo.isPending}
             />
           </div>
@@ -152,7 +170,11 @@ export function MemoWorkspace() {
             ) : detailQuery.isError || !detailQuery.data ? (
               <FieldError>메모를 불러오지 못했어요.</FieldError>
             ) : (
-              <MemoEditor key={detailQuery.data.id} memo={detailQuery.data} />
+              <MemoEditor
+                key={detailQuery.data.id}
+                memo={detailQuery.data}
+                onOpenMemo={setActiveMemo}
+              />
             )}
           </div>
         </div>

--- a/fe/src/features/memo/hooks/useMemoMutations.test.tsx
+++ b/fe/src/features/memo/hooks/useMemoMutations.test.tsx
@@ -1,0 +1,59 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import { server } from "@/test/mocks/server";
+
+import { useMoveMemo } from "./useMemoMutations";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useMoveMemo", () => {
+  it("orderedIds를 sortOrder 0..n으로 순차 PATCH하고 드래그 노드는 parentId까지 담는다", async () => {
+    const calls: { id: number; body: unknown }[] = [];
+    server.use(
+      http.patch(`${API_BASE}/memos/:id`, async ({ request, params }) => {
+        calls.push({ id: Number(params.id), body: await request.json() });
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            id: Number(params.id),
+            parentId: null,
+            title: "t",
+            sortOrder: 0,
+            updatedAt: "2026-07-05T10:00:00",
+          },
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useMoveMemo(), { wrapper });
+    // 메모 1을 부모 2의 마지막 자식으로 이동 (기존 자식 21,22 뒤)
+    result.current.mutate({
+      plan: { parentId: 2, orderedIds: [21, 22, 1] },
+      dragId: 1,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(calls).toEqual([
+      { id: 21, body: { sortOrder: 0 } },
+      { id: 22, body: { sortOrder: 1 } },
+      { id: 1, body: { parentId: 2, sortOrder: 2 } },
+    ]);
+  });
+});

--- a/fe/src/features/memo/hooks/useMemoMutations.ts
+++ b/fe/src/features/memo/hooks/useMemoMutations.ts
@@ -5,8 +5,10 @@ import {
   deleteMemo,
   type MemoCreateRequest,
   type MemoDetail,
+  updateMemo,
 } from "../api/memos";
 import { memoKeys } from "../queryKeys";
+import type { MovePlan } from "../treeMove";
 
 export function useCreateMemo() {
   const queryClient = useQueryClient();
@@ -22,6 +24,32 @@ export function useDeleteMemo() {
   const queryClient = useQueryClient();
   return useMutation<void, Error, number>({
     mutationFn: deleteMemo,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: memoKeys.tree() });
+    },
+  });
+}
+
+/**
+ * 트리 드래그 이동/정렬. 새 부모의 자식 순서(orderedIds)를 0..n으로 재배치하고,
+ * 드래그 노드는 parentId까지 함께 PATCH한다. BE는 단건 PATCH만 지원하므로
+ * 그룹 내 각 노드를 순차 PATCH한 뒤 트리를 한 번 무효화한다.
+ * (옮겨진 노드가 빠진 기존 부모 그룹은 sortOrder에 빈틈이 생겨도 순서는 유지된다.)
+ */
+export function useMoveMemo() {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, { plan: MovePlan; dragId: number }>({
+    mutationFn: async ({ plan, dragId }) => {
+      for (let i = 0; i < plan.orderedIds.length; i++) {
+        const id = plan.orderedIds[i];
+        await updateMemo(
+          id,
+          id === dragId
+            ? { parentId: plan.parentId, sortOrder: i }
+            : { sortOrder: i },
+        );
+      }
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: memoKeys.tree() });
     },

--- a/fe/src/features/memo/treeMove.test.ts
+++ b/fe/src/features/memo/treeMove.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import type { MemoTreeNode } from "./api/memos";
+import { computeMove } from "./treeMove";
+
+function node(
+  id: number,
+  children: MemoTreeNode[] = [],
+  parentId: number | null = null,
+): MemoTreeNode {
+  return { id, title: `n${id}`, parentId, sortOrder: 0, children };
+}
+
+// 트리: 1, 2(자식 21,22), 3
+const tree: MemoTreeNode[] = [
+  node(1),
+  node(2, [node(21, [], 2), node(22, [], 2)]),
+  node(3),
+];
+
+describe("computeMove", () => {
+  it("inside: 대상의 마지막 자식으로 들어간다", () => {
+    expect(computeMove(tree, 1, 2, "inside")).toEqual({
+      parentId: 2,
+      orderedIds: [21, 22, 1],
+    });
+  });
+
+  it("before: 대상 앞 형제로 재배치한다", () => {
+    expect(computeMove(tree, 3, 1, "before")).toEqual({
+      parentId: null,
+      orderedIds: [3, 1, 2],
+    });
+  });
+
+  it("after: 대상 뒤 형제로 재배치한다", () => {
+    expect(computeMove(tree, 1, 3, "after")).toEqual({
+      parentId: null,
+      orderedIds: [2, 3, 1],
+    });
+  });
+
+  it("같은 부모 내 재정렬 시 드래그 노드를 빼고 다시 끼운다", () => {
+    expect(computeMove(tree, 21, 22, "after")).toEqual({
+      parentId: 2,
+      orderedIds: [22, 21],
+    });
+  });
+
+  it("자기 자신에게 드롭하면 null", () => {
+    expect(computeMove(tree, 2, 2, "inside")).toBeNull();
+  });
+
+  it("자손을 부모로 삼는 순환 이동은 null", () => {
+    // 2를 자식 21 안으로 → 순환
+    expect(computeMove(tree, 2, 21, "inside")).toBeNull();
+  });
+
+  it("변화 없는 드롭(같은 자리)은 null", () => {
+    // 1을 2 앞에 놓아도 이미 그 순서 → no-op
+    expect(computeMove(tree, 1, 2, "before")).toBeNull();
+  });
+
+  it("루트 노드 before/after로 최상위 이동", () => {
+    // 21을 루트 3 뒤로 → 루트 레벨로 승격
+    expect(computeMove(tree, 21, 3, "after")).toEqual({
+      parentId: null,
+      orderedIds: [1, 2, 3, 21],
+    });
+  });
+});

--- a/fe/src/features/memo/treeMove.ts
+++ b/fe/src/features/memo/treeMove.ts
@@ -1,0 +1,108 @@
+import type { MemoTreeNode } from "./api/memos";
+
+export type DropPosition = "inside" | "before" | "after";
+
+/** 이동 결과: 대상 부모(parentId)와 그 부모의 새 자식 순서(id 배열). */
+export interface MovePlan {
+  parentId: number | null;
+  orderedIds: number[];
+}
+
+function findNode(nodes: MemoTreeNode[], id: number): MemoTreeNode | null {
+  for (const n of nodes) {
+    if (n.id === id) return n;
+    const found = findNode(n.children, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** id의 부모 id를 찾는다. 루트면 null, 트리에 없으면 undefined. */
+function findParentId(
+  nodes: MemoTreeNode[],
+  id: number,
+  parent: number | null = null,
+): number | null | undefined {
+  for (const n of nodes) {
+    if (n.id === id) return parent;
+    const found = findParentId(n.children, id, n.id);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+/** parentId의 자식 목록(루트는 parentId=null). */
+function childrenOf(
+  tree: MemoTreeNode[],
+  parentId: number | null,
+): MemoTreeNode[] {
+  if (parentId == null) return tree;
+  return findNode(tree, parentId)?.children ?? [];
+}
+
+/** candidateId가 rootId 자신이거나 그 서브트리(자손)에 속하면 true. */
+function isSelfOrDescendant(
+  tree: MemoTreeNode[],
+  rootId: number,
+  candidateId: number,
+): boolean {
+  const root = findNode(tree, rootId);
+  if (!root) return false;
+  const walk = (node: MemoTreeNode): boolean =>
+    node.id === candidateId || node.children.some(walk);
+  return walk(root);
+}
+
+/**
+ * 드래그 이동을 계산한다. 순환(자기/자손을 부모로)·무변화(no-op)면 null.
+ * position: inside=대상의 마지막 자식으로, before/after=대상의 형제로.
+ */
+export function computeMove(
+  tree: MemoTreeNode[],
+  dragId: number,
+  targetId: number,
+  position: DropPosition,
+): MovePlan | null {
+  if (dragId === targetId) return null;
+  if (findNode(tree, dragId) == null || findNode(tree, targetId) == null) {
+    return null;
+  }
+
+  const newParentId =
+    position === "inside" ? targetId : (findParentId(tree, targetId) ?? null);
+
+  // 순환 방지: 새 부모가 드래그 노드 자신이거나 그 자손이면 불가
+  if (newParentId != null && isSelfOrDescendant(tree, dragId, newParentId)) {
+    return null;
+  }
+
+  const siblings = childrenOf(tree, newParentId).map((n) => n.id);
+  const withoutDrag = siblings.filter((id) => id !== dragId);
+
+  let insertIndex: number;
+  if (position === "inside") {
+    insertIndex = withoutDrag.length; // 마지막 자식으로 append
+  } else {
+    const targetIndex = withoutDrag.indexOf(targetId);
+    insertIndex = position === "before" ? targetIndex : targetIndex + 1;
+  }
+
+  const orderedIds = [
+    ...withoutDrag.slice(0, insertIndex),
+    dragId,
+    ...withoutDrag.slice(insertIndex),
+  ];
+
+  // 무변화면 no-op: 같은 부모 + 같은 순서
+  const currentParentId = findParentId(tree, dragId) ?? null;
+  const currentOrder = siblings;
+  if (
+    currentParentId === newParentId &&
+    orderedIds.length === currentOrder.length &&
+    orderedIds.every((id, i) => id === currentOrder[i])
+  ) {
+    return null;
+  }
+
+  return { parentId: newParentId, orderedIds };
+}

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -15,9 +15,11 @@ import { Input } from "@/components/ui/input";
 
 import type { NoteContent, NoteDetail } from "../api/notes";
 import { ChildPage, collectChildPageIds } from "../editor/childPage";
+import { ChildPageContext } from "../editor/childPageContext";
 import { extractImageFiles, uploadAndInsertImage } from "../editor/imageUpload";
 import { useAutoSaveNote } from "../hooks/useAutoSaveNote";
 import { useCreateNote, useDeleteNote } from "../hooks/useNoteMutations";
+import { useNoteTree } from "../hooks/useNoteTree";
 import { noteKeys } from "../queryKeys";
 import { EditorToolbar } from "./EditorToolbar";
 import { SaveStatusIndicator } from "./SaveStatusIndicator";
@@ -46,6 +48,7 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
   });
   const createNote = useCreateNote(materialId);
   const deleteNote = useDeleteNote(materialId);
+  const { data: noteTree } = useNoteTree(materialId);
 
   const [title, setTitle] = useState(note.title);
   const [pendingDelete, setPendingDelete] = useState<number | null>(null);
@@ -67,7 +70,7 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
         Placeholder.configure({
           placeholder: "내용을 입력하거나 페이지를 추가하세요...",
         }),
-        ChildPage.configure({ onOpen: onOpenNote, materialId }),
+        ChildPage,
       ],
       content: note.content as JSONContent,
       editorProps: {
@@ -215,7 +218,11 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
             </button>
           </DragHandle>
         )}
-        <EditorContent editor={editor} className="relative" />
+        <ChildPageContext.Provider
+          value={{ onOpen: onOpenNote, tree: noteTree }}
+        >
+          <EditorContent editor={editor} className="relative" />
+        </ChildPageContext.Provider>
       </div>
 
       <ConfirmDialog

--- a/fe/src/features/note/editor/ChildPageView.tsx
+++ b/fe/src/features/note/editor/ChildPageView.tsx
@@ -1,13 +1,11 @@
 import { type NodeViewProps, NodeViewWrapper } from "@tiptap/react";
 import { FileText } from "lucide-react";
 
-import type { NoteTreeNode } from "../api/notes";
-import { useNoteTree } from "../hooks/useNoteTree";
-import type { ChildPageOptions } from "./childPage";
+import { type LiveTreeNode, useChildPageContext } from "./childPageContext";
 
-/** 트리에서 noteId에 해당하는 노드의 현재 제목을 찾는다. */
+/** 트리에서 id에 해당하는 노드의 현재 제목을 찾는다. */
 function findTitle(
-  nodes: NoteTreeNode[] | undefined,
+  nodes: LiveTreeNode[] | undefined,
   id: number,
 ): string | undefined {
   if (!nodes) return undefined;
@@ -21,21 +19,20 @@ function findTitle(
 
 /**
  * 본문 안의 하위 페이지 줄. 한 줄을 차지하되 박스 없이 아이콘 + 제목만 보인다.
- * 클릭 시 ChildPage 노드 옵션의 onOpen(noteId) 호출 → 자식 노트로 라우팅.
+ * 클릭 시 컨텍스트의 onOpen(id) 호출 → 자식 노트/메모로 라우팅.
  * 제목은 트리(라이브)에서 조회하고, 없으면 attrs.title(삽입 시점 캐시)로 폴백한다.
  */
-export function ChildPageView({ node, extension }: NodeViewProps) {
+export function ChildPageView({ node }: NodeViewProps) {
   const noteId = node.attrs.noteId as number | null;
   const cachedTitle = (node.attrs.title as string) || "제목 없음";
-  const options = extension.options as ChildPageOptions;
+  const { onOpen, tree } = useChildPageContext();
 
-  const { data: tree } = useNoteTree(options.materialId);
   const liveTitle = noteId != null ? findTitle(tree, noteId) : undefined;
   const title = liveTitle ?? cachedTitle;
 
   const handleOpen = () => {
     if (noteId == null) return;
-    options.onOpen(noteId);
+    onOpen(noteId);
   };
 
   return (

--- a/fe/src/features/note/editor/childPage.ts
+++ b/fe/src/features/note/editor/childPage.ts
@@ -10,12 +10,6 @@ export interface ChildPageAttrs {
   title: string;
 }
 
-export interface ChildPageOptions {
-  onOpen: (noteId: number) => void;
-  /** 라이브 제목 조회용. attrs.title은 삽입 시점 캐시라 stale할 수 있어 트리에서 보강한다. */
-  materialId: number;
-}
-
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     childPage: {
@@ -26,21 +20,15 @@ declare module "@tiptap/core" {
 
 /**
  * Notion 스타일 인라인 하위 페이지. atom block 노드.
- * attrs.noteId = 실제 note 레코드 id, attrs.title = 표시용 캐시.
+ * attrs.noteId = 참조하는 레코드 id(노트 또는 메모), attrs.title = 표시용 캐시.
+ * onOpen·라이브 제목은 ChildPageContext로 주입한다(노트/메모 공용).
  */
-export const ChildPage = Node.create<ChildPageOptions>({
+export const ChildPage = Node.create({
   name: "childPage",
   group: "block",
   atom: true,
   selectable: true,
   draggable: true,
-
-  addOptions() {
-    return {
-      onOpen: () => {},
-      materialId: 0,
-    };
-  },
 
   addAttributes() {
     return {

--- a/fe/src/features/note/editor/childPageContext.ts
+++ b/fe/src/features/note/editor/childPageContext.ts
@@ -1,0 +1,30 @@
+import { createContext, useContext } from "react";
+
+/** 라이브 제목 조회에 필요한 최소 트리 노드(노트·메모 공용). */
+export interface LiveTreeNode {
+  id: number;
+  title: string;
+  children: LiveTreeNode[];
+}
+
+export interface ChildPageContextValue {
+  /** childPage 블록 클릭 → 해당 노트/메모로 이동. */
+  onOpen: (id: number) => void;
+  /** 라이브 제목 조회용 트리(attrs.title은 삽입 시점 캐시라 stale할 수 있음). */
+  tree: LiveTreeNode[] | undefined;
+}
+
+/**
+ * childPage NodeView에 onOpen·트리를 주입하는 컨텍스트.
+ * NoteEditor·MemoEditor가 각자의 훅(useNoteTree/useMemoTree)으로 값을 채워
+ * EditorContent를 이 Provider로 감싼다. Tiptap React NodeView는 상위 컨텍스트를
+ * 상속하므로 ChildPageView에서 읽을 수 있다.
+ */
+export const ChildPageContext = createContext<ChildPageContextValue>({
+  onOpen: () => {},
+  tree: undefined,
+});
+
+export function useChildPageContext(): ChildPageContextValue {
+  return useContext(ChildPageContext);
+}


### PR DESCRIPTION
## 이슈
closes #721

## 작업 내용
메모(Memo) 모듈 **M2**. 트리 드래그 이동·정렬과 인라인 하위 페이지를 붙이고 엣지 테스트를 보강했다. (Epic #718 · 선행 M0 #719, M1 #720)

### 트리 드래그 이동·정렬 (FE)
- `MemoTreeSidebar` 네이티브 HTML5 DnD — 행 상단/중앙/하단 = `before`/`inside`/`after`, 드롭 인디케이터(선·하이라이트)
- `treeMove.ts`의 `computeMove` 순수 로직 — 순환(자기·자손을 부모로) 방지, 형제 재배치 계산, 무변화 no-op
- `useMoveMemo` — 새 부모의 자식 순서를 `sortOrder` 0..n으로 순차 PATCH, 드래그 노드는 `parentId`까지 (BE 단건 PATCH만 지원)

### childPage 일반화 → 메모 인라인 하위 페이지
- note 전용 결합(`materialId` 기반 라이브 제목)을 **`ChildPageContext`** 로 분리 — `onOpen`·트리를 주입식으로 바꿔 note/memo 공용화. **노트 동작·직렬화는 그대로**(노트 테스트 전부 통과)
- `MemoEditor`에 childPage 활성화: 도구모음 `[페이지]`로 하위 메모 생성 + 본문 블록 삽입, 블록 제거 시 삭제 확인, 트리에서 라이브 제목 보강

### BE 정렬 엣지 테스트
- `sortOrder` 변경이 트리 정렬에 반영 / `parentId`+`sortOrder` 동시 이동이 트리에 반영

### 결정 반영
- 선택 상태 URL: **`?memo=id` query param 유지** (path param 대비 단순, 추가 작업 없음)
- 이미지 업로드: member 단위 저장이라 노트 엔드포인트 공유 유지

## 테스트
- FE: `computeMove` 8종, `useMoveMemo` 배치 PATCH, childPage 생성·이동 통합 등 — 전체 **245개 통과**, 노트 회귀 없음, tsc·eslint·prettier·build 통과
- BE: MemoControllerTest **17종**(정렬 2종 추가) + checkstyle 통과

## 확인 안 된 것 (후속)
- **실제 브라우저 확인**(드래그 제스처·반응형·다크모드): 로컬 BE 스택 미기동으로 이번에도 미실행. 드래그는 jsdom이 제스처를 재현 못 해 `computeMove`/`useMoveMemo` 단위·훅 테스트로 대체 검증. **네이티브 HTML5 DnD라 모바일 터치 드래그는 미지원**(데스크톱 기능). 반응형·다크모드는 노트와 동일 디자인 토큰·클래스 재사용.