### PR TITLE
feat : 수식 평가 엔진 (쓸 때 계산·집계 semantics)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaEvaluator.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaEvaluator.java
@@ -1,0 +1,149 @@
+package ds.project.orino.planner.dataset.formula;
+
+import ds.project.orino.domain.planner.dataset.entity.FormulaRefKind;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 구문 트리 평가.
+ *
+ * <p>엑셀 모델을 따른다(O11) — <b>열에 타입이 없고 셀 단위로 평가·에러</b>한다.
+ * 집계는 숫자가 아닌 칸(텍스트·빈 칸)을 <b>무시</b>하지만, 산술은 무시하지 않고
+ * {@code #VALUE!}를 낸다. "합계는 숫자만 더한다"와 "곱셈에 글자가 오면 잘못이다"가 둘 다 자연스럽다.
+ */
+public final class FormulaEvaluator {
+
+    /** 나눗셈은 무한소수가 될 수 있어 정밀도를 정해야 한다. */
+    private static final MathContext DIV = new MathContext(20, RoundingMode.HALF_UP);
+
+    /** 평가에 필요한 셀 값을 읽어 온다. 없는 열·행이면 empty — 호출부가 {@code #REF!}로 만든다. */
+    public interface ValueSource {
+
+        /** 계산 중인 그 행의 열 값. */
+        Optional<String> sameRow(String colKey);
+
+        /** 특정 행의 열 값. 행이 지워졌으면 empty. */
+        Optional<String> absolute(long rowId, String colKey);
+
+        /** 열 전체 값. 열이 없으면 empty. */
+        Optional<List<String>> column(String colKey);
+    }
+
+    private FormulaEvaluator() {
+    }
+
+    public static FormulaValue evaluate(FormulaNode node, ValueSource src) {
+        return switch (node) {
+            case FormulaNode.Num n -> new FormulaValue.Num(n.value());
+            case FormulaNode.Unary u -> {
+                FormulaValue v = evaluate(u.operand(), src);
+                yield switch (v) {
+                    case FormulaValue.Err e -> e;
+                    case FormulaValue.Num n ->
+                            new FormulaValue.Num(u.op() == '-' ? n.value().negate() : n.value());
+                };
+            }
+            case FormulaNode.Binary b -> binary(b, src);
+            case FormulaNode.Ref r -> ref(r, src);
+            case FormulaNode.Agg a -> agg(a, src);
+        };
+    }
+
+    private static FormulaValue binary(FormulaNode.Binary b, ValueSource src) {
+        FormulaValue l = evaluate(b.left(), src);
+        if (l instanceof FormulaValue.Err) {
+            return l;
+        }
+        FormulaValue r = evaluate(b.right(), src);
+        if (r instanceof FormulaValue.Err) {
+            return r;
+        }
+        BigDecimal x = ((FormulaValue.Num) l).value();
+        BigDecimal y = ((FormulaValue.Num) r).value();
+        return switch (b.op()) {
+            case '+' -> new FormulaValue.Num(x.add(y));
+            case '-' -> new FormulaValue.Num(x.subtract(y));
+            case '*' -> new FormulaValue.Num(x.multiply(y));
+            case '/' -> y.signum() == 0
+                    ? new FormulaValue.Err(FormulaValue.Err.DIV0)
+                    : new FormulaValue.Num(x.divide(y, DIV));
+            default -> new FormulaValue.Err(FormulaValue.Err.VALUE);
+        };
+    }
+
+    /** 산술 속 참조. 빈 칸은 0으로 보고(엑셀과 같다), 숫자가 아니면 {@code #VALUE!}. */
+    private static FormulaValue ref(FormulaNode.Ref r, ValueSource src) {
+        Optional<String> raw = r.kind() == FormulaRefKind.ABSOLUTE
+                ? src.absolute(r.rowId(), r.colKey())
+                : src.sameRow(r.colKey());
+        if (raw.isEmpty()) {
+            return new FormulaValue.Err(FormulaValue.Err.REF);
+        }
+        String s = raw.get().trim();
+        if (s.isEmpty()) {
+            return new FormulaValue.Num(BigDecimal.ZERO);
+        }
+        // 참조한 셀이 이미 에러면 그 에러가 번진다.
+        if (s.startsWith("#")) {
+            return new FormulaValue.Err(s);
+        }
+        return number(s)
+                .<FormulaValue>map(FormulaValue.Num::new)
+                .orElseGet(() -> new FormulaValue.Err(FormulaValue.Err.VALUE));
+    }
+
+    /**
+     * 집계. O11 — 숫자가 아닌 칸과 빈 칸은 <b>무시</b>한다.
+     * 참조한 열이 없으면 {@code #REF!}, 셀이 에러면 그 에러가 번진다.
+     */
+    private static FormulaValue agg(FormulaNode.Agg a, ValueSource src) {
+        List<BigDecimal> nums = new ArrayList<>();
+        for (String key : a.colKeys()) {
+            Optional<List<String>> col = src.column(key);
+            if (col.isEmpty()) {
+                return new FormulaValue.Err(FormulaValue.Err.REF);
+            }
+            for (String cell : col.get()) {
+                String s = cell == null ? "" : cell.trim();
+                if (s.startsWith("#")) {
+                    return new FormulaValue.Err(s);
+                }
+                number(s).ifPresent(nums::add);
+            }
+        }
+
+        return switch (a.func()) {
+            // 숫자만 센다. 비어있지 않은 걸 세는 COUNTA는 D8 범위 밖.
+            case "COUNT" -> new FormulaValue.Num(BigDecimal.valueOf(nums.size()));
+            case "SUM" -> new FormulaValue.Num(
+                    nums.stream().reduce(BigDecimal.ZERO, BigDecimal::add));
+            // 분모는 숫자인 셀 수. 하나도 없으면 나눌 게 없다.
+            case "AVG" -> nums.isEmpty()
+                    ? new FormulaValue.Err(FormulaValue.Err.DIV0)
+                    : new FormulaValue.Num(nums.stream().reduce(BigDecimal.ZERO, BigDecimal::add)
+                            .divide(BigDecimal.valueOf(nums.size()), DIV));
+            // 엑셀은 숫자가 없으면 0을 낸다.
+            case "MIN" -> new FormulaValue.Num(
+                    nums.stream().min(BigDecimal::compareTo).orElse(BigDecimal.ZERO));
+            case "MAX" -> new FormulaValue.Num(
+                    nums.stream().max(BigDecimal::compareTo).orElse(BigDecimal.ZERO));
+            default -> new FormulaValue.Err(FormulaValue.Err.VALUE);
+        };
+    }
+
+    private static Optional<BigDecimal> number(String s) {
+        if (s.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(new BigDecimal(s));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaValue.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaValue.java
@@ -1,0 +1,30 @@
+package ds.project.orino.planner.dataset.formula;
+
+import java.math.BigDecimal;
+
+/**
+ * 평가 결과. 값 아니면 에러다 — 엑셀처럼 <b>셀 단위로</b> 에러를 낸다.
+ * 열에 타입을 두지 않으므로, 같은 열의 어떤 셀은 값이고 어떤 셀은 에러일 수 있다.
+ */
+public sealed interface FormulaValue {
+
+    /** 계산된 숫자. */
+    record Num(BigDecimal value) implements FormulaValue {
+    }
+
+    /** {@code #VALUE!} {@code #DIV/0!} {@code #REF!} 같은 셀 에러. */
+    record Err(String code) implements FormulaValue {
+
+        public static final String VALUE = "#VALUE!";
+        public static final String DIV0 = "#DIV/0!";
+        public static final String REF = "#REF!";
+    }
+
+    /** 셀에 담길 문자열. 에러면 에러 코드가 그대로 값 자리에 들어간다. */
+    default String asCell() {
+        return switch (this) {
+            case Num n -> n.value().stripTrailingZeros().toPlainString();
+            case Err e -> e.code();
+        };
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetCells.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetCells.java
@@ -1,0 +1,67 @@
+package ds.project.orino.planner.dataset.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.dataset.dto.DatasetColumn;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@code dataset_row.cells}(열 key → 값 맵)와 API의 위치 배열 사이를 오간다.
+ * 저장은 주소로, API는 위치로 — 그 경계가 여기다.
+ */
+final class DatasetCells {
+
+    private static final JsonMapper MAPPER = JsonMapper.builder().build();
+    private static final TypeReference<Map<String, String>> TYPE = new TypeReference<>() {
+    };
+
+    private DatasetCells() {
+    }
+
+    static Map<String, String> parse(String json) {
+        try {
+            return MAPPER.readValue(json, TYPE);
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+
+    static String serialize(Map<String, String> cells) {
+        try {
+            return MAPPER.writeValueAsString(cells);
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST, e);
+        }
+    }
+
+    /** 저장소 맵 → API 위치 배열. 열 순서대로 뽑고, 값이 없는 열은 빈 문자열로 채운다. */
+    static List<String> toList(String cellsJson, List<DatasetColumn> columns) {
+        Map<String, String> cells = parse(cellsJson);
+        List<String> list = new ArrayList<>(columns.size());
+        for (DatasetColumn column : columns) {
+            list.add(cells.getOrDefault(column.key(), ""));
+        }
+        return list;
+    }
+
+    /**
+     * API 위치 배열 → 저장소 맵. 열 순서로 짝지으며, 열 수를 넘는 값은 담을 key가 없어 버린다.
+     * 열 수보다 짧으면 나머지 열은 빈 문자열로 채워 직사각형을 유지한다.
+     */
+    static Map<String, String> toMap(List<String> cells, List<DatasetColumn> columns) {
+        Map<String, String> map = new LinkedHashMap<>();
+        for (int i = 0; i < columns.size(); i++) {
+            String value = i < cells.size() ? cells.get(i) : null;
+            map.put(columns.get(i).key(), value == null ? "" : value);
+        }
+        return map;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
@@ -1,0 +1,189 @@
+package ds.project.orino.planner.dataset.service;
+
+import ds.project.orino.domain.planner.dataset.entity.DatasetFormula;
+import ds.project.orino.domain.planner.dataset.entity.DatasetFormulaRef;
+import ds.project.orino.domain.planner.dataset.entity.DatasetRow;
+import ds.project.orino.domain.planner.dataset.repository.DatasetFormulaRefRepository;
+import ds.project.orino.domain.planner.dataset.repository.DatasetFormulaRepository;
+import ds.project.orino.domain.planner.dataset.repository.DatasetRowRepository;
+import ds.project.orino.planner.dataset.dto.DatasetColumn;
+import ds.project.orino.planner.dataset.formula.FormulaContext;
+import ds.project.orino.planner.dataset.formula.FormulaEvaluator;
+import ds.project.orino.planner.dataset.formula.FormulaNode;
+import ds.project.orino.planner.dataset.formula.FormulaParser;
+import ds.project.orino.planner.dataset.formula.FormulaValue;
+import ds.project.orino.planner.dataset.formula.FormulaWriter;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 수식 저장·평가. 파서·평가기를 DB에 잇는다.
+ *
+ * <p>값은 {@code dataset_row.cells}에 그대로 들어가고 수식만 {@code dataset_formula}에 담긴다 —
+ * 그래서 읽기 경로가 안 바뀐다.
+ *
+ * <p><b>이 클래스는 수식 셀 자신을 저장할 때만 계산한다.</b> 참조하던 셀이 나중에 바뀌었을 때의
+ * 재계산(전파)과 순환 참조 거부는 #813의 몫이다.
+ */
+@Service
+public class DatasetFormulaService {
+
+    /** 셀 값이 이걸로 시작하면 수식이다. 엑셀과 같다. */
+    static final String PREFIX = "=";
+
+    private final DatasetFormulaRepository formulaRepository;
+    private final DatasetFormulaRefRepository refRepository;
+    private final DatasetRowRepository rowRepository;
+
+    public DatasetFormulaService(DatasetFormulaRepository formulaRepository,
+                                 DatasetFormulaRefRepository refRepository,
+                                 DatasetRowRepository rowRepository) {
+        this.formulaRepository = formulaRepository;
+        this.refRepository = refRepository;
+        this.rowRepository = rowRepository;
+    }
+
+    static boolean isFormula(String value) {
+        return value != null && value.startsWith(PREFIX);
+    }
+
+    /**
+     * 수식을 저장하고 계산해 셀에 담길 값을 돌려준다.
+     *
+     * @param rowCells 지금 만들고 있는 그 행의 값들. 같은 행 참조가 이걸 본다 —
+     *                 같은 요청에서 바뀐 값을 즉시 반영하기 위함이다.
+     */
+    String saveAndEvaluate(Long datasetId, DatasetRow row, String colKey, String input,
+                           List<DatasetColumn> columns, Map<String, String> rowCells) {
+        FormulaContext ctx = new DbContext(datasetId, columns);
+        FormulaNode node = FormulaParser.parseInput(input, ctx);
+
+        DatasetFormula formula = formulaRepository.findByRowIdAndColKey(row.getId(), colKey)
+                .orElseGet(() -> formulaRepository.save(
+                        new DatasetFormula(datasetId, row.getId(), colKey, FormulaWriter.toStored(node))));
+        formula.updateRaw(FormulaWriter.toStored(node));
+        formulaRepository.save(formula);
+
+        // 참조는 통째로 갈아 끼운다. 수식이 바뀌면 무엇을 참조하는지도 통째로 바뀐다.
+        refRepository.deleteByFormulaId(formula.getId());
+        for (FormulaNode.Ref ref : FormulaParser.collectRefs(node)) {
+            refRepository.save(toEntity(formula.getId(), datasetId, ref));
+        }
+
+        FormulaValue value = FormulaEvaluator.evaluate(node, new DbValues(datasetId, row, rowCells));
+        if (value instanceof FormulaValue.Err e) {
+            formula.markError(e.code());
+        } else {
+            formula.clearError();
+        }
+        return value.asCell();
+    }
+
+    /** 셀이 더 이상 수식이 아니면(리터럴로 덮어씀) 수식과 참조를 지운다. */
+    void removeIfAny(Long rowId, String colKey) {
+        formulaRepository.findByRowIdAndColKey(rowId, colKey).ifPresent(f -> {
+            refRepository.deleteByFormulaId(f.getId());
+            formulaRepository.delete(f);
+        });
+    }
+
+    private DatasetFormulaRef toEntity(Long formulaId, Long datasetId, FormulaNode.Ref ref) {
+        return switch (ref.kind()) {
+            case SAME_ROW -> DatasetFormulaRef.sameRow(formulaId, datasetId, ref.colKey());
+            case ABSOLUTE -> DatasetFormulaRef.absolute(formulaId, datasetId, ref.rowId(),
+                    ref.colKey());
+            case COLUMN_ALL -> DatasetFormulaRef.columnAll(formulaId, datasetId, ref.colKey());
+        };
+    }
+
+    /** 파서가 필요로 하는 열·행 조회를 DB로 잇는다. */
+    private final class DbContext implements FormulaContext {
+        private final Long datasetId;
+        private final List<DatasetColumn> columns;
+
+        private DbContext(Long datasetId, List<DatasetColumn> columns) {
+            this.datasetId = datasetId;
+            this.columns = columns;
+        }
+
+        @Override
+        public List<String> columnKeys() {
+            return columns.stream().map(DatasetColumn::key).toList();
+        }
+
+        @Override
+        public Optional<String> keyByLabel(String label) {
+            return columns.stream()
+                    .filter(c -> c.label().equals(label))
+                    .map(DatasetColumn::key)
+                    .findFirst();
+        }
+
+        @Override
+        public Optional<String> labelByKey(String key) {
+            return columns.stream()
+                    .filter(c -> c.key().equals(key))
+                    .map(DatasetColumn::label)
+                    .findFirst();
+        }
+
+        @Override
+        public Optional<Long> rowIdByNumber(int rowNumber) {
+            // 화면은 1-base, row_index는 0-base.
+            return rowRepository.findByDatasetIdAndRowIndex(datasetId, rowNumber - 1)
+                    .map(DatasetRow::getId);
+        }
+
+        @Override
+        public Optional<Integer> rowNumberById(long rowId) {
+            return rowRepository.findById(rowId)
+                    .filter(r -> r.getDatasetId().equals(datasetId))
+                    .map(r -> r.getRowIndex() + 1);
+        }
+    }
+
+    /** 평가기가 읽을 셀 값을 DB(와 지금 만드는 행)에서 가져온다. */
+    private final class DbValues implements FormulaEvaluator.ValueSource {
+        private final Long datasetId;
+        private final DatasetRow row;
+        private final Map<String, String> rowCells;
+
+        private DbValues(Long datasetId, DatasetRow row, Map<String, String> rowCells) {
+            this.datasetId = datasetId;
+            this.row = row;
+            this.rowCells = rowCells;
+        }
+
+        @Override
+        public Optional<String> sameRow(String colKey) {
+            // 지금 저장 중인 값을 본다 — 같은 요청에서 c0을 고치며 c1=c0*2를 넣으면 새 c0을 써야 한다.
+            return Optional.ofNullable(rowCells.get(colKey));
+        }
+
+        @Override
+        public Optional<String> absolute(long rowId, String colKey) {
+            if (row.getId() != null && row.getId().equals(rowId)) {
+                return sameRow(colKey);
+            }
+            return rowRepository.findById(rowId)
+                    .filter(r -> r.getDatasetId().equals(datasetId))
+                    .map(r -> DatasetCells.parse(r.getCells()).getOrDefault(colKey, ""));
+        }
+
+        /** 열이 실재하는지는 파서가 저장 시점에 이미 검증했다. 지워진 열은 #814가 다룬다. */
+        @Override
+        public Optional<List<String>> column(String colKey) {
+            // 열 집계는 전체 행을 읽는다. O1(쓸 때 계산)이 감수하기로 한 비용이다 —
+            // 읽을 때 계산하면 페이지를 볼 때마다 이 비용을 치른다.
+            List<String> values = rowRepository.findByDatasetIdOrderByRowIndexAsc(datasetId).stream()
+                    .map(r -> r.getId().equals(row.getId())
+                            ? rowCells.getOrDefault(colKey, "")
+                            : DatasetCells.parse(r.getCells()).getOrDefault(colKey, ""))
+                    .toList();
+            return Optional.of(values);
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -63,10 +63,13 @@ public class DatasetService {
 
     private final DatasetRepository datasetRepository;
     private final DatasetRowRepository rowRepository;
+    private final DatasetFormulaService formulaService;
 
-    public DatasetService(DatasetRepository datasetRepository, DatasetRowRepository rowRepository) {
+    public DatasetService(DatasetRepository datasetRepository, DatasetRowRepository rowRepository,
+                          DatasetFormulaService formulaService) {
         this.datasetRepository = datasetRepository;
         this.rowRepository = rowRepository;
+        this.formulaService = formulaService;
     }
 
     /**
@@ -299,14 +302,37 @@ public class DatasetService {
         return new RowsResponse(rows, off, lim);
     }
 
+    /**
+     * 셀/행 편집. {@code =}로 시작하는 값은 수식으로 보고 파싱·평가해 <b>계산된 값</b>을 셀에 담는다
+     * (수식 원본은 {@code dataset_formula}에 따로). 엑셀과 같은 진입이라 별도 API가 없다.
+     */
     @Transactional
     public RowView updateRow(Long memberId, Long datasetId, int rowIndex, UpdateRowRequest request) {
         Dataset dataset = getOwned(memberId, datasetId);
         List<DatasetColumn> columns = parseColumns(dataset.getColumns());
         DatasetRow row = rowRepository.findByDatasetIdAndRowIndex(datasetId, rowIndex)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
-        row.updateCells(toCellMap(request.cells(), columns));
-        // 저장된 값을 그대로 되돌려준다(열 수에 맞춰 잘리거나 채워진 결과).
+
+        // 리터럴을 먼저 채운다 — 같은 행 참조가 이번 요청에서 바뀐 값을 봐야 한다.
+        // (cells=["5","={c0}*2"] 면 c1은 옛 c0이 아니라 5를 써야 한다)
+        Map<String, String> cells = DatasetCells.toMap(request.cells(), columns);
+        Map<String, String> formulas = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : cells.entrySet()) {
+            if (DatasetFormulaService.isFormula(entry.getValue())) {
+                formulas.put(entry.getKey(), entry.getValue());
+            } else {
+                formulaService.removeIfAny(row.getId(), entry.getKey());
+            }
+        }
+        // 수식은 열 순서로 계산한다. 앞쪽 수식이 뒤쪽 수식 셀을 참조하면 옛 값을 보는데,
+        // 그 재계산은 전파(#813)가 맡는다.
+        for (Map.Entry<String, String> entry : formulas.entrySet()) {
+            cells.put(entry.getKey(), formulaService.saveAndEvaluate(
+                    datasetId, row, entry.getKey(), entry.getValue(), columns, cells));
+        }
+
+        row.updateCells(DatasetCells.serialize(cells));
+        // 저장된 값을 그대로 되돌려준다(열 수에 맞춰 잘리거나 채워진 결과, 수식은 계산된 값).
         return new RowView(row.getId(), rowIndex, toCellList(row.getCells(), columns));
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFormulaTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFormulaTest.java
@@ -1,0 +1,275 @@
+package ds.project.orino.planner.dataset.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.dataset.entity.DatasetFormula;
+import ds.project.orino.domain.planner.dataset.entity.FormulaRefKind;
+import ds.project.orino.domain.planner.dataset.repository.DatasetFormulaRefRepository;
+import ds.project.orino.domain.planner.dataset.repository.DatasetFormulaRepository;
+import ds.project.orino.domain.planner.dataset.repository.DatasetRowRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 수식을 셀에 넣었을 때의 API 왕복. 별도 엔드포인트가 없고 {@code =}로 시작하는 값이면
+ * 수식으로 보는 게 계약이라, 기존 셀 편집 API로 검증한다.
+ */
+class DatasetFormulaTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DatasetFormulaRepository formulaRepository;
+    @Autowired
+    private DatasetFormulaRefRepository refRepository;
+    @Autowired
+    private DatasetRowRepository rowRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long datasetId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"단가"},{"key":"c1","label":"수량"},
+                                            {"key":"c2","label":"합계"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        datasetId = ((Number) JsonPath.read(body, "$.data.id")).longValue();
+        mockMvc.perform(post("/api/datasets/{id}/rows/bulk", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rows\":[[\"10\",\"3\",\"\"],[\"20\",\"2\",\"\"]]}"))
+                .andExpect(status().isOk());
+    }
+
+    private org.springframework.test.web.servlet.ResultActions patchRow(int rowIndex, String cells)
+            throws Exception {
+        return mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", datasetId, rowIndex)
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cells\":" + cells + "}"));
+    }
+
+    @Test
+    @DisplayName("셀에 수식을 넣으면 계산된 값이 셀에 담기고 수식은 따로 저장된다")
+    void formulaComputesAndStoresSeparately() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+
+        // 읽기 경로는 그대로 — cells엔 계산된 값이 들어 있다.
+        mockMvc.perform(get("/api/datasets/{id}/rows", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells[2]").value("30"));
+
+        long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
+        DatasetFormula f = formulaRepository.findByRowIdAndColKey(rowId, "c2").orElseThrow();
+        // 저장형엔 label이 없다 — 이름을 바꿔도 안 깨진다.
+        assertThat(f.getRaw()).isEqualTo("=({c0} * {c1})").doesNotContain("단가");
+        assertThat(f.getError()).isNull();
+    }
+
+    @Test
+    @DisplayName("같은 행 참조는 SAME_ROW로 기록된다 — 행 id를 안 쓴다")
+    void sameRowRefsRecorded() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+
+        long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
+        long formulaId = formulaRepository.findByRowIdAndColKey(rowId, "c2").orElseThrow().getId();
+        assertThat(refRepository.findByFormulaId(formulaId))
+                .allSatisfy(r -> {
+                    assertThat(r.getToKind()).isEqualTo(FormulaRefKind.SAME_ROW);
+                    assertThat(r.getToRowId()).isNull();
+                })
+                .extracting(r -> r.getToColKey())
+                .containsExactlyInAnyOrder("c0", "c1");
+    }
+
+    @Test
+    @DisplayName("같은 요청에서 바뀐 값을 수식이 즉시 반영한다")
+    void formulaSeesValuesFromSameRequest() throws Exception {
+        // 단가를 10 → 7로 바꾸면서 합계 수식을 넣는다. 옛 값 10이 아니라 7을 써야 한다.
+        patchRow(0, "[\"7\",\"3\",\"={단가} * {수량}\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("21"));
+    }
+
+    @Test
+    @DisplayName("열 집계는 전체 행을 본다")
+    void columnAggregate() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"=SUM({단가})\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+
+        long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
+        long formulaId = formulaRepository.findByRowIdAndColKey(rowId, "c2").orElseThrow().getId();
+        assertThat(refRepository.findByFormulaId(formulaId))
+                .singleElement()
+                .satisfies(r -> assertThat(r.getToKind()).isEqualTo(FormulaRefKind.COLUMN_ALL));
+    }
+
+    @Test
+    @DisplayName("절대 참조는 그 행의 값을 본다")
+    void absoluteRef() throws Exception {
+        // 1행의 합계가 2행의 단가(20)를 가리킨다.
+        patchRow(0, "[\"10\",\"3\",\"={단가}2\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("20"));
+
+        long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
+        long row2 = rowRepository.findByDatasetIdAndRowIndex(datasetId, 1).orElseThrow().getId();
+        long formulaId = formulaRepository.findByRowIdAndColKey(rowId, "c2").orElseThrow().getId();
+        assertThat(refRepository.findByFormulaId(formulaId))
+                .singleElement()
+                .satisfies(r -> {
+                    assertThat(r.getToKind()).isEqualTo(FormulaRefKind.ABSOLUTE);
+                    // 행 번호가 아니라 행 id로 굳었다.
+                    assertThat(r.getToRowId()).isEqualTo(row2);
+                });
+    }
+
+    @Test
+    @DisplayName("O11 — 집계는 숫자 아닌 칸을 무시하고, 산술은 #VALUE!를 낸다")
+    void aggregateIgnoresNonNumericButArithmeticFails() throws Exception {
+        patchRow(1, "[\"글자\",\"2\",\"\"]").andExpect(status().isOk());
+
+        // SUM은 '글자'를 무시하고 1행의 10만 더한다.
+        patchRow(0, "[\"10\",\"3\",\"=SUM({단가})\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("10"));
+        // COUNT도 숫자만 센다.
+        patchRow(0, "[\"10\",\"3\",\"=COUNT({단가})\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("1"));
+        // 산술은 무시하지 않는다.
+        patchRow(1, "[\"글자\",\"2\",\"={단가} * {수량}\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("#VALUE!"));
+    }
+
+    @Test
+    @DisplayName("0으로 나누면 #DIV/0!, 숫자 없는 열의 AVG도 #DIV/0!")
+    void divisionErrors() throws Exception {
+        patchRow(0, "[\"10\",\"0\",\"={단가} / {수량}\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("#DIV/0!"));
+
+        patchRow(0, "[\"글자\",\"0\",\"\"]").andExpect(status().isOk());
+        patchRow(1, "[\"글자\",\"0\",\"=AVG({단가})\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("#DIV/0!"));
+    }
+
+    @Test
+    @DisplayName("에러는 셀 단위다 — 같은 열의 다른 행은 멀쩡하다")
+    void errorIsPerCell() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+        patchRow(1, "[\"글자\",\"2\",\"={단가} * {수량}\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("#VALUE!"));
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells[2]").value("30"))
+                .andExpect(jsonPath("$.data.rows[1].cells[2]").value("#VALUE!"));
+    }
+
+    @Test
+    @DisplayName("수식을 리터럴로 덮으면 수식과 참조가 지워진다")
+    void overwritingFormulaRemovesIt() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+        long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
+        long formulaId = formulaRepository.findByRowIdAndColKey(rowId, "c2").orElseThrow().getId();
+
+        patchRow(0, "[\"10\",\"3\",\"직접입력\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("직접입력"));
+
+        assertThat(formulaRepository.findByRowIdAndColKey(rowId, "c2")).isEmpty();
+        assertThat(refRepository.findByFormulaId(formulaId)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("문법이 틀리면 400이고 아무것도 저장되지 않는다")
+    void syntaxErrorRollsBack() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={없는열} * 2\"]")
+                .andExpect(status().isBadRequest());
+
+        long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
+        assertThat(formulaRepository.findByRowIdAndColKey(rowId, "c2")).isEmpty();
+        // 같은 요청의 리터럴도 롤백된다.
+        mockMvc.perform(get("/api/datasets/{id}/rows", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells[2]").value(""));
+    }
+
+    @Test
+    @DisplayName("열 이름을 바꿔도 수식이 안 깨진다 — 저장형에 이름이 없다")
+    void renameDoesNotBreakFormula() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}", datasetId, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"가격\"}"))
+                .andExpect(status().isOk());
+
+        long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
+        assertThat(formulaRepository.findByRowIdAndColKey(rowId, "c2").orElseThrow().getRaw())
+                .isEqualTo("=({c0} * {c1})");
+        // 값도 그대로 남아 있다(재계산은 #813).
+        mockMvc.perform(get("/api/datasets/{id}/rows", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells[2]").value("30"));
+    }
+
+    @Test
+    @DisplayName("열 범위 집계는 입력 시 집합으로 굳는다")
+    void rangeSnapshot() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"=SUM({단가}:{수량})\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("35")); // 10+3+20+2
+
+        long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
+        long formulaId = formulaRepository.findByRowIdAndColKey(rowId, "c2").orElseThrow().getId();
+        // 범위가 아니라 열 목록으로 굳었다.
+        assertThat(refRepository.findByFormulaId(formulaId))
+                .extracting(r -> r.getToColKey())
+                .containsExactlyInAnyOrder("c0", "c1");
+        assertThat(formulaRepository.findByRowIdAndColKey(rowId, "c2").orElseThrow().getRaw())
+                .isEqualTo("=SUM({c0}, {c1})");
+    }
+
+    @Test
+    @DisplayName("여러 열에 수식을 동시에 넣을 수 있다")
+    void multipleFormulasInOneRow() throws Exception {
+        patchRow(0, "[\"10\",\"=2 + 1\",\"={단가} * {수량}\"]")
+                .andExpect(jsonPath("$.data.cells[1]").value("3"))
+                // c1이 먼저 계산돼 c2가 그 값을 본다(열 순서).
+                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+
+        long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
+        assertThat(List.of(
+                formulaRepository.findByRowIdAndColKey(rowId, "c1").isPresent(),
+                formulaRepository.findByRowIdAndColKey(rowId, "c2").isPresent()))
+                .containsExactly(true, true);
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetRowRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetRowRepository.java
@@ -18,6 +18,9 @@ public interface DatasetRowRepository extends JpaRepository<DatasetRow, Long> {
 
     Optional<DatasetRow> findByDatasetIdAndRowIndex(Long datasetId, int rowIndex);
 
+    /** 열 집계용 전체 조회. 수식이 열 전체를 참조할 때만 쓴다(비싸다). */
+    List<DatasetRow> findByDatasetIdOrderByRowIndexAsc(Long datasetId);
+
     long countByDatasetId(Long datasetId);
 
     /**


### PR DESCRIPTION
## 이슈
closes #812
## 작업 내용
수식 평가 엔진. **여기서 수식이 처음 실제로 동작한다.** [#799](https://github.com/wcorn/orino/issues/799) 구현 4단계.

### 별도 API가 없다
셀 값이 `=`로 시작하면 수식으로 본다 — 엑셀과 같은 진입이라 기존 셀 편집 API(`PATCH /rows/{i}`)를 그대로 쓴다. 계산된 값은 `cells`에, 수식 원본은 `dataset_formula`에 들어간다. **그래서 읽기 경로가 안 바뀐다.**

```
PATCH cells: ["10","3","={단가} * {수량}"]
→ 응답 cells: ["10","3","30"]
→ dataset_row.cells: {"c0":"10","c1":"3","c2":"30"}      ← 값만
→ dataset_formula:   row=1 col=c2 raw="=({c0} * {c1})"   ← 수식만, label 없음
```

### 리터럴을 먼저, 수식을 나중에
`cells=["7","3","={단가}*{수량}"]`처럼 **단가를 고치면서 동시에 수식을 넣으면** 옛 값이 아니라 새 값(7)을 써야 한다. 그래서 리터럴을 먼저 채운 뒤 수식을 계산한다.

> 앞쪽 수식이 뒤쪽 수식 셀을 참조하면 옛 값을 본다. 그 재계산은 전파(#813)의 몫이라 이 PR 범위 밖이며, 주석에 남겼다.

### O11 — 집계와 산술이 다르게 군다
- **집계**(`SUM`/`AVG`/`COUNT`/`MIN`/`MAX`)는 비숫자·빈 칸을 **무시**
- **산술**은 무시하지 않고 `#VALUE!`
- `AVG` 분모는 숫자인 셀 수, 하나도 없으면 `#DIV/0!`
- `COUNT`는 **숫자만** 센다 (`COUNTA`는 D8 범위 밖)
- `MIN`/`MAX`는 숫자가 없으면 0 (엑셀과 같다)
- 참조한 셀이 이미 에러면 **그 에러가 번진다**

"합계는 숫자만 더한다"와 "곱셈에 글자가 오면 잘못이다"가 둘 다 자연스러워서, 이 비대칭이 엑셀 모델의 핵심이다.

### 그 밖
- **열 집계는 전체 행을 읽는다.** O1(쓸 때 계산)이 감수하기로 한 비용이다 — 읽을 때 계산하면 페이지를 볼 때마다 이 비용을 치른다
- 셀 JSON 변환을 `DatasetCells`로 분리했다(`DatasetService`의 private였는데 수식 쪽도 필요)

## 테스트
통합 13건: 계산·별도 저장 / 참조 3종이 각각 `SAME_ROW`·`ABSOLUTE`(행 id로 굳음)·`COLUMN_ALL`로 기록 / **같은 요청의 새 값 반영** / O11(집계는 무시, 산술은 `#VALUE!`) / `#DIV/0!` / **에러는 셀 단위** / 리터럴로 덮으면 수식·참조 삭제 / 문법 오류 400 + 롤백 / **열 이름 변경해도 안 깨짐** / 범위 집합 스냅샷 / 한 행에 수식 여러 개

`./gradlew check` 통과. 기존 테스트 전부 무수정 통과.

## 로컬 확인
MySQL 8.4.4 + `bootRun`으로 실제 왕복:
- `={단가} * {수량}` → `30`, `=SUM({단가})` → `30`(전체 행)
- **저장 상태 확인**: `cells`엔 `{"c0":"10","c1":"3","c2":"30"}`(값만), `dataset_formula`엔 `=({c0} * {c1})`(수식만, label 없음)
- **열 이름을 `단가`→`가격`으로 바꿔도** 저장형이 `=({c0} * {c1})` 그대로 — 수식이 안 깨진다
- 문법 오류(`={없는열}`, `=IF(1,2,3)`) → 400
