### PR TITLE
feat : 데이터셋 저장소 BE — dataset/dataset_row + CRUD·페이지·벌크·patch (#769)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -1,0 +1,99 @@
+package ds.project.orino.planner.dataset.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.dataset.dto.BulkRowsRequest;
+import ds.project.orino.planner.dataset.dto.CreateDatasetRequest;
+import ds.project.orino.planner.dataset.dto.DatasetResponse;
+import ds.project.orino.planner.dataset.dto.InsertRowRequest;
+import ds.project.orino.planner.dataset.dto.InsertRowResponse;
+import ds.project.orino.planner.dataset.dto.RowView;
+import ds.project.orino.planner.dataset.dto.RowsResponse;
+import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
+import ds.project.orino.planner.dataset.service.DatasetService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 데이터 그리드 블록의 표 데이터 저장소 API. 노트 content와 분리된 dataset 리소스.
+ */
+@RestController
+@RequestMapping("/api/datasets")
+public class DatasetController {
+
+    private final DatasetService datasetService;
+
+    public DatasetController(DatasetService datasetService) {
+        this.datasetService = datasetService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<DatasetResponse>> create(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody CreateDatasetRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(datasetService.create(memberId, request)));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<DatasetResponse> meta(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id) {
+        return ApiResponse.success(datasetService.getMeta(memberId, id));
+    }
+
+    /** Import 청크 — 행을 끝에 벌크 추가. */
+    @PostMapping("/{id}/rows/bulk")
+    public ApiResponse<DatasetResponse> bulkAppend(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @Valid @RequestBody BulkRowsRequest request) {
+        return ApiResponse.success(datasetService.bulkAppend(memberId, id, request));
+    }
+
+    @GetMapping("/{id}/rows")
+    public ApiResponse<RowsResponse> rows(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @RequestParam(required = false) Integer offset,
+            @RequestParam(required = false) Integer limit) {
+        return ApiResponse.success(datasetService.getRows(memberId, id, offset, limit));
+    }
+
+    @PatchMapping("/{id}/rows/{rowIndex}")
+    public ApiResponse<RowView> updateRow(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable int rowIndex,
+            @Valid @RequestBody UpdateRowRequest request) {
+        return ApiResponse.success(datasetService.updateRow(memberId, id, rowIndex, request));
+    }
+
+    @PostMapping("/{id}/rows")
+    public ResponseEntity<ApiResponse<InsertRowResponse>> insertRow(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @Valid @RequestBody InsertRowRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(datasetService.insertRow(memberId, id, request)));
+    }
+
+    @DeleteMapping("/{id}/rows/{rowIndex}")
+    public ResponseEntity<Void> deleteRow(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable int rowIndex) {
+        datasetService.deleteRow(memberId, id, rowIndex);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/BulkRowsRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/BulkRowsRequest.java
@@ -1,0 +1,12 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+/** 행 벌크 추가(끝에 append). Import 청크 업로드에 사용. */
+public record BulkRowsRequest(
+        @NotNull(message = "rows는 필수입니다.")
+        List<List<String>> rows
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/CreateDatasetRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/CreateDatasetRequest.java
@@ -1,0 +1,11 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record CreateDatasetRequest(
+        @NotEmpty(message = "columns는 최소 1개여야 합니다.")
+        List<DatasetColumn> columns
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetColumn.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetColumn.java
@@ -1,0 +1,5 @@
+package ds.project.orino.planner.dataset.dto;
+
+/** 데이터셋 열 메타. key는 안정 식별자, label은 표시명. */
+public record DatasetColumn(String key, String label) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetResponse.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.dataset.dto;
+
+import ds.project.orino.domain.planner.dataset.entity.Dataset;
+
+import java.util.List;
+
+public record DatasetResponse(
+        Long id,
+        List<DatasetColumn> columns,
+        int rowCount
+) {
+    public static DatasetResponse of(Dataset dataset, List<DatasetColumn> columns) {
+        return new DatasetResponse(dataset.getId(), columns, dataset.getRowCount());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/InsertRowRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/InsertRowRequest.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+/** 행 추가. atIndex가 null이면 끝에 append, 있으면 그 위치에 삽입(뒤 행 시프트). */
+public record InsertRowRequest(
+        Integer atIndex,
+        @NotNull(message = "cells는 필수입니다.")
+        List<String> cells
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/InsertRowResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/InsertRowResponse.java
@@ -1,0 +1,4 @@
+package ds.project.orino.planner.dataset.dto;
+
+public record InsertRowResponse(int rowIndex) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowView.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowView.java
@@ -1,0 +1,6 @@
+package ds.project.orino.planner.dataset.dto;
+
+import java.util.List;
+
+public record RowView(int rowIndex, List<String> cells) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowsResponse.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.dataset.dto;
+
+import java.util.List;
+
+public record RowsResponse(
+        List<RowView> rows,
+        int offset,
+        int limit
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/UpdateRowRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/UpdateRowRequest.java
@@ -1,0 +1,11 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record UpdateRowRequest(
+        @NotNull(message = "cells는 필수입니다.")
+        List<String> cells
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -1,0 +1,173 @@
+package ds.project.orino.planner.dataset.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.dataset.entity.Dataset;
+import ds.project.orino.domain.planner.dataset.entity.DatasetRow;
+import ds.project.orino.domain.planner.dataset.repository.DatasetRepository;
+import ds.project.orino.domain.planner.dataset.repository.DatasetRowRepository;
+import ds.project.orino.planner.dataset.dto.BulkRowsRequest;
+import ds.project.orino.planner.dataset.dto.CreateDatasetRequest;
+import ds.project.orino.planner.dataset.dto.DatasetColumn;
+import ds.project.orino.planner.dataset.dto.DatasetResponse;
+import ds.project.orino.planner.dataset.dto.InsertRowRequest;
+import ds.project.orino.planner.dataset.dto.InsertRowResponse;
+import ds.project.orino.planner.dataset.dto.RowView;
+import ds.project.orino.planner.dataset.dto.RowsResponse;
+import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class DatasetService {
+
+    private static final JsonMapper MAPPER = JsonMapper.builder().build();
+    private static final TypeReference<List<DatasetColumn>> COLUMNS_TYPE = new TypeReference<>() {
+    };
+    private static final TypeReference<List<String>> CELLS_TYPE = new TypeReference<>() {
+    };
+
+    static final int DEFAULT_PAGE_SIZE = 100;
+    static final int MAX_PAGE_SIZE = 500;
+    static final int MAX_BULK_ROWS = 2000;
+    /** 데이터셋 전체 셀 상한(폭주 방지). */
+    static final long MAX_CELLS = 1_000_000L;
+
+    private final DatasetRepository datasetRepository;
+    private final DatasetRowRepository rowRepository;
+
+    public DatasetService(DatasetRepository datasetRepository, DatasetRowRepository rowRepository) {
+        this.datasetRepository = datasetRepository;
+        this.rowRepository = rowRepository;
+    }
+
+    @Transactional
+    public DatasetResponse create(Long memberId, CreateDatasetRequest request) {
+        Dataset dataset = datasetRepository.save(
+                new Dataset(memberId, serialize(request.columns())));
+        return DatasetResponse.of(dataset, request.columns());
+    }
+
+    public DatasetResponse getMeta(Long memberId, Long datasetId) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        return DatasetResponse.of(dataset, parseColumns(dataset.getColumns()));
+    }
+
+    /** 행 벌크 추가(끝에 append). Import 청크에 사용. */
+    @Transactional
+    public DatasetResponse bulkAppend(Long memberId, Long datasetId, BulkRowsRequest request) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<List<String>> rows = request.rows();
+        if (rows.size() > MAX_BULK_ROWS) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        int colCount = parseColumns(dataset.getColumns()).size();
+        long totalCells = (long) (dataset.getRowCount() + rows.size()) * colCount;
+        if (totalCells > MAX_CELLS) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        int start = dataset.getRowCount();
+        List<DatasetRow> entities = new java.util.ArrayList<>(rows.size());
+        for (int i = 0; i < rows.size(); i++) {
+            entities.add(new DatasetRow(datasetId, start + i, serialize(rows.get(i))));
+        }
+        rowRepository.saveAll(entities);
+        dataset.setRowCount(start + rows.size());
+        return DatasetResponse.of(dataset, parseColumns(dataset.getColumns()));
+    }
+
+    public RowsResponse getRows(Long memberId, Long datasetId, Integer offset, Integer limit) {
+        getOwned(memberId, datasetId);
+        int off = offset == null ? 0 : Math.max(0, offset);
+        int lim = clampLimit(limit);
+        List<RowView> rows = rowRepository
+                .findByDatasetIdAndRowIndexGreaterThanEqualAndRowIndexLessThanOrderByRowIndexAsc(
+                        datasetId, off, off + lim)
+                .stream()
+                .map(r -> new RowView(r.getRowIndex(), parseCells(r.getCells())))
+                .toList();
+        return new RowsResponse(rows, off, lim);
+    }
+
+    @Transactional
+    public RowView updateRow(Long memberId, Long datasetId, int rowIndex, UpdateRowRequest request) {
+        getOwned(memberId, datasetId);
+        DatasetRow row = rowRepository.findByDatasetIdAndRowIndex(datasetId, rowIndex)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        row.updateCells(serialize(request.cells()));
+        return new RowView(rowIndex, request.cells());
+    }
+
+    @Transactional
+    public InsertRowResponse insertRow(Long memberId, Long datasetId, InsertRowRequest request) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        int rowCount = dataset.getRowCount();
+        int at = request.atIndex() == null
+                ? rowCount
+                : Math.max(0, Math.min(request.atIndex(), rowCount));
+        long totalCells = (long) (rowCount + 1) * parseColumns(dataset.getColumns()).size();
+        if (totalCells > MAX_CELLS) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        if (at < rowCount) {
+            rowRepository.shiftUp(datasetId, at); // 뒤 행을 밀어 자리 확보(flush)
+        }
+        rowRepository.save(new DatasetRow(datasetId, at, serialize(request.cells())));
+        dataset.setRowCount(rowCount + 1);
+        return new InsertRowResponse(at);
+    }
+
+    @Transactional
+    public void deleteRow(Long memberId, Long datasetId, int rowIndex) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        DatasetRow row = rowRepository.findByDatasetIdAndRowIndex(datasetId, rowIndex)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        rowRepository.delete(row);
+        rowRepository.shiftDown(datasetId, rowIndex); // 삭제 flush 후 뒤 행 당김
+        dataset.setRowCount(dataset.getRowCount() - 1);
+    }
+
+    private Dataset getOwned(Long memberId, Long datasetId) {
+        return datasetRepository.findByIdAndMemberId(datasetId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    private int clampLimit(Integer limit) {
+        if (limit == null) {
+            return DEFAULT_PAGE_SIZE;
+        }
+        return Math.max(1, Math.min(limit, MAX_PAGE_SIZE));
+    }
+
+    private String serialize(Object value) {
+        try {
+            return MAPPER.writeValueAsString(value);
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST, e);
+        }
+    }
+
+    private List<DatasetColumn> parseColumns(String json) {
+        try {
+            return MAPPER.readValue(json, COLUMNS_TYPE);
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+
+    private List<String> parseCells(String json) {
+        try {
+            return MAPPER.readValue(json, CELLS_TYPE);
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/037-create-dataset.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/037-create-dataset.yaml
@@ -1,0 +1,106 @@
+databaseChangeLog:
+  # 데이터 그리드 블록 (#769, Epic #768).
+  # 대용량 편집 표를 노트 content와 분리해 저장한다. 노트엔 datasetTable{datasetId} 참조 노드만,
+  # 표 데이터는 dataset(메타) + dataset_row(행별 cells JSON)에 둔다.
+  - changeSet:
+      id: 037-create-dataset
+      author: wcorn
+      comment: dataset 메타 테이블(columns JSON + row_count).
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: dataset
+      changes:
+        - createTable:
+            tableName: dataset
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_dataset_member
+                    references: member(id)
+              - column:
+                  name: columns_json
+                  type: JSON
+                  constraints:
+                    nullable: false
+              - column:
+                  name: row_count
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: dataset
+            indexName: idx_dataset_member
+            columns:
+              - column:
+                  name: member_id
+
+  - changeSet:
+      id: 037-create-dataset-row
+      author: wcorn
+      comment: dataset_row 행 테이블(row_index 정렬 + cells JSON). dataset 삭제 시 cascade.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: dataset_row
+      changes:
+        - createTable:
+            tableName: dataset_row
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: dataset_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_dataset_row_dataset
+                    references: dataset(id)
+                    deleteCascade: true
+              - column:
+                  name: row_index
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: cells
+                  type: JSON
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: dataset_row
+            indexName: uq_dataset_row_dataset_index
+            unique: true
+            columns:
+              - column:
+                  name: dataset_id
+              - column:
+                  name: row_index

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -71,3 +71,5 @@ databaseChangeLog:
       file: db/changelog/changes/035-add-flashcard-sibling-group.yaml
   - include:
       file: db/changelog/changes/036-add-review-schedule-completed-index.yaml
+  - include:
+      file: db/changelog/changes/037-create-dataset.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -1,0 +1,225 @@
+package ds.project.orino.planner.dataset.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class DatasetControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        memberRepository.save(MemberFixture.create("other", "password"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    /** 2열 dataset을 만들고 id를 반환한다. */
+    private long createDataset() throws Exception {
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"과목"},{"key":"c1","label":"점수"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.rowCount").value(0))
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private void bulk(long id, String rowsJson) throws Exception {
+        mockMvc.perform(post("/api/datasets/{id}/rows/bulk", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rows\":" + rowsJson + "}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("POST datasets - 생성 시 columns/rowCount 반환, 이후 메타 조회")
+    void create_and_meta() throws Exception {
+        long id = createDataset();
+
+        mockMvc.perform(get("/api/datasets/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(id))
+                .andExpect(jsonPath("$.data.columns", hasSize(2)))
+                .andExpect(jsonPath("$.data.columns[0].label").value("과목"))
+                .andExpect(jsonPath("$.data.rowCount").value(0));
+    }
+
+    @Test
+    @DisplayName("POST datasets - columns 비면 400")
+    void create_empty_columns_400() throws Exception {
+        mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"columns\":[]}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("bulk 추가 후 rows를 row_index 순으로 조회한다")
+    void bulk_and_list() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"],[\"운영체제\",\"78\"]]");
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rows", hasSize(2)))
+                .andExpect(jsonPath("$.data.rows[0].rowIndex").value(0))
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value("네트워크"))
+                .andExpect(jsonPath("$.data.rows[1].rowIndex").value(1))
+                .andExpect(jsonPath("$.data.rows[1].cells[1]").value("78"));
+
+        mockMvc.perform(get("/api/datasets/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rowCount").value(2));
+    }
+
+    @Test
+    @DisplayName("GET rows - offset/limit 페이지네이션")
+    void rows_pagination() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"0\",\"a\"],[\"1\",\"b\"],[\"2\",\"c\"],[\"3\",\"d\"],[\"4\",\"e\"]]");
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .param("offset", "1").param("limit", "2")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.offset").value(1))
+                .andExpect(jsonPath("$.data.rows", hasSize(2)))
+                .andExpect(jsonPath("$.data.rows[0].rowIndex").value(1))
+                .andExpect(jsonPath("$.data.rows[1].rowIndex").value(2));
+    }
+
+    @Test
+    @DisplayName("PATCH row - 셀 수정이 반영된다")
+    void update_row() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", id, 0)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"네트워크\",\"100\"]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.cells[1]").value("100"));
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("100"));
+    }
+
+    @Test
+    @DisplayName("PATCH row - 없는 rowIndex면 404")
+    void update_missing_row_404() throws Exception {
+        long id = createDataset();
+        mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", id, 5)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"x\"]}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("POST row - atIndex 삽입 시 뒤 행이 밀린다")
+    void insert_row_shifts() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"A\",\"1\"],[\"B\",\"2\"]]");
+
+        mockMvc.perform(post("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"atIndex\":1,\"cells\":[\"NEW\",\"9\"]}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.rowIndex").value(1));
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows", hasSize(3)))
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value("A"))
+                .andExpect(jsonPath("$.data.rows[1].cells[0]").value("NEW"))
+                .andExpect(jsonPath("$.data.rows[2].cells[0]").value("B"));
+    }
+
+    @Test
+    @DisplayName("POST row - atIndex 생략 시 끝에 append")
+    void insert_row_append() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"A\",\"1\"]]");
+
+        mockMvc.perform(post("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"B\",\"2\"]}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.rowIndex").value(1));
+    }
+
+    @Test
+    @DisplayName("DELETE row - 삭제 후 뒤 행이 당겨지고 rowCount 감소")
+    void delete_row_shifts() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"A\",\"1\"],[\"B\",\"2\"],[\"C\",\"3\"]]");
+
+        mockMvc.perform(delete("/api/datasets/{id}/rows/{i}", id, 0)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows", hasSize(2)))
+                .andExpect(jsonPath("$.data.rows[0].rowIndex").value(0))
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value("B"))
+                .andExpect(jsonPath("$.data.rows[1].cells[0]").value("C"));
+
+        mockMvc.perform(get("/api/datasets/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rowCount").value(2));
+    }
+
+    @Test
+    @DisplayName("타인 dataset 접근 시 404")
+    void other_member_404() throws Exception {
+        long id = createDataset();
+        String otherAuth = "Bearer " + AuthFixture.loginAndGetAccessToken(
+                mockMvc, "other", "password");
+
+        mockMvc.perform(get("/api/datasets/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, otherAuth))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(post("/api/datasets/{id}/rows/bulk", id)
+                        .header(HttpHeaders.AUTHORIZATION, otherAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rows\":[[\"x\"]]}"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/Dataset.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/Dataset.java
@@ -1,0 +1,88 @@
+package ds.project.orino.domain.planner.dataset.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+/**
+ * 데이터 그리드 블록의 표 메타. 실제 행 데이터는 {@link DatasetRow}에 분리 저장한다.
+ * 노트 content엔 {@code datasetTable{datasetId}} 참조 노드만 담긴다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "dataset")
+public class Dataset {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    /** 열 메타 JSON 문자열: {@code [{"key","label"}, ...]}. */
+    @Column(name = "columns_json", columnDefinition = "JSON", nullable = false)
+    private String columns;
+
+    /** 행 수(비정규화, 조회 최적화). */
+    @Column(name = "row_count", nullable = false)
+    private int rowCount;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected Dataset() {
+    }
+
+    public Dataset(Long memberId, String columns) {
+        this.memberId = memberId;
+        this.columns = columns;
+        this.rowCount = 0;
+    }
+
+    public void updateColumns(String columns) {
+        this.columns = columns;
+    }
+
+    public void setRowCount(int rowCount) {
+        this.rowCount = rowCount;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public String getColumns() {
+        return columns;
+    }
+
+    public int getRowCount() {
+        return rowCount;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetRow.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetRow.java
@@ -1,0 +1,63 @@
+package ds.project.orino.domain.planner.dataset.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * 데이터셋의 한 행. {@code cells}는 값만 담은 문자열 배열 JSON({@code ["a","b",...]}).
+ * {@code rowIndex}(0-base)로 정렬·페이지네이션한다. dataset 삭제 시 cascade.
+ */
+@Entity
+@Table(name = "dataset_row")
+public class DatasetRow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "dataset_id", nullable = false)
+    private Long datasetId;
+
+    @Column(name = "row_index", nullable = false)
+    private int rowIndex;
+
+    @Column(columnDefinition = "JSON", nullable = false)
+    private String cells;
+
+    protected DatasetRow() {
+    }
+
+    public DatasetRow(Long datasetId, int rowIndex, String cells) {
+        this.datasetId = datasetId;
+        this.rowIndex = rowIndex;
+        this.cells = cells;
+    }
+
+    public void updateCells(String cells) {
+        this.cells = cells;
+    }
+
+    public void updateRowIndex(int rowIndex) {
+        this.rowIndex = rowIndex;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getDatasetId() {
+        return datasetId;
+    }
+
+    public int getRowIndex() {
+        return rowIndex;
+    }
+
+    public String getCells() {
+        return cells;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetRepository.java
@@ -1,0 +1,11 @@
+package ds.project.orino.domain.planner.dataset.repository;
+
+import ds.project.orino.domain.planner.dataset.entity.Dataset;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DatasetRepository extends JpaRepository<Dataset, Long> {
+
+    Optional<Dataset> findByIdAndMemberId(Long id, Long memberId);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetRowRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetRowRepository.java
@@ -1,0 +1,39 @@
+package ds.project.orino.domain.planner.dataset.repository;
+
+import ds.project.orino.domain.planner.dataset.entity.DatasetRow;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DatasetRowRepository extends JpaRepository<DatasetRow, Long> {
+
+    /** 페이지 조회 — row_index ∈ [from, to). */
+    List<DatasetRow>
+    findByDatasetIdAndRowIndexGreaterThanEqualAndRowIndexLessThanOrderByRowIndexAsc(
+            Long datasetId, int fromInclusive, int toExclusive);
+
+    Optional<DatasetRow> findByDatasetIdAndRowIndex(Long datasetId, int rowIndex);
+
+    long countByDatasetId(Long datasetId);
+
+    /**
+     * 삽입 자리 확보 — row_index ≥ from 을 +1. UNIQUE(dataset_id,row_index) 충돌을 피하려
+     * 높은 인덱스부터(DESC) 옮긴다. (MySQL은 UPDATE ... ORDER BY 지원)
+     */
+    @Modifying(flushAutomatically = true)
+    @Query(value = "UPDATE dataset_row SET row_index = row_index + 1 "
+            + "WHERE dataset_id = :datasetId AND row_index >= :from ORDER BY row_index DESC",
+            nativeQuery = true)
+    void shiftUp(@Param("datasetId") Long datasetId, @Param("from") int from);
+
+    /** 삭제 후 메우기 — row_index &gt; from 을 -1. 낮은 인덱스부터(ASC) 옮긴다. */
+    @Modifying(flushAutomatically = true)
+    @Query(value = "UPDATE dataset_row SET row_index = row_index - 1 "
+            + "WHERE dataset_id = :datasetId AND row_index > :from ORDER BY row_index ASC",
+            nativeQuery = true)
+    void shiftDown(@Param("datasetId") Long datasetId, @Param("from") int from);
+}


### PR DESCRIPTION
## 이슈
closes #769

## 작업 내용
[데이터 그리드 블록](https://github.com/wcorn/orino/wiki/Data-Grid-Block)(Epic #768)의 **표 데이터 저장소**. 노트 content와 분리된 `dataset` 리소스로, 대용량 표를 행별 저장·페이지 조회·행 patch한다.

### 스키마 (037 changeset)
- `dataset(id, member_id, columns_json JSON, row_count, created/updated)` — `columns`는 MySQL 예약어라 `columns_json`
- `dataset_row(id, dataset_id FK cascade, row_index, cells JSON)` + `UNIQUE(dataset_id, row_index)`

### API (`/api/datasets`, member 스코프)
| 메서드·경로 | 용도 |
|---|---|
| `POST /datasets` | 생성(columns) → 201 |
| `GET /datasets/{id}` | 메타(columns, rowCount) |
| `POST /datasets/{id}/rows/bulk` | Import 청크 — 끝에 벌크 추가 |
| `GET /datasets/{id}/rows?offset&limit` | 가상화 페이지 |
| `PATCH /datasets/{id}/rows/{i}` | 셀 편집 |
| `POST /datasets/{id}/rows` | 행 추가(atIndex 삽입/끝 append) → 201 |
| `DELETE /datasets/{id}/rows/{i}` | 행 삭제 → 204 |

### 핵심
- **행 시프트**: 삽입/삭제 시 `row_index`를 `UNIQUE` 충돌 없이 옮기려 **native `UPDATE ... ORDER BY`**(삽입=DESC +1, 삭제=ASC −1). `@Modifying(flushAutomatically=true)`로 detach 방지
- `row_count` 비정규화 유지, 페이지/벌크(≤2000행)/전체 셀(≤100만) 상한, `getOwned` 인가(타인 404)

## 테스트
- **MockMvc + TestContainers** 10종: 생성·메타·벌크·페이지네이션·셀 patch·삽입 시프트·append·삭제 시프트·타인 404·검증(빈 columns 400)
- `./gradlew check`(checkstyle) 통과
- **로컬 bootRun + curl 실검증**: fresh MySQL에 037 적용(dataset/dataset_row 생성) 확인, create→bulk→페이지→patch→삽입(shiftUp)→삭제(shiftDown) 전 플로우·JSON·한글·row_index 재정렬 정상

## 참고
- Epic: #768 · 설계: [Data-Grid-Block §3·§4](https://github.com/wcorn/orino/wiki/Data-Grid-Block)
- 후속: #770(FE datasetTable 노드 + TanStack 그리드), #771(Import 임계치 분기)