### PR TITLE
feat : 데이터 그리드 열 이름 변경(rename)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -6,6 +6,7 @@ import ds.project.orino.planner.dataset.dto.CreateDatasetRequest;
 import ds.project.orino.planner.dataset.dto.DatasetResponse;
 import ds.project.orino.planner.dataset.dto.InsertRowRequest;
 import ds.project.orino.planner.dataset.dto.InsertRowResponse;
+import ds.project.orino.planner.dataset.dto.RenameColumnRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
@@ -59,6 +60,16 @@ public class DatasetController {
             @PathVariable Long id) {
         datasetService.delete(memberId, id);
         return ResponseEntity.noContent().build();
+    }
+
+    /** 열 이름 변경. key는 불변이며 label만 바꾼다. */
+    @PatchMapping("/{id}/columns/{key}")
+    public ApiResponse<DatasetResponse> renameColumn(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable String key,
+            @Valid @RequestBody RenameColumnRequest request) {
+        return ApiResponse.success(datasetService.renameColumn(memberId, id, key, request));
     }
 
     /** Import 청크 — 행을 끝에 벌크 추가. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RenameColumnRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RenameColumnRequest.java
@@ -1,0 +1,11 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RenameColumnRequest(
+        @NotBlank(message = "label은 필수입니다.")
+        @Size(max = 255, message = "label은 255자 이하여야 합니다.")
+        String label
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -12,6 +12,7 @@ import ds.project.orino.planner.dataset.dto.DatasetColumn;
 import ds.project.orino.planner.dataset.dto.DatasetResponse;
 import ds.project.orino.planner.dataset.dto.InsertRowRequest;
 import ds.project.orino.planner.dataset.dto.InsertRowResponse;
+import ds.project.orino.planner.dataset.dto.RenameColumnRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
@@ -57,6 +58,32 @@ public class DatasetService {
     public DatasetResponse getMeta(Long memberId, Long datasetId) {
         Dataset dataset = getOwned(memberId, datasetId);
         return DatasetResponse.of(dataset, parseColumns(dataset.getColumns()));
+    }
+
+    /**
+     * 열 이름(label) 변경. key는 cells 배열의 위치와 묶인 식별자라 바꾸지 않으며,
+     * columns_json만 갱신하므로 행 데이터는 건드리지 않는다.
+     */
+    @Transactional
+    public DatasetResponse renameColumn(Long memberId, Long datasetId, String key,
+                                        RenameColumnRequest request) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        int at = -1;
+        for (int i = 0; i < columns.size(); i++) {
+            if (columns.get(i).key().equals(key)) {
+                at = i;
+                break;
+            }
+        }
+        if (at < 0) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+
+        List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
+        updated.set(at, new DatasetColumn(key, request.label()));
+        dataset.updateColumns(serialize(updated));
+        return DatasetResponse.of(dataset, updated);
     }
 
     /** 행 벌크 추가(끝에 append). Import 청크에 사용. */

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -210,6 +210,55 @@ class DatasetControllerTest extends ApiTestSupport {
     }
 
     @Test
+    @DisplayName("PATCH column - label이 변경되고 행 데이터는 그대로다")
+    void rename_column() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}", id, "c1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"최종점수\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns", hasSize(2)))
+                .andExpect(jsonPath("$.data.columns[0].label").value("과목"))
+                .andExpect(jsonPath("$.data.columns[1].key").value("c1"))
+                .andExpect(jsonPath("$.data.columns[1].label").value("최종점수"));
+
+        mockMvc.perform(get("/api/datasets/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.columns[1].label").value("최종점수"));
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows", hasSize(1)))
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value("네트워크"))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("92"));
+    }
+
+    @Test
+    @DisplayName("PATCH column - 없는 key면 404")
+    void rename_missing_column_404() throws Exception {
+        long id = createDataset();
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}", id, "c9")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"x\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("PATCH column - label이 비면 400")
+    void rename_blank_label_400() throws Exception {
+        long id = createDataset();
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}", id, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"  \"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("타인 dataset 접근 시 404")
     void other_member_404() throws Exception {
         long id = createDataset();
@@ -218,6 +267,11 @@ class DatasetControllerTest extends ApiTestSupport {
 
         mockMvc.perform(get("/api/datasets/{id}", id)
                         .header(HttpHeaders.AUTHORIZATION, otherAuth))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}", id, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, otherAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"해킹\"}"))
                 .andExpect(status().isNotFound());
         mockMvc.perform(post("/api/datasets/{id}/rows/bulk", id)
                         .header(HttpHeaders.AUTHORIZATION, otherAuth)

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -128,6 +128,63 @@ describe("DatasetGrid", () => {
     await waitFor(() => expect(inserted).toBe(true));
   });
 
+  it("열 헤더를 더블클릭해 편집하면 PATCH로 저장하고 새 이름을 보여준다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let renamed: { key: string; label: string } | null = null;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/columns/:key`,
+        async ({ params, request }) => {
+          const body = (await request.json()) as { label: string };
+          renamed = { key: String(params.key), label: body.label };
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              id: 1,
+              columns: [
+                { key: "c0", label: "과목" },
+                { key: "c1", label: body.label },
+              ],
+              rowCount: 1,
+            },
+          });
+        },
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    fireEvent.doubleClick(await screen.findByText("점수"));
+    const input = await screen.findByLabelText("열 이름 c1");
+    fireEvent.change(input, { target: { value: "최종점수" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(renamed).toEqual({ key: "c1", label: "최종점수" });
+    });
+    expect(await screen.findByText("최종점수")).toBeInTheDocument();
+  });
+
+  it("열 이름을 비우면 PATCH를 보내지 않는다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let called = false;
+    server.use(
+      http.patch(`${API_BASE}/datasets/1/columns/:key`, () => {
+        called = true;
+        return new HttpResponse(null, { status: 400 });
+      }),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    fireEvent.doubleClick(await screen.findByText("점수"));
+    const input = await screen.findByLabelText("열 이름 c1");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // 편집이 닫히고 원래 이름이 남는다
+    expect(await screen.findByText("점수")).toBeInTheDocument();
+    expect(called).toBe(false);
+  });
+
   it("행 삭제 버튼으로 DELETE를 호출한다", async () => {
     mockDataset([["네트워크", "92"]]);
     let deleted: number | null = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -15,8 +15,10 @@ import { LoadingText } from "@/components/ui/loading-text";
 import { cn } from "@/lib/utils";
 
 import {
+  type DatasetMeta,
   deleteDatasetRow,
   insertDatasetRow,
+  renameDatasetColumn,
   updateDatasetRow,
 } from "./api/datasets";
 import { useDatasetMeta } from "./hooks/useDatasetMeta";
@@ -40,6 +42,8 @@ export function DatasetGrid({ datasetId }: Props) {
     null,
   );
   const [draft, setDraft] = useState("");
+  const [editingCol, setEditingCol] = useState<string | null>(null);
+  const [colDraft, setColDraft] = useState("");
 
   const colCount = meta?.columns.length ?? 0;
   const rowCount = meta?.rowCount ?? 0;
@@ -65,6 +69,13 @@ export function DatasetGrid({ datasetId }: Props) {
       reset();
       void invalidateMeta();
     },
+  });
+  const renameColMut = useMutation({
+    mutationFn: (v: { key: string; label: string }) =>
+      renameDatasetColumn(datasetId, v.key, v.label),
+    onSuccess: (next: DatasetMeta) =>
+      queryClient.setQueryData(datasetKeys.meta(datasetId), next),
+    onError: () => void invalidateMeta(),
   });
 
   // TanStack Table — 열/헤더 모델만(본문은 가상화로 직접 렌더).
@@ -129,6 +140,22 @@ export function DatasetGrid({ datasetId }: Props) {
   const addRow = () =>
     insertMut.mutate(Array.from({ length: colCount }, () => ""));
 
+  const startColEdit = (key: string, label: string) => {
+    setEditingCol(key);
+    setColDraft(label);
+  };
+
+  const commitColEdit = () => {
+    if (!editingCol) return;
+    const key = editingCol;
+    const label = colDraft.trim();
+    const current = meta.columns.find((c) => c.key === key);
+    setEditingCol(null);
+    // 빈 이름은 서버가 거부하므로 보내지 않고, 변경 없으면 요청 자체를 생략한다.
+    if (!label || label === current?.label) return;
+    renameColMut.mutate({ key, label });
+  };
+
   return (
     <div
       className="border-border bg-card my-2 flex flex-col overflow-hidden rounded-md border"
@@ -146,11 +173,38 @@ export function DatasetGrid({ datasetId }: Props) {
           style={{ gridTemplateColumns }}
         >
           {table.getFlatHeaders().map((header) => (
-            <div
-              key={header.id}
-              className="border-border truncate border-r px-2 py-1.5"
-            >
-              {flexRender(header.column.columnDef.header, header.getContext())}
+            <div key={header.id} className="border-border border-r">
+              {editingCol === header.id ? (
+                <input
+                  autoFocus
+                  value={colDraft}
+                  onChange={(e) => setColDraft(e.target.value)}
+                  onBlur={commitColEdit}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") commitColEdit();
+                    if (e.key === "Escape") setEditingCol(null);
+                  }}
+                  aria-label={`열 이름 ${header.id}`}
+                  className="focus-visible:ring-ring h-full w-full bg-transparent px-2 py-1.5 font-semibold outline-none focus-visible:ring-1"
+                />
+              ) : (
+                <div
+                  className="cursor-text truncate px-2 py-1.5"
+                  title="더블클릭해 열 이름 변경"
+                  onDoubleClick={() =>
+                    startColEdit(
+                      header.id,
+                      meta.columns.find((c) => c.key === header.id)?.label ??
+                        "",
+                    )
+                  }
+                >
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext(),
+                  )}
+                </div>
+              )}
             </div>
           ))}
           <div aria-hidden />

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -57,6 +57,19 @@ export async function fetchDatasetMeta(
   return data.data;
 }
 
+/** 열 이름 변경. key는 cells 위치와 묶인 식별자라 바뀌지 않고 label만 바뀐다. */
+export async function renameDatasetColumn(
+  datasetId: number,
+  key: string,
+  label: string,
+): Promise<DatasetMeta> {
+  const { data } = await client.patch<ApiEnvelope<DatasetMeta>>(
+    `/datasets/${datasetId}/columns/${key}`,
+    { label },
+  );
+  return data.data;
+}
+
 export async function fetchDatasetRows(
   datasetId: number,
   offset: number,


### PR DESCRIPTION
## 이슈
closes #792
## 작업 내용
- `PATCH /api/datasets/{id}/columns/{key}` 추가 — 열 `label`만 변경
- `key`는 `cells` 배열 위치와 묶인 식별자라 불변으로 두고, `columns_json`만 갱신해 **행 데이터는 건드리지 않는다**
- 정의만 있고 호출부가 0건이던 `Dataset.updateColumns()`에 실제 호출부 연결
- FE: 열 헤더 더블클릭 → 인라인 편집(Enter 저장 / Escape 취소), 응답 메타로 캐시 갱신
- FE: 빈 이름·변경 없음이면 요청 자체를 생략

### 배경
착수 시점에 #778의 "열 rename/add 외 삭제·순서 변경" 전제가 틀렸음을 확인했다. `/columns` 엔드포인트가 없고 `Dataset.updateColumns()`는 dead code라 **rename/add/delete/reorder 넷 다 미구현**이었다. 4건(#792~#795)으로 분리했고 그중 rename만 다룬다.

rename은 넷 중 유일하게 행 데이터를 안 건드린다. add/delete/reorder는 `cells`가 위치 기반 배열이라 전 행 재작성이 필요해 저장 방식 결정(#793)이 선행되어야 한다.

## 테스트
- BE 통합 3건: rename 반영+행 불변 / 없는 key 404 / 빈 label 400, 타인 dataset 404에 열 조작 케이스 추가
- FE 2건: 헤더 더블클릭→PATCH→새 이름 표시 / 빈 이름이면 미전송
- `./gradlew check`, `npm test`(324건), `format:check`, `lint` 통과

## 로컬 확인
MySQL 8.4.4 + Redis 컨테이너에 `bootRun`으로 직접 확인:
- curl: rename 200 → 메타 재조회 시 유지, 행 `cells` 그대로, 빈 label 400, 없는 key 404
- 브라우저: 노트에 표 삽입 → 헤더 더블클릭 → "최종점수" 입력 → `PATCH /api/datasets/2/columns/c1` 200 → **새로고침 후에도 유지**, Escape 시 요청 없이 원복
- DB에 UTF-8로 정상 저장 확인(HEX 대조)
