### PR TITLE
chore : 레거시 native 표 → datasetTable 일괄 마이그레이션

### DIFF
--- a/fe/eslint.config.js
+++ b/fe/eslint.config.js
@@ -33,5 +33,12 @@ export default tseslint.config(
       "simple-import-sort/exports": "error",
     },
   },
+  // 일회성 Node 스크립트(빌드 대상 아님) — node 전역 허용.
+  {
+    files: ["scripts/**/*.ts"],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
   prettier,
 );

--- a/fe/scripts/migrate-tables-to-datasets.ts
+++ b/fe/scripts/migrate-tables-to-datasets.ts
@@ -1,0 +1,153 @@
+/**
+ * 레거시 native 표(`table` 노드) → dataset 그리드 일괄 마이그레이션 (일회성).
+ *
+ * 노트 본문을 순회하며 TableKit `table` 노드를 dataset(+dataset_row)으로 옮기고
+ * `datasetTable` 참조 노드로 치환한다. 변환 규칙(컬럼 생성)은 앱의 표 삽입·Import와
+ * 동일한 순수 함수(datasetColumns·tableMigration)를 그대로 재사용한다(SSOT).
+ *
+ * 사용법:
+ *   # dry-run(기본) — 변환 대상·손실 경고만 리포트, 서버 변경 없음
+ *   ORINO_TOKEN=<accessToken> npx tsx scripts/migrate-tables-to-datasets.ts
+ *
+ *   # 실제 적용
+ *   ORINO_TOKEN=<accessToken> DRY_RUN=false npx tsx scripts/migrate-tables-to-datasets.ts
+ *
+ * 환경변수:
+ *   ORINO_TOKEN     (필수) 브라우저 devtools 요청의 Authorization 헤더 Bearer 값
+ *   ORINO_API_BASE  (기본 https://api.orino.dev/api)
+ *   ORINO_TIMEZONE  (기본 Asia/Seoul) 서버 X-Timezone 헤더
+ *   DRY_RUN         (기본 true) "false"일 때만 실제 dataset 생성·노트 저장
+ */
+import type { JSONContent } from "@tiptap/react";
+import axios from "axios";
+
+import { buildDatasetColumns } from "../src/features/note/import/datasetColumns";
+import type { NormalizedTable } from "../src/features/note/import/tableContent";
+import { migrateDocTables } from "../src/features/note/import/tableMigration";
+
+const API_BASE = process.env.ORINO_API_BASE ?? "https://api.orino.dev/api";
+const TOKEN = process.env.ORINO_TOKEN;
+const TIMEZONE = process.env.ORINO_TIMEZONE ?? "Asia/Seoul";
+const DRY_RUN = process.env.DRY_RUN !== "false";
+/** BE 벌크 한 요청당 행 상한(2000)보다 작게. */
+const BULK_CHUNK = 1000;
+
+if (!TOKEN) {
+  console.error("ORINO_TOKEN 환경변수가 필요합니다.");
+  process.exit(1);
+}
+
+const api = axios.create({
+  baseURL: API_BASE,
+  headers: { Authorization: `Bearer ${TOKEN}`, "X-Timezone": TIMEZONE },
+});
+
+interface Envelope<T> {
+  code: string;
+  data: T;
+}
+interface TreeNode {
+  id: number;
+  children: TreeNode[];
+}
+
+function flattenIds(nodes: TreeNode[]): number[] {
+  const ids: number[] = [];
+  const walk = (n: TreeNode) => {
+    ids.push(n.id);
+    (n.children ?? []).forEach(walk);
+  };
+  nodes.forEach(walk);
+  return ids;
+}
+
+/** 독립 노트 + 모든 학습자료 노트를 합쳐 전체 노트 id를 모은다(중복 제거). */
+async function allNoteIds(): Promise<number[]> {
+  const ids = new Set<number>();
+
+  const independent = await api.get<Envelope<{ notes: TreeNode[] }>>("/notes");
+  flattenIds(independent.data.data.notes).forEach((id) => ids.add(id));
+
+  const materials =
+    await api.get<Envelope<{ materials: { id: number }[] }>>(
+      "/planner/materials",
+    );
+  for (const material of materials.data.data.materials) {
+    const tree = await api.get<Envelope<{ notes: TreeNode[] }>>("/notes", {
+      params: { materialId: material.id },
+    });
+    flattenIds(tree.data.data.notes).forEach((id) => ids.add(id));
+  }
+
+  return [...ids];
+}
+
+/** apply 모드 convert: dataset 생성 + 행 벌크 업로드 후 datasetId 반환. */
+async function createDatasetFromTable(table: NormalizedTable): Promise<number> {
+  const created = await api.post<Envelope<{ id: number }>>("/datasets", {
+    columns: buildDatasetColumns(table),
+  });
+  const datasetId = created.data.data.id;
+  for (let i = 0; i < table.rows.length; i += BULK_CHUNK) {
+    await api.post(`/datasets/${datasetId}/rows/bulk`, {
+      rows: table.rows.slice(i, i + BULK_CHUNK),
+    });
+  }
+  return datasetId;
+}
+
+async function main(): Promise<void> {
+  console.log(`[migrate] API=${API_BASE} DRY_RUN=${DRY_RUN}`);
+  const noteIds = await allNoteIds();
+  console.log(`[migrate] 노트 ${noteIds.length}개 스캔`);
+
+  let totalTables = 0;
+  let changedNotes = 0;
+  const warnCount: Record<string, number> = {};
+  // dry-run은 서버를 건드리지 않는 로컬 스텁(id 0)을 쓴다.
+  const convert = DRY_RUN
+    ? async () => 0
+    : (table: NormalizedTable) => createDatasetFromTable(table);
+
+  for (const noteId of noteIds) {
+    const detail = await api.get<
+      Envelope<{ content: JSONContent; title: string }>
+    >(`/notes/${noteId}`);
+    const { content, title } = detail.data.data;
+    const { doc, converted, warnings } = await migrateDocTables(
+      content,
+      convert,
+    );
+    if (converted === 0) continue;
+
+    totalTables += converted;
+    changedNotes += 1;
+    for (const w of warnings) warnCount[w.kind] = (warnCount[w.kind] ?? 0) + 1;
+    console.log(
+      `  note#${noteId} "${title}" — 표 ${converted}개` +
+        (warnings.length ? `, 손실 경고 ${warnings.length}` : ""),
+    );
+
+    if (!DRY_RUN) await api.patch(`/notes/${noteId}`, { content: doc });
+  }
+
+  console.log(
+    `\n[migrate] ${DRY_RUN ? "(dry-run) " : ""}표 ${totalTables}개 / 노트 ${changedNotes}개 ` +
+      (DRY_RUN ? "변환 예정" : "변환 완료"),
+  );
+  if (Object.keys(warnCount).length) {
+    console.log(
+      "[migrate] 손실 경고:",
+      Object.entries(warnCount)
+        .map(([kind, n]) => `${kind}=${n}`)
+        .join(", "),
+    );
+  }
+  if (DRY_RUN) console.log("[migrate] 실제 적용하려면 DRY_RUN=false 로 재실행");
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error("[migrate] 실패:", message);
+  process.exit(1);
+});

--- a/fe/src/features/note/import/datasetColumns.ts
+++ b/fe/src/features/note/import/datasetColumns.ts
@@ -1,0 +1,36 @@
+import type { DatasetColumn } from "@/features/note/dataset/api/datasets";
+
+import type { NormalizedTable } from "./tableContent";
+
+/** 툴바 "표 삽입" 기본 크기(열·행). */
+export const DEFAULT_COLS = 3;
+export const DEFAULT_ROWS = 3;
+
+/** 정규화 표의 실제 열 개수(헤더/본문 중 최대 폭). */
+export function columnCount(table: NormalizedTable): number {
+  return Math.max(
+    table.headers?.length ?? 0,
+    ...table.rows.map((r) => r.length),
+    0,
+  );
+}
+
+/** 열 개수만큼 `열 N` 라벨의 기본 컬럼을 만든다. */
+export function defaultColumns(cols: number): DatasetColumn[] {
+  return Array.from({ length: cols }, (_, i) => ({
+    key: `c${i}`,
+    label: `열 ${i + 1}`,
+  }));
+}
+
+/**
+ * 정규화 표 → dataset 컬럼 메타. 표 삽입·Import·마이그레이션이 모두 이 규칙을
+ * 공유한다(SSOT). key는 안정 식별자 `cN`, label은 헤더 값(없거나 빈 값이면 `열 N`).
+ */
+export function buildDatasetColumns(table: NormalizedTable): DatasetColumn[] {
+  if (!table.headers) return defaultColumns(columnCount(table));
+  return table.headers.map((label, i) => ({
+    key: `c${i}`,
+    label: label || `열 ${i + 1}`,
+  }));
+}

--- a/fe/src/features/note/import/datasetImport.ts
+++ b/fe/src/features/note/import/datasetImport.ts
@@ -1,47 +1,24 @@
 import {
   bulkAppendRows,
   createDataset,
-  type DatasetColumn,
 } from "@/features/note/dataset/api/datasets";
 
+import {
+  buildDatasetColumns,
+  DEFAULT_COLS,
+  DEFAULT_ROWS,
+  defaultColumns,
+} from "./datasetColumns";
 import type { NormalizedTable } from "./tableContent";
 
 /** 벌크 업로드 청크 크기(BE 최대 2000행). */
 const BULK_CHUNK = 1000;
 
-/** 툴바 "표 삽입" 기본 크기(열·행). */
-export const DEFAULT_COLS = 3;
-export const DEFAULT_ROWS = 3;
-
-function columnCount(table: NormalizedTable): number {
-  return Math.max(
-    table.headers?.length ?? 0,
-    ...table.rows.map((r) => r.length),
-    0,
-  );
-}
-
-/** 열 개수만큼 `열 N` 라벨의 기본 컬럼을 만든다. */
-function defaultColumns(cols: number): DatasetColumn[] {
-  return Array.from({ length: cols }, (_, i) => ({
-    key: `c${i}`,
-    label: `열 ${i + 1}`,
-  }));
-}
-
 /** 정규화 표 → dataset 생성 + 행 벌크 업로드(청크). datasetId 반환. */
 export async function createDatasetFromTable(
   table: NormalizedTable,
 ): Promise<number> {
-  const cols = columnCount(table);
-  const columns: DatasetColumn[] = table.headers
-    ? table.headers.map((label, i) => ({
-        key: `c${i}`,
-        label: label || `열 ${i + 1}`,
-      }))
-    : defaultColumns(cols);
-
-  const dataset = await createDataset(columns);
+  const dataset = await createDataset(buildDatasetColumns(table));
   for (let i = 0; i < table.rows.length; i += BULK_CHUNK) {
     await bulkAppendRows(dataset.id, table.rows.slice(i, i + BULK_CHUNK));
   }

--- a/fe/src/features/note/import/tableMigration.test.ts
+++ b/fe/src/features/note/import/tableMigration.test.ts
@@ -1,0 +1,222 @@
+import type { JSONContent } from "@tiptap/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { migrateDocTables, tableNodeToNormalized } from "./tableMigration";
+
+const para = (text?: string): JSONContent =>
+  text == null
+    ? { type: "paragraph" }
+    : { type: "paragraph", content: [{ type: "text", text }] };
+
+const cell = (
+  text: string | undefined,
+  attrs?: Record<string, unknown>,
+): JSONContent => ({
+  type: "tableCell",
+  content: [para(text)],
+  ...(attrs ? { attrs } : {}),
+});
+
+const header = (text: string): JSONContent => ({
+  type: "tableHeader",
+  content: [para(text)],
+});
+
+const row = (cells: JSONContent[]): JSONContent => ({
+  type: "tableRow",
+  content: cells,
+});
+
+describe("tableNodeToNormalized", () => {
+  it("첫 행이 전부 tableHeader면 headers로 승격하고 나머지는 본문", () => {
+    const table: JSONContent = {
+      type: "table",
+      content: [
+        row([header("H1"), header("H2")]),
+        row([cell("a"), cell("b")]),
+        row([cell("c"), cell("d")]),
+      ],
+    };
+
+    const { normalized, warnings } = tableNodeToNormalized(table);
+
+    expect(normalized.headers).toEqual(["H1", "H2"]);
+    expect(normalized.rows).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("헤더 행이 없으면 headers=null, 전부 본문", () => {
+    const table: JSONContent = {
+      type: "table",
+      content: [row([cell("a"), cell("b")]), row([cell("c"), cell("d")])],
+    };
+
+    const { normalized } = tableNodeToNormalized(table);
+
+    expect(normalized.headers).toBeNull();
+    expect(normalized.rows).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+  });
+
+  it("여러 문단 셀은 줄바꿈으로 잇고 빈 문단은 빈 문자열", () => {
+    const table: JSONContent = {
+      type: "table",
+      content: [
+        row([
+          { type: "tableCell", content: [para("l1"), para("l2")] },
+          cell(undefined),
+        ]),
+      ],
+    };
+
+    const { normalized } = tableNodeToNormalized(table);
+
+    expect(normalized.rows).toEqual([["l1\nl2", ""]]);
+  });
+
+  it("colspan은 빈 열로 펼치고 경고를 남긴다", () => {
+    const table: JSONContent = {
+      type: "table",
+      content: [row([cell("x", { colspan: 2 }), cell("y")])],
+    };
+
+    const { normalized, warnings } = tableNodeToNormalized(table);
+
+    expect(normalized.rows).toEqual([["x", "", "y"]]);
+    expect(warnings.map((w) => w.kind)).toContain("colspan");
+  });
+
+  it("rowspan과 셀 내 이미지는 경고로 남기되 텍스트는 보존", () => {
+    const table: JSONContent = {
+      type: "table",
+      content: [
+        row([
+          {
+            type: "tableCell",
+            attrs: { rowspan: 2 },
+            content: [
+              {
+                type: "paragraph",
+                content: [
+                  { type: "image", attrs: { src: "x" } },
+                  { type: "text", text: "설명" },
+                ],
+              },
+            ],
+          },
+        ]),
+      ],
+    };
+
+    const { normalized, warnings } = tableNodeToNormalized(table);
+
+    expect(normalized.rows).toEqual([["설명"]]);
+    const kinds = warnings.map((w) => w.kind);
+    expect(kinds).toContain("rowspan");
+    expect(kinds).toContain("image");
+  });
+});
+
+describe("migrateDocTables", () => {
+  it("본문 중 table을 datasetTable로 치환하고 주변 노드는 보존한다", async () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        para("앞 문단"),
+        {
+          type: "table",
+          content: [row([header("A")]), row([cell("1")])],
+        },
+        para("뒤 문단"),
+      ],
+    };
+    const convert = vi.fn(async () => 42);
+
+    const {
+      doc: out,
+      converted,
+      warnings,
+    } = await migrateDocTables(doc, convert);
+
+    expect(converted).toBe(1);
+    expect(warnings).toHaveLength(0);
+    expect(out.content).toEqual([
+      para("앞 문단"),
+      { type: "datasetTable", attrs: { datasetId: 42 } },
+      para("뒤 문단"),
+    ]);
+    expect(convert).toHaveBeenCalledTimes(1);
+    expect(convert).toHaveBeenCalledWith({
+      headers: ["A"],
+      rows: [["1"]],
+    });
+  });
+
+  it("표가 여러 개면 순서대로 각기 다른 datasetId로 치환한다", async () => {
+    const table = (v: string): JSONContent => ({
+      type: "table",
+      content: [row([cell(v)])],
+    });
+    const doc: JSONContent = {
+      type: "doc",
+      content: [table("first"), table("second")],
+    };
+    let next = 100;
+    const convert = vi.fn(async () => next++);
+
+    const { doc: out, converted } = await migrateDocTables(doc, convert);
+
+    expect(converted).toBe(2);
+    expect(out.content).toEqual([
+      { type: "datasetTable", attrs: { datasetId: 100 } },
+      { type: "datasetTable", attrs: { datasetId: 101 } },
+    ]);
+  });
+
+  it("표가 없으면 doc을 그대로 두고 convert를 호출하지 않는다", async () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [para("그냥 텍스트")],
+    };
+    const convert = vi.fn(async () => 1);
+
+    const { converted, doc: out } = await migrateDocTables(doc, convert);
+
+    expect(converted).toBe(0);
+    expect(convert).not.toHaveBeenCalled();
+    expect(out).toEqual(doc);
+  });
+
+  it("열이 없는 표는 건너뛰고 emptyTable 경고를 남긴다", async () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        { type: "table", content: [{ type: "tableRow", content: [] }] },
+      ],
+    };
+    const convert = vi.fn(async () => 1);
+
+    const { converted, warnings } = await migrateDocTables(doc, convert);
+
+    expect(converted).toBe(0);
+    expect(convert).not.toHaveBeenCalled();
+    expect(warnings.map((w) => w.kind)).toContain("emptyTable");
+  });
+
+  it("원본 doc은 변경하지 않는다(불변)", async () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [{ type: "table", content: [row([cell("x")])] }],
+    };
+    const snapshot = JSON.stringify(doc);
+
+    await migrateDocTables(doc, async () => 7);
+
+    expect(JSON.stringify(doc)).toBe(snapshot);
+  });
+});

--- a/fe/src/features/note/import/tableMigration.ts
+++ b/fe/src/features/note/import/tableMigration.ts
@@ -1,0 +1,148 @@
+import type { JSONContent } from "@tiptap/react";
+
+import { columnCount } from "./datasetColumns";
+import type { NormalizedTable } from "./tableContent";
+
+/**
+ * 레거시 native Tiptap 표(`table` 노드)를 datasetTable로 옮길 때 발생하는 손실.
+ * dataset 셀은 평문 문자열이라 서식/이미지/병합은 그대로 보존되지 않는다.
+ */
+export interface MigrationWarning {
+  kind: "colspan" | "rowspan" | "image" | "emptyTable";
+  detail: string;
+}
+
+/** 노드 트리에서 텍스트만 모은다(서식 제거). 이미지 노드는 경고로 남긴다. */
+function collectText(
+  node: JSONContent,
+  parts: string[],
+  warnings: MigrationWarning[],
+): void {
+  if (!node || typeof node !== "object") return;
+  if (node.type === "text" && typeof node.text === "string") {
+    parts.push(node.text);
+  } else if (node.type === "image") {
+    warnings.push({
+      kind: "image",
+      detail: "셀 안의 이미지는 텍스트로 보존되지 않습니다",
+    });
+  }
+  if (Array.isArray(node.content)) {
+    for (const child of node.content) {
+      collectText(child as JSONContent, parts, warnings);
+    }
+  }
+}
+
+/** 셀(tableHeader|tableCell)의 텍스트. 블록(문단 등)은 줄바꿈으로 잇는다. */
+function cellText(cell: JSONContent, warnings: MigrationWarning[]): string {
+  const blocks = Array.isArray(cell.content) ? cell.content : [];
+  return blocks
+    .map((block) => {
+      const parts: string[] = [];
+      collectText(block as JSONContent, parts, warnings);
+      return parts.join("");
+    })
+    .join("\n");
+}
+
+/**
+ * native `table` 노드 → NormalizedTable + 손실 경고.
+ * 첫 행의 셀이 전부 tableHeader면 headers로 승격하고 나머지를 본문으로 둔다.
+ * colspan은 빈 열을 채워 정렬을 맞추고, rowspan/이미지는 경고만 남긴다.
+ */
+export function tableNodeToNormalized(table: JSONContent): {
+  normalized: NormalizedTable;
+  warnings: MigrationWarning[];
+} {
+  const warnings: MigrationWarning[] = [];
+  const tableRows = (Array.isArray(table.content) ? table.content : []).filter(
+    (r): r is JSONContent =>
+      !!r && typeof r === "object" && (r as JSONContent).type === "tableRow",
+  );
+
+  let headers: string[] | null = null;
+  const rows: string[][] = [];
+
+  tableRows.forEach((row, rowIndex) => {
+    const cells = Array.isArray(row.content)
+      ? (row.content as JSONContent[])
+      : [];
+    const allHeader =
+      cells.length > 0 && cells.every((c) => c.type === "tableHeader");
+
+    const line: string[] = [];
+    for (const cell of cells) {
+      const colspan = Number(cell.attrs?.colspan ?? 1) || 1;
+      const rowspan = Number(cell.attrs?.rowspan ?? 1) || 1;
+      if (colspan > 1) {
+        warnings.push({
+          kind: "colspan",
+          detail: `병합 셀(colspan=${colspan})을 빈 열로 펼쳤습니다`,
+        });
+      }
+      if (rowspan > 1) {
+        warnings.push({
+          kind: "rowspan",
+          detail: `세로 병합(rowspan=${rowspan})은 첫 행에만 값이 남습니다`,
+        });
+      }
+      line.push(cellText(cell, warnings));
+      for (let k = 1; k < colspan; k++) line.push("");
+    }
+
+    if (rowIndex === 0 && allHeader) headers = line;
+    else rows.push(line);
+  });
+
+  return { normalized: { headers, rows }, warnings };
+}
+
+export interface MigrationResult {
+  /** 변환된 새 doc. 원본은 수정하지 않는다. */
+  doc: JSONContent;
+  /** datasetTable로 치환된 표 개수. */
+  converted: number;
+  warnings: MigrationWarning[];
+}
+
+/**
+ * doc을 순회하며 모든 `table` 노드를 datasetTable 참조 노드로 치환한다.
+ * convert(정규화표)는 dataset을 만들고 datasetId를 돌려주는 주입 함수다
+ * (앱에선 createDatasetFromTable, dry-run에선 로컬 스텁). 열이 0개인 표는 건너뛴다.
+ */
+export async function migrateDocTables(
+  doc: JSONContent,
+  convert: (table: NormalizedTable) => Promise<number>,
+): Promise<MigrationResult> {
+  const warnings: MigrationWarning[] = [];
+  let converted = 0;
+
+  const walk = async (node: JSONContent): Promise<JSONContent> => {
+    if (node.type === "table") {
+      const { normalized, warnings: w } = tableNodeToNormalized(node);
+      warnings.push(...w);
+      if (columnCount(normalized) === 0) {
+        warnings.push({
+          kind: "emptyTable",
+          detail: "열이 없는 표라 변환하지 않고 그대로 두었습니다",
+        });
+        return node;
+      }
+      const datasetId = await convert(normalized);
+      converted += 1;
+      return { type: "datasetTable", attrs: { datasetId } };
+    }
+    if (Array.isArray(node.content)) {
+      const content: JSONContent[] = [];
+      for (const child of node.content as JSONContent[]) {
+        content.push(await walk(child));
+      }
+      return { ...node, content };
+    }
+    return node;
+  };
+
+  const migrated = await walk(doc);
+  return { doc: migrated, converted, warnings };
+}


### PR DESCRIPTION
## 이슈
closes #785

## 작업 내용
native 표 제거 → dataset 단일화의 **2단계**. 기존 노트에 저장된 native `table` 노드를 dataset(+dataset_row)으로 옮기고 `datasetTable` 참조 노드로 치환한다. #784(진입점 전환) 이후엔 새 native 표가 생기지 않으므로, 이걸 실행해 잔여분을 정리하면 #786(TableKit 제거)을 안전하게 진행할 수 있다.

### 변환 규칙은 앱과 공유 (SSOT)
- `datasetColumns.ts`(신규): 컬럼 생성 규칙(`cN` key, 헤더값 or `열 N` label)을 **순수 모듈로 추출**. 표 삽입·Import·마이그레이션이 모두 이걸 재사용 → 마이그레이션 산출물이 라이브 import 경로와 동일. (BE는 columns를 저장만 하는 덤프 스토어라 이 규칙은 FE가 유일 소스)
- `datasetImport.ts`: 위 순수 규칙을 재사용하도록 리팩터(동작 불변)

### 변환기 (`tableMigration.ts`, 순수·주입식)
- `tableNodeToNormalized`: `table` 노드 → `NormalizedTable`. 첫 행이 전부 `tableHeader`면 headers로 승격, colspan은 빈 열로 펼침
- `migrateDocTables(doc, convert)`: doc 순회하며 `table` → `datasetTable{datasetId}` 치환(원본 불변). `convert`는 dataset 생성 함수를 주입 → 앱/스크립트/테스트가 동일 로직 공유
- **손실은 경고로 표면화**: 셀 서식/이미지→평문, 병합(colspan/rowspan)→펼침/경고, 열 0개 표→스킵

### 실행 스크립트 (`scripts/migrate-tables-to-datasets.ts`, 일회성)
- 독립 노트 + 전 학습자료 노트를 전수 열거 → 표 포함 노트만 변환
- **dry-run 기본**(서버 변경 없이 대상·경고 리포트), `DRY_RUN=false`일 때만 실제 적용
- 실행: \`ORINO_TOKEN=<accessToken> npx tsx scripts/migrate-tables-to-datasets.ts\`

## 검증
- FE 전체 테스트 통과(`tsc -b`·eslint·prettier clean), `tableMigration` 유닛 35케이스(헤더 승격/무헤더/멀티문단/colspan/rowspan·이미지 경고/치환·순서/무표/빈표/불변)
- 로컬 목 서버로 스크립트 end-to-end 실증:
  - **dry-run**: 노트 전수 스캔·표 감지·리포트, 서버 쓰기 0
  - **apply**: `POST /datasets {columns:[{c0,"과목"}]}` → `bulk {rows:[["쿠버네티스"]]}` → `PATCH /notes/10`에 table이 `datasetTable{datasetId}`로 치환된 content 저장, 앞뒤 노드 보존 확인
- ⚠️ **실제 프로드 적용은 개발자 몫**: #784 배포 후 dry-run으로 대상 확인 → `DRY_RUN=false` 실행 → 잔여 `table` 노드 0개 확인 → #786 진행

관련: #784(선행 완료) · #786(후행)