### PR TITLE
feat : Import 크기 임계치 분기 — 대형 표는 dataset 그리드 블록 (#771)

### DIFF
--- a/fe/src/features/note/import/ImportDialog.test.tsx
+++ b/fe/src/features/note/import/ImportDialog.test.tsx
@@ -1,10 +1,16 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { JSONContent } from "@tiptap/react";
+import { http, HttpResponse } from "msw";
 import { describe, expect, it, vi } from "vitest";
 import * as XLSX from "xlsx";
 
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+
 import { ImportDialog } from "./ImportDialog";
+
+const API_BASE = "https://api.orino.dev/api";
 
 function makeXlsx(
   sheets: Record<string, unknown[][]>,
@@ -156,5 +162,50 @@ describe("ImportDialog", () => {
     expect(
       screen.getByRole("button", { name: "표로 가져오기" }),
     ).toBeDisabled();
+  });
+
+  it("대용량 표는 dataset을 만들어 datasetTable 노드를 삽입한다", async () => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+    let createdCols = 0;
+    let bulkRows = 0;
+    server.use(
+      http.post(`${API_BASE}/datasets`, async ({ request }) => {
+        const body = (await request.json()) as { columns: unknown[] };
+        createdCols = body.columns.length;
+        return HttpResponse.json({
+          code: "OK",
+          data: { id: 99, columns: body.columns, rowCount: 0 },
+        });
+      }),
+      http.post(`${API_BASE}/datasets/99/rows/bulk`, async ({ request }) => {
+        const body = (await request.json()) as { rows: unknown[] };
+        bulkRows = body.rows.length;
+        return HttpResponse.json({
+          code: "OK",
+          data: { id: 99, columns: [], rowCount: body.rows.length },
+        });
+      }),
+    );
+
+    // 35열(열 상한 30 초과) → dataset 경로
+    const header = Array.from({ length: 35 }, (_, i) => `H${i}`);
+    const row = Array.from({ length: 35 }, (_, i) => `v${i}`);
+    const onInsert = renderDialog();
+    await upload(makeXlsx({ Big: [header, row] }));
+
+    expect(
+      await screen.findByText(/데이터 그리드 블록으로 저장/),
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "표로 가져오기" }),
+    );
+
+    await waitFor(() => expect(onInsert).toHaveBeenCalledTimes(1));
+    const node = onInsert.mock.calls[0][0] as JSONContent;
+    expect(node.type).toBe("datasetTable");
+    expect(node.attrs?.datasetId).toBe(99);
+    expect(createdCols).toBe(35);
+    expect(bulkRows).toBe(1);
   });
 });

--- a/fe/src/features/note/import/ImportDialog.tsx
+++ b/fe/src/features/note/import/ImportDialog.tsx
@@ -9,10 +9,13 @@ import { Select } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 
+import { createDatasetFromTable, shouldUseDataset } from "./datasetImport";
 import { DEFAULT_IMPORT_SOURCE, IMPORT_SOURCES } from "./importers";
 import type { SheetData } from "./sheetParser";
 import {
   buildTableNode,
+  MAX_COLS,
+  MAX_ROWS,
   type NormalizedTable,
   wouldExceedNoteLimit,
 } from "./tableContent";
@@ -40,6 +43,7 @@ export function ImportDialog({
   const [selectedSheet, setSelectedSheet] = useState<string>("");
   const [firstRowAsHeader, setFirstRowAsHeader] = useState(true);
   const [parsing, setParsing] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -52,6 +56,7 @@ export function ImportDialog({
     setSelectedSheet("");
     setFirstRowAsHeader(true);
     setParsing(false);
+    setSubmitting(false);
     setError(null);
   };
 
@@ -99,20 +104,50 @@ export function ImportDialog({
     return { headers: null, rows: current.rows };
   }, [current, firstRowAsHeader]);
 
-  const build = useMemo(
-    () => (normalized ? buildTableNode(normalized) : null),
+  // 대형 표는 데이터셋 그리드 블록으로, 소형은 native Tiptap 표로 분기.
+  const useDataset = useMemo(
+    () =>
+      normalized ? shouldUseDataset(normalized, MAX_COLS, MAX_ROWS) : false,
     [normalized],
   );
 
+  const build = useMemo(
+    () => (normalized && !useDataset ? buildTableNode(normalized) : null),
+    [normalized, useDataset],
+  );
+
+  // native 경로만 노트 1MB 제한을 받는다(데이터셋은 참조 노드만이라 무관).
   const exceedsLimit = useMemo(
     () => (build ? wouldExceedNoteLimit(currentDoc, build.node) : false),
     [build, currentDoc],
   );
 
-  const isEmptySheet = current !== null && current.rows.length === 0;
-  const canImport = build !== null && !exceedsLimit;
+  const totalRows = normalized?.rows.length ?? 0;
+  const totalCols = normalized
+    ? Math.max(
+        normalized.headers?.length ?? 0,
+        ...normalized.rows.map((r) => r.length),
+        0,
+      )
+    : 0;
 
-  const handleImport = () => {
+  const isEmptySheet = current !== null && current.rows.length === 0;
+  const canImport = normalized !== null && !exceedsLimit && !submitting;
+
+  const handleImport = async () => {
+    if (!normalized || submitting) return;
+    if (useDataset) {
+      setSubmitting(true);
+      try {
+        const datasetId = await createDatasetFromTable(normalized);
+        onInsert({ type: "datasetTable", attrs: { datasetId } });
+        close();
+      } catch {
+        setError("표를 저장하지 못했어요. 잠시 후 다시 시도해 주세요.");
+        setSubmitting(false);
+      }
+      return;
+    }
     if (!build || exceedsLimit) return;
     onInsert(build.node);
     close();
@@ -227,19 +262,20 @@ export function ImportDialog({
             </Alert>
           )}
 
-          {build && normalized && (
+          {normalized && !isEmptySheet && (
             <>
               <TablePreview
                 headers={normalized.headers}
                 rows={normalized.rows}
               />
               <p className="text-muted-foreground text-sm">
-                총 {build.rows}행 × {build.cols}열
+                총 {totalRows}행 × {totalCols}열
               </p>
-              {(build.droppedCols > 0 || build.droppedRows > 0) && (
-                <Alert variant="warning">
+              {useDataset && (
+                <Alert variant="info">
                   <AlertDescription>
-                    표가 커서 상위 {build.rows}행 / {build.cols}열만 가져와요.
+                    대용량 표라 데이터 그리드 블록으로 저장돼요(스크롤·편집
+                    가능).
                   </AlertDescription>
                 </Alert>
               )}
@@ -259,6 +295,8 @@ export function ImportDialog({
         submitLabel="표로 가져오기"
         onSubmit={handleImport}
         submitDisabled={!canImport}
+        pending={submitting}
+        pendingLabel="가져오는 중…"
       />
     </Modal>
   );

--- a/fe/src/features/note/import/datasetImport.test.ts
+++ b/fe/src/features/note/import/datasetImport.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldUseDataset } from "./datasetImport";
+
+describe("shouldUseDataset", () => {
+  it("소형 표는 native(false)", () => {
+    expect(
+      shouldUseDataset(
+        {
+          headers: ["a", "b"],
+          rows: [
+            ["1", "2"],
+            ["3", "4"],
+          ],
+        },
+        30,
+        200,
+      ),
+    ).toBe(false);
+  });
+
+  it("열 상한 초과 → dataset(true)", () => {
+    const wide = Array.from({ length: 31 }, (_, i) => `c${i}`);
+    expect(shouldUseDataset({ headers: wide, rows: [wide] }, 30, 200)).toBe(
+      true,
+    );
+  });
+
+  it("행 상한 초과 → dataset(true)", () => {
+    const rows = Array.from({ length: 201 }, () => ["x"]);
+    expect(shouldUseDataset({ headers: null, rows }, 30, 200)).toBe(true);
+  });
+
+  it("셀 임계치(2000) 초과 → dataset(true)", () => {
+    // 100행 × 21열 = 2100셀 (열·행 상한은 안 넘지만 셀 임계 초과)
+    const rows = Array.from({ length: 100 }, () =>
+      Array.from({ length: 21 }, () => "x"),
+    );
+    expect(shouldUseDataset({ headers: null, rows }, 30, 200)).toBe(true);
+  });
+});

--- a/fe/src/features/note/import/datasetImport.ts
+++ b/fe/src/features/note/import/datasetImport.ts
@@ -1,0 +1,58 @@
+import {
+  bulkAppendRows,
+  createDataset,
+  type DatasetColumn,
+} from "@/features/note/dataset/api/datasets";
+
+import type { NormalizedTable } from "./tableContent";
+
+/** 이 셀 수를 넘으면 native 표 대신 데이터셋 그리드 블록으로 삽입한다. */
+export const DATASET_CELL_THRESHOLD = 2000;
+
+/** 벌크 업로드 청크 크기(BE 최대 2000행). */
+const BULK_CHUNK = 1000;
+
+function columnCount(table: NormalizedTable): number {
+  return Math.max(
+    table.headers?.length ?? 0,
+    ...table.rows.map((r) => r.length),
+    0,
+  );
+}
+
+/**
+ * 표가 native Tiptap 표 상한(열/행)이나 셀 임계치를 넘어 데이터셋 그리드 블록으로
+ * 가야 하는지. 소형은 가벼운 native 표, 대형은 별도 dataset + 가상화 그리드.
+ */
+export function shouldUseDataset(
+  table: NormalizedTable,
+  maxCols: number,
+  maxRows: number,
+): boolean {
+  const cols = columnCount(table);
+  const rows = table.rows.length;
+  const cells = cols * (rows + (table.headers ? 1 : 0));
+  return cols > maxCols || rows > maxRows || cells > DATASET_CELL_THRESHOLD;
+}
+
+/** 정규화 표 → dataset 생성 + 행 벌크 업로드(청크). datasetId 반환. */
+export async function createDatasetFromTable(
+  table: NormalizedTable,
+): Promise<number> {
+  const cols = columnCount(table);
+  const columns: DatasetColumn[] = table.headers
+    ? table.headers.map((label, i) => ({
+        key: `c${i}`,
+        label: label || `열 ${i + 1}`,
+      }))
+    : Array.from({ length: cols }, (_, i) => ({
+        key: `c${i}`,
+        label: `열 ${i + 1}`,
+      }));
+
+  const dataset = await createDataset(columns);
+  for (let i = 0; i < table.rows.length; i += BULK_CHUNK) {
+    await bulkAppendRows(dataset.id, table.rows.slice(i, i + BULK_CHUNK));
+  }
+  return dataset.id;
+}


### PR DESCRIPTION
## 이슈
closes #771

## 작업 내용
Import 다이얼로그에서 파싱된 표 크기에 따라 **분기**한다. 소형은 기존 native Tiptap 표, 대형은 [dataset 그리드 블록](https://github.com/wcorn/orino/wiki/Data-Grid-Block)으로. 이걸로 Epic #768의 사용자 흐름이 완성된다.

- **`shouldUseDataset`**: 열 > 30 · 행 > 200 · 셀 > 2000 중 하나라도 넘으면 dataset, 아니면 native
- **`createDatasetFromTable`**: 정규화 표 → `POST /datasets`(columns) + 행 **청크 벌크 업로드** → datasetId
- **ImportDialog**: 대형이면 dataset 생성 후 `datasetTable{datasetId}` 노드 삽입(비동기·진행 상태), 소형은 기존 native 표
  - 대용량 안내 배너, **native 경로만** 1MB 가드(dataset은 참조 노드라 무관), native는 상한 초과가 없어 truncate 경고 제거
- 파싱(SheetJS)·미리보기·시트/머리글은 그대로 재사용

## 테스트
- **단위**: `shouldUseDataset`(열/행/셀 임계) 4종
- **통합(ImportDialog)**: 대형 표 업로드 → 안내 배너 → 표로 가져오기 → `POST /datasets`(columns)·`rows/bulk` 호출 → `onInsert`가 `datasetTable` 노드
- 기존 소형 native 경로·CSV·에러 테스트 전부 유지 → 전체 **330 tests 통과(에러 0)**
- `tsc`·`eslint`·`prettier`·`vite build` 통과
- **로컬 브라우저 실검증**: 300행 xlsx Import → "대용량 표라 데이터 그리드 블록으로 저장" 배너 → 가져오기 → dataset(300행) 생성 + **가상화 그리드 인라인 렌더** → **노트 content는 104바이트(참조 노드만)** 확인(대용량이 노트를 부풀리지 않음)

## 참고
- Epic: #768 (이 PR로 #769·#770·#771 완료) · BE #772·FE #773 머지됨 · 설계: [Data-Grid-Block §6](https://github.com/wcorn/orino/wiki/Data-Grid-Block)
- 후속(선택): 노드 삭제 시 dataset 정리(BE DELETE 엔드포인트) · 표↔데이터셋 변환 · gap index