### PR TITLE
fix : 데이터 그리드 헤더-본문 열 정렬 (#775)

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -134,28 +134,29 @@ export function DatasetGrid({ datasetId }: Props) {
       className="border-border bg-card my-2 flex flex-col overflow-hidden rounded-md border"
       data-testid="dataset-grid"
     >
-      {/* 헤더 (TanStack Table) */}
-      <div
-        className="bg-muted text-muted-foreground grid border-b text-sm font-semibold"
-        style={{ gridTemplateColumns }}
-      >
-        {table.getFlatHeaders().map((header) => (
-          <div
-            key={header.id}
-            className="border-border truncate border-r px-2 py-1.5"
-          >
-            {flexRender(header.column.columnDef.header, header.getContext())}
-          </div>
-        ))}
-        <div aria-hidden />
-      </div>
-
-      {/* 본문 (가상화) */}
+      {/* 헤더+본문을 한 스크롤 컨테이너에 두어 스크롤바 폭과 무관하게 열이 정렬되게 한다. */}
       <div
         ref={scrollRef}
         className="overflow-auto"
         style={{ maxHeight: MAX_BODY_HEIGHT }}
       >
+        {/* 헤더 (TanStack Table) — sticky로 상단 고정 */}
+        <div
+          className="bg-muted text-muted-foreground sticky top-0 z-10 grid border-b text-sm font-semibold"
+          style={{ gridTemplateColumns }}
+        >
+          {table.getFlatHeaders().map((header) => (
+            <div
+              key={header.id}
+              className="border-border truncate border-r px-2 py-1.5"
+            >
+              {flexRender(header.column.columnDef.header, header.getContext())}
+            </div>
+          ))}
+          <div aria-hidden />
+        </div>
+
+        {/* 본문 (가상화) */}
         <div
           style={{ height: virtualizer.getTotalSize(), position: "relative" }}
         >


### PR DESCRIPTION
## 이슈
closes #775

## 작업 내용
데이터 그리드 블록(#770)에서 **헤더 열이 본문과 미세하게 어긋나던** 문제 수정.

### 원인
헤더는 스크롤 컨테이너 **밖**, 본문은 **안**이라 세로 스크롤바 너비만큼 본문의 사용 가능 폭이 줄어들어, 양쪽 `repeat(N, minmax(120px, 1fr))`의 `1fr` 분배가 달라짐 → 헤더가 본문보다 살짝 넓어짐.

### 조치
헤더를 본문과 **같은 스크롤 컨테이너 안**으로 옮기고 `position: sticky; top: 0; z-10`으로 상단 고정. 두 영역이 동일 폭(스크롤바 제외)을 공유해 정렬되고, 세로 스크롤 시 헤더는 고정 유지. 가상화 본문 로직은 그대로.

## 확인
- `tsc -b`·`eslint`·`prettier --check`·DatasetGrid 테스트 통과
- **로컬 브라우저**: 스크롤바 있는 표에서 헤더 4열이 본문과 정확히 정렬됨(sticky 고정 확인)