### PR TITLE
feat : 양방향 짝 카드 FE — 추가 옵션 + 복습 큐 sibling bury 처리

### DIFF
--- a/fe/src/features/flashcard/api/flashcards.ts
+++ b/fe/src/features/flashcard/api/flashcards.ts
@@ -30,6 +30,8 @@ export interface Flashcard {
   back: string | null;
   /** ORDERING 카드만 정답 순서 배열, BASIC은 없음(null/생략). */
   items: OrderingItem[] | null;
+  /** 양방향 짝 카드가 공유하는 그룹 키. 단방향 카드는 null. */
+  siblingGroupId: number | null;
   nextReview: NextReview | null;
   createdAt: string;
 }
@@ -46,13 +48,21 @@ export type FlashcardMutationPayload =
   | { type: "BASIC"; front: string; back: string }
   | { type: "ORDERING"; front: string; items: OrderingItem[] };
 
-export type FlashcardCreateRequest = FlashcardMutationPayload;
+/** 생성 요청. BASIC은 `bidirectional`로 역방향 짝 카드도 함께 만들 수 있다(ORDERING 불가). */
+export type FlashcardCreateRequest =
+  | { type: "BASIC"; front: string; back: string; bidirectional?: boolean }
+  | { type: "ORDERING"; front: string; items: OrderingItem[] };
 
 export type FlashcardUpdateRequest = FlashcardMutationPayload;
 
 export interface FlashcardCreateResponse {
   flashcard: Flashcard;
   firstReview: FirstReview;
+  /** 양방향 생성일 때만 짝(역방향) 카드가 담긴다. */
+  sibling?: {
+    flashcard: Flashcard;
+    firstReview: FirstReview;
+  };
 }
 
 interface ApiEnvelope<T> {

--- a/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
+++ b/fe/src/features/flashcard/components/FlashcardFormDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useState } from "react";
 
+import { Checkbox } from "@/components/ui/checkbox";
 import { FormField } from "@/components/ui/form-field";
 import { Modal } from "@/components/ui/modal";
 import { Textarea } from "@/components/ui/textarea";
@@ -29,7 +30,10 @@ interface Props {
   initialBack?: string | null;
   initialItems?: OrderingItem[] | null;
   pending?: boolean;
-  onSubmit: (payload: FlashcardMutationPayload) => void;
+  onSubmit: (
+    payload: FlashcardMutationPayload,
+    options: { bidirectional: boolean },
+  ) => void;
   onDelete?: () => void;
 }
 
@@ -53,6 +57,7 @@ export function FlashcardFormDialog({
   const [items, setItems] = useState<OrderingItem[]>(() =>
     ensureMinItems(initialItems ?? []),
   );
+  const [bidirectional, setBidirectional] = useState(false);
 
   useEffect(() => {
     if (open) {
@@ -60,6 +65,7 @@ export function FlashcardFormDialog({
       setFront(initialFront);
       setBack(initialBack ?? "");
       setItems(ensureMinItems(initialItems ?? []));
+      setBidirectional(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
@@ -82,17 +88,23 @@ export function FlashcardFormDialog({
       ? back !== (initialBack ?? "")
       : !itemsEqual(items, initialItemsFilled));
 
+  // 양방향은 BASIC + 추가 모드 + 앞·뒤 채움일 때만
+  const showBidirectional = mode === "create" && type === "BASIC";
+  const bidirectionalEnabled = showBidirectional && valid;
+
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     if (!valid || !dirty || pending) return;
     if (type === "ORDERING") {
-      onSubmit({
-        type: "ORDERING",
-        front: frontTrim,
-        items: normalizeItems(items),
-      });
+      onSubmit(
+        { type: "ORDERING", front: frontTrim, items: normalizeItems(items) },
+        { bidirectional: false },
+      );
     } else {
-      onSubmit({ type: "BASIC", front: frontTrim, back: backTrim });
+      onSubmit(
+        { type: "BASIC", front: frontTrim, back: backTrim },
+        { bidirectional: bidirectionalEnabled && bidirectional },
+      );
     }
   };
 
@@ -130,6 +142,29 @@ export function FlashcardFormDialog({
             onChange={setBack}
             max={MAX_LEN}
           />
+        )}
+
+        {showBidirectional && (
+          <label
+            className={cn(
+              "flex items-start gap-2 text-sm",
+              !bidirectionalEnabled && "opacity-50",
+            )}
+          >
+            <Checkbox
+              checked={bidirectional}
+              disabled={!bidirectionalEnabled}
+              onChange={(e) => setBidirectional(e.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="font-medium">양방향</span>
+              <span className="text-muted-foreground">
+                {" "}
+                — 역방향 카드도 함께 만들기 (앞↔뒤)
+              </span>
+            </span>
+          </label>
         )}
 
         <Modal.Footer

--- a/fe/src/features/flashcard/components/FlashcardListTab.test.tsx
+++ b/fe/src/features/flashcard/components/FlashcardListTab.test.tsx
@@ -399,4 +399,120 @@ describe("FlashcardListTab", () => {
     // 기본 카드의 "뒤:" 프리픽스는 나타나지 않는다
     expect(screen.queryByText(/^뒤:/)).not.toBeInTheDocument();
   });
+
+  it("양방향 체크 후 생성하면 bidirectional 요청 + 2장 토스트", async () => {
+    mockListEmpty();
+    let posted: Record<string, unknown> | null = null;
+    server.use(
+      http.post(
+        `${API_BASE}/planner/materials/1/flashcards`,
+        async ({ request }) => {
+          posted = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(
+            {
+              code: "OK",
+              data: {
+                flashcard: {
+                  id: 40,
+                  materialId: 1,
+                  type: "BASIC",
+                  front: "정의",
+                  back: "설명",
+                  items: null,
+                  siblingGroupId: 40,
+                  nextReview: null,
+                  createdAt: "2026-05-18T00:00:00",
+                },
+                firstReview: {
+                  id: 400,
+                  flashcardId: 40,
+                  sequence: 1,
+                  scheduledAt: "2026-05-19T04:00:00",
+                  intervalDays: 1,
+                  easeFactor: 2.5,
+                  status: "PENDING",
+                },
+                sibling: {
+                  flashcard: {
+                    id: 41,
+                    materialId: 1,
+                    type: "BASIC",
+                    front: "설명",
+                    back: "정의",
+                    items: null,
+                    siblingGroupId: 40,
+                    nextReview: null,
+                    createdAt: "2026-05-18T00:00:00",
+                  },
+                  firstReview: {
+                    id: 401,
+                    flashcardId: 41,
+                    sequence: 1,
+                    scheduledAt: "2026-05-20T04:00:00",
+                    intervalDays: 1,
+                    easeFactor: 2.5,
+                    status: "PENDING",
+                  },
+                },
+              },
+            },
+            { status: 201 },
+          );
+        },
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 카드가 없습니다.")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /첫 카드 추가/ }));
+
+    const checkbox = await screen.findByRole("checkbox", { name: /양방향/ });
+    // 앞·뒤 채우기 전에는 비활성
+    expect(checkbox).toBeDisabled();
+
+    await user.type(await screen.findByLabelText("앞면 (질문)"), "정의");
+    await user.type(screen.getByLabelText("뒷면 (답)"), "설명");
+    expect(checkbox).toBeEnabled();
+
+    await user.click(checkbox);
+    await user.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() => {
+      expect(posted).toEqual({
+        type: "BASIC",
+        front: "정의",
+        back: "설명",
+        bidirectional: true,
+      });
+    });
+    expect(
+      await screen.findByText(/양방향 카드 2장이 추가되었어요/),
+    ).toBeInTheDocument();
+  });
+
+  it("양방향 체크박스는 기본(BASIC) 추가 모드에서만 노출된다", async () => {
+    mockListEmpty();
+    const user = userEvent.setup();
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 카드가 없습니다.")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /첫 카드 추가/ }));
+
+    // BASIC 추가 모드: 노출
+    expect(
+      await screen.findByRole("checkbox", { name: /양방향/ }),
+    ).toBeInTheDocument();
+
+    // 순서 모드로 전환하면 사라진다
+    await user.click(screen.getByRole("radio", { name: "순서" }));
+    expect(
+      screen.queryByRole("checkbox", { name: /양방향/ }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/fe/src/features/flashcard/components/FlashcardListTab.tsx
+++ b/fe/src/features/flashcard/components/FlashcardListTab.tsx
@@ -7,7 +7,11 @@ import { FieldError } from "@/components/ui/field-error";
 import { LoadingText } from "@/components/ui/loading-text";
 import { toast } from "@/shared/lib/toast";
 
-import type { Flashcard, FlashcardMutationPayload } from "../api/flashcards";
+import type {
+  Flashcard,
+  FlashcardCreateRequest,
+  FlashcardMutationPayload,
+} from "../api/flashcards";
 import { useCreateFlashcard } from "../hooks/useCreateFlashcard";
 import { useDeleteFlashcard } from "../hooks/useDeleteFlashcard";
 import { useFlashcards } from "../hooks/useFlashcards";
@@ -30,11 +34,23 @@ export function FlashcardListTab({ materialId }: Props) {
   const updateMutation = useUpdateFlashcard(materialId, editing?.id ?? 0);
   const deleteMutation = useDeleteFlashcard(materialId);
 
-  const handleCreate = (values: FlashcardMutationPayload) => {
-    createMutation.mutate(values, {
+  const handleCreate = (
+    values: FlashcardMutationPayload,
+    { bidirectional }: { bidirectional: boolean },
+  ) => {
+    const request: FlashcardCreateRequest =
+      bidirectional && values.type === "BASIC"
+        ? { ...values, bidirectional: true }
+        : values;
+    createMutation.mutate(request, {
       onSuccess: () => {
         setCreateOpen(false);
-        toast("카드가 추가되었어요. 첫 복습은 내일.", "success");
+        toast(
+          bidirectional
+            ? "양방향 카드 2장이 추가되었어요."
+            : "카드가 추가되었어요. 첫 복습은 내일.",
+          "success",
+        );
       },
       onError: () =>
         toast("카드 추가에 실패했어요. 잠시 후 다시 시도해주세요.", "error"),

--- a/fe/src/features/review/api/reviews.ts
+++ b/fe/src/features/review/api/reviews.ts
@@ -20,6 +20,8 @@ export interface TodayReviewFlashcard {
   back: string | null;
   /** ORDERING 카드만 정답 순서 배열. */
   items: OrderingItem[] | null;
+  /** 양방향 짝 카드가 공유하는 그룹 키. 단방향 카드는 null. */
+  siblingGroupId: number | null;
   material: TodayReviewMaterial;
 }
 
@@ -80,6 +82,8 @@ export interface NextReview {
 export interface CompleteReviewResponse {
   completed: CompletedReview;
   nextReview: NextReview;
+  /** sibling burying으로 오늘 큐에서 밀려난 짝 복습 id들(없으면 빈 배열). */
+  buriedReviewIds: number[];
 }
 
 export async function completeReview(

--- a/fe/src/pages/planner/TodayReviewsPage.test.tsx
+++ b/fe/src/pages/planner/TodayReviewsPage.test.tsx
@@ -56,6 +56,7 @@ function mockToday(reviewIds: number[], opts?: { delayDays?: number }) {
               front: `질문 ${id}`,
               back: `답 ${id}`,
               items: null,
+              siblingGroupId: null,
               material: { id: 1, title: "테스트 자료", type: "BOOK" },
             },
             preview: { again: 1, hard: 6, good: 6, easy: 15 },
@@ -90,6 +91,7 @@ function mockTodayOrdering(
                 front,
                 back: null,
                 items,
+                siblingGroupId: null,
                 material: { id: 1, title: "테스트 자료", type: "BOOK" },
               },
               preview: { again: 1, hard: 6, good: 6, easy: 15 },
@@ -101,7 +103,10 @@ function mockTodayOrdering(
   );
 }
 
-function mockComplete(captureRatings: Array<{ id: number; rating: string }>) {
+function mockComplete(
+  captureRatings: Array<{ id: number; rating: string }>,
+  buriedReviewIds: number[] = [],
+) {
   server.use(
     http.post(
       `${API_BASE}/planner/reviews/:id/complete`,
@@ -127,6 +132,7 @@ function mockComplete(captureRatings: Array<{ id: number; rating: string }>) {
               easeFactor: 2.5,
               status: "PENDING",
             },
+            buriedReviewIds,
           },
         });
       },
@@ -310,5 +316,31 @@ describe("TodayReviewsPage", () => {
     await waitFor(() => {
       expect(ratings).toEqual([{ id: 1, rating: "GOOD" }]);
     });
+  });
+
+  it("짝 카드가 밀리면 큐에서 제거되고 카운터 분모가 감소한다", async () => {
+    // 큐 [1,2,3] 중 1을 완료하면 짝(review 2)이 밀린다
+    mockToday([1, 2, 3]);
+    mockComplete([], [2]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("질문 1")).toBeInTheDocument();
+    });
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+
+    await user.keyboard(" ");
+    await user.click(await screen.findByRole("button", { name: /Good/ }));
+
+    // 짝(질문 2)은 건너뛰고 질문 3으로, 분모는 3 → 2
+    await waitFor(() => {
+      expect(screen.getByText("질문 3")).toBeInTheDocument();
+    });
+    expect(screen.getByText("2 / 2")).toBeInTheDocument();
+    expect(screen.queryByText("질문 2")).not.toBeInTheDocument();
+    expect(
+      await screen.findByText(/짝 카드는 다른 날 복습해요/),
+    ).toBeInTheDocument();
   });
 });

--- a/fe/src/pages/planner/TodayReviewsPage.tsx
+++ b/fe/src/pages/planner/TodayReviewsPage.tsx
@@ -48,6 +48,14 @@ export function TodayReviewsPage() {
       {
         onSuccess: (res) => {
           toast(formatNextReviewMessage(res.nextReview.scheduledAt), "success");
+          // sibling burying — 밀려난 짝 복습을 오늘 세션 큐에서 제거(분모도 함께 감소)
+          const buried = res.buriedReviewIds ?? [];
+          if (buried.length > 0) {
+            setQueue((q) =>
+              q === null ? q : q.filter((r) => !buried.includes(r.id)),
+            );
+            toast("짝 카드는 다른 날 복습해요.", "info");
+          }
           setCurrentIndex((i) => i + 1);
         },
       },


### PR DESCRIPTION
## 이슈
closes #749

## 작업 내용
카드 추가 다이얼로그(BASIC)에 **양방향 옵션**을 넣고, 복습 화면에서 **sibling burying**으로 밀린 짝 카드를 세션 큐에서 제거한다. (Epic #747, 선행 #748 BE)

### 타입/API 레이어
- `Flashcard`에 `siblingGroupId: number | null`
- 생성 요청 BASIC에 `bidirectional?: boolean`
- 생성 응답에 `sibling?: { flashcard, firstReview }`
- 복습 완료 응답에 `buriedReviewIds: number[]`, 복습 flashcard에 `siblingGroupId`

### 카드 추가 다이얼로그 (BASIC, 추가 모드 전용)
- 뒷면 아래 체크박스 `☐ 양방향 — 역방향 카드도 함께 만들기 (앞↔뒤)`
- 앞·뒤 모두 채워졌을 때만 활성. 편집 모드/순서 모드에는 미노출
- 체크 시 요청에 `bidirectional: true` → 생성 후 캐시 무효화(카드 목록/오늘 복습)로 2장 반영
- 토스트: `양방향 카드 2장이 추가되었어요.`

### 복습 화면 (오늘 복습)
- 완료 응답의 `buriedReviewIds`가 있으면 **현재 세션 큐에서 해당 review 제거**(오늘 안 나오게) + 진행 카운터 분모 감소
- 보조 토스트: `짝 카드는 다른 날 복습해요.`
- 밀린 review는 index보다 뒤(아직 안 본 카드)에만 존재하므로 filter + `currentIndex+1`로 자연히 다음 카드로 이동

## 테스트
- `FlashcardListTab.test.tsx`: 양방향 체크 후 생성 요청(`bidirectional:true`)·2장 토스트, 체크박스는 BASIC 추가 모드에서만 노출(순서 전환 시 사라짐)
- `TodayReviewsPage.test.tsx`: 짝 밀림 시 큐에서 제거(질문 2 건너뛰고 질문 3)·분모 3→2·bury 토스트
- `npm test`(282) · `tsc -b` 빌드 · `eslint` · `prettier --check` 통과
- **로컬 브라우저 검증**(BE #748 + FE, Playwright): 양방향 체크박스(앞·뒤 채움 시 활성) → 생성 시 요청 `bidirectional:true` → 뒤집힌 2장 목록 반영(같은 `sibling_group_id`) → 두 짝 오늘 due로 설정 후 복습에서 한쪽 완료 시 **나머지 짝이 큐에서 제거("1개 완료")**·DB에서 짝 review가 내일 04:00로 이동(SM-2 불변)까지 확인