### PR TITLE
feat : 복습 허브 BE — 요약·집계 + upcoming/completed 조회 API (#755)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/controller/ReviewController.java
@@ -3,11 +3,14 @@ package ds.project.orino.planner.review.controller;
 import ds.project.orino.common.response.ApiResponse;
 import ds.project.orino.core.time.UserTimeZone;
 import ds.project.orino.planner.review.dto.CalendarReviewsResponse;
+import ds.project.orino.planner.review.dto.CompletedReviewsResponse;
 import ds.project.orino.planner.review.dto.ReviewCompletionRequest;
 import ds.project.orino.planner.review.dto.ReviewCompletionResponse;
 import ds.project.orino.planner.review.dto.ReviewMirrorStatusResponse;
 import ds.project.orino.planner.review.dto.ReviewMirrorToggleRequest;
+import ds.project.orino.planner.review.dto.ReviewSummaryResponse;
 import ds.project.orino.planner.review.dto.TodayReviewsResponse;
+import ds.project.orino.planner.review.dto.UpcomingReviewsResponse;
 import ds.project.orino.planner.review.service.ReviewCompletionService;
 import ds.project.orino.planner.review.service.ReviewMirrorService;
 import ds.project.orino.planner.review.service.ReviewQueryService;
@@ -45,6 +48,38 @@ public class ReviewController {
     @GetMapping("/today")
     public ApiResponse<TodayReviewsResponse> today(@AuthenticationPrincipal Long memberId) {
         return ApiResponse.success(reviewQueryService.findToday(memberId));
+    }
+
+    /** 복습 허브 현황 집계 — counts(now/overdue/upcoming/doneToday) + estimatedMinutes + 자료별. */
+    @GetMapping("/summary")
+    public ApiResponse<ReviewSummaryResponse> summary(@AuthenticationPrincipal Long memberId) {
+        return ApiResponse.success(reviewQueryService.summary(memberId));
+    }
+
+    /** 앞으로의 복습 — 전 PENDING, scheduled_at ASC, 커서 keyset 페이징 + scope/자료/기간/종류 필터. */
+    @GetMapping("/upcoming")
+    public ApiResponse<UpcomingReviewsResponse> upcoming(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam(defaultValue = "all") String scope,
+            @RequestParam(required = false) Long materialId,
+            @RequestParam(defaultValue = "all") String when,
+            @RequestParam(defaultValue = "all") String type,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) Integer size) {
+        return ApiResponse.success(
+                reviewQueryService.findUpcoming(memberId, scope, materialId, when, type, cursor, size));
+    }
+
+    /** 완료된 복습 — COMPLETED, completed_at DESC, 커서 keyset 페이징 + 자료/평가 필터. */
+    @GetMapping("/completed")
+    public ApiResponse<CompletedReviewsResponse> completed(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam(required = false) Long materialId,
+            @RequestParam(required = false) String grade,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) Integer size) {
+        return ApiResponse.success(
+                reviewQueryService.findCompleted(memberId, materialId, grade, cursor, size));
     }
 
     @GetMapping("/calendar")

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CardType.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CardType.java
@@ -1,0 +1,21 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.entity.FlashcardType;
+
+/**
+ * 복습 허브 목록에서 노출하는 카드 종류. {@code PAIR}는 저장 타입이 아니라
+ * BASIC + siblingGroupId 조합에서 파생한다.
+ */
+public enum CardType {
+    BASIC,
+    ORDERING,
+    PAIR;
+
+    public static CardType from(Flashcard f) {
+        if (f.getType() == FlashcardType.ORDERING) {
+            return ORDERING;
+        }
+        return f.getSiblingGroupId() != null ? PAIR : BASIC;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CompletedReviewItem.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CompletedReviewItem.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.review.entity.Rating;
+
+import java.time.Instant;
+
+public record CompletedReviewItem(
+        Long id,
+        Instant completedAt,
+        Rating rating,
+        int sequence,
+        CardType cardType,
+        ReviewCardView flashcard
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CompletedReviewsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CompletedReviewsResponse.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.review.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CompletedReviewsResponse(
+        List<CompletedReviewItem> items,
+        String nextCursor,
+        boolean hasNext
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewCardMaterial.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewCardMaterial.java
@@ -1,0 +1,14 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+
+public record ReviewCardMaterial(
+        Long id,
+        String title,
+        MaterialType type
+) {
+    public static ReviewCardMaterial of(StudyMaterial m) {
+        return new ReviewCardMaterial(m.getId(), m.getTitle(), m.getType());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewCardView.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewCardView.java
@@ -1,0 +1,20 @@
+package ds.project.orino.planner.review.dto;
+
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.entity.FlashcardType;
+
+/**
+ * 복습 허브 목록(앞으로/완료) 항목에 동봉하는 카드 뷰. 목록은 앞면만 보여주므로 back/items는 싣지 않는다.
+ * siblingGroupId는 null도 명시적으로 노출한다(양방향 파생 판단용).
+ */
+public record ReviewCardView(
+        Long id,
+        FlashcardType type,
+        String front,
+        Long siblingGroupId,
+        ReviewCardMaterial material
+) {
+    public static ReviewCardView of(Flashcard f, ReviewCardMaterial material) {
+        return new ReviewCardView(f.getId(), f.getType(), f.getFront(), f.getSiblingGroupId(), material);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewSummaryResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/ReviewSummaryResponse.java
@@ -1,0 +1,31 @@
+package ds.project.orino.planner.review.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 복습 허브 현황 집계. counts는 목록 길이가 아니라 서버 총계다.
+ */
+public record ReviewSummaryResponse(
+        LocalDate today,
+        Counts counts,
+        int estimatedMinutes,
+        List<Material> materials
+) {
+    public record Counts(
+            long now,
+            long overdue,
+            long upcoming,
+            long doneToday
+    ) {
+    }
+
+    public record Material(
+            Long id,
+            String name,
+            long due,
+            long overdue,
+            String nextLabel
+    ) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/UpcomingReviewItem.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/UpcomingReviewItem.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.review.dto;
+
+import java.time.Instant;
+
+public record UpcomingReviewItem(
+        Long id,
+        Instant scheduledAt,
+        WhenKind whenKind,
+        boolean overdue,
+        CardType cardType,
+        ReviewCardView flashcard
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/UpcomingReviewsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/UpcomingReviewsResponse.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.review.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record UpcomingReviewsResponse(
+        LocalDate today,
+        List<UpcomingReviewItem> items,
+        String nextCursor,
+        boolean hasNext
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/WhenKind.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/WhenKind.java
@@ -1,0 +1,23 @@
+package ds.project.orino.planner.review.dto;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * 앞으로의 복습 항목이 언제 due인지. 시각 라벨은 FE가 포맷하고, 서버는 이 대분류만 제공한다.
+ *
+ * <ul>
+ *     <li>{@link #NOW} — due 또는 임박한 재복습(scheduled_at ≤ now)</li>
+ *     <li>{@link #TODAY} — 오늘 남음(scheduled_at &gt; now, 같은 날짜)</li>
+ *     <li>{@link #FUTURE} — 내일 이후</li>
+ * </ul>
+ */
+public enum WhenKind {
+    NOW,
+    TODAY,
+    FUTURE;
+
+    @JsonValue
+    public String json() {
+        return name().toLowerCase();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCursor.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCursor.java
@@ -1,0 +1,33 @@
+package ds.project.orino.planner.review.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+
+/**
+ * keyset 페이지네이션 커서. 정렬 키 {@code (Instant, id)}를 base64로 인코딩한 불투명 문자열이다.
+ * 앞으로 목록은 {@code (scheduledAt, id)}, 완료 목록은 {@code (completedAt, id)}를 담는다.
+ * 형식은 내부 구현 세부사항이며 FE는 이전 응답의 {@code nextCursor}를 그대로 되돌려준다.
+ */
+public record ReviewCursor(Instant at, long id) {
+
+    public String encode() {
+        String raw = at.toString() + "|" + id;
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static ReviewCursor decode(String cursor) {
+        try {
+            String raw = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
+            int sep = raw.lastIndexOf('|');
+            return new ReviewCursor(Instant.parse(raw.substring(0, sep)),
+                    Long.parseLong(raw.substring(sep + 1)));
+        } catch (RuntimeException e) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
@@ -1,6 +1,7 @@
 package ds.project.orino.planner.review.service;
 
 import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.entity.FlashcardType;
 import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
 import ds.project.orino.domain.planner.material.entity.StudyMaterial;
 import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
@@ -14,13 +15,23 @@ import ds.project.orino.planner.review.dto.CalendarReviewFlashcard;
 import ds.project.orino.planner.review.dto.CalendarReviewItem;
 import ds.project.orino.planner.review.dto.CalendarReviewMaterial;
 import ds.project.orino.planner.review.dto.CalendarReviewsResponse;
+import ds.project.orino.planner.review.dto.CardType;
+import ds.project.orino.planner.review.dto.CompletedReviewItem;
+import ds.project.orino.planner.review.dto.CompletedReviewsResponse;
 import ds.project.orino.planner.review.dto.PreviewView;
+import ds.project.orino.planner.review.dto.ReviewCardMaterial;
+import ds.project.orino.planner.review.dto.ReviewCardView;
+import ds.project.orino.planner.review.dto.ReviewSummaryResponse;
 import ds.project.orino.planner.review.dto.TodayReviewFlashcard;
 import ds.project.orino.planner.review.dto.TodayReviewItem;
 import ds.project.orino.planner.review.dto.TodayReviewMaterial;
 import ds.project.orino.planner.review.dto.TodayReviewsResponse;
+import ds.project.orino.planner.review.dto.UpcomingReviewItem;
+import ds.project.orino.planner.review.dto.UpcomingReviewsResponse;
+import ds.project.orino.planner.review.dto.WhenKind;
 import ds.project.orino.planner.review.sm2.Sm2Calculator;
 import ds.project.orino.planner.flashcard.service.FlashcardItemsCodec;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +43,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -163,5 +175,251 @@ public class ReviewQueryService {
                 Sm2Calculator.next(newSeq, r.getIntervalDays(), r.getEaseFactor(), Rating.HARD).intervalDays(),
                 Sm2Calculator.next(newSeq, r.getIntervalDays(), r.getEaseFactor(), Rating.GOOD).intervalDays(),
                 Sm2Calculator.next(newSeq, r.getIntervalDays(), r.getEaseFactor(), Rating.EASY).intervalDays());
+    }
+
+    // ===== v2.5 복습 허브 (조회 전용) =====
+
+    /** 목록 페이지 기본/최대 크기. */
+    static final int DEFAULT_SIZE = 20;
+    static final int MAX_SIZE = 50;
+
+    /** estimatedMinutes 대략치 계산용 카드당 상수(초). */
+    static final int SECONDS_PER_CARD = 40;
+
+    /** 복습 허브 현황 집계. counts는 목록 길이가 아니라 서버 총계다. */
+    public ReviewSummaryResponse summary(Long memberId) {
+        ZoneId zone = UserTimeZone.get();
+        Instant now = clock.instant();
+        LocalDate today = now.atZone(zone).toLocalDate();
+        Instant todayStart = today.atStartOfDay(zone).toInstant();
+        Instant tomorrowStart = today.plusDays(1).atStartOfDay(zone).toInstant();
+
+        List<ReviewSchedule> pending = reviewScheduleRepository
+                .findAllByMemberIdAndStatus(memberId, ReviewStatus.PENDING);
+
+        long nowCount = pending.stream().filter(r -> !r.getScheduledAt().isAfter(now)).count();
+        long overdueCount = pending.stream().filter(r -> r.getScheduledAt().isBefore(todayStart)).count();
+        long upcomingCount = pending.size();
+        long doneToday = reviewScheduleRepository
+                .countByMemberIdAndStatusAndCompletedAtGreaterThanEqualAndCompletedAtLessThan(
+                        memberId, ReviewStatus.COMPLETED, todayStart, tomorrowStart);
+
+        int estimatedMinutes = (int) Math.round(nowCount * SECONDS_PER_CARD / 60.0);
+
+        List<ReviewSummaryResponse.Material> materials =
+                buildMaterialSummaries(pending, now, todayStart, tomorrowStart, today, zone);
+
+        ReviewSummaryResponse.Counts counts =
+                new ReviewSummaryResponse.Counts(nowCount, overdueCount, upcomingCount, doneToday);
+        return new ReviewSummaryResponse(today, counts, estimatedMinutes, materials);
+    }
+
+    private List<ReviewSummaryResponse.Material> buildMaterialSummaries(
+            List<ReviewSchedule> pending, Instant now, Instant todayStart, Instant tomorrowStart,
+            LocalDate today, ZoneId zone) {
+        if (pending.isEmpty()) {
+            return List.of();
+        }
+        Map<Long, Flashcard> cardById = loadCards(pending);
+        Map<Long, StudyMaterial> materialById = loadMaterials(cardById);
+
+        Map<Long, List<ReviewSchedule>> byMaterial = pending.stream()
+                .collect(Collectors.groupingBy(r -> cardById.get(r.getFlashcardId()).getMaterialId()));
+
+        return byMaterial.entrySet().stream()
+                .map(e -> {
+                    StudyMaterial material = materialById.get(e.getKey());
+                    List<ReviewSchedule> rows = e.getValue();
+                    long due = rows.stream()
+                            .filter(r -> !r.getScheduledAt().isBefore(todayStart)
+                                    && r.getScheduledAt().isBefore(tomorrowStart))
+                            .count();
+                    long overdue = rows.stream()
+                            .filter(r -> r.getScheduledAt().isBefore(todayStart))
+                            .count();
+                    Instant earliest = rows.stream()
+                            .map(ReviewSchedule::getScheduledAt)
+                            .min(Comparator.naturalOrder())
+                            .orElseThrow();
+                    return new ReviewSummaryResponse.Material(
+                            material.getId(), material.getTitle(), due, overdue,
+                            nextLabel(earliest, now, today, zone));
+                })
+                .sorted(Comparator
+                        .comparingLong((ReviewSummaryResponse.Material m) -> m.due() + m.overdue()).reversed()
+                        .thenComparing(ReviewSummaryResponse.Material::name))
+                .toList();
+    }
+
+    /** 자료별 다음 due 대략 라벨. 목록의 세밀한 시각 라벨은 FE가 포맷하지만, 레일 자료 행은 서버가 요약한다. */
+    private String nextLabel(Instant earliest, Instant now, LocalDate today, ZoneId zone) {
+        if (!earliest.isAfter(now)) {
+            return "지금";
+        }
+        LocalDate date = earliest.atZone(zone).toLocalDate();
+        if (date.equals(today)) {
+            return "오늘";
+        }
+        String md = String.format("%02d/%02d", date.getMonthValue(), date.getDayOfMonth());
+        return date.equals(today.plusDays(1)) ? "내일 " + md : md;
+    }
+
+    /** 앞으로의 복습 목록 — 전 PENDING, scheduled_at ASC, 커서 keyset 페이징 + scope/자료/기간/종류 필터. */
+    public UpcomingReviewsResponse findUpcoming(Long memberId, String scope, Long materialId,
+                                                String when, String type, String cursor, Integer size) {
+        ZoneId zone = UserTimeZone.get();
+        Instant now = clock.instant();
+        LocalDate today = now.atZone(zone).toLocalDate();
+        Instant todayStart = today.atStartOfDay(zone).toInstant();
+        int pageSize = clampSize(size);
+
+        Instant upperBound = upperBound(scope, when, today, zone);
+        TypeFilter typeFilter = typeFilter(type);
+        ReviewCursor c = cursor == null ? null : ReviewCursor.decode(cursor);
+
+        List<ReviewSchedule> rows = reviewScheduleRepository.findUpcoming(
+                memberId, materialId, upperBound, typeFilter.cardType(), typeFilter.siblingRequired(),
+                c == null ? null : c.at(), c == null ? null : c.id(),
+                PageRequest.of(0, pageSize + 1));
+
+        boolean hasNext = rows.size() > pageSize;
+        List<ReviewSchedule> page = hasNext ? rows.subList(0, pageSize) : rows;
+
+        Map<Long, Flashcard> cardById = loadCards(page);
+        Map<Long, StudyMaterial> materialById = loadMaterials(cardById);
+
+        List<UpcomingReviewItem> items = page.stream()
+                .map(r -> {
+                    Flashcard card = cardById.get(r.getFlashcardId());
+                    StudyMaterial material = materialById.get(card.getMaterialId());
+                    ReviewCardView flashcard = ReviewCardView.of(card, ReviewCardMaterial.of(material));
+                    return new UpcomingReviewItem(
+                            r.getId(), r.getScheduledAt(),
+                            whenKind(r.getScheduledAt(), now, today, zone),
+                            r.getScheduledAt().isBefore(todayStart),
+                            CardType.from(card), flashcard);
+                })
+                .toList();
+
+        String nextCursor = null;
+        if (hasNext) {
+            ReviewSchedule last = page.get(page.size() - 1);
+            nextCursor = new ReviewCursor(last.getScheduledAt(), last.getId()).encode();
+        }
+        return new UpcomingReviewsResponse(today, items, nextCursor, hasNext);
+    }
+
+    /** 완료된 복습 목록 — COMPLETED, completed_at DESC, 커서 keyset 페이징 + 자료/평가 필터. */
+    public CompletedReviewsResponse findCompleted(Long memberId, Long materialId, String grade,
+                                                  String cursor, Integer size) {
+        int pageSize = clampSize(size);
+        Rating rating = grade(grade);
+        ReviewCursor c = cursor == null ? null : ReviewCursor.decode(cursor);
+
+        List<ReviewSchedule> rows = reviewScheduleRepository.findCompleted(
+                memberId, materialId, rating,
+                c == null ? null : c.at(), c == null ? null : c.id(),
+                PageRequest.of(0, pageSize + 1));
+
+        boolean hasNext = rows.size() > pageSize;
+        List<ReviewSchedule> page = hasNext ? rows.subList(0, pageSize) : rows;
+
+        Map<Long, Flashcard> cardById = loadCards(page);
+        Map<Long, StudyMaterial> materialById = loadMaterials(cardById);
+
+        List<CompletedReviewItem> items = page.stream()
+                .map(r -> {
+                    Flashcard card = cardById.get(r.getFlashcardId());
+                    StudyMaterial material = materialById.get(card.getMaterialId());
+                    ReviewCardView flashcard = ReviewCardView.of(card, ReviewCardMaterial.of(material));
+                    return new CompletedReviewItem(
+                            r.getId(), r.getCompletedAt(), r.getRating(), r.getSequence(),
+                            CardType.from(card), flashcard);
+                })
+                .toList();
+
+        String nextCursor = null;
+        if (hasNext) {
+            ReviewSchedule last = page.get(page.size() - 1);
+            nextCursor = new ReviewCursor(last.getCompletedAt(), last.getId()).encode();
+        }
+        return new CompletedReviewsResponse(items, nextCursor, hasNext);
+    }
+
+    private int clampSize(Integer size) {
+        if (size == null) {
+            return DEFAULT_SIZE;
+        }
+        return Math.max(1, Math.min(size, MAX_SIZE));
+    }
+
+    private WhenKind whenKind(Instant at, Instant now, LocalDate today, ZoneId zone) {
+        if (!at.isAfter(now)) {
+            return WhenKind.NOW;
+        }
+        return at.atZone(zone).toLocalDate().equals(today) ? WhenKind.TODAY : WhenKind.FUTURE;
+    }
+
+    /** scope와 when 상한을 하나로 합친다(둘 다 scheduled_at 상한이므로 더 좁은 쪽). null이면 상한 없음. */
+    private Instant upperBound(String scope, String when, LocalDate today, ZoneId zone) {
+        Instant fromScope = scopeBound(scope, today, zone);
+        Instant fromWhen = whenBound(when, today, zone);
+        if (fromScope == null) {
+            return fromWhen;
+        }
+        if (fromWhen == null) {
+            return fromScope;
+        }
+        return fromScope.isBefore(fromWhen) ? fromScope : fromWhen;
+    }
+
+    private Instant scopeBound(String scope, LocalDate today, ZoneId zone) {
+        if (scope == null || scope.equals("all")) {
+            return null;
+        }
+        return switch (scope) {
+            case "today" -> today.plusDays(1).atStartOfDay(zone).toInstant();
+            case "overdue" -> today.atStartOfDay(zone).toInstant();
+            default -> throw new CustomException(ErrorCode.INVALID_REQUEST);
+        };
+    }
+
+    private Instant whenBound(String when, LocalDate today, ZoneId zone) {
+        if (when == null || when.equals("all")) {
+            return null;
+        }
+        return switch (when) {
+            case "today" -> today.plusDays(1).atStartOfDay(zone).toInstant();
+            case "3d" -> today.plusDays(3).atStartOfDay(zone).toInstant();
+            case "7d" -> today.plusDays(7).atStartOfDay(zone).toInstant();
+            default -> throw new CustomException(ErrorCode.INVALID_REQUEST);
+        };
+    }
+
+    private TypeFilter typeFilter(String type) {
+        if (type == null || type.equals("all")) {
+            return new TypeFilter(null, null);
+        }
+        return switch (type) {
+            case "basic" -> new TypeFilter(FlashcardType.BASIC, Boolean.FALSE);
+            case "order" -> new TypeFilter(FlashcardType.ORDERING, null);
+            case "pair" -> new TypeFilter(FlashcardType.BASIC, Boolean.TRUE);
+            default -> throw new CustomException(ErrorCode.INVALID_REQUEST);
+        };
+    }
+
+    private Rating grade(String grade) {
+        if (grade == null || grade.equals("all")) {
+            return null;
+        }
+        try {
+            return Rating.valueOf(grade);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    /** 종류 필터를 쿼리 파라미터로 환산한 값. siblingRequired: TRUE=NOT NULL, FALSE=NULL, null=무관. */
+    private record TypeFilter(FlashcardType cardType, Boolean siblingRequired) {
     }
 }

--- a/be/orino-app-api/src/main/resources/application-mysql.yml
+++ b/be/orino-app-api/src/main/resources/application-mysql.yml
@@ -55,6 +55,13 @@ spring:
     url: jdbc:tc:mysql:8.4.4:///toy
     username: test
     password: test
+    # 통합 테스트는 단일 TestContainer MySQL을 여러 Spring 컨텍스트가 공유한다.
+    # 컨텍스트마다 Hikari 풀이 붙고 캐시된 컨텍스트가 커넥션을 물고 있어, 컨텍스트 수가
+    # 늘면 MySQL max_connections(기본 151)를 넘겨 SQLNonTransientConnectionException이 난다.
+    # 풀을 작게 잡고 유휴 시 0까지 반납하게 해 커넥션 누적을 막는다.
+    hikari:
+      maximum-pool-size: 4
+      minimum-idle: 0
   jpa:
     hibernate:
       ddl-auto: validate

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/036-add-review-schedule-completed-index.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/036-add-review-schedule-completed-index.yaml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  # 복습 허브 완료 목록 (#755, Epic #754, Study Planner v2.5).
+  # completed_at DESC 커서 페이지네이션을 위한 인덱스. 멤버의 COMPLETED 복습만 최신순으로
+  # keyset 스캔한다. member_id(leftmost) → status → completed_at 순서. 스키마 변경 없음(인덱스만).
+  - changeSet:
+      id: 036-add-review-schedule-completed-index
+      author: wcorn
+      comment: 완료 목록 커서 페이징용 (member_id, status, completed_at) 인덱스 추가.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: review_schedule
+                indexName: idx_review_schedule_member_status_completed_at
+      changes:
+        - createIndex:
+            tableName: review_schedule
+            indexName: idx_review_schedule_member_status_completed_at
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: status
+              - column:
+                  name: completed_at

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -69,3 +69,5 @@ databaseChangeLog:
       file: db/changelog/changes/034-add-flashcard-type-items.yaml
   - include:
       file: db/changelog/changes/035-add-flashcard-sibling-group.yaml
+  - include:
+      file: db/changelog/changes/036-add-review-schedule-completed-index.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewCompletedControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewCompletedControllerTest.java
@@ -1,0 +1,186 @@
+package ds.project.orino.planner.review.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.Rating;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.FixedClockConfig;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(FixedClockConfig.class)
+class ReviewCompletedControllerTest extends ApiTestSupport {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 1, 15);
+    private static final BigDecimal EF = new BigDecimal("2.50");
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+    @Autowired
+    private FlashcardRepository flashcardRepository;
+    @Autowired
+    private ReviewScheduleRepository reviewScheduleRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Member member;
+    private Member otherMember;
+    private StudyMaterial materialA;
+    private StudyMaterial materialB;
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        member = memberRepository.save(MemberFixture.create());
+        otherMember = memberRepository.save(MemberFixture.create("other", "password"));
+        materialA = studyMaterialRepository.save(new StudyMaterial(member.getId(), "이펙티브 자바", MaterialType.BOOK));
+        materialB = studyMaterialRepository.save(new StudyMaterial(member.getId(), "모던 자바", MaterialType.LECTURE));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    private Flashcard basicCard(StudyMaterial material) {
+        return flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "앞면", "뒷면"));
+    }
+
+    private ReviewSchedule completed(Flashcard c, int sequence, Rating rating, LocalDateTime completedLocal) {
+        ReviewSchedule r = new ReviewSchedule(member.getId(), c.getId(), sequence,
+                atTestZone(TODAY.minusDays(sequence).atTime(4, 0)), 1, EF);
+        r.complete(rating, atTestZone(completedLocal), TEST_ZONE);
+        return reviewScheduleRepository.save(r);
+    }
+
+    @Test
+    @DisplayName("GET completed - completed_at DESC 정렬 + rating/sequence/cardType/flashcard 동봉")
+    void descending_with_fields() throws Exception {
+        Flashcard a = basicCard(materialA);
+        ReviewSchedule oldest = completed(a, 1, Rating.HARD, TODAY.atTime(8, 0));
+        ReviewSchedule newest = completed(a, 2, Rating.GOOD, TODAY.atTime(10, 0));
+
+        mockMvc.perform(get("/api/planner/reviews/completed")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(2)))
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                .andExpect(jsonPath("$.data.items[0].id").value(newest.getId()))
+                .andExpect(jsonPath("$.data.items[0].rating").value("GOOD"))
+                .andExpect(jsonPath("$.data.items[0].sequence").value(2))
+                .andExpect(jsonPath("$.data.items[0].cardType").value("BASIC"))
+                .andExpect(jsonPath("$.data.items[0].flashcard.front").value("앞면"))
+                .andExpect(jsonPath("$.data.items[0].flashcard.material.id").value(materialA.getId()))
+                .andExpect(jsonPath("$.data.items[1].id").value(oldest.getId()))
+                .andExpect(jsonPath("$.data.items[1].rating").value("HARD"));
+    }
+
+    @Test
+    @DisplayName("GET completed - grade 필터")
+    void grade_filter() throws Exception {
+        Flashcard a = basicCard(materialA);
+        completed(a, 1, Rating.AGAIN, TODAY.atTime(8, 0));
+        ReviewSchedule good = completed(a, 2, Rating.GOOD, TODAY.atTime(10, 0));
+
+        mockMvc.perform(get("/api/planner/reviews/completed")
+                        .param("grade", "GOOD")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.items[0].id").value(good.getId()))
+                .andExpect(jsonPath("$.data.items[0].rating").value("GOOD"));
+    }
+
+    @Test
+    @DisplayName("GET completed - materialId 필터")
+    void material_filter() throws Exception {
+        completed(basicCard(materialA), 1, Rating.GOOD, TODAY.atTime(8, 0));
+        ReviewSchedule b = completed(basicCard(materialB), 1, Rating.GOOD, TODAY.atTime(9, 0));
+
+        mockMvc.perform(get("/api/planner/reviews/completed")
+                        .param("materialId", String.valueOf(materialB.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.items[0].id").value(b.getId()));
+    }
+
+    @Test
+    @DisplayName("GET completed - 커서 페이징: 동일 completed_at은 id DESC로 tie-break, 경계 무중복")
+    void keyset_pagination() throws Exception {
+        Flashcard a = basicCard(materialA);
+        // 동일 completed_at → id DESC tie-break. r3(최대 id)가 먼저.
+        ReviewSchedule r1 = completed(a, 1, Rating.GOOD, TODAY.atTime(9, 0));
+        ReviewSchedule r2 = completed(a, 2, Rating.GOOD, TODAY.atTime(9, 0));
+        ReviewSchedule r3 = completed(a, 3, Rating.GOOD, TODAY.atTime(9, 0));
+
+        MvcResult first = mockMvc.perform(get("/api/planner/reviews/completed")
+                        .param("size", "2")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(2)))
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andExpect(jsonPath("$.data.items[0].id").value(r3.getId()))
+                .andExpect(jsonPath("$.data.items[1].id").value(r2.getId()))
+                .andReturn();
+        String cursor = JsonPath.read(first.getResponse().getContentAsString(), "$.data.nextCursor");
+
+        mockMvc.perform(get("/api/planner/reviews/completed")
+                        .param("size", "2")
+                        .param("cursor", cursor)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                .andExpect(jsonPath("$.data.nextCursor").doesNotExist())
+                .andExpect(jsonPath("$.data.items[0].id").value(r1.getId()));
+    }
+
+    @Test
+    @DisplayName("GET completed - PENDING/타인은 제외된다")
+    void excludes_pending_and_others() throws Exception {
+        Flashcard a = basicCard(materialA);
+        completed(a, 1, Rating.GOOD, TODAY.atTime(9, 0));
+        reviewScheduleRepository.save(new ReviewSchedule(   // PENDING
+                member.getId(), a.getId(), 2, atTestZone(TODAY.atTime(4, 0)), 1, EF));
+
+        StudyMaterial otherMaterial = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+        Flashcard otherCard = flashcardRepository.save(
+                new Flashcard(otherMember.getId(), otherMaterial.getId(), "Q2", "A2"));
+        ReviewSchedule otherDone = new ReviewSchedule(otherMember.getId(), otherCard.getId(), 1,
+                atTestZone(TODAY.minusDays(1).atTime(4, 0)), 1, EF);
+        otherDone.complete(Rating.GOOD, atTestZone(TODAY.atTime(9, 0)), TEST_ZONE);
+        reviewScheduleRepository.save(otherDone);
+
+        mockMvc.perform(get("/api/planner/reviews/completed")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.items[0].flashcard.front").value("앞면"));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewSummaryControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewSummaryControllerTest.java
@@ -1,0 +1,159 @@
+package ds.project.orino.planner.review.controller;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.Rating;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.FixedClockConfig;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(FixedClockConfig.class)
+class ReviewSummaryControllerTest extends ApiTestSupport {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 1, 15);
+    private static final BigDecimal EF = new BigDecimal("2.50");
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+    @Autowired
+    private FlashcardRepository flashcardRepository;
+    @Autowired
+    private ReviewScheduleRepository reviewScheduleRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Member member;
+    private Member otherMember;
+    private StudyMaterial materialA;
+    private StudyMaterial materialB;
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        member = memberRepository.save(MemberFixture.create());
+        otherMember = memberRepository.save(MemberFixture.create("other", "password"));
+        materialA = studyMaterialRepository.save(new StudyMaterial(member.getId(), "이펙티브 자바", MaterialType.BOOK));
+        materialB = studyMaterialRepository.save(new StudyMaterial(member.getId(), "모던 자바", MaterialType.LECTURE));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    private Flashcard card(StudyMaterial material) {
+        return flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
+    }
+
+    private ReviewSchedule pending(Flashcard c, LocalDateTime scheduledLocal) {
+        return reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), c.getId(), 1, atTestZone(scheduledLocal), 1, EF));
+    }
+
+    private void completed(Flashcard c, LocalDateTime completedLocal) {
+        ReviewSchedule r = new ReviewSchedule(member.getId(), c.getId(), 1,
+                atTestZone(TODAY.minusDays(3).atTime(4, 0)), 1, EF);
+        r.complete(Rating.GOOD, atTestZone(completedLocal), TEST_ZONE);
+        reviewScheduleRepository.save(r);
+    }
+
+    @Test
+    @DisplayName("GET summary - counts는 목록 길이가 아니라 서버 총계(now/overdue/upcoming/doneToday)")
+    void counts_are_server_totals() throws Exception {
+        Flashcard a = card(materialA);
+        pending(a, TODAY.minusDays(2).atTime(4, 0));  // overdue → now
+        pending(a, TODAY.atTime(4, 0));               // due now
+        pending(a, TODAY.atTime(20, 0));              // 오늘 남음
+        Flashcard b = card(materialB);
+        pending(b, TODAY.plusDays(3).atTime(4, 0));   // future
+        completed(a, TODAY.atTime(9, 0));             // doneToday
+        completed(a, TODAY.minusDays(1).atTime(22, 0)); // 어제 완료 → 제외
+
+        mockMvc.perform(get("/api/planner/reviews/summary")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.today").value("2026-01-15"))
+                .andExpect(jsonPath("$.data.counts.now").value(2))
+                .andExpect(jsonPath("$.data.counts.overdue").value(1))
+                .andExpect(jsonPath("$.data.counts.upcoming").value(4))
+                .andExpect(jsonPath("$.data.counts.doneToday").value(1))
+                .andExpect(jsonPath("$.data.estimatedMinutes").value(1));
+    }
+
+    @Test
+    @DisplayName("GET summary - 자료별 due/overdue/nextLabel, due+overdue 내림차순 정렬")
+    void materials_grouped_and_sorted() throws Exception {
+        Flashcard a = card(materialA);
+        pending(a, TODAY.minusDays(2).atTime(4, 0));  // A overdue
+        pending(a, TODAY.atTime(4, 0));               // A due now
+        pending(a, TODAY.atTime(20, 0));              // A 오늘 남음
+        Flashcard b = card(materialB);
+        pending(b, TODAY.plusDays(3).atTime(4, 0));   // B future only
+
+        mockMvc.perform(get("/api/planner/reviews/summary")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.materials", hasSize(2)))
+                .andExpect(jsonPath("$.data.materials[0].id").value(materialA.getId()))
+                .andExpect(jsonPath("$.data.materials[0].name").value("이펙티브 자바"))
+                .andExpect(jsonPath("$.data.materials[0].due").value(2))
+                .andExpect(jsonPath("$.data.materials[0].overdue").value(1))
+                .andExpect(jsonPath("$.data.materials[0].nextLabel").value("지금"))
+                .andExpect(jsonPath("$.data.materials[1].id").value(materialB.getId()))
+                .andExpect(jsonPath("$.data.materials[1].due").value(0))
+                .andExpect(jsonPath("$.data.materials[1].overdue").value(0))
+                .andExpect(jsonPath("$.data.materials[1].nextLabel").value("01/18"));
+    }
+
+    @Test
+    @DisplayName("GET summary - PENDING이 없으면 counts 0, materials 빈 배열")
+    void empty_state() throws Exception {
+        mockMvc.perform(get("/api/planner/reviews/summary")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.counts.upcoming").value(0))
+                .andExpect(jsonPath("$.data.counts.now").value(0))
+                .andExpect(jsonPath("$.data.estimatedMinutes").value(0))
+                .andExpect(jsonPath("$.data.materials", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("GET summary - 타인 복습은 집계에서 제외된다")
+    void excludes_other_member() throws Exception {
+        StudyMaterial otherMaterial = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+        Flashcard otherCard = flashcardRepository.save(
+                new Flashcard(otherMember.getId(), otherMaterial.getId(), "Q2", "A2"));
+        reviewScheduleRepository.save(new ReviewSchedule(
+                otherMember.getId(), otherCard.getId(), 1, atTestZone(TODAY.atTime(4, 0)), 1, EF));
+
+        mockMvc.perform(get("/api/planner/reviews/summary")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.counts.upcoming").value(0))
+                .andExpect(jsonPath("$.data.materials", hasSize(0)));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewUpcomingControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewUpcomingControllerTest.java
@@ -1,0 +1,263 @@
+package ds.project.orino.planner.review.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.FixedClockConfig;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(FixedClockConfig.class)
+class ReviewUpcomingControllerTest extends ApiTestSupport {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 1, 15);
+    private static final BigDecimal EF = new BigDecimal("2.50");
+    private static final String ITEMS = "[{\"id\":\"a\",\"text\":\"1단계\"},{\"id\":\"b\",\"text\":\"2단계\"}]";
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+    @Autowired
+    private FlashcardRepository flashcardRepository;
+    @Autowired
+    private ReviewScheduleRepository reviewScheduleRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Member member;
+    private Member otherMember;
+    private StudyMaterial materialA;
+    private StudyMaterial materialB;
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        member = memberRepository.save(MemberFixture.create());
+        otherMember = memberRepository.save(MemberFixture.create("other", "password"));
+        materialA = studyMaterialRepository.save(new StudyMaterial(member.getId(), "이펙티브 자바", MaterialType.BOOK));
+        materialB = studyMaterialRepository.save(new StudyMaterial(member.getId(), "모던 자바", MaterialType.LECTURE));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    private Flashcard basicCard(StudyMaterial material) {
+        return flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "기본 앞면", "뒷면"));
+    }
+
+    private Flashcard orderingCard() {
+        return flashcardRepository.save(
+                Flashcard.ordering(member.getId(), materialA.getId(), "순서 앞면", ITEMS));
+    }
+
+    private Flashcard pairCard() {
+        Flashcard c = new Flashcard(member.getId(), materialA.getId(), "짝 앞면", "짝 뒷면");
+        c.assignSiblingGroup(777L);
+        return flashcardRepository.save(c);
+    }
+
+    private ReviewSchedule pending(Flashcard c, LocalDateTime scheduledLocal) {
+        return reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), c.getId(), 1, atTestZone(scheduledLocal), 1, EF));
+    }
+
+    @Test
+    @DisplayName("GET upcoming - scheduled_at ASC 정렬 + whenKind/overdue/cardType/flashcard 동봉")
+    void ascending_with_whenkind_and_flags() throws Exception {
+        Flashcard a = basicCard(materialA);
+        pending(a, TODAY.minusDays(2).atTime(4, 0));  // now, overdue
+        pending(a, TODAY.atTime(4, 0));               // now
+        pending(a, TODAY.atTime(20, 0));              // today
+        pending(a, TODAY.plusDays(3).atTime(4, 0));   // future
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.today").value("2026-01-15"))
+                .andExpect(jsonPath("$.data.items", hasSize(4)))
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                .andExpect(jsonPath("$.data.items[0].whenKind").value("now"))
+                .andExpect(jsonPath("$.data.items[0].overdue").value(true))
+                .andExpect(jsonPath("$.data.items[0].cardType").value("BASIC"))
+                .andExpect(jsonPath("$.data.items[0].flashcard.front").value("기본 앞면"))
+                .andExpect(jsonPath("$.data.items[0].flashcard.type").value("BASIC"))
+                .andExpect(jsonPath("$.data.items[0].flashcard.material.id").value(materialA.getId()))
+                .andExpect(jsonPath("$.data.items[1].whenKind").value("now"))
+                .andExpect(jsonPath("$.data.items[1].overdue").value(false))
+                .andExpect(jsonPath("$.data.items[2].whenKind").value("today"))
+                .andExpect(jsonPath("$.data.items[3].whenKind").value("future"))
+                .andExpect(jsonPath("$.data.items[3].overdue").value(false));
+    }
+
+    @Test
+    @DisplayName("GET upcoming - scope=overdue는 오늘 이전(밀림)만")
+    void scope_overdue() throws Exception {
+        Flashcard a = basicCard(materialA);
+        ReviewSchedule overdue = pending(a, TODAY.minusDays(2).atTime(4, 0));
+        pending(a, TODAY.atTime(4, 0));
+        pending(a, TODAY.plusDays(3).atTime(4, 0));
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("scope", "overdue")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.items[0].id").value(overdue.getId()));
+    }
+
+    @Test
+    @DisplayName("GET upcoming - when=today는 오늘 끝까지, when=3d는 3일 내")
+    void when_window() throws Exception {
+        Flashcard a = basicCard(materialA);
+        pending(a, TODAY.atTime(4, 0));               // 오늘
+        pending(a, TODAY.plusDays(2).atTime(4, 0));   // +2일
+        pending(a, TODAY.plusDays(5).atTime(4, 0));   // +5일
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("when", "today")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)));
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("when", "3d")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(2)));
+    }
+
+    @Test
+    @DisplayName("GET upcoming - type 필터: basic/order/pair(파생)")
+    void type_filter() throws Exception {
+        pending(basicCard(materialA), TODAY.atTime(4, 0));
+        pending(orderingCard(), TODAY.atTime(4, 0));
+        pending(pairCard(), TODAY.atTime(4, 0));
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("type", "basic")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.items[0].cardType").value("BASIC"));
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("type", "order")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.items[0].cardType").value("ORDERING"));
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("type", "pair")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.items[0].cardType").value("PAIR"))
+                .andExpect(jsonPath("$.data.items[0].flashcard.type").value("BASIC"))
+                .andExpect(jsonPath("$.data.items[0].flashcard.siblingGroupId").value(777));
+    }
+
+    @Test
+    @DisplayName("GET upcoming - materialId 필터")
+    void material_filter() throws Exception {
+        pending(basicCard(materialA), TODAY.atTime(4, 0));
+        Flashcard b = basicCard(materialB);
+        pending(b, TODAY.atTime(4, 0));
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("materialId", String.valueOf(materialB.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.items[0].flashcard.material.id").value(materialB.getId()));
+    }
+
+    @Test
+    @DisplayName("GET upcoming - 커서 페이징: 동일 scheduled_at은 id ASC로 tie-break, 경계 무중복")
+    void keyset_pagination() throws Exception {
+        Flashcard a = basicCard(materialA);
+        ReviewSchedule r1 = pending(a, TODAY.atTime(4, 0));
+        ReviewSchedule r2 = pending(a, TODAY.atTime(4, 0));
+        ReviewSchedule r3 = pending(a, TODAY.atTime(4, 0));
+
+        MvcResult first = mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("size", "2")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(2)))
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andExpect(jsonPath("$.data.items[0].id").value(r1.getId()))
+                .andExpect(jsonPath("$.data.items[1].id").value(r2.getId()))
+                .andReturn();
+        String cursor = JsonPath.read(first.getResponse().getContentAsString(), "$.data.nextCursor");
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("size", "2")
+                        .param("cursor", cursor)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                .andExpect(jsonPath("$.data.nextCursor").doesNotExist())
+                .andExpect(jsonPath("$.data.items[0].id").value(r3.getId()));
+    }
+
+    @Test
+    @DisplayName("GET upcoming - 타인/COMPLETED는 제외된다")
+    void excludes_others_and_completed() throws Exception {
+        Flashcard a = basicCard(materialA);
+        pending(a, TODAY.atTime(4, 0));
+        ReviewSchedule done = new ReviewSchedule(member.getId(), a.getId(), 1,
+                atTestZone(TODAY.minusDays(1).atTime(4, 0)), 1, EF);
+        done.complete(ds.project.orino.domain.planner.review.entity.Rating.GOOD,
+                atTestZone(TODAY.atTime(9, 0)), TEST_ZONE);
+        reviewScheduleRepository.save(done);
+
+        StudyMaterial otherMaterial = studyMaterialRepository.save(
+                new StudyMaterial(otherMember.getId(), "남의 자료", MaterialType.BOOK));
+        Flashcard otherCard = flashcardRepository.save(
+                new Flashcard(otherMember.getId(), otherMaterial.getId(), "Q2", "A2"));
+        reviewScheduleRepository.save(new ReviewSchedule(
+                otherMember.getId(), otherCard.getId(), 1, atTestZone(TODAY.atTime(4, 0)), 1, EF));
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.items[0].flashcard.front").value("기본 앞면"));
+    }
+
+    @Test
+    @DisplayName("GET upcoming - 잘못된 scope는 400")
+    void invalid_scope_returns_400() throws Exception {
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("scope", "bogus")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/FixedClockConfig.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/FixedClockConfig.java
@@ -1,0 +1,30 @@
+package ds.project.orino.support;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+/**
+ * 복습 "now"를 고정 시각으로 못박는 테스트 설정. whenKind(now/today/future)·doneToday 같은
+ * 시각 의존 로직을 결정적으로 검증하기 위함이다. JWT는 실시각({@code new Date()})을 쓰므로
+ * 이 Clock을 고정해도 인증에는 영향이 없다.
+ *
+ * <p>고정 시각 {@code 2026-01-15T02:00:00Z} = KST 2026-01-15 11:00. 즉 사용자(Asia/Seoul) 기준
+ * 오늘은 2026-01-15, 현재 11:00.
+ */
+@TestConfiguration
+public class FixedClockConfig {
+
+    /** 고정 현재 시각(UTC). KST로는 2026-01-15 11:00. */
+    public static final Instant FIXED_NOW = Instant.parse("2026-01-15T02:00:00Z");
+
+    @Bean
+    @Primary
+    public Clock fixedClock() {
+        return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
@@ -1,8 +1,13 @@
 package ds.project.orino.domain.planner.review.repository;
 
+import ds.project.orino.domain.planner.flashcard.entity.FlashcardType;
+import ds.project.orino.domain.planner.review.entity.Rating;
 import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
 import ds.project.orino.domain.planner.review.entity.ReviewStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
 import java.util.Collection;
@@ -35,4 +40,63 @@ public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, 
 
     /** 미러 enable 백필용 — 멤버의 모든 PENDING 복습(과거·미래 포함). */
     List<ReviewSchedule> findAllByMemberIdAndStatus(Long memberId, ReviewStatus status);
+
+    /** 오늘 완료 수 — completed_at 이 [todayStart, tomorrowStart) 인 COMPLETED. */
+    long countByMemberIdAndStatusAndCompletedAtGreaterThanEqualAndCompletedAtLessThan(
+            Long memberId, ReviewStatus status, Instant todayStart, Instant tomorrowStart);
+
+    /**
+     * 앞으로의 복습 — 전 PENDING을 {@code scheduled_at ASC, id ASC}로 keyset 페이징한다.
+     * {@code upperBound}는 scope/when 필터를 하나로 합친 상한(scheduled_at &lt; upperBound),
+     * {@code cardType}/{@code siblingRequired}는 종류 필터(pair는 BASIC + siblingGroupId NOT NULL 파생),
+     * {@code cursorAt}/{@code cursorId}는 이전 페이지 마지막 keyset이다. 모든 필터 파라미터는 null이면 무시된다.
+     */
+    @Query("""
+            SELECT r FROM ReviewSchedule r, Flashcard f
+            WHERE r.flashcardId = f.id
+              AND r.memberId = :memberId
+              AND r.status = ds.project.orino.domain.planner.review.entity.ReviewStatus.PENDING
+              AND (:materialId IS NULL OR f.materialId = :materialId)
+              AND (:upperBound IS NULL OR r.scheduledAt < :upperBound)
+              AND (:cardType IS NULL OR f.type = :cardType)
+              AND (:siblingRequired IS NULL
+                   OR (:siblingRequired = TRUE AND f.siblingGroupId IS NOT NULL)
+                   OR (:siblingRequired = FALSE AND f.siblingGroupId IS NULL))
+              AND (:cursorAt IS NULL
+                   OR r.scheduledAt > :cursorAt
+                   OR (r.scheduledAt = :cursorAt AND r.id > :cursorId))
+            ORDER BY r.scheduledAt ASC, r.id ASC
+            """)
+    List<ReviewSchedule> findUpcoming(@Param("memberId") Long memberId,
+                                      @Param("materialId") Long materialId,
+                                      @Param("upperBound") Instant upperBound,
+                                      @Param("cardType") FlashcardType cardType,
+                                      @Param("siblingRequired") Boolean siblingRequired,
+                                      @Param("cursorAt") Instant cursorAt,
+                                      @Param("cursorId") Long cursorId,
+                                      Pageable pageable);
+
+    /**
+     * 완료된 복습 — COMPLETED를 {@code completed_at DESC, id DESC}로 keyset 페이징한다.
+     * {@code materialId}/{@code grade}는 필터(null이면 무시), {@code cursorAt}/{@code cursorId}는
+     * 이전 페이지 마지막 keyset이다.
+     */
+    @Query("""
+            SELECT r FROM ReviewSchedule r, Flashcard f
+            WHERE r.flashcardId = f.id
+              AND r.memberId = :memberId
+              AND r.status = ds.project.orino.domain.planner.review.entity.ReviewStatus.COMPLETED
+              AND (:materialId IS NULL OR f.materialId = :materialId)
+              AND (:grade IS NULL OR r.rating = :grade)
+              AND (:cursorAt IS NULL
+                   OR r.completedAt < :cursorAt
+                   OR (r.completedAt = :cursorAt AND r.id < :cursorId))
+            ORDER BY r.completedAt DESC, r.id DESC
+            """)
+    List<ReviewSchedule> findCompleted(@Param("memberId") Long memberId,
+                                       @Param("materialId") Long materialId,
+                                       @Param("grade") Rating grade,
+                                       @Param("cursorAt") Instant cursorAt,
+                                       @Param("cursorId") Long cursorId,
+                                       Pageable pageable);
 }


### PR DESCRIPTION
## 이슈
closes #755

## 작업 내용
복습 허브(Study Planner v2.5)를 위한 **조회 전용 API 3종** 추가. 복습 로직·SM-2·평가·burying은 **무변경**, `ReviewQueryService`에 조회만 추가했다.

- **`GET /reviews/summary`** — 현황 집계(서버 총계). `counts`(now/overdue/upcoming/doneToday) + `estimatedMinutes`(now 기반 대략치) + `materials[]`(자료별 due/overdue/nextLabel, due+overdue 내림차순)
- **`GET /reviews/upcoming`** — 전 PENDING, `scheduled_at ASC, id ASC` **커서(keyset) 페이징**
  - 필터: `scope`(all/today/overdue) · `materialId` · `when`(all/today/3d/7d) · `type`(all/basic/order/pair)
  - `pair`는 파생: `BASIC + siblingGroupId IS NOT NULL`
  - 항목: `scheduledAt` · `whenKind`(now/today/future) · `overdue` · `cardType`(BASIC/ORDERING/PAIR) · `flashcard{front,type,siblingGroupId,material}`
- **`GET /reviews/completed`** — COMPLETED, `completed_at DESC, id DESC` 커서 페이징 + `materialId`/`grade` 필터
- **스키마 변경 없음.** 완료 목록 커서 정렬용 인덱스 `(member_id, status, completed_at)`만 추가 — changeset `036-add-review-schedule-completed-index.yaml`(`indexExists` 가드, author `wcorn`)
  - ℹ️ 이슈 본문의 `035`는 이미 #752에서 선점되어 **`036`** 으로 부여
- 시각 라벨(지금/10분 후/…)은 FE가 포맷 — 서버는 `scheduledAt`/`completedAt` + `whenKind`만 제공

## 테스트
- **MockMvc + TestContainers** 통합 테스트 3종(summary/upcoming/completed): 필터·커서 페이징(동일 키 id tie-break)·경계값·타인/상태 제외·400 검증
- 시각 의존 로직(whenKind·doneToday) 결정성 위해 `FixedClockConfig`(고정 Clock, `@Primary`) 도입 — JWT는 실시각을 쓰므로 인증 영향 없음
- `./gradlew check`(checkstyle) 통과
- **로컬 bootRun + curl 실검증**: fresh MySQL 8.4.4에 Liquibase 036 인덱스 적용 확인, 3종 엔드포인트 응답·필터·커서 페이징(무중복)·400 정상 동작 확인

## 참고
- Epic: #754 (FE #756 완료 후 Epic close 예정)
- 설계: [API §7.4~7.6](https://github.com/wcorn/orino/wiki/Study-Planner-API-Spec) · [Data-Model §6.5](https://github.com/wcorn/orino/wiki/Study-Planner-Data-Model)

---
**추가 커밋** (`487ba3a`): 통합 테스트 Hikari 풀 축소(max=4, min-idle=0). 단일 TestContainer를 공유하는 다수 Spring 컨텍스트의 커넥션 누적이 CI에서 `max_connections`를 넘겨 mirror 통합 테스트가 `SQLNonTransientConnectionException`으로 실패한 것을 해결(FixedClockConfig 컨텍스트 추가가 방아쇠). app-api 전체 테스트 통과.