### PR TITLE
feat : 순서 카드 FE — 카드 편집 폼 항목 에디터 (@dnd-kit)

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.1",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@grafana/faro-react": "^2.6.3",
         "@grafana/faro-web-tracing": "^2.6.3",
         "@tailwindcss/vite": "^4.2.2",
@@ -785,6 +788,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {

--- a/fe/package.json
+++ b/fe/package.json
@@ -17,6 +17,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@grafana/faro-react": "^2.6.3",
     "@grafana/faro-web-tracing": "^2.6.3",
     "@tailwindcss/vite": "^4.2.2",

--- a/fe/src/features/flashcard/api/flashcards.ts
+++ b/fe/src/features/flashcard/api/flashcards.ts
@@ -13,11 +13,23 @@ export interface FirstReview extends NextReview {
   status: "PENDING" | "COMPLETED";
 }
 
+export type FlashcardType = "BASIC" | "ORDERING";
+
+/** 순서 카드의 항목. 배열 순서 자체가 정답 순서. `id`는 드래그 안정 키(FE 생성). */
+export interface OrderingItem {
+  id: string;
+  text: string;
+}
+
 export interface Flashcard {
   id: number;
   materialId: number;
+  type: FlashcardType;
   front: string;
-  back: string;
+  /** ORDERING 카드는 없음(null/생략). */
+  back: string | null;
+  /** ORDERING 카드만 정답 순서 배열, BASIC은 없음(null/생략). */
+  items: OrderingItem[] | null;
   nextReview: NextReview | null;
   createdAt: string;
 }
@@ -26,19 +38,21 @@ export interface FlashcardListResponse {
   flashcards: Flashcard[];
 }
 
-export interface FlashcardCreateRequest {
-  front: string;
-  back: string;
-}
+/**
+ * 카드 생성/수정 페이로드. 종류별로 필요한 필드만 담는다. 편집 시 종류 전환도 이 형태로 전달한다.
+ * (BE는 PATCH에서 type이 있으면 해당 종류로 전환하며 대상 종류 제약을 검증한다)
+ */
+export type FlashcardMutationPayload =
+  | { type: "BASIC"; front: string; back: string }
+  | { type: "ORDERING"; front: string; items: OrderingItem[] };
+
+export type FlashcardCreateRequest = FlashcardMutationPayload;
+
+export type FlashcardUpdateRequest = FlashcardMutationPayload;
 
 export interface FlashcardCreateResponse {
   flashcard: Flashcard;
   firstReview: FirstReview;
-}
-
-export interface FlashcardUpdateRequest {
-  front?: string;
-  back?: string;
 }
 
 interface ApiEnvelope<T> {

--- a/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
+++ b/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
@@ -5,16 +5,31 @@ import { Modal } from "@/components/ui/modal";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 
+import type {
+  FlashcardMutationPayload,
+  FlashcardType,
+  OrderingItem,
+} from "../api/flashcards";
+import {
+  ensureMinItems,
+  isOrderingValid,
+  itemsEqual,
+  normalizeItems,
+} from "../orderingItems";
+import { OrderingItemsEditor } from "./OrderingItemsEditor";
+
 const MAX_LEN = 1000;
 
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   mode: "create" | "edit";
+  initialType?: FlashcardType;
   initialFront?: string;
-  initialBack?: string;
+  initialBack?: string | null;
+  initialItems?: OrderingItem[] | null;
   pending?: boolean;
-  onSubmit: (values: { front: string; back: string }) => void;
+  onSubmit: (payload: FlashcardMutationPayload) => void;
   onDelete?: () => void;
 }
 
@@ -22,39 +37,63 @@ export function FlashcardFormDialog({
   open,
   onOpenChange,
   mode,
+  initialType = "BASIC",
   initialFront = "",
   initialBack = "",
+  initialItems = null,
   pending = false,
   onSubmit,
   onDelete,
 }: Props) {
   const frontId = useId();
   const backId = useId();
+  const [type, setType] = useState<FlashcardType>(initialType);
   const [front, setFront] = useState(initialFront);
-  const [back, setBack] = useState(initialBack);
+  const [back, setBack] = useState(initialBack ?? "");
+  const [items, setItems] = useState<OrderingItem[]>(() =>
+    ensureMinItems(initialItems ?? []),
+  );
 
   useEffect(() => {
     if (open) {
+      setType(initialType);
       setFront(initialFront);
-      setBack(initialBack);
+      setBack(initialBack ?? "");
+      setItems(ensureMinItems(initialItems ?? []));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const frontTrim = front.trim();
   const backTrim = back.trim();
+  const frontValid = frontTrim.length >= 1 && frontTrim.length <= MAX_LEN;
+
   const valid =
-    frontTrim.length >= 1 &&
-    frontTrim.length <= MAX_LEN &&
-    backTrim.length >= 1 &&
-    backTrim.length <= MAX_LEN;
+    type === "ORDERING"
+      ? frontValid && isOrderingValid(items, MAX_LEN)
+      : frontValid && backTrim.length >= 1 && backTrim.length <= MAX_LEN;
+
+  const initialItemsFilled = ensureMinItems(initialItems ?? []);
   const dirty =
-    mode === "create" || front !== initialFront || back !== initialBack;
+    mode === "create" ||
+    type !== initialType ||
+    front !== initialFront ||
+    (type === "BASIC"
+      ? back !== (initialBack ?? "")
+      : !itemsEqual(items, initialItemsFilled));
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     if (!valid || !dirty || pending) return;
-    onSubmit({ front: frontTrim, back: backTrim });
+    if (type === "ORDERING") {
+      onSubmit({
+        type: "ORDERING",
+        front: frontTrim,
+        items: normalizeItems(items),
+      });
+    } else {
+      onSubmit({ type: "BASIC", front: frontTrim, back: backTrim });
+    }
   };
 
   return (
@@ -64,23 +103,34 @@ export function FlashcardFormDialog({
       title={mode === "create" ? "카드 추가" : "카드 편집"}
     >
       <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-4">
+        <TypeToggle value={type} onChange={setType} />
+
         <CharField
           id={frontId}
-          label="앞면 (질문)"
-          rows={3}
+          label={type === "ORDERING" ? "지시문" : "앞면 (질문)"}
+          rows={type === "ORDERING" ? 2 : 3}
           value={front}
           onChange={setFront}
           max={MAX_LEN}
           autoFocus
         />
-        <CharField
-          id={backId}
-          label="뒷면 (답)"
-          rows={4}
-          value={back}
-          onChange={setBack}
-          max={MAX_LEN}
-        />
+
+        {type === "ORDERING" ? (
+          <OrderingItemsEditor
+            items={items}
+            onChange={setItems}
+            maxLen={MAX_LEN}
+          />
+        ) : (
+          <CharField
+            id={backId}
+            label="뒷면 (답)"
+            rows={4}
+            value={back}
+            onChange={setBack}
+            max={MAX_LEN}
+          />
+        )}
 
         <Modal.Footer
           submitLabel="저장"
@@ -91,6 +141,43 @@ export function FlashcardFormDialog({
         />
       </form>
     </Modal>
+  );
+}
+
+interface TypeToggleProps {
+  value: FlashcardType;
+  onChange: (next: FlashcardType) => void;
+}
+
+function TypeToggle({ value, onChange }: TypeToggleProps) {
+  const options: Array<{ key: FlashcardType; label: string }> = [
+    { key: "BASIC", label: "기본" },
+    { key: "ORDERING", label: "순서" },
+  ];
+  return (
+    <div
+      role="radiogroup"
+      aria-label="카드 종류"
+      className="bg-muted flex gap-1 rounded-lg p-1"
+    >
+      {options.map((opt) => (
+        <button
+          key={opt.key}
+          type="button"
+          role="radio"
+          aria-checked={value === opt.key}
+          onClick={() => onChange(opt.key)}
+          className={cn(
+            "flex-1 rounded-md py-1.5 text-sm font-medium transition-colors",
+            value === opt.key
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
   );
 }
 

--- a/fe/src/features/flashcard/components/FlashcardItem.tsx
+++ b/fe/src/features/flashcard/components/FlashcardItem.tsx
@@ -30,9 +30,19 @@ export function FlashcardItem({ index, flashcard, onEdit }: Props) {
           <p className="text-sm font-medium whitespace-pre-line">
             {flashcard.front}
           </p>
-          <p className="text-muted-foreground text-xs whitespace-pre-line">
-            뒤: {flashcard.back}
-          </p>
+          {flashcard.type === "ORDERING" ? (
+            <ol className="text-muted-foreground flex list-decimal flex-col gap-0.5 pl-4 text-xs">
+              {flashcard.items?.map((item) => (
+                <li key={item.id} className="whitespace-pre-line">
+                  {item.text}
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <p className="text-muted-foreground text-xs whitespace-pre-line">
+              뒤: {flashcard.back}
+            </p>
+          )}
         </div>
         <Button
           variant="ghost"

--- a/fe/src/features/flashcard/components/FlashcardListTab.test.tsx
+++ b/fe/src/features/flashcard/components/FlashcardListTab.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { Providers } from "@/app/providers";
 import { Toaster } from "@/components/Toaster";
 import { useAuthStore } from "@/features/auth/store/authStore";
+import { useToastStore } from "@/shared/lib/toast";
 import { server } from "@/test/mocks/server";
 import { renderWithRouter } from "@/test/render";
 
@@ -72,6 +73,8 @@ function mockListWith(
 describe("FlashcardListTab", () => {
   beforeEach(() => {
     useAuthStore.setState({ accessToken: "mock-token" });
+    // 전역 toast 스토어는 3.5s 유지되어 테스트 간 누적되므로 초기화
+    useToastStore.setState({ toasts: [] });
   });
 
   it("빈 목록이면 빈 상태와 [첫 카드 추가] 버튼을 표시한다", async () => {
@@ -109,12 +112,12 @@ describe("FlashcardListTab", () => {
 
   it("[카드 추가] 다이얼로그를 열어 카드 생성 후 토스트가 표시된다", async () => {
     mockListEmpty();
-    let posted: { front: string; back: string } | null = null;
+    let posted: Record<string, unknown> | null = null;
     server.use(
       http.post(
         `${API_BASE}/planner/materials/1/flashcards`,
         async ({ request }) => {
-          posted = (await request.json()) as { front: string; back: string };
+          posted = (await request.json()) as Record<string, unknown>;
           return HttpResponse.json(
             {
               code: "OK",
@@ -122,8 +125,10 @@ describe("FlashcardListTab", () => {
                 flashcard: {
                   id: 10,
                   materialId: 1,
+                  type: "BASIC",
                   front: posted.front,
                   back: posted.back,
+                  items: null,
                   nextReview: null,
                   createdAt: "2026-05-18T00:00:00",
                 },
@@ -157,7 +162,11 @@ describe("FlashcardListTab", () => {
     await user.click(screen.getByRole("button", { name: "저장" }));
 
     await waitFor(() => {
-      expect(posted).toEqual({ front: "front-text", back: "back-text" });
+      expect(posted).toEqual({
+        type: "BASIC",
+        front: "front-text",
+        back: "back-text",
+      });
     });
     expect(await screen.findByText(/카드가 추가되었어요/)).toBeInTheDocument();
   });
@@ -238,5 +247,156 @@ describe("FlashcardListTab", () => {
 
     await user.type(screen.getByLabelText("뒷면 (답)"), "A");
     expect(screen.getByRole("button", { name: "저장" })).toBeEnabled();
+  });
+
+  it("순서 카드를 생성하면 type/items 페이로드가 화면 순서대로 전송된다", async () => {
+    mockListEmpty();
+    let posted: Record<string, unknown> | null = null;
+    server.use(
+      http.post(
+        `${API_BASE}/planner/materials/1/flashcards`,
+        async ({ request }) => {
+          posted = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(
+            {
+              code: "OK",
+              data: {
+                flashcard: {
+                  id: 20,
+                  materialId: 1,
+                  type: "ORDERING",
+                  front: "순서대로",
+                  back: null,
+                  items: (posted as { items: unknown }).items,
+                  nextReview: null,
+                  createdAt: "2026-05-18T00:00:00",
+                },
+                firstReview: {
+                  id: 200,
+                  flashcardId: 20,
+                  sequence: 1,
+                  scheduledAt: "2026-05-19T04:00:00",
+                  intervalDays: 1,
+                  easeFactor: 2.5,
+                  status: "PENDING",
+                },
+              },
+            },
+            { status: 201 },
+          );
+        },
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 카드가 없습니다.")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /첫 카드 추가/ }));
+
+    // 순서 모드로 전환하면 최소 3개의 빈 항목 행이 나타난다
+    await user.click(await screen.findByRole("radio", { name: "순서" }));
+    await user.type(screen.getByLabelText("지시문"), "순서대로");
+    await user.type(screen.getByLabelText("항목 1"), "첫째");
+    await user.type(screen.getByLabelText("항목 2"), "둘째");
+    await user.type(screen.getByLabelText("항목 3"), "셋째");
+
+    await user.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() => expect(posted).not.toBeNull());
+    const payload = posted as unknown as {
+      type: string;
+      front: string;
+      items: Array<{ id: string; text: string }>;
+    };
+    expect(payload.type).toBe("ORDERING");
+    expect(payload.front).toBe("순서대로");
+    expect(payload.items.map((i) => i.text)).toEqual(["첫째", "둘째", "셋째"]);
+    expect(payload.items.every((i) => typeof i.id === "string" && i.id)).toBe(
+      true,
+    );
+    expect(await screen.findByText(/카드가 추가되었어요/)).toBeInTheDocument();
+  });
+
+  it("순서 모드: 항목이 비어 있으면 저장 비활성, 모두 채우면 활성", async () => {
+    mockListEmpty();
+    const user = userEvent.setup();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 카드가 없습니다.")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /첫 카드 추가/ }));
+    await user.click(await screen.findByRole("radio", { name: "순서" }));
+
+    await user.type(screen.getByLabelText("지시문"), "지시");
+    expect(screen.getByRole("button", { name: "저장" })).toBeDisabled();
+
+    await user.type(screen.getByLabelText("항목 1"), "a");
+    await user.type(screen.getByLabelText("항목 2"), "b");
+    expect(screen.getByRole("button", { name: "저장" })).toBeDisabled();
+
+    await user.type(screen.getByLabelText("항목 3"), "c");
+    expect(screen.getByRole("button", { name: "저장" })).toBeEnabled();
+  });
+
+  it("순서 모드: 7개 도달 시 [항목 추가]가 비활성된다", async () => {
+    mockListEmpty();
+    const user = userEvent.setup();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 카드가 없습니다.")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /첫 카드 추가/ }));
+    await user.click(await screen.findByRole("radio", { name: "순서" }));
+
+    const addButton = screen.getByRole("button", { name: "항목 추가" });
+    // 3개에서 시작 → 4번 추가하면 7개
+    for (let i = 0; i < 4; i++) {
+      await user.click(addButton);
+    }
+    expect(screen.getByText("7 / 7")).toBeInTheDocument();
+    expect(addButton).toBeDisabled();
+  });
+
+  it("순서 카드 목록은 항목을 번호 목록으로 표시한다", async () => {
+    server.use(
+      http.get(`${API_BASE}/planner/materials/1/flashcards`, () => {
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            flashcards: [
+              {
+                id: 30,
+                materialId: 1,
+                type: "ORDERING",
+                front: "kubectl 순서",
+                back: null,
+                items: [
+                  { id: "a", text: "인증" },
+                  { id: "b", text: "저장" },
+                  { id: "c", text: "생성" },
+                ],
+                nextReview: null,
+                createdAt: "2026-05-18T00:00:00",
+              },
+            ],
+          },
+        });
+      }),
+    );
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("kubectl 순서")).toBeInTheDocument();
+    });
+    expect(screen.getByText("인증")).toBeInTheDocument();
+    expect(screen.getByText("저장")).toBeInTheDocument();
+    expect(screen.getByText("생성")).toBeInTheDocument();
+    // 기본 카드의 "뒤:" 프리픽스는 나타나지 않는다
+    expect(screen.queryByText(/^뒤:/)).not.toBeInTheDocument();
   });
 });

--- a/fe/src/features/flashcard/components/FlashcardListTab.tsx
+++ b/fe/src/features/flashcard/components/FlashcardListTab.tsx
@@ -7,7 +7,7 @@ import { FieldError } from "@/components/ui/field-error";
 import { LoadingText } from "@/components/ui/loading-text";
 import { toast } from "@/shared/lib/toast";
 
-import type { Flashcard } from "../api/flashcards";
+import type { Flashcard, FlashcardMutationPayload } from "../api/flashcards";
 import { useCreateFlashcard } from "../hooks/useCreateFlashcard";
 import { useDeleteFlashcard } from "../hooks/useDeleteFlashcard";
 import { useFlashcards } from "../hooks/useFlashcards";
@@ -30,7 +30,7 @@ export function FlashcardListTab({ materialId }: Props) {
   const updateMutation = useUpdateFlashcard(materialId, editing?.id ?? 0);
   const deleteMutation = useDeleteFlashcard(materialId);
 
-  const handleCreate = (values: { front: string; back: string }) => {
+  const handleCreate = (values: FlashcardMutationPayload) => {
     createMutation.mutate(values, {
       onSuccess: () => {
         setCreateOpen(false);
@@ -41,7 +41,7 @@ export function FlashcardListTab({ materialId }: Props) {
     });
   };
 
-  const handleUpdate = (values: { front: string; back: string }) => {
+  const handleUpdate = (values: FlashcardMutationPayload) => {
     if (!editing) return;
     updateMutation.mutate(values, {
       onSuccess: () => setEditing(null),
@@ -116,8 +116,10 @@ export function FlashcardListTab({ materialId }: Props) {
             updateMutation.reset();
           }
         }}
+        initialType={editing?.type}
         initialFront={editing?.front}
         initialBack={editing?.back}
+        initialItems={editing?.items}
         pending={updateMutation.isPending}
         onSubmit={handleUpdate}
         onDelete={() => setDeleteConfirmOpen(true)}

--- a/fe/src/features/flashcard/components/OrderingItemsEditor.tsx
+++ b/fe/src/features/flashcard/components/OrderingItemsEditor.tsx
@@ -1,0 +1,201 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, Plus, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+import type { OrderingItem } from "../api/flashcards";
+import {
+  createOrderingItem,
+  MAX_ORDERING_ITEMS,
+  MIN_ORDERING_ITEMS,
+  reorderItems,
+} from "../orderingItems";
+
+interface Props {
+  items: OrderingItem[];
+  onChange: (next: OrderingItem[]) => void;
+  maxLen: number;
+}
+
+/**
+ * 순서 카드 항목 에디터. 화면 순서가 곧 정답 순서다.
+ * - @dnd-kit sortable(핸들만 잡기, PointerSensor 8px 임계값, arrayMove)
+ * - 3~7개: 3개 미만이면 저장 비활성(상위에서 판정), 7개 도달 시 추가 비활성
+ */
+export function OrderingItemsEditor({ items, onChange, maxLen }: Props) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+    onChange(reorderItems(items, String(active.id), String(over.id)));
+  };
+
+  const updateText = (id: string, text: string) => {
+    onChange(items.map((i) => (i.id === id ? { ...i, text } : i)));
+  };
+
+  const removeItem = (id: string) => {
+    onChange(items.filter((i) => i.id !== id));
+  };
+
+  const addItem = () => {
+    if (items.length >= MAX_ORDERING_ITEMS) return;
+    onChange([...items, createOrderingItem()]);
+  };
+
+  const belowMin = items.length < MIN_ORDERING_ITEMS;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium">항목 (정답 순서로 입력)</span>
+        <span
+          className={cn(
+            "text-muted-foreground text-xs",
+            belowMin && "text-destructive",
+          )}
+        >
+          {items.length} / {MAX_ORDERING_ITEMS}
+        </span>
+      </div>
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={items.map((i) => i.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <ul className="flex flex-col gap-2">
+            {items.map((item, index) => (
+              <SortableRow
+                key={item.id}
+                item={item}
+                index={index}
+                maxLen={maxLen}
+                canDelete={items.length > MIN_ORDERING_ITEMS}
+                onTextChange={(text) => updateText(item.id, text)}
+                onRemove={() => removeItem(item.id)}
+              />
+            ))}
+          </ul>
+        </SortableContext>
+      </DndContext>
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="self-start"
+        onClick={addItem}
+        disabled={items.length >= MAX_ORDERING_ITEMS}
+      >
+        <Plus className="size-3.5" /> 항목 추가
+      </Button>
+
+      {belowMin && (
+        <span className="text-destructive text-xs">
+          최소 {MIN_ORDERING_ITEMS}개 항목이 필요해요.
+        </span>
+      )}
+    </div>
+  );
+}
+
+interface RowProps {
+  item: OrderingItem;
+  index: number;
+  maxLen: number;
+  canDelete: boolean;
+  onTextChange: (text: string) => void;
+  onRemove: () => void;
+}
+
+function SortableRow({
+  item,
+  index,
+  maxLen,
+  canDelete,
+  onTextChange,
+  onRemove,
+}: RowProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+
+  const over = item.text.length > maxLen;
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        "bg-background flex items-center gap-2",
+        isDragging && "relative z-10 opacity-80",
+      )}
+    >
+      <button
+        type="button"
+        ref={setActivatorNodeRef}
+        className="text-muted-foreground hover:text-foreground shrink-0 cursor-grab touch-none active:cursor-grabbing"
+        aria-label={`항목 ${index + 1} 순서 이동`}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="size-4" />
+      </button>
+      <span className="text-muted-foreground w-4 shrink-0 text-center text-xs font-medium tabular-nums">
+        {index + 1}
+      </span>
+      <Input
+        value={item.text}
+        onChange={(e) => onTextChange(e.target.value)}
+        aria-label={`항목 ${index + 1}`}
+        aria-invalid={over || undefined}
+        placeholder="항목 내용"
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        className="text-muted-foreground hover:text-destructive shrink-0"
+        aria-label={`항목 ${index + 1} 삭제`}
+        onClick={onRemove}
+        disabled={!canDelete}
+      >
+        <Trash2 className="size-4" />
+      </Button>
+    </li>
+  );
+}

--- a/fe/src/features/flashcard/hooks/useCreateFlashcard.test.tsx
+++ b/fe/src/features/flashcard/hooks/useCreateFlashcard.test.tsx
@@ -56,7 +56,7 @@ describe("useCreateFlashcard", () => {
     const { wrapper, spy } = makeWrapper();
     const { result } = renderHook(() => useCreateFlashcard(1), { wrapper });
 
-    result.current.mutate({ front: "test", back: "test" });
+    result.current.mutate({ type: "BASIC", front: "test", back: "test" });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 

--- a/fe/src/features/flashcard/orderingItems.test.ts
+++ b/fe/src/features/flashcard/orderingItems.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import type { OrderingItem } from "./api/flashcards";
+import {
+  ensureMinItems,
+  isOrderingValid,
+  itemsEqual,
+  MAX_ORDERING_ITEMS,
+  MIN_ORDERING_ITEMS,
+  normalizeItems,
+  reorderItems,
+} from "./orderingItems";
+
+const item = (id: string, text: string): OrderingItem => ({ id, text });
+
+describe("ensureMinItems", () => {
+  it("3개 미만이면 빈 항목으로 최소 개수를 채운다", () => {
+    const result = ensureMinItems([item("a", "1")]);
+    expect(result).toHaveLength(MIN_ORDERING_ITEMS);
+    expect(result[0]).toEqual(item("a", "1"));
+    expect(result[1].text).toBe("");
+    expect(result[1].id).not.toBe("");
+  });
+
+  it("이미 3개 이상이면 그대로 둔다", () => {
+    const src = [
+      item("a", "1"),
+      item("b", "2"),
+      item("c", "3"),
+      item("d", "4"),
+    ];
+    expect(ensureMinItems(src)).toEqual(src);
+  });
+});
+
+describe("isOrderingValid", () => {
+  const three = [item("a", "1"), item("b", "2"), item("c", "3")];
+
+  it("3~7개 + 모든 text 1~1000자면 유효", () => {
+    expect(isOrderingValid(three, 1000)).toBe(true);
+  });
+
+  it("3개 미만이면 무효", () => {
+    expect(isOrderingValid(three.slice(0, 2), 1000)).toBe(false);
+  });
+
+  it("7개 초과면 무효", () => {
+    const eight = Array.from({ length: MAX_ORDERING_ITEMS + 1 }, (_, i) =>
+      item(`i${i}`, `t${i}`),
+    );
+    expect(isOrderingValid(eight, 1000)).toBe(false);
+  });
+
+  it("빈(공백) 항목이 있으면 무효", () => {
+    expect(isOrderingValid([...three.slice(0, 2), item("c", "  ")], 1000)).toBe(
+      false,
+    );
+  });
+
+  it("최대 길이를 넘는 항목이 있으면 무효", () => {
+    const long = item("c", "x".repeat(1001));
+    expect(isOrderingValid([...three.slice(0, 2), long], 1000)).toBe(false);
+  });
+});
+
+describe("reorderItems", () => {
+  const src = [item("a", "1"), item("b", "2"), item("c", "3")];
+
+  it("activeId를 overId 위치로 이동한다", () => {
+    expect(reorderItems(src, "a", "c").map((i) => i.id)).toEqual([
+      "b",
+      "c",
+      "a",
+    ]);
+  });
+
+  it("같은 위치면 원본을 그대로 반환", () => {
+    expect(reorderItems(src, "b", "b")).toBe(src);
+  });
+
+  it("존재하지 않는 id면 원본을 그대로 반환", () => {
+    expect(reorderItems(src, "a", "zzz")).toBe(src);
+  });
+});
+
+describe("normalizeItems", () => {
+  it("각 text를 trim하고 순서는 유지한다", () => {
+    const result = normalizeItems([item("a", "  x "), item("b", "y")]);
+    expect(result).toEqual([item("a", "x"), item("b", "y")]);
+  });
+});
+
+describe("itemsEqual", () => {
+  const base = [item("a", "1"), item("b", "2")];
+
+  it("id·text·순서가 같으면 true", () => {
+    expect(itemsEqual(base, [item("a", "1"), item("b", "2")])).toBe(true);
+  });
+
+  it("순서가 다르면 false", () => {
+    expect(itemsEqual(base, [item("b", "2"), item("a", "1")])).toBe(false);
+  });
+
+  it("text가 다르면 false", () => {
+    expect(itemsEqual(base, [item("a", "1"), item("b", "changed")])).toBe(
+      false,
+    );
+  });
+
+  it("길이가 다르면 false", () => {
+    expect(itemsEqual(base, [item("a", "1")])).toBe(false);
+  });
+});

--- a/fe/src/features/flashcard/orderingItems.ts
+++ b/fe/src/features/flashcard/orderingItems.ts
@@ -1,0 +1,62 @@
+import { arrayMove } from "@dnd-kit/sortable";
+
+import type { OrderingItem } from "./api/flashcards";
+
+export const MIN_ORDERING_ITEMS = 3;
+export const MAX_ORDERING_ITEMS = 7;
+
+/** 순서 카드 항목의 드래그 안정 키. 카드 내에서 유일하면 되므로 UUID로 생성한다. */
+export function newOrderingItemId(): string {
+  return crypto.randomUUID();
+}
+
+export function createOrderingItem(text = ""): OrderingItem {
+  return { id: newOrderingItemId(), text };
+}
+
+/** 3개 미만이면 편집 시작 시 최소 개수를 채운다(빈 항목). */
+export function ensureMinItems(items: OrderingItem[]): OrderingItem[] {
+  const filled = [...items];
+  while (filled.length < MIN_ORDERING_ITEMS) {
+    filled.push(createOrderingItem());
+  }
+  return filled;
+}
+
+/** 저장 페이로드용: 각 항목 text를 trim. 순서는 화면 순서를 그대로 유지. */
+export function normalizeItems(items: OrderingItem[]): OrderingItem[] {
+  return items.map((item) => ({ id: item.id, text: item.text.trim() }));
+}
+
+/** ORDERING 저장 가능 여부: 3~7개 + 모든 text 1~1000자. */
+export function isOrderingValid(
+  items: OrderingItem[],
+  maxLen: number,
+): boolean {
+  if (items.length < MIN_ORDERING_ITEMS || items.length > MAX_ORDERING_ITEMS) {
+    return false;
+  }
+  return items.every((item) => {
+    const t = item.text.trim();
+    return t.length >= 1 && t.length <= maxLen;
+  });
+}
+
+/** 드래그 종료 시 activeId를 overId 위치로 이동한 새 배열. 대상이 없거나 동일하면 원본 유지. */
+export function reorderItems(
+  items: OrderingItem[],
+  activeId: string,
+  overId: string,
+): OrderingItem[] {
+  if (activeId === overId) return items;
+  const from = items.findIndex((i) => i.id === activeId);
+  const to = items.findIndex((i) => i.id === overId);
+  if (from === -1 || to === -1) return items;
+  return arrayMove(items, from, to);
+}
+
+/** 편집 dirty 판정: id+text+순서가 초기값과 동일한지. */
+export function itemsEqual(a: OrderingItem[], b: OrderingItem[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((item, i) => item.id === b[i].id && item.text === b[i].text);
+}


### PR DESCRIPTION
## 이슈
closes #744

## 작업 내용
카드 추가/편집 다이얼로그(`FlashcardFormDialog`)에 **카드 종류 토글**과 **순서 카드 항목 에디터**를 추가한다. (Epic #742, 선행 #743 BE)

### 의존성
- `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` 추가

### 타입/API 레이어 (`api/flashcards.ts`)
- `Flashcard`에 `type: 'BASIC' | 'ORDERING'`, `items: OrderingItem[] | null`, `back` nullable
- 생성/수정 요청은 `FlashcardMutationPayload` 유니온 (`BASIC → {front,back}` / `ORDERING → {front,items}`). 편집 시 종류 전환도 이 형태로 전달 → BE가 대상 종류 제약 검증

### 다이얼로그
- 상단 카드 종류 토글 `[ 기본 | 순서 ]` (radiogroup)
- 기본: 기존 앞/뒷면 textarea
- 순서: 지시문 + `OrderingItemsEditor`
  - 항목 행 = 드래그 핸들(⠿) + 번호 + 텍스트 입력 + 삭제
  - **@dnd-kit sortable**: 핸들만 잡기, PointerSensor 8px 임계값, `arrayMove` 재정렬, KeyboardSensor
  - `[+ 항목 추가]`, 항목 수 `n / 7`, **3개 미만 저장 비활성**, 7개 도달 시 추가 비활성
  - 신규 항목 `id`는 `crypto.randomUUID`로 FE 생성(드래그 안정 키)
- 종류별 검증 + dirty(키 입력·재정렬·추가/삭제) 후 저장 활성
- `FlashcardItem`: 순서 카드는 항목을 번호 목록으로 표시

## 테스트
- `orderingItems.test.ts`(단위): 최소 개수 채움·검증(3~7개/길이)·재정렬(`reorderItems`)·dirty 비교
- `FlashcardListTab.test.tsx`(통합, MSW): 순서 카드 생성 페이로드(type/items·화면 순서), 항목 미충족 저장 차단, 7개 추가 상한, 순서 카드 목록 번호 표시. 기존 BASIC 생성 페이로드도 `type` 포함으로 갱신
- `npm test`(268) · `tsc -b` 빌드 · `eslint` · `prettier --check` 모두 통과
- **로컬 브라우저 검증**(BE+FE 기동, Playwright): 종류 토글 → 순서 에디터(3행/3·7 카운터) → **@dnd-kit 드래그로 항목 1→3 재정렬** → 저장 → 실제 API 반영 → 목록·**DB의 items JSON 순서**까지 확인. 편집 시 기존 type/front/items 프리필도 확인