### PR TITLE
feat : 수식 파서 (구분자 표기·참조 3종 바인딩·범위 스냅샷)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaContext.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaContext.java
@@ -1,0 +1,26 @@
+package ds.project.orino.planner.dataset.formula;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 파서가 바깥 세계를 보는 창. 열 목록과 행 번호↔id 변환만 제공한다 —
+ * 파서 자체는 DB를 모른다.
+ */
+public interface FormulaContext {
+
+    /** 현재 열 key 목록(표시 순서). 범위 스냅샷이 이 순서를 기준으로 펼쳐진다. */
+    List<String> columnKeys();
+
+    /** label → key. 없으면 empty. 중복 label은 참조를 지목할 수 없어 예외다. */
+    Optional<String> keyByLabel(String label);
+
+    /** key → label. 표시 문자열을 만들 때. */
+    Optional<String> labelByKey(String key);
+
+    /** 화면의 행 번호(1-base) → 행 id. 파싱 시점에 한 번만 해석한다. */
+    Optional<Long> rowIdByNumber(int rowNumber);
+
+    /** 행 id → 현재 행 번호(1-base). 표시할 때. 지워진 행이면 empty. */
+    Optional<Integer> rowNumberById(long rowId);
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaNode.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaNode.java
@@ -1,0 +1,46 @@
+package ds.project.orino.planner.dataset.formula;
+
+import ds.project.orino.domain.planner.dataset.entity.FormulaRefKind;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 수식 구문 트리. 파싱이 끝난 뒤엔 label·행 번호가 남지 않고 <b>열 key와 행 id로만</b> 이뤄진다 —
+ * 그래야 열 이름을 바꾸거나 행이 밀려도 수식이 안 깨진다.
+ *
+ * <p>표시 문자열은 이 트리에서 그때그때 만든다({@link FormulaWriter}).
+ */
+public sealed interface FormulaNode {
+
+    /** 리터럴 숫자. */
+    record Num(BigDecimal value) implements FormulaNode {
+    }
+
+    /** 단항 부호. {@code op}는 '+' 또는 '-'. */
+    record Unary(char op, FormulaNode operand) implements FormulaNode {
+    }
+
+    /** 이항 산술. {@code op}는 '+' '-' '*' '/'. */
+    record Binary(char op, FormulaNode left, FormulaNode right) implements FormulaNode {
+    }
+
+    /**
+     * 셀 참조.
+     *
+     * <ul>
+     *   <li>{@link FormulaRefKind#SAME_ROW} — {@code rowId}는 null. 각 행이 자기 행을 가리킨다
+     *   <li>{@link FormulaRefKind#ABSOLUTE} — {@code rowId}에 값
+     * </ul>
+     */
+    record Ref(FormulaRefKind kind, String colKey, Long rowId) implements FormulaNode {
+    }
+
+    /**
+     * 열 집계. 인자는 <b>열 key 목록</b>이다 — 범위({@code {a}:{c}})는 파싱 시점에
+     * 그 사이의 열들로 펼쳐져 집합으로 굳는다(D7). 그래서 이후 순서를 바꿔도 의미가 안 변하고,
+     * 저장형·표시형 어디에도 범위 문법이 남지 않는다.
+     */
+    record Agg(String func, List<String> colKeys) implements FormulaNode {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaParser.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaParser.java
@@ -1,0 +1,306 @@
+package ds.project.orino.planner.dataset.formula;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.dataset.entity.FormulaRefKind;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * 수식 파서. 재귀 하강.
+ *
+ * <pre>
+ * formula := '=' expr EOF
+ * expr    := term (('+' | '-') term)*
+ * term    := unary (('*' | '/') unary)*
+ * unary   := ('-' | '+') unary | primary
+ * primary := NUMBER | '(' expr ')' | agg | ref
+ * agg     := FUNC '(' colRef (':' colRef | (',' colRef)*) ')'
+ * ref     := '{' label '}' row?
+ * row     := DIGITS          (입력형: 화면 행 번호)
+ *          | '@' DIGITS      (저장형: 행 id)
+ * </pre>
+ *
+ * <p><b>열 이름은 반드시 중괄호로 감싼다.</b> 실제 데이터의 label이 {@code 열 1}처럼 숫자로 끝나고
+ * ({@code =열 15}가 "열 1의 5행"인지 "열 15"인지 모호) 공백·괄호를 품기 때문에
+ * ({@code Adjusted Frequency per Million (U)}), 구분자 없이는 파싱 자체가 성립하지 않는다.
+ * 중괄호 안은 통째로 이름으로 읽는다.
+ *
+ * <p><b>같은 표기가 문맥에 따라 다른 참조가 된다.</b> 집계 함수 안의 {@code {점수}}는 열 전체이고,
+ * 산술 속 {@code {점수}}는 같은 행이다. 그래서 집계 인자는 <b>열 참조만</b> 받는다 —
+ * {@code SUM({a} * 2)} 같은 걸 허용하면 "열을 2배해서 합"의 의미가 정의되지 않는다.
+ */
+public final class FormulaParser {
+
+    /** D8이 정한 함수 범위. IF는 비교·논리 연산자와 세트라 제외. */
+    private static final Set<String> AGGREGATES = Set.of("SUM", "AVG", "COUNT", "MIN", "MAX");
+
+    private final String src;
+    private final FormulaContext ctx;
+    private final boolean stored;
+    private int pos;
+
+    private FormulaParser(String src, FormulaContext ctx, boolean stored) {
+        this.src = src;
+        this.ctx = ctx;
+        this.stored = stored;
+    }
+
+    /** 사용자가 친 수식(label·행 번호) → 바인딩된 트리. */
+    public static FormulaNode parseInput(String text, FormulaContext ctx) {
+        return new FormulaParser(text, ctx, false).parseAll();
+    }
+
+    /** 저장된 수식(열 key·행 id) → 트리. */
+    public static FormulaNode parseStored(String text, FormulaContext ctx) {
+        return new FormulaParser(text, ctx, true).parseAll();
+    }
+
+    /** 트리가 참조하는 것들. 중복은 합친다. */
+    public static List<FormulaNode.Ref> collectRefs(FormulaNode node) {
+        List<FormulaNode.Ref> out = new ArrayList<>();
+        collect(node, out);
+        return List.copyOf(new LinkedHashSet<>(out));
+    }
+
+    private static void collect(FormulaNode node, List<FormulaNode.Ref> out) {
+        switch (node) {
+            case FormulaNode.Ref r -> out.add(r);
+            case FormulaNode.Agg a -> a.colKeys()
+                    .forEach(k -> out.add(new FormulaNode.Ref(FormulaRefKind.COLUMN_ALL, k, null)));
+            case FormulaNode.Binary b -> {
+                collect(b.left(), out);
+                collect(b.right(), out);
+            }
+            case FormulaNode.Unary u -> collect(u.operand(), out);
+            case FormulaNode.Num ignored -> {
+            }
+        }
+    }
+
+    private FormulaNode parseAll() {
+        skipSpace();
+        expect('=');
+        FormulaNode node = expr();
+        skipSpace();
+        if (pos < src.length()) {
+            throw syntaxError("수식 뒤에 남은 문자가 있습니다");
+        }
+        return node;
+    }
+
+    private FormulaNode expr() {
+        FormulaNode left = term();
+        while (true) {
+            skipSpace();
+            char c = peek();
+            if (c != '+' && c != '-') {
+                return left;
+            }
+            pos++;
+            left = new FormulaNode.Binary(c, left, term());
+        }
+    }
+
+    private FormulaNode term() {
+        FormulaNode left = unary();
+        while (true) {
+            skipSpace();
+            char c = peek();
+            if (c != '*' && c != '/') {
+                return left;
+            }
+            pos++;
+            left = new FormulaNode.Binary(c, left, unary());
+        }
+    }
+
+    private FormulaNode unary() {
+        skipSpace();
+        char c = peek();
+        if (c == '-' || c == '+') {
+            pos++;
+            return new FormulaNode.Unary(c, unary());
+        }
+        return primary();
+    }
+
+    private FormulaNode primary() {
+        skipSpace();
+        char c = peek();
+        if (c == '(') {
+            pos++;
+            FormulaNode inner = expr();
+            skipSpace();
+            expect(')');
+            return inner;
+        }
+        if (c == '{') {
+            return ref(false);
+        }
+        if (Character.isDigit(c) || c == '.') {
+            return number();
+        }
+        if (Character.isLetter(c)) {
+            return agg();
+        }
+        throw syntaxError("예상하지 못한 문자: '" + c + "'");
+    }
+
+    private FormulaNode number() {
+        int start = pos;
+        while (pos < src.length() && (Character.isDigit(src.charAt(pos)) || src.charAt(pos) == '.')) {
+            pos++;
+        }
+        try {
+            return new FormulaNode.Num(new BigDecimal(src.substring(start, pos)));
+        } catch (NumberFormatException e) {
+            throw syntaxError("숫자를 읽을 수 없습니다: " + src.substring(start, pos));
+        }
+    }
+
+    private FormulaNode agg() {
+        int start = pos;
+        while (pos < src.length() && Character.isLetter(src.charAt(pos))) {
+            pos++;
+        }
+        String name = src.substring(start, pos).toUpperCase(Locale.ROOT);
+        if (!AGGREGATES.contains(name)) {
+            throw syntaxError("지원하지 않는 함수: " + name);
+        }
+        skipSpace();
+        expect('(');
+
+        List<String> keys = new ArrayList<>();
+        FormulaNode.Ref first = (FormulaNode.Ref) ref(true);
+        skipSpace();
+        if (peek() == ':') {
+            // 범위 — 지금 그 사이에 있는 열들로 펼쳐 집합으로 굳힌다(D7).
+            pos++;
+            FormulaNode.Ref last = (FormulaNode.Ref) ref(true);
+            keys.addAll(expandRange(first.colKey(), last.colKey()));
+        } else {
+            keys.add(first.colKey());
+            while (peek() == ',') {
+                pos++;
+                keys.add(((FormulaNode.Ref) ref(true)).colKey());
+                skipSpace();
+            }
+        }
+        skipSpace();
+        expect(')');
+        return new FormulaNode.Agg(name, List.copyOf(new LinkedHashSet<>(keys)));
+    }
+
+    /** {@code {a}:{c}} → 현재 열 순서에서 a..c 구간. 역방향으로 줘도 받아준다. */
+    private List<String> expandRange(String fromKey, String toKey) {
+        List<String> all = ctx.columnKeys();
+        int from = all.indexOf(fromKey);
+        int to = all.indexOf(toKey);
+        if (from < 0 || to < 0) {
+            throw syntaxError("범위의 열을 찾을 수 없습니다");
+        }
+        return new ArrayList<>(all.subList(Math.min(from, to), Math.max(from, to) + 1));
+    }
+
+    /**
+     * {@code '{' 이름 '}' 행?} — 열 참조.
+     *
+     * @param columnOnly 집계 인자 자리면 true. 행을 붙일 수 없고 열 전체를 뜻한다.
+     */
+    private FormulaNode ref(boolean columnOnly) {
+        skipSpace();
+        expect('{');
+        int close = src.indexOf('}', pos);
+        if (close < 0) {
+            throw syntaxError("열 이름을 닫는 '}'가 없습니다");
+        }
+        String name = src.substring(pos, close);
+        pos = close + 1;
+        if (name.isBlank()) {
+            throw syntaxError("열 이름이 비었습니다");
+        }
+
+        String key = resolveKey(name);
+        Long rowId = rowSuffix();
+        if (rowId != null && columnOnly) {
+            throw syntaxError("집계 함수 안에서는 행을 지정할 수 없습니다: {" + name + "}");
+        }
+        if (columnOnly) {
+            return new FormulaNode.Ref(FormulaRefKind.COLUMN_ALL, key, null);
+        }
+        return rowId == null
+                ? new FormulaNode.Ref(FormulaRefKind.SAME_ROW, key, null)
+                : new FormulaNode.Ref(FormulaRefKind.ABSOLUTE, key, rowId);
+    }
+
+    private String resolveKey(String name) {
+        if (stored) {
+            if (!ctx.columnKeys().contains(name)) {
+                throw syntaxError("없는 열: " + name);
+            }
+            return name;
+        }
+        return ctx.keyByLabel(name)
+                .orElseThrow(() -> syntaxError("없는 열: " + name));
+    }
+
+    /** 행 지정을 읽는다. 없으면 null. 저장형은 {@code @id}, 입력형은 화면 행 번호. */
+    private Long rowSuffix() {
+        if (stored) {
+            if (peek() != '@') {
+                return null;
+            }
+            pos++;
+            return digits("행 id");
+        }
+        if (!Character.isDigit(peek())) {
+            return null;
+        }
+        long number = digits("행 번호");
+        // 화면 번호 → 행 id. 파싱 시점에 한 번만 해석하므로 이후 행이 밀려도 안 깨진다.
+        return ctx.rowIdByNumber((int) number)
+                .orElseThrow(() -> syntaxError("없는 행: " + number));
+    }
+
+    private long digits(String what) {
+        int start = pos;
+        while (pos < src.length() && Character.isDigit(src.charAt(pos))) {
+            pos++;
+        }
+        if (start == pos) {
+            throw syntaxError(what + "가 필요합니다");
+        }
+        try {
+            return Long.parseLong(src.substring(start, pos));
+        } catch (NumberFormatException e) {
+            throw syntaxError(what + "가 너무 큽니다");
+        }
+    }
+
+    private char peek() {
+        return pos < src.length() ? src.charAt(pos) : '\0';
+    }
+
+    private void expect(char c) {
+        if (peek() != c) {
+            throw syntaxError("'" + c + "'가 필요합니다");
+        }
+        pos++;
+    }
+
+    private void skipSpace() {
+        while (pos < src.length() && src.charAt(pos) == ' ') {
+            pos++;
+        }
+    }
+
+    private CustomException syntaxError(String detail) {
+        return new CustomException(ErrorCode.FORMULA_SYNTAX_ERROR, detail);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaWriter.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaWriter.java
@@ -1,0 +1,91 @@
+package ds.project.orino.planner.dataset.formula;
+
+import ds.project.orino.domain.planner.dataset.entity.FormulaRefKind;
+
+import java.math.BigDecimal;
+import java.util.stream.Collectors;
+
+/**
+ * 구문 트리를 문자열로. 두 방향이 있다.
+ *
+ * <ul>
+ *   <li>{@link #toStored} — 열 key·행 id. DB에 담기는 형태. 이름을 바꾸거나 행이 밀려도 안 변한다
+ *   <li>{@link #toDisplay} — 열 label·행 번호. 사용자에게 보이는 형태. <b>읽을 때마다 새로 만든다</b>
+ * </ul>
+ *
+ * <p>저장은 주소로, 표시는 위치로 — {@code cells}가 key 맵이고 API가 위치 배열인 것과 같은 전략이다.
+ * 덕분에 열 이름을 바꾸면 저장된 수식은 그대로인데 표시만 새 이름으로 따라온다.
+ */
+public final class FormulaWriter {
+
+    private FormulaWriter() {
+    }
+
+    /** 저장형. {@code =SUM({c2})*{c0}} / {@code ={c1}@142} */
+    public static String toStored(FormulaNode node) {
+        StringBuilder sb = new StringBuilder("=");
+        write(node, sb, null);
+        return sb.toString();
+    }
+
+    /**
+     * 표시형. {@code =SUM({점수})*{과목}} / {@code ={점수}5}
+     *
+     * <p>지워진 열·행을 가리키면 {@code #REF!}로 보여준다 — 저장형은 끊긴 참조를 그대로 안고 있고,
+     * 그게 {@code #REF!}를 만들 수 있는 근거다.
+     */
+    public static String toDisplay(FormulaNode node, FormulaContext ctx) {
+        StringBuilder sb = new StringBuilder("=");
+        write(node, sb, ctx);
+        return sb.toString();
+    }
+
+    /** {@code ctx}가 null이면 저장형, 아니면 표시형. 트리를 한 번만 순회하도록 합쳤다. */
+    private static void write(FormulaNode node, StringBuilder sb, FormulaContext ctx) {
+        switch (node) {
+            case FormulaNode.Num n -> sb.append(plain(n.value()));
+            case FormulaNode.Unary u -> {
+                sb.append(u.op());
+                write(u.operand(), sb, ctx);
+            }
+            case FormulaNode.Binary b -> {
+                // 트리 모양을 잃지 않도록 괄호를 항상 친다. 우선순위를 되짚어 생략하지 않는다.
+                sb.append('(');
+                write(b.left(), sb, ctx);
+                sb.append(' ').append(b.op()).append(' ');
+                write(b.right(), sb, ctx);
+                sb.append(')');
+            }
+            case FormulaNode.Agg a -> sb.append(a.func()).append('(')
+                    .append(a.colKeys().stream()
+                            .map(k -> "{" + name(k, ctx) + "}")
+                            .collect(Collectors.joining(", ")))
+                    .append(')');
+            case FormulaNode.Ref r -> {
+                sb.append('{').append(name(r.colKey(), ctx)).append('}');
+                if (r.kind() == FormulaRefKind.ABSOLUTE) {
+                    sb.append(rowToken(r.rowId(), ctx));
+                }
+            }
+        }
+    }
+
+    private static String name(String key, FormulaContext ctx) {
+        if (ctx == null) {
+            return key;
+        }
+        return ctx.labelByKey(key).orElse("#REF!");
+    }
+
+    private static String rowToken(Long rowId, FormulaContext ctx) {
+        if (ctx == null) {
+            return "@" + rowId;
+        }
+        return ctx.rowNumberById(rowId).map(String::valueOf).orElse("#REF!");
+    }
+
+    /** 지수 표기를 피한다 — {@code 1E+2} 같은 게 수식에 보이면 곤란하다. */
+    private static String plain(BigDecimal value) {
+        return value.stripTrailingZeros().toPlainString();
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/formula/FormulaParserTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/formula/FormulaParserTest.java
@@ -1,0 +1,317 @@
+package ds.project.orino.planner.dataset.formula;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.dataset.entity.FormulaRefKind;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 파서·표시 왕복 검증.
+ *
+ * <p>label은 <b>운영 데이터에서 실제로 쓰이는 것</b>을 그대로 쓴다 — 숫자로 끝나는 {@code 열 1},
+ * 공백이 든 {@code SFI Rank}, 괄호가 든 {@code Adjusted Frequency per Million (U)}.
+ * 구분자 문법이 이론이 아니라 이 데이터 때문에 필요하다.
+ */
+class FormulaParserTest {
+
+    /** 운영 데이터의 열 구성을 본뜬 컨텍스트. 행 번호 N ↔ 행 id 100+N. */
+    private static class FakeContext implements FormulaContext {
+        private final Map<String, String> labelByKey = new LinkedHashMap<>();
+        private final int rowCount;
+
+        FakeContext(int rowCount, String... keyLabelPairs) {
+            this.rowCount = rowCount;
+            for (int i = 0; i < keyLabelPairs.length; i += 2) {
+                labelByKey.put(keyLabelPairs[i], keyLabelPairs[i + 1]);
+            }
+        }
+
+        @Override
+        public List<String> columnKeys() {
+            return List.copyOf(labelByKey.keySet());
+        }
+
+        @Override
+        public Optional<String> keyByLabel(String label) {
+            return labelByKey.entrySet().stream()
+                    .filter(e -> e.getValue().equals(label))
+                    .map(Map.Entry::getKey)
+                    .findFirst();
+        }
+
+        @Override
+        public Optional<String> labelByKey(String key) {
+            return Optional.ofNullable(labelByKey.get(key));
+        }
+
+        @Override
+        public Optional<Long> rowIdByNumber(int rowNumber) {
+            return rowNumber >= 1 && rowNumber <= rowCount
+                    ? Optional.of(100L + rowNumber) : Optional.empty();
+        }
+
+        @Override
+        public Optional<Integer> rowNumberById(long rowId) {
+            int n = (int) (rowId - 100L);
+            return n >= 1 && n <= rowCount ? Optional.of(n) : Optional.empty();
+        }
+    }
+
+    private final FakeContext ctx = new FakeContext(5,
+            "c0", "Lemma",
+            "c1", "SFI Rank",
+            "c2", "SFI",
+            "c3", "Adjusted Frequency per Million (U)");
+
+    private final FakeContext simple = new FakeContext(3, "c0", "열 1", "c1", "열 2", "c2", "열 3");
+
+    @Nested
+    @DisplayName("구분자 — 실제 label이 요구하는 것")
+    class Delimiter {
+
+        @Test
+        @DisplayName("공백이 든 label을 통째로 읽는다")
+        void labelWithSpace() {
+            FormulaNode n = FormulaParser.parseInput("={SFI Rank}", ctx);
+            assertThat(n).isEqualTo(new FormulaNode.Ref(FormulaRefKind.SAME_ROW, "c1", null));
+        }
+
+        @Test
+        @DisplayName("괄호가 든 label을 함수 괄호와 헷갈리지 않는다")
+        void labelWithParens() {
+            FormulaNode n = FormulaParser.parseInput(
+                    "=SUM({Adjusted Frequency per Million (U)})", ctx);
+            assertThat(n).isEqualTo(new FormulaNode.Agg("SUM", List.of("c3")));
+        }
+
+        @Test
+        @DisplayName("숫자로 끝나는 label과 행 번호를 구분한다 — 구분자가 없으면 불가능했던 것")
+        void labelEndingWithDigitVsRowNumber() {
+            // {열 1} → 같은 행. 뒤에 붙은 2가 행 번호다.
+            assertThat(FormulaParser.parseInput("={열 1}2", simple))
+                    .isEqualTo(new FormulaNode.Ref(FormulaRefKind.ABSOLUTE, "c0", 102L));
+            // 행 번호가 없으면 같은 행.
+            assertThat(FormulaParser.parseInput("={열 1}", simple))
+                    .isEqualTo(new FormulaNode.Ref(FormulaRefKind.SAME_ROW, "c0", null));
+        }
+    }
+
+    @Nested
+    @DisplayName("참조 3종 바인딩 (D9)")
+    class Refs {
+
+        @Test
+        @DisplayName("산술 속 열 참조는 같은 행 — 행 id를 쓰지 않는다")
+        void arithmeticIsSameRow() {
+            FormulaNode n = FormulaParser.parseInput("={SFI Rank} * {SFI}", ctx);
+            assertThat(FormulaParser.collectRefs(n)).containsExactly(
+                    new FormulaNode.Ref(FormulaRefKind.SAME_ROW, "c1", null),
+                    new FormulaNode.Ref(FormulaRefKind.SAME_ROW, "c2", null));
+        }
+
+        @Test
+        @DisplayName("행 번호를 붙이면 절대 참조 — 파싱 시점에 행 id로 굳는다")
+        void rowNumberBecomesRowId() {
+            FormulaNode n = FormulaParser.parseInput("={SFI}3", ctx);
+            assertThat(n).isEqualTo(new FormulaNode.Ref(FormulaRefKind.ABSOLUTE, "c2", 103L));
+        }
+
+        @Test
+        @DisplayName("집계 속 열 참조는 열 전체")
+        void aggregateIsColumnAll() {
+            FormulaNode n = FormulaParser.parseInput("=SUM({SFI})", ctx);
+            assertThat(FormulaParser.collectRefs(n)).containsExactly(
+                    new FormulaNode.Ref(FormulaRefKind.COLUMN_ALL, "c2", null));
+        }
+
+        @Test
+        @DisplayName("같은 표기가 문맥에 따라 다르게 바인딩된다")
+        void sameNotationDiffersByContext() {
+            FormulaNode n = FormulaParser.parseInput("=SUM({SFI}) + {SFI}", ctx);
+            assertThat(FormulaParser.collectRefs(n)).containsExactlyInAnyOrder(
+                    new FormulaNode.Ref(FormulaRefKind.COLUMN_ALL, "c2", null),
+                    new FormulaNode.Ref(FormulaRefKind.SAME_ROW, "c2", null));
+        }
+    }
+
+    @Nested
+    @DisplayName("열 범위 — 입력 시 집합으로 굳는다 (D7)")
+    class Range {
+
+        @Test
+        @DisplayName("범위는 현재 순서로 펼쳐진다")
+        void rangeExpands() {
+            FormulaNode n = FormulaParser.parseInput("=SUM({Lemma}:{SFI})", ctx);
+            assertThat(n).isEqualTo(new FormulaNode.Agg("SUM", List.of("c0", "c1", "c2")));
+        }
+
+        @Test
+        @DisplayName("저장형·표시형 어디에도 범위 문법이 남지 않는다")
+        void rangeDoesNotSurviveAsRange() {
+            FormulaNode n = FormulaParser.parseInput("=SUM({Lemma}:{SFI})", ctx);
+            assertThat(FormulaWriter.toStored(n)).isEqualTo("=SUM({c0}, {c1}, {c2})");
+            assertThat(FormulaWriter.toDisplay(n, ctx))
+                    .isEqualTo("=SUM({Lemma}, {SFI Rank}, {SFI})");
+        }
+
+        @Test
+        @DisplayName("거꾸로 준 범위도 받아준다")
+        void reversedRange() {
+            assertThat(FormulaParser.parseInput("=SUM({SFI}:{Lemma})", ctx))
+                    .isEqualTo(new FormulaNode.Agg("SUM", List.of("c0", "c1", "c2")));
+        }
+
+        @Test
+        @DisplayName("열을 나열해도 된다")
+        void explicitList() {
+            assertThat(FormulaParser.parseInput("=SUM({Lemma}, {SFI})", ctx))
+                    .isEqualTo(new FormulaNode.Agg("SUM", List.of("c0", "c2")));
+        }
+    }
+
+    @Nested
+    @DisplayName("왕복 — 저장은 주소로, 표시는 위치로")
+    class RoundTrip {
+
+        @Test
+        @DisplayName("저장형은 key·행 id로만 이뤄진다")
+        void storedHasNoLabels() {
+            FormulaNode n = FormulaParser.parseInput("={SFI Rank} * {SFI}3 + 2", ctx);
+            assertThat(FormulaWriter.toStored(n))
+                    .isEqualTo("=(({c1} * {c2}@103) + 2)")
+                    .doesNotContain("SFI");
+        }
+
+        @Test
+        @DisplayName("저장형을 다시 파싱하면 같은 트리다")
+        void storedReparsesIdentically() {
+            FormulaNode a = FormulaParser.parseInput("=SUM({Lemma}:{SFI}) / {SFI Rank}2", ctx);
+            FormulaNode b = FormulaParser.parseStored(FormulaWriter.toStored(a), ctx);
+            assertThat(b).isEqualTo(a);
+        }
+
+        @Test
+        @DisplayName("열 이름을 바꾸면 저장형은 그대로인데 표시만 새 이름이 된다")
+        void renameChangesDisplayOnly() {
+            FormulaNode n = FormulaParser.parseInput("={SFI Rank}", ctx);
+            String stored = FormulaWriter.toStored(n);
+
+            FakeContext renamed = new FakeContext(5, "c0", "Lemma", "c1", "순위",
+                    "c2", "SFI", "c3", "x");
+            FormulaNode reparsed = FormulaParser.parseStored(stored, renamed);
+
+            assertThat(FormulaWriter.toStored(reparsed)).isEqualTo(stored);
+            assertThat(FormulaWriter.toDisplay(reparsed, renamed)).isEqualTo("={순위}");
+        }
+
+        @Test
+        @DisplayName("지워진 열·행을 가리키면 표시에서 #REF!")
+        void danglingShowsRef() {
+            FormulaNode n = FormulaParser.parseInput("={SFI}3", ctx);
+            // 그 열도 그 행도 없는 컨텍스트
+            FakeContext shrunk = new FakeContext(1, "c0", "Lemma");
+            assertThat(FormulaWriter.toDisplay(n, shrunk)).isEqualTo("={#REF!}#REF!");
+        }
+    }
+
+    @Nested
+    @DisplayName("문법 오류")
+    class Errors {
+
+        private void expectSyntaxError(String input) {
+            assertThatThrownBy(() -> FormulaParser.parseInput(input, ctx))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(e -> ((CustomException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.FORMULA_SYNTAX_ERROR);
+        }
+
+        @Test
+        @DisplayName("= 로 시작하지 않으면 오류")
+        void mustStartWithEquals() {
+            expectSyntaxError("{SFI} + 1");
+        }
+
+        @Test
+        @DisplayName("없는 열·행이면 오류")
+        void unknownRefs() {
+            expectSyntaxError("={없는열}");
+            expectSyntaxError("={SFI}99");
+        }
+
+        @Test
+        @DisplayName("닫히지 않은 괄호·중괄호면 오류")
+        void unbalanced() {
+            expectSyntaxError("={SFI");
+            expectSyntaxError("=({SFI}");
+            expectSyntaxError("=SUM({SFI}");
+        }
+
+        @Test
+        @DisplayName("D8 범위 밖 함수면 오류 — IF는 아직 없다")
+        void unsupportedFunction() {
+            expectSyntaxError("=IF({SFI} > 1, 1, 0)");
+            expectSyntaxError("=COUNTA({SFI})");
+        }
+
+        @Test
+        @DisplayName("집계 안에서 행을 지정하면 오류 — 열 전체와 뜻이 충돌한다")
+        void rowInsideAggregate() {
+            expectSyntaxError("=SUM({SFI}3)");
+        }
+
+        @Test
+        @DisplayName("집계 인자에 산술을 넣으면 오류 — 의미가 정의되지 않는다")
+        void expressionInsideAggregate() {
+            expectSyntaxError("=SUM({SFI} * 2)");
+        }
+
+        @Test
+        @DisplayName("수식 뒤에 군더더기가 있으면 오류")
+        void trailingGarbage() {
+            expectSyntaxError("={SFI} 1 2");
+        }
+    }
+
+    @Nested
+    @DisplayName("산술")
+    class Arithmetic {
+
+        @Test
+        @DisplayName("사칙연산 우선순위를 지킨다")
+        void precedence() {
+            FormulaNode n = FormulaParser.parseInput("=1 + 2 * 3", ctx);
+            assertThat(FormulaWriter.toStored(n)).isEqualTo("=(1 + (2 * 3))");
+        }
+
+        @Test
+        @DisplayName("괄호로 우선순위를 바꾼다")
+        void parens() {
+            FormulaNode n = FormulaParser.parseInput("=(1 + 2) * 3", ctx);
+            assertThat(FormulaWriter.toStored(n)).isEqualTo("=((1 + 2) * 3)");
+        }
+
+        @Test
+        @DisplayName("단항 부호")
+        void unary() {
+            assertThat(FormulaWriter.toStored(FormulaParser.parseInput("=-{SFI}", ctx)))
+                    .isEqualTo("=-{c2}");
+        }
+
+        @Test
+        @DisplayName("소수를 지수 표기 없이 쓴다")
+        void decimals() {
+            assertThat(FormulaWriter.toStored(FormulaParser.parseInput("=0.50", ctx)))
+                    .isEqualTo("=0.5");
+        }
+    }
+}

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/CustomException.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/CustomException.java
@@ -9,6 +9,12 @@ public class CustomException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
+    /** 사용자에게 어디가 틀렸는지 알려야 하는 경우(예: 수식 문법 오류)에 상세를 덧붙인다. */
+    public CustomException(ErrorCode errorCode, String detail) {
+        super(errorCode.getMessage(detail));
+        this.errorCode = errorCode;
+    }
+
     public CustomException(ErrorCode errorCode, Throwable cause) {
         super(errorCode.getMessage(cause), cause);
         this.errorCode = errorCode;

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
     INVALID_REQUEST("SP-ERR-002", "유효하지 않은 요청입니다.", 400),
     INVALID_STATE("SP-ERR-003", "현재 상태에서 수행할 수 없는 작업입니다.", 409),
     DUPLICATE_COLUMN_LABEL("SP-ERR-004", "이미 있는 열 이름입니다.", 409),
+    FORMULA_SYNTAX_ERROR("SP-ERR-005", "수식을 이해할 수 없습니다.", 400),
+    FORMULA_CIRCULAR_REFERENCE("SP-ERR-006", "수식이 자기 자신을 참조합니다.", 409),
 
     // PLANNER (Google Calendar 연동)
     ROUTINE_INVALID_RULE("PLN-ERR-002", "유효하지 않은 반복 규칙입니다.", 400),


### PR DESCRIPTION
## 이슈
closes #811
## 작업 내용
수식 파서. 사용자가 친 문자열 ↔ 바인딩된 정규형을 양방향으로 오간다. [#799](https://github.com/wcorn/orino/issues/799) 구현 3단계.

```
formula := '=' expr
expr    := term (('+' | '-') term)*
term    := unary (('*' | '/') unary)*
unary   := ('-' | '+') unary | primary
primary := NUMBER | '(' expr ')' | agg | ref
agg     := FUNC '(' colRef (':' colRef | (',' colRef)*) ')'
ref     := '{' 이름 '}' row?
row     := DIGITS  (입력형: 행 번호) | '@' DIGITS  (저장형: 행 id)
```

### 구분자는 취향이 아니라 필수였다
[#810 조사](https://github.com/wcorn/orino/issues/810#issuecomment-5000969440)에서 본 **운영 데이터의 실제 label**이 그대로 근거다:
- `열 1`, `열 2`, `열 3` — **숫자로 끝난다.** `=열 15`가 "`열 1`의 5행"인지 "`열 15`"인지 구분 불가
- `SFI Rank` — **공백.** 토큰 경계로 공백을 못 쓴다
- `Adjusted Frequency per Million (U)` — **괄호.** 함수 괄호와 충돌

→ 중괄호 안은 통째로 이름으로 읽는다. 테스트도 이 label들을 그대로 쓴다.

### 참조 3종은 문맥이 가른다 (D9)
| 표기 | 바인딩 |
|---|---|
| `={SFI Rank} * {SFI}` | 둘 다 `SAME_ROW` — **행 id를 안 쓴다** |
| `={SFI}3` | `ABSOLUTE` + 행 id (파싱 시점에 굳음) |
| `=SUM({SFI})` | `COLUMN_ALL` |

`=SUM({SFI}) + {SFI}` 처럼 **같은 표기가 문맥에 따라 다르게** 바인딩된다.

### 집계 인자는 열 참조만
`SUM({a} * 2)`는 "열을 2배해서 합"의 의미가 정의되지 않아 **거부**한다. D8이 말한 건 "열 집계"이고, 여기서 멈추면 모호성이 사라진다. `SUM({a}3)`(집계 안 행 지정)도 열 전체와 뜻이 충돌해 거부.

### 범위는 입력 시 집합으로 굳는다 (D7)
`SUM({Lemma}:{SFI})` → 파싱 시점에 현재 순서로 펼쳐 `{c0, c1, c2}`. **저장형·표시형 어디에도 범위 문법이 안 남는다** — 순서를 바꿔도 의미가 안 변하고, 표시가 거짓말하지 않는다.

## 테스트
26건 (`@Nested`로 묶음):
- **구분자** — 공백·괄호 든 label, 숫자로 끝나는 label vs 행 번호
- **참조 3종** — 산술=같은 행 / 행 번호=절대 / 집계=열 전체 / 같은 표기의 문맥 차이
- **범위** — 펼침, 역방향, 나열, 범위 문법이 안 남음
- **왕복** — 저장형에 label이 없음, 저장형 재파싱이 동일 트리, **이름을 바꾸면 저장형은 그대로인데 표시만 바뀜**, 지워진 열·행은 `#REF!`
- **오류** — `=` 누락, 없는 열·행, 괄호 불균형, D8 범위 밖 함수(IF·COUNTA), 집계 안 행 지정, 집계 안 산술, 군더더기
- **산술** — 우선순위, 괄호, 단항, 지수 표기 회피

`./gradlew check` 통과. 기존 테스트 전부 무수정 통과.

## 로컬 확인 — 해당 없음
파서는 아직 **어떤 엔드포인트에도 연결돼 있지 않다**(#812에서 평가 엔진이 연결한다). 구동해서 볼 표면이 없어 bootRun 확인을 하지 않았다. 대신 테스트가 운영 데이터의 실제 label을 그대로 사용한다.
