### PR TITLE
feat : 순서 카드 복습 화면 — 셔플·드래그·정답 색 비교

### DIFF
--- a/fe/src/features/review/api/reviews.ts
+++ b/fe/src/features/review/api/reviews.ts
@@ -1,3 +1,7 @@
+import type {
+  FlashcardType,
+  OrderingItem,
+} from "@/features/flashcard/api/flashcards";
 import { client } from "@/shared/api";
 
 export type Rating = "AGAIN" | "HARD" | "GOOD" | "EASY";
@@ -10,8 +14,12 @@ export interface TodayReviewMaterial {
 
 export interface TodayReviewFlashcard {
   id: number;
+  type: FlashcardType;
   front: string;
-  back: string;
+  /** ORDERING 카드는 없음(null/생략). */
+  back: string | null;
+  /** ORDERING 카드만 정답 순서 배열. */
+  items: OrderingItem[] | null;
   material: TodayReviewMaterial;
 }
 

--- a/fe/src/features/review/components/OrderingReviewCard.tsx
+++ b/fe/src/features/review/components/OrderingReviewCard.tsx
@@ -1,0 +1,164 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical } from "lucide-react";
+import { useState } from "react";
+
+import type { OrderingItem } from "@/features/flashcard/api/flashcards";
+import { cn } from "@/lib/utils";
+
+import { reorder, shuffleForReview } from "../ordering";
+
+interface Props {
+  /** 정답 순서의 항목 배열. */
+  items: OrderingItem[];
+  /** true면 드래그 잠금 + 위치별 정오 색 표시 + 정답 순서 노출. */
+  revealed: boolean;
+}
+
+/**
+ * 순서 카드 복습 본문. 마운트 시 1회 셔플(정답 회피) → 드래그로 재정렬 → 공개 시 색 비교.
+ * 채점(점수·정답률)은 하지 않는다. 위치별 정오를 색으로만 보여준다.
+ */
+export function OrderingReviewCard({ items, revealed }: Props) {
+  const [order, setOrder] = useState<OrderingItem[]>(() =>
+    shuffleForReview(items),
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    if (revealed) return;
+    const { active, over } = event;
+    if (!over) return;
+    setOrder((prev) => reorder(prev, String(active.id), String(over.id)));
+  };
+
+  if (revealed) {
+    return (
+      <div className="flex flex-col gap-4">
+        <section className="flex flex-col gap-2">
+          <h3 className="text-muted-foreground text-xs font-medium">내 배열</h3>
+          <ul className="flex flex-col gap-1.5">
+            {order.map((item, i) => {
+              const correct = item.id === items[i].id;
+              return (
+                <li
+                  key={item.id}
+                  className="border-border flex items-center gap-2 rounded-lg border px-3 py-2"
+                >
+                  <span
+                    aria-label={correct ? "정답 위치" : "오답 위치"}
+                    className={cn(
+                      "size-3 shrink-0 rounded-[4px]",
+                      correct ? "bg-success" : "bg-destructive",
+                    )}
+                  />
+                  <span className="text-sm whitespace-pre-wrap">
+                    {item.text}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+
+        <section className="flex flex-col gap-2">
+          <h3 className="text-muted-foreground text-xs font-medium">
+            정답 순서
+          </h3>
+          <ol className="flex flex-col gap-1.5">
+            {items.map((item, i) => (
+              <li
+                key={item.id}
+                className="bg-muted/40 flex items-center gap-2 rounded-lg px-3 py-2"
+              >
+                <span className="text-muted-foreground w-4 shrink-0 text-center text-xs font-medium tabular-nums">
+                  {i + 1}
+                </span>
+                <span className="text-sm whitespace-pre-wrap">{item.text}</span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={order.map((i) => i.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <ul data-ordering-drag className="flex flex-col gap-1.5">
+          {order.map((item, index) => (
+            <SortableRow key={item.id} item={item} index={index} />
+          ))}
+        </ul>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+interface RowProps {
+  item: OrderingItem;
+  index: number;
+}
+
+function SortableRow({ item, index }: RowProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        "bg-card border-border flex items-center gap-2 rounded-lg border px-3 py-2",
+        isDragging && "relative z-10 opacity-80 shadow-sm",
+      )}
+    >
+      <button
+        type="button"
+        ref={setActivatorNodeRef}
+        className="text-muted-foreground hover:text-foreground shrink-0 cursor-grab touch-none active:cursor-grabbing"
+        aria-label={`${index + 1}번째 항목 순서 이동`}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="size-4" />
+      </button>
+      <span className="text-sm whitespace-pre-wrap">{item.text}</span>
+    </li>
+  );
+}

--- a/fe/src/features/review/components/ReviewCard.tsx
+++ b/fe/src/features/review/components/ReviewCard.tsx
@@ -6,6 +6,7 @@ import { MATERIAL_TYPE_ICONS } from "@/features/material/utils";
 import { cn } from "@/lib/utils";
 
 import type { Rating, TodayReview } from "../api/reviews";
+import { OrderingReviewCard } from "./OrderingReviewCard";
 
 interface Props {
   review: TodayReview;
@@ -55,6 +56,7 @@ const RATING_BUTTONS: RatingButton[] = [
 
 export function ReviewCard({ review, pending, onRate }: Props) {
   const [revealed, setRevealed] = useState(false);
+  const isOrdering = review.flashcard.type === "ORDERING";
 
   useEffect(() => {
     setRevealed(false);
@@ -65,6 +67,8 @@ export function ReviewCard({ review, pending, onRate }: Props) {
       if (isTypingTarget(event.target)) return;
       if (!revealed) {
         if (event.code === "Space" || event.key === "Enter") {
+          // 순서 카드 드래그 핸들의 Space/Enter(항목 집기)에는 양보한다
+          if (isInDragArea(event.target)) return;
           event.preventDefault();
           setRevealed(true);
         }
@@ -97,29 +101,42 @@ export function ReviewCard({ review, pending, onRate }: Props) {
           )}
         </div>
 
-        <div className="bg-muted/30 rounded-lg px-4 py-10 text-center">
-          <p
-            className={cn(
-              "text-foreground text-2xl font-medium whitespace-pre-wrap",
-            )}
-          >
-            {review.flashcard.front}
-          </p>
-        </div>
+        {isOrdering ? (
+          <>
+            <div className="bg-muted/30 rounded-lg px-4 py-5 text-center">
+              <p className="text-foreground text-lg font-medium whitespace-pre-wrap">
+                {review.flashcard.front}
+              </p>
+            </div>
+            <OrderingReviewCard
+              key={review.flashcard.id}
+              items={review.flashcard.items ?? []}
+              revealed={revealed}
+            />
+          </>
+        ) : (
+          <div className="bg-muted/30 rounded-lg px-4 py-10 text-center">
+            <p className="text-foreground text-2xl font-medium whitespace-pre-wrap">
+              {review.flashcard.front}
+            </p>
+          </div>
+        )}
 
         {!revealed ? (
           <div className="flex justify-center">
             <Button size="lg" onClick={() => setRevealed(true)}>
-              답 보기 (Space)
+              {isOrdering ? "정답 확인 (Space)" : "답 보기 (Space)"}
             </Button>
           </div>
         ) : (
           <>
-            <div className="bg-card border-border rounded-lg border px-4 py-6 text-center">
-              <p className="text-foreground text-lg whitespace-pre-wrap">
-                {review.flashcard.back}
-              </p>
-            </div>
+            {!isOrdering && (
+              <div className="bg-card border-border rounded-lg border px-4 py-6 text-center">
+                <p className="text-foreground text-lg whitespace-pre-wrap">
+                  {review.flashcard.back}
+                </p>
+              </div>
+            )}
 
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
               {RATING_BUTTONS.map((btn) => {
@@ -158,4 +175,12 @@ function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   const tag = target.tagName;
   return tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable;
+}
+
+/** 순서 카드 드래그 리스트 내부 요소인지(핸들 Space/Enter를 reveal에 뺏기지 않도록). */
+function isInDragArea(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    target.closest("[data-ordering-drag]") !== null
+  );
 }

--- a/fe/src/features/review/ordering.test.ts
+++ b/fe/src/features/review/ordering.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import type { OrderingItem } from "@/features/flashcard/api/flashcards";
+
+import { fisherYates, reorder, sameOrder, shuffleForReview } from "./ordering";
+
+const items: OrderingItem[] = [
+  { id: "a", text: "1" },
+  { id: "b", text: "2" },
+  { id: "c", text: "3" },
+  { id: "d", text: "4" },
+];
+
+/** 정해진 시퀀스를 순서대로 뱉는 rng 스텁. */
+function seq(values: number[]): () => number {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+describe("sameOrder", () => {
+  it("id 순서가 같으면 true, 다르면 false", () => {
+    expect(sameOrder(items, [...items])).toBe(true);
+    expect(sameOrder(items, [items[1], items[0], items[2], items[3]])).toBe(
+      false,
+    );
+  });
+});
+
+describe("fisherYates", () => {
+  it("항목을 보존하는 순열이다(비파괴)", () => {
+    const copy = [...items];
+    const out = fisherYates(items, seq([0.99, 0.5, 0.1]));
+    expect(items).toEqual(copy); // 원본 불변
+    expect([...out].map((i) => i.id).sort()).toEqual(["a", "b", "c", "d"]);
+  });
+});
+
+describe("shuffleForReview", () => {
+  it("항목 집합을 보존한다", () => {
+    const out = shuffleForReview(items, Math.random);
+    expect(out.map((i) => i.id).sort()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("항상 정답 순서와 다르게 만든다", () => {
+    for (let s = 0; s < 50; s++) {
+      const out = shuffleForReview(items, seq([s / 50, ((s * 7) % 11) / 11]));
+      expect(sameOrder(out, items)).toBe(false);
+    }
+  });
+
+  it("rng가 매번 항등 순열을 내도 앞 두 항목 교환으로 정답을 회피한다", () => {
+    // rng=0이면 Fisher–Yates가 항등 순열 → 재셔플해도 동일 → 스왑 폴백
+    const out = shuffleForReview(items, () => 0);
+    expect(sameOrder(out, items)).toBe(false);
+    expect(out.map((i) => i.id).sort()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("항목이 2개 미만이면 그대로 둔다", () => {
+    const one = [{ id: "x", text: "only" }];
+    expect(shuffleForReview(one, () => 0)).toEqual(one);
+  });
+});
+
+describe("reorder", () => {
+  it("activeId를 overId 위치로 이동한다", () => {
+    expect(reorder(items, "a", "c").map((i) => i.id)).toEqual([
+      "b",
+      "c",
+      "a",
+      "d",
+    ]);
+  });
+
+  it("같은 id면 원본을 그대로 반환", () => {
+    expect(reorder(items, "b", "b")).toBe(items);
+  });
+
+  it("존재하지 않는 id면 원본을 그대로 반환", () => {
+    expect(reorder(items, "a", "zzz")).toBe(items);
+  });
+});

--- a/fe/src/features/review/ordering.ts
+++ b/fe/src/features/review/ordering.ts
@@ -1,0 +1,56 @@
+import { arrayMove } from "@dnd-kit/sortable";
+
+import type { OrderingItem } from "@/features/flashcard/api/flashcards";
+
+/** id 배열의 순서가 같은지. */
+export function sameOrder(a: OrderingItem[], b: OrderingItem[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((item, i) => item.id === b[i].id);
+}
+
+/** Fisher–Yates 셔플(비파괴). rng는 [0,1) 난수. */
+export function fisherYates(
+  items: OrderingItem[],
+  rng: () => number,
+): OrderingItem[] {
+  const a = [...items];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+/**
+ * 복습 시작용 셔플. 마운트 시 1회만 호출한다(렌더마다 재셔플 금지).
+ * 정답 순서와 같으면 재셔플하며, 그래도 같으면(난수 편향 등) 앞 두 항목을 교환해 반드시 다르게 만든다.
+ * 항목이 2개 미만이면 그대로 둔다(실제로는 최소 3개).
+ */
+export function shuffleForReview(
+  items: OrderingItem[],
+  rng: () => number = Math.random,
+): OrderingItem[] {
+  if (items.length < 2) return [...items];
+
+  let shuffled = fisherYates(items, rng);
+  for (let attempt = 0; attempt < 10 && sameOrder(shuffled, items); attempt++) {
+    shuffled = fisherYates(items, rng);
+  }
+  if (sameOrder(shuffled, items)) {
+    [shuffled[0], shuffled[1]] = [shuffled[1], shuffled[0]];
+  }
+  return shuffled;
+}
+
+/** 드래그 종료 시 재정렬(비파괴). 대상이 없거나 같으면 원본 유지. */
+export function reorder(
+  order: OrderingItem[],
+  activeId: string,
+  overId: string,
+): OrderingItem[] {
+  if (activeId === overId) return order;
+  const from = order.findIndex((i) => i.id === activeId);
+  const to = order.findIndex((i) => i.id === overId);
+  if (from === -1 || to === -1) return order;
+  return arrayMove(order, from, to);
+}

--- a/fe/src/pages/planner/TodayReviewsPage.test.tsx
+++ b/fe/src/pages/planner/TodayReviewsPage.test.tsx
@@ -52,12 +52,49 @@ function mockToday(reviewIds: number[], opts?: { delayDays?: number }) {
             easeFactor: 2.5,
             flashcard: {
               id: id * 10,
+              type: "BASIC",
               front: `질문 ${id}`,
               back: `답 ${id}`,
+              items: null,
               material: { id: 1, title: "테스트 자료", type: "BOOK" },
             },
             preview: { again: 1, hard: 6, good: 6, easy: 15 },
           })),
+        },
+      });
+    }),
+  );
+}
+
+function mockTodayOrdering(
+  items: Array<{ id: string; text: string }>,
+  front = "순서대로 배열",
+) {
+  server.use(
+    http.get(`${API_BASE}/planner/reviews/today`, () => {
+      return HttpResponse.json({
+        code: "OK",
+        data: {
+          today: "2026-05-18",
+          reviews: [
+            {
+              id: 1,
+              scheduledAt: "2026-05-18T04:00:00",
+              delayDays: 0,
+              sequence: 2,
+              intervalDays: 6,
+              easeFactor: 2.5,
+              flashcard: {
+                id: 10,
+                type: "ORDERING",
+                front,
+                back: null,
+                items,
+                material: { id: 1, title: "테스트 자료", type: "BOOK" },
+              },
+              preview: { again: 1, hard: 6, good: 6, easy: 15 },
+            },
+          ],
         },
       });
     }),
@@ -210,6 +247,68 @@ describe("TodayReviewsPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("3일 밀린 복습")).toBeInTheDocument();
+    });
+  });
+
+  it("순서 카드는 셔플된 항목과 [정답 확인] 버튼을 보여준다", async () => {
+    const items = [
+      { id: "a", text: "1단계" },
+      { id: "b", text: "2단계" },
+      { id: "c", text: "3단계" },
+    ];
+    mockTodayOrdering(items);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("순서대로 배열")).toBeInTheDocument();
+    });
+    // 순서 카드는 [답 보기]가 아니라 [정답 확인]
+    expect(
+      screen.getByRole("button", { name: /정답 확인/ }),
+    ).toBeInTheDocument();
+    // 모든 항목이 드래그 핸들과 함께 보인다
+    for (const it of items) {
+      expect(screen.getByText(it.text)).toBeInTheDocument();
+    }
+    expect(screen.getAllByRole("button", { name: /순서 이동/ })).toHaveLength(
+      3,
+    );
+    // 아직 정답 순서 섹션은 없다
+    expect(screen.queryByText("정답 순서")).not.toBeInTheDocument();
+  });
+
+  it("[정답 확인] 후 내 배열/정답 순서와 위치별 정오 색이 보이고 평가가 전송된다", async () => {
+    const items = [
+      { id: "a", text: "SYN" },
+      { id: "b", text: "SYN-ACK" },
+      { id: "c", text: "ACK" },
+    ];
+    mockTodayOrdering(items);
+    const ratings: Array<{ id: number; rating: string }> = [];
+    mockComplete(ratings);
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("순서대로 배열")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /정답 확인/ }));
+
+    // 공개 후 정답 순서 섹션 + 위치별 정오 표시(초록/빨강)
+    expect(await screen.findByText("정답 순서")).toBeInTheDocument();
+    expect(screen.getByText("내 배열")).toBeInTheDocument();
+    const marks = screen.getAllByLabelText(/정답 위치|오답 위치/);
+    expect(marks).toHaveLength(3);
+    // 드래그 핸들은 사라진다(잠금)
+    expect(
+      screen.queryByRole("button", { name: /순서 이동/ }),
+    ).not.toBeInTheDocument();
+
+    // 기존 4지선다 평가 그대로 연결
+    await user.click(screen.getByRole("button", { name: /Good/ }));
+    await waitFor(() => {
+      expect(ratings).toEqual([{ id: 1, rating: "GOOD" }]);
     });
   });
 });


### PR DESCRIPTION
## 이슈
closes #745

## 작업 내용
오늘 복습 화면(`ReviewCard`)에서 순서 카드(`type: "ORDERING"`)를 분기해 **셔플 배열 → 드래그 재정렬 → 정답 확인 → 색 비교 → 4지선다** 흐름을 구현한다. 상단 진행 카운터·자료 헤더·평가 버튼은 기존 것을 재사용한다. (Epic #742, 선행 #743·#744)

### 컴포넌트
- `ReviewCard`가 `type`으로 분기 → **`OrderingReviewCard`** 신설. `revealed`·키보드·평가 버튼은 `ReviewCard`가 공유

### 상태 (2개)
- `order`: 사용자 배열(셔플로 시작), `revealed`: 공개 여부(=드래그 잠금). 카드별 `key={flashcard.id}`로 리마운트해 1회 셔플

### 셔플
- 마운트 시 **1회** Fisher–Yates(`useState` lazy init). 정답과 같으면 재셔플, 그래도 같으면 앞 두 항목 스왑으로 반드시 다르게. 렌더마다 재셔플 금지

### 드래그
- @dnd-kit sortable: 핸들만 잡기, PointerSensor 8px 임계값, `arrayMove`, `revealed`면 잠금(정적 렌더). KeyboardSensor

### 공개 (정답 확인)
- 위치별 색 = 채점 아님: `order[i].id === items[i].id` → 초록(정답 위치)/빨강(오답 위치). **점수·정답률 계산·표시 없음**
- 아래에 **정답 순서**를 번호 리스트로 표시
- 기존 4지선다(AGAIN/HARD/GOOD/EASY) → `useCompleteReview` 그대로. 정오가 버튼을 자동 선택하지 않음

### 키보드
- `Space`/`Enter` = 정답 확인(단, 드래그 핸들 조작에는 양보), 공개 후 `1`/`2`/`3`/`4` 평가. 드래그는 @dnd-kit KeyboardSensor

## 테스트
- `ordering.test.ts`(단위): 셔플이 집합 보존·정답 회피(스왑 폴백 포함)·1개 이하 스킵, `reorder`, `sameOrder`
- `TodayReviewsPage.test.tsx`(통합, MSW): 순서 카드 진입 시 셔플 항목+[정답 확인], 공개 후 내 배열/정답 순서·위치별 정오 색·드래그 잠금, 4지선다 평가 전송. 기존 BASIC mock에 type/items 반영
- `npm test`(279) · `tsc -b` 빌드 · `eslint` · `prettier --check` 통과
- **로컬 브라우저 검증**(BE+FE, Playwright): 순서 카드 복습 진입 → 셔플 확인(정답과 다름) → **@dnd-kit 드래그 재정렬** → 정답 확인 → **위치별 초록/빨강**(정답 위치 1건 초록 포함) + 정답 순서 → 드래그 핸들 잠금 → 키보드 Space 공개·숫자키 평가 → 완료 화면까지 전 흐름 확인