### PR TITLE
feat : 월간 목표 BE — monthly_goal 테이블 + 조회/upsert/삭제 API (PLN-008)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/controller/MonthlyGoalController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/controller/MonthlyGoalController.java
@@ -1,0 +1,51 @@
+package ds.project.orino.planner.goal.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.goal.dto.MonthlyGoalRequest;
+import ds.project.orino.planner.goal.dto.MonthlyGoalResponse;
+import ds.project.orino.planner.goal.service.MonthlyGoalService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/planner/monthly-goals")
+public class MonthlyGoalController {
+
+    private final MonthlyGoalService monthlyGoalService;
+
+    public MonthlyGoalController(MonthlyGoalService monthlyGoalService) {
+        this.monthlyGoalService = monthlyGoalService;
+    }
+
+    @GetMapping("/{year}/{month}")
+    public ApiResponse<MonthlyGoalResponse> get(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable int year,
+            @PathVariable int month) {
+        return ApiResponse.success(monthlyGoalService.find(memberId, year, month));
+    }
+
+    @PutMapping("/{year}/{month}")
+    public ApiResponse<MonthlyGoalResponse> upsert(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable int year,
+            @PathVariable int month,
+            @RequestBody MonthlyGoalRequest request) {
+        return ApiResponse.success(monthlyGoalService.upsert(memberId, year, month, request));
+    }
+
+    @DeleteMapping("/{year}/{month}")
+    public ApiResponse<Void> delete(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable int year,
+            @PathVariable int month) {
+        monthlyGoalService.delete(memberId, year, month);
+        return ApiResponse.success(null);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/MonthlyGoalRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/MonthlyGoalRequest.java
@@ -1,0 +1,5 @@
+package ds.project.orino.planner.goal.dto;
+
+/** 월간 목표 upsert 요청. content 검증은 서비스에서 수행한다(1~1000자·공백만 불가). */
+public record MonthlyGoalRequest(String content) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/MonthlyGoalResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/dto/MonthlyGoalResponse.java
@@ -1,0 +1,17 @@
+package ds.project.orino.planner.goal.dto;
+
+import ds.project.orino.domain.planner.goal.entity.MonthlyGoal;
+
+import java.time.Instant;
+
+public record MonthlyGoalResponse(
+        int year,
+        int month,
+        String content,
+        Instant updatedAt
+) {
+    public static MonthlyGoalResponse of(MonthlyGoal goal) {
+        return new MonthlyGoalResponse(
+                goal.getYear(), goal.getMonth(), goal.getContent(), goal.getUpdatedAt());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/service/MonthlyGoalService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/goal/service/MonthlyGoalService.java
@@ -1,0 +1,63 @@
+package ds.project.orino.planner.goal.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.goal.entity.MonthlyGoal;
+import ds.project.orino.domain.planner.goal.repository.MonthlyGoalRepository;
+import ds.project.orino.planner.goal.dto.MonthlyGoalRequest;
+import ds.project.orino.planner.goal.dto.MonthlyGoalResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MonthlyGoalService {
+
+    private static final int MAX_CONTENT_LENGTH = 1000;
+
+    private final MonthlyGoalRepository repository;
+
+    public MonthlyGoalService(MonthlyGoalRepository repository) {
+        this.repository = repository;
+    }
+
+    /** 조회. 없으면 null(응답 data:null). */
+    public MonthlyGoalResponse find(Long memberId, int year, int month) {
+        return repository.findByMemberIdAndYearAndMonth(memberId, year, month)
+                .map(MonthlyGoalResponse::of)
+                .orElse(null);
+    }
+
+    /** upsert. 있으면 content 갱신, 없으면 생성. */
+    @Transactional
+    public MonthlyGoalResponse upsert(Long memberId, int year, int month,
+                                      MonthlyGoalRequest request) {
+        validateMonth(month);
+        String content = request.content();
+        if (content == null || content.isBlank() || content.length() > MAX_CONTENT_LENGTH) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        MonthlyGoal goal = repository.findByMemberIdAndYearAndMonth(memberId, year, month)
+                .orElse(null);
+        if (goal == null) {
+            goal = repository.save(new MonthlyGoal(memberId, year, month, content));
+        } else {
+            goal.updateContent(content);
+        }
+        return MonthlyGoalResponse.of(goal);
+    }
+
+    /** 삭제. 없어도 성공(idempotent). */
+    @Transactional
+    public void delete(Long memberId, int year, int month) {
+        repository.findByMemberIdAndYearAndMonth(memberId, year, month)
+                .ifPresent(repository::delete);
+    }
+
+    private void validateMonth(int month) {
+        if (month < 1 || month > 12) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+}

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/032-create-monthly-goal.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/032-create-monthly-goal.yaml
@@ -1,0 +1,61 @@
+databaseChangeLog:
+  - changeSet:
+      id: 032-create-monthly-goal
+      author: wcorn
+      comment: |
+        월간 목표(monthly_goal) — (member, year, month)당 자유 텍스트 목표 1개 (PLN-008).
+        year/month는 SMALLINT/TINYINT 대신 INT로 둔다(Hibernate validate 안전, 저장 차이 무의미).
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: monthly_goal
+      changes:
+        - createTable:
+            tableName: monthly_goal
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_monthly_goal_member
+                    references: member(id)
+              - column:
+                  name: year
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: month
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: content
+                  type: VARCHAR(1000)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+
+        # 년월당 1개 보장
+        - addUniqueConstraint:
+            tableName: monthly_goal
+            columnNames: member_id, year, month
+            constraintName: uq_monthly_goal_member_ym

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -61,3 +61,5 @@ databaseChangeLog:
       file: db/changelog/changes/030-day-plan-block-minutes.yaml
   - include:
       file: db/changelog/changes/031-create-memo.yaml
+  - include:
+      file: db/changelog/changes/032-create-monthly-goal.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/goal/controller/MonthlyGoalControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/goal/controller/MonthlyGoalControllerTest.java
@@ -1,0 +1,167 @@
+package ds.project.orino.planner.goal.controller;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.goal.entity.MonthlyGoal;
+import ds.project.orino.domain.planner.goal.repository.MonthlyGoalRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MonthlyGoalControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MonthlyGoalRepository monthlyGoalRepository;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Member member;
+    private Member otherMember;
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        member = memberRepository.save(MemberFixture.create());
+        otherMember = memberRepository.save(MemberFixture.create("other", "password"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    @Test
+    @DisplayName("GET - 목표가 없으면 data:null")
+    void get_none_returns_null() throws Exception {
+        mockMvc.perform(get("/api/planner/monthly-goals/{y}/{m}", 2026, 7)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("PUT - 신규 생성 후 GET으로 조회된다")
+    void upsert_creates() throws Exception {
+        mockMvc.perform(put("/api/planner/monthly-goals/{y}/{m}", 2026, 7)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\": \"운동 꾸준히\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.year").value(2026))
+                .andExpect(jsonPath("$.data.month").value(7))
+                .andExpect(jsonPath("$.data.content").value("운동 꾸준히"));
+
+        mockMvc.perform(get("/api/planner/monthly-goals/{y}/{m}", 2026, 7)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.content").value("운동 꾸준히"));
+    }
+
+    @Test
+    @DisplayName("PUT - 같은 년월 재요청은 같은 행을 갱신한다(중복 생성 없음)")
+    void upsert_updates_same_row() throws Exception {
+        upsertGoal(2026, 7, "첫 목표");
+        upsertGoal(2026, 7, "바뀐 목표");
+
+        mockMvc.perform(get("/api/planner/monthly-goals/{y}/{m}", 2026, 7)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.content").value("바뀐 목표"));
+        assertThat(monthlyGoalRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("PUT - 공백만 있는 content는 400")
+    void upsert_blank_400() throws Exception {
+        mockMvc.perform(put("/api/planner/monthly-goals/{y}/{m}", 2026, 7)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\": \"   \"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("PUT - 1000자 초과 content는 400")
+    void upsert_too_long_400() throws Exception {
+        String tooLong = "가".repeat(1001);
+        mockMvc.perform(put("/api/planner/monthly-goals/{y}/{m}", 2026, 7)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\": \"" + tooLong + "\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PUT - month 범위(1~12) 위반은 400")
+    void upsert_month_out_of_range_400() throws Exception {
+        mockMvc.perform(put("/api/planner/monthly-goals/{y}/{m}", 2026, 13)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\": \"목표\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("DELETE - 목표를 제거하면 GET은 null")
+    void delete_removes() throws Exception {
+        upsertGoal(2026, 7, "지울 목표");
+
+        mockMvc.perform(delete("/api/planner/monthly-goals/{y}/{m}", 2026, 7)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/planner/monthly-goals/{y}/{m}", 2026, 7)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("DELETE - 목표가 없어도 200(idempotent)")
+    void delete_idempotent() throws Exception {
+        mockMvc.perform(delete("/api/planner/monthly-goals/{y}/{m}", 2026, 7)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("타인 격리 - 다른 멤버의 목표는 보이지 않고 각자 저장된다")
+    void isolation_between_members() throws Exception {
+        // 타인이 같은 년월에 목표 저장
+        monthlyGoalRepository.save(new MonthlyGoal(otherMember.getId(), 2026, 7, "남의 목표"));
+
+        // 내 조회는 null
+        mockMvc.perform(get("/api/planner/monthly-goals/{y}/{m}", 2026, 7)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        // 내가 같은 년월에 저장 → 별도 행
+        upsertGoal(2026, 7, "내 목표");
+        mockMvc.perform(get("/api/planner/monthly-goals/{y}/{m}", 2026, 7)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.content").value("내 목표"));
+        assertThat(monthlyGoalRepository.count()).isEqualTo(2);
+    }
+
+    private void upsertGoal(int year, int month, String content) throws Exception {
+        mockMvc.perform(put("/api/planner/monthly-goals/{y}/{m}", year, month)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\": \"" + content + "\"}"))
+                .andExpect(status().isOk());
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
@@ -14,6 +14,8 @@ public class DbCleaner {
             "review_schedule",
             "flashcard",
             "note",
+            "memo",
+            "monthly_goal",
             "study_material",
             "google_account",
             "member"

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/goal/entity/MonthlyGoal.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/goal/entity/MonthlyGoal.java
@@ -1,0 +1,87 @@
+package ds.project.orino.domain.planner.goal.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+/** 월간 목표: (member, year, month)당 자유 텍스트 목표 1개. */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "monthly_goal")
+public class MonthlyGoal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private Integer year;
+
+    @Column(nullable = false)
+    private Integer month;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected MonthlyGoal() {
+    }
+
+    public MonthlyGoal(Long memberId, int year, int month, String content) {
+        this.memberId = memberId;
+        this.year = year;
+        this.month = month;
+        this.content = content;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Integer getYear() {
+        return year;
+    }
+
+    public Integer getMonth() {
+        return month;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/goal/repository/MonthlyGoalRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/goal/repository/MonthlyGoalRepository.java
@@ -1,0 +1,11 @@
+package ds.project.orino.domain.planner.goal.repository;
+
+import ds.project.orino.domain.planner.goal.entity.MonthlyGoal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MonthlyGoalRepository extends JpaRepository<MonthlyGoal, Long> {
+
+    Optional<MonthlyGoal> findByMemberIdAndYearAndMonth(Long memberId, int year, int month);
+}


### PR DESCRIPTION
## 이슈
closes #736

## 작업 내용
월간 목표(Monthly Goal, PLN-008) **BE**. (member, year, month)당 자유 텍스트 목표 1개를 저장한다.

- `domain.planner.goal` — `MonthlyGoal` 엔티티 + `MonthlyGoalRepository`(member·year·month 단건 조회), JPA Auditing
- `planner.goal` — `MonthlyGoalService`(find/upsert/delete) + `MonthlyGoalController` + DTO
  - `GET /api/planner/monthly-goals/{year}/{month}` — 있으면 목표, 없으면 **`data: null`**
  - `PUT /api/planner/monthly-goals/{year}/{month}` — upsert(있으면 갱신, 없으면 생성). `content` 1~1000자·공백만 불가 → **400**, `month` 1~12 위반 → **400**
  - `DELETE /api/planner/monthly-goals/{year}/{month}` — **idempotent 200**(없어도 200)
- Liquibase `032-create-monthly-goal.yaml` — member FK, **UNIQUE(member_id, year, month)**(년월당 1개)

## 설계 대비 결정
- `year`/`month`를 스펙의 **SMALLINT/TINYINT 대신 INT**로 저장 — Hibernate `validate` 엄격성(과거 BOOLEAN→BIT 사례) 회피, 저장 차이는 무의미. month 범위(1~12)는 서비스에서 검증.
- 검증 실패 코드는 planner 도메인의 `INVALID_REQUEST`(SP-ERR-002, 400) 사용.

## 테스트
- MockMvc + TestContainers 통합 **9종**: GET 없음(null)·upsert 신규/갱신(중복 행 없음)·공백 400·1000자 초과 400·month 범위 400·DELETE 제거·DELETE idempotent·타인 격리
- `:orino-app-api:test` 전체 + checkstyle 통과, 실제 MySQL 8.4.4에서 liquibase 032 적용 실증
- 부수: `DbCleaner`에 `memo`·`monthly_goal` 추가(기존 누락으로 테스트 간 행 누적 → 전역 count 검증이 오염되던 문제 해소)