### PR TITLE
feat : RowView에 행 id 노출

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowView.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowView.java
@@ -2,5 +2,12 @@ package ds.project.orino.planner.dataset.dto;
 
 import java.util.List;
 
-public record RowView(int rowIndex, List<String> cells) {
+/**
+ * 행 조회 결과.
+ *
+ * <p>{@code id}는 행의 안정적 식별자다. {@code rowIndex}는 정렬·페이지네이션용 순번이라
+ * 삽입·삭제 때마다 밀리지만 {@code id}는 바뀌지 않는다. 수식이 다른 행을 참조할 때
+ * 묶어야 할 대상은 {@code rowIndex}가 아니라 {@code id}다.
+ */
+public record RowView(Long id, int rowIndex, List<String> cells) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -207,7 +207,7 @@ public class DatasetService {
                 .findByDatasetIdAndRowIndexGreaterThanEqualAndRowIndexLessThanOrderByRowIndexAsc(
                         datasetId, off, off + lim)
                 .stream()
-                .map(r -> new RowView(r.getRowIndex(), toCellList(r.getCells(), columns)))
+                .map(r -> new RowView(r.getId(), r.getRowIndex(), toCellList(r.getCells(), columns)))
                 .toList();
         return new RowsResponse(rows, off, lim);
     }
@@ -220,7 +220,7 @@ public class DatasetService {
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
         row.updateCells(toCellMap(request.cells(), columns));
         // 저장된 값을 그대로 되돌려준다(열 수에 맞춰 잘리거나 채워진 결과).
-        return new RowView(rowIndex, toCellList(row.getCells(), columns));
+        return new RowView(row.getId(), rowIndex, toCellList(row.getCells(), columns));
     }
 
     @Transactional

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -209,6 +209,97 @@ class DatasetControllerTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.rowCount").value(2));
     }
 
+    /** rowIndex 순으로 각 행의 id를 뽑는다. */
+    private java.util.List<Long> rowIds(long id) throws Exception {
+        String body = mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        java.util.List<Number> raw = JsonPath.read(body, "$.data.rows[*].id");
+        return raw.stream().map(Number::longValue).toList();
+    }
+
+    @Test
+    @DisplayName("GET rows - 행 id를 함께 반환한다")
+    void rows_expose_id() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"A\",\"1\"],[\"B\",\"2\"]]");
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rows[0].id").isNumber())
+                .andExpect(jsonPath("$.data.rows[1].id").isNumber());
+
+        // PATCH 응답에도 같은 id가 실린다.
+        long firstId = rowIds(id).get(0);
+        mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", id, 0)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"A수정\",\"1\"]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(firstId));
+    }
+
+    @Test
+    @DisplayName("행을 앞에 끼워 rowIndex가 밀려도 기존 행의 id는 그대로다")
+    void row_id_survives_insert_shift() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"A\",\"1\"],[\"B\",\"2\"]]");
+        java.util.List<Long> before = rowIds(id);
+
+        // 맨 앞에 삽입 — 기존 두 행의 rowIndex는 0,1 → 1,2로 밀린다.
+        mockMvc.perform(post("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"atIndex\":0,\"cells\":[\"NEW\",\"9\"]}"))
+                .andExpect(status().isCreated());
+
+        java.util.List<Long> after = rowIds(id);
+        org.assertj.core.api.Assertions.assertThat(after).hasSize(3);
+        // rowIndex는 밀렸지만 id는 보존된다 — 수식 참조가 id에 묶여야 하는 이유.
+        org.assertj.core.api.Assertions.assertThat(after.subList(1, 3))
+                .as("삽입 후에도 기존 행 id가 순서대로 유지돼야 한다")
+                .isEqualTo(before);
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[1].rowIndex").value(1))
+                .andExpect(jsonPath("$.data.rows[1].cells[0]").value("A"));
+    }
+
+    @Test
+    @DisplayName("행을 지워 rowIndex가 당겨져도 남은 행의 id는 그대로다")
+    void row_id_survives_delete_shift() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"A\",\"1\"],[\"B\",\"2\"],[\"C\",\"3\"]]");
+        java.util.List<Long> before = rowIds(id);
+
+        mockMvc.perform(delete("/api/datasets/{id}/rows/{i}", id, 0)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNoContent());
+
+        // B, C의 rowIndex는 1,2 → 0,1로 당겨지지만 id는 그대로다.
+        org.assertj.core.api.Assertions.assertThat(rowIds(id))
+                .isEqualTo(before.subList(1, 3));
+    }
+
+    @Test
+    @DisplayName("셀을 수정해도 행 id는 바뀌지 않는다")
+    void row_id_survives_update() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"A\",\"1\"]]");
+        long before = rowIds(id).get(0);
+
+        mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", id, 0)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"수정됨\",\"9\"]}"))
+                .andExpect(status().isOk());
+
+        org.assertj.core.api.Assertions.assertThat(rowIds(id).get(0)).isEqualTo(before);
+    }
+
     @Test
     @DisplayName("DELETE column - 열이 빠지고 남은 열 값은 유지된다")
     void delete_column() throws Exception {

--- a/fe/src/features/note/components/NoteTab.test.tsx
+++ b/fe/src/features/note/components/NoteTab.test.tsx
@@ -92,7 +92,11 @@ function mockDataset(id: number, columns: DatasetColumn[], rows: string[][]) {
       HttpResponse.json({
         code: "OK",
         data: {
-          rows: rows.map((cells, rowIndex) => ({ rowIndex, cells })),
+          rows: rows.map((cells, rowIndex) => ({
+            id: 100 + rowIndex,
+            rowIndex,
+            cells,
+          })),
           offset: 0,
           limit: 100,
         },

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -30,9 +30,11 @@ function mockDataset(rows: string[][]) {
       const url = new URL(request.url);
       const offset = Number(url.searchParams.get("offset") ?? "0");
       const limit = Number(url.searchParams.get("limit") ?? "100");
-      const slice = rows
-        .slice(offset, offset + limit)
-        .map((cells, i) => ({ rowIndex: offset + i, cells }));
+      const slice = rows.slice(offset, offset + limit).map((cells, i) => ({
+        id: 100 + offset + i,
+        rowIndex: offset + i,
+        cells,
+      }));
       return HttpResponse.json({
         code: "OK",
         data: { rows: slice, offset, limit },
@@ -91,7 +93,7 @@ describe("DatasetGrid", () => {
           patched = { index: Number(params.i), cells: body.cells };
           return HttpResponse.json({
             code: "OK",
-            data: { rowIndex: Number(params.i), cells: body.cells },
+            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
           });
         },
       ),
@@ -150,7 +152,9 @@ describe("DatasetGrid", () => {
         HttpResponse.json({
           code: "OK",
           data: {
-            rows: [{ rowIndex: 0, cells: ["네트워크", "92", "재수강"] }],
+            rows: [
+              { id: 100, rowIndex: 0, cells: ["네트워크", "92", "재수강"] },
+            ],
             offset: 0,
             limit: 100,
           },
@@ -182,7 +186,7 @@ describe("DatasetGrid", () => {
         HttpResponse.json({
           code: "OK",
           data: {
-            rows: [{ rowIndex: 0, cells: ["네트워크", "재수강"] }],
+            rows: [{ id: 100, rowIndex: 0, cells: ["네트워크", "재수강"] }],
             offset: 0,
             limit: 100,
           },
@@ -220,7 +224,7 @@ describe("DatasetGrid", () => {
         HttpResponse.json({
           code: "OK",
           data: {
-            rows: [{ rowIndex: 0, cells: ["네트워크"] }],
+            rows: [{ id: 100, rowIndex: 0, cells: ["네트워크"] }],
             offset: 0,
             limit: 100,
           },
@@ -293,7 +297,7 @@ describe("DatasetGrid", () => {
         patched = body.cells;
         return HttpResponse.json({
           code: "OK",
-          data: { rowIndex: 0, cells: body.cells },
+          data: { id: 100, rowIndex: 0, cells: body.cells },
         });
       }),
     );

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -12,6 +12,11 @@ export interface DatasetMeta {
 }
 
 export interface DatasetRow {
+  /**
+   * 행의 안정적 식별자. rowIndex는 삽입·삭제 때마다 밀리지만 id는 바뀌지 않는다.
+   * 수식이 다른 행을 참조할 때 묶을 대상(아직 사용처 없음).
+   */
+  id: number;
   rowIndex: number;
   cells: string[];
 }


### PR DESCRIPTION
## 이슈
closes #801
## 작업 내용
`RowView`에 행의 안정적 식별자 `id`를 노출한다. #799 D3(참조는 정체성에 바인딩, 표시는 위치로)의 선행 작업.

- 조회·수정 응답에 `id` 추가
- **스키마 변경 없음.** `dataset_row.id`는 037부터 있던 BIGINT autoincrement PK이고, 이 값을 바꾸는 코드가 없다 — `shiftUp`/`shiftDown`은 `row_index`만 건드린다. 정체성과 순서가 **이미 분리돼 있었고 단지 응답에 안 실렸을 뿐**이다
- 추가 필드라 기존 클라이언트는 영향 없음
- FE는 타입만 반영하고 **아직 소비하지 않는다**(수식 도입 시 사용)

### 왜 필요한가
수식이 다른 행을 참조하려면(`=B5`) 참조가 안 변하는 대상에 묶여야 한다. `row_index`는 행 하나만 끼워도 밀려서 **에러 없이 다른 행을 가리키게 된다.**

> 참고: 이 문제는 **gap/fractional index로 해결되지 않는다.** 분수 인덱스는 정렬 키가 안 밀리게 할 뿐, 2번 자리에 행을 끼우면 5번째 행이 6번째가 되는 건 똑같다. 초기에 #778 gap index를 "correctness 선결 조건"으로 승격시켰던 판단은 [철회했다](https://github.com/wcorn/orino/issues/778#issuecomment-4999822792). 정체성 문제의 답은 `id`이고, gap index는 삽입 성능 항목으로 남는다.

## 테스트
BE 4건 추가 — **핵심은 id가 시프트를 견디는지 확인하는 것**(D3가 기대는 전제):
- 조회·수정 응답에 id가 실림
- **맨 앞에 행 삽입 → 기존 행 rowIndex는 0,1 → 1,2로 밀리지만 id는 그대로**
- **행 삭제 → 남은 행 rowIndex는 당겨지지만 id는 그대로**
- 셀 수정에도 id 불변

기존 테스트 전부 무수정 통과 (BE 30건, FE 328건), `./gradlew check` · format · lint · tsc 통과.

**테스트 mock 정정**: FE MSW mock이 행을 `{rowIndex, cells}`로만 돌려줘 실제 응답과 어긋나게 됐다. `id`를 채워 계약과 맞췄다 — 수식 작업에서 id를 쓰기 시작할 때 거짓말하는 mock 위에서 테스트가 통과하는 걸 막는다.

## 로컬 확인
MySQL 8.4.4 + `bootRun`으로 API 직접 확인:
- 2행(`id=1` A, `id=2` B) 생성 후 **맨 앞에 삽입** → `id=3`이 rowIndex 0을 차지하고, **A는 `id=1` 유지한 채 rowIndex만 1로**, B는 `id=2` 유지한 채 2로 이동
- D3의 전제가 실제 구동 시스템에서 성립함을 확인

> 브라우저 확인은 생략했다. FE가 아직 `id`를 소비하지 않아 UI 변화가 없고, 이 변경의 실제 검증면은 API 응답이다.
