### PR TITLE
feat : 순서 카드 BE — flashcard type/items 컬럼 + CRUD 검증 (SP v2.3)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardCreateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardCreateRequest.java
@@ -1,15 +1,29 @@
 package ds.project.orino.planner.flashcard.dto;
 
+import ds.project.orino.domain.planner.flashcard.entity.FlashcardType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+import java.util.List;
+
+/**
+ * 카드 생성 요청.
+ *
+ * <p>{@code type} 생략 시 BASIC. 종류별 제약(BASIC: back 필수 / ORDERING: items 3~7개)은
+ * 서비스에서 검증하며, 위반 시 {@code SP-ERR-002}(400)로 응답한다.
+ */
 public record FlashcardCreateRequest(
+        FlashcardType type,
+
         @NotBlank(message = "front는 비어 있을 수 없습니다.")
         @Size(min = 1, max = 1000, message = "front는 1~1000자여야 합니다.")
         String front,
 
-        @NotBlank(message = "back은 비어 있을 수 없습니다.")
-        @Size(min = 1, max = 1000, message = "back은 1~1000자여야 합니다.")
-        String back
+        String back,
+
+        List<OrderingItem> items
 ) {
+    public FlashcardType typeOrDefault() {
+        return type == null ? FlashcardType.BASIC : type;
+    }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardResponse.java
@@ -2,28 +2,30 @@ package ds.project.orino.planner.flashcard.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.entity.FlashcardType;
 import ds.project.orino.planner.review.dto.ReviewScheduleView;
 
 import java.time.Instant;
+import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record FlashcardResponse(
         Long id,
         Long materialId,
+        FlashcardType type,
         String front,
         String back,
+        List<OrderingItem> items,
         ReviewScheduleView nextReview,
         Instant createdAt
 ) {
-    public static FlashcardResponse of(Flashcard f, ReviewScheduleView nextReview) {
+    public static FlashcardResponse of(Flashcard f, List<OrderingItem> items, ReviewScheduleView nextReview) {
         return new FlashcardResponse(
-                f.getId(), f.getMaterialId(), f.getFront(), f.getBack(),
-                nextReview, f.getCreatedAt());
+                f.getId(), f.getMaterialId(), f.getType(), f.getFront(), f.getBack(),
+                items, nextReview, f.getCreatedAt());
     }
 
-    public static FlashcardResponse withoutReview(Flashcard f) {
-        return new FlashcardResponse(
-                f.getId(), f.getMaterialId(), f.getFront(), f.getBack(),
-                null, f.getCreatedAt());
+    public static FlashcardResponse withoutReview(Flashcard f, List<OrderingItem> items) {
+        return of(f, items, null);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardUpdateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardUpdateRequest.java
@@ -1,12 +1,24 @@
 package ds.project.orino.planner.flashcard.dto;
 
+import ds.project.orino.domain.planner.flashcard.entity.FlashcardType;
 import jakarta.validation.constraints.Size;
 
+import java.util.List;
+
+/**
+ * 카드 부분 수정 요청.
+ *
+ * <p>{@code type}이 있으면 해당 종류로 전환하며, 전환 후 상태가 대상 종류 제약을 만족해야 한다.
+ * 종류별 제약 위반 시 {@code SP-ERR-002}(400)로 응답한다.
+ */
 public record FlashcardUpdateRequest(
+        FlashcardType type,
+
         @Size(min = 1, max = 1000, message = "front는 1~1000자여야 합니다.")
         String front,
 
-        @Size(min = 1, max = 1000, message = "back은 1~1000자여야 합니다.")
-        String back
+        String back,
+
+        List<OrderingItem> items
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/OrderingItem.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/OrderingItem.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.flashcard.dto;
+
+/**
+ * 순서 카드의 항목. 배열의 순서 자체가 정답 순서이며, 정답을 별도로 저장하지 않는다.
+ *
+ * @param id   드래그 안정 키(FE 생성). 카드 내에서 유일해야 한다.
+ * @param text 항목 표시 텍스트(1~1000자).
+ */
+public record OrderingItem(
+        String id,
+        String text
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/service/FlashcardItemsCodec.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/service/FlashcardItemsCodec.java
@@ -1,0 +1,47 @@
+package ds.project.orino.planner.flashcard.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.flashcard.dto.OrderingItem;
+import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.List;
+
+/**
+ * 순서 카드 항목(List&lt;OrderingItem&gt;) ↔ JSON 문자열 직렬화. 저장 시 항상 정답 순서를 유지한다.
+ * ({@code note.content}와 동일하게 원문 JSON 문자열을 엔티티에 보관하는 패턴)
+ */
+@Component
+public class FlashcardItemsCodec {
+
+    private static final JsonMapper MAPPER = JsonMapper.builder().build();
+    private static final TypeReference<List<OrderingItem>> LIST_TYPE = new TypeReference<>() {
+    };
+
+    /** 항목 리스트를 JSON 문자열로 직렬화한다. null이면 null(=BASIC 카드). */
+    public String serialize(List<OrderingItem> items) {
+        if (items == null) {
+            return null;
+        }
+        try {
+            return MAPPER.writeValueAsString(items);
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST, e);
+        }
+    }
+
+    /** 저장된 JSON 문자열을 항목 리스트로 역직렬화한다. null이면 null(=BASIC 카드). */
+    public List<OrderingItem> parse(String json) {
+        if (json == null) {
+            return null;
+        }
+        try {
+            return MAPPER.readValue(json, LIST_TYPE);
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/service/FlashcardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/service/FlashcardService.java
@@ -3,6 +3,7 @@ package ds.project.orino.planner.flashcard.service;
 import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
 import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.entity.FlashcardType;
 import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
 import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
 import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
@@ -12,6 +13,7 @@ import ds.project.orino.planner.flashcard.dto.FlashcardCreateRequest;
 import ds.project.orino.planner.flashcard.dto.FlashcardCreateResponse;
 import ds.project.orino.planner.flashcard.dto.FlashcardResponse;
 import ds.project.orino.planner.flashcard.dto.FlashcardUpdateRequest;
+import ds.project.orino.planner.flashcard.dto.OrderingItem;
 import ds.project.orino.planner.review.dto.ReviewScheduleView;
 import ds.project.orino.planner.review.service.ReviewMirrorService;
 import ds.project.orino.core.time.UserTimeZone;
@@ -22,8 +24,12 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import static ds.project.orino.domain.planner.flashcard.entity.FlashcardType.ORDERING;
 
 @Service
 @Transactional(readOnly = true)
@@ -33,17 +39,20 @@ public class FlashcardService {
     private final ReviewScheduleRepository reviewScheduleRepository;
     private final StudyMaterialRepository studyMaterialRepository;
     private final ReviewMirrorService reviewMirrorService;
+    private final FlashcardItemsCodec itemsCodec;
     private final Clock clock;
 
     public FlashcardService(FlashcardRepository flashcardRepository,
                             ReviewScheduleRepository reviewScheduleRepository,
                             StudyMaterialRepository studyMaterialRepository,
                             ReviewMirrorService reviewMirrorService,
+                            FlashcardItemsCodec itemsCodec,
                             Clock clock) {
         this.flashcardRepository = flashcardRepository;
         this.reviewScheduleRepository = reviewScheduleRepository;
         this.studyMaterialRepository = studyMaterialRepository;
         this.reviewMirrorService = reviewMirrorService;
+        this.itemsCodec = itemsCodec;
         this.clock = clock;
     }
 
@@ -59,7 +68,8 @@ public class FlashcardService {
         return cards.stream()
                 .map(c -> {
                     ReviewSchedule next = nextReviewByCard.get(c.getId());
-                    return FlashcardResponse.of(c, next == null ? null : ReviewScheduleView.nextReview(next));
+                    return FlashcardResponse.of(c, itemsCodec.parse(c.getItems()),
+                            next == null ? null : ReviewScheduleView.nextReview(next));
                 })
                 .toList();
     }
@@ -68,8 +78,7 @@ public class FlashcardService {
     public FlashcardCreateResponse create(Long memberId, Long materialId, FlashcardCreateRequest request) {
         requireOwnedMaterial(memberId, materialId);
 
-        Flashcard saved = flashcardRepository.save(
-                new Flashcard(memberId, materialId, request.front(), request.back()));
+        Flashcard saved = flashcardRepository.save(buildCard(memberId, materialId, request));
         ZoneId zone = UserTimeZone.get();
         LocalDate today = clock.instant().atZone(zone).toLocalDate();
         ReviewSchedule firstReview = reviewScheduleRepository.save(
@@ -80,23 +89,74 @@ public class FlashcardService {
                 List.of(firstReview.getScheduledAt().atZone(zone).toLocalDate()), zone);
 
         return new FlashcardCreateResponse(
-                FlashcardResponse.withoutReview(saved),
+                FlashcardResponse.withoutReview(saved, itemsCodec.parse(saved.getItems())),
                 ReviewScheduleView.firstReview(firstReview));
     }
 
     @Transactional
     public FlashcardResponse update(Long memberId, Long flashcardId, FlashcardUpdateRequest request) {
-        if (request.front() == null && request.back() == null) {
+        if (request.type() == null && request.front() == null
+                && request.back() == null && request.items() == null) {
             throw new CustomException(ErrorCode.BAD_REQUEST);
         }
         Flashcard card = getOwnedFlashcard(memberId, flashcardId);
+
+        // type 생략 시 기존 종류 유지. 전환 시 대상 종류 제약을 만족해야 한다.
+        FlashcardType targetType = request.type() != null ? request.type() : card.getType();
+
         if (request.front() != null) {
             card.updateFront(request.front());
         }
-        if (request.back() != null) {
-            card.updateBack(request.back());
+        if (targetType == ORDERING) {
+            // items 미지정이면 기존 항목 유지. (BASIC→ORDERING 전환이면 기존 items가 없어 반드시 지정해야 함)
+            List<OrderingItem> items = request.items() != null
+                    ? request.items()
+                    : itemsCodec.parse(card.getItems());
+            validateOrdering(items);
+            card.changeToOrdering(itemsCodec.serialize(items));
+        } else {
+            // back 미지정이면 기존 back 유지. (ORDERING→BASIC 전환이면 기존 back이 없어 반드시 지정해야 함)
+            String back = request.back() != null ? request.back() : card.getBack();
+            validateBasicBack(back);
+            card.changeToBasic(back);
         }
-        return FlashcardResponse.withoutReview(card);
+        return FlashcardResponse.withoutReview(card, itemsCodec.parse(card.getItems()));
+    }
+
+    /** 종류별 제약을 검증하고 해당 종류의 카드 엔티티를 만든다. */
+    private Flashcard buildCard(Long memberId, Long materialId, FlashcardCreateRequest request) {
+        if (request.typeOrDefault() == ORDERING) {
+            validateOrdering(request.items());
+            return Flashcard.ordering(memberId, materialId, request.front(),
+                    itemsCodec.serialize(request.items()));
+        }
+        validateBasicBack(request.back());
+        return new Flashcard(memberId, materialId, request.front(), request.back());
+    }
+
+    /** BASIC: back 필수(1~1000자). 위반 시 SP-ERR-002. */
+    private static void validateBasicBack(String back) {
+        if (back == null || back.isBlank() || back.length() > 1000) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    /** ORDERING: items 3~7개, 각 text 1~1000자, id 카드 내 유일. 위반 시 SP-ERR-002. */
+    private static void validateOrdering(List<OrderingItem> items) {
+        if (items == null || items.size() < 3 || items.size() > 7) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        Set<String> ids = new HashSet<>();
+        for (OrderingItem item : items) {
+            if (item == null
+                    || item.id() == null || item.id().isBlank()
+                    || item.text() == null || item.text().isBlank() || item.text().length() > 1000) {
+                throw new CustomException(ErrorCode.INVALID_REQUEST);
+            }
+            if (!ids.add(item.id())) {
+                throw new CustomException(ErrorCode.INVALID_REQUEST);
+            }
+        }
     }
 
     @Transactional

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewFlashcard.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewFlashcard.java
@@ -1,14 +1,22 @@
 package ds.project.orino.planner.review.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.entity.FlashcardType;
+import ds.project.orino.planner.flashcard.dto.OrderingItem;
 
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record TodayReviewFlashcard(
         Long id,
+        FlashcardType type,
         String front,
         String back,
+        List<OrderingItem> items,
         TodayReviewMaterial material
 ) {
-    public static TodayReviewFlashcard of(Flashcard f, TodayReviewMaterial material) {
-        return new TodayReviewFlashcard(f.getId(), f.getFront(), f.getBack(), material);
+    public static TodayReviewFlashcard of(Flashcard f, List<OrderingItem> items, TodayReviewMaterial material) {
+        return new TodayReviewFlashcard(f.getId(), f.getType(), f.getFront(), f.getBack(), items, material);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
@@ -20,6 +20,7 @@ import ds.project.orino.planner.review.dto.TodayReviewItem;
 import ds.project.orino.planner.review.dto.TodayReviewMaterial;
 import ds.project.orino.planner.review.dto.TodayReviewsResponse;
 import ds.project.orino.planner.review.sm2.Sm2Calculator;
+import ds.project.orino.planner.flashcard.service.FlashcardItemsCodec;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,15 +44,18 @@ public class ReviewQueryService {
     private final ReviewScheduleRepository reviewScheduleRepository;
     private final FlashcardRepository flashcardRepository;
     private final StudyMaterialRepository studyMaterialRepository;
+    private final FlashcardItemsCodec itemsCodec;
     private final Clock clock;
 
     public ReviewQueryService(ReviewScheduleRepository reviewScheduleRepository,
                               FlashcardRepository flashcardRepository,
                               StudyMaterialRepository studyMaterialRepository,
+                              FlashcardItemsCodec itemsCodec,
                               Clock clock) {
         this.reviewScheduleRepository = reviewScheduleRepository;
         this.flashcardRepository = flashcardRepository;
         this.studyMaterialRepository = studyMaterialRepository;
+        this.itemsCodec = itemsCodec;
         this.clock = clock;
     }
 
@@ -142,7 +146,8 @@ public class ReviewQueryService {
                                    ZoneId zone) {
         Flashcard card = cardById.get(r.getFlashcardId());
         StudyMaterial material = materialById.get(card.getMaterialId());
-        TodayReviewFlashcard flashcardDto = TodayReviewFlashcard.of(card, TodayReviewMaterial.of(material));
+        TodayReviewFlashcard flashcardDto = TodayReviewFlashcard.of(
+                card, itemsCodec.parse(card.getItems()), TodayReviewMaterial.of(material));
         PreviewView preview = preview(r);
         int delayDays = (int) ChronoUnit.DAYS.between(r.getScheduledAt().atZone(zone).toLocalDate(), today);
         return new TodayReviewItem(

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/034-add-flashcard-type-items.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/034-add-flashcard-type-items.yaml
@@ -1,0 +1,57 @@
+databaseChangeLog:
+  # 순서 카드(Ordering Card) 도입 (#743, Epic #742, Study Planner v2.3).
+  # flashcard에 카드 종류(type)와 순서 항목(items JSON)을 추가하고, 순서 카드는
+  # back이 없으므로 back의 NOT NULL 제약을 완화한다. 기존 카드는 전부 BASIC/items=NULL로 무손실 유지.
+  - changeSet:
+      id: 034-add-flashcard-type
+      author: wcorn
+      comment: flashcard에 카드 종류(type) 추가. 기존 카드는 기본값 BASIC.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: flashcard
+                columnName: type
+      changes:
+        - addColumn:
+            tableName: flashcard
+            columns:
+              - column:
+                  name: type
+                  type: VARCHAR(10)
+                  defaultValue: BASIC
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 034-add-flashcard-items
+      author: wcorn
+      comment: 순서 카드 항목 배열(items JSON) 컬럼 추가. BASIC 카드는 NULL.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: flashcard
+                columnName: items
+      changes:
+        - addColumn:
+            tableName: flashcard
+            columns:
+              - column:
+                  name: items
+                  type: JSON
+
+  - changeSet:
+      id: 034-relax-flashcard-back-nullable
+      author: wcorn
+      comment: 순서 카드는 back이 없으므로 back의 NOT NULL 제약을 완화한다.
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: flashcard
+            columnName: back
+      changes:
+        - dropNotNullConstraint:
+            tableName: flashcard
+            columnName: back
+            columnDataType: VARCHAR(1000)

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -65,3 +65,5 @@ databaseChangeLog:
       file: db/changelog/changes/032-create-monthly-goal.yaml
   - include:
       file: db/changelog/changes/033-merge-memo-into-note.yaml
+  - include:
+      file: db/changelog/changes/034-add-flashcard-type-items.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/flashcard/controller/FlashcardControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/flashcard/controller/FlashcardControllerTest.java
@@ -298,4 +298,211 @@ class FlashcardControllerTest extends ApiTestSupport {
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
                 .andExpect(status().isNotFound());
     }
+
+    // ===== 순서 카드(ORDERING) =====
+
+    private static final String ORDERING_ITEMS_3 = """
+            [{"id":"a","text":"1단계"},{"id":"b","text":"2단계"},{"id":"c","text":"3단계"}]
+            """;
+
+    @Test
+    @DisplayName("POST ORDERING - 순서 카드 생성 + 첫 복습이 종류 무관하게 자동 생성")
+    void create_ordering_with_first_review() throws Exception {
+        LocalDate today = testToday(clock);
+
+        mockMvc.perform(post("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"type":"ORDERING","front":"순서대로 배열",
+                                 "items":[{"id":"a","text":"1단계"},{"id":"b","text":"2단계"},
+                                          {"id":"c","text":"3단계"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.flashcard.type").value("ORDERING"))
+                .andExpect(jsonPath("$.data.flashcard.front").value("순서대로 배열"))
+                .andExpect(jsonPath("$.data.flashcard.back").doesNotExist())
+                .andExpect(jsonPath("$.data.flashcard.items", hasSize(3)))
+                .andExpect(jsonPath("$.data.flashcard.items[0].id").value("a"))
+                .andExpect(jsonPath("$.data.flashcard.items[0].text").value("1단계"))
+                .andExpect(jsonPath("$.data.flashcard.items[2].id").value("c"))
+                // 첫 복습은 flashcard_id만 참조 → 종류 무관하게 동일하게 생성
+                .andExpect(jsonPath("$.data.firstReview.sequence").value(1))
+                .andExpect(jsonPath("$.data.firstReview.intervalDays").value(1))
+                .andExpect(jsonPath("$.data.firstReview.scheduledAt",
+                        startsWith(today.plusDays(1) + "T04:00")));
+    }
+
+    @Test
+    @DisplayName("POST ORDERING - items 3개 미만이면 400")
+    void create_ordering_too_few_items() throws Exception {
+        mockMvc.perform(post("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"type":"ORDERING","front":"F",
+                                 "items":[{"id":"a","text":"1"},{"id":"b","text":"2"}]}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("POST ORDERING - items 7개 초과면 400")
+    void create_ordering_too_many_items() throws Exception {
+        StringBuilder items = new StringBuilder("[");
+        for (int i = 0; i < 8; i++) {
+            if (i > 0) {
+                items.append(",");
+            }
+            items.append("{\"id\":\"i").append(i).append("\",\"text\":\"t").append(i).append("\"}");
+        }
+        items.append("]");
+
+        mockMvc.perform(post("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"type\":\"ORDERING\",\"front\":\"F\",\"items\":" + items + "}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("POST ORDERING - id가 카드 내에서 중복이면 400")
+    void create_ordering_duplicate_id() throws Exception {
+        mockMvc.perform(post("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"type":"ORDERING","front":"F",
+                                 "items":[{"id":"a","text":"1"},{"id":"a","text":"2"},{"id":"c","text":"3"}]}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("POST ORDERING - 항목 text가 빈 문자열이면 400")
+    void create_ordering_blank_item_text() throws Exception {
+        mockMvc.perform(post("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"type":"ORDERING","front":"F",
+                                 "items":[{"id":"a","text":""},{"id":"b","text":"2"},{"id":"c","text":"3"}]}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("POST BASIC - back이 없으면 400 (BASIC은 back 필수)")
+    void create_basic_without_back() throws Exception {
+        mockMvc.perform(post("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"type":"BASIC","front":"Q"}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("POST - type 생략 시 BASIC으로 저장된다")
+    void create_defaults_to_basic() throws Exception {
+        mockMvc.perform(post("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"front":"Q","back":"A"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.flashcard.type").value("BASIC"))
+                .andExpect(jsonPath("$.data.flashcard.items").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET - 순서 카드 목록은 type/items를 포함하고 back은 생략된다")
+    void list_includes_type_and_items() throws Exception {
+        flashcardRepository.save(
+                Flashcard.ordering(member.getId(), material.getId(), "순서", ORDERING_ITEMS_3.strip()));
+
+        mockMvc.perform(get("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.flashcards[0].type").value("ORDERING"))
+                .andExpect(jsonPath("$.data.flashcards[0].items", hasSize(3)))
+                .andExpect(jsonPath("$.data.flashcards[0].items[1].text").value("2단계"))
+                .andExpect(jsonPath("$.data.flashcards[0].back").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("PATCH ORDERING - 항목 재정렬이 저장 순서에 반영된다")
+    void update_ordering_reorder_items() throws Exception {
+        Flashcard card = flashcardRepository.save(
+                Flashcard.ordering(member.getId(), material.getId(), "순서", ORDERING_ITEMS_3.strip()));
+
+        mockMvc.perform(patch("/api/planner/flashcards/{id}", card.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"items":[{"id":"c","text":"3단계"},{"id":"b","text":"2단계"},
+                                          {"id":"a","text":"1단계"}]}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.type").value("ORDERING"))
+                .andExpect(jsonPath("$.data.items[0].id").value("c"))
+                .andExpect(jsonPath("$.data.items[2].id").value("a"));
+    }
+
+    @Test
+    @DisplayName("PATCH - BASIC → ORDERING 전환 (items 지정, back은 비워짐)")
+    void update_convert_basic_to_ordering() throws Exception {
+        Flashcard card = flashcardRepository.save(
+                new Flashcard(member.getId(), material.getId(), "Q", "A"));
+
+        mockMvc.perform(patch("/api/planner/flashcards/{id}", card.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"type\":\"ORDERING\",\"items\":" + ORDERING_ITEMS_3.strip() + "}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.type").value("ORDERING"))
+                .andExpect(jsonPath("$.data.items", hasSize(3)))
+                .andExpect(jsonPath("$.data.back").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("PATCH - ORDERING → BASIC 전환 (back 지정, items는 비워짐)")
+    void update_convert_ordering_to_basic() throws Exception {
+        Flashcard card = flashcardRepository.save(
+                Flashcard.ordering(member.getId(), material.getId(), "순서", ORDERING_ITEMS_3.strip()));
+
+        mockMvc.perform(patch("/api/planner/flashcards/{id}", card.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"type":"BASIC","back":"정답"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.type").value("BASIC"))
+                .andExpect(jsonPath("$.data.back").value("정답"))
+                .andExpect(jsonPath("$.data.items").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("PATCH - BASIC → ORDERING 전환인데 items 미지정이면 400")
+    void update_convert_to_ordering_without_items_fails() throws Exception {
+        Flashcard card = flashcardRepository.save(
+                new Flashcard(member.getId(), material.getId(), "Q", "A"));
+
+        mockMvc.perform(patch("/api/planner/flashcards/{id}", card.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"type":"ORDERING"}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
 }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsControllerTest.java
@@ -178,4 +178,25 @@ class TodayReviewsControllerTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.reviews", hasSize(1)))
                 .andExpect(jsonPath("$.data.reviews[0].id").value(pending.getId()));
     }
+
+    @Test
+    @DisplayName("GET today - 순서 카드는 type/items를 포함하고 back은 생략된다")
+    void embeds_ordering_card_with_items() throws Exception {
+        LocalDate today = testToday(clock);
+        Flashcard ordering = flashcardRepository.save(Flashcard.ordering(
+                member.getId(), material.getId(), "순서대로 배열",
+                "[{\"id\":\"a\",\"text\":\"1단계\"},{\"id\":\"b\",\"text\":\"2단계\"},{\"id\":\"c\",\"text\":\"3단계\"}]"));
+        reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), ordering.getId(), 1, atTestZone(today.atStartOfDay()), 1,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.type").value("ORDERING"))
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.front").value("순서대로 배열"))
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.back").doesNotExist())
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.items", hasSize(3)))
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.items[0].text").value("1단계"));
+    }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/entity/Flashcard.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/entity/Flashcard.java
@@ -3,6 +3,8 @@ package ds.project.orino.domain.planner.flashcard.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -28,11 +30,20 @@ public class Flashcard {
     @Column(name = "material_id", nullable = false)
     private Long materialId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private FlashcardType type;
+
     @Column(nullable = false, length = 1000)
     private String front;
 
-    @Column(nullable = false, length = 1000)
+    /** BASIC 카드의 뒷면. ORDERING 카드는 null. */
+    @Column(length = 1000)
     private String back;
+
+    /** ORDERING 카드의 항목 배열(정답 순서). BASIC 카드는 null. {@code [{"id","text"}]} JSON 문자열. */
+    @Column(columnDefinition = "JSON")
+    private String items;
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
@@ -45,19 +56,42 @@ public class Flashcard {
     protected Flashcard() {
     }
 
+    /** BASIC 카드를 생성한다. */
     public Flashcard(Long memberId, Long materialId, String front, String back) {
+        this(memberId, materialId, FlashcardType.BASIC, front, back, null);
+    }
+
+    private Flashcard(Long memberId, Long materialId, FlashcardType type,
+                      String front, String back, String items) {
         this.memberId = memberId;
         this.materialId = materialId;
+        this.type = type;
         this.front = front;
         this.back = back;
+        this.items = items;
+    }
+
+    /** ORDERING 카드를 생성한다. {@code items}는 정답 순서로 직렬화된 JSON 문자열. */
+    public static Flashcard ordering(Long memberId, Long materialId, String front, String items) {
+        return new Flashcard(memberId, materialId, FlashcardType.ORDERING, front, null, items);
     }
 
     public void updateFront(String front) {
         this.front = front;
     }
 
-    public void updateBack(String back) {
+    /** BASIC 카드로 전환/갱신한다. items는 비운다. */
+    public void changeToBasic(String back) {
+        this.type = FlashcardType.BASIC;
         this.back = back;
+        this.items = null;
+    }
+
+    /** ORDERING 카드로 전환/갱신한다. back은 비운다. {@code items}는 정답 순서 JSON 문자열. */
+    public void changeToOrdering(String items) {
+        this.type = FlashcardType.ORDERING;
+        this.items = items;
+        this.back = null;
     }
 
     public Long getId() {
@@ -72,12 +106,20 @@ public class Flashcard {
         return materialId;
     }
 
+    public FlashcardType getType() {
+        return type;
+    }
+
     public String getFront() {
         return front;
     }
 
     public String getBack() {
         return back;
+    }
+
+    public String getItems() {
+        return items;
     }
 
     public Instant getCreatedAt() {

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/entity/FlashcardType.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/entity/FlashcardType.java
@@ -1,0 +1,14 @@
+package ds.project.orino.domain.planner.flashcard.entity;
+
+/**
+ * 플래시카드 종류.
+ *
+ * <ul>
+ *     <li>{@link #BASIC} — 앞/뒷면 Q&amp;A 카드. {@code back} 필수, {@code items} 없음.</li>
+ *     <li>{@link #ORDERING} — 순서 배열 카드. {@code items}(정답 순서) 필수, {@code back} 없음.</li>
+ * </ul>
+ */
+public enum FlashcardType {
+    BASIC,
+    ORDERING
+}


### PR DESCRIPTION
## 이슈
closes #743

## 작업 내용
플래시카드에 카드 종류(`type`)를 도입해 **순서 카드(ORDERING)** 를 저장·검증한다. 복습(SM-2)은 `flashcard_id`만 참조하므로 **review 로직은 변경하지 않았다**. (Epic #742, Study Planner v2.3)

### 마이그레이션 — `034-add-flashcard-type-items.yaml`
> `033`은 이미 `033-merge-memo-into-note`로 사용 중이라 `034`로 진행

- `type VARCHAR(10) NOT NULL DEFAULT 'BASIC'` (기존 카드 무손실 BASIC)
- `items JSON NULL` (`note.content`와 동일 패턴)
- `back` 제약 완화: `NOT NULL → NULL`
- `columnExists` 가드, author `wcorn`

### 엔티티/도메인
- `FlashcardType { BASIC, ORDERING }` enum + `Flashcard`에 `type`/`items`(JSON String), `back` nullable
- `OrderingItem { id, text }` DTO + `FlashcardItemsCodec` (`List<OrderingItem>` ↔ JSON 직렬화, 항상 정답 순서 유지)

### API (엔드포인트 추가 없음, DTO 확장)
- Create/Update Request·Response에 `type`/`items` 반영, `back` nullable (`@JsonInclude(NON_NULL)`로 종류별 불필요 필드 생략)
- `GET /reviews/today`의 flashcard 객체에 `type`/`items` 포함

### 검증 (위반 시 `400 SP-ERR-002`)
- **ORDERING**: `items` 3~7개, 각 `text` 1~1000자, `id` 카드 내 유일, `back` 무시(NULL 저장)
- **BASIC**: `back` 필수(1~1000자), `items` 무시(NULL 저장)
- `type` 전환(PATCH) 시 전환 후 상태가 대상 종류 제약을 만족해야 함

## 테스트
- `FlashcardControllerTest`: ORDERING 생성(+첫 복습 종류 무관), 항목 3개 미만/7개 초과/id 중복/빈 text → 400, BASIC back 필수, 목록 type/items 노출, 재정렬 반영, BASIC↔ORDERING 전환, 전환 시 대상 제약 위반 → 400
- `TodayReviewsControllerTest`: 순서 카드 type/items 동봉·back 생략
- `./gradlew check` 통과 (전 모듈 테스트 + checkstyle)
- **로컬 검증**: docker-compose + bootRun(local)으로 Hibernate `validate` 통과 확인 후, 자료 생성 → ORDERING 생성 → 목록 → 재정렬 PATCH → 검증 실패 3종(SP-ERR-002) → `reviews/today` 동봉까지 curl로 전 흐름 확인