### PR TITLE
feat : 데이터 그리드 열 순서 변경(reorder)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -8,6 +8,7 @@ import ds.project.orino.planner.dataset.dto.DatasetResponse;
 import ds.project.orino.planner.dataset.dto.InsertRowRequest;
 import ds.project.orino.planner.dataset.dto.InsertRowResponse;
 import ds.project.orino.planner.dataset.dto.RenameColumnRequest;
+import ds.project.orino.planner.dataset.dto.ReorderColumnsRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
@@ -80,6 +81,15 @@ public class DatasetController {
             @PathVariable Long id,
             @PathVariable String key) {
         return ApiResponse.success(datasetService.deleteColumn(memberId, id, key));
+    }
+
+    /** 열 순서 변경. 전체 순서를 받으며 현재 열 집합과 정확히 같아야 한다. */
+    @PatchMapping("/{id}/columns/order")
+    public ApiResponse<DatasetResponse> reorderColumns(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @Valid @RequestBody ReorderColumnsRequest request) {
+        return ApiResponse.success(datasetService.reorderColumns(memberId, id, request));
     }
 
     /** 열 이름 변경. key는 불변이며 label만 바꾼다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/ReorderColumnsRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/ReorderColumnsRequest.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+/**
+ * 열 순서 변경 요청. 바뀐 위치 하나가 아니라 <b>전체 순서</b>를 받는다.
+ * 멱등이고, 현재 열 집합과 정확히 일치하는지 한 번에 검증할 수 있다.
+ */
+public record ReorderColumnsRequest(
+        @NotEmpty(message = "keys는 필수입니다.")
+        List<String> keys
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -14,6 +14,7 @@ import ds.project.orino.planner.dataset.dto.DatasetResponse;
 import ds.project.orino.planner.dataset.dto.InsertRowRequest;
 import ds.project.orino.planner.dataset.dto.InsertRowResponse;
 import ds.project.orino.planner.dataset.dto.RenameColumnRequest;
+import ds.project.orino.planner.dataset.dto.ReorderColumnsRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
@@ -200,6 +201,34 @@ public class DatasetService {
         List<DatasetColumn> updated = columns.stream()
                 .filter(c -> !c.key().equals(key))
                 .toList();
+        dataset.updateColumns(serialize(updated));
+        return DatasetResponse.of(dataset, updated);
+    }
+
+    /**
+     * 열 순서 변경. columns_json 배열 순서만 바꾸고 행은 건드리지 않아 O(1)이다 —
+     * cells가 key 맵이라 값이 위치에 묶여 있지 않고, 읽을 때 투영이 새 순서를 따라간다.
+     *
+     * <p>요청은 전체 순서이며, 현재 열 집합과 정확히 같아야 한다. 열 추가·삭제는 이 API의
+     * 일이 아니므로 집합이 다르면 거부한다.
+     */
+    @Transactional
+    public DatasetResponse reorderColumns(Long memberId, Long datasetId,
+                                          ReorderColumnsRequest request) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+
+        Map<String, DatasetColumn> byKey = new LinkedHashMap<>();
+        for (DatasetColumn column : columns) {
+            byKey.put(column.key(), column);
+        }
+        // 중복 key가 오면 size 비교만으론 못 걸러내므로 집합으로 견준다.
+        if (request.keys().size() != columns.size()
+                || !new java.util.HashSet<>(request.keys()).equals(byKey.keySet())) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        List<DatasetColumn> updated = request.keys().stream().map(byKey::get).toList();
         dataset.updateColumns(serialize(updated));
         return DatasetResponse.of(dataset, updated);
     }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -300,6 +300,137 @@ class DatasetControllerTest extends ApiTestSupport {
         org.assertj.core.api.Assertions.assertThat(rowIds(id).get(0)).isEqualTo(before);
     }
 
+    /** 3열(과목/점수/비고) dataset을 만들고 1행을 채운다. */
+    private long createThreeColumnDataset() throws Exception {
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"과목"},{"key":"c1","label":"점수"},
+                                            {"key":"c2","label":"비고"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        long id = ((Number) JsonPath.read(body, "$.data.id")).longValue();
+        bulk(id, "[[\"네트워크\",\"92\",\"재수강\"]]");
+        return id;
+    }
+
+    @Test
+    @DisplayName("PATCH columns/order - 순서가 바뀌고 값이 열을 따라간다")
+    void reorder_columns() throws Exception {
+        long id = createThreeColumnDataset();
+
+        // 비고를 맨 앞으로: c2, c0, c1
+        mockMvc.perform(patch("/api/datasets/{id}/columns/order", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keys\":[\"c2\",\"c0\",\"c1\"]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].label").value("비고"))
+                .andExpect(jsonPath("$.data.columns[1].label").value("과목"))
+                .andExpect(jsonPath("$.data.columns[2].label").value("점수"));
+
+        // 값이 새 순서를 따라온다 — 위치가 아니라 key에 묶여 있으므로.
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value("재수강"))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("네트워크"))
+                .andExpect(jsonPath("$.data.rows[0].cells[2]").value("92"));
+    }
+
+    @Test
+    @DisplayName("열 순서 변경은 행을 건드리지 않는다")
+    void reorder_does_not_touch_rows() throws Exception {
+        long id = createThreeColumnDataset();
+        String before = datasetRowRepository.findByDatasetIdAndRowIndex(id, 0)
+                .orElseThrow().getCells();
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/order", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keys\":[\"c2\",\"c1\",\"c0\"]}"))
+                .andExpect(status().isOk());
+
+        org.assertj.core.api.Assertions.assertThat(
+                        datasetRowRepository.findByDatasetIdAndRowIndex(id, 0).orElseThrow().getCells())
+                .as("순서 변경은 O(1)이어야 하므로 행 JSON이 그대로여야 한다")
+                .isEqualTo(before);
+    }
+
+    @Test
+    @DisplayName("PATCH columns/order - 열 집합이 다르면 400")
+    void reorder_rejects_wrong_key_set() throws Exception {
+        long id = createThreeColumnDataset();
+
+        // 하나 빠짐
+        mockMvc.perform(patch("/api/datasets/{id}/columns/order", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keys\":[\"c1\",\"c0\"]}"))
+                .andExpect(status().isBadRequest());
+        // 없는 key
+        mockMvc.perform(patch("/api/datasets/{id}/columns/order", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keys\":[\"c0\",\"c1\",\"c9\"]}"))
+                .andExpect(status().isBadRequest());
+        // 중복 key — 개수는 맞지만 집합이 다르다
+        mockMvc.perform(patch("/api/datasets/{id}/columns/order", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keys\":[\"c0\",\"c0\",\"c1\"]}"))
+                .andExpect(status().isBadRequest());
+        // 빈 배열
+        mockMvc.perform(patch("/api/datasets/{id}/columns/order", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keys\":[]}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PATCH columns/order - 타인 dataset이면 404")
+    void reorder_other_member_404() throws Exception {
+        long id = createThreeColumnDataset();
+        String otherAuth = "Bearer " + AuthFixture.loginAndGetAccessToken(
+                mockMvc, "other", "password");
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/order", id)
+                        .header(HttpHeaders.AUTHORIZATION, otherAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keys\":[\"c2\",\"c1\",\"c0\"]}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("순서를 바꿔도 rename·삭제가 key 기준으로 계속 동작한다")
+    void reorder_then_rename_and_delete() throws Exception {
+        long id = createThreeColumnDataset();
+        mockMvc.perform(patch("/api/datasets/{id}/columns/order", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keys\":[\"c2\",\"c0\",\"c1\"]}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}", id, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"과목명\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[1].label").value("과목명"));
+
+        mockMvc.perform(delete("/api/datasets/{id}/columns/{key}", id, "c2")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].label").value("과목명"));
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value("네트워크"))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("92"));
+    }
+
     @Test
     @DisplayName("DELETE column - 열이 빠지고 남은 열 값은 유지된다")
     void delete_column() throws Exception {

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -208,6 +208,117 @@ describe("DatasetGrid", () => {
     expect(screen.queryByText("92")).not.toBeInTheDocument();
   });
 
+  it("헤더를 드래그해 순서를 바꾸면 PATCH하고 값이 열을 따라간다", async () => {
+    // 3열 과목/점수/비고 — 비고(c2)를 맨 앞으로 끈다.
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "점수" },
+              { key: "c2", label: "비고" },
+            ],
+            rowCount: 1,
+          },
+        }),
+      ),
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              { id: 100, rowIndex: 0, cells: ["네트워크", "92", "재수강"] },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+
+    let sentKeys: string[] | null = null;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/columns/order`,
+        async ({ request }) => {
+          const body = (await request.json()) as { keys: string[] };
+          sentKeys = body.keys;
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              id: 1,
+              columns: [
+                { key: "c2", label: "비고" },
+                { key: "c0", label: "과목" },
+                { key: "c1", label: "점수" },
+              ],
+              rowCount: 1,
+            },
+          });
+        },
+      ),
+      // 서버는 새 열 순서로 투영해 준다.
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              { id: 100, rowIndex: 0, cells: ["재수강", "네트워크", "92"] },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+
+    const headers = document.querySelectorAll(
+      '[data-testid="dataset-grid"] .sticky > div',
+    );
+    fireEvent.dragStart(headers[2]); // 비고
+    fireEvent.dragOver(headers[0]);
+    fireEvent.drop(headers[0]); // 과목 자리에 놓기
+
+    await waitFor(() => expect(sentKeys).toEqual(["c2", "c0", "c1"]));
+    expect(await screen.findByText("비고")).toBeInTheDocument();
+    // 재조회가 안 되면 여기서 옛 순서(네트워크가 첫 칸)가 남아 실패한다.
+    await waitFor(() => {
+      const row = document.querySelector(
+        '[data-testid="dataset-grid"] div[style*="translateY(0px)"]',
+      );
+      const cells = Array.from(row!.querySelectorAll(":scope > div")).map((c) =>
+        c.textContent?.trim(),
+      );
+      expect(cells).toEqual(["재수강", "네트워크", "92"]);
+    });
+  });
+
+  it("같은 자리에 놓으면 PATCH하지 않는다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let called = false;
+    server.use(
+      http.patch(`${API_BASE}/datasets/1/columns/order`, () => {
+        called = true;
+        return new HttpResponse(null, { status: 400 });
+      }),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+
+    const headers = document.querySelectorAll(
+      '[data-testid="dataset-grid"] .sticky > div',
+    );
+    fireEvent.dragStart(headers[0]);
+    fireEvent.drop(headers[0]);
+
+    expect(called).toBe(false);
+  });
+
   it("마지막 한 열만 남으면 삭제 버튼을 내보내지 않는다", async () => {
     server.use(
       http.get(`${API_BASE}/datasets/1`, () =>

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -22,6 +22,7 @@ import {
   deleteDatasetRow,
   insertDatasetRow,
   renameDatasetColumn,
+  reorderDatasetColumns,
   updateDatasetRow,
 } from "./api/datasets";
 import { useDatasetMeta } from "./hooks/useDatasetMeta";
@@ -48,6 +49,7 @@ export function DatasetGrid({ datasetId }: Props) {
   const [editingCol, setEditingCol] = useState<string | null>(null);
   const [colDraft, setColDraft] = useState("");
   const [pendingColDelete, setPendingColDelete] = useState<string | null>(null);
+  const [dragKey, setDragKey] = useState<string | null>(null);
 
   const colCount = meta?.columns.length ?? 0;
   const rowCount = meta?.rowCount ?? 0;
@@ -79,6 +81,15 @@ export function DatasetGrid({ datasetId }: Props) {
       renameDatasetColumn(datasetId, v.key, v.label),
     onSuccess: (next: DatasetMeta) =>
       queryClient.setQueryData(datasetKeys.meta(datasetId), next),
+    onError: () => void invalidateMeta(),
+  });
+  const reorderColMut = useMutation({
+    mutationFn: (keys: string[]) => reorderDatasetColumns(datasetId, keys),
+    onSuccess: (next: DatasetMeta) => {
+      queryClient.setQueryData(datasetKeys.meta(datasetId), next);
+      // 캐시된 cells는 이전 열 순서 기준이라 그대로 쓰면 값이 어긋난다.
+      reset();
+    },
     onError: () => void invalidateMeta(),
   });
   const deleteColMut = useMutation({
@@ -167,6 +178,19 @@ export function DatasetGrid({ datasetId }: Props) {
   const columnLabel = (key: string) =>
     meta.columns.find((c) => c.key === key)?.label ?? key;
 
+  /** 끌던 열을 대상 열 자리에 놓는다. */
+  const dropColumnOn = (targetKey: string) => {
+    const from = dragKey;
+    setDragKey(null);
+    if (!from || from === targetKey) return;
+    const keys = meta.columns.map((c) => c.key);
+    const at = keys.indexOf(from);
+    const to = keys.indexOf(targetKey);
+    if (at < 0 || to < 0) return;
+    keys.splice(to, 0, keys.splice(at, 1)[0]);
+    reorderColMut.mutate(keys);
+  };
+
   const startColEdit = (key: string, label: string) => {
     setEditingCol(key);
     setColDraft(label);
@@ -202,7 +226,18 @@ export function DatasetGrid({ datasetId }: Props) {
           {table.getFlatHeaders().map((header) => (
             <div
               key={header.id}
-              className="border-border group flex items-center border-r"
+              // 이름 편집 중엔 텍스트 선택을 막지 않도록 드래그를 끈다.
+              draggable={editingCol !== header.id}
+              onDragStart={() => setDragKey(header.id)}
+              onDragEnd={() => setDragKey(null)}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={() => dropColumnOn(header.id)}
+              data-dragging={dragKey === header.id || undefined}
+              className={cn(
+                "border-border group flex items-center border-r",
+                editingCol !== header.id && "cursor-grab",
+                dragKey === header.id && "opacity-50",
+              )}
             >
               {editingCol === header.id ? (
                 <input

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -76,6 +76,21 @@ export async function addDatasetColumn(
   return data.data;
 }
 
+/**
+ * 열 순서 변경. 전체 순서를 보내며 현재 열 집합과 정확히 같아야 한다.
+ * cells가 key 맵이라 서버는 columns_json 순서만 바꾸고 행은 건드리지 않는다.
+ */
+export async function reorderDatasetColumns(
+  datasetId: number,
+  keys: string[],
+): Promise<DatasetMeta> {
+  const { data } = await client.patch<ApiEnvelope<DatasetMeta>>(
+    `/datasets/${datasetId}/columns/order`,
+    { keys },
+  );
+  return data.data;
+}
+
 /** 열 삭제. 마지막 열은 지울 수 없다(400). */
 export async function deleteDatasetColumn(
   datasetId: number,


### PR DESCRIPTION
## 이슈
closes #795
## 작업 내용
열 순서 변경. **열 조작 4종(rename/add/delete/reorder)이 이걸로 완결된다.**

- `PATCH /api/datasets/{id}/columns/order`
- **행을 건드리지 않는다(O(1)).** `columns_json` 배열 순서만 바꾼다 — cells가 key 맵(#797)이라 값이 위치에 묶여 있지 않고, 읽을 때 투영이 새 순서를 따라간다
- FE: 헤더 드래그로 순서 변경

### 왜 전체 순서를 받나
"이 열을 N번으로" 대신 `{"keys":["c2","c0","c1"]}`처럼 **전체 순서**를 받는다. 멱등이고, 현재 열 집합과 정확히 같은지 한 번에 검증할 수 있다. 열 추가·삭제는 이 API의 일이 아니므로 집합이 다르면 400.

중복 key(`["c0","c0","c1"]`)는 **개수 비교만으론 못 걸러진다** — 집합으로 견준다.

### 수식과의 관계
#799 D7(열 범위를 입력 시 정체성 집합으로 스냅샷)로 [차단이 해제된](https://github.com/wcorn/orino/issues/795#issuecomment-5000118635) 작업이다. 집합은 순서와 무관하므로 순서를 바꿔도 `SUM(...)`의 의미가 변하지 않는다.

## 테스트
BE 5건: 순서 변경 후 값이 열을 따라감 / **행 JSON 불변(O(1) 검증)** / 잘못된 집합 400(누락·없는 key·중복·빈 배열) / 타인 404 / **순서 변경 후에도 rename·삭제가 key 기준으로 동작**
FE 2건: 드래그 → PATCH → 값이 새 순서로 / 같은 자리에 놓으면 미전송

- **reset 필요성 검증**: reorder 후 `reset()`을 빼면 드래그 테스트가 실패하고, 되돌리면 통과하는 것을 양방향으로 확인했다. 캐시된 cells가 이전 순서 기준이라 그대로 쓰면 값이 어긋난다 (#800에서 고친 `reset()` 재조회 버그가 여기서 세 번째로 쓰인다)
- 기존 테스트 전부 무수정 통과 (BE 41건, FE 330건), `./gradlew check` · format · lint · tsc 통과

## 로컬 확인
MySQL 8.4.4 + `bootRun`:
- 과목/점수/비고 → `{"keys":["c2","c0","c1"]}` → API가 `['재수강','네트워크','92']` 반환
- **행 JSON은 순서 변경 전후 완전히 동일** — `{"c0":"네트워크","c1":"92","c2":"재수강"}`. 서버가 columns_json 한 줄만 고쳤다는 증거
- 잘못된 집합(하나 빠짐·중복 key) → 400
- 브라우저: 표에 `A값/B값/C값`을 넣고 **열 3을 맨 앞으로 드래그** → `열 3/열 1/열 2` + `C값/A값/B값`. DB 확인 결과 `columns_json`만 `c2,c0,c1`로 바뀌고 `cells`는 `{"c0":"A값","c1":"B값","c2":"C값"}` 그대로

> 브라우저 확인 중 `/api/auth/reissue` 401이 콘솔에 찍혔는데, 시드용 curl 로그인이 브라우저 세션을 무효화해서 생긴 것으로 이번 변경과 무관하다.
