### PR TITLE
feat : datasetTable 블록 삭제 시 dataset 정리

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -52,6 +52,15 @@ public class DatasetController {
         return ApiResponse.success(datasetService.getMeta(memberId, id));
     }
 
+    /** 데이터셋 삭제(노트에서 datasetTable 블록 제거 시). 행은 cascade로 함께 삭제. */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id) {
+        datasetService.delete(memberId, id);
+        return ResponseEntity.noContent().build();
+    }
+
     /** Import 청크 — 행을 끝에 벌크 추가. */
     @PostMapping("/{id}/rows/bulk")
     public ApiResponse<DatasetResponse> bulkAppend(

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -135,6 +135,13 @@ public class DatasetService {
         dataset.setRowCount(dataset.getRowCount() - 1);
     }
 
+    /** 데이터셋 삭제. dataset_row는 FK ON DELETE CASCADE로 함께 지워진다. */
+    @Transactional
+    public void delete(Long memberId, Long datasetId) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        datasetRepository.delete(dataset);
+    }
+
     private Dataset getOwned(Long memberId, Long datasetId) {
         return datasetRepository.findByIdAndMemberId(datasetId, memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -2,6 +2,7 @@ package ds.project.orino.planner.dataset.controller;
 
 import com.jayway.jsonpath.JsonPath;
 import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.dataset.repository.DatasetRowRepository;
 import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
@@ -25,6 +26,8 @@ class DatasetControllerTest extends ApiTestSupport {
 
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private DatasetRowRepository datasetRowRepository;
     @Autowired
     private DbCleaner dbCleaner;
 
@@ -221,5 +224,26 @@ class DatasetControllerTest extends ApiTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"rows\":[[\"x\"]]}"))
                 .andExpect(status().isNotFound());
+        mockMvc.perform(delete("/api/datasets/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, otherAuth))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("DELETE dataset - 삭제 시 행도 cascade로 함께 삭제된다")
+    void delete_dataset_cascades_rows() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"A\",\"1\"],[\"B\",\"2\"]]");
+
+        mockMvc.perform(delete("/api/datasets/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/datasets/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNotFound());
+        org.assertj.core.api.Assertions
+                .assertThat(datasetRowRepository.countByDatasetId(id))
+                .isZero();
     }
 }

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -1,4 +1,4 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { DragHandle } from "@tiptap/extension-drag-handle-react";
 import Image from "@tiptap/extension-image";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -14,9 +14,10 @@ import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Input } from "@/components/ui/input";
 
 import type { NoteContent, NoteDetail } from "../api/notes";
+import { deleteDataset } from "../dataset/api/datasets";
 import { ChildPage, collectChildPageIds } from "../editor/childPage";
 import { ChildPageContext } from "../editor/childPageContext";
-import { DatasetTable } from "../editor/datasetTable";
+import { collectDatasetIds, DatasetTable } from "../editor/datasetTable";
 import { extractImageFiles, uploadAndInsertImage } from "../editor/imageUpload";
 import { useAutoSaveNote } from "../hooks/useAutoSaveNote";
 import { useCreateNote, useDeleteNote } from "../hooks/useNoteMutations";
@@ -54,9 +55,14 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
 
   const [title, setTitle] = useState(note.title);
   const [pendingDelete, setPendingDelete] = useState<number | null>(null);
+  const [pendingDatasetDelete, setPendingDatasetDelete] = useState<
+    number | null
+  >(null);
   // 본문에 현재 박혀 있는 childPage noteId 집합 (삭제 diff 기준).
   // NoteTab이 key={note.id}로 리마운트하므로 마운트 시점 content 기준으로 1회 초기화한다.
   const childIdsRef = useRef<Set<number>>(collectChildPageIds(note.content));
+  // 본문의 datasetTable datasetId 집합 (블록 삭제 시 dataset 정리 diff 기준).
+  const datasetIdsRef = useRef<Set<number>>(collectDatasetIds(note.content));
   // editorProps 핸들러(handlePaste/handleDrop)는 생성 시점 클로저라 editor를
   // 직접 못 잡으므로 ref로 우회한다.
   const editorRef = useRef<ReturnType<typeof useEditor>>(null);
@@ -111,6 +117,7 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
         const json = editor.getJSON() as NoteContent;
         schedule({ content: json });
         detectRemovedChildPage(json);
+        detectRemovedDataset(json);
       },
     },
     [note.id],
@@ -135,6 +142,16 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
     childIdsRef.current = current;
     if (removed.length > 0) {
       setPendingDelete(removed[0]);
+    }
+  };
+
+  const detectRemovedDataset = (json: NoteContent) => {
+    const current = collectDatasetIds(json);
+    const prev = datasetIdsRef.current;
+    const removed = [...prev].filter((id) => !current.has(id));
+    datasetIdsRef.current = current;
+    if (removed.length > 0) {
+      setPendingDatasetDelete(removed[0]);
     }
   };
 
@@ -170,6 +187,15 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
     deleteNote.mutate(pendingDelete, {
       onSuccess: () => setPendingDelete(null),
       onError: () => setPendingDelete(null),
+    });
+  };
+
+  const deleteDatasetMut = useMutation({ mutationFn: deleteDataset });
+  const confirmDatasetDelete = () => {
+    if (pendingDatasetDelete == null) return;
+    deleteDatasetMut.mutate(pendingDatasetDelete, {
+      onSuccess: () => setPendingDatasetDelete(null),
+      onError: () => setPendingDatasetDelete(null),
     });
   };
 
@@ -239,6 +265,19 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
         destructive
         onConfirm={confirmDelete}
         pending={deleteNote.isPending}
+      />
+
+      <ConfirmDialog
+        open={pendingDatasetDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDatasetDelete(null);
+        }}
+        title="표(데이터셋)를 삭제할까요?"
+        description="본문에서 제거한 데이터 그리드 표와 그 안의 모든 행이 삭제됩니다. 되돌릴 수 없어요."
+        confirmLabel="삭제"
+        destructive
+        onConfirm={confirmDatasetDelete}
+        pending={deleteDatasetMut.isPending}
       />
     </div>
   );

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -99,3 +99,8 @@ export async function deleteDatasetRow(
 ): Promise<void> {
   await client.delete(`/datasets/${datasetId}/rows/${rowIndex}`);
 }
+
+/** 데이터셋 삭제(노트에서 datasetTable 블록 제거 시). 행은 서버에서 cascade 삭제. */
+export async function deleteDataset(datasetId: number): Promise<void> {
+  await client.delete(`/datasets/${datasetId}`);
+}

--- a/fe/src/features/note/editor/datasetTable.test.ts
+++ b/fe/src/features/note/editor/datasetTable.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { collectDatasetIds, DatasetTable } from "./datasetTable";
+
+describe("collectDatasetIds", () => {
+  it("중첩 doc에서 모든 datasetTable datasetId를 수집한다", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "hi" }] },
+        { type: "datasetTable", attrs: { datasetId: 7 } },
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [{ type: "datasetTable", attrs: { datasetId: 8 } }],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect([...collectDatasetIds(doc)].sort()).toEqual([7, 8]);
+  });
+
+  it("datasetTable이 없으면 빈 집합", () => {
+    const doc = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "x" }] }],
+    };
+    expect(collectDatasetIds(doc).size).toBe(0);
+  });
+
+  it("datasetId가 number가 아니면 무시한다", () => {
+    const doc = {
+      type: "doc",
+      content: [{ type: "datasetTable", attrs: {} }],
+    };
+    expect(collectDatasetIds(doc).size).toBe(0);
+  });
+});
+
+describe("DatasetTable 노드 스펙", () => {
+  it("atom block 이고 draggable=true 이다", () => {
+    expect(DatasetTable.config.atom).toBe(true);
+    expect(DatasetTable.config.draggable).toBe(true);
+  });
+});


### PR DESCRIPTION
## 이슈
closes #777

## 작업 내용
- **BE**: `DELETE /api/datasets/{id}` 추가 — 소유자 검증 후 dataset 삭제, `dataset_row`는 FK cascade로 함께 제거
- **FE**: 노트 본문에서 `datasetTable` 블록 제거를 감지하면 확인 다이얼로그(`표(데이터셋)를 삭제할까요?`)를 띄우고, 확인 시 `deleteDataset` 호출 — 기존 childPage 삭제 흐름과 동일 패턴
- 테스트: `collectDatasetIds` 유닛 테스트, DELETE cascade / 타인 접근 404 통합 테스트 추가

## 검증
- BE: `DatasetControllerTest` 통과(cascade 삭제 후 `countByDatasetId == 0`, GET 404)
- FE: `tsc -b`/eslint/prettier/vitest(334 tests) 통과
- 로컬 브라우저: 300행 그리드 블록 삭제 → 확인 다이얼로그 → 서버 dataset·rows 실제 삭제(DB `dataset=0`, `dataset_row=0`, GET 404) end-to-end 확인