### PR TITLE
refactor : dataset cells를 key 기반 맵으로 전환

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -22,8 +22,18 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.json.JsonMapper;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
+/**
+ * 데이터셋 CRUD.
+ *
+ * <p>저장소의 {@code dataset_row.cells}는 열 key 기반 맵({@code {"c0":"a","c1":"b"}})이지만,
+ * API 계약({@link RowView#cells})은 위치 배열이다. 경계에서 {@code columns_json} 순서로
+ * 투영·역투영한다({@link #toCellList}/{@link #toCellMap}). 덕분에 열 추가·삭제·순서변경이
+ * columns_json 갱신만으로 끝나고(행 무손상), 클라이언트는 여전히 직사각형 표만 다루면 된다.
+ */
 @Service
 @Transactional(readOnly = true)
 public class DatasetService {
@@ -31,7 +41,7 @@ public class DatasetService {
     private static final JsonMapper MAPPER = JsonMapper.builder().build();
     private static final TypeReference<List<DatasetColumn>> COLUMNS_TYPE = new TypeReference<>() {
     };
-    private static final TypeReference<List<String>> CELLS_TYPE = new TypeReference<>() {
+    private static final TypeReference<Map<String, String>> CELLS_TYPE = new TypeReference<>() {
     };
 
     static final int DEFAULT_PAGE_SIZE = 100;
@@ -61,7 +71,7 @@ public class DatasetService {
     }
 
     /**
-     * 열 이름(label) 변경. key는 cells 배열의 위치와 묶인 식별자라 바꾸지 않으며,
+     * 열 이름(label) 변경. key는 cells 맵의 주소라 바꾸지 않으며(바꾸면 기존 값과 연결이 끊긴다),
      * columns_json만 갱신하므로 행 데이터는 건드리지 않는다.
      */
     @Transactional
@@ -94,8 +104,8 @@ public class DatasetService {
         if (rows.size() > MAX_BULK_ROWS) {
             throw new CustomException(ErrorCode.INVALID_REQUEST);
         }
-        int colCount = parseColumns(dataset.getColumns()).size();
-        long totalCells = (long) (dataset.getRowCount() + rows.size()) * colCount;
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        long totalCells = (long) (dataset.getRowCount() + rows.size()) * columns.size();
         if (totalCells > MAX_CELLS) {
             throw new CustomException(ErrorCode.INVALID_REQUEST);
         }
@@ -103,43 +113,47 @@ public class DatasetService {
         int start = dataset.getRowCount();
         List<DatasetRow> entities = new java.util.ArrayList<>(rows.size());
         for (int i = 0; i < rows.size(); i++) {
-            entities.add(new DatasetRow(datasetId, start + i, serialize(rows.get(i))));
+            entities.add(new DatasetRow(datasetId, start + i, toCellMap(rows.get(i), columns)));
         }
         rowRepository.saveAll(entities);
         dataset.setRowCount(start + rows.size());
-        return DatasetResponse.of(dataset, parseColumns(dataset.getColumns()));
+        return DatasetResponse.of(dataset, columns);
     }
 
     public RowsResponse getRows(Long memberId, Long datasetId, Integer offset, Integer limit) {
-        getOwned(memberId, datasetId);
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
         int off = offset == null ? 0 : Math.max(0, offset);
         int lim = clampLimit(limit);
         List<RowView> rows = rowRepository
                 .findByDatasetIdAndRowIndexGreaterThanEqualAndRowIndexLessThanOrderByRowIndexAsc(
                         datasetId, off, off + lim)
                 .stream()
-                .map(r -> new RowView(r.getRowIndex(), parseCells(r.getCells())))
+                .map(r -> new RowView(r.getRowIndex(), toCellList(r.getCells(), columns)))
                 .toList();
         return new RowsResponse(rows, off, lim);
     }
 
     @Transactional
     public RowView updateRow(Long memberId, Long datasetId, int rowIndex, UpdateRowRequest request) {
-        getOwned(memberId, datasetId);
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
         DatasetRow row = rowRepository.findByDatasetIdAndRowIndex(datasetId, rowIndex)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
-        row.updateCells(serialize(request.cells()));
-        return new RowView(rowIndex, request.cells());
+        row.updateCells(toCellMap(request.cells(), columns));
+        // 저장된 값을 그대로 되돌려준다(열 수에 맞춰 잘리거나 채워진 결과).
+        return new RowView(rowIndex, toCellList(row.getCells(), columns));
     }
 
     @Transactional
     public InsertRowResponse insertRow(Long memberId, Long datasetId, InsertRowRequest request) {
         Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
         int rowCount = dataset.getRowCount();
         int at = request.atIndex() == null
                 ? rowCount
                 : Math.max(0, Math.min(request.atIndex(), rowCount));
-        long totalCells = (long) (rowCount + 1) * parseColumns(dataset.getColumns()).size();
+        long totalCells = (long) (rowCount + 1) * columns.size();
         if (totalCells > MAX_CELLS) {
             throw new CustomException(ErrorCode.INVALID_REQUEST);
         }
@@ -147,7 +161,7 @@ public class DatasetService {
         if (at < rowCount) {
             rowRepository.shiftUp(datasetId, at); // 뒤 행을 밀어 자리 확보(flush)
         }
-        rowRepository.save(new DatasetRow(datasetId, at, serialize(request.cells())));
+        rowRepository.save(new DatasetRow(datasetId, at, toCellMap(request.cells(), columns)));
         dataset.setRowCount(rowCount + 1);
         return new InsertRowResponse(at);
     }
@@ -197,11 +211,34 @@ public class DatasetService {
         }
     }
 
-    private List<String> parseCells(String json) {
+    private Map<String, String> parseCells(String json) {
         try {
             return MAPPER.readValue(json, CELLS_TYPE);
         } catch (JacksonException e) {
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, e);
         }
+    }
+
+    /** 저장소 맵 → API 위치 배열. 열 순서대로 뽑고, 값이 없는 열은 빈 문자열로 채운다. */
+    private List<String> toCellList(String cellsJson, List<DatasetColumn> columns) {
+        Map<String, String> cells = parseCells(cellsJson);
+        List<String> list = new java.util.ArrayList<>(columns.size());
+        for (DatasetColumn column : columns) {
+            list.add(cells.getOrDefault(column.key(), ""));
+        }
+        return list;
+    }
+
+    /**
+     * API 위치 배열 → 저장소 맵. 열 순서로 짝지으며, 열 수를 넘는 값은 담을 key가 없어 버린다.
+     * 열 수보다 짧으면 나머지 열은 빈 문자열로 채워 직사각형을 유지한다.
+     */
+    private String toCellMap(List<String> cells, List<DatasetColumn> columns) {
+        Map<String, String> map = new LinkedHashMap<>();
+        for (int i = 0; i < columns.size(); i++) {
+            String value = i < cells.size() ? cells.get(i) : null;
+            map.put(columns.get(i).key(), value == null ? "" : value);
+        }
+        return serialize(map);
     }
 }

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/038-dataset-cells-to-map.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/038-dataset-cells-to-map.yaml
@@ -1,0 +1,83 @@
+databaseChangeLog:
+  # dataset_row.cells를 위치 기반 배열 → key 기반 맵으로 전환 (#793).
+  #
+  # 배열(["네트워크","92"])은 열 위치와 값이 묶여 있어, 열 추가·삭제·순서변경 때마다
+  # 그 dataset의 모든 행을 재작성해야 했다(O(행수)). key 맵({"c0":"네트워크","c1":"92"})으로
+  # 두면 열 조작이 columns_json 갱신만으로 끝난다(O(1)).
+  #
+  # API 계약(RowView.cells)은 위치 배열 그대로다. DatasetService가 columns_json 순서로
+  # 맵을 투영해 배열로 내보내고, 쓰기 때 되돌린다. 그래서 FE는 이 변경의 영향을 받지 않는다.
+  - changeSet:
+      id: 038-dataset-cells-to-map
+      author: wcorn
+      comment: dataset_row.cells 배열 → columns_json의 key 기반 맵으로 백필.
+      preConditions:
+        - onFail: MARK_RAN
+        - tableExists:
+            tableName: dataset_row
+      changes:
+        # JSON_TABLE로 columns_json을 (순번, key)로 펼친 뒤, 같은 순번의 배열 원소와 짝지어
+        # JSON_OBJECTAGG로 맵을 만든다. FOR ORDINALITY는 1-base라 배열 인덱스는 ord-1.
+        # 열 수보다 짧은 행(패딩 안 된 legacy)은 해당 key를 빈 문자열로 채운다.
+        - sql:
+            dbms: mysql
+            comment: 배열 형태인 행만 맵으로 변환(이미 맵이면 건너뜀 → 재실행 안전).
+            sql: |
+              UPDATE dataset_row r
+              JOIN dataset d ON d.id = r.dataset_id
+              SET r.cells = COALESCE(
+                (
+                  SELECT JSON_OBJECTAGG(
+                           c.col_key,
+                           COALESCE(
+                             JSON_UNQUOTE(
+                               JSON_EXTRACT(r.cells, CONCAT('$[', c.ord - 1, ']'))
+                             ),
+                             ''
+                           )
+                         )
+                  FROM JSON_TABLE(
+                         d.columns_json,
+                         '$[*]' COLUMNS (
+                           ord FOR ORDINALITY,
+                           col_key VARCHAR(64) PATH '$.key'
+                         )
+                       ) AS c
+                ),
+                JSON_OBJECT()
+              )
+              WHERE JSON_TYPE(r.cells) = 'ARRAY';
+      rollback:
+        # 맵 → 배열 복원. columns_json 순서대로 값을 뽑아 JSON_ARRAYAGG로 되돌린다.
+        # 주의: MySQL은 JSON_ARRAYAGG가 파생 테이블의 ORDER BY를 따르는 것을 보장하지 않는다.
+        # 실측(8.4.4)으로는 순서가 유지되나, 복구 후 열 순서를 눈으로 확인할 것.
+        - sql:
+            dbms: mysql
+            sql: |
+              UPDATE dataset_row r
+              JOIN dataset d ON d.id = r.dataset_id
+              SET r.cells = COALESCE(
+                (
+                  SELECT JSON_ARRAYAGG(
+                           COALESCE(
+                             JSON_UNQUOTE(
+                               JSON_EXTRACT(r.cells, CONCAT('$."', c.col_key, '"'))
+                             ),
+                             ''
+                           )
+                         )
+                  FROM (
+                         SELECT col_key, ord
+                         FROM JSON_TABLE(
+                                d.columns_json,
+                                '$[*]' COLUMNS (
+                                  ord FOR ORDINALITY,
+                                  col_key VARCHAR(64) PATH '$.key'
+                                )
+                              ) AS t
+                         ORDER BY ord
+                       ) AS c
+                ),
+                JSON_ARRAY()
+              )
+              WHERE JSON_TYPE(r.cells) = 'OBJECT';

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -73,3 +73,5 @@ databaseChangeLog:
       file: db/changelog/changes/036-add-review-schedule-completed-index.yaml
   - include:
       file: db/changelog/changes/037-create-dataset.yaml
+  - include:
+      file: db/changelog/changes/038-dataset-cells-to-map.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -210,6 +210,83 @@ class DatasetControllerTest extends ApiTestSupport {
     }
 
     @Test
+    @DisplayName("cells는 열 key 기반 맵으로 저장된다(API 계약은 위치 배열 유지)")
+    void cells_stored_as_key_map() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        String stored = datasetRowRepository.findByDatasetIdAndRowIndex(id, 0)
+                .orElseThrow().getCells();
+        org.assertj.core.api.Assertions.assertThat(stored)
+                .contains("\"c0\"").contains("\"c1\"")
+                .contains("네트워크").contains("92")
+                .doesNotStartWith("[");
+
+        // 저장 포맷이 바뀌어도 응답은 위치 배열 그대로다.
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value("네트워크"))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("92"));
+    }
+
+    @Test
+    @DisplayName("PATCH row - 열 수보다 짧은 cells는 빈 값으로 채워진다")
+    void update_row_pads_short_cells() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", id, 0)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"운영체제\"]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.cells", hasSize(2)))
+                .andExpect(jsonPath("$.data.cells[1]").value(""));
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells", hasSize(2)))
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value("운영체제"))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value(""));
+    }
+
+    @Test
+    @DisplayName("PATCH row - 열 수를 넘는 cells는 담을 key가 없어 버려진다")
+    void update_row_drops_excess_cells() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", id, 0)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"운영체제\",\"78\",\"초과분\"]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.cells", hasSize(2)));
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells", hasSize(2)))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("78"));
+    }
+
+    @Test
+    @DisplayName("열 이름을 바꿔도 key가 그대로라 셀 값이 유지된다")
+    void rename_column_keeps_cell_values() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}", id, "c1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"최종점수\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("92"));
+    }
+
+    @Test
     @DisplayName("PATCH column - label이 변경되고 행 데이터는 그대로다")
     void rename_column() throws Exception {
         long id = createDataset();

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetRow.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetRow.java
@@ -8,7 +8,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 /**
- * 데이터셋의 한 행. {@code cells}는 값만 담은 문자열 배열 JSON({@code ["a","b",...]}).
+ * 데이터셋의 한 행. {@code cells}는 열 key를 주소로 쓰는 맵 JSON({@code {"c0":"a","c1":"b"}}).
+ * 위치가 아닌 key에 값을 묶어, 열 추가·삭제·순서변경이 행을 건드리지 않게 한다.
  * {@code rowIndex}(0-base)로 정렬·페이지네이션한다. dataset 삭제 시 cascade.
  */
 @Entity


### PR DESCRIPTION
## 이슈
#793 의 선행 작업 (열 추가 API·UI는 후속 PR)
## 작업 내용
`dataset_row.cells`를 **위치 배열 → 열 key 기반 맵**으로 전환한다. #793의 결정(B)을 이행하는 저장소 변경만 담고, 열 추가 기능은 후속 PR로 뺐다.

- 저장소: `["네트워크","92"]` → `{"c0":"네트워크","c1":"92"}`
- **API 계약은 위치 배열 그대로 유지.** `DatasetService`가 경계에서 `columns_json` 순서로 투영(`toCellList`)·역투영(`toCellMap`)한다
- Liquibase `038` changeSet으로 기존 데이터 백필 (`JSON_TABLE` + `JSON_OBJECTAGG`). 배열인 행만 대상이라 재실행 안전, rollback도 정의
- 열 수보다 짧은 `cells`는 빈 값으로 채우고, 넘는 값은 담을 key가 없어 버린다
- 낡은 주석 정리: `DatasetRow` Javadoc, `renameColumn`의 "key는 배열 위치와 묶인 식별자" 서술

### 왜 API는 그대로 두나
수식 지원 계획을 감안해도 이 선택이 유리하다. 수식이 요구하는 건 "값이 안정적 key로 주소화될 것" = **저장소** 요구이고 이미 충족된다. 수식이 오면 셀은 `string`이 아니라 `{raw, value}` 객체가 되어 API가 어차피 바뀌므로, 지금 wire format을 건드리면 FE를 두 번 고치게 된다.

부수 효과로 `MAX_CELLS`의 `rowCount * colCount` 계산이 그대로 유효하다 (API가 직사각형을 유지하므로 sparse 문제 없음).

### 후속 (열 추가 PR에서 다룰 것)
- **key 재사용 금지**: 지운 열의 key를 재사용하면 orphan 값이 되살아난다. 새 열 key는 "기존 최대 인덱스+1"로 할당해야 한다 (현재 `datasetColumns.ts`의 `c${i}`는 열 순번 파생이라 그대로 두면 밟는다)
- 열 삭제 시 행에 남는 orphan key 정리 정책

## 테스트
- **기존 테스트 13건 무수정 통과** — 순수 리팩터링이라 이게 검증 기준
- 신규 4건: 맵 저장 확인(API는 배열 유지) / 짧은 cells 패딩 / 초과 cells 버림 / rename 후 값 유지
- **FE 변경 0** — `fe/` 무수정으로 324건 통과
- `./gradlew check` 통과

## 로컬 확인
MySQL 8.4.4 컨테이너 + `bootRun`:
- 038 이전 형태(배열) 데이터를 심고 changelog를 되감아 **Liquibase 경로로 실제 백필 실행** → 맵 전환 확인, 짧은 행(`["짧은행"]`)도 `{"c0":"짧은행","c1":""}`로 정상 보정
- 마이그레이션된 데이터를 API로 조회 → **위치 배열 그대로 반환**(계약 유지), 수정 시 맵으로 저장, rename 후에도 값 유지
- 브라우저: **무수정 FE**로 표 삽입·셀 편집 → `{"c0":"브라우저입력","c1":"","c2":""}` 저장 확인
- 마이그레이션 SQL은 정상/빈값/짧은행/초과행/빈배열/이미맵 6개 케이스로 사전 검증, 멱등성·rollback 확인
