### PR TITLE
feat : 표 진입점을 dataset 그리드로 전환 (툴바·Import)

### DIFF
--- a/fe/src/features/note/components/EditorToolbar.tsx
+++ b/fe/src/features/note/components/EditorToolbar.tsx
@@ -21,8 +21,10 @@ import { useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { toast } from "@/shared/lib/toast";
 
 import { uploadAndInsertImage } from "../editor/imageUpload";
+import { createEmptyDataset } from "../import/datasetImport";
 import { ImportDialog } from "../import/ImportDialog";
 
 interface Props {
@@ -50,8 +52,23 @@ export function EditorToolbar({
   });
   const imageInputRef = useRef<HTMLInputElement>(null);
   const [importOpen, setImportOpen] = useState(false);
+  const [insertingTable, setInsertingTable] = useState(false);
 
   if (!editor) return null;
+
+  // 표 삽입 = 빈 dataset(3×3) 생성 후 datasetTable 블록 삽입. 대용량 표와 동일 저장 방식.
+  const handleInsertTable = async () => {
+    if (insertingTable) return;
+    setInsertingTable(true);
+    try {
+      const datasetId = await createEmptyDataset();
+      editor.chain().focus().insertDatasetTable({ datasetId }).run();
+    } catch {
+      toast("표를 만들지 못했어요. 잠시 후 다시 시도해 주세요.", "error");
+    } finally {
+      setInsertingTable(false);
+    }
+  };
 
   const buttons: ToolbarButton[] = [
     {
@@ -108,18 +125,6 @@ export function EditorToolbar({
       isActive: () => editor.isActive("codeBlock"),
       onClick: () => editor.chain().focus().toggleCodeBlock().run(),
     },
-    {
-      label: "표 삽입",
-      icon: Table,
-      isActive: () => editor.isActive("table"),
-      // 제목 행은 강제하지 않는다. 필요하면 표 편집의 [헤더] 버튼으로 켠다.
-      onClick: () =>
-        editor
-          .chain()
-          .focus()
-          .insertTable({ rows: 3, cols: 3, withHeaderRow: false })
-          .run(),
-    },
   ];
 
   return (
@@ -145,6 +150,16 @@ export function EditorToolbar({
           </Button>
         );
       })}
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        aria-label="표 삽입"
+        disabled={insertingTable}
+        onClick={() => void handleInsertTable()}
+      >
+        <Table className="size-4" />
+      </Button>
       <Button
         type="button"
         variant="ghost"
@@ -179,7 +194,6 @@ export function EditorToolbar({
       <ImportDialog
         open={importOpen}
         onOpenChange={setImportOpen}
-        currentDoc={importOpen ? editor.getJSON() : null}
         onInsert={(node) => editor.chain().focus().insertContent(node).run()}
       />
       {onInsertPage && (

--- a/fe/src/features/note/components/NoteTab.test.tsx
+++ b/fe/src/features/note/components/NoteTab.test.tsx
@@ -64,6 +64,43 @@ function mockNoteDetail(
   );
 }
 
+interface DatasetColumn {
+  key: string;
+  label: string;
+}
+
+/** 표 삽입/가져오기가 만드는 dataset의 생성·조회 엔드포인트를 목킹한다. */
+function mockDataset(id: number, columns: DatasetColumn[], rows: string[][]) {
+  server.use(
+    http.post(`${API_BASE}/datasets`, () =>
+      HttpResponse.json({ code: "OK", data: { id, columns, rowCount: 0 } }),
+    ),
+    http.post(`${API_BASE}/datasets/${id}/rows/bulk`, async ({ request }) => {
+      const body = (await request.json()) as { rows: string[][] };
+      return HttpResponse.json({
+        code: "OK",
+        data: { id, columns, rowCount: body.rows.length },
+      });
+    }),
+    http.get(`${API_BASE}/datasets/${id}`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: { id, columns, rowCount: rows.length },
+      }),
+    ),
+    http.get(`${API_BASE}/datasets/${id}/rows`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          rows: rows.map((cells, rowIndex) => ({ rowIndex, cells })),
+          offset: 0,
+          limit: 100,
+        },
+      }),
+    ),
+  );
+}
+
 describe("NoteTab", () => {
   beforeEach(() => {
     useAuthStore.setState({ accessToken: "mock-token" });
@@ -298,35 +335,37 @@ describe("NoteTab", () => {
     await waitFor(() => expect(deletedId).toBe(1));
   });
 
-  it("툴바 [표 삽입] 클릭 시 표가 본문에 삽입되고 표 편집 컨트롤이 나타난다", async () => {
+  it("툴바 [표 삽입] 클릭 시 빈 dataset을 만들어 데이터 그리드가 삽입된다", async () => {
     mockTree([
       { id: 1, title: "노트", parentId: null, sortOrder: 0, children: [] },
     ]);
     mockNoteDetail(1, { type: "doc", content: [] }, "노트");
+    mockDataset(
+      7,
+      [
+        { key: "c0", label: "열 1" },
+        { key: "c1", label: "열 2" },
+        { key: "c2", label: "열 3" },
+      ],
+      [
+        ["", "", ""],
+        ["", "", ""],
+        ["", "", ""],
+      ],
+    );
 
     const user = userEvent.setup();
-    const { container } = renderTab();
+    renderTab();
 
     await waitFor(() => {
       expect(screen.getByLabelText("노트 제목")).toHaveValue("노트");
     });
 
-    // 표 삽입 전에는 표가 없다
-    expect(container.querySelector("table")).toBeNull();
-
     await user.click(screen.getByRole("button", { name: "표 삽입" }));
 
-    // 표가 렌더되고 (헤더행 없이 3x3 = td 9개), 제목 행은 기본값이 아니다
-    await waitFor(() => {
-      expect(container.querySelector("table")).not.toBeNull();
-    });
-    expect(container.querySelectorAll("table td")).toHaveLength(9);
-    expect(container.querySelectorAll("table th")).toHaveLength(0);
-
-    // 커서가 표 안에 있으므로 표 편집 컨트롤이 노출된다
-    expect(screen.getByRole("button", { name: "열 추가" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "행 추가" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "표 삭제" })).toBeInTheDocument();
+    // dataset 생성 → datasetTable 노드 → NodeView → DatasetGrid 렌더
+    expect(await screen.findByTestId("dataset-grid")).toBeInTheDocument();
+    expect(screen.getByText("열 1")).toBeInTheDocument();
   });
 
   it("툴바 [이미지 추가]로 파일 선택 시 presign→PUT 후 본문에 이미지가 삽입된다", async () => {
@@ -384,78 +423,26 @@ describe("NoteTab", () => {
     });
   });
 
-  it("표 삽입 후 [헤더] 버튼으로 제목 행을 선택적으로 켤 수 있다", async () => {
+  it("[가져오기]로 엑셀을 업로드하면 dataset을 만들어 데이터 그리드가 삽입된다", async () => {
     mockTree([
       { id: 1, title: "노트", parentId: null, sortOrder: 0, children: [] },
     ]);
     mockNoteDetail(1, { type: "doc", content: [] }, "노트");
+    mockDataset(
+      7,
+      [
+        { key: "c0", label: "항목" },
+        { key: "c1", label: "값" },
+      ],
+      [["A", "1"]],
+    );
 
     const user = userEvent.setup();
-    const { container } = renderTab();
+    renderTab();
 
     await waitFor(() => {
       expect(screen.getByLabelText("노트 제목")).toHaveValue("노트");
     });
-
-    await user.click(screen.getByRole("button", { name: "표 삽입" }));
-    await waitFor(() => {
-      expect(container.querySelector("table")).not.toBeNull();
-    });
-    // 기본은 헤더 없음
-    expect(container.querySelectorAll("table th")).toHaveLength(0);
-
-    // 헤더 전환 → 첫 행이 헤더(th)가 된다
-    await user.click(screen.getByRole("button", { name: "헤더 행 전환" }));
-    await waitFor(() => {
-      expect(container.querySelectorAll("table th")).toHaveLength(3);
-    });
-  });
-
-  it("표 삽입 후 [행 추가]로 행이 늘고 [표 삭제]로 표가 제거된다", async () => {
-    mockTree([
-      { id: 1, title: "노트", parentId: null, sortOrder: 0, children: [] },
-    ]);
-    mockNoteDetail(1, { type: "doc", content: [] }, "노트");
-
-    const user = userEvent.setup();
-    const { container } = renderTab();
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("노트 제목")).toHaveValue("노트");
-    });
-
-    await user.click(screen.getByRole("button", { name: "표 삽입" }));
-    await waitFor(() => {
-      expect(container.querySelector("table")).not.toBeNull();
-    });
-    const rowsBefore = container.querySelectorAll("table tr").length;
-
-    await user.click(screen.getByRole("button", { name: "행 추가" }));
-    await waitFor(() => {
-      expect(container.querySelectorAll("table tr").length).toBe(
-        rowsBefore + 1,
-      );
-    });
-
-    await user.click(screen.getByRole("button", { name: "표 삭제" }));
-    await waitFor(() => {
-      expect(container.querySelector("table")).toBeNull();
-    });
-  });
-
-  it("[가져오기]로 엑셀을 업로드하면 값이 표로 본문에 삽입된다", async () => {
-    mockTree([
-      { id: 1, title: "노트", parentId: null, sortOrder: 0, children: [] },
-    ]);
-    mockNoteDetail(1, { type: "doc", content: [] }, "노트");
-
-    const user = userEvent.setup();
-    const { container } = renderTab();
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("노트 제목")).toHaveValue("노트");
-    });
-    expect(container.querySelector("table")).toBeNull();
 
     await user.click(screen.getByRole("button", { name: "가져오기" }));
 
@@ -478,13 +465,9 @@ describe("NoteTab", () => {
     await screen.findByText("총 1행 × 2열");
     await user.click(screen.getByRole("button", { name: "표로 가져오기" }));
 
-    // 본문에 표가 삽입되고(헤더행 th 2 + 본문 td 2) 값이 보인다
-    await waitFor(() => {
-      expect(container.querySelector("table")).not.toBeNull();
-    });
-    expect(container.querySelectorAll("table th")).toHaveLength(2);
+    // 본문에 datasetTable → DatasetGrid가 렌더되고 헤더 라벨이 보인다
+    expect(await screen.findByTestId("dataset-grid")).toBeInTheDocument();
     expect(screen.getByText("항목")).toBeInTheDocument();
-    expect(screen.getByText("A")).toBeInTheDocument();
   });
 
   it("표를 담은 노트 content를 열면 표가 그대로 렌더된다(라운드트립)", async () => {

--- a/fe/src/features/note/import/ImportDialog.test.tsx
+++ b/fe/src/features/note/import/ImportDialog.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { JSONContent } from "@tiptap/react";
 import { http, HttpResponse } from "msw";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as XLSX from "xlsx";
 
 import { useAuthStore } from "@/features/auth/store/authStore";
@@ -11,6 +11,36 @@ import { server } from "@/test/mocks/server";
 import { ImportDialog } from "./ImportDialog";
 
 const API_BASE = "https://api.orino.dev/api";
+
+/** 모든 가져오기가 dataset을 만들므로, 생성·벌크 요청을 캡처하는 목을 매 테스트 등록한다. */
+let createdColumns: { key: string; label: string }[] | null;
+let bulkRows: string[][] | null;
+
+beforeEach(() => {
+  useAuthStore.setState({ accessToken: "mock-token" });
+  createdColumns = null;
+  bulkRows = null;
+  server.use(
+    http.post(`${API_BASE}/datasets`, async ({ request }) => {
+      const body = (await request.json()) as {
+        columns: { key: string; label: string }[];
+      };
+      createdColumns = body.columns;
+      return HttpResponse.json({
+        code: "OK",
+        data: { id: 99, columns: body.columns, rowCount: 0 },
+      });
+    }),
+    http.post(`${API_BASE}/datasets/99/rows/bulk`, async ({ request }) => {
+      const body = (await request.json()) as { rows: string[][] };
+      bulkRows = body.rows;
+      return HttpResponse.json({
+        code: "OK",
+        data: { id: 99, columns: [], rowCount: body.rows.length },
+      });
+    }),
+  );
+});
 
 function makeXlsx(
   sheets: Record<string, unknown[][]>,
@@ -26,18 +56,8 @@ function makeXlsx(
   });
 }
 
-function renderDialog(
-  onInsert = vi.fn(),
-  currentDoc: unknown = { type: "doc" },
-) {
-  render(
-    <ImportDialog
-      open
-      onOpenChange={() => {}}
-      currentDoc={currentDoc}
-      onInsert={onInsert}
-    />,
-  );
+function renderDialog(onInsert = vi.fn()) {
+  render(<ImportDialog open onOpenChange={() => {}} onInsert={onInsert} />);
   return onInsert;
 }
 
@@ -47,7 +67,7 @@ async function upload(file: File) {
 }
 
 describe("ImportDialog", () => {
-  it("xlsx 업로드 → 미리보기 후 [표로 가져오기]로 표 노드를 삽입한다", async () => {
+  it("xlsx 업로드 → dataset을 만들어 datasetTable 노드를 삽입한다", async () => {
     const onInsert = renderDialog();
     await upload(
       makeXlsx({
@@ -58,24 +78,28 @@ describe("ImportDialog", () => {
       }),
     );
 
-    // 미리보기(머리글 + 총계)
+    // 미리보기(머리글 + 총계 + 안내)
     expect(await screen.findByText("총 1행 × 2열")).toBeInTheDocument();
     expect(screen.getByText("점수")).toBeInTheDocument();
+    expect(screen.getByText(/데이터 그리드 블록으로 저장/)).toBeInTheDocument();
 
     await userEvent.click(
       screen.getByRole("button", { name: "표로 가져오기" }),
     );
 
-    expect(onInsert).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onInsert).toHaveBeenCalledTimes(1));
     const node = onInsert.mock.calls[0][0] as JSONContent;
-    expect(node.type).toBe("table");
-    // 헤더 행(tableHeader) + 본문 1행
-    expect(node.content).toHaveLength(2);
-    const header = node.content![0] as JSONContent;
-    expect((header.content![0] as JSONContent).type).toBe("tableHeader");
+    expect(node.type).toBe("datasetTable");
+    expect(node.attrs?.datasetId).toBe(99);
+    // 첫 행이 머리글(기본값) → 컬럼 라벨 + 본문 1행
+    expect(createdColumns).toEqual([
+      { key: "c0", label: "이름" },
+      { key: "c1", label: "점수" },
+    ]);
+    expect(bulkRows).toEqual([["김철수", "90"]]);
   });
 
-  it("'첫 행을 머리글로'를 끄면 헤더 없이 전부 본문 행", async () => {
+  it("'첫 행을 머리글로'를 끄면 열 N 라벨 + 전부 본문 행", async () => {
     const onInsert = renderDialog();
     await upload(
       makeXlsx({
@@ -92,11 +116,16 @@ describe("ImportDialog", () => {
     await userEvent.click(
       screen.getByRole("button", { name: "표로 가져오기" }),
     );
-    const node = onInsert.mock.calls[0][0] as JSONContent;
-    // 헤더 없음 → 2행 모두 tableCell
-    expect(node.content).toHaveLength(2);
-    const first = node.content![0] as JSONContent;
-    expect((first.content![0] as JSONContent).type).toBe("tableCell");
+
+    await waitFor(() => expect(onInsert).toHaveBeenCalledTimes(1));
+    expect(createdColumns).toEqual([
+      { key: "c0", label: "열 1" },
+      { key: "c1", label: "열 2" },
+    ]);
+    expect(bulkRows).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
   });
 
   it("여러 시트면 시트를 선택할 수 있다", async () => {
@@ -120,7 +149,7 @@ describe("ImportDialog", () => {
     ).toBeInTheDocument();
   });
 
-  it("CSV 소스로 전환해 .csv를 표로 가져온다", async () => {
+  it("CSV 소스로 전환해 .csv를 dataset으로 가져온다", async () => {
     const onInsert = renderDialog();
     await userEvent.click(screen.getByRole("button", { name: "CSV (.csv)" }));
 
@@ -134,10 +163,13 @@ describe("ImportDialog", () => {
       screen.getByRole("button", { name: "표로 가져오기" }),
     );
 
-    expect(onInsert).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onInsert).toHaveBeenCalledTimes(1));
     const node = onInsert.mock.calls[0][0] as JSONContent;
-    expect(node.type).toBe("table");
-    expect(node.content).toHaveLength(3); // 헤더 + 2행
+    expect(node.type).toBe("datasetTable");
+    expect(bulkRows).toEqual([
+      ["A", "1"],
+      ["B", "2"],
+    ]);
   });
 
   it("빈 시트는 '데이터가 없어요' 경고 + 가져오기 비활성", async () => {
@@ -150,62 +182,5 @@ describe("ImportDialog", () => {
     expect(
       screen.getByRole("button", { name: "표로 가져오기" }),
     ).toBeDisabled();
-  });
-
-  it("노트가 이미 크면 초과 경고 + 가져오기 비활성", async () => {
-    renderDialog(vi.fn(), { type: "doc", big: "x".repeat(1_000_001) });
-    await upload(makeXlsx({ S: [["a"]] }));
-
-    expect(
-      await screen.findByText("노트가 너무 커서 이 표를 넣을 수 없어요."),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "표로 가져오기" }),
-    ).toBeDisabled();
-  });
-
-  it("대용량 표는 dataset을 만들어 datasetTable 노드를 삽입한다", async () => {
-    useAuthStore.setState({ accessToken: "mock-token" });
-    let createdCols = 0;
-    let bulkRows = 0;
-    server.use(
-      http.post(`${API_BASE}/datasets`, async ({ request }) => {
-        const body = (await request.json()) as { columns: unknown[] };
-        createdCols = body.columns.length;
-        return HttpResponse.json({
-          code: "OK",
-          data: { id: 99, columns: body.columns, rowCount: 0 },
-        });
-      }),
-      http.post(`${API_BASE}/datasets/99/rows/bulk`, async ({ request }) => {
-        const body = (await request.json()) as { rows: unknown[] };
-        bulkRows = body.rows.length;
-        return HttpResponse.json({
-          code: "OK",
-          data: { id: 99, columns: [], rowCount: body.rows.length },
-        });
-      }),
-    );
-
-    // 35열(열 상한 30 초과) → dataset 경로
-    const header = Array.from({ length: 35 }, (_, i) => `H${i}`);
-    const row = Array.from({ length: 35 }, (_, i) => `v${i}`);
-    const onInsert = renderDialog();
-    await upload(makeXlsx({ Big: [header, row] }));
-
-    expect(
-      await screen.findByText(/데이터 그리드 블록으로 저장/),
-    ).toBeInTheDocument();
-
-    await userEvent.click(
-      screen.getByRole("button", { name: "표로 가져오기" }),
-    );
-
-    await waitFor(() => expect(onInsert).toHaveBeenCalledTimes(1));
-    const node = onInsert.mock.calls[0][0] as JSONContent;
-    expect(node.type).toBe("datasetTable");
-    expect(node.attrs?.datasetId).toBe(99);
-    expect(createdCols).toBe(35);
-    expect(bulkRows).toBe(1);
   });
 });

--- a/fe/src/features/note/import/ImportDialog.tsx
+++ b/fe/src/features/note/import/ImportDialog.tsx
@@ -9,34 +9,21 @@ import { Select } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 
-import { createDatasetFromTable, shouldUseDataset } from "./datasetImport";
+import { createDatasetFromTable } from "./datasetImport";
 import { DEFAULT_IMPORT_SOURCE, IMPORT_SOURCES } from "./importers";
 import type { SheetData } from "./sheetParser";
-import {
-  buildTableNode,
-  MAX_COLS,
-  MAX_ROWS,
-  type NormalizedTable,
-  wouldExceedNoteLimit,
-} from "./tableContent";
+import type { NormalizedTable } from "./tableContent";
 
 const PREVIEW_ROWS = 5;
 
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** 현재 에디터 문서(삽입 시 1MB 초과 가드용). */
-  currentDoc: unknown;
-  /** 표 노드를 커서 위치에 삽입한다. */
+  /** datasetTable 노드를 커서 위치에 삽입한다. */
   onInsert: (node: JSONContent) => void;
 }
 
-export function ImportDialog({
-  open,
-  onOpenChange,
-  currentDoc,
-  onInsert,
-}: Props) {
+export function ImportDialog({ open, onOpenChange, onInsert }: Props) {
   const [source, setSource] = useState(DEFAULT_IMPORT_SOURCE);
   const [fileName, setFileName] = useState<string | null>(null);
   const [sheets, setSheets] = useState<SheetData[] | null>(null);
@@ -104,24 +91,6 @@ export function ImportDialog({
     return { headers: null, rows: current.rows };
   }, [current, firstRowAsHeader]);
 
-  // 대형 표는 데이터셋 그리드 블록으로, 소형은 native Tiptap 표로 분기.
-  const useDataset = useMemo(
-    () =>
-      normalized ? shouldUseDataset(normalized, MAX_COLS, MAX_ROWS) : false,
-    [normalized],
-  );
-
-  const build = useMemo(
-    () => (normalized && !useDataset ? buildTableNode(normalized) : null),
-    [normalized, useDataset],
-  );
-
-  // native 경로만 노트 1MB 제한을 받는다(데이터셋은 참조 노드만이라 무관).
-  const exceedsLimit = useMemo(
-    () => (build ? wouldExceedNoteLimit(currentDoc, build.node) : false),
-    [build, currentDoc],
-  );
-
   const totalRows = normalized?.rows.length ?? 0;
   const totalCols = normalized
     ? Math.max(
@@ -132,25 +101,19 @@ export function ImportDialog({
     : 0;
 
   const isEmptySheet = current !== null && current.rows.length === 0;
-  const canImport = normalized !== null && !exceedsLimit && !submitting;
+  const canImport = normalized !== null && !submitting;
 
   const handleImport = async () => {
     if (!normalized || submitting) return;
-    if (useDataset) {
-      setSubmitting(true);
-      try {
-        const datasetId = await createDatasetFromTable(normalized);
-        onInsert({ type: "datasetTable", attrs: { datasetId } });
-        close();
-      } catch {
-        setError("표를 저장하지 못했어요. 잠시 후 다시 시도해 주세요.");
-        setSubmitting(false);
-      }
-      return;
+    setSubmitting(true);
+    try {
+      const datasetId = await createDatasetFromTable(normalized);
+      onInsert({ type: "datasetTable", attrs: { datasetId } });
+      close();
+    } catch {
+      setError("표를 저장하지 못했어요. 잠시 후 다시 시도해 주세요.");
+      setSubmitting(false);
     }
-    if (!build || exceedsLimit) return;
-    onInsert(build.node);
-    close();
   };
 
   return (
@@ -271,21 +234,11 @@ export function ImportDialog({
               <p className="text-muted-foreground text-sm">
                 총 {totalRows}행 × {totalCols}열
               </p>
-              {useDataset && (
-                <Alert variant="info">
-                  <AlertDescription>
-                    대용량 표라 데이터 그리드 블록으로 저장돼요(스크롤·편집
-                    가능).
-                  </AlertDescription>
-                </Alert>
-              )}
-              {exceedsLimit && (
-                <Alert variant="destructive">
-                  <AlertDescription>
-                    노트가 너무 커서 이 표를 넣을 수 없어요.
-                  </AlertDescription>
-                </Alert>
-              )}
+              <Alert variant="info">
+                <AlertDescription>
+                  표는 데이터 그리드 블록으로 저장돼요(스크롤·편집 가능).
+                </AlertDescription>
+              </Alert>
             </>
           )}
         </div>

--- a/fe/src/features/note/import/datasetImport.test.ts
+++ b/fe/src/features/note/import/datasetImport.test.ts
@@ -1,41 +1,96 @@
-import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
 
-import { shouldUseDataset } from "./datasetImport";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
 
-describe("shouldUseDataset", () => {
-  it("소형 표는 native(false)", () => {
-    expect(
-      shouldUseDataset(
-        {
-          headers: ["a", "b"],
-          rows: [
-            ["1", "2"],
-            ["3", "4"],
-          ],
-        },
-        30,
-        200,
-      ),
-    ).toBe(false);
-  });
+import { createDatasetFromTable, createEmptyDataset } from "./datasetImport";
 
-  it("열 상한 초과 → dataset(true)", () => {
-    const wide = Array.from({ length: 31 }, (_, i) => `c${i}`);
-    expect(shouldUseDataset({ headers: wide, rows: [wide] }, 30, 200)).toBe(
-      true,
+const API_BASE = "https://api.orino.dev/api";
+
+describe("datasetImport", () => {
+  let columns: { key: string; label: string }[] | null;
+  let bulk: string[][] | null;
+
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+    columns = null;
+    bulk = null;
+    server.use(
+      http.post(`${API_BASE}/datasets`, async ({ request }) => {
+        const body = (await request.json()) as { columns: typeof columns };
+        columns = body.columns;
+        return HttpResponse.json({
+          code: "OK",
+          data: { id: 7, columns: body.columns, rowCount: 0 },
+        });
+      }),
+      http.post(`${API_BASE}/datasets/7/rows/bulk`, async ({ request }) => {
+        const body = (await request.json()) as { rows: string[][] };
+        bulk = body.rows;
+        return HttpResponse.json({
+          code: "OK",
+          data: { id: 7, columns: [], rowCount: body.rows.length },
+        });
+      }),
     );
   });
 
-  it("행 상한 초과 → dataset(true)", () => {
-    const rows = Array.from({ length: 201 }, () => ["x"]);
-    expect(shouldUseDataset({ headers: null, rows }, 30, 200)).toBe(true);
+  describe("createEmptyDataset", () => {
+    it("기본 3×3 빈 dataset을 만든다", async () => {
+      const id = await createEmptyDataset();
+
+      expect(id).toBe(7);
+      expect(columns).toEqual([
+        { key: "c0", label: "열 1" },
+        { key: "c1", label: "열 2" },
+        { key: "c2", label: "열 3" },
+      ]);
+      expect(bulk).toEqual([
+        ["", "", ""],
+        ["", "", ""],
+        ["", "", ""],
+      ]);
+    });
+
+    it("행 0개면 벌크 호출을 생략한다", async () => {
+      await createEmptyDataset(2, 0);
+
+      expect(columns).toHaveLength(2);
+      expect(bulk).toBeNull();
+    });
   });
 
-  it("셀 임계치(2000) 초과 → dataset(true)", () => {
-    // 100행 × 21열 = 2100셀 (열·행 상한은 안 넘지만 셀 임계 초과)
-    const rows = Array.from({ length: 100 }, () =>
-      Array.from({ length: 21 }, () => "x"),
-    );
-    expect(shouldUseDataset({ headers: null, rows }, 30, 200)).toBe(true);
+  describe("createDatasetFromTable", () => {
+    it("헤더가 있으면 라벨로 컬럼을 만들고 본문을 벌크 업로드한다", async () => {
+      await createDatasetFromTable({
+        headers: ["이름", "점수"],
+        rows: [["김", "9"]],
+      });
+
+      expect(columns).toEqual([
+        { key: "c0", label: "이름" },
+        { key: "c1", label: "점수" },
+      ]);
+      expect(bulk).toEqual([["김", "9"]]);
+    });
+
+    it("헤더가 없으면 열 N 라벨을 만든다", async () => {
+      await createDatasetFromTable({ headers: null, rows: [["a", "b"]] });
+
+      expect(columns).toEqual([
+        { key: "c0", label: "열 1" },
+        { key: "c1", label: "열 2" },
+      ]);
+    });
+
+    it("빈 헤더 라벨은 열 N으로 대체한다", async () => {
+      await createDatasetFromTable({ headers: ["", "x"], rows: [] });
+
+      expect(columns?.[0].label).toBe("열 1");
+      expect(columns?.[1].label).toBe("x");
+      // rows 0개 → 벌크 생략
+      expect(bulk).toBeNull();
+    });
   });
 });

--- a/fe/src/features/note/import/datasetImport.ts
+++ b/fe/src/features/note/import/datasetImport.ts
@@ -6,11 +6,12 @@ import {
 
 import type { NormalizedTable } from "./tableContent";
 
-/** 이 셀 수를 넘으면 native 표 대신 데이터셋 그리드 블록으로 삽입한다. */
-export const DATASET_CELL_THRESHOLD = 2000;
-
 /** 벌크 업로드 청크 크기(BE 최대 2000행). */
 const BULK_CHUNK = 1000;
+
+/** 툴바 "표 삽입" 기본 크기(열·행). */
+export const DEFAULT_COLS = 3;
+export const DEFAULT_ROWS = 3;
 
 function columnCount(table: NormalizedTable): number {
   return Math.max(
@@ -20,19 +21,12 @@ function columnCount(table: NormalizedTable): number {
   );
 }
 
-/**
- * 표가 native Tiptap 표 상한(열/행)이나 셀 임계치를 넘어 데이터셋 그리드 블록으로
- * 가야 하는지. 소형은 가벼운 native 표, 대형은 별도 dataset + 가상화 그리드.
- */
-export function shouldUseDataset(
-  table: NormalizedTable,
-  maxCols: number,
-  maxRows: number,
-): boolean {
-  const cols = columnCount(table);
-  const rows = table.rows.length;
-  const cells = cols * (rows + (table.headers ? 1 : 0));
-  return cols > maxCols || rows > maxRows || cells > DATASET_CELL_THRESHOLD;
+/** 열 개수만큼 `열 N` 라벨의 기본 컬럼을 만든다. */
+function defaultColumns(cols: number): DatasetColumn[] {
+  return Array.from({ length: cols }, (_, i) => ({
+    key: `c${i}`,
+    label: `열 ${i + 1}`,
+  }));
 }
 
 /** 정규화 표 → dataset 생성 + 행 벌크 업로드(청크). datasetId 반환. */
@@ -45,14 +39,29 @@ export async function createDatasetFromTable(
         key: `c${i}`,
         label: label || `열 ${i + 1}`,
       }))
-    : Array.from({ length: cols }, (_, i) => ({
-        key: `c${i}`,
-        label: `열 ${i + 1}`,
-      }));
+    : defaultColumns(cols);
 
   const dataset = await createDataset(columns);
   for (let i = 0; i < table.rows.length; i += BULK_CHUNK) {
     await bulkAppendRows(dataset.id, table.rows.slice(i, i + BULK_CHUNK));
+  }
+  return dataset.id;
+}
+
+/**
+ * 빈 dataset(열 라벨 `열 N`, 빈 셀 rows행)을 생성한다. 툴바 "표 삽입"용.
+ * datasetId 반환.
+ */
+export async function createEmptyDataset(
+  cols = DEFAULT_COLS,
+  rows = DEFAULT_ROWS,
+): Promise<number> {
+  const dataset = await createDataset(defaultColumns(cols));
+  if (rows > 0) {
+    const emptyRows = Array.from({ length: rows }, () =>
+      Array.from({ length: cols }, () => ""),
+    );
+    await bulkAppendRows(dataset.id, emptyRows);
   }
   return dataset.id;
 }


### PR DESCRIPTION
## 이슈
closes #784

## 작업 내용
native 표 제거 → dataset 그리드 단일화의 **1단계**. TableKit은 유지한 채(구·신 병존) 새 표 생성 경로를 전부 dataset으로 전환한다. 이 단계 이후에는 native 표가 더 이상 새로 생기지 않아, 후속 마이그레이션(#785)·native 제거(#786)의 선행이 된다.

- **툴바 "표 삽입"**: native `insertTable(3×3)` → 빈 dataset(3열 `열 1/2/3` × 3행) 생성 후 `datasetTable` 블록 삽입. `createEmptyDataset` 헬퍼 추가. 생성 중 중복 클릭 방지(pending), 실패 시 toast
- **Import**: `shouldUseDataset` 크기 분기 제거 → 크기 무관 전부 `createDatasetFromTable` + `datasetTable`. native 경로(`buildTableNode`)·노트 1MB 가드(`wouldExceedNoteLimit`)·`currentDoc` prop 제거
- **TableKit 유지**: 기존 노트에 저장된 native 표는 계속 렌더/편집됨(마이그레이션 #785 전까지 데이터 보존)

> `tableContent.ts`의 native 빌더와 툴바 표편집 그룹은 이 PR에서 제거하지 않는다 — 레거시 표가 남아 있는 동안 필요하며 #786에서 정리한다.

## 검증
- FE 전체 테스트 통과: **331 tests / 71 files** (`tsc -b`·eslint·prettier clean)
  - `datasetImport.test`: `createEmptyDataset`(3×3·행0), `createDatasetFromTable`(헤더/무헤더/빈 라벨) 요청 바디 검증
  - `ImportDialog.test`: 소·대형 무관 datasetTable 삽입, 머리글 토글별 컬럼/행 검증
  - `NoteTab.test`: 툴바 표 삽입 → DatasetGrid 렌더, Import → DatasetGrid 렌더, **기존 native 표 라운드트립 렌더 유지**
- ⚠️ 로컬 브라우저 실동작 확인은 BE(MySQL·Redis) 스택 기동이 필요해 별도 확인 예정. 통합 테스트가 API 경계(POST /datasets·bulk, GET meta·rows)를 MSW로 재현해 세 흐름을 커버함