### PR TITLE
feat : 열 label 유일성 확보

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/AddColumnRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/AddColumnRequest.java
@@ -1,11 +1,15 @@
 package ds.project.orino.planner.dataset.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-/** 열 추가 요청. key는 서버가 발급하므로 label만 받는다. */
+/**
+ * 열 추가 요청. key는 서버가 발급한다.
+ *
+ * <p>{@code label}은 선택이다. 비우면 서버가 유일한 기본 이름을 발급한다 —
+ * 클라이언트가 열 개수로 이름을 지으면 열을 지운 뒤 중복이 생긴다.
+ * 값을 주면 기존 열과 겹칠 때 거부한다.
+ */
 public record AddColumnRequest(
-        @NotBlank(message = "label은 필수입니다.")
         @Size(max = 255, message = "label은 255자 이하여야 합니다.")
         String label
 ) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -57,6 +57,8 @@ public class DatasetService {
 
     /** 열 key 규칙: {@code c<발급번호>}. 번호는 dataset의 next_column_seq에서 받는다. */
     private static final Pattern COLUMN_KEY = Pattern.compile("c(\\d+)");
+    /** 기본 열 이름 접두사. 뒤에 붙는 번호는 비어 있는 것을 찾아 쓴다. */
+    private static final String DEFAULT_LABEL_PREFIX = "열 ";
 
     private final DatasetRepository datasetRepository;
     private final DatasetRowRepository rowRepository;
@@ -66,14 +68,61 @@ public class DatasetService {
         this.rowRepository = rowRepository;
     }
 
+    /**
+     * 데이터셋 생성. 열 label은 수식이 참조를 유일하게 지목할 수 있어야 하므로 중복을 허용하지 않는다.
+     *
+     * <p>다만 여기서 오는 label은 대개 <b>기계가 만든 것</b>(Import한 스프레드시트 헤더, 기본 이름)이라
+     * 거부하지 않고 {@link #deduplicateLabels 자동 구분}한다. 중복 헤더를 가진 엑셀 파일은 흔한데,
+     * 400으로 막으면 Import 자체가 불가능해진다. 엑셀·구글시트도 같은 방식으로 붙여 구분한다.
+     */
     @Transactional
     public DatasetResponse create(Long memberId, CreateDatasetRequest request) {
         if (request.columns().size() > MAX_COLUMNS) {
             throw new CustomException(ErrorCode.INVALID_REQUEST);
         }
+        List<DatasetColumn> columns = deduplicateLabels(request.columns());
         Dataset dataset = datasetRepository.save(new Dataset(
-                memberId, serialize(request.columns()), nextSeqFor(request.columns())));
-        return DatasetResponse.of(dataset, request.columns());
+                memberId, serialize(columns), nextSeqFor(columns)));
+        return DatasetResponse.of(dataset, columns);
+    }
+
+    /**
+     * 중복 label에 {@code (2)}, {@code (3)}… 을 붙여 유일하게 만든다. 순서는 보존한다.
+     * 붙인 이름이 또 다른 label과 겹치면 번호를 계속 올린다.
+     */
+    private List<DatasetColumn> deduplicateLabels(List<DatasetColumn> columns) {
+        java.util.Set<String> taken = new java.util.HashSet<>();
+        List<DatasetColumn> result = new java.util.ArrayList<>(columns.size());
+        for (DatasetColumn column : columns) {
+            String label = column.label();
+            for (int n = 2; !taken.add(label); n++) {
+                label = column.label() + " (" + n + ")";
+            }
+            result.add(new DatasetColumn(column.key(), label));
+        }
+        return result;
+    }
+
+    /** 이미 쓰이고 있는 label이면 거부한다. {@code selfKey}는 자기 자신(rename 시 무변경 허용). */
+    private void requireLabelFree(List<DatasetColumn> columns, String label, String selfKey) {
+        boolean taken = columns.stream()
+                .anyMatch(c -> !c.key().equals(selfKey) && c.label().equals(label));
+        if (taken) {
+            throw new CustomException(ErrorCode.DUPLICATE_COLUMN_LABEL);
+        }
+    }
+
+    /** 아직 안 쓰인 {@code 열 N}을 찾아 준다. */
+    private String generateLabel(List<DatasetColumn> columns) {
+        java.util.Set<String> taken = columns.stream()
+                .map(DatasetColumn::label)
+                .collect(java.util.stream.Collectors.toSet());
+        for (int n = columns.size() + 1; ; n++) {
+            String candidate = DEFAULT_LABEL_PREFIX + n;
+            if (taken.add(candidate)) {
+                return candidate;
+            }
+        }
     }
 
     /**
@@ -109,8 +158,15 @@ public class DatasetService {
             throw new CustomException(ErrorCode.INVALID_REQUEST);
         }
 
+        // label을 안 주면 서버가 유일한 기본 이름을 발급한다(key 발급과 같은 방식).
+        // 클라이언트가 이름을 지으면 열 개수 기반 규칙이 삭제 후 중복을 만든다.
+        String label = request.label() == null || request.label().isBlank()
+                ? generateLabel(columns)
+                : request.label();
+        requireLabelFree(columns, label, null);
+
         List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
-        updated.add(new DatasetColumn("c" + dataset.issueColumnSeq(), request.label()));
+        updated.add(new DatasetColumn("c" + dataset.issueColumnSeq(), label));
         dataset.updateColumns(serialize(updated));
         return DatasetResponse.of(dataset, updated);
     }
@@ -167,6 +223,8 @@ public class DatasetService {
         if (at < 0) {
             throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
         }
+        // 사람이 직접 지정한 이름이므로 자동 구분하지 않고 충돌을 알린다.
+        requireLabelFree(columns, request.label(), key);
 
         List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
         updated.set(at, new DatasetColumn(key, request.label()));

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -476,11 +476,13 @@ class DatasetControllerTest extends ApiTestSupport {
     @DisplayName("POST column - label이 비면 400, 타인 dataset이면 404")
     void add_column_validation() throws Exception {
         long id = createDataset();
+        // label을 비우면 거부가 아니라 서버가 기본 이름을 발급한다.
         mockMvc.perform(post("/api/datasets/{id}/columns", id)
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"label\":\"  \"}"))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.columns[2].label").value("열 3"));
 
         String otherAuth = "Bearer " + AuthFixture.loginAndGetAccessToken(
                 mockMvc, "other", "password");
@@ -489,6 +491,108 @@ class DatasetControllerTest extends ApiTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"label\":\"침입\"}"))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("생성 - Import한 중복 헤더는 거부하지 않고 자동 구분한다")
+    void create_deduplicates_labels() throws Exception {
+        // 같은 이름 헤더를 가진 스프레드시트 Import를 막으면 안 된다.
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"점수"},{"key":"c1","label":"점수"},
+                                            {"key":"c2","label":"점수"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.columns[0].label").value("점수"))
+                .andExpect(jsonPath("$.data.columns[1].label").value("점수 (2)"))
+                .andExpect(jsonPath("$.data.columns[2].label").value("점수 (3)"))
+                .andReturn().getResponse().getContentAsString();
+
+        // 순서와 key 대응은 그대로여야 한다.
+        long id = ((Number) JsonPath.read(body, "$.data.id")).longValue();
+        mockMvc.perform(get("/api/datasets/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.columns[1].key").value("c1"));
+    }
+
+    @Test
+    @DisplayName("생성 - 자동 구분한 이름이 다른 헤더와 또 겹치면 번호를 올린다")
+    void create_dedup_avoids_secondary_collision() throws Exception {
+        mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"점수"},{"key":"c1","label":"점수 (2)"},
+                                            {"key":"c2","label":"점수"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.columns[0].label").value("점수"))
+                .andExpect(jsonPath("$.data.columns[1].label").value("점수 (2)"))
+                // "점수 (2)"가 이미 있으므로 "점수 (3)"으로
+                .andExpect(jsonPath("$.data.columns[2].label").value("점수 (3)"));
+    }
+
+    @Test
+    @DisplayName("열 추가 - 서버가 발급한 기본 이름은 삭제 후에도 중복되지 않는다")
+    void generated_label_never_collides_after_delete() throws Exception {
+        long id = createDataset(); // 과목(c0), 점수(c1)
+        // 열 3 추가 → 열1/열2 아님. 기존 label은 과목/점수라 "열 3"이 나온다.
+        mockMvc.perform(post("/api/datasets/{id}/columns", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.columns[2].label").value("열 3"));
+
+        // 가운데 열을 지우면 열 개수가 2로 줄지만, 기본 이름이 "열 3"으로 되돌아가면 안 된다.
+        mockMvc.perform(delete("/api/datasets/{id}/columns/{key}", id, "c1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/datasets/{id}/columns", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isCreated())
+                // 남은 label이 과목/열 3이므로 "열 3"을 피해 "열 4"
+                .andExpect(jsonPath("$.data.columns[2].label").value("열 4"));
+
+        mockMvc.perform(get("/api/datasets/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.columns[*].label",
+                        org.hamcrest.Matchers.containsInAnyOrder("과목", "열 3", "열 4")));
+    }
+
+    @Test
+    @DisplayName("열 추가 - 사람이 지정한 이름이 겹치면 409")
+    void add_column_duplicate_label_409() throws Exception {
+        long id = createDataset(); // 과목, 점수
+        mockMvc.perform(post("/api/datasets/{id}/columns", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"점수\"}"))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("rename - 다른 열과 겹치면 409, 자기 이름 그대로는 허용")
+    void rename_duplicate_label_409() throws Exception {
+        long id = createDataset(); // 과목(c0), 점수(c1)
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}", id, "c1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"과목\"}"))
+                .andExpect(status().isConflict());
+
+        // 자기 자신과의 비교는 충돌이 아니다.
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}", id, "c1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"점수\"}"))
+                .andExpect(status().isOk());
     }
 
     @Test

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     RESOURCE_NOT_FOUND("SP-ERR-001", "존재하지 않는 리소스입니다.", 404),
     INVALID_REQUEST("SP-ERR-002", "유효하지 않은 요청입니다.", 400),
     INVALID_STATE("SP-ERR-003", "현재 상태에서 수행할 수 없는 작업입니다.", 409),
+    DUPLICATE_COLUMN_LABEL("SP-ERR-004", "이미 있는 열 이름입니다.", 409),
 
     // PLANNER (Google Calendar 연동)
     ROUTINE_INVALID_RULE("PLN-ERR-002", "유효하지 않은 반복 규칙입니다.", 400),

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -241,11 +241,11 @@ describe("DatasetGrid", () => {
 
   it("[열 추가]로 POST를 호출하고 새 열이 빈 칸으로 붙는다", async () => {
     mockDataset([["네트워크", "92"]]);
-    let addedLabel: string | null = null;
+    let sentBody: Record<string, unknown> | null = null;
     server.use(
       http.post(`${API_BASE}/datasets/1/columns`, async ({ request }) => {
-        const body = (await request.json()) as { label: string };
-        addedLabel = body.label;
+        sentBody = (await request.json()) as Record<string, unknown>;
+        // 이름은 서버가 붙인다.
         return HttpResponse.json({
           code: "OK",
           data: {
@@ -253,7 +253,7 @@ describe("DatasetGrid", () => {
             columns: [
               { key: "c0", label: "과목" },
               { key: "c1", label: "점수" },
-              { key: "c2", label: body.label },
+              { key: "c2", label: "열 3" },
             ],
             rowCount: 1,
           },
@@ -266,8 +266,9 @@ describe("DatasetGrid", () => {
     await screen.findByText("네트워크");
     await user.click(screen.getByRole("button", { name: "열 추가" }));
 
-    await waitFor(() => expect(addedLabel).toBe("열 3"));
     expect(await screen.findByText("열 3")).toBeInTheDocument();
+    // 클라이언트는 이름을 짓지 않는다 — 열 개수 기반 규칙이 삭제 후 중복을 만들었다.
+    expect(sentBody).toEqual({});
     // 행을 다시 받지 않으므로 기존 값이 깜빡임 없이 그대로 남는다.
     expect(screen.getByText("네트워크")).toBeInTheDocument();
     expect(screen.getByText("92")).toBeInTheDocument();

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -91,7 +91,7 @@ export function DatasetGrid({ datasetId }: Props) {
     onError: () => void invalidateMeta(),
   });
   const addColMut = useMutation({
-    mutationFn: (label: string) => addDatasetColumn(datasetId, label),
+    mutationFn: () => addDatasetColumn(datasetId),
     // 행은 다시 받지 않는다. 새 열의 key는 방금 발급돼 어느 행에도 값이 없으므로,
     // 캐시된 짧은 cells를 그대로 두면 렌더가 새 열을 빈 칸으로 그린다(편집 시 패딩됨).
     onSuccess: (next: DatasetMeta) =>
@@ -161,7 +161,8 @@ export function DatasetGrid({ datasetId }: Props) {
   const addRow = () =>
     insertMut.mutate(Array.from({ length: colCount }, () => ""));
 
-  const addColumn = () => addColMut.mutate(`열 ${colCount + 1}`);
+  // 이름은 서버가 붙인다 — 열 개수로 지으면 삭제 후 중복된다.
+  const addColumn = () => addColMut.mutate();
 
   const columnLabel = (key: string) =>
     meta.columns.find((c) => c.key === key)?.label ?? key;

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -62,14 +62,16 @@ export async function fetchDatasetMeta(
   return data.data;
 }
 
-/** 열 추가(끝에). key는 서버가 발급한다. 기존 행은 서버에서 건드리지 않는다. */
+/**
+ * 열 추가(끝에). key와 기본 이름을 서버가 발급한다 — 클라이언트가 열 개수로 이름을 지으면
+ * 열을 지운 뒤 중복이 생긴다. 기존 행은 서버에서 건드리지 않는다.
+ */
 export async function addDatasetColumn(
   datasetId: number,
-  label: string,
 ): Promise<DatasetMeta> {
   const { data } = await client.post<ApiEnvelope<DatasetMeta>>(
     `/datasets/${datasetId}/columns`,
-    { label },
+    {},
   );
   return data.data;
 }


### PR DESCRIPTION
## 이슈
closes #803
## 작업 내용
열 label 유일성 확보. #799 O10의 실행 가능한 절반(구분자 문법 `={점수}5`는 파서와 함께).

### 핵심: 단순 거부는 Import를 깨뜨린다
`buildDatasetColumns`는 **스프레드시트 헤더를 그대로 label로 쓴다.** 같은 이름 헤더가 둘인 엑셀 파일은 흔하다. 중복을 400으로 막으면 그런 파일을 아예 못 올린다. 그래서 **출처에 따라 다르게** 다룬다:

| 출처 | 처리 |
|---|---|
| 기계가 만든 label (Import 헤더, 기본 이름) | **자동 구분** — `점수`, `점수 (2)`. 엑셀·구글시트와 같은 동작 |
| 사람이 지정한 label (rename, 명시적 지정) | **409 거부** — 충돌을 사용자가 알아야 한다 |

### #798 버그 원천 제거
`DatasetGrid.tsx`의 `열 ${colCount + 1}`이 중복을 직접 만들었다 — 열1/열2/열3에서 **열2를 지우면 colCount=2라 다음 추가가 다시 "열 3"**. 이름 발급을 서버로 옮겨(key 발급과 같은 방식) 클라이언트가 이름을 지을 수 없게 했다. `AddColumnRequest.label`은 선택이 되고, 비우면 서버가 안 쓰인 `열 N`을 찾아 준다.

### 선택
- **409 Conflict** (`SP-ERR-004`). 이슈엔 400으로 적었으나 "이미 있는 이름"은 409가 정확하다.
- **빈 label은 이제 거부가 아니라 기본 이름 발급.** `add_column_validation` 테스트가 그에 맞게 바뀌었다.
- **자동 구분이 투박해질 수 있다.** 입력이 `점수 / 점수 / 점수 (2)`면 결과는 `점수 / 점수 (2) / 점수 (2) (2)`다. `점수 (3)`으로 만들려면 기존 접미사를 벗겨 재번호해야 하는데, 그러면 **사용자가 실제로 그렇게 쓴 헤더를 말없이 바꾸는 것**이 된다. 원문 보존을 택했다.

## 범위 밖 (#799 O10에 남김)
**기존 데이터의 중복 정리.** 유일성이 실제로 필요해지는 건 수식 파서가 붙을 때이고, 지금 `columns_json` 배열을 재작성하는 마이그레이션은 **열 순서를 깨뜨릴 위험**이 있다(MySQL은 `JSON_ARRAYAGG`가 `ORDER BY`를 따르는 걸 보장하지 않는다 — 038에서 확인한 그 제약). 이 PR은 **새 중복이 생기는 걸 막고**, 레거시 정리는 파서 작업 때 안전한 방법(stored procedure 등)으로 다루는 게 맞다고 본다.

## 테스트
BE 6건 추가:
- Import 중복 헤더 자동 구분 + **순서·key 대응 보존**
- 자동 구분이 다른 헤더와 또 겹치면 번호 상승
- **삭제 후 추가해도 기본 이름이 중복되지 않음** (#798 버그 고정)
- 사람이 지정한 중복 → 409 (add·rename), 자기 이름 그대로 rename은 허용
- FE 1건 수정: 클라이언트가 label을 안 보냄(`{}`)

기존 테스트 전부 통과 (BE 36건, FE 328건), `./gradlew check` · format · lint · tsc 통과.

## 로컬 확인
MySQL 8.4.4 + `bootRun`:
- Import 중복 헤더 `점수/점수/점수 (2)` → `점수 / 점수 (2) / 점수 (2) (2)` (거부 없음)
- **#798 버그 재현 시도**: 열1/열2/열3 → 열2 삭제 → 추가 → **`열 4`** (예전 규칙이면 `열 3` 중복)
- 사람이 지정한 중복: add `열 1` → 409, rename → `열 3` → 409, rename → `과목` → 200
- 브라우저: 표 삽입 → 열 2 삭제 → 열 추가 → **`열 1 / 열 3 / 열 4`, 중복 없음**
