### PR TITLE
feat : 데이터 그리드 열 추가(add)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -1,6 +1,7 @@
 package ds.project.orino.planner.dataset.controller;
 
 import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.dataset.dto.AddColumnRequest;
 import ds.project.orino.planner.dataset.dto.BulkRowsRequest;
 import ds.project.orino.planner.dataset.dto.CreateDatasetRequest;
 import ds.project.orino.planner.dataset.dto.DatasetResponse;
@@ -60,6 +61,16 @@ public class DatasetController {
             @PathVariable Long id) {
         datasetService.delete(memberId, id);
         return ResponseEntity.noContent().build();
+    }
+
+    /** 열 추가(끝에). key는 서버가 발급하며 기존 행은 건드리지 않는다. */
+    @PostMapping("/{id}/columns")
+    public ResponseEntity<ApiResponse<DatasetResponse>> addColumn(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @Valid @RequestBody AddColumnRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(datasetService.addColumn(memberId, id, request)));
     }
 
     /** 열 이름 변경. key는 불변이며 label만 바꾼다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/AddColumnRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/AddColumnRequest.java
@@ -1,0 +1,12 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/** 열 추가 요청. key는 서버가 발급하므로 label만 받는다. */
+public record AddColumnRequest(
+        @NotBlank(message = "label은 필수입니다.")
+        @Size(max = 255, message = "label은 255자 이하여야 합니다.")
+        String label
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -6,6 +6,7 @@ import ds.project.orino.domain.planner.dataset.entity.Dataset;
 import ds.project.orino.domain.planner.dataset.entity.DatasetRow;
 import ds.project.orino.domain.planner.dataset.repository.DatasetRepository;
 import ds.project.orino.domain.planner.dataset.repository.DatasetRowRepository;
+import ds.project.orino.planner.dataset.dto.AddColumnRequest;
 import ds.project.orino.planner.dataset.dto.BulkRowsRequest;
 import ds.project.orino.planner.dataset.dto.CreateDatasetRequest;
 import ds.project.orino.planner.dataset.dto.DatasetColumn;
@@ -25,6 +26,8 @@ import tools.jackson.databind.json.JsonMapper;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * 데이터셋 CRUD.
@@ -49,6 +52,11 @@ public class DatasetService {
     static final int MAX_BULK_ROWS = 2000;
     /** 데이터셋 전체 셀 상한(폭주 방지). */
     static final long MAX_CELLS = 1_000_000L;
+    /** 열 개수 상한. 행이 0이면 MAX_CELLS가 열 증가를 못 막으므로 별도로 둔다. */
+    static final int MAX_COLUMNS = 100;
+
+    /** 열 key 규칙: {@code c<발급번호>}. 번호는 dataset의 next_column_seq에서 받는다. */
+    private static final Pattern COLUMN_KEY = Pattern.compile("c(\\d+)");
 
     private final DatasetRepository datasetRepository;
     private final DatasetRowRepository rowRepository;
@@ -60,9 +68,51 @@ public class DatasetService {
 
     @Transactional
     public DatasetResponse create(Long memberId, CreateDatasetRequest request) {
-        Dataset dataset = datasetRepository.save(
-                new Dataset(memberId, serialize(request.columns())));
+        if (request.columns().size() > MAX_COLUMNS) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        Dataset dataset = datasetRepository.save(new Dataset(
+                memberId, serialize(request.columns()), nextSeqFor(request.columns())));
         return DatasetResponse.of(dataset, request.columns());
+    }
+
+    /**
+     * 생성 시 카운터 시작값. 클라이언트가 보낸 key 중 {@code c<N>} 규칙에 맞는 최대 N보다 1 크게 잡아,
+     * 이후 발급될 key가 기존 열과 겹치지 않게 한다.
+     */
+    private int nextSeqFor(List<DatasetColumn> columns) {
+        int max = -1;
+        for (DatasetColumn column : columns) {
+            Matcher matcher = COLUMN_KEY.matcher(column.key());
+            if (matcher.matches()) {
+                max = Math.max(max, Integer.parseInt(matcher.group(1)));
+            }
+        }
+        return max + 1;
+    }
+
+    /**
+     * 열 추가. columns_json에 append만 하고 행은 건드리지 않는다 — 기존 행엔 새 key가 없고,
+     * 읽을 때 투영이 빈 값으로 채운다. 그래서 행 수와 무관하게 O(1)이다.
+     *
+     * <p>key는 dataset의 카운터에서 발급받는다. 지워진 열의 key를 다시 쓰면 행에 남은 옛 값이
+     * 새 열에 되살아나므로, 현재 열의 최대 번호가 아니라 발급 이력을 기준으로 삼는다.
+     */
+    @Transactional
+    public DatasetResponse addColumn(Long memberId, Long datasetId, AddColumnRequest request) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        if (columns.size() + 1 > MAX_COLUMNS) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        if ((long) dataset.getRowCount() * (columns.size() + 1) > MAX_CELLS) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
+        updated.add(new DatasetColumn("c" + dataset.issueColumnSeq(), request.label()));
+        dataset.updateColumns(serialize(updated));
+        return DatasetResponse.of(dataset, updated);
     }
 
     public DatasetResponse getMeta(Long memberId, Long datasetId) {

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/039-dataset-next-column-seq.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/039-dataset-next-column-seq.yaml
@@ -1,0 +1,41 @@
+databaseChangeLog:
+  # 열 key 발급용 단조 증가 카운터 (#793).
+  #
+  # cells가 key 기반 맵(038)이 되면서 열 key는 값의 주소가 됐다. 그래서 key를 재사용하면
+  # 안 된다 — c2를 지운 뒤 새 열에 c2를 다시 발급하면, 행에 남아 있던 옛 c2 값이
+  # 새 열의 값으로 되살아난다. 수식이 들어오면 참조가 조용히 다른 데이터에 재바인딩된다.
+  #
+  # "현재 열의 최대 인덱스 + 1"은 삭제 후 최대값이 내려가므로 이 문제를 막지 못한다.
+  # dataset마다 발급 이력을 기억하는 카운터를 두고 한 방향으로만 올린다.
+  - changeSet:
+      id: 039-dataset-next-column-seq
+      author: wcorn
+      comment: dataset.next_column_seq 추가 — 열 key 발급 카운터(재사용 방지).
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: dataset
+                columnName: next_column_seq
+      changes:
+        - addColumn:
+            tableName: dataset
+            columns:
+              - column:
+                  name: next_column_seq
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+        # 기존 dataset은 열이 c0..c(n-1) 규칙으로 만들어졌으므로 다음 발급 번호는 n이다.
+        - sql:
+            dbms: mysql
+            comment: 기존 dataset의 카운터를 현재 열 개수로 백필.
+            sql: |
+              UPDATE dataset
+              SET next_column_seq = JSON_LENGTH(columns_json)
+              WHERE next_column_seq = 0;
+      rollback:
+        - dropColumn:
+            tableName: dataset
+            columnName: next_column_seq

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -75,3 +75,5 @@ databaseChangeLog:
       file: db/changelog/changes/037-create-dataset.yaml
   - include:
       file: db/changelog/changes/038-dataset-cells-to-map.yaml
+  - include:
+      file: db/changelog/changes/039-dataset-next-column-seq.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -210,6 +210,114 @@ class DatasetControllerTest extends ApiTestSupport {
     }
 
     @Test
+    @DisplayName("POST column - 열이 끝에 추가되고 기존 행 값은 그대로, 새 열은 빈 값")
+    void add_column() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        mockMvc.perform(post("/api/datasets/{id}/columns", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"비고\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.columns", hasSize(3)))
+                .andExpect(jsonPath("$.data.columns[2].key").value("c2"))
+                .andExpect(jsonPath("$.data.columns[2].label").value("비고"))
+                .andExpect(jsonPath("$.data.rowCount").value(1));
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells", hasSize(3)))
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value("네트워크"))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("92"))
+                .andExpect(jsonPath("$.data.rows[0].cells[2]").value(""));
+    }
+
+    @Test
+    @DisplayName("열 추가는 행을 건드리지 않는다(저장된 맵에 새 key가 안 생김)")
+    void add_column_does_not_touch_rows() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+        String before = datasetRowRepository.findByDatasetIdAndRowIndex(id, 0)
+                .orElseThrow().getCells();
+
+        mockMvc.perform(post("/api/datasets/{id}/columns", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"비고\"}"))
+                .andExpect(status().isCreated());
+
+        String after = datasetRowRepository.findByDatasetIdAndRowIndex(id, 0)
+                .orElseThrow().getCells();
+        org.assertj.core.api.Assertions.assertThat(after)
+                .as("열 추가는 O(1)이어야 하므로 행 JSON이 그대로여야 한다")
+                .isEqualTo(before)
+                .doesNotContain("c2");
+    }
+
+    @Test
+    @DisplayName("열 key는 재사용되지 않는다 - 연속 추가 시 번호가 계속 올라간다")
+    void add_column_never_reuses_key() throws Exception {
+        long id = createDataset();
+
+        for (String label : new String[]{"셋째", "넷째"}) {
+            mockMvc.perform(post("/api/datasets/{id}/columns", id)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"label\":\"" + label + "\"}"))
+                    .andExpect(status().isCreated());
+        }
+
+        mockMvc.perform(get("/api/datasets/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.columns", hasSize(4)))
+                .andExpect(jsonPath("$.data.columns[2].key").value("c2"))
+                .andExpect(jsonPath("$.data.columns[3].key").value("c3"));
+    }
+
+    @Test
+    @DisplayName("POST column - label이 비면 400, 타인 dataset이면 404")
+    void add_column_validation() throws Exception {
+        long id = createDataset();
+        mockMvc.perform(post("/api/datasets/{id}/columns", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"  \"}"))
+                .andExpect(status().isBadRequest());
+
+        String otherAuth = "Bearer " + AuthFixture.loginAndGetAccessToken(
+                mockMvc, "other", "password");
+        mockMvc.perform(post("/api/datasets/{id}/columns", id)
+                        .header(HttpHeaders.AUTHORIZATION, otherAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"침입\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("추가한 열에 값을 쓰면 새 key로 저장된다")
+    void write_to_added_column() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+        mockMvc.perform(post("/api/datasets/{id}/columns", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"비고\"}"))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", id, 0)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"네트워크\",\"92\",\"재수강\"]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.cells[2]").value("재수강"));
+
+        org.assertj.core.api.Assertions.assertThat(
+                        datasetRowRepository.findByDatasetIdAndRowIndex(id, 0).orElseThrow().getCells())
+                .contains("\"c2\"").contains("재수강");
+    }
+
+    @Test
     @DisplayName("cells는 열 key 기반 맵으로 저장된다(API 계약은 위치 배열 유지)")
     void cells_stored_as_key_map() throws Exception {
         long id = createDataset();

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/Dataset.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/Dataset.java
@@ -37,6 +37,13 @@ public class Dataset {
     @Column(name = "row_count", nullable = false)
     private int rowCount;
 
+    /**
+     * 다음 열 key 발급 번호. key는 cells 맵의 주소라 재사용하면 지워진 열의 값이 되살아나므로,
+     * 열이 삭제돼도 되돌리지 않고 한 방향으로만 올린다.
+     */
+    @Column(name = "next_column_seq", nullable = false)
+    private int nextColumnSeq;
+
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private Instant createdAt;
@@ -48,14 +55,20 @@ public class Dataset {
     protected Dataset() {
     }
 
-    public Dataset(Long memberId, String columns) {
+    public Dataset(Long memberId, String columns, int nextColumnSeq) {
         this.memberId = memberId;
         this.columns = columns;
         this.rowCount = 0;
+        this.nextColumnSeq = nextColumnSeq;
     }
 
     public void updateColumns(String columns) {
         this.columns = columns;
+    }
+
+    /** 열 key 하나를 발급하고 카운터를 올린다. */
+    public int issueColumnSeq() {
+        return nextColumnSeq++;
     }
 
     public void setRowCount(int rowCount) {
@@ -76,6 +89,10 @@ public class Dataset {
 
     public int getRowCount() {
         return rowCount;
+    }
+
+    public int getNextColumnSeq() {
+        return nextColumnSeq;
     }
 
     public Instant getCreatedAt() {

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -128,6 +128,89 @@ describe("DatasetGrid", () => {
     await waitFor(() => expect(inserted).toBe(true));
   });
 
+  it("[열 추가]로 POST를 호출하고 새 열이 빈 칸으로 붙는다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let addedLabel: string | null = null;
+    server.use(
+      http.post(`${API_BASE}/datasets/1/columns`, async ({ request }) => {
+        const body = (await request.json()) as { label: string };
+        addedLabel = body.label;
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "점수" },
+              { key: "c2", label: body.label },
+            ],
+            rowCount: 1,
+          },
+        });
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    await screen.findByText("네트워크");
+    await user.click(screen.getByRole("button", { name: "열 추가" }));
+
+    await waitFor(() => expect(addedLabel).toBe("열 3"));
+    expect(await screen.findByText("열 3")).toBeInTheDocument();
+    // 행을 다시 받지 않으므로 기존 값이 깜빡임 없이 그대로 남는다.
+    expect(screen.getByText("네트워크")).toBeInTheDocument();
+    expect(screen.getByText("92")).toBeInTheDocument();
+  });
+
+  it("추가한 열의 셀을 편집하면 짧은 cells가 채워져 전송된다", async () => {
+    // 캐시된 행은 2칸인데 열은 3개 — 편집 시 빈 값으로 패딩돼야 한다.
+    mockDataset([["네트워크", "92"]]);
+    let patched: string[] | null = null;
+    server.use(
+      http.post(`${API_BASE}/datasets/1/columns`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "점수" },
+              { key: "c2", label: "열 3" },
+            ],
+            rowCount: 1,
+          },
+        }),
+      ),
+      http.patch(`${API_BASE}/datasets/1/rows/:i`, async ({ request }) => {
+        const body = (await request.json()) as { cells: string[] };
+        patched = body.cells;
+        return HttpResponse.json({
+          code: "OK",
+          data: { rowIndex: 0, cells: body.cells },
+        });
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    await screen.findByText("네트워크");
+    await user.click(screen.getByRole("button", { name: "열 추가" }));
+    await screen.findByText("열 3");
+
+    // 편집 전엔 input이 없어 라벨로 못 찾는다 — 행의 3번째 셀 div를 눌러 편집을 연다.
+    const thirdCell = document.querySelector(
+      '[data-testid="dataset-grid"] div[style*="translateY(0px)"] > div:nth-child(3)',
+    );
+    fireEvent.click(thirdCell!);
+    const input = await screen.findByLabelText("셀 1행 3열");
+    fireEvent.change(input, { target: { value: "재수강" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(patched).toEqual(["네트워크", "92", "재수강"]);
+    });
+  });
+
   it("열 헤더를 더블클릭해 편집하면 PATCH로 저장하고 새 이름을 보여준다", async () => {
     mockDataset([["네트워크", "92"]]);
     let renamed: { key: string; label: string } | null = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -15,6 +15,7 @@ import { LoadingText } from "@/components/ui/loading-text";
 import { cn } from "@/lib/utils";
 
 import {
+  addDatasetColumn,
   type DatasetMeta,
   deleteDatasetRow,
   insertDatasetRow,
@@ -73,6 +74,14 @@ export function DatasetGrid({ datasetId }: Props) {
   const renameColMut = useMutation({
     mutationFn: (v: { key: string; label: string }) =>
       renameDatasetColumn(datasetId, v.key, v.label),
+    onSuccess: (next: DatasetMeta) =>
+      queryClient.setQueryData(datasetKeys.meta(datasetId), next),
+    onError: () => void invalidateMeta(),
+  });
+  const addColMut = useMutation({
+    mutationFn: (label: string) => addDatasetColumn(datasetId, label),
+    // 행은 다시 받지 않는다. 새 열의 key는 방금 발급돼 어느 행에도 값이 없으므로,
+    // 캐시된 짧은 cells를 그대로 두면 렌더가 새 열을 빈 칸으로 그린다(편집 시 패딩됨).
     onSuccess: (next: DatasetMeta) =>
       queryClient.setQueryData(datasetKeys.meta(datasetId), next),
     onError: () => void invalidateMeta(),
@@ -139,6 +148,8 @@ export function DatasetGrid({ datasetId }: Props) {
 
   const addRow = () =>
     insertMut.mutate(Array.from({ length: colCount }, () => ""));
+
+  const addColumn = () => addColMut.mutate(`열 ${colCount + 1}`);
 
   const startColEdit = (key: string, label: string) => {
     setEditingCol(key);
@@ -207,7 +218,17 @@ export function DatasetGrid({ datasetId }: Props) {
               )}
             </div>
           ))}
-          <div aria-hidden />
+          {/* 행 삭제 버튼 열(44px) 위 자리 — 열 추가 버튼을 둔다. */}
+          <button
+            type="button"
+            aria-label="열 추가"
+            title="열 추가"
+            onClick={addColumn}
+            disabled={addColMut.isPending}
+            className="text-muted-foreground hover:text-foreground flex items-center justify-center disabled:opacity-50"
+          >
+            <Plus className="size-3.5" />
+          </button>
         </div>
 
         {/* 본문 (가상화) */}

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -57,7 +57,19 @@ export async function fetchDatasetMeta(
   return data.data;
 }
 
-/** 열 이름 변경. key는 cells 위치와 묶인 식별자라 바뀌지 않고 label만 바뀐다. */
+/** 열 추가(끝에). key는 서버가 발급한다. 기존 행은 서버에서 건드리지 않는다. */
+export async function addDatasetColumn(
+  datasetId: number,
+  label: string,
+): Promise<DatasetMeta> {
+  const { data } = await client.post<ApiEnvelope<DatasetMeta>>(
+    `/datasets/${datasetId}/columns`,
+    { label },
+  );
+  return data.data;
+}
+
+/** 열 이름 변경. key는 cells 맵의 주소라 바뀌지 않고 label만 바뀐다. */
 export async function renameDatasetColumn(
   datasetId: number,
   key: string,


### PR DESCRIPTION
## 이슈
closes #793
## 작업 내용
열 추가(add). #797(cells key 맵 전환)의 후속이자 #793의 본체.

- `POST /api/datasets/{id}/columns` — label만 받고 key는 서버가 발급
- **행을 건드리지 않는다(O(1)).** 기존 행엔 새 key가 없고, 읽을 때 투영이 빈 값으로 채운다. 이게 key 맵 전환의 목적이었다
- FE: 헤더 우측 `+` 버튼

### key 재사용 방지 — 039 카운터
#797에서 후속으로 남겨둔 항목을 여기서 닫는다. `dataset.next_column_seq`를 추가해 열 key를 발급한다.

`c2`를 지운 뒤 "현재 열의 최대 번호 + 1"로 발급하면 다시 `c2`가 나오고, 행에 남아 있던 **옛 `c2` 값이 새 열에 되살아난다.** 그래서 현재 열이 아니라 **발급 이력**을 기준으로 삼고, 열이 삭제돼도 카운터를 되돌리지 않는다. 수식이 들어오면 이 문제는 "참조가 조용히 다른 데이터에 재바인딩되는" 형태로 커진다.

기존 dataset은 `JSON_LENGTH(columns_json)`으로 백필한다(열이 `c0..c(n-1)` 규칙이므로 다음은 n).

### 그 밖의 선택
- **`MAX_COLUMNS = 100`**: 행이 0개면 `MAX_CELLS`(rowCount × colCount)가 열 증가를 전혀 못 막아 별도 상한이 필요했다. 100은 근거 있는 수치라기보다 정한 값이라, 이견 있으면 조정 가능하다.
- **열 추가 후 행을 refetch하지 않는다**: 새 key는 방금 발급돼 어느 행에도 값이 없으므로, 캐시된 짧은 `cells`를 그대로 두면 렌더가 새 열을 빈 칸으로 그린다(편집 시 `commitEdit`이 패딩). 불필요한 재조회와 깜빡임이 없다.

## 발견한 기존 버그 (이 PR에선 안 고침)
`useDatasetRows.reset()`은 캐시만 비우고 **스스로 재조회하지 않는다.** 재로드는 `ensureRange` effect가 `rowCount` 변화로 다시 돌 때 일어난다. 행 추가·삭제는 `rowCount`가 바뀌어 우연히 동작하지만, **`rowCount`가 안 바뀌는 호출자가 reset()을 쓰면 그리드가 `…` 상태로 영구히 멈춘다.**

처음에 열 추가 후 `reset()`을 호출했다가 테스트로 이 증상을 잡았다. 지금은 reset을 안 쓰는 쪽이 더 나은 구현이라 그렇게 바꿨고, 현재 트리거되는 호출자는 없다. 다만 잠복 지뢰라 별도 이슈로 올릴지 판단 필요.

## 테스트
- BE 5건 추가: 열 추가·투영 / **행 JSON 불변(O(1) 검증)** / key 미재사용 / label·소유권 검증 / 새 열 쓰기
- FE 2건 추가: `+` 버튼 → POST → 새 열이 빈 칸으로 붙고 기존 값 유지 / 추가한 열 편집 시 짧은 cells 패딩 전송
- 기존 테스트 전부 무수정 통과 (BE 22건, FE 326건), `./gradlew check` · format · lint 통과

## 로컬 확인
MySQL 8.4.4 + `bootRun`:
- **039 이전 상태를 재현**(next_column_seq 컬럼을 drop하고 changelog 되감기) → 재기동 시 Liquibase가 열 3개짜리 레거시 dataset의 카운터를 3으로 백필
- 그 dataset에 열 추가 → **`c3` 발급(기존 c0/c1/c2와 충돌 없음)**, 기존 값 보존, 새 열은 빈 값, **행 JSON에 `c3`가 안 생김**(행 무손상 확인), 카운터 4로 증가
- 브라우저: 표 삽입 → `+`로 열 추가 → 4열로 확장, 새 열에 입력 → `{"c0":"","c1":"","c2":"","c3":"새열값"}` 저장. **편집 안 한 행은 key 3개 그대로** 남아 있고 새로고침 시 4칸으로 정상 렌더 → 투영이 의도대로 동작
