### PR TITLE
fix : ReviewControllerTest 고정 clock 적용으로 flaky 제거

### DIFF
--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
@@ -13,11 +13,13 @@ import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepositor
 import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.FixedClockConfig;
 import ds.project.orino.support.MemberFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
@@ -34,6 +36,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@Import(FixedClockConfig.class)
 class ReviewControllerTest extends ApiTestSupport {
 
     @Autowired


### PR DESCRIPTION
## 이슈
closes #782

## 작업 내용
- `ReviewControllerTest`에 `@Import(FixedClockConfig.class)` 적용 — 실제 시스템 clock 대신 고정 clock(`now = 2026-01-15 11:00 KST`) 사용
- 기존에 이 테스트만 고정 clock이 빠져 있어, CI가 **00:00~04:00 KST(=15:00~19:00 UTC)** 구간에 돌면 `complete_buries_due_sibling`이 실패했음
  - 형제 review를 오늘 04:00 KST에 생성 → bury 조건 `scheduled_at <= now` → 새벽 구간엔 아직 미래라 bury 안 됨 → `hasSize(1)` 실패
  - 실측: PR #779 CI가 `2026-07-13 01:28 KST`에 돌아 실패
- 동일 도메인의 `ReviewSummaryControllerTest`·`ReviewCompletedControllerTest`·`ReviewUpcomingControllerTest`와 동일한 패턴으로 정렬

## 검증
- `./gradlew :orino-app-api:test --tests "*.ReviewControllerTest"` 통과 (고정 clock이라 실제 시각 무관하게 결정적)
- `./gradlew :orino-app-api:checkstyleTest` 통과