### PR TITLE
feat : 엑셀(.xlsx) Import — 노트·메모 표 가져오기 (v1) (#763)

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -38,6 +38,7 @@
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
         "tw-animate-css": "^1.4.0",
+        "xlsx": "^0.18.5",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -4407,6 +4408,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -4745,6 +4755,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -4913,6 +4936,15 @@
       "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
       "license": "MIT"
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5050,6 +5082,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -6174,6 +6218,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -9173,6 +9226,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -10058,6 +10123,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -10143,6 +10226,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {

--- a/fe/package.json
+++ b/fe/package.json
@@ -46,6 +46,7 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
     "tw-animate-css": "^1.4.0",
+    "xlsx": "^0.18.5",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/fe/src/features/note/components/EditorToolbar.tsx
+++ b/fe/src/features/note/components/EditorToolbar.tsx
@@ -13,15 +13,17 @@ import {
   ListOrdered,
   Quote,
   Rows3,
+  Sheet,
   Table,
   Trash2,
 } from "lucide-react";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 import { uploadAndInsertImage } from "../editor/imageUpload";
+import { ImportDialog } from "../import/ImportDialog";
 
 interface Props {
   editor: Editor | null;
@@ -47,6 +49,7 @@ export function EditorToolbar({
     selector: ({ editor }) => editor?.isActive("table") ?? false,
   });
   const imageInputRef = useRef<HTMLInputElement>(null);
+  const [importOpen, setImportOpen] = useState(false);
 
   if (!editor) return null;
 
@@ -163,6 +166,21 @@ export function EditorToolbar({
           files.forEach((file) => void uploadAndInsertImage(editor, file));
           e.target.value = "";
         }}
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        aria-label="가져오기"
+        onClick={() => setImportOpen(true)}
+      >
+        <Sheet className="size-4" />
+      </Button>
+      <ImportDialog
+        open={importOpen}
+        onOpenChange={setImportOpen}
+        currentDoc={importOpen ? editor.getJSON() : null}
+        onInsert={(node) => editor.chain().focus().insertContent(node).run()}
       />
       {onInsertPage && (
         <>

--- a/fe/src/features/note/components/NoteTab.test.tsx
+++ b/fe/src/features/note/components/NoteTab.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it } from "vitest";
+import * as XLSX from "xlsx";
 
 import { Providers } from "@/app/providers";
 import { useAuthStore } from "@/features/auth/store/authStore";
@@ -440,6 +441,111 @@ describe("NoteTab", () => {
     await waitFor(() => {
       expect(container.querySelector("table")).toBeNull();
     });
+  });
+
+  it("[가져오기]로 엑셀을 업로드하면 값이 표로 본문에 삽입된다", async () => {
+    mockTree([
+      { id: 1, title: "노트", parentId: null, sortOrder: 0, children: [] },
+    ]);
+    mockNoteDetail(1, { type: "doc", content: [] }, "노트");
+
+    const user = userEvent.setup();
+    const { container } = renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("노트");
+    });
+    expect(container.querySelector("table")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "가져오기" }));
+
+    // 엑셀 생성 후 업로드
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(
+      wb,
+      XLSX.utils.aoa_to_sheet([
+        ["항목", "값"],
+        ["A", "1"],
+      ]),
+      "Sheet1",
+    );
+    const buf = XLSX.write(wb, { type: "array", bookType: "xlsx" });
+    const file = new File([buf], "data.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    });
+    await user.upload(screen.getByLabelText("엑셀 파일"), file);
+
+    await screen.findByText("총 1행 × 2열");
+    await user.click(screen.getByRole("button", { name: "표로 가져오기" }));
+
+    // 본문에 표가 삽입되고(헤더행 th 2 + 본문 td 2) 값이 보인다
+    await waitFor(() => {
+      expect(container.querySelector("table")).not.toBeNull();
+    });
+    expect(container.querySelectorAll("table th")).toHaveLength(2);
+    expect(screen.getByText("항목")).toBeInTheDocument();
+    expect(screen.getByText("A")).toBeInTheDocument();
+  });
+
+  it("표를 담은 노트 content를 열면 표가 그대로 렌더된다(라운드트립)", async () => {
+    mockTree([
+      { id: 1, title: "표노트", parentId: null, sortOrder: 0, children: [] },
+    ]);
+    mockNoteDetail(
+      1,
+      {
+        type: "doc",
+        content: [
+          {
+            type: "table",
+            content: [
+              {
+                type: "tableRow",
+                content: [
+                  {
+                    type: "tableHeader",
+                    content: [
+                      {
+                        type: "paragraph",
+                        content: [{ type: "text", text: "H1" }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "tableRow",
+                content: [
+                  {
+                    type: "tableCell",
+                    content: [
+                      {
+                        type: "paragraph",
+                        content: [{ type: "text", text: "V1" }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "표노트",
+    );
+
+    const { container } = renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("표노트");
+    });
+    // 저장된 표 노드가 헤더/셀로 보존되어 렌더된다
+    await waitFor(() => {
+      expect(container.querySelector("table")).not.toBeNull();
+    });
+    expect(container.querySelectorAll("table th")).toHaveLength(1);
+    expect(screen.getByText("H1")).toBeInTheDocument();
+    expect(screen.getByText("V1")).toBeInTheDocument();
   });
 
   it("자손이 있는 노트 삭제 시 확인 문구에 하위 개수를 표시한다", async () => {

--- a/fe/src/features/note/import/ImportDialog.test.tsx
+++ b/fe/src/features/note/import/ImportDialog.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { JSONContent } from "@tiptap/react";
+import { describe, expect, it, vi } from "vitest";
+import * as XLSX from "xlsx";
+
+import { ImportDialog } from "./ImportDialog";
+
+function makeXlsx(
+  sheets: Record<string, unknown[][]>,
+  name = "test.xlsx",
+): File {
+  const wb = XLSX.utils.book_new();
+  for (const [sheetName, aoa] of Object.entries(sheets)) {
+    XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet(aoa), sheetName);
+  }
+  const buf = XLSX.write(wb, { type: "array", bookType: "xlsx" });
+  return new File([buf], name, {
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  });
+}
+
+function renderDialog(
+  onInsert = vi.fn(),
+  currentDoc: unknown = { type: "doc" },
+) {
+  render(
+    <ImportDialog
+      open
+      onOpenChange={() => {}}
+      currentDoc={currentDoc}
+      onInsert={onInsert}
+    />,
+  );
+  return onInsert;
+}
+
+async function upload(file: File) {
+  const input = screen.getByLabelText("엑셀 파일");
+  await userEvent.upload(input, file);
+}
+
+describe("ImportDialog", () => {
+  it("xlsx 업로드 → 미리보기 후 [표로 가져오기]로 표 노드를 삽입한다", async () => {
+    const onInsert = renderDialog();
+    await upload(
+      makeXlsx({
+        Sheet1: [
+          ["이름", "점수"],
+          ["김철수", 90],
+        ],
+      }),
+    );
+
+    // 미리보기(머리글 + 총계)
+    expect(await screen.findByText("총 1행 × 2열")).toBeInTheDocument();
+    expect(screen.getByText("점수")).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "표로 가져오기" }),
+    );
+
+    expect(onInsert).toHaveBeenCalledTimes(1);
+    const node = onInsert.mock.calls[0][0] as JSONContent;
+    expect(node.type).toBe("table");
+    // 헤더 행(tableHeader) + 본문 1행
+    expect(node.content).toHaveLength(2);
+    const header = node.content![0] as JSONContent;
+    expect((header.content![0] as JSONContent).type).toBe("tableHeader");
+  });
+
+  it("'첫 행을 머리글로'를 끄면 헤더 없이 전부 본문 행", async () => {
+    const onInsert = renderDialog();
+    await upload(
+      makeXlsx({
+        S: [
+          ["a", "b"],
+          ["c", "d"],
+        ],
+      }),
+    );
+    await screen.findByText(/총 \d행 × 2열/);
+
+    await userEvent.click(screen.getByRole("switch"));
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "표로 가져오기" }),
+    );
+    const node = onInsert.mock.calls[0][0] as JSONContent;
+    // 헤더 없음 → 2행 모두 tableCell
+    expect(node.content).toHaveLength(2);
+    const first = node.content![0] as JSONContent;
+    expect((first.content![0] as JSONContent).type).toBe("tableCell");
+  });
+
+  it("여러 시트면 시트를 선택할 수 있다", async () => {
+    renderDialog();
+    await upload(makeXlsx({ 첫째: [["x"]], 둘째: [["y1", "y2"]] }));
+
+    // 시트 셀렉트 노출
+    expect(await screen.findByText("시트")).toBeInTheDocument();
+  });
+
+  it(".xlsx가 아니면 에러를 보여준다", async () => {
+    renderDialog();
+    const csv = new File(["a,b"], "data.csv", { type: "text/csv" });
+    // accept=".xlsx" 필터를 우회해 비-xlsx가 핸들러에 도달하는 상황(드롭 등) 재현
+    await userEvent.upload(screen.getByLabelText("엑셀 파일"), csv, {
+      applyAccept: false,
+    });
+
+    expect(
+      await screen.findByText("엑셀(.xlsx) 파일만 가져올 수 있어요."),
+    ).toBeInTheDocument();
+  });
+
+  it("빈 시트는 '데이터가 없어요' 경고 + 가져오기 비활성", async () => {
+    renderDialog();
+    await upload(makeXlsx({ Empty: [] }));
+
+    expect(
+      await screen.findByText("이 시트에는 데이터가 없어요."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "표로 가져오기" }),
+    ).toBeDisabled();
+  });
+
+  it("노트가 이미 크면 초과 경고 + 가져오기 비활성", async () => {
+    renderDialog(vi.fn(), { type: "doc", big: "x".repeat(1_000_001) });
+    await upload(makeXlsx({ S: [["a"]] }));
+
+    expect(
+      await screen.findByText("노트가 너무 커서 이 표를 넣을 수 없어요."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "표로 가져오기" }),
+    ).toBeDisabled();
+  });
+});

--- a/fe/src/features/note/import/ImportDialog.tsx
+++ b/fe/src/features/note/import/ImportDialog.tsx
@@ -1,0 +1,295 @@
+import type { JSONContent } from "@tiptap/react";
+import { UploadCloud } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
+import { Select } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+
+import { DEFAULT_IMPORT_SOURCE, IMPORT_SOURCES } from "./importers";
+import {
+  buildTableNode,
+  type NormalizedTable,
+  wouldExceedNoteLimit,
+} from "./tableContent";
+import { parseXlsxSheets, type SheetData } from "./xlsxParser";
+
+const PREVIEW_ROWS = 5;
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** 현재 에디터 문서(삽입 시 1MB 초과 가드용). */
+  currentDoc: unknown;
+  /** 표 노드를 커서 위치에 삽입한다. */
+  onInsert: (node: JSONContent) => void;
+}
+
+export function ImportDialog({
+  open,
+  onOpenChange,
+  currentDoc,
+  onInsert,
+}: Props) {
+  const [source] = useState(DEFAULT_IMPORT_SOURCE);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [sheets, setSheets] = useState<SheetData[] | null>(null);
+  const [selectedSheet, setSelectedSheet] = useState<string>("");
+  const [firstRowAsHeader, setFirstRowAsHeader] = useState(true);
+  const [parsing, setParsing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const reset = () => {
+    setFileName(null);
+    setSheets(null);
+    setSelectedSheet("");
+    setFirstRowAsHeader(true);
+    setParsing(false);
+    setError(null);
+  };
+
+  const close = () => {
+    reset();
+    onOpenChange(false);
+  };
+
+  const handleFile = async (file: File) => {
+    if (!file.name.toLowerCase().endsWith(".xlsx")) {
+      setError("엑셀(.xlsx) 파일만 가져올 수 있어요.");
+      return;
+    }
+    setError(null);
+    setParsing(true);
+    setFileName(file.name);
+    try {
+      const parsed = await parseXlsxSheets(file);
+      const firstWithData = parsed.find((s) => s.rows.length > 0) ?? parsed[0];
+      setSheets(parsed);
+      setSelectedSheet(firstWithData?.name ?? "");
+    } catch {
+      setError("파일을 읽을 수 없어요. 손상되지 않은 .xlsx인지 확인해 주세요.");
+      setSheets(null);
+      setFileName(null);
+    } finally {
+      setParsing(false);
+    }
+  };
+
+  const current = sheets?.find((s) => s.name === selectedSheet) ?? null;
+
+  const normalized: NormalizedTable | null = useMemo(() => {
+    if (!current || current.rows.length === 0) return null;
+    if (firstRowAsHeader) {
+      return { headers: current.rows[0], rows: current.rows.slice(1) };
+    }
+    return { headers: null, rows: current.rows };
+  }, [current, firstRowAsHeader]);
+
+  const build = useMemo(
+    () => (normalized ? buildTableNode(normalized) : null),
+    [normalized],
+  );
+
+  const exceedsLimit = useMemo(
+    () => (build ? wouldExceedNoteLimit(currentDoc, build.node) : false),
+    [build, currentDoc],
+  );
+
+  const isEmptySheet = current !== null && current.rows.length === 0;
+  const canImport = build !== null && !exceedsLimit;
+
+  const handleImport = () => {
+    if (!build || exceedsLimit) return;
+    onInsert(build.node);
+    close();
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={(next) => (next ? onOpenChange(true) : close())}
+      title="데이터 가져오기"
+      description="엑셀 파일을 표로 삽입합니다. 값만 가져오고 서식·수식은 무시해요."
+      size="lg"
+    >
+      {/* 소스 선택 (v1: Excel만, 나머지 곧) */}
+      <div className="mt-4 flex flex-wrap gap-2">
+        {IMPORT_SOURCES.map((s) => (
+          <button
+            key={s.id}
+            type="button"
+            disabled={!s.available}
+            aria-pressed={s.available && source === s.id}
+            className={cn(
+              "rounded-md border px-3 py-1.5 text-sm transition-colors",
+              s.available && source === s.id
+                ? "border-primary bg-primary/10 text-primary"
+                : "border-border text-muted-foreground",
+              !s.available && "cursor-not-allowed opacity-50",
+            )}
+          >
+            {s.label}
+            {!s.available && " · 곧"}
+          </button>
+        ))}
+      </div>
+
+      {/* 파일 드롭/선택 */}
+      <div
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={(e) => {
+          e.preventDefault();
+          const file = e.dataTransfer.files[0];
+          if (file) void handleFile(file);
+        }}
+        className="border-border mt-4 flex flex-col items-center gap-2 rounded-lg border border-dashed p-6 text-center"
+      >
+        <UploadCloud className="text-muted-foreground size-6" />
+        <p className="text-muted-foreground text-sm">
+          {fileName ?? ".xlsx 파일을 끌어 놓거나 선택하세요"}
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          파일 선택
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".xlsx"
+          aria-label="엑셀 파일"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) void handleFile(file);
+            e.target.value = "";
+          }}
+        />
+      </div>
+
+      {parsing && (
+        <p className="text-muted-foreground mt-3 text-sm">파싱 중…</p>
+      )}
+
+      {error && (
+        <Alert variant="destructive" className="mt-3">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {sheets && !parsing && (
+        <div className="mt-4 flex flex-col gap-3">
+          {/* 시트 선택 (2개 이상) */}
+          {sheets.length > 1 && (
+            <div className="flex items-center gap-2">
+              <span id="import-sheet-label" className="text-sm font-medium">
+                시트
+              </span>
+              <Select
+                value={selectedSheet}
+                onValueChange={setSelectedSheet}
+                options={sheets.map((s) => ({ value: s.name, label: s.name }))}
+                ariaLabelledby="import-sheet-label"
+              />
+            </div>
+          )}
+
+          {/* 첫 행 머리글 토글 */}
+          <label className="flex items-center gap-2 text-sm">
+            <Switch
+              checked={firstRowAsHeader}
+              onCheckedChange={setFirstRowAsHeader}
+            />
+            첫 행을 머리글로
+          </label>
+
+          {isEmptySheet && (
+            <Alert variant="warning">
+              <AlertDescription>이 시트에는 데이터가 없어요.</AlertDescription>
+            </Alert>
+          )}
+
+          {build && normalized && (
+            <>
+              <TablePreview
+                headers={normalized.headers}
+                rows={normalized.rows}
+              />
+              <p className="text-muted-foreground text-sm">
+                총 {build.rows}행 × {build.cols}열
+              </p>
+              {(build.droppedCols > 0 || build.droppedRows > 0) && (
+                <Alert variant="warning">
+                  <AlertDescription>
+                    표가 커서 상위 {build.rows}행 / {build.cols}열만 가져와요.
+                  </AlertDescription>
+                </Alert>
+              )}
+              {exceedsLimit && (
+                <Alert variant="destructive">
+                  <AlertDescription>
+                    노트가 너무 커서 이 표를 넣을 수 없어요.
+                  </AlertDescription>
+                </Alert>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      <Modal.Footer
+        submitLabel="표로 가져오기"
+        onSubmit={handleImport}
+        submitDisabled={!canImport}
+      />
+    </Modal>
+  );
+}
+
+function TablePreview({
+  headers,
+  rows,
+}: {
+  headers: string[] | null;
+  rows: string[][];
+}) {
+  const previewRows = rows.slice(0, PREVIEW_ROWS);
+  return (
+    <div className="max-h-56 overflow-auto rounded-md border">
+      <table className="w-full border-collapse text-sm">
+        {headers && (
+          <thead>
+            <tr>
+              {headers.map((h, i) => (
+                <th
+                  key={i}
+                  className="border-border bg-muted border px-2 py-1 text-left font-semibold"
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+        )}
+        <tbody>
+          {previewRows.map((row, r) => (
+            <tr key={r}>
+              {row.map((cell, c) => (
+                <td key={c} className="border-border border px-2 py-1">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/fe/src/features/note/import/importers.ts
+++ b/fe/src/features/note/import/importers.ts
@@ -1,6 +1,7 @@
 /**
- * 데이터 Import 소스 레지스트리. v1은 Excel(.xlsx)만 활성. 이후 소스(CSV/붙여넣기/Google Sheets)는
+ * 데이터 Import 소스 레지스트리. v1은 Excel(.xlsx)만 활성. 이후 소스(CSV/Google Sheets)는
  * 이 목록에 `available: true` + 파서만 얹으면 미리보기·표 삽입 파이프라인을 그대로 재사용한다.
+ * 가져오기는 파일 업로드 기반만 지원한다(붙여넣기 미지원).
  */
 export interface ImportSource {
   id: string;
@@ -13,7 +14,7 @@ export interface ImportSource {
 
 export const IMPORT_SOURCES: ImportSource[] = [
   { id: "xlsx", label: "Excel (.xlsx)", accept: ".xlsx", available: true },
-  { id: "csv", label: "CSV · 붙여넣기", available: false },
+  { id: "csv", label: "CSV (.csv)", accept: ".csv", available: false },
   { id: "gsheets", label: "Google Sheets", available: false },
 ];
 

--- a/fe/src/features/note/import/importers.ts
+++ b/fe/src/features/note/import/importers.ts
@@ -1,0 +1,20 @@
+/**
+ * 데이터 Import 소스 레지스트리. v1은 Excel(.xlsx)만 활성. 이후 소스(CSV/붙여넣기/Google Sheets)는
+ * 이 목록에 `available: true` + 파서만 얹으면 미리보기·표 삽입 파이프라인을 그대로 재사용한다.
+ */
+export interface ImportSource {
+  id: string;
+  label: string;
+  /** 파일 input accept(파일 기반 소스만). */
+  accept?: string;
+  /** v1 활성 여부. false면 "곧" 안내로 비활성 노출. */
+  available: boolean;
+}
+
+export const IMPORT_SOURCES: ImportSource[] = [
+  { id: "xlsx", label: "Excel (.xlsx)", accept: ".xlsx", available: true },
+  { id: "csv", label: "CSV · 붙여넣기", available: false },
+  { id: "gsheets", label: "Google Sheets", available: false },
+];
+
+export const DEFAULT_IMPORT_SOURCE = "xlsx";

--- a/fe/src/features/note/import/tableContent.test.ts
+++ b/fe/src/features/note/import/tableContent.test.ts
@@ -1,0 +1,91 @@
+import type { JSONContent } from "@tiptap/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTableNode,
+  byteLength,
+  MAX_COLS,
+  MAX_ROWS,
+  wouldExceedNoteLimit,
+} from "./tableContent";
+
+function cellText(cell: JSONContent): string {
+  const p = cell.content?.[0];
+  return p?.content?.[0]?.text ?? "";
+}
+
+describe("buildTableNode", () => {
+  it("헤더가 있으면 첫 행은 tableHeader, 본문은 tableCell", () => {
+    const { node, cols, rows } = buildTableNode({
+      headers: ["A", "B"],
+      rows: [
+        ["1", "2"],
+        ["3", "4"],
+      ],
+    });
+    expect(node.type).toBe("table");
+    expect(node.content).toHaveLength(3); // 헤더 + 2행
+    expect(cols).toBe(2);
+    expect(rows).toBe(2);
+
+    const headerRow = node.content![0] as JSONContent;
+    expect(headerRow.content!.every((c) => c.type === "tableHeader")).toBe(
+      true,
+    );
+    expect(cellText(headerRow.content![0] as JSONContent)).toBe("A");
+
+    const bodyRow = node.content![1] as JSONContent;
+    expect(bodyRow.content!.every((c) => c.type === "tableCell")).toBe(true);
+    expect(cellText(bodyRow.content![0] as JSONContent)).toBe("1");
+  });
+
+  it("헤더가 없으면 전부 tableCell", () => {
+    const { node } = buildTableNode({ headers: null, rows: [["x"]] });
+    const row = node.content![0] as JSONContent;
+    expect((row.content![0] as JSONContent).type).toBe("tableCell");
+  });
+
+  it("빈 셀은 내용 없는 paragraph", () => {
+    const { node } = buildTableNode({ headers: null, rows: [["", "v"]] });
+    const row = node.content![0] as JSONContent;
+    const emptyCell = row.content![0] as JSONContent;
+    expect(emptyCell.content).toEqual([{ type: "paragraph" }]);
+  });
+
+  it("열 상한 초과 시 잘라내고 droppedCols 보고", () => {
+    const wide = Array.from({ length: MAX_COLS + 5 }, (_, i) => String(i));
+    const { cols, droppedCols } = buildTableNode({
+      headers: null,
+      rows: [wide],
+    });
+    expect(cols).toBe(MAX_COLS);
+    expect(droppedCols).toBe(5);
+  });
+
+  it("행 상한 초과 시 잘라내고 droppedRows 보고", () => {
+    const many = Array.from({ length: MAX_ROWS + 3 }, () => ["a"]);
+    const { rows, droppedRows } = buildTableNode({ headers: null, rows: many });
+    expect(rows).toBe(MAX_ROWS);
+    expect(droppedRows).toBe(3);
+  });
+});
+
+describe("wouldExceedNoteLimit", () => {
+  it("작은 문서 + 작은 표는 초과하지 않는다", () => {
+    const { node } = buildTableNode({ headers: ["A"], rows: [["1"]] });
+    expect(wouldExceedNoteLimit({ type: "doc", content: [] }, node)).toBe(
+      false,
+    );
+  });
+
+  it("이미 큰 문서면 초과로 판정한다", () => {
+    const { node } = buildTableNode({ headers: ["A"], rows: [["1"]] });
+    const huge = { type: "doc", big: "x".repeat(1_000_001) };
+    expect(wouldExceedNoteLimit(huge, node)).toBe(true);
+  });
+
+  it("byteLength는 UTF-8 바이트 수", () => {
+    // JSON.stringify("한") = "한"(따옴표 2 + 3바이트 한글) = 5바이트
+    expect(byteLength("한")).toBe(5);
+  });
+});

--- a/fe/src/features/note/import/tableContent.ts
+++ b/fe/src/features/note/import/tableContent.ts
@@ -1,0 +1,81 @@
+import type { JSONContent } from "@tiptap/react";
+
+/** 표 상한(초과 시 잘라서 삽입 + 경고). */
+export const MAX_COLS = 30;
+export const MAX_ROWS = 200;
+/** 노트 content 직렬화 크기 상한(BE 1MB 제한). 근접 시 삽입을 막는다. */
+export const NOTE_MAX_BYTES = 1_000_000;
+
+/** 정규화된 표 입력. headers가 있으면 헤더 행으로, 없으면 전부 본문. */
+export interface NormalizedTable {
+  headers: string[] | null;
+  rows: string[][];
+}
+
+export interface TableBuildResult {
+  node: JSONContent;
+  /** 상한 초과로 잘린 열 수. */
+  droppedCols: number;
+  /** 상한 초과로 잘린 본문 행 수. */
+  droppedRows: number;
+  /** 삽입되는 최종 열 수. */
+  cols: number;
+  /** 삽입되는 최종 본문 행 수(헤더 제외). */
+  rows: number;
+}
+
+/** 정규화된 2D 표를 Tiptap `table` 노드로 변환한다. 상한을 넘으면 잘라내고 잘린 수를 보고한다. */
+export function buildTableNode(input: NormalizedTable): TableBuildResult {
+  const totalCols = Math.max(
+    input.headers?.length ?? 0,
+    ...input.rows.map((r) => r.length),
+    0,
+  );
+  const cols = Math.min(totalCols, MAX_COLS);
+  const droppedCols = Math.max(0, totalCols - cols);
+
+  const keptBody = input.rows.slice(0, MAX_ROWS);
+  const droppedRows = input.rows.length - keptBody.length;
+
+  const content: JSONContent[] = [];
+  if (input.headers) content.push(rowNode(input.headers, cols, true));
+  for (const row of keptBody) content.push(rowNode(row, cols, false));
+  if (content.length === 0) content.push(rowNode([], Math.max(cols, 1), false));
+
+  return {
+    node: { type: "table", content },
+    droppedCols,
+    droppedRows,
+    cols,
+    rows: keptBody.length,
+  };
+}
+
+function rowNode(cells: string[], cols: number, header: boolean): JSONContent {
+  const cellType = header ? "tableHeader" : "tableCell";
+  const content: JSONContent[] = [];
+  for (let c = 0; c < cols; c++) {
+    content.push({ type: cellType, content: [paragraph(cells[c] ?? "")] });
+  }
+  return { type: "tableRow", content };
+}
+
+function paragraph(text: string): JSONContent {
+  const trimmed = text ?? "";
+  return trimmed === ""
+    ? { type: "paragraph" }
+    : { type: "paragraph", content: [{ type: "text", text: trimmed }] };
+}
+
+/** 값의 JSON 직렬화 UTF-8 바이트 수. */
+export function byteLength(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).length;
+}
+
+/** 현재 문서에 노드를 삽입하면 노트 크기 상한을 넘는지. */
+export function wouldExceedNoteLimit(
+  currentDoc: unknown,
+  node: JSONContent,
+): boolean {
+  return byteLength(currentDoc) + byteLength(node) > NOTE_MAX_BYTES;
+}

--- a/fe/src/features/note/import/xlsxParser.test.ts
+++ b/fe/src/features/note/import/xlsxParser.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import * as XLSX from "xlsx";
+
+import { parseXlsxSheets } from "./xlsxParser";
+
+/** 테스트용 .xlsx File을 SheetJS로 생성한다. */
+function makeXlsx(sheets: Record<string, unknown[][]>): File {
+  const wb = XLSX.utils.book_new();
+  for (const [name, aoa] of Object.entries(sheets)) {
+    XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet(aoa), name);
+  }
+  const buf = XLSX.write(wb, { type: "array", bookType: "xlsx" });
+  return new File([buf], "test.xlsx", {
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  });
+}
+
+describe("parseXlsxSheets", () => {
+  it("셀 값을 행 우선 2D 문자열로 파싱한다", async () => {
+    const file = makeXlsx({
+      Sheet1: [
+        ["이름", "점수"],
+        ["김철수", 90],
+        ["이영희", 85],
+      ],
+    });
+    const sheets = await parseXlsxSheets(file);
+    expect(sheets).toHaveLength(1);
+    expect(sheets[0].name).toBe("Sheet1");
+    expect(sheets[0].rows).toEqual([
+      ["이름", "점수"],
+      ["김철수", "90"],
+      ["이영희", "85"],
+    ]);
+  });
+
+  it("여러 시트를 모두 반환한다", async () => {
+    const file = makeXlsx({
+      A: [["a"]],
+      B: [["b1", "b2"]],
+    });
+    const sheets = await parseXlsxSheets(file);
+    expect(sheets.map((s) => s.name)).toEqual(["A", "B"]);
+    expect(sheets[1].rows).toEqual([["b1", "b2"]]);
+  });
+
+  it("전 행이 빈 뒤쪽 열을 잘라 직사각형으로 만든다", async () => {
+    const file = makeXlsx({
+      S: [
+        ["a", "", ""],
+        ["b", "", ""],
+      ],
+    });
+    const sheets = await parseXlsxSheets(file);
+    // 값 있는 행 길이는 다르지만 정규화로 직사각형 + 빈 뒤쪽 열 제거
+    expect(sheets[0].rows).toEqual([["a"], ["b"]]);
+  });
+
+  it("빈 시트는 빈 rows", async () => {
+    const file = makeXlsx({ Empty: [] });
+    const sheets = await parseXlsxSheets(file);
+    expect(sheets[0].rows).toEqual([]);
+  });
+});

--- a/fe/src/features/note/import/xlsxParser.ts
+++ b/fe/src/features/note/import/xlsxParser.ts
@@ -1,0 +1,52 @@
+import * as XLSX from "xlsx";
+
+/** 파싱된 한 시트. rows는 값만 담은 행 우선 2D 문자열 배열(직사각형). */
+export interface SheetData {
+  name: string;
+  rows: string[][];
+}
+
+/**
+ * .xlsx 파일을 클라이언트에서 파싱해 시트별 2D 문자열 배열로 정규화한다.
+ * 값(표시 텍스트)만 가져오고 서식·수식·차트·병합은 무시한다(병합은 좌상단 값만).
+ */
+export async function parseXlsxSheets(file: File): Promise<SheetData[]> {
+  const buffer = await file.arrayBuffer();
+  const workbook = XLSX.read(buffer, { type: "array" });
+  return workbook.SheetNames.map((name) => {
+    const sheet = workbook.Sheets[name];
+    // header:1 → 행 우선 AoA, raw:false → 표시 텍스트(숫자/날짜 서식 반영), defval:"" → 빈 셀은 빈 문자열
+    const aoa = XLSX.utils.sheet_to_json<unknown[]>(sheet, {
+      header: 1,
+      blankrows: false,
+      defval: "",
+      raw: false,
+    });
+    const rows = aoa.map((row) => row.map(cellToString));
+    return { name, rows: normalizeRows(rows) };
+  });
+}
+
+function cellToString(cell: unknown): string {
+  if (cell === null || cell === undefined) return "";
+  return String(cell);
+}
+
+/** 각 행을 최대 열 수로 패딩해 직사각형으로 만들고, 전 행이 빈 뒤쪽 열을 제거한다. */
+function normalizeRows(rows: string[][]): string[][] {
+  const maxCols = rows.reduce((max, row) => Math.max(max, row.length), 0);
+  if (maxCols === 0) return [];
+
+  const rectangular = rows.map((row) => {
+    const padded = row.slice(0, maxCols);
+    while (padded.length < maxCols) padded.push("");
+    return padded;
+  });
+
+  let lastNonEmptyCol = -1;
+  for (let c = 0; c < maxCols; c++) {
+    if (rectangular.some((row) => row[c].trim() !== "")) lastNonEmptyCol = c;
+  }
+  if (lastNonEmptyCol < 0) return [];
+  return rectangular.map((row) => row.slice(0, lastNonEmptyCol + 1));
+}

--- a/fe/src/test/setup.ts
+++ b/fe/src/test/setup.ts
@@ -13,6 +13,33 @@ if (!URL.revokeObjectURL) {
   URL.revokeObjectURL = () => {};
 }
 
+// ProseMirror(coordsAtPos 등)가 텍스트 노드/Range의 getClientRects·getBoundingClientRect를
+// 호출하는데 jsdom엔 없어 표 삽입 후 좌표 계산이 unhandled error를 낸다. 빈 값으로 폴리필.
+const emptyRects = () =>
+  Object.assign([] as unknown[], {
+    item: () => null,
+  }) as unknown as DOMRectList;
+const zeroRect = () =>
+  ({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    toJSON: () => ({}),
+  }) as DOMRect;
+for (const proto of [globalThis.Text?.prototype, globalThis.Range?.prototype]) {
+  if (proto && typeof proto.getClientRects !== "function") {
+    proto.getClientRects = emptyRects;
+  }
+  if (proto && typeof proto.getBoundingClientRect !== "function") {
+    proto.getBoundingClientRect = zeroRect;
+  }
+}
+
 // jsdom에는 IntersectionObserver가 없다. 무한 스크롤 sentinel용 목.
 // 생성된 인스턴스를 전역에 모아 테스트에서 교차(intersection)를 명시적으로 트리거한다.
 // (src/test/io.ts의 triggerIntersection 헬퍼)

--- a/fe/src/test/setup.ts
+++ b/fe/src/test/setup.ts
@@ -31,7 +31,14 @@ const zeroRect = () =>
     left: 0,
     toJSON: () => ({}),
   }) as DOMRect;
-for (const proto of [globalThis.Text?.prototype, globalThis.Range?.prototype]) {
+type RectHost = {
+  getClientRects?: () => DOMRectList;
+  getBoundingClientRect?: () => DOMRect;
+};
+for (const proto of [
+  globalThis.Text?.prototype,
+  globalThis.Range?.prototype,
+] as (RectHost | undefined)[]) {
   if (proto && typeof proto.getClientRects !== "function") {
     proto.getClientRects = emptyRects;
   }


### PR DESCRIPTION
## 이슈
closes #761
closes #763

## 작업 내용
외부 데이터(v1: **Excel .xlsx**)를 공유 `NoteEditor`에 **Tiptap 표로 삽입**하는 확장형 임포터. **클라이언트 파싱(SheetJS) → BE·스키마 변경 없음**(기존 `PATCH /notes` 자동저장 재사용).

- **파싱** `parseXlsxSheets` — `.xlsx`를 시트별 2D 문자열로 정규화(값만, 서식·수식·병합 무시). 빈 뒤쪽 열 제거·직사각형화
- **임포터 레지스트리** — `{ id, label, accept, available }`. v1은 `xlsx`만 활성, CSV·Google Sheets는 "곧" 비활성 노출(차기 소스는 `parse`만 얹으면 재사용)
- **표 변환·가드** `buildTableNode` — 2D → Tiptap `table` 노드(헤더 행 선택). 상한 **열 30 / 행 200** 초과 시 잘라서 + 경고, 삽입 시 **1MB 근접 차단**
- **Import 다이얼로그** — 소스 선택 · 파일 드롭/선택 · 다중 시트 선택 · "첫 행을 머리글로" 토글 · 미리보기(상위 N행 + 총 R×C) · 에러(비-xlsx/빈 시트/초과)
- **툴바 [가져오기]** → 커서 위치에 `insertContent`로 표 삽입 → 기존 자동저장으로 저장
- 표 렌더는 공유 `NoteEditor`의 Table 확장(#438)을 그대로 사용 → **자료 노트·/notes 양쪽 반영**

> ℹ️ 선행 이슈 #762(Table 확장 등록)는 확인 결과 **이미 #438/#441로 구현되어 있어** 재구현하지 않고 [코멘트](https://github.com/wcorn/orino/issues/762#issuecomment-4945699922)로 close 제안했습니다. 그 미충족 항목이던 "표 노드 라운드트립 보존 테스트"는 본 PR에 포함했습니다.

## 테스트
- **단위**: 파싱(다중 시트·정규화·빈 시트) / 표 변환(헤더·빈 셀·상한 truncate) / 1MB 가드
- **RTL(ImportDialog)**: xlsx 업로드→미리보기→삽입, 머리글 토글, 시트 선택, 비-xlsx 에러, 빈 시트·초과 시 비활성
- **통합(NoteTab)**: [가져오기]→엑셀 업로드→본문에 표 삽입 + **표 담은 content 로드 시 표 보존(라운드트립)**
- setup: ProseMirror 좌표 계산이 jsdom에 없는 텍스트노드 `getClientRects`/`getBoundingClientRect`를 호출해 나던 unhandled error 폴리필
- `tsc -b`, `eslint`, `prettier --check`, 전체 **317 tests 통과(에러 0)**, `vite build` 통과
- **로컬 브라우저 실검증(실 BE 기동)**: `/notes`에서 2시트 .xlsx 업로드 → 미리보기(시트 선택·머리글·총계) → [표로 가져오기] → 본문에 표 삽입·저장 → **새로고침 후에도 표 유지(저장→로드 라운드트립)** 확인

## 참고
- Epic: #761 · 설계: [Data-Import (Wiki)](https://github.com/wcorn/orino/wiki/Data-Import)
- 로드맵(차기): CSV(파일) → Google Sheets → 표→플래시카드 변환

---
**추가 커밋** (`bb6213a`): Import는 **파일 업로드만** 지원(붙여넣기 제거). 미래 CSV 소스 라벨을 `CSV (.csv)`로. 겸사겸사 `setup.ts` 폴리필의 `Text|Range` 타입 오류를 수정해 `tsc -b`/`vite build` 게이트 통과.

---
**추가 커밋** (`18350ba`): **CSV(.csv) Import 지원**. 파서를 `sheetParser`(xlsx+csv 공용)로 일반화하고 다이얼로그에서 Excel/CSV 소스를 선택하도록 확장. CSV는 `file.text()`→SheetJS로 따옴표·구분자 처리(단일 시트). RTL(따옴표 쉼표 파싱·소스 전환 삽입) + **로컬 브라우저 실검증**(CSV 업로드→미리보기→표 삽입→저장) 완료. 전체 320 tests 통과.