### PR TITLE
feat : 데이터 그리드 블록 FE — datasetTable 노드 + 가상화 편집 그리드 (#770)

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -16,6 +16,8 @@
         "@grafana/faro-web-tracing": "^2.6.3",
         "@tailwindcss/vite": "^4.2.2",
         "@tanstack/react-query": "^5.96.1",
+        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-virtual": "^3.14.5",
         "@tiptap/extension-drag-handle": "3.23.4",
         "@tiptap/extension-drag-handle-react": "3.23.4",
         "@tiptap/extension-image": "^3.23.4",
@@ -3058,6 +3060,66 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.5.tgz",
+      "integrity": "sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.3.tgz",
+      "integrity": "sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/fe/package.json
+++ b/fe/package.json
@@ -24,6 +24,8 @@
     "@grafana/faro-web-tracing": "^2.6.3",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-query": "^5.96.1",
+    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.14.5",
     "@tiptap/extension-drag-handle": "3.23.4",
     "@tiptap/extension-drag-handle-react": "3.23.4",
     "@tiptap/extension-image": "^3.23.4",

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import type { NoteContent, NoteDetail } from "../api/notes";
 import { ChildPage, collectChildPageIds } from "../editor/childPage";
 import { ChildPageContext } from "../editor/childPageContext";
+import { DatasetTable } from "../editor/datasetTable";
 import { extractImageFiles, uploadAndInsertImage } from "../editor/imageUpload";
 import { useAutoSaveNote } from "../hooks/useAutoSaveNote";
 import { useCreateNote, useDeleteNote } from "../hooks/useNoteMutations";
@@ -72,6 +73,7 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
           placeholder: "내용을 입력하거나 페이지를 추가하세요...",
         }),
         ChildPage,
+        DatasetTable,
       ],
       content: note.content as JSONContent,
       editorProps: {

--- a/fe/src/features/note/components/NoteTab.test.tsx
+++ b/fe/src/features/note/components/NoteTab.test.tsx
@@ -584,4 +584,41 @@ describe("NoteTab", () => {
       await screen.findByText(/하위 노트 2개도 함께 삭제됩니다/),
     ).toBeInTheDocument();
   });
+
+  it("datasetTable 노드가 있는 노트를 열면 데이터 그리드가 렌더된다", async () => {
+    mockTree([
+      { id: 1, title: "표노트", parentId: null, sortOrder: 0, children: [] },
+    ]);
+    mockNoteDetail(
+      1,
+      {
+        type: "doc",
+        content: [{ type: "datasetTable", attrs: { datasetId: 7 } }],
+      },
+      "표노트",
+    );
+    server.use(
+      http.get(`${API_BASE}/datasets/7`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: { id: 7, columns: [{ key: "c0", label: "과목" }], rowCount: 0 },
+        }),
+      ),
+      http.get(`${API_BASE}/datasets/7/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: { rows: [], offset: 0, limit: 100 },
+        }),
+      ),
+    );
+
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("노트 제목")).toHaveValue("표노트");
+    });
+    // 노드 → NodeView → DatasetGrid(헤더) 렌더
+    expect(await screen.findByTestId("dataset-grid")).toBeInTheDocument();
+    expect(screen.getByText("과목")).toBeInTheDocument();
+  });
 });

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { DatasetGrid } from "./DatasetGrid";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function mockDataset(rows: string[][]) {
+  server.use(
+    http.get(`${API_BASE}/datasets/1`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          id: 1,
+          columns: [
+            { key: "c0", label: "과목" },
+            { key: "c1", label: "점수" },
+          ],
+          rowCount: rows.length,
+        },
+      }),
+    ),
+    http.get(`${API_BASE}/datasets/1/rows`, ({ request }) => {
+      const url = new URL(request.url);
+      const offset = Number(url.searchParams.get("offset") ?? "0");
+      const limit = Number(url.searchParams.get("limit") ?? "100");
+      const slice = rows
+        .slice(offset, offset + limit)
+        .map((cells, i) => ({ rowIndex: offset + i, cells }));
+      return HttpResponse.json({
+        code: "OK",
+        data: { rows: slice, offset, limit },
+      });
+    }),
+  );
+}
+
+// jsdom엔 레이아웃이 없어 스크롤 요소 크기가 0이라 TanStack Virtual이 행을 안 그린다.
+// getBoundingClientRect를 고정 크기로 목킹해 뷰포트를 만들어 준다.
+const FAKE_RECT = {
+  x: 0,
+  y: 0,
+  width: 800,
+  height: 600,
+  top: 0,
+  right: 800,
+  bottom: 600,
+  left: 0,
+  toJSON: () => ({}),
+} as DOMRect;
+
+describe("DatasetGrid", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue(
+      FAKE_RECT,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("헤더와 행을 지연 로드해 렌더한다", async () => {
+    mockDataset([
+      ["네트워크", "92"],
+      ["운영체제", "78"],
+    ]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    expect(await screen.findByText("과목")).toBeInTheDocument();
+    expect(screen.getByText("점수")).toBeInTheDocument();
+    expect(await screen.findByText("네트워크")).toBeInTheDocument();
+    expect(screen.getByText("78")).toBeInTheDocument();
+  });
+
+  it("셀을 클릭해 편집하면 PATCH로 저장한다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let patched: { index: number; cells: string[] } | null = null;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/rows/:i`,
+        async ({ params, request }) => {
+          const body = (await request.json()) as { cells: string[] };
+          patched = { index: Number(params.i), cells: body.cells };
+          return HttpResponse.json({
+            code: "OK",
+            data: { rowIndex: Number(params.i), cells: body.cells },
+          });
+        },
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    await user.click(await screen.findByText("92"));
+    const input = await screen.findByLabelText("셀 1행 2열");
+    // 컨트롤드 input 값을 통째로 교체 후 Enter로 커밋
+    fireEvent.change(input, { target: { value: "100" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(patched).toEqual({ index: 0, cells: ["네트워크", "100"] });
+    });
+  });
+
+  it("[행 추가]로 POST를 호출한다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let inserted = false;
+    server.use(
+      http.post(`${API_BASE}/datasets/1/rows`, () => {
+        inserted = true;
+        return HttpResponse.json({ code: "OK", data: { rowIndex: 1 } });
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    await screen.findByText("네트워크");
+    await user.click(screen.getByRole("button", { name: "행 추가" }));
+
+    await waitFor(() => expect(inserted).toBe(true));
+  });
+
+  it("행 삭제 버튼으로 DELETE를 호출한다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let deleted: number | null = null;
+    server.use(
+      http.delete(`${API_BASE}/datasets/1/rows/:i`, ({ params }) => {
+        deleted = Number(params.i);
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    await screen.findByText("네트워크");
+    await user.click(screen.getByRole("button", { name: "1행 삭제" }));
+
+    await waitFor(() => expect(deleted).toBe(0));
+  });
+});

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -1,0 +1,239 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { Plus, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { FieldError } from "@/components/ui/field-error";
+import { LoadingText } from "@/components/ui/loading-text";
+import { cn } from "@/lib/utils";
+
+import {
+  deleteDatasetRow,
+  insertDatasetRow,
+  updateDatasetRow,
+} from "./api/datasets";
+import { useDatasetMeta } from "./hooks/useDatasetMeta";
+import { useDatasetRows } from "./hooks/useDatasetRows";
+import { datasetKeys } from "./queryKeys";
+
+const ROW_HEIGHT = 36;
+const MAX_BODY_HEIGHT = 420;
+
+interface Props {
+  datasetId: number;
+}
+
+/** 대용량 편집 표. TanStack Table(열/헤더) + Virtual(행 가상화) + 지연 로드 + 셀/행 편집. */
+export function DatasetGrid({ datasetId }: Props) {
+  const queryClient = useQueryClient();
+  const { data: meta, isLoading, isError } = useDatasetMeta(datasetId);
+  const { getRow, ensureRange, setRowLocal, reset } = useDatasetRows(datasetId);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [editing, setEditing] = useState<{ row: number; col: number } | null>(
+    null,
+  );
+  const [draft, setDraft] = useState("");
+
+  const colCount = meta?.columns.length ?? 0;
+  const rowCount = meta?.rowCount ?? 0;
+
+  const invalidateMeta = () =>
+    queryClient.invalidateQueries({ queryKey: datasetKeys.meta(datasetId) });
+
+  const updateMut = useMutation({
+    mutationFn: (v: { index: number; cells: string[] }) =>
+      updateDatasetRow(datasetId, v.index, v.cells),
+    onError: () => reset(),
+  });
+  const insertMut = useMutation({
+    mutationFn: (cells: string[]) => insertDatasetRow(datasetId, cells),
+    onSuccess: () => {
+      reset();
+      void invalidateMeta();
+    },
+  });
+  const deleteMut = useMutation({
+    mutationFn: (index: number) => deleteDatasetRow(datasetId, index),
+    onSuccess: () => {
+      reset();
+      void invalidateMeta();
+    },
+  });
+
+  // TanStack Table — 열/헤더 모델만(본문은 가상화로 직접 렌더).
+  const columns = useMemo<ColumnDef<string[]>[]>(
+    () =>
+      (meta?.columns ?? []).map((col, c) => ({
+        id: col.key,
+        header: col.label,
+        accessorFn: (row) => row[c] ?? "",
+      })),
+    [meta],
+  );
+  const table = useReactTable({
+    data: EMPTY,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  const virtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 12,
+  });
+  const virtualItems = virtualizer.getVirtualItems();
+  const firstIndex = virtualItems[0]?.index ?? 0;
+  const lastIndex = virtualItems[virtualItems.length - 1]?.index ?? 0;
+
+  useEffect(() => {
+    if (rowCount > 0) ensureRange(firstIndex, lastIndex);
+  }, [firstIndex, lastIndex, rowCount, ensureRange]);
+
+  if (isLoading) return <LoadingText />;
+  if (isError || !meta) {
+    return <FieldError>표를 불러오지 못했어요.</FieldError>;
+  }
+
+  const gridTemplateColumns = `repeat(${colCount}, minmax(120px, 1fr)) 44px`;
+
+  const startEdit = (row: number, col: number) => {
+    const cells = getRow(row);
+    if (!cells) return;
+    setEditing({ row, col });
+    setDraft(cells[col] ?? "");
+  };
+
+  const commitEdit = () => {
+    if (!editing) return;
+    const cells = getRow(editing.row);
+    if (!cells) {
+      setEditing(null);
+      return;
+    }
+    const next = [...cells];
+    while (next.length < colCount) next.push("");
+    next[editing.col] = draft;
+    setRowLocal(editing.row, next);
+    updateMut.mutate({ index: editing.row, cells: next });
+    setEditing(null);
+  };
+
+  const addRow = () =>
+    insertMut.mutate(Array.from({ length: colCount }, () => ""));
+
+  return (
+    <div
+      className="border-border bg-card my-2 flex flex-col overflow-hidden rounded-md border"
+      data-testid="dataset-grid"
+    >
+      {/* 헤더 (TanStack Table) */}
+      <div
+        className="bg-muted text-muted-foreground grid border-b text-sm font-semibold"
+        style={{ gridTemplateColumns }}
+      >
+        {table.getFlatHeaders().map((header) => (
+          <div
+            key={header.id}
+            className="border-border truncate border-r px-2 py-1.5"
+          >
+            {flexRender(header.column.columnDef.header, header.getContext())}
+          </div>
+        ))}
+        <div aria-hidden />
+      </div>
+
+      {/* 본문 (가상화) */}
+      <div
+        ref={scrollRef}
+        className="overflow-auto"
+        style={{ maxHeight: MAX_BODY_HEIGHT }}
+      >
+        <div
+          style={{ height: virtualizer.getTotalSize(), position: "relative" }}
+        >
+          {virtualItems.map((vi) => {
+            const cells = getRow(vi.index);
+            return (
+              <div
+                key={vi.key}
+                className="border-border absolute top-0 left-0 grid w-full border-b text-sm"
+                style={{
+                  height: ROW_HEIGHT,
+                  transform: `translateY(${vi.start}px)`,
+                  gridTemplateColumns,
+                }}
+              >
+                {Array.from({ length: colCount }, (_, c) => {
+                  const isEditing =
+                    editing?.row === vi.index && editing.col === c;
+                  return (
+                    <div
+                      key={c}
+                      className="border-border truncate border-r"
+                      onClick={() => startEdit(vi.index, c)}
+                    >
+                      {isEditing ? (
+                        <input
+                          autoFocus
+                          value={draft}
+                          onChange={(e) => setDraft(e.target.value)}
+                          onBlur={commitEdit}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") commitEdit();
+                            if (e.key === "Escape") setEditing(null);
+                          }}
+                          aria-label={`셀 ${vi.index + 1}행 ${c + 1}열`}
+                          className="focus-visible:ring-ring h-full w-full bg-transparent px-2 py-1 outline-none focus-visible:ring-1"
+                        />
+                      ) : (
+                        <div
+                          className={cn(
+                            "h-full cursor-text truncate px-2 py-1.5",
+                            cells === undefined && "text-muted-foreground/40",
+                          )}
+                        >
+                          {cells === undefined ? "…" : (cells[c] ?? "")}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+                <button
+                  type="button"
+                  aria-label={`${vi.index + 1}행 삭제`}
+                  onClick={() => deleteMut.mutate(vi.index)}
+                  className="text-muted-foreground hover:text-destructive flex items-center justify-center"
+                >
+                  <Trash2 className="size-3.5" />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* 행 추가 */}
+      <div className="border-border border-t p-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={addRow}
+          disabled={insertMut.isPending}
+        >
+          <Plus className="size-4" /> 행 추가
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+const EMPTY: string[][] = [];

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -1,0 +1,101 @@
+import { client } from "@/shared/api";
+
+export interface DatasetColumn {
+  key: string;
+  label: string;
+}
+
+export interface DatasetMeta {
+  id: number;
+  columns: DatasetColumn[];
+  rowCount: number;
+}
+
+export interface DatasetRow {
+  rowIndex: number;
+  cells: string[];
+}
+
+export interface RowsPage {
+  rows: DatasetRow[];
+  offset: number;
+  limit: number;
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export async function createDataset(
+  columns: DatasetColumn[],
+): Promise<DatasetMeta> {
+  const { data } = await client.post<ApiEnvelope<DatasetMeta>>("/datasets", {
+    columns,
+  });
+  return data.data;
+}
+
+/** Import 청크 — 행을 끝에 벌크 추가. */
+export async function bulkAppendRows(
+  datasetId: number,
+  rows: string[][],
+): Promise<DatasetMeta> {
+  const { data } = await client.post<ApiEnvelope<DatasetMeta>>(
+    `/datasets/${datasetId}/rows/bulk`,
+    { rows },
+  );
+  return data.data;
+}
+
+export async function fetchDatasetMeta(
+  datasetId: number,
+): Promise<DatasetMeta> {
+  const { data } = await client.get<ApiEnvelope<DatasetMeta>>(
+    `/datasets/${datasetId}`,
+  );
+  return data.data;
+}
+
+export async function fetchDatasetRows(
+  datasetId: number,
+  offset: number,
+  limit: number,
+): Promise<RowsPage> {
+  const { data } = await client.get<ApiEnvelope<RowsPage>>(
+    `/datasets/${datasetId}/rows`,
+    { params: { offset, limit } },
+  );
+  return data.data;
+}
+
+export async function updateDatasetRow(
+  datasetId: number,
+  rowIndex: number,
+  cells: string[],
+): Promise<DatasetRow> {
+  const { data } = await client.patch<ApiEnvelope<DatasetRow>>(
+    `/datasets/${datasetId}/rows/${rowIndex}`,
+    { cells },
+  );
+  return data.data;
+}
+
+export async function insertDatasetRow(
+  datasetId: number,
+  cells: string[],
+  atIndex?: number,
+): Promise<{ rowIndex: number }> {
+  const { data } = await client.post<ApiEnvelope<{ rowIndex: number }>>(
+    `/datasets/${datasetId}/rows`,
+    { atIndex, cells },
+  );
+  return data.data;
+}
+
+export async function deleteDatasetRow(
+  datasetId: number,
+  rowIndex: number,
+): Promise<void> {
+  await client.delete(`/datasets/${datasetId}/rows/${rowIndex}`);
+}

--- a/fe/src/features/note/dataset/hooks/useDatasetMeta.ts
+++ b/fe/src/features/note/dataset/hooks/useDatasetMeta.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchDatasetMeta } from "../api/datasets";
+import { datasetKeys } from "../queryKeys";
+
+export function useDatasetMeta(datasetId: number) {
+  return useQuery({
+    queryKey: datasetKeys.meta(datasetId),
+    queryFn: () => fetchDatasetMeta(datasetId),
+    staleTime: 60 * 1000,
+  });
+}

--- a/fe/src/features/note/dataset/hooks/useDatasetRows.ts
+++ b/fe/src/features/note/dataset/hooks/useDatasetRows.ts
@@ -1,0 +1,68 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useRef, useState } from "react";
+
+import { fetchDatasetRows } from "../api/datasets";
+import { datasetKeys } from "../queryKeys";
+
+/** 가상화 스크롤에 맞춰 페이지 단위로 행을 지연 로드하는 크기. */
+export const DATASET_PAGE_SIZE = 100;
+
+/**
+ * 데이터셋 행을 페이지 단위로 지연 로드해 rowIndex→cells 캐시로 제공한다.
+ * 가상화 그리드가 보이는 범위를 {@link ensureRange}로 알리면 해당 페이지만 fetch한다.
+ */
+export function useDatasetRows(datasetId: number) {
+  const queryClient = useQueryClient();
+  const [cache, setCache] = useState<Map<number, string[]>>(() => new Map());
+  const loadedPages = useRef<Set<number>>(new Set());
+  const inflight = useRef<Set<number>>(new Set());
+
+  const ensureRange = useCallback(
+    (start: number, end: number) => {
+      const firstPage = Math.max(0, Math.floor(start / DATASET_PAGE_SIZE));
+      const lastPage = Math.floor(end / DATASET_PAGE_SIZE);
+      for (let page = firstPage; page <= lastPage; page++) {
+        if (loadedPages.current.has(page) || inflight.current.has(page)) {
+          continue;
+        }
+        inflight.current.add(page);
+        const offset = page * DATASET_PAGE_SIZE;
+        queryClient
+          .fetchQuery({
+            queryKey: datasetKeys.rows(datasetId, offset, DATASET_PAGE_SIZE),
+            queryFn: () =>
+              fetchDatasetRows(datasetId, offset, DATASET_PAGE_SIZE),
+            staleTime: 60 * 1000,
+          })
+          .then((pageData) => {
+            loadedPages.current.add(page);
+            setCache((prev) => {
+              const next = new Map(prev);
+              pageData.rows.forEach((r) => next.set(r.rowIndex, r.cells));
+              return next;
+            });
+          })
+          .catch(() => {})
+          .finally(() => inflight.current.delete(page));
+      }
+    },
+    [datasetId, queryClient],
+  );
+
+  /** 편집 낙관적 반영. */
+  const setRowLocal = useCallback((index: number, cells: string[]) => {
+    setCache((prev) => new Map(prev).set(index, cells));
+  }, []);
+
+  /** 행 추가/삭제로 인덱스가 밀리면 전체 재로드. */
+  const reset = useCallback(() => {
+    loadedPages.current.clear();
+    inflight.current.clear();
+    setCache(new Map());
+    queryClient.removeQueries({ queryKey: ["datasets", datasetId, "rows"] });
+  }, [datasetId, queryClient]);
+
+  const getRow = useCallback((index: number) => cache.get(index), [cache]);
+
+  return { getRow, ensureRange, setRowLocal, reset };
+}

--- a/fe/src/features/note/dataset/queryKeys.ts
+++ b/fe/src/features/note/dataset/queryKeys.ts
@@ -1,0 +1,6 @@
+export const datasetKeys = {
+  all: ["datasets"] as const,
+  meta: (id: number) => ["datasets", id, "meta"] as const,
+  rows: (id: number, offset: number, limit: number) =>
+    ["datasets", id, "rows", offset, limit] as const,
+};

--- a/fe/src/features/note/editor/DatasetTableView.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.tsx
@@ -1,0 +1,20 @@
+import { type NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+
+import { DatasetGrid } from "../dataset/DatasetGrid";
+
+/**
+ * 노트 본문의 데이터 그리드 블록. 노드엔 datasetId만 있고, 실제 표는 별도 dataset
+ * 리소스에서 지연 로드해 편집한다. contentEditable=false로 ProseMirror 편집과 분리.
+ */
+export function DatasetTableView({ node }: NodeViewProps) {
+  const datasetId = node.attrs.datasetId as number | null;
+  return (
+    <NodeViewWrapper
+      as="div"
+      data-dataset-table={datasetId ?? ""}
+      contentEditable={false}
+    >
+      {datasetId != null && <DatasetGrid datasetId={datasetId} />}
+    </NodeViewWrapper>
+  );
+}

--- a/fe/src/features/note/editor/datasetTable.ts
+++ b/fe/src/features/note/editor/datasetTable.ts
@@ -1,0 +1,111 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+import { Fragment, type Node as PMNode, Slice } from "@tiptap/pm/model";
+import { Plugin } from "@tiptap/pm/state";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+
+import { DatasetTableView } from "./DatasetTableView";
+
+export interface DatasetTableAttrs {
+  datasetId: number;
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    datasetTable: {
+      insertDatasetTable: (attrs: DatasetTableAttrs) => ReturnType;
+    };
+  }
+}
+
+/**
+ * 대용량 편집 표(데이터 그리드 블록). atom block 노드로, attrs.datasetId만 담는다.
+ * 실제 표 데이터는 별도 dataset 리소스에 있고 NodeView(가상화 그리드)가 지연 로드·편집한다.
+ */
+export const DatasetTable = Node.create({
+  name: "datasetTable",
+  group: "block",
+  atom: true,
+  selectable: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      datasetId: {
+        default: null,
+        parseHTML: (el) => {
+          const v = el.getAttribute("data-dataset-id");
+          return v ? Number(v) : null;
+        },
+        renderHTML: (attrs) =>
+          attrs.datasetId == null
+            ? {}
+            : { "data-dataset-id": String(attrs.datasetId) },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "div[data-dataset-table]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, { "data-dataset-table": "" }),
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(DatasetTableView);
+  },
+
+  addCommands() {
+    return {
+      insertDatasetTable:
+        (attrs: DatasetTableAttrs) =>
+        ({ commands }) =>
+          commands.insertContent({ type: this.name, attrs }),
+    };
+  },
+
+  // 복붙 복제 차단: 붙여넣기 slice에서 datasetTable 제거(datasetId 중복 방지).
+  addProseMirrorPlugins() {
+    const nodeType = this.name;
+    return [
+      new Plugin({
+        props: {
+          transformPasted(slice) {
+            const kept: PMNode[] = [];
+            slice.content.forEach((node) => {
+              if (node.type.name !== nodeType) kept.push(node);
+            });
+            return new Slice(
+              Fragment.fromArray(kept),
+              slice.openStart,
+              slice.openEnd,
+            );
+          },
+        },
+      }),
+    ];
+  },
+});
+
+/** Tiptap doc JSON에서 모든 datasetTable 노드의 datasetId 집합을 수집한다(정리/추적용). */
+export function collectDatasetIds(doc: unknown): Set<number> {
+  const ids = new Set<number>();
+  const walk = (node: unknown) => {
+    if (!node || typeof node !== "object") return;
+    const n = node as {
+      type?: string;
+      attrs?: { datasetId?: number };
+      content?: unknown[];
+    };
+    if (n.type === "datasetTable" && typeof n.attrs?.datasetId === "number") {
+      ids.add(n.attrs.datasetId);
+    }
+    if (Array.isArray(n.content)) n.content.forEach(walk);
+  };
+  walk(doc);
+  return ids;
+}

--- a/fe/src/test/setup.ts
+++ b/fe/src/test/setup.ts
@@ -94,6 +94,38 @@ afterEach(() => {
   ioInstances.length = 0;
 });
 
+// jsdom엔 ResizeObserver가 없다. TanStack Virtual이 뷰포트 크기를 얻도록,
+// observe 시 콜백을 한 번 호출해 관찰 요소의 크기를 전달한다(크기는 getBoundingClientRect 목).
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = class {
+    private readonly callback: ResizeObserverCallback;
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+    }
+    observe(el: Element) {
+      const rect = el.getBoundingClientRect();
+      this.callback(
+        [
+          {
+            target: el,
+            contentRect: rect,
+            borderBoxSize: [{ inlineSize: rect.width, blockSize: rect.height }],
+            contentBoxSize: [
+              { inlineSize: rect.width, blockSize: rect.height },
+            ],
+            devicePixelContentBoxSize: [
+              { inlineSize: rect.width, blockSize: rect.height },
+            ],
+          } as unknown as ResizeObserverEntry,
+        ],
+        this as unknown as ResizeObserver,
+      );
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
 beforeAll(() => server.listen());
 afterEach(() => {
   server.resetHandlers();


### PR DESCRIPTION
## 이슈
closes #770

## 작업 내용
[데이터 그리드 블록](https://github.com/wcorn/orino/wiki/Data-Grid-Block)(Epic #768)의 FE. 노트에 **대용량 편집 표를 인라인**으로 넣되, 표 데이터는 별도 dataset 리소스(#772)에서 지연 로드·편집한다.

- **`datasetTable` Tiptap 노드**(atom block, attrs `datasetId`) + ReactNodeView → 공유 `NoteEditor`에 등록
  - 노트 content엔 참조 노드만 담겨 **content가 작게 유지**됨(1MB 문제 없음). 붙여넣기 복제 차단
- **`DatasetGrid`** — **TanStack Table**(열/헤더 모델) + **TanStack Virtual**(행 가상화, 보이는 행만 DOM)
  - **지연 로드**: 가상화 스크롤 범위 → 페이지 단위(`GET /rows?offset&limit`) fetch + 캐시
  - **편집**: 셀 인라인 편집 → 행 `PATCH`(낙관적), 행 추가(`POST`)·삭제(`DELETE`) — 인덱스 시프트 시 재로드
- dataset API 클라이언트/타입/queryKeys + `useDatasetMeta` + `useDatasetRows`(윈도우 캐시)

## 테스트
- **RTL + MSW**: 헤더·행 지연 로드 렌더 · 셀 편집→PATCH · 행 추가→POST · 삭제→DELETE · **노트 내 datasetTable 노드 렌더**
- setup: jsdom엔 없는 `ResizeObserver` 목(TanStack Virtual 뷰포트 측정용)
- `tsc -b`, `eslint`, `prettier --check`, **전체 325 tests 통과(에러 0)**, `vite build` 통과
- **로컬 브라우저 실검증**: 12행 데이터셋을 datasetTable 노드로 노트에 인라인 렌더 → 가상화 스크롤 → 셀 편집(78→88) **저장·새로고침 생존** → 행 추가(rowCount 12→13) 확인

## 참고
- Epic: #768 · BE: #772(머지됨) · 설계: [Data-Grid-Block §5](https://github.com/wcorn/orino/wiki/Data-Grid-Block)
- 후속: #771(Import 임계치 분기 → 대형 표는 이 노드로 삽입) · 노드 삭제 시 dataset 정리(BE DELETE 엔드포인트 필요, 후속)