### PR TITLE
fix : be HPA memory 기준 제거 + JVM heap 명시

### DIFF
--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -66,6 +66,8 @@ spec:
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: {{ .Values.env.SPRING_PROFILES_ACTIVE | quote }}
+            - name: JAVA_TOOL_OPTIONS
+              value: {{ .Values.env.JAVA_TOOL_OPTIONS | quote }}
             - name: MYSQL_HOST
               value: {{ .Values.env.MYSQL_HOST | quote }}
             - name: DB_NAME

--- a/infra/helm/be/values.yaml
+++ b/infra/helm/be/values.yaml
@@ -6,6 +6,10 @@ replicas: 1
 
 env:
   SPRING_PROFILES_ACTIVE: prod
+  # JVM heap 상한을 컨테이너 limit(1Gi) 대비 50%(=512Mi)로 명시.
+  # java -jar 엔트리포인트는 JAVA_OPTS를 참조하지 않으므로 JVM이 자동 인식하는
+  # JAVA_TOOL_OPTIONS로 주입한다. heap 512 + 비힙 여유 → RSS가 1Gi 아래로 유지된다.
+  JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=50.0"
   MYSQL_HOST: mysql.orino.svc.cluster.local
   MYSQL_USERNAME: orino_app
   REDIS_HOST: redis.orino.svc.cluster.local
@@ -28,8 +32,10 @@ hpa:
   enabled: true
   minReplicas: 1
   maxReplicas: 3
+  # JVM은 부하와 무관하게 heap을 상시 점유해 memory 이용률이 항상 높다.
+  # memory 기준 타겟을 두면 max에서 못 내려와 KubeHpaMaxedOut이 상시 발화하므로
+  # CPU 기준으로만 스케일한다(#780).
   targetCPUUtilization: 70
-  targetMemoryUtilization: 80
   behavior:
     scaleUp:
       stabilizationWindowSeconds: 60


### PR DESCRIPTION
## 이슈
closes #780

## 작업 내용

`KubeHpaMaxedOut` 경보가 2026-07-14부터 4시간 간격으로 상시 재발화하던 문제 대응.

### 원인
- HPA `orino/be`가 `memory 87%/80%`로 max replicas(3)에 영구 고정 (CPU는 1%로 유휴)
- JVM(Java 25)이 heap을 상시 점유해 RSS가 부하와 무관하게 ~500Mi(request 512Mi의 96~100%) 유지
- memory 이용률이 타겟 80%를 절대 밑돌 수 없어 HPA가 max에서 못 내려옴 → **JVM에 memory 기준 HPA를 건 안티패턴**

### 변경
- `values.yaml`: HPA `targetMemoryUtilization` 제거 → CPU 기준으로만 스케일 (유휴 시 minReplicas=1로 정상 축소)
- `values.yaml` / `deployment.yaml`: `JAVA_TOOL_OPTIONS: -XX:MaxRAMPercentage=50.0` 명시로 heap 상한(512Mi) 예측 가능화
  - `java -jar` 엔트리포인트가 `JAVA_OPTS`를 참조하지 않아 JVM 자동 인식 변수인 `JAVA_TOOL_OPTIONS` 사용

### 검증
- `helm template be .` 렌더링: HPA metrics에 CPU만 남음, `JAVA_TOOL_OPTIONS` 정상 주입 확인

### 기대 효과
- KubeHpaMaxedOut 해소, 유휴 서비스에 낭비되던 3배 리소스 회수