### PR TITLE
feat : 데이터 그리드 열 삭제(delete)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -73,6 +73,15 @@ public class DatasetController {
                 .body(ApiResponse.success(datasetService.addColumn(memberId, id, request)));
     }
 
+    /** 열 삭제. 마지막 열은 지울 수 없다(400). */
+    @DeleteMapping("/{id}/columns/{key}")
+    public ApiResponse<DatasetResponse> deleteColumn(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable String key) {
+        return ApiResponse.success(datasetService.deleteColumn(memberId, id, key));
+    }
+
     /** 열 이름 변경. key는 불변이며 label만 바꾼다. */
     @PatchMapping("/{id}/columns/{key}")
     public ApiResponse<DatasetResponse> renameColumn(

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -121,6 +121,34 @@ public class DatasetService {
     }
 
     /**
+     * 열 삭제. columns_json에서만 빼고 행은 건드리지 않아 O(1)이다.
+     *
+     * <p>행에 남은 값은 투영이 columns 기준으로만 읽으므로 API로 드러나지 않고,
+     * 그 행을 다음에 수정할 때 {@link #toCellMap}이 맵을 새로 만들며 함께 사라진다.
+     * 즉 즉시 물리 삭제는 아니고 지연 정리다. 재발급되지 않는 key({@link Dataset#issueColumnSeq})
+     * 덕분에 남은 값이 새 열에 되살아날 일은 없다.
+     *
+     * <p>마지막 열은 지울 수 없다. 열이 0개면 행이 값을 담을 자리가 없어진다.
+     */
+    @Transactional
+    public DatasetResponse deleteColumn(Long memberId, Long datasetId, String key) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        if (columns.stream().noneMatch(c -> c.key().equals(key))) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+        if (columns.size() <= 1) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        List<DatasetColumn> updated = columns.stream()
+                .filter(c -> !c.key().equals(key))
+                .toList();
+        dataset.updateColumns(serialize(updated));
+        return DatasetResponse.of(dataset, updated);
+    }
+
+    /**
      * 열 이름(label) 변경. key는 cells 맵의 주소라 바꾸지 않으며(바꾸면 기존 값과 연결이 끊긴다),
      * columns_json만 갱신하므로 행 데이터는 건드리지 않는다.
      */

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -210,6 +210,112 @@ class DatasetControllerTest extends ApiTestSupport {
     }
 
     @Test
+    @DisplayName("DELETE column - 열이 빠지고 남은 열 값은 유지된다")
+    void delete_column() throws Exception {
+        long id = createDataset();
+        mockMvc.perform(post("/api/datasets/{id}/columns", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"비고\"}"))
+                .andExpect(status().isCreated());
+        bulk(id, "[[\"네트워크\",\"92\",\"재수강\"]]");
+
+        // 가운데 열(c1) 삭제 — 뒤 열 값이 앞으로 당겨져야 한다.
+        mockMvc.perform(delete("/api/datasets/{id}/columns/{key}", id, "c1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns", hasSize(2)))
+                .andExpect(jsonPath("$.data.columns[0].key").value("c0"))
+                .andExpect(jsonPath("$.data.columns[1].key").value("c2"));
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells", hasSize(2)))
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value("네트워크"))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("재수강"));
+    }
+
+    @Test
+    @DisplayName("열 삭제는 행을 건드리지 않고, 남은 값은 다음 수정 때 정리된다")
+    void delete_column_purges_lazily() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        mockMvc.perform(delete("/api/datasets/{id}/columns/{key}", id, "c1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+
+        // O(1) — 삭제 시점엔 행 JSON이 그대로다(지운 c1 값이 남아 있음).
+        org.assertj.core.api.Assertions.assertThat(
+                        datasetRowRepository.findByDatasetIdAndRowIndex(id, 0).orElseThrow().getCells())
+                .contains("\"c1\"").contains("92");
+
+        // 다만 API로는 드러나지 않는다.
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells", hasSize(1)))
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value("네트워크"));
+
+        // 그 행을 수정하면 맵이 새로 만들어지며 남은 값이 사라진다.
+        mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", id, 0)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"운영체제\"]}"))
+                .andExpect(status().isOk());
+
+        org.assertj.core.api.Assertions.assertThat(
+                        datasetRowRepository.findByDatasetIdAndRowIndex(id, 0).orElseThrow().getCells())
+                .doesNotContain("\"c1\"").doesNotContain("92");
+    }
+
+    @Test
+    @DisplayName("열을 지운 뒤 추가해도 지운 key가 재사용되지 않아 옛 값이 되살아나지 않는다")
+    void delete_then_add_does_not_resurrect_values() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        mockMvc.perform(delete("/api/datasets/{id}/columns/{key}", id, "c1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/api/datasets/{id}/columns", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"새 열\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.columns[1].key").value("c2"));
+
+        // 행엔 c1="92"가 남아 있지만 새 열은 c2라 빈 값으로 보여야 한다.
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value("네트워크"))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value(""));
+    }
+
+    @Test
+    @DisplayName("DELETE column - 마지막 열은 400, 없는 key는 404, 타인 dataset은 404")
+    void delete_column_validation() throws Exception {
+        long id = createDataset();
+
+        mockMvc.perform(delete("/api/datasets/{id}/columns/{key}", id, "c9")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNotFound());
+
+        String otherAuth = "Bearer " + AuthFixture.loginAndGetAccessToken(
+                mockMvc, "other", "password");
+        mockMvc.perform(delete("/api/datasets/{id}/columns/{key}", id, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, otherAuth))
+                .andExpect(status().isNotFound());
+
+        // 2열 중 하나를 지우면 남은 1열은 못 지운다.
+        mockMvc.perform(delete("/api/datasets/{id}/columns/{key}", id, "c1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+        mockMvc.perform(delete("/api/datasets/{id}/columns/{key}", id, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("POST column - 열이 끝에 추가되고 기존 행 값은 그대로, 새 열은 빈 값")
     void add_column() throws Exception {
         long id = createDataset();

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -128,6 +128,113 @@ describe("DatasetGrid", () => {
     await waitFor(() => expect(inserted).toBe(true));
   });
 
+  it("열 삭제는 확인 후 DELETE를 호출하고, 남은 값이 밀리지 않게 행을 다시 받는다", async () => {
+    // 3열 중 가운데(c1)를 지운다. 캐시된 배열을 그대로 쓰면 "92"(삭제된 c1 값)가
+    // 두 번째 칸에 남는다 — 다시 받아 와야 "재수강"이 와야 한다.
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "점수" },
+              { key: "c2", label: "비고" },
+            ],
+            rowCount: 1,
+          },
+        }),
+      ),
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [{ rowIndex: 0, cells: ["네트워크", "92", "재수강"] }],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("92");
+
+    let deletedKey: string | null = null;
+    server.use(
+      http.delete(`${API_BASE}/datasets/1/columns/:key`, ({ params }) => {
+        deletedKey = String(params.key);
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c2", label: "비고" },
+            ],
+            rowCount: 1,
+          },
+        });
+      }),
+      // 삭제 후 서버는 남은 열 기준으로 투영해 준다.
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [{ rowIndex: 0, cells: ["네트워크", "재수강"] }],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+
+    await user.click(screen.getByRole("button", { name: "점수 열 삭제" }));
+    // 확인 전엔 요청이 나가지 않는다.
+    expect(deletedKey).toBeNull();
+    await user.click(screen.getByRole("button", { name: "삭제" }));
+
+    await waitFor(() => expect(deletedKey).toBe("c1"));
+    await waitFor(() => {
+      expect(screen.queryByText("점수")).not.toBeInTheDocument();
+    });
+    // 재조회가 안 되면 여기서 "92"가 남아 실패한다.
+    expect(await screen.findByText("재수강")).toBeInTheDocument();
+    expect(screen.queryByText("92")).not.toBeInTheDocument();
+  });
+
+  it("마지막 한 열만 남으면 삭제 버튼을 내보내지 않는다", async () => {
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [{ key: "c0", label: "과목" }],
+            rowCount: 1,
+          },
+        }),
+      ),
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [{ rowIndex: 0, cells: ["네트워크"] }],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    expect(await screen.findByText("과목")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "과목 열 삭제" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("[열 추가]로 POST를 호출하고 새 열이 빈 칸으로 붙는다", async () => {
     mockDataset([["네트워크", "92"]]);
     let addedLabel: string | null = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -6,9 +6,10 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { Plus, Trash2 } from "lucide-react";
+import { Plus, Trash2, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import { FieldError } from "@/components/ui/field-error";
 import { LoadingText } from "@/components/ui/loading-text";
@@ -17,6 +18,7 @@ import { cn } from "@/lib/utils";
 import {
   addDatasetColumn,
   type DatasetMeta,
+  deleteDatasetColumn,
   deleteDatasetRow,
   insertDatasetRow,
   renameDatasetColumn,
@@ -45,6 +47,7 @@ export function DatasetGrid({ datasetId }: Props) {
   const [draft, setDraft] = useState("");
   const [editingCol, setEditingCol] = useState<string | null>(null);
   const [colDraft, setColDraft] = useState("");
+  const [pendingColDelete, setPendingColDelete] = useState<string | null>(null);
 
   const colCount = meta?.columns.length ?? 0;
   const rowCount = meta?.rowCount ?? 0;
@@ -76,6 +79,15 @@ export function DatasetGrid({ datasetId }: Props) {
       renameDatasetColumn(datasetId, v.key, v.label),
     onSuccess: (next: DatasetMeta) =>
       queryClient.setQueryData(datasetKeys.meta(datasetId), next),
+    onError: () => void invalidateMeta(),
+  });
+  const deleteColMut = useMutation({
+    mutationFn: (key: string) => deleteDatasetColumn(datasetId, key),
+    onSuccess: (next: DatasetMeta) => {
+      queryClient.setQueryData(datasetKeys.meta(datasetId), next);
+      // 캐시된 cells는 삭제 전 열 순서 기준이라 그대로 쓰면 값이 밀린다. 다시 받아 온다.
+      reset();
+    },
     onError: () => void invalidateMeta(),
   });
   const addColMut = useMutation({
@@ -151,6 +163,9 @@ export function DatasetGrid({ datasetId }: Props) {
 
   const addColumn = () => addColMut.mutate(`열 ${colCount + 1}`);
 
+  const columnLabel = (key: string) =>
+    meta.columns.find((c) => c.key === key)?.label ?? key;
+
   const startColEdit = (key: string, label: string) => {
     setEditingCol(key);
     setColDraft(label);
@@ -184,7 +199,10 @@ export function DatasetGrid({ datasetId }: Props) {
           style={{ gridTemplateColumns }}
         >
           {table.getFlatHeaders().map((header) => (
-            <div key={header.id} className="border-border border-r">
+            <div
+              key={header.id}
+              className="border-border group flex items-center border-r"
+            >
               {editingCol === header.id ? (
                 <input
                   autoFocus
@@ -199,22 +217,35 @@ export function DatasetGrid({ datasetId }: Props) {
                   className="focus-visible:ring-ring h-full w-full bg-transparent px-2 py-1.5 font-semibold outline-none focus-visible:ring-1"
                 />
               ) : (
-                <div
-                  className="cursor-text truncate px-2 py-1.5"
-                  title="더블클릭해 열 이름 변경"
-                  onDoubleClick={() =>
-                    startColEdit(
-                      header.id,
-                      meta.columns.find((c) => c.key === header.id)?.label ??
-                        "",
-                    )
-                  }
-                >
-                  {flexRender(
-                    header.column.columnDef.header,
-                    header.getContext(),
+                <>
+                  <div
+                    className="min-w-0 flex-1 cursor-text truncate px-2 py-1.5"
+                    title="더블클릭해 열 이름 변경"
+                    onDoubleClick={() =>
+                      startColEdit(
+                        header.id,
+                        meta.columns.find((c) => c.key === header.id)?.label ??
+                          "",
+                      )
+                    }
+                  >
+                    {flexRender(
+                      header.column.columnDef.header,
+                      header.getContext(),
+                    )}
+                  </div>
+                  {/* 마지막 한 열은 서버가 거부하므로 버튼도 내보내지 않는다. */}
+                  {colCount > 1 && (
+                    <button
+                      type="button"
+                      aria-label={`${columnLabel(header.id)} 열 삭제`}
+                      onClick={() => setPendingColDelete(header.id)}
+                      className="text-muted-foreground hover:text-destructive mr-1 shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+                    >
+                      <X className="size-3.5" />
+                    </button>
                   )}
-                </div>
+                </>
               )}
             </div>
           ))}
@@ -308,6 +339,26 @@ export function DatasetGrid({ datasetId }: Props) {
           <Plus className="size-4" /> 행 추가
         </Button>
       </div>
+
+      <ConfirmDialog
+        open={pendingColDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingColDelete(null);
+        }}
+        title={
+          pendingColDelete
+            ? `'${columnLabel(pendingColDelete)}' 열을 삭제할까요?`
+            : "열을 삭제할까요?"
+        }
+        description="이 열의 모든 셀 값이 표에서 사라집니다. 되돌릴 수 없어요."
+        confirmLabel="삭제"
+        destructive
+        onConfirm={() => {
+          if (pendingColDelete) deleteColMut.mutate(pendingColDelete);
+          setPendingColDelete(null);
+        }}
+        pending={deleteColMut.isPending}
+      />
     </div>
   );
 }

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -69,6 +69,17 @@ export async function addDatasetColumn(
   return data.data;
 }
 
+/** 열 삭제. 마지막 열은 지울 수 없다(400). */
+export async function deleteDatasetColumn(
+  datasetId: number,
+  key: string,
+): Promise<DatasetMeta> {
+  const { data } = await client.delete<ApiEnvelope<DatasetMeta>>(
+    `/datasets/${datasetId}/columns/${key}`,
+  );
+  return data.data;
+}
+
 /** 열 이름 변경. key는 cells 맵의 주소라 바뀌지 않고 label만 바뀐다. */
 export async function renameDatasetColumn(
   datasetId: number,

--- a/fe/src/features/note/dataset/hooks/useDatasetRows.ts
+++ b/fe/src/features/note/dataset/hooks/useDatasetRows.ts
@@ -16,6 +16,9 @@ export function useDatasetRows(datasetId: number) {
   const [cache, setCache] = useState<Map<number, string[]>>(() => new Map());
   const loadedPages = useRef<Set<number>>(new Set());
   const inflight = useRef<Set<number>>(new Set());
+  // reset()이 스스로 재조회를 일으키기 위한 세대 번호. 호출자의 useEffect는 ensureRange를
+  // 의존성으로 갖는데, 이 값이 바뀌면 ensureRange 정체성이 바뀌어 effect가 다시 돈다.
+  const [generation, setGeneration] = useState(0);
 
   const ensureRange = useCallback(
     (start: number, end: number) => {
@@ -46,7 +49,10 @@ export function useDatasetRows(datasetId: number) {
           .finally(() => inflight.current.delete(page));
       }
     },
-    [datasetId, queryClient],
+    // generation은 본문에서 안 쓰지만, 바뀔 때마다 새 ensureRange를 만들어
+    // 호출자의 effect를 다시 돌리려는 의도적 의존성이다(= reset 후 재조회).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [datasetId, queryClient, generation],
   );
 
   /** 편집 낙관적 반영. */
@@ -54,12 +60,16 @@ export function useDatasetRows(datasetId: number) {
     setCache((prev) => new Map(prev).set(index, cells));
   }, []);
 
-  /** 행 추가/삭제로 인덱스가 밀리면 전체 재로드. */
+  /**
+   * 캐시를 비우고 다시 받아 온다. 행 인덱스가 밀리거나(행 추가·삭제) 열 구성이 바뀌어
+   * 캐시된 위치 배열이 더 이상 유효하지 않을 때(열 삭제) 쓴다.
+   */
   const reset = useCallback(() => {
     loadedPages.current.clear();
     inflight.current.clear();
     setCache(new Map());
     queryClient.removeQueries({ queryKey: ["datasets", datasetId, "rows"] });
+    setGeneration((g) => g + 1);
   }, [datasetId, queryClient]);
 
   const getRow = useCallback((index: number) => cache.get(index), [cache]);


### PR DESCRIPTION
## 이슈
closes #794
## 작업 내용
열 삭제. `DELETE /api/datasets/{id}/columns/{key}`.

- **행을 건드리지 않는다(O(1)).** `columns_json`에서만 뺀다
- 마지막 열은 거부(400) — 열이 0개면 행이 값을 담을 자리가 없다
- FE: 헤더 hover 시 `×` 버튼 → `ConfirmDialog`(기존 하위 페이지·표 삭제와 같은 프리셋) → 삭제

### 지운 값은 어떻게 되나 — 지연 정리
행에 남은 값은 **즉시 물리 삭제하지 않는다.** 전 행을 훑으면 O(n)이 되어 #793에서 key 맵을 택한 이유가 무너지기 때문이다.

- 투영이 `columns` 기준으로만 읽으므로 **API로는 드러나지 않는다** (기능적으로 삭제됨)
- 그 행을 다음에 수정할 때 `toCellMap`이 맵을 columns 기준으로 새로 만들며 **남은 값이 함께 사라진다**
- #798의 발급 카운터 덕에 **지운 key가 재발급되지 않으므로**, 남은 값이 새 열에 되살아날 일은 없다

즉 "즉시 물리 삭제"가 아니라 "즉시 도달 불가 + 지연 정리"다. 한 번도 수정되지 않는 행은 값이 남지만 어떤 경로로도 읽히지 않는다. 물리 삭제 보장이 필요하다고 판단되면 별도 이슈로 다루는 게 맞다.

## 같이 고친 것 — `useDatasetRows.reset()` 재조회 버그
#798에서 발견해 적어뒀던 잠복 버그를 여기서 닫는다. **열 삭제가 정확히 이 버그를 밟는 첫 호출자다.**

`reset()`은 캐시만 비우고 스스로 재조회하지 않았다. 재로드는 `ensureRange` effect가 `rowCount` 변화로 다시 돌 때 일어난다 — 행 추가·삭제는 `rowCount`가 바뀌어 우연히 동작했을 뿐이다. **열 삭제는 `rowCount`가 안 바뀐다.**

이게 왜 실제 문제인가: 캐시된 `cells`는 삭제 전 열 순서 기준의 **위치 배열**이다. 3열 `["A값","B값","C값"]`에서 가운데 `c1`을 지우면 열은 `[c0, c2]`가 되는데, 캐시를 그대로 쓰면 `cells[1]` = `"B값"` — **지운 열의 값이 이웃 자리에 밀려 보인다.**

수정: `generation` 세대 번호를 두고 `reset()`이 올리면 `ensureRange` 정체성이 바뀌어 호출자 effect가 다시 돈다.

## 테스트
- BE 4건: 가운데 열 삭제 후 값 유지 / **행 JSON 불변 + 지연 정리 확인** / **지운 뒤 추가해도 옛 값 미부활** / 마지막 열 400·없는 key 404·타인 404
- FE 2건: 확인 후 DELETE + **가운데 열 삭제 시 값이 안 밀림** / 마지막 한 열이면 삭제 버튼 미노출
- **reset 수정이 실제로 필요한지 검증**: `generation` 의존성을 빼면 가운데 열 삭제 테스트가 실패하고, 되돌리면 통과하는 것을 확인했다 (테스트가 버그를 실제로 고정함)
- 기존 테스트 전부 무수정 통과 (BE 26건, FE 328건), `./gradlew check` · format · lint 통과

## 로컬 확인
MySQL 8.4.4 + `bootRun`:
- 가운데 열 `c1` 삭제 → API는 `["네트워크","재수강"]`로 당겨 반환, **저장소엔 `c1:"92"`가 그대로** (O(1) 확인)
- **삭제 후 열 추가 → `c3` 발급**(c1 재사용 X) → 새 열은 빈 값, `"92"` 부활하지 않음
- 그 행을 수정 → `{"c0":"운영체제","c2":"청강","c3":"메모"}` — **`c1`이 지연 정리로 사라짐**
- 마지막 열 삭제 시도 → 400
- 브라우저: 3열에 `A값/B값/C값`을 넣고 가운데 열 삭제 → 확인 다이얼로그가 `'열 2' 열을 삭제할까요?`로 대상 명시 → 확인 후 **`[A값, C값]`** 표시(밀림 없음)
