### PR TITLE
feat : 데이터 Import — CSV(.csv) 소스 추가 (#765)

### DIFF
--- a/fe/src/features/note/components/NoteTab.test.tsx
+++ b/fe/src/features/note/components/NoteTab.test.tsx
@@ -473,7 +473,7 @@ describe("NoteTab", () => {
     const file = new File([buf], "data.xlsx", {
       type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     });
-    await user.upload(screen.getByLabelText("엑셀 파일"), file);
+    await user.upload(screen.getByLabelText("가져올 파일"), file);
 
     await screen.findByText("총 1행 × 2열");
     await user.click(screen.getByRole("button", { name: "표로 가져오기" }));

--- a/fe/src/features/note/import/ImportDialog.test.tsx
+++ b/fe/src/features/note/import/ImportDialog.test.tsx
@@ -36,7 +36,7 @@ function renderDialog(
 }
 
 async function upload(file: File) {
-  const input = screen.getByLabelText("엑셀 파일");
+  const input = screen.getByLabelText("가져올 파일");
   await userEvent.upload(input, file);
 }
 
@@ -101,17 +101,37 @@ describe("ImportDialog", () => {
     expect(await screen.findByText("시트")).toBeInTheDocument();
   });
 
-  it(".xlsx가 아니면 에러를 보여준다", async () => {
+  it("확장자가 안 맞으면 에러를 보여준다", async () => {
     renderDialog();
-    const csv = new File(["a,b"], "data.csv", { type: "text/csv" });
-    // accept=".xlsx" 필터를 우회해 비-xlsx가 핸들러에 도달하는 상황(드롭 등) 재현
-    await userEvent.upload(screen.getByLabelText("엑셀 파일"), csv, {
+    // Excel 소스에 확장자가 안 맞는 파일 → accept 필터를 우회해 핸들러 도달(드롭 등) 재현
+    const txt = new File(["a,b"], "data.txt", { type: "text/plain" });
+    await userEvent.upload(screen.getByLabelText("가져올 파일"), txt, {
       applyAccept: false,
     });
 
     expect(
-      await screen.findByText("엑셀(.xlsx) 파일만 가져올 수 있어요."),
+      await screen.findByText(".xlsx 파일만 가져올 수 있어요."),
     ).toBeInTheDocument();
+  });
+
+  it("CSV 소스로 전환해 .csv를 표로 가져온다", async () => {
+    const onInsert = renderDialog();
+    await userEvent.click(screen.getByRole("button", { name: "CSV (.csv)" }));
+
+    const csv = new File(["항목,값\nA,1\nB,2"], "data.csv", {
+      type: "text/csv",
+    });
+    await userEvent.upload(screen.getByLabelText("가져올 파일"), csv);
+
+    expect(await screen.findByText("총 2행 × 2열")).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "표로 가져오기" }),
+    );
+
+    expect(onInsert).toHaveBeenCalledTimes(1);
+    const node = onInsert.mock.calls[0][0] as JSONContent;
+    expect(node.type).toBe("table");
+    expect(node.content).toHaveLength(3); // 헤더 + 2행
   });
 
   it("빈 시트는 '데이터가 없어요' 경고 + 가져오기 비활성", async () => {

--- a/fe/src/features/note/import/ImportDialog.tsx
+++ b/fe/src/features/note/import/ImportDialog.tsx
@@ -10,12 +10,12 @@ import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 
 import { DEFAULT_IMPORT_SOURCE, IMPORT_SOURCES } from "./importers";
+import type { SheetData } from "./sheetParser";
 import {
   buildTableNode,
   type NormalizedTable,
   wouldExceedNoteLimit,
 } from "./tableContent";
-import { parseXlsxSheets, type SheetData } from "./xlsxParser";
 
 const PREVIEW_ROWS = 5;
 
@@ -34,7 +34,7 @@ export function ImportDialog({
   currentDoc,
   onInsert,
 }: Props) {
-  const [source] = useState(DEFAULT_IMPORT_SOURCE);
+  const [source, setSource] = useState(DEFAULT_IMPORT_SOURCE);
   const [fileName, setFileName] = useState<string | null>(null);
   const [sheets, setSheets] = useState<SheetData[] | null>(null);
   const [selectedSheet, setSelectedSheet] = useState<string>("");
@@ -42,6 +42,9 @@ export function ImportDialog({
   const [parsing, setParsing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const activeSource =
+    IMPORT_SOURCES.find((s) => s.id === source) ?? IMPORT_SOURCES[0];
 
   const reset = () => {
     setFileName(null);
@@ -57,16 +60,23 @@ export function ImportDialog({
     onOpenChange(false);
   };
 
+  const selectSource = (id: string) => {
+    setSource(id);
+    reset();
+  };
+
   const handleFile = async (file: File) => {
-    if (!file.name.toLowerCase().endsWith(".xlsx")) {
-      setError("엑셀(.xlsx) 파일만 가져올 수 있어요.");
+    const accept = activeSource.accept;
+    if (accept && !file.name.toLowerCase().endsWith(accept)) {
+      setError(`${accept} 파일만 가져올 수 있어요.`);
       return;
     }
+    if (!activeSource.parse) return;
     setError(null);
     setParsing(true);
     setFileName(file.name);
     try {
-      const parsed = await parseXlsxSheets(file);
+      const parsed = await activeSource.parse(file);
       const firstWithData = parsed.find((s) => s.rows.length > 0) ?? parsed[0];
       setSheets(parsed);
       setSelectedSheet(firstWithData?.name ?? "");
@@ -113,7 +123,7 @@ export function ImportDialog({
       open={open}
       onOpenChange={(next) => (next ? onOpenChange(true) : close())}
       title="데이터 가져오기"
-      description="엑셀 파일을 표로 삽입합니다. 값만 가져오고 서식·수식은 무시해요."
+      description="엑셀·CSV 파일을 표로 삽입합니다. 값만 가져오고 서식·수식은 무시해요."
       size="lg"
     >
       {/* 소스 선택 (v1: Excel만, 나머지 곧) */}
@@ -124,6 +134,7 @@ export function ImportDialog({
             type="button"
             disabled={!s.available}
             aria-pressed={s.available && source === s.id}
+            onClick={() => selectSource(s.id)}
             className={cn(
               "rounded-md border px-3 py-1.5 text-sm transition-colors",
               s.available && source === s.id
@@ -150,7 +161,7 @@ export function ImportDialog({
       >
         <UploadCloud className="text-muted-foreground size-6" />
         <p className="text-muted-foreground text-sm">
-          {fileName ?? ".xlsx 파일을 끌어 놓거나 선택하세요"}
+          {fileName ?? `${activeSource.accept} 파일을 끌어 놓거나 선택하세요`}
         </p>
         <Button
           type="button"
@@ -163,8 +174,8 @@ export function ImportDialog({
         <input
           ref={fileInputRef}
           type="file"
-          accept=".xlsx"
-          aria-label="엑셀 파일"
+          accept={activeSource.accept}
+          aria-label="가져올 파일"
           className="hidden"
           onChange={(e) => {
             const file = e.target.files?.[0];

--- a/fe/src/features/note/import/importers.ts
+++ b/fe/src/features/note/import/importers.ts
@@ -1,20 +1,36 @@
+import { parseCsvSheets, parseXlsxSheets, type SheetData } from "./sheetParser";
+
 /**
- * 데이터 Import 소스 레지스트리. v1은 Excel(.xlsx)만 활성. 이후 소스(CSV/Google Sheets)는
- * 이 목록에 `available: true` + 파서만 얹으면 미리보기·표 삽입 파이프라인을 그대로 재사용한다.
+ * 데이터 Import 소스 레지스트리. v1은 파일 업로드 소스(Excel·CSV)만 활성. 이후 소스(Google Sheets 등)는
+ * 이 목록에 `available: true` + `parse`만 얹으면 미리보기·표 삽입 파이프라인을 그대로 재사용한다.
  * 가져오기는 파일 업로드 기반만 지원한다(붙여넣기 미지원).
  */
 export interface ImportSource {
   id: string;
   label: string;
-  /** 파일 input accept(파일 기반 소스만). */
+  /** 파일 input accept(활성 파일 소스만). */
   accept?: string;
   /** v1 활성 여부. false면 "곧" 안내로 비활성 노출. */
   available: boolean;
+  /** 파일을 시트별 2D로 파싱(활성 소스만). */
+  parse?: (file: File) => Promise<SheetData[]>;
 }
 
 export const IMPORT_SOURCES: ImportSource[] = [
-  { id: "xlsx", label: "Excel (.xlsx)", accept: ".xlsx", available: true },
-  { id: "csv", label: "CSV (.csv)", accept: ".csv", available: false },
+  {
+    id: "xlsx",
+    label: "Excel (.xlsx)",
+    accept: ".xlsx",
+    available: true,
+    parse: parseXlsxSheets,
+  },
+  {
+    id: "csv",
+    label: "CSV (.csv)",
+    accept: ".csv",
+    available: true,
+    parse: parseCsvSheets,
+  },
   { id: "gsheets", label: "Google Sheets", available: false },
 ];
 

--- a/fe/src/features/note/import/sheetParser.test.ts
+++ b/fe/src/features/note/import/sheetParser.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import * as XLSX from "xlsx";
 
-import { parseXlsxSheets } from "./xlsxParser";
+import { parseCsvSheets, parseXlsxSheets } from "./sheetParser";
 
 /** 테스트용 .xlsx File을 SheetJS로 생성한다. */
 function makeXlsx(sheets: Record<string, unknown[][]>): File {
@@ -60,5 +60,31 @@ describe("parseXlsxSheets", () => {
     const file = makeXlsx({ Empty: [] });
     const sheets = await parseXlsxSheets(file);
     expect(sheets[0].rows).toEqual([]);
+  });
+});
+
+function makeCsv(text: string): File {
+  return new File([text], "test.csv", { type: "text/csv" });
+}
+
+describe("parseCsvSheets", () => {
+  it("CSV를 단일 시트 2D 문자열로 파싱한다", async () => {
+    const sheets = await parseCsvSheets(
+      makeCsv("이름,점수\n김철수,90\n이영희,85"),
+    );
+    expect(sheets).toHaveLength(1);
+    expect(sheets[0].rows).toEqual([
+      ["이름", "점수"],
+      ["김철수", "90"],
+      ["이영희", "85"],
+    ]);
+  });
+
+  it("따옴표로 감싼 쉼표는 한 셀로 파싱한다", async () => {
+    const sheets = await parseCsvSheets(makeCsv('제목,값\n"a,b",2'));
+    expect(sheets[0].rows).toEqual([
+      ["제목", "값"],
+      ["a,b", "2"],
+    ]);
   });
 });

--- a/fe/src/features/note/import/sheetParser.ts
+++ b/fe/src/features/note/import/sheetParser.ts
@@ -12,7 +12,20 @@ export interface SheetData {
  */
 export async function parseXlsxSheets(file: File): Promise<SheetData[]> {
   const buffer = await file.arrayBuffer();
-  const workbook = XLSX.read(buffer, { type: "array" });
+  return sheetsFromWorkbook(XLSX.read(buffer, { type: "array" }));
+}
+
+/**
+ * .csv 파일을 파싱한다. CSV는 시트 개념이 없어 단일 시트로 반환한다.
+ * UTF-8 텍스트로 읽으며 따옴표·구분자는 SheetJS가 처리한다.
+ */
+export async function parseCsvSheets(file: File): Promise<SheetData[]> {
+  const text = await file.text();
+  return sheetsFromWorkbook(XLSX.read(text, { type: "string" }));
+}
+
+/** 워크북(xlsx·csv 공통)을 시트별 2D 문자열 배열로 정규화한다. */
+function sheetsFromWorkbook(workbook: XLSX.WorkBook): SheetData[] {
   return workbook.SheetNames.map((name) => {
     const sheet = workbook.Sheets[name];
     // header:1 → 행 우선 AoA, raw:false → 표시 텍스트(숫자/날짜 서식 반영), defval:"" → 빈 셀은 빈 문자열


### PR DESCRIPTION
## 이슈
closes #765

## 작업 내용
노트·메모 Import(#761/#763, 머지됨)에 **CSV(.csv) 파일 소스**를 추가한다. 기존 xlsx 파이프라인(파싱→미리보기→표 삽입)을 그대로 재사용하고 파서·소스 선택만 확장한다. **BE 변경 없음**.

- **파서 일반화**: `xlsxParser` → `sheetParser`(`parseXlsxSheets` + `parseCsvSheets`, 공용 정규화 `sheetsFromWorkbook` 공유)
  - CSV는 `file.text()` → SheetJS 파싱(따옴표·구분자 처리). 시트 개념이 없어 단일 시트로 반환
- **레지스트리**: 각 소스에 `parse` 연결, `csv` 소스 활성화(`available: true`)
- **다이얼로그**: 소스 버튼으로 **Excel ↔ CSV 전환**(전환 시 초기화), accept·에러·드롭 문구를 소스별로 일반화, 파일 input 라벨 "가져올 파일"
- 상한(열30/행200)·1MB 가드·미리보기·삽입은 기존 그대로

## 테스트
- **RTL**: CSV 파싱(따옴표 감싼 쉼표 → 한 셀) · 소스 전환 후 `.csv` 삽입 · 확장자 불일치 에러
- `tsc -b`, `prettier --check`, import 스위트 35 tests 통과
- **로컬 브라우저 실검증**(직전 확인): `/notes`에서 CSV 소스 전환 → grades.csv 업로드 → 미리보기(`"우수, 통과"` 한 셀) → 표 삽입 → 저장

## 참고
- 이 변경은 머지된 PR #764(#761/#763)에 이어지는 후속으로, **머지 이후 분리한 새 PR**입니다.
- 로드맵(차기): 붙여넣기 없이 파일 소스만 — Google Sheets 등