### PR TITLE
fix : 키네틱 로고 회전 피벗을 링 중심으로 (transform-box)

### DIFF
--- a/fe/src/components/brand/Logo.tsx
+++ b/fe/src/components/brand/Logo.tsx
@@ -52,6 +52,9 @@ export function BrandMark({
   const spin: React.CSSProperties | undefined =
     animated && !reduce
       ? {
+          // transform-box를 view-box로 고정해야 origin이 뷰박스 좌표(링 중심)로 잡힌다.
+          // 없으면 회전 그룹 자신의 bbox(상단의 점) 기준이라 점이 위쪽에서 도는 것처럼 보인다.
+          transformBox: "view-box",
           transformOrigin: "49.14px 50.86px",
           animation: "orino-orbit 3.4s linear infinite",
         }


### PR DESCRIPTION
## 이슈
closes #732 (키네틱 #730 후속)

## 증상
로딩 화면의 키네틱 궤도(`<BrandMark animated>`)가 링 중심이 아니라 점이 있는 **상단에서 회전**.

## 원인
회전 그룹에 `transform-origin: 49.14px 50.86px`(링 중심)만 주고 `transform-box`를 지정하지 않아, 브라우저가 origin을 뷰박스(0~100)가 아니라 **회전 그룹 자신의 bbox(=상단의 점 위치)** 기준으로 해석 → 피벗이 위쪽에 잡힘.

## 해결
`spin`에 **`transform-box: view-box`** 추가 → origin이 뷰박스 좌표(링 중심 49.14,50.86)로 고정되어 점이 중심 둘레를 정상 공전.

## 검증
- tsc·eslint·build 클린(빌드 JS에 transformBox 반영), Logo 6 테스트 통과
- 정적 마크·좌표 변화 없음(animated 회전 피벗만 교정)