### PR TITLE
fix : 노트 체크박스 글자가 아래 줄에 입력되는 문제

### DIFF
--- a/fe/e2e/note-task-list.spec.ts
+++ b/fe/e2e/note-task-list.spec.ts
@@ -1,0 +1,173 @@
+import { expect, test } from "@playwright/test";
+
+const NOTE_ID = 1;
+
+/**
+ * 노트 화면까지 도달하는 데 필요한 API만 목킹한다.
+ * (체크박스 레이아웃은 CSS라 jsdom에서 검증할 수 없어 실제 브라우저로 확인한다)
+ *
+ * dev는 VITE_API_URL=/api로 Vite 프록시를 타므로 호스트가 아닌 경로로 가로챈다.
+ */
+async function mockNoteApi(page: import("@playwright/test").Page) {
+  await page.route("**/api/auth/login", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: "OK",
+        data: { accessToken: "mock-access-token" },
+      }),
+    }),
+  );
+
+  // 액세스 토큰은 메모리에만 있어 페이지 이동(리로드) 시 사라진다.
+  // 실제 앱과 같이 재발급으로 세션을 되살린다.
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: "OK",
+        data: { accessToken: "mock-access-token" },
+      }),
+    }),
+  );
+
+  await page.route("**/api/notes", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: "OK",
+        data: {
+          notes: [
+            {
+              id: NOTE_ID,
+              title: "테스트 노트",
+              parentId: null,
+              sortOrder: 0,
+              children: [],
+            },
+          ],
+        },
+      }),
+    }),
+  );
+
+  await page.route(`**/api/notes/${NOTE_ID}`, (route) => {
+    if (route.request().method() === "PATCH") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          code: "OK",
+          data: {
+            id: NOTE_ID,
+            materialId: null,
+            parentId: null,
+            title: "테스트 노트",
+            sortOrder: 0,
+            updatedAt: "2026-01-01T00:00:00Z",
+          },
+        }),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: "OK",
+        data: {
+          id: NOTE_ID,
+          materialId: null,
+          parentId: null,
+          title: "테스트 노트",
+          sortOrder: 0,
+          content: { type: "doc", content: [{ type: "paragraph" }] },
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+      }),
+    });
+  });
+}
+
+async function openNote(page: import("@playwright/test").Page) {
+  // 재발급 목킹으로 세션이 서므로 로그인 화면을 거치지 않는다.
+  await page.goto("/notes");
+  await expect(page.getByLabel("노트 본문")).toBeVisible();
+}
+
+test.describe("노트 체크박스 목록", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockNoteApi(page);
+    await openNote(page);
+  });
+
+  test("'[] ' 입력 후 글자가 체크박스와 같은 줄에 들어간다", async ({
+    page,
+  }) => {
+    await page.getByLabel("노트 본문").click();
+    await page.keyboard.type("[] 우유 사기");
+
+    const item = page.locator('ul[data-type="taskList"] > li').first();
+    await expect(item).toBeVisible();
+
+    const label = item.locator("label");
+    const content = item.locator("> div");
+    await expect(content).toHaveText("우유 사기");
+
+    const labelBox = await label.boundingBox();
+    const contentBox = await content.boundingBox();
+
+    // 회귀 대상: div(block)가 label(inline) 뒤에서 줄바꿈돼 글자가 아래 줄에 찍히던 버그.
+    expect(labelBox).not.toBeNull();
+    expect(contentBox).not.toBeNull();
+    expect(Math.abs(contentBox!.y - labelBox!.y)).toBeLessThan(6);
+    expect(contentBox!.x).toBeGreaterThan(labelBox!.x);
+  });
+
+  test("체크박스 목록엔 불릿 마커가 보이지 않는다", async ({ page }) => {
+    await page.getByLabel("노트 본문").click();
+    await page.keyboard.type("[] 우유 사기");
+
+    const item = page.locator('ul[data-type="taskList"] > li').first();
+    await expect(item).toBeVisible();
+    await expect(item).toHaveCSS("list-style-type", "none");
+  });
+
+  test("체크하면 취소선이 표시된다", async ({ page }) => {
+    await page.getByLabel("노트 본문").click();
+    await page.keyboard.type("[] 우유 사기");
+
+    const item = page.locator('ul[data-type="taskList"] > li').first();
+    await item.locator('input[type="checkbox"]').click();
+
+    await expect(item).toHaveAttribute("data-checked", "true");
+    await expect(item.locator("> div")).toHaveCSS(
+      "text-decoration-line",
+      "line-through",
+    );
+  });
+
+  test("중첩 항목도 체크박스와 글자가 같은 줄에 있다", async ({ page }) => {
+    await page.getByLabel("노트 본문").click();
+    await page.keyboard.type("[] 우유 사기");
+    await page.keyboard.press("Enter");
+    await page.keyboard.press("Tab");
+    await page.keyboard.type("저지방으로");
+
+    const nested = page
+      .locator('ul[data-type="taskList"] ul[data-type="taskList"] > li')
+      .first();
+    await expect(nested).toBeVisible();
+
+    const label = nested.locator("label");
+    const content = nested.locator("> div");
+    await expect(content).toHaveText("저지방으로");
+
+    const labelBox = await label.boundingBox();
+    const contentBox = await content.boundingBox();
+    expect(Math.abs(contentBox!.y - labelBox!.y)).toBeLessThan(6);
+    expect(contentBox!.x).toBeGreaterThan(labelBox!.x);
+  });
+});

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -173,6 +173,49 @@
   margin-bottom: 0;
 }
 
+/* 체크박스 목록(taskList).
+   TipTap TaskItem은 li 안에 label(inline)과 본문 div(block)를 나란히 넣는데,
+   block인 div가 label 뒤에서 줄바꿈돼 글자가 체크박스 아래 줄에 찍힌다.
+   li를 flex로 만들어 체크박스와 글자를 한 줄에 둔다.
+   prose의 disc 마커도 꺼야 체크박스 옆에 불릿이 겹치지 않는다.
+   주의: li엔 data-type이 없다(nodeView가 data-checked만 붙인다) — ul로 지목한다. */
+.tiptap ul[data-type="taskList"] {
+  list-style: none;
+  padding-left: 0;
+}
+
+.tiptap ul[data-type="taskList"] > li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5em;
+}
+
+.tiptap ul[data-type="taskList"] > li > label {
+  flex: 0 0 auto;
+  user-select: none;
+}
+
+/* 체크박스를 첫 줄 글자의 시각 중심에 맞춘다(글자 line-height 기준). */
+.tiptap ul[data-type="taskList"] > li > label > input[type="checkbox"] {
+  margin: 0;
+  vertical-align: middle;
+  translate: 0 0.25em;
+  accent-color: var(--primary);
+  cursor: pointer;
+}
+
+/* min-width: 0 — 긴 단어/코드가 flex 항목을 밀어 넘치는 것을 막는다. */
+.tiptap ul[data-type="taskList"] > li > div {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* 체크 완료 항목은 흐리게 + 취소선. */
+.tiptap ul[data-type="taskList"] > li[data-checked="true"] > div {
+  color: var(--muted-foreground);
+  text-decoration: line-through;
+}
+
 .tiptap img {
   max-width: 100%;
   height: auto;


### PR DESCRIPTION
## 이슈
closes #806
## 작업 내용
- 노트에서 `[] ` 입력 후 글자를 치면 체크박스 **아래 줄**에 입력되던 문제 수정
- 원인: TipTap `TaskItem`이 `li` 안에 `label`(inline)과 본문 `div`(block)를 나란히 넣는데, block인 `div`가 줄바꿈돼 글자가 아래 줄로 밀림. TipTap은 이 레이아웃 CSS를 앱에 맡기는데 `index.css`에 taskList 스타일이 전무했음 (`#430`과 같은 부류 — 스타일 누락)
- `li`를 flex로 만들어 체크박스와 글자를 한 줄에 배치
- 체크박스를 첫 줄 글자 중심에 정렬 (아래 참고)
- prose의 `disc` 마커를 꺼 체크박스 옆 불릿(•) 중복 제거
- 체크 완료 항목에 취소선/흐림, 체크박스 accent를 primary로
- E2E 회귀 테스트 5건 추가

### 셀렉터 주의
`li`에는 `data-type="taskItem"`이 **붙지 않는다** — nodeView가 `data-checked`만 설정한다. TipTap 문서 예제에서 흔히 쓰는 `li[data-type="taskItem"]`은 이 코드베이스에서 매치되지 않아, `ul[data-type="taskList"] > li`로 지목했다.

### 체크박스 세로 정렬 — 진짜 원인은 문단 여백
한 줄로 붙인 뒤 체크박스가 글자보다 아래로 치우쳐 보였다. 파고 보니 정렬 코드가 아니라 **문단 여백** 문제였다.

기존 `.tiptap li > p { margin: 0 }`은 리스트 항목 문단의 여백을 없애는 규칙인데, 체크박스 항목은 `li > div > p` 구조라 **이 규칙이 걸리지 않는다.** 그래서 문단만 `margin-top: 0.15em`(=2.1px)만큼 내려가 있었고, 그만큼 체크박스가 위로 뜬 것처럼 보였다.

따라서 임의 보정값(`translate`)을 넣지 않고 원인을 제거했다:
- `ul[data-type="taskList"] > li > div > p`의 세로 margin 제거
- `label` 높이를 `1lh`로 잡고 그 안에서 중앙 정렬 → 글꼴/크기가 바뀌어도 따라간다

### 검증
브라우저에서 실제 좌표를 측정해 확인했다.

**한 줄 배치** (label top vs 본문 div top)

| | label | 본문 div | 결과 |
|---|---|---|---|
| 수정 전 | 45 | 67 | 22px 아래 줄 ❌ |
| 수정 후 | 41 | 41 | 같은 줄 ✅ |

**세로 정렬** — 폰트 메트릭(`actualBoundingBox*`)으로 글자의 실제 잉크 중심을 계산해 비교

| | 체크박스 중심 − 글자 중심 |
|---|---|
| `translate: 0.25em` 보정 | +2.7px (아래로 치우침) ❌ |
| 보정 제거 + `1lh` 정렬만 | −2.1px (위로 치우침) ❌ |
| **문단 margin 제거까지** | **±0.1px 이내** ✅ |

- `[] 우유 사기` 타이핑 → 체크박스 + 같은 줄 글자 확인
- 체크 토글 → `data-checked=true` + 취소선 확인
- Enter → Tab 중첩 항목도 같은 줄 + 들여쓰기 확인
- 여러 줄 항목에서 체크박스가 첫 줄에 붙는 것 확인
- 추가한 E2E는 **해당 CSS를 빼면 실패**함을 각각 확인(회귀 가드 성립). 기존 4건은 허용오차가 6px이라 정렬 어긋남을 못 잡아 정렬 전용 테스트를 따로 뒀다
- `npm test` 328건 통과 · lint · format:check · build · E2E 5건 통과

### 참고 (이 PR 범위 밖)
기존 `e2e/auth.spec.ts` 2건이 **main에서 이미 실패**한다 → #808로 분리했다.