### PR TITLE
feat : 월간 목표 FE — 월 뷰 헤더 인라인 표시·편집 (PLN-008)

### DIFF
--- a/fe/src/features/planner/api/monthlyGoal.ts
+++ b/fe/src/features/planner/api/monthlyGoal.ts
@@ -1,0 +1,45 @@
+import { client } from "@/shared/api";
+
+export interface MonthlyGoal {
+  year: number;
+  month: number;
+  content: string;
+  updatedAt: string;
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+/** 해당 년월 목표 조회. 없으면 null. */
+export async function fetchMonthlyGoal(
+  year: number,
+  month: number,
+): Promise<MonthlyGoal | null> {
+  const { data } = await client.get<ApiEnvelope<MonthlyGoal | null>>(
+    `/planner/monthly-goals/${year}/${month}`,
+  );
+  return data.data;
+}
+
+/** upsert(PUT). content 1~1000자·공백만 불가는 BE가 검증. */
+export async function saveMonthlyGoal(
+  year: number,
+  month: number,
+  content: string,
+): Promise<MonthlyGoal> {
+  const { data } = await client.put<ApiEnvelope<MonthlyGoal>>(
+    `/planner/monthly-goals/${year}/${month}`,
+    { content },
+  );
+  return data.data;
+}
+
+/** 삭제(idempotent). */
+export async function deleteMonthlyGoal(
+  year: number,
+  month: number,
+): Promise<void> {
+  await client.delete(`/planner/monthly-goals/${year}/${month}`);
+}

--- a/fe/src/features/planner/components/calendar/MonthlyGoalInline.test.tsx
+++ b/fe/src/features/planner/components/calendar/MonthlyGoalInline.test.tsx
@@ -1,0 +1,129 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { MonthlyGoalInline } from "./MonthlyGoalInline";
+
+const API_BASE = "https://api.orino.dev/api";
+
+interface StoredGoal {
+  year: number;
+  month: number;
+  content: string;
+  updatedAt: string;
+}
+
+/** GET/PUT/DELETE를 하나의 가변 저장소로 묶어 실제 upsert/삭제 흐름을 흉내낸다. */
+function mockGoalStore(initial: StoredGoal | null) {
+  let stored = initial;
+  const puts: string[] = [];
+  let deleted = false;
+  server.use(
+    http.get(`${API_BASE}/planner/monthly-goals/:year/:month`, () =>
+      HttpResponse.json({ code: "OK", data: stored }),
+    ),
+    http.put(
+      `${API_BASE}/planner/monthly-goals/:year/:month`,
+      async ({ request, params }) => {
+        const body = (await request.json()) as { content: string };
+        puts.push(body.content);
+        stored = {
+          year: Number(params.year),
+          month: Number(params.month),
+          content: body.content,
+          updatedAt: "2026-07-05T10:00:00",
+        };
+        return HttpResponse.json({ code: "OK", data: stored });
+      },
+    ),
+    http.delete(`${API_BASE}/planner/monthly-goals/:year/:month`, () => {
+      deleted = true;
+      stored = null;
+      return HttpResponse.json({ code: "OK", data: null });
+    }),
+  );
+  return {
+    puts,
+    wasDeleted: () => deleted,
+  };
+}
+
+describe("MonthlyGoalInline", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+  });
+
+  it("목표가 없으면 플레이스홀더를 보여준다", async () => {
+    mockGoalStore(null);
+    renderWithRouter(<MonthlyGoalInline year={2026} month={7} />);
+    expect(
+      await screen.findByRole("button", { name: "이번 달 목표 추가" }),
+    ).toBeInTheDocument();
+  });
+
+  it("플레이스홀더에서 목표를 입력·저장하면 PUT 후 목표가 표시된다", async () => {
+    const store = mockGoalStore(null);
+    const user = userEvent.setup();
+    renderWithRouter(<MonthlyGoalInline year={2026} month={7} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "이번 달 목표 추가" }),
+    );
+    await user.type(
+      await screen.findByLabelText("이번 달 목표 내용"),
+      "책 2권 읽기",
+    );
+    await user.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() => expect(store.puts).toContain("책 2권 읽기"));
+    expect(
+      await screen.findByRole("button", { name: /이번 달 목표: 책 2권 읽기/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("기존 목표를 [삭제]하면 DELETE 후 플레이스홀더로 돌아간다", async () => {
+    const store = mockGoalStore({
+      year: 2026,
+      month: 7,
+      content: "운동 꾸준히",
+      updatedAt: "2026-07-01T00:00:00",
+    });
+    const user = userEvent.setup();
+    renderWithRouter(<MonthlyGoalInline year={2026} month={7} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: /이번 달 목표: 운동 꾸준히/ }),
+    );
+    await user.click(await screen.findByRole("button", { name: "삭제" }));
+
+    await waitFor(() => expect(store.wasDeleted()).toBe(true));
+    expect(
+      await screen.findByRole("button", { name: "이번 달 목표 추가" }),
+    ).toBeInTheDocument();
+  });
+
+  it("내용을 비우고 저장하면 DELETE를 호출한다", async () => {
+    const store = mockGoalStore({
+      year: 2026,
+      month: 7,
+      content: "지울 목표",
+      updatedAt: "2026-07-01T00:00:00",
+    });
+    const user = userEvent.setup();
+    renderWithRouter(<MonthlyGoalInline year={2026} month={7} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: /이번 달 목표: 지울 목표/ }),
+    );
+    await user.clear(await screen.findByLabelText("이번 달 목표 내용"));
+    await user.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() => expect(store.wasDeleted()).toBe(true));
+    expect(store.puts).toHaveLength(0);
+  });
+});

--- a/fe/src/features/planner/components/calendar/MonthlyGoalInline.tsx
+++ b/fe/src/features/planner/components/calendar/MonthlyGoalInline.tsx
@@ -1,0 +1,117 @@
+import { Popover } from "@base-ui/react/popover";
+import { Plus, Target } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+import { useMonthlyGoal } from "../../hooks/useMonthlyGoal";
+import { useMonthlyGoalMutations } from "../../hooks/useMonthlyGoalMutations";
+
+interface Props {
+  year: number;
+  month: number;
+}
+
+/**
+ * 월 뷰 헤더 년월 옆 인라인 월간 목표. 없으면 플레이스홀더, 있으면 아이콘+말줄임.
+ * 클릭 시 팝오버(textarea)로 편집한다. 내용을 비우고 저장하면 삭제한다.
+ */
+export function MonthlyGoalInline({ year, month }: Props) {
+  const { data: goal } = useMonthlyGoal(year, month);
+  const { save, remove } = useMonthlyGoalMutations(year, month);
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  // 팝오버 열 때 현재 목표로 초기화
+  const handleOpenChange = (next: boolean) => {
+    if (next) setDraft(goal?.content ?? "");
+    setOpen(next);
+  };
+
+  const handleSave = () => {
+    if (draft.trim().length === 0) {
+      // 비우고 저장 → 기존 목표 삭제(없으면 그냥 닫기)
+      if (goal) remove.mutate(undefined, { onSuccess: () => setOpen(false) });
+      else setOpen(false);
+      return;
+    }
+    save.mutate(draft, { onSuccess: () => setOpen(false) });
+  };
+
+  const handleDelete = () => {
+    remove.mutate(undefined, { onSuccess: () => setOpen(false) });
+  };
+
+  const pending = save.isPending || remove.isPending;
+  const failed = save.isError || remove.isError;
+
+  return (
+    <Popover.Root open={open} onOpenChange={handleOpenChange}>
+      <Popover.Trigger
+        render={
+          goal ? (
+            <button
+              type="button"
+              aria-label={`이번 달 목표: ${goal.content}`}
+              title={goal.content}
+              className="text-foreground/80 hover:bg-muted flex max-w-[10rem] items-center gap-1.5 rounded-md px-2 py-1 text-sm sm:max-w-[16rem]"
+            >
+              <Target className="text-primary size-3.5 shrink-0" />
+              <span className="truncate">{goal.content}</span>
+            </button>
+          ) : (
+            <button
+              type="button"
+              aria-label="이번 달 목표 추가"
+              className="text-muted-foreground hover:bg-muted hover:text-foreground flex items-center gap-1 rounded-md px-2 py-1 text-sm"
+            >
+              <Plus className="size-3.5" /> 이번 달 목표
+            </button>
+          )
+        }
+      />
+      <Popover.Portal>
+        <Popover.Positioner sideOffset={6} align="start" className="z-50">
+          <Popover.Popup className="bg-popover text-popover-foreground w-72 rounded-md border p-3 shadow-md">
+            <p className="text-muted-foreground mb-1.5 text-xs font-medium">
+              {year}년 {month}월 목표
+            </p>
+            <Textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              rows={3}
+              maxLength={1000}
+              autoFocus
+              aria-label="이번 달 목표 내용"
+              placeholder="이번 달 목표를 적어보세요"
+            />
+            {failed && (
+              <p className="text-destructive mt-1 text-xs">
+                저장에 실패했어요. 다시 시도해 주세요.
+              </p>
+            )}
+            <div className="mt-2 flex items-center justify-between gap-2">
+              {goal ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-destructive"
+                  disabled={pending}
+                  onClick={handleDelete}
+                >
+                  삭제
+                </Button>
+              ) : (
+                <span />
+              )}
+              <Button size="sm" disabled={pending} onClick={handleSave}>
+                저장
+              </Button>
+            </div>
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.test.tsx
@@ -270,6 +270,25 @@ describe("PlannerCalendar", () => {
     expect(await screen.findByText("회의")).toBeInTheDocument();
   });
 
+  it("월 뷰에서만 월간 목표 인라인을 노출한다", async () => {
+    mockFeed({});
+
+    renderWithRouter(<PlannerCalendar />);
+
+    // 월 뷰(기본)에서 목표 플레이스홀더 노출
+    expect(
+      await screen.findByRole("button", { name: "이번 달 목표 추가" }),
+    ).toBeInTheDocument();
+
+    // 주 뷰로 전환하면 사라진다
+    await userEvent.click(screen.getByRole("button", { name: "주" }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "이번 달 목표 추가" }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
   it("주 뷰 빈 시간대 클릭 시 그 시각으로 생성 다이얼로그가 열린다", async () => {
     mockGoogleConnected(true);
     mockFeed({ googleConnected: true });

--- a/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
+++ b/fe/src/features/planner/components/calendar/PlannerCalendar.tsx
@@ -31,6 +31,7 @@ import {
 import { weekDays } from "../../weekLayout";
 import { TodayRoutines } from "../routine/TodayRoutines";
 import { EventFormDialog } from "./EventFormDialog";
+import { MonthlyGoalInline } from "./MonthlyGoalInline";
 import { PlannerCalendarCell } from "./PlannerCalendarCell";
 import { PlannerCalendarLegend } from "./PlannerCalendarLegend";
 import { PlannerConnectionBanner } from "./PlannerConnectionBanner";
@@ -151,6 +152,13 @@ export function PlannerCalendar() {
           >
             <ChevronRight className="size-4" />
           </Button>
+          {/* 월 뷰에서만 년월 옆에 그 달 목표를 인라인 표시·편집 */}
+          {view === "month" && (
+            <MonthlyGoalInline
+              year={cursor.getFullYear()}
+              month={cursor.getMonth() + 1}
+            />
+          )}
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <div className="flex gap-1">

--- a/fe/src/features/planner/hooks/useMonthlyGoal.ts
+++ b/fe/src/features/planner/hooks/useMonthlyGoal.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchMonthlyGoal } from "../api/monthlyGoal";
+import { monthlyGoalKeys } from "../queryKeys";
+
+/** 해당 년월 목표 조회(없으면 null). */
+export function useMonthlyGoal(year: number, month: number) {
+  return useQuery({
+    queryKey: monthlyGoalKeys.ym(year, month),
+    queryFn: () => fetchMonthlyGoal(year, month),
+  });
+}

--- a/fe/src/features/planner/hooks/useMonthlyGoalMutations.ts
+++ b/fe/src/features/planner/hooks/useMonthlyGoalMutations.ts
@@ -12,7 +12,9 @@ export function useMonthlyGoalMutations(year: number, month: number) {
   const queryClient = useQueryClient();
 
   const invalidate = () =>
-    queryClient.invalidateQueries({ queryKey: monthlyGoalKeys.ym(year, month) });
+    queryClient.invalidateQueries({
+      queryKey: monthlyGoalKeys.ym(year, month),
+    });
 
   const save = useMutation<MonthlyGoal, Error, string>({
     mutationFn: (content) => saveMonthlyGoal(year, month, content),

--- a/fe/src/features/planner/hooks/useMonthlyGoalMutations.ts
+++ b/fe/src/features/planner/hooks/useMonthlyGoalMutations.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  deleteMonthlyGoal,
+  type MonthlyGoal,
+  saveMonthlyGoal,
+} from "../api/monthlyGoal";
+import { monthlyGoalKeys } from "../queryKeys";
+
+/** 해당 년월 목표 저장(PUT)·삭제. 성공 시 그 년월 캐시를 무효화한다. */
+export function useMonthlyGoalMutations(year: number, month: number) {
+  const queryClient = useQueryClient();
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: monthlyGoalKeys.ym(year, month) });
+
+  const save = useMutation<MonthlyGoal, Error, string>({
+    mutationFn: (content) => saveMonthlyGoal(year, month, content),
+    onSuccess: invalidate,
+  });
+
+  const remove = useMutation<void, Error, void>({
+    mutationFn: () => deleteMonthlyGoal(year, month),
+    onSuccess: invalidate,
+  });
+
+  return { save, remove };
+}

--- a/fe/src/features/planner/queryKeys.ts
+++ b/fe/src/features/planner/queryKeys.ts
@@ -14,3 +14,8 @@ export const holidayKeys = {
   all: ["holiday"] as const,
   range: (from: string, to: string) => ["holiday", from, to] as const,
 };
+
+export const monthlyGoalKeys = {
+  all: ["monthlyGoal"] as const,
+  ym: (year: number, month: number) => ["monthlyGoal", year, month] as const,
+};

--- a/fe/src/test/mocks/handlers.ts
+++ b/fe/src/test/mocks/handlers.ts
@@ -69,4 +69,9 @@ export const handlers = [
   http.get(`${API_BASE}/planner/holidays`, () => {
     return HttpResponse.json({ code: "OK", data: [] });
   }),
+
+  // 기본값: 월간 목표 없음. 목표를 검증하는 테스트는 server.use로 덮어쓴다.
+  http.get(`${API_BASE}/planner/monthly-goals/:year/:month`, () => {
+    return HttpResponse.json({ code: "OK", data: null });
+  }),
 ];


### PR DESCRIPTION
## 이슈
closes #737

## 작업 내용
월간 목표(Monthly Goal, PLN-008) **FE**. 통합 캘린더 **월 뷰** 헤더의 년월 제목 오른쪽에 그 달 목표를 인라인으로 표시·편집한다. (선행 BE #736)

- `api/monthlyGoal.ts` — `fetchMonthlyGoal` / `saveMonthlyGoal`(PUT) / `deleteMonthlyGoal`
- `useMonthlyGoal(year, month)` + `useMonthlyGoalMutations`(저장/삭제 → 해당 년월 캐시 무효화)
- `MonthlyGoalInline` — base-ui **Popover + textarea** 편집
  - 목표 없음 → `＋ 이번 달 목표` 플레이스홀더 / 있음 → 아이콘 + 말줄임(hover 시 전체 `title`)
  - `[저장]`(PUT) · `[삭제]`(DELETE), **내용 비우고 저장 → DELETE**, 실패 시 팝오버 유지(내용 보존), 1000자 `maxLength`
- `PlannerCalendar` 월 뷰 헤더 년월 옆에 배선 — **`view === "month"` 한정**, 커서 년/월 전달(월 이동 시 재로드), 헤더 flex 그룹 내 배치(좁으면 wrap)

## 테스트
- `MonthlyGoalInline` 통합 4종: 플레이스홀더 / 입력·저장(PUT 후 표시) / 삭제(DELETE→플레이스홀더) / 비우고 저장→DELETE
- `PlannerCalendar` 1종: **월 뷰에서만 노출**(주 뷰 전환 시 사라짐)
- 전체 **252개 통과**, tsc·eslint·prettier·build 통과
- `handlers`에 monthly-goals 기본값(data:null) 추가(기존 캘린더 테스트 무해)

## 확인 안 된 것 (후속)
- **실제 브라우저 확인**(팝오버 위치·반응형·다크모드): 로컬 BE 스택 미기동으로 미실행. 실제 컴포넌트(base-ui Popover 포함)+네트워크 MSW 통합 테스트와 빌드로 대체 검증. 다크모드·레이아웃은 공통 토큰·컴포넌트 재사용.