### PR TITLE
feat : 양방향 짝 카드 BE — sibling_group_id + 양방향 생성 + burying (SP v2.4)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardCreateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardCreateRequest.java
@@ -21,9 +21,16 @@ public record FlashcardCreateRequest(
 
         String back,
 
-        List<OrderingItem> items
+        List<OrderingItem> items,
+
+        /** 켜면 역방향 카드도 함께 생성한다. BASIC + back 존재일 때만 허용(위반 시 SP-ERR-002). */
+        Boolean bidirectional
 ) {
     public FlashcardType typeOrDefault() {
         return type == null ? FlashcardType.BASIC : type;
+    }
+
+    public boolean isBidirectional() {
+        return Boolean.TRUE.equals(bidirectional);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardCreateResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardCreateResponse.java
@@ -1,9 +1,18 @@
 package ds.project.orino.planner.flashcard.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import ds.project.orino.planner.review.dto.ReviewScheduleView;
 
+/**
+ * 카드 생성 응답. 양방향으로 생성하면 짝 카드를 {@code sibling}에 함께 담는다(단방향이면 생략).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record FlashcardCreateResponse(
         FlashcardResponse flashcard,
-        ReviewScheduleView firstReview
+        ReviewScheduleView firstReview,
+        FlashcardCreateResponse sibling
 ) {
+    public static FlashcardCreateResponse of(FlashcardResponse flashcard, ReviewScheduleView firstReview) {
+        return new FlashcardCreateResponse(flashcard, firstReview, null);
+    }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/dto/FlashcardResponse.java
@@ -16,13 +16,14 @@ public record FlashcardResponse(
         String front,
         String back,
         List<OrderingItem> items,
+        Long siblingGroupId,
         ReviewScheduleView nextReview,
         Instant createdAt
 ) {
     public static FlashcardResponse of(Flashcard f, List<OrderingItem> items, ReviewScheduleView nextReview) {
         return new FlashcardResponse(
                 f.getId(), f.getMaterialId(), f.getType(), f.getFront(), f.getBack(),
-                items, nextReview, f.getCreatedAt());
+                items, f.getSiblingGroupId(), nextReview, f.getCreatedAt());
     }
 
     public static FlashcardResponse withoutReview(Flashcard f, List<OrderingItem> items) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/service/FlashcardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/flashcard/service/FlashcardService.java
@@ -77,10 +77,14 @@ public class FlashcardService {
     @Transactional
     public FlashcardCreateResponse create(Long memberId, Long materialId, FlashcardCreateRequest request) {
         requireOwnedMaterial(memberId, materialId);
-
-        Flashcard saved = flashcardRepository.save(buildCard(memberId, materialId, request));
         ZoneId zone = UserTimeZone.get();
         LocalDate today = clock.instant().atZone(zone).toLocalDate();
+
+        if (request.isBidirectional()) {
+            return createBidirectional(memberId, materialId, request, today, zone);
+        }
+
+        Flashcard saved = flashcardRepository.save(buildCard(memberId, materialId, request));
         ReviewSchedule firstReview = reviewScheduleRepository.save(
                 ReviewSchedule.firstReview(memberId, saved.getId(), today, zone));
 
@@ -88,9 +92,52 @@ public class FlashcardService {
         reviewMirrorService.reconcileAfterCommit(memberId,
                 List.of(firstReview.getScheduledAt().atZone(zone).toLocalDate()), zone);
 
-        return new FlashcardCreateResponse(
+        return FlashcardCreateResponse.of(
                 FlashcardResponse.withoutReview(saved, itemsCodec.parse(saved.getItems())),
                 ReviewScheduleView.firstReview(firstReview));
+    }
+
+    /**
+     * 양방향 짝 카드 생성: A(front→back)·B(back→front)를 같은 siblingGroupId로 만들고
+     * 첫 복습을 엇갈리게(A today+1, B today+2) 예약한다. 응답에 짝(B)을 sibling으로 함께 담는다.
+     */
+    private FlashcardCreateResponse createBidirectional(Long memberId, Long materialId,
+                                                        FlashcardCreateRequest request,
+                                                        LocalDate today, ZoneId zone) {
+        validateBidirectional(request);
+
+        // A: 그룹 키 = 자기 id (짝이 공유)
+        Flashcard a = flashcardRepository.save(
+                new Flashcard(memberId, materialId, request.front(), request.back()));
+        a.assignSiblingGroup(a.getId());
+        // B: front/back 뒤집고 같은 그룹
+        Flashcard b = new Flashcard(memberId, materialId, request.back(), request.front());
+        b.assignSiblingGroup(a.getId());
+        b = flashcardRepository.save(b);
+
+        ReviewSchedule reviewA = reviewScheduleRepository.save(
+                ReviewSchedule.firstReview(memberId, a.getId(), today, zone));
+        ReviewSchedule reviewB = reviewScheduleRepository.save(
+                ReviewSchedule.firstReview(memberId, b.getId(), today, zone, 2));
+
+        reviewMirrorService.reconcileAfterCommit(memberId, List.of(
+                reviewA.getScheduledAt().atZone(zone).toLocalDate(),
+                reviewB.getScheduledAt().atZone(zone).toLocalDate()), zone);
+
+        FlashcardCreateResponse sibling = FlashcardCreateResponse.of(
+                FlashcardResponse.withoutReview(b, null), ReviewScheduleView.firstReview(reviewB));
+        return new FlashcardCreateResponse(
+                FlashcardResponse.withoutReview(a, null),
+                ReviewScheduleView.firstReview(reviewA),
+                sibling);
+    }
+
+    /** 양방향은 BASIC + back 존재(1~1000자)일 때만. ORDERING/back 없음이면 SP-ERR-002. */
+    private static void validateBidirectional(FlashcardCreateRequest request) {
+        if (request.typeOrDefault() != FlashcardType.BASIC) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        validateBasicBack(request.back());
     }
 
     @Transactional

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewCompletionResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewCompletionResponse.java
@@ -1,7 +1,14 @@
 package ds.project.orino.planner.review.dto;
 
+import java.util.List;
+
+/**
+ * 복습 완료 응답. {@code buriedReviewIds}는 sibling burying으로 오늘 큐에서 밀려난 짝 복습 id들
+ * (없으면 빈 배열). FE는 이 id들을 세션 복습 큐에서 제거한다.
+ */
 public record ReviewCompletionResponse(
         CompletedReviewView completed,
-        ReviewScheduleView nextReview
+        ReviewScheduleView nextReview,
+        List<Long> buriedReviewIds
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewFlashcard.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/TodayReviewFlashcard.java
@@ -14,9 +14,11 @@ public record TodayReviewFlashcard(
         String front,
         String back,
         List<OrderingItem> items,
+        Long siblingGroupId,
         TodayReviewMaterial material
 ) {
     public static TodayReviewFlashcard of(Flashcard f, List<OrderingItem> items, TodayReviewMaterial material) {
-        return new TodayReviewFlashcard(f.getId(), f.getType(), f.getFront(), f.getBack(), items, material);
+        return new TodayReviewFlashcard(
+                f.getId(), f.getType(), f.getFront(), f.getBack(), items, f.getSiblingGroupId(), material);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCompletionService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCompletionService.java
@@ -2,6 +2,8 @@ package ds.project.orino.planner.review.service;
 
 import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
 import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
 import ds.project.orino.domain.planner.review.entity.ReviewStatus;
 import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
@@ -18,18 +20,22 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
 public class ReviewCompletionService {
 
     private final ReviewScheduleRepository reviewScheduleRepository;
+    private final FlashcardRepository flashcardRepository;
     private final ReviewMirrorService reviewMirrorService;
     private final Clock clock;
 
     public ReviewCompletionService(ReviewScheduleRepository reviewScheduleRepository,
+                                   FlashcardRepository flashcardRepository,
                                    ReviewMirrorService reviewMirrorService, Clock clock) {
         this.reviewScheduleRepository = reviewScheduleRepository;
+        this.flashcardRepository = flashcardRepository;
         this.reviewMirrorService = reviewMirrorService;
         this.clock = clock;
     }
@@ -58,14 +64,55 @@ public class ReviewCompletionService {
                 memberId, current.getFlashcardId(), newSequence,
                 scheduledAt, computed.intervalDays(), computed.easeFactor()));
 
-        // 완료된 dueDate(감소)와 다음 dueDate(증가) 묶음을 모두 재동기화(커밋 후, 미러 활성 시에만).
+        // Sibling burying — 오늘 due인 짝 복습을 내일로 미룬다(regurgitation 방지). SM-2는 불변.
+        List<Long> affectedDates = new ArrayList<>();
+        List<Long> buriedReviewIds = burySiblings(memberId, current.getFlashcardId(), now, zone, affectedDates);
+
+        // 완료된 dueDate(감소)와 다음 dueDate(증가) 묶음 + burying으로 바뀐 dueDate들을 재동기화(커밋 후).
         // AGAIN은 04:00 정각이 아니어서 reconcile 집계에서 자연히 제외된다.
-        LocalDate completedDate = current.getScheduledAt().atZone(zone).toLocalDate();
-        LocalDate nextDate = next.getScheduledAt().atZone(zone).toLocalDate();
-        reviewMirrorService.reconcileAfterCommit(memberId, List.of(completedDate, nextDate), zone);
+        List<LocalDate> reconcileDates = new ArrayList<>();
+        reconcileDates.add(current.getScheduledAt().atZone(zone).toLocalDate());
+        reconcileDates.add(next.getScheduledAt().atZone(zone).toLocalDate());
+        for (Long epochDay : affectedDates) {
+            reconcileDates.add(LocalDate.ofEpochDay(epochDay));
+        }
+        reviewMirrorService.reconcileAfterCommit(memberId, reconcileDates, zone);
 
         return new ReviewCompletionResponse(
                 CompletedReviewView.of(current),
-                ReviewScheduleView.firstReview(next));
+                ReviewScheduleView.firstReview(next),
+                buriedReviewIds);
+    }
+
+    /**
+     * 완료한 카드에 짝(siblingGroupId)이 있으면, 지금 due(scheduled_at ≤ now, PENDING)인 짝 복습을
+     * 내일 04:00으로 미룬다. SM-2 간격/ease는 건드리지 않는다. 밀린 복습 id들을 반환한다.
+     * {@code affectedDates}에는 재동기화가 필요한 날짜(밀리기 전/후)를 epochDay로 담는다.
+     */
+    private List<Long> burySiblings(Long memberId, Long flashcardId, Instant now, ZoneId zone,
+                                    List<Long> affectedDates) {
+        Flashcard card = flashcardRepository.findById(flashcardId).orElse(null);
+        if (card == null || card.getSiblingGroupId() == null) {
+            return List.of();
+        }
+        List<Long> siblingIds = flashcardRepository.findAllBySiblingGroupId(card.getSiblingGroupId()).stream()
+                .map(Flashcard::getId)
+                .filter(id -> !id.equals(flashcardId))
+                .toList();
+        if (siblingIds.isEmpty()) {
+            return List.of();
+        }
+        List<ReviewSchedule> dueSiblings = reviewScheduleRepository
+                .findAllByFlashcardIdInAndStatusAndScheduledAtLessThanEqual(
+                        siblingIds, ReviewStatus.PENDING, now);
+
+        List<Long> buriedIds = new ArrayList<>();
+        for (ReviewSchedule sibling : dueSiblings) {
+            affectedDates.add(sibling.getScheduledAt().atZone(zone).toLocalDate().toEpochDay());
+            sibling.bury(now, zone);
+            affectedDates.add(sibling.getScheduledAt().atZone(zone).toLocalDate().toEpochDay());
+            buriedIds.add(sibling.getId());
+        }
+        return buriedIds;
     }
 }

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/035-add-flashcard-sibling-group.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/035-add-flashcard-sibling-group.yaml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+  # 양방향 짝 카드 (#748, Epic #747, Study Planner v2.4).
+  # flashcard에 짝 공유 키(sibling_group_id)를 추가한다. 양방향으로 생성된 (앞→뒤)·(뒤→앞)
+  # 두 카드가 같은 그룹 값을 공유한다. FK 없음(그룹 키), 기존 카드는 전부 NULL로 무손실 유지.
+  - changeSet:
+      id: 035-add-flashcard-sibling-group
+      author: wcorn
+      comment: flashcard에 짝 그룹 키(sibling_group_id) + 인덱스 추가.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: flashcard
+                columnName: sibling_group_id
+      changes:
+        - addColumn:
+            tableName: flashcard
+            columns:
+              - column:
+                  name: sibling_group_id
+                  type: BIGINT
+        - createIndex:
+            tableName: flashcard
+            indexName: idx_flashcard_sibling_group
+            columns:
+              - column:
+                  name: sibling_group_id

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -67,3 +67,5 @@ databaseChangeLog:
       file: db/changelog/changes/033-merge-memo-into-note.yaml
   - include:
       file: db/changelog/changes/034-add-flashcard-type-items.yaml
+  - include:
+      file: db/changelog/changes/035-add-flashcard-sibling-group.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/flashcard/controller/FlashcardControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/flashcard/controller/FlashcardControllerTest.java
@@ -490,6 +490,72 @@ class FlashcardControllerTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.items").doesNotExist());
     }
 
+    // ===== 양방향 짝 카드(Bidirectional) =====
+
+    @Test
+    @DisplayName("POST bidirectional - 앞↔뒤 2장 생성 + 같은 siblingGroupId + 첫 복습 엇갈림(A+1, B+2)")
+    void create_bidirectional_pair() throws Exception {
+        LocalDate today = testToday(clock);
+
+        String body = mockMvc.perform(post("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"front":"쿠버네티스","back":"컨테이너 오케스트레이션","bidirectional":true}
+                                """))
+                .andExpect(status().isCreated())
+                // A: front→back, siblingGroupId = A.id, 첫 복습 today+1
+                .andExpect(jsonPath("$.data.flashcard.front").value("쿠버네티스"))
+                .andExpect(jsonPath("$.data.flashcard.back").value("컨테이너 오케스트레이션"))
+                .andExpect(jsonPath("$.data.flashcard.siblingGroupId").exists())
+                .andExpect(jsonPath("$.data.firstReview.scheduledAt",
+                        startsWith(today.plusDays(1) + "T04:00")))
+                .andExpect(jsonPath("$.data.firstReview.intervalDays").value(1))
+                // sibling B: front/back 뒤집힘, 같은 그룹, 첫 복습 today+2
+                .andExpect(jsonPath("$.data.sibling.flashcard.front").value("컨테이너 오케스트레이션"))
+                .andExpect(jsonPath("$.data.sibling.flashcard.back").value("쿠버네티스"))
+                .andExpect(jsonPath("$.data.sibling.firstReview.scheduledAt",
+                        startsWith(today.plusDays(2) + "T04:00")))
+                .andExpect(jsonPath("$.data.sibling.firstReview.intervalDays").value(1))
+                .andReturn().getResponse().getContentAsString();
+
+        Number groupA = com.jayway.jsonpath.JsonPath.read(body, "$.data.flashcard.siblingGroupId");
+        Number groupB = com.jayway.jsonpath.JsonPath.read(body, "$.data.sibling.flashcard.siblingGroupId");
+        org.assertj.core.api.Assertions.assertThat(groupA.longValue())
+                .isEqualTo(groupB.longValue());
+
+        // 실제로 2장 + 2 review 저장
+        org.assertj.core.api.Assertions.assertThat(flashcardRepository.findAll()).hasSize(2);
+        org.assertj.core.api.Assertions.assertThat(reviewScheduleRepository.findAll()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("POST bidirectional - ORDERING + bidirectional이면 400")
+    void create_bidirectional_ordering_returns_400() throws Exception {
+        mockMvc.perform(post("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"type":"ORDERING","front":"F","bidirectional":true,
+                                 "items":[{"id":"a","text":"1"},{"id":"b","text":"2"},{"id":"c","text":"3"}]}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
+    @Test
+    @DisplayName("POST bidirectional - back 없으면 400")
+    void create_bidirectional_without_back_returns_400() throws Exception {
+        mockMvc.perform(post("/api/planner/materials/{id}/flashcards", material.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"front":"Q","bidirectional":true}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SP-ERR-002"));
+    }
+
     @Test
     @DisplayName("PATCH - BASIC → ORDERING 전환인데 items 미지정이면 400")
     void update_convert_to_ordering_without_items_fails() throws Exception {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
@@ -27,6 +27,8 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -254,5 +256,93 @@ class ReviewControllerTest extends ApiTestSupport {
             Number nextId = com.jayway.jsonpath.JsonPath.read(body, "$.data.nextReview.id");
             currentId = nextId.longValue();
         }
+    }
+
+    @Test
+    @DisplayName("POST complete - 단방향 카드는 buriedReviewIds가 빈 배열")
+    void complete_solo_card_returns_empty_buried() throws Exception {
+        LocalDate today = testToday(clock);
+        ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 1, atTestZone(today.atTime(4, 0)), 1,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating":"GOOD"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.buriedReviewIds", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("POST complete - 짝 카드 완료 시 오늘 due인 형제 review를 내일로 밀어내고 buriedReviewIds로 반환")
+    void complete_buries_due_sibling() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "자료2", MaterialType.BOOK));
+        Flashcard a = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "정의", "설명"));
+        a.assignSiblingGroup(a.getId());
+        flashcardRepository.save(a);
+        Flashcard b = new Flashcard(member.getId(), material.getId(), "설명", "정의");
+        b.assignSiblingGroup(a.getId());
+        b = flashcardRepository.save(b);
+
+        LocalDate today = testToday(clock);
+        ReviewSchedule reviewA = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), a.getId(), 1, atTestZone(today.atTime(4, 0)), 1, new BigDecimal("2.50")));
+        ReviewSchedule reviewB = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), b.getId(), 1, atTestZone(today.atTime(4, 0)), 1, new BigDecimal("2.50")));
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", reviewA.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating":"GOOD"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.buriedReviewIds", hasSize(1)))
+                .andExpect(jsonPath("$.data.buriedReviewIds",
+                        contains(reviewB.getId().intValue())));
+
+        // 형제 review는 내일 04:00으로 이동 (SM-2 간격/ease/status는 불변)
+        ReviewSchedule buried = reviewScheduleRepository.findById(reviewB.getId()).orElseThrow();
+        assertThat(buried.getScheduledAt()).isEqualTo(atTestZone(today.plusDays(1).atTime(4, 0)));
+        assertThat(buried.getIntervalDays()).isEqualTo(1);
+        assertThat(buried.getEaseFactor()).isEqualByComparingTo("2.50");
+        assertThat(buried.getStatus()).isEqualTo(ReviewStatus.PENDING);
+        assertThat(buried.getSequence()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("POST complete - 형제 review가 미래(내일)면 밀어내지 않는다")
+    void complete_does_not_bury_future_sibling() throws Exception {
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "자료3", MaterialType.BOOK));
+        Flashcard a = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "정의", "설명"));
+        a.assignSiblingGroup(a.getId());
+        flashcardRepository.save(a);
+        Flashcard b = new Flashcard(member.getId(), material.getId(), "설명", "정의");
+        b.assignSiblingGroup(a.getId());
+        b = flashcardRepository.save(b);
+
+        LocalDate today = testToday(clock);
+        ReviewSchedule reviewA = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), a.getId(), 1, atTestZone(today.atTime(4, 0)), 1, new BigDecimal("2.50")));
+        ReviewSchedule futureB = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), b.getId(), 1, atTestZone(today.plusDays(1).atTime(4, 0)), 1,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", reviewA.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating":"GOOD"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.buriedReviewIds", hasSize(0)));
+
+        ReviewSchedule unchanged = reviewScheduleRepository.findById(futureB.getId()).orElseThrow();
+        assertThat(unchanged.getScheduledAt()).isEqualTo(atTestZone(today.plusDays(1).atTime(4, 0)));
     }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/entity/Flashcard.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/entity/Flashcard.java
@@ -45,6 +45,10 @@ public class Flashcard {
     @Column(columnDefinition = "JSON")
     private String items;
 
+    /** 양방향 짝 카드가 공유하는 그룹 키(짝 카드끼리 동일 값). 단방향 카드는 null. FK 아님. */
+    @Column(name = "sibling_group_id")
+    private Long siblingGroupId;
+
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private Instant createdAt;
@@ -78,6 +82,11 @@ public class Flashcard {
 
     public void updateFront(String front) {
         this.front = front;
+    }
+
+    /** 양방향 짝 그룹 키를 지정한다(짝 두 카드가 같은 값을 공유). */
+    public void assignSiblingGroup(Long siblingGroupId) {
+        this.siblingGroupId = siblingGroupId;
     }
 
     /** BASIC 카드로 전환/갱신한다. items는 비운다. */
@@ -120,6 +129,10 @@ public class Flashcard {
 
     public String getItems() {
         return items;
+    }
+
+    public Long getSiblingGroupId() {
+        return siblingGroupId;
     }
 
     public Instant getCreatedAt() {

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/repository/FlashcardRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/flashcard/repository/FlashcardRepository.java
@@ -14,4 +14,7 @@ public interface FlashcardRepository extends JpaRepository<Flashcard, Long> {
     Optional<Flashcard> findByIdAndMemberId(Long id, Long memberId);
 
     List<Flashcard> findAllByIdIn(Collection<Long> ids);
+
+    /** 같은 양방향 짝 그룹에 속한 카드들. */
+    List<Flashcard> findAllBySiblingGroupId(Long siblingGroupId);
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewSchedule.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewSchedule.java
@@ -94,7 +94,16 @@ public class ReviewSchedule {
      * 첫 복습 일정을 생성한다. due 시각은 사용자 시간대 기준 익일 04:00(롤오버)을 UTC로 환산한 값이다.
      */
     public static ReviewSchedule firstReview(Long memberId, Long flashcardId, LocalDate today, ZoneId zone) {
-        Instant scheduledAt = today.plusDays(1).atTime(ROLLOVER_HOUR, 0).atZone(zone).toInstant();
+        return firstReview(memberId, flashcardId, today, zone, 1);
+    }
+
+    /**
+     * 첫 복습 일정을 {@code afterDays}일 뒤 04:00으로 생성한다. 양방향 짝 카드의 첫 복습 엇갈림
+     * (A=today+1, B=today+2)에 사용한다. {@code interval_days}는 1로 동일하다.
+     */
+    public static ReviewSchedule firstReview(Long memberId, Long flashcardId, LocalDate today,
+                                             ZoneId zone, int afterDays) {
+        Instant scheduledAt = today.plusDays(afterDays).atTime(ROLLOVER_HOUR, 0).atZone(zone).toInstant();
         return new ReviewSchedule(memberId, flashcardId, 1, scheduledAt, 1, INITIAL_EASE_FACTOR);
     }
 
@@ -120,6 +129,15 @@ public class ReviewSchedule {
         this.elapsedDays = (int) ChronoUnit.DAYS.between(
                 this.scheduledAt.atZone(zone).toLocalDate(), now.atZone(zone).toLocalDate());
         this.completedAt = now;
+    }
+
+    /**
+     * Sibling burying — due 시각을 익일 04:00(사용자 시간대)으로 미룬다.
+     * SM-2 간격/ease/sequence/status는 건드리지 않고 due 날짜만 이동한다.
+     */
+    public void bury(Instant now, ZoneId zone) {
+        LocalDate tomorrow = now.atZone(zone).toLocalDate().plusDays(1);
+        this.scheduledAt = tomorrow.atTime(ROLLOVER_HOUR, 0).atZone(zone).toInstant();
     }
 
     public Long getId() {

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
@@ -14,6 +14,10 @@ public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, 
     List<ReviewSchedule> findAllByFlashcardIdInAndStatusOrderByScheduledAtAscIdAsc(
             Collection<Long> flashcardIds, ReviewStatus status);
 
+    /** Sibling burying용 — 짝 카드들의 현재 due(scheduled_at ≤ now) PENDING 복습. */
+    List<ReviewSchedule> findAllByFlashcardIdInAndStatusAndScheduledAtLessThanEqual(
+            Collection<Long> flashcardIds, ReviewStatus status, Instant scheduledAt);
+
     Optional<ReviewSchedule> findByIdAndMemberId(Long id, Long memberId);
 
     List<ReviewSchedule> findAllByMemberIdAndStatusAndScheduledAtLessThanEqualOrderByScheduledAtAscIdAsc(


### PR DESCRIPTION
## 이슈
closes #748

## 작업 내용
`flashcard`에 짝 그룹 키를 더해 양방향 카드 생성과 sibling burying을 구현한다. `review_schedule` 스키마는 **변경 없음**(burying은 `scheduled_at` 이동만). (Epic #747, Study Planner v2.4)

### 마이그레이션 — `035-add-flashcard-sibling-group.yaml`
> v2.3에서 `034-add-flashcard-type-items`를 이미 썼으므로 `035`로 진행 (이슈의 034는 v2.3 기준 표기)

- `sibling_group_id BIGINT NULL` + 인덱스 `(sibling_group_id)`
- `columnExists` 가드, FK 없음(그룹 키). 기존 카드 전부 NULL — 무손실

### 양방향 생성 (`POST .../flashcards`, `bidirectional: true`)
- BASIC + `back` 존재일 때만. ORDERING/back 없음이면 `400 SP-ERR-002`
- `A(front→back)`·`B(back→front)` 두 행을 같은 `siblingGroupId`(=A.id)로 한 트랜잭션에 생성
- **첫 복습 엇갈림**: A `today+1` 04:00, B `today+2` 04:00 (`interval_days`는 둘 다 1)
- 응답: `{ flashcard, firstReview }` + 짝을 `sibling: { flashcard, firstReview }`로 동봉 (`@JsonInclude(NON_NULL)`로 단방향이면 생략)
- `siblingGroupId`를 list/today/create 응답에 노출

### Sibling burying (`POST /reviews/{id}/complete`)
- 완료 후, 완료 카드의 `siblingGroupId`가 있으면 **현재 due(`scheduled_at ≤ now`, PENDING)인 형제 review**를 **내일 04:00**으로 이동
- SM-2 간격/ease/sequence/status는 불변 — due 날짜만 지연
- 밀린 review id들을 `buriedReviewIds`로 반환(없으면 빈 배열), 캘린더 미러 정합 유지

## 테스트
- `FlashcardControllerTest`: 양방향 2행 생성(같은 group·엇갈림·sibling 동봉), ORDERING+bidirectional → 400, back 없음 → 400
- `ReviewControllerTest`: 단방향 완료 시 빈 `buriedReviewIds`, 짝 완료 시 오늘 due 형제만 내일로 이동(SM-2 불변)·미래 형제 미이동
- `./gradlew check` 통과 (전 모듈 테스트 + checkstyle)
- **로컬 검증**(docker-compose + bootRun): Hibernate `validate` 통과(035 적용) 후 curl로 — 양방향 생성(같은 group=4·A 7/7·B 7/8) → 두 review due 당김 → A 완료 시 `buriedReviewIds:[7]`·B가 내일 04:00로 이동·interval/ease 불변 → 목록에 `siblingGroupId` 노출까지 확인