### PR TITLE
feat : 수식 의존성 전파 · 순환 참조 거부 (+#812 결함 수정)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowView.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowView.java
@@ -1,6 +1,7 @@
 package ds.project.orino.planner.dataset.dto;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 행 조회 결과.
@@ -8,6 +9,18 @@ import java.util.List;
  * <p>{@code id}는 행의 안정적 식별자다. {@code rowIndex}는 정렬·페이지네이션용 순번이라
  * 삽입·삭제 때마다 밀리지만 {@code id}는 바뀌지 않는다. 수식이 다른 행을 참조할 때
  * 묶어야 할 대상은 {@code rowIndex}가 아니라 {@code id}다.
+ *
+ * <p>{@code cells}엔 <b>계산된 값</b>이, {@code formulas}엔 수식이 있는 셀의 <b>원본</b>이
+ * 열 key로 담긴다(수식 없는 셀은 아예 없다). 클라이언트는 값을 보여주되 행을 수정할 땐
+ * 수식 셀에 이 원본을 그대로 돌려줘야 한다 — 계산된 값을 돌려주면 서버가 리터럴로 보고
+ * 수식을 지운다.
+ *
+ * <p>{@code formulas}는 <b>표시형</b>(열 이름·행 번호)이다. 저장형(key·행 id)은 서버 안에만 있다.
  */
-public record RowView(Long id, int rowIndex, List<String> cells) {
+public record RowView(
+        Long id,
+        int rowIndex,
+        List<String> cells,
+        Map<String, String> formulas
+) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetColumns.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetColumns.java
@@ -1,0 +1,30 @@
+package ds.project.orino.planner.dataset.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.dataset.dto.DatasetColumn;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.List;
+
+/** {@code dataset.columns_json} 변환. 열 순서가 곧 표시 순서이자 투영 순서다. */
+final class DatasetColumns {
+
+    private static final JsonMapper MAPPER = JsonMapper.builder().build();
+    private static final TypeReference<List<DatasetColumn>> TYPE = new TypeReference<>() {
+    };
+
+    private DatasetColumns() {
+    }
+
+    static List<DatasetColumn> parse(String json) {
+        try {
+            return MAPPER.readValue(json, TYPE);
+        } catch (JacksonException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
@@ -3,8 +3,11 @@ package ds.project.orino.planner.dataset.service;
 import ds.project.orino.domain.planner.dataset.entity.DatasetFormula;
 import ds.project.orino.domain.planner.dataset.entity.DatasetFormulaRef;
 import ds.project.orino.domain.planner.dataset.entity.DatasetRow;
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
 import ds.project.orino.domain.planner.dataset.repository.DatasetFormulaRefRepository;
 import ds.project.orino.domain.planner.dataset.repository.DatasetFormulaRepository;
+import ds.project.orino.domain.planner.dataset.repository.DatasetRepository;
 import ds.project.orino.domain.planner.dataset.repository.DatasetRowRepository;
 import ds.project.orino.planner.dataset.dto.DatasetColumn;
 import ds.project.orino.planner.dataset.formula.FormulaContext;
@@ -15,9 +18,12 @@ import ds.project.orino.planner.dataset.formula.FormulaValue;
 import ds.project.orino.planner.dataset.formula.FormulaWriter;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * 수식 저장·평가. 파서·평가기를 DB에 잇는다.
@@ -25,8 +31,9 @@ import java.util.Optional;
  * <p>값은 {@code dataset_row.cells}에 그대로 들어가고 수식만 {@code dataset_formula}에 담긴다 —
  * 그래서 읽기 경로가 안 바뀐다.
  *
- * <p><b>이 클래스는 수식 셀 자신을 저장할 때만 계산한다.</b> 참조하던 셀이 나중에 바뀌었을 때의
- * 재계산(전파)과 순환 참조 거부는 #813의 몫이다.
+ * <p>셀이 바뀌면 그 셀을 참조하던 수식을 전이적으로 다시 계산한다({@link #propagateFrom}).
+ * 순환 참조는 <b>쓰기 시점에 거부</b>한다 — 쓸 때 계산하는 구조(O1)에서 순환이 저장되면
+ * 재계산이 끝나지 않는다.
  */
 @Service
 public class DatasetFormulaService {
@@ -34,16 +41,35 @@ public class DatasetFormulaService {
     /** 셀 값이 이걸로 시작하면 수식이다. 엑셀과 같다. */
     static final String PREFIX = "=";
 
+    /**
+     * 한 번의 쓰기가 다시 계산할 수 있는 수식 수의 상한.
+     *
+     * <p>병적인 표(예: 모든 행이 {@code =SUM(c0)})에선 셀 하나를 고치는 데 행 수만큼의 집계가
+     * 재계산되고 각 집계가 다시 전체 행을 훑어 폭발한다. 조용히 멈추면 값이 낡은 채 남으므로
+     * 차라리 거부한다. 실사용에서 걸리면 값을 올리기 전에 그 표의 설계를 먼저 볼 것.
+     */
+    static final int MAX_PROPAGATION = 1_000;
+
     private final DatasetFormulaRepository formulaRepository;
     private final DatasetFormulaRefRepository refRepository;
     private final DatasetRowRepository rowRepository;
+    private final DatasetRepository datasetRepository;
 
     public DatasetFormulaService(DatasetFormulaRepository formulaRepository,
                                  DatasetFormulaRefRepository refRepository,
-                                 DatasetRowRepository rowRepository) {
+                                 DatasetRowRepository rowRepository,
+                                 DatasetRepository datasetRepository) {
         this.formulaRepository = formulaRepository;
         this.refRepository = refRepository;
         this.rowRepository = rowRepository;
+        this.datasetRepository = datasetRepository;
+    }
+
+    /** 재계산은 그 dataset의 열 구성을 다시 읽어야 한다(호출부가 안 넘겨주는 경로). */
+    private List<DatasetColumn> columnsOf(Long datasetId) {
+        return datasetRepository.findById(datasetId)
+                .map(d -> DatasetColumns.parse(d.getColumns()))
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
     }
 
     static boolean isFormula(String value) {
@@ -73,6 +99,9 @@ public class DatasetFormulaService {
             refRepository.save(toEntity(formula.getId(), datasetId, ref));
         }
 
+        // 참조를 저장한 뒤에 본다 — 자기 참조를 그래프에서 따라갈 수 있어야 한다.
+        assertNoCycle(datasetId, row.getId(), colKey, node, columns);
+
         FormulaValue value = FormulaEvaluator.evaluate(node, new DbValues(datasetId, row, rowCells));
         if (value instanceof FormulaValue.Err e) {
             formula.markError(e.code());
@@ -80,6 +109,140 @@ public class DatasetFormulaService {
             formula.clearError();
         }
         return value.asCell();
+    }
+
+    /**
+     * 셀 {@code (rowId, colKey)}가 바뀌었을 때 그 셀을 참조하던 수식들을 전이적으로 다시 계산한다.
+     *
+     * <p>전파 범위는 참조 종류가 가른다(D9) — {@code SAME_ROW}는 <b>같은 행 안에서만</b> 번지므로
+     * 계산 열(가장 흔한 패턴)의 편집이 다른 행을 건드리지 않는다. {@code COLUMN_ALL}(집계)만
+     * 열의 아무 행이 바뀌어도 걸린다.
+     *
+     * @param seen 이미 다시 계산한 셀. 재귀 사이에 공유해 같은 셀을 두 번 계산하지 않는다.
+     */
+    void propagateFrom(Long datasetId, Long rowId, String colKey, Set<String> seen) {
+        for (Long formulaId : refRepository.findDependentFormulaIds(datasetId, rowId, colKey)) {
+            DatasetFormula formula = formulaRepository.findById(formulaId).orElse(null);
+            if (formula == null) {
+                continue;
+            }
+            String cell = formula.getRowId() + ":" + formula.getColKey();
+            if (!seen.add(cell)) {
+                continue;
+            }
+            if (seen.size() > MAX_PROPAGATION) {
+                throw new CustomException(ErrorCode.FORMULA_PROPAGATION_TOO_WIDE,
+                        "다시 계산할 수식이 " + MAX_PROPAGATION + "개를 넘습니다");
+            }
+            recompute(datasetId, formula);
+            // 이 수식의 셀도 값이 바뀌었으니 그걸 참조하던 것들로 계속 번진다.
+            propagateFrom(datasetId, formula.getRowId(), formula.getColKey(), seen);
+        }
+    }
+
+    /** 수식 하나를 다시 계산해 그 셀에 값을 쓴다. */
+    private void recompute(Long datasetId, DatasetFormula formula) {
+        DatasetRow row = rowRepository.findById(formula.getRowId()).orElse(null);
+        if (row == null) {
+            return;
+        }
+        List<DatasetColumn> columns = columnsOf(datasetId);
+        Map<String, String> cells = DatasetCells.parse(row.getCells());
+
+        FormulaValue value;
+        try {
+            FormulaNode node = FormulaParser.parseStored(formula.getRaw(),
+                    new DbContext(datasetId, columns));
+            value = FormulaEvaluator.evaluate(node, new DbValues(datasetId, row, cells));
+        } catch (CustomException e) {
+            // 저장된 수식이 지금 구성으로 파싱이 안 된다 = 참조하던 열이 사라졌다는 뜻.
+            value = new FormulaValue.Err(FormulaValue.Err.REF);
+        }
+
+        if (value instanceof FormulaValue.Err e) {
+            formula.markError(e.code());
+        } else {
+            formula.clearError();
+        }
+        cells.put(formula.getColKey(), value.asCell());
+        row.updateCells(DatasetCells.serialize(cells));
+    }
+
+    /**
+     * 새 수식이 자기 자신에 닿는지 본다. 닿으면 저장 자체를 막는다.
+     *
+     * <p>참조를 따라 <b>앞으로</b> 걷는다 — 이 수식이 무엇을 참조하고, 그것들이 또 무엇을
+     * 참조하는지. 도중에 자기 셀을 만나면 순환이다.
+     */
+    private void assertNoCycle(Long datasetId, Long rowId, String colKey, FormulaNode node,
+                               List<DatasetColumn> columns) {
+        Set<Long> visited = new HashSet<>();
+        for (FormulaNode.Ref ref : FormulaParser.collectRefs(node)) {
+            for (DatasetFormula target : targetsOf(datasetId, rowId, ref)) {
+                walk(datasetId, rowId, colKey, target, visited, columns);
+            }
+        }
+    }
+
+    private void walk(Long datasetId, Long selfRow, String selfCol, DatasetFormula formula,
+                      Set<Long> visited, List<DatasetColumn> columns) {
+        if (formula.getRowId().equals(selfRow) && formula.getColKey().equals(selfCol)) {
+            throw new CustomException(ErrorCode.FORMULA_CIRCULAR_REFERENCE);
+        }
+        if (!visited.add(formula.getId())) {
+            return;
+        }
+        FormulaNode node;
+        try {
+            node = FormulaParser.parseStored(formula.getRaw(), new DbContext(datasetId, columns));
+        } catch (CustomException e) {
+            return; // 이미 깨진 수식은 순환 판정에 쓰지 않는다.
+        }
+        for (FormulaNode.Ref ref : FormulaParser.collectRefs(node)) {
+            for (DatasetFormula next : targetsOf(datasetId, formula.getRowId(), ref)) {
+                walk(datasetId, selfRow, selfCol, next, visited, columns);
+            }
+        }
+    }
+
+    /** 참조가 가리키는 자리에 있는 수식들. 값만 있는 셀은 더 따라갈 게 없다. */
+    private List<DatasetFormula> targetsOf(Long datasetId, Long fromRowId, FormulaNode.Ref ref) {
+        return switch (ref.kind()) {
+            case SAME_ROW -> formulaRepository.findByRowIdAndColKey(fromRowId, ref.colKey())
+                    .map(List::of).orElseGet(List::of);
+            case ABSOLUTE -> formulaRepository.findByRowIdAndColKey(ref.rowId(), ref.colKey())
+                    .map(List::of).orElseGet(List::of);
+            // 집계는 그 열의 모든 수식에 닿는다.
+            case COLUMN_ALL -> formulaRepository.findByDatasetIdAndColKey(datasetId, ref.colKey());
+        };
+    }
+
+    /**
+     * 그 행들의 수식을 <b>표시형</b>(열 이름·행 번호)으로. 수식 없는 셀은 담기지 않는다.
+     *
+     * <p>표시형은 저장형과 같은 문법이라 클라이언트가 그대로 돌려주면 다시 파싱된다 —
+     * 그게 행을 수정해도 수식이 안 지워지는 방법이다.
+     */
+    Map<Long, Map<String, String>> displayFormulas(Long datasetId, List<Long> rowIds,
+                                                   List<DatasetColumn> columns) {
+        if (rowIds.isEmpty()) {
+            return Map.of();
+        }
+        FormulaContext ctx = new DbContext(datasetId, columns);
+        Map<Long, Map<String, String>> out = new LinkedHashMap<>();
+        for (DatasetFormula f : formulaRepository.findByRowIdIn(rowIds)) {
+            String display;
+            try {
+                display = FormulaWriter.toDisplay(
+                        FormulaParser.parseStored(f.getRaw(), ctx), ctx);
+            } catch (CustomException e) {
+                // 참조하던 열이 사라져 파싱이 안 되면 표시할 수식이 없다(#814가 #REF!로 정리).
+                display = FormulaValue.Err.REF;
+            }
+            out.computeIfAbsent(f.getRowId(), k -> new LinkedHashMap<>())
+                    .put(f.getColKey(), display);
+        }
+        return out;
     }
 
     /** 셀이 더 이상 수식이 아니면(리터럴로 덮어씀) 수식과 참조를 지운다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -24,9 +24,11 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.json.JsonMapper;
 
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -293,11 +295,15 @@ public class DatasetService {
         List<DatasetColumn> columns = parseColumns(dataset.getColumns());
         int off = offset == null ? 0 : Math.max(0, offset);
         int lim = clampLimit(limit);
-        List<RowView> rows = rowRepository
+        List<DatasetRow> found = rowRepository
                 .findByDatasetIdAndRowIndexGreaterThanEqualAndRowIndexLessThanOrderByRowIndexAsc(
-                        datasetId, off, off + lim)
-                .stream()
-                .map(r -> new RowView(r.getId(), r.getRowIndex(), toCellList(r.getCells(), columns)))
+                        datasetId, off, off + lim);
+        // 페이지의 수식을 한 번에 가져온다. 수식 있는 셀만 담기므로 대개 비어 있다.
+        Map<Long, Map<String, String>> formulas = formulaService.displayFormulas(
+                datasetId, found.stream().map(DatasetRow::getId).toList(), columns);
+        List<RowView> rows = found.stream()
+                .map(r -> new RowView(r.getId(), r.getRowIndex(), toCellList(r.getCells(), columns),
+                        formulas.getOrDefault(r.getId(), Map.of())))
                 .toList();
         return new RowsResponse(rows, off, lim);
     }
@@ -331,9 +337,21 @@ public class DatasetService {
                     datasetId, row, entry.getKey(), entry.getValue(), columns, cells));
         }
 
+        Map<String, String> before = DatasetCells.parse(row.getCells());
         row.updateCells(DatasetCells.serialize(cells));
-        // 저장된 값을 그대로 되돌려준다(열 수에 맞춰 잘리거나 채워진 결과, 수식은 계산된 값).
-        return new RowView(row.getId(), rowIndex, toCellList(row.getCells(), columns));
+
+        // 값이 실제로 바뀐 셀만 전파한다 — 안 바뀐 셀까지 번지면 헛일이다.
+        Set<String> recomputed = new HashSet<>();
+        for (Map.Entry<String, String> entry : cells.entrySet()) {
+            if (!entry.getValue().equals(before.get(entry.getKey()))) {
+                formulaService.propagateFrom(datasetId, row.getId(), entry.getKey(), recomputed);
+            }
+        }
+
+        // 전파가 이 행의 다른 셀을 고쳤을 수 있어 다시 읽는다.
+        return new RowView(row.getId(), rowIndex, toCellList(row.getCells(), columns),
+                formulaService.displayFormulas(datasetId, List.of(row.getId()), columns)
+                        .getOrDefault(row.getId(), Map.of()));
     }
 
     @Transactional

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFormulaPropagationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFormulaPropagationTest.java
@@ -1,0 +1,248 @@
+package ds.project.orino.planner.dataset.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.dataset.repository.DatasetFormulaRepository;
+import ds.project.orino.domain.planner.dataset.repository.DatasetRowRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** 참조하던 셀이 바뀌었을 때의 재계산과 순환 참조 거부. */
+class DatasetFormulaPropagationTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DatasetFormulaRepository formulaRepository;
+    @Autowired
+    private DatasetRowRepository rowRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long datasetId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"단가"},{"key":"c1","label":"수량"},
+                                            {"key":"c2","label":"합계"},{"key":"c3","label":"비고"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        datasetId = ((Number) JsonPath.read(body, "$.data.id")).longValue();
+        mockMvc.perform(post("/api/datasets/{id}/rows/bulk", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rows\":[[\"10\",\"3\",\"\",\"\"],[\"20\",\"2\",\"\",\"\"]]}"))
+                .andExpect(status().isOk());
+    }
+
+    private ResultActions patchRow(int rowIndex, String cells) throws Exception {
+        return mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", datasetId, rowIndex)
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cells\":" + cells + "}"));
+    }
+
+    private ResultActions rows() throws Exception {
+        return mockMvc.perform(get("/api/datasets/{id}/rows", datasetId)
+                .header(HttpHeaders.AUTHORIZATION, authHeader));
+    }
+
+    @Test
+    @DisplayName("참조하던 셀을 고치면 수식이 따라 바뀐다 — 이 이슈의 핵심")
+    void editingReferencedCellRecomputesFormula() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\",\"\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+
+        // 단가만 고친다. 합계는 손대지 않는다.
+        patchRow(0, "[\"7\",\"3\",\"={단가} * {수량}\",\"\"]").andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("21"));
+    }
+
+    @Test
+    @DisplayName("연쇄로 번진다 — c2가 바뀌면 c2를 참조하던 c3도 따라 바뀐다")
+    void propagatesTransitively() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\",\"\"]").andExpect(status().isOk());
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\",\"={합계} + 1\"]")
+                .andExpect(jsonPath("$.data.cells[3]").value("31"));
+
+        // 단가 → 합계 → 비고 로 두 단계 번져야 한다.
+        patchRow(0, "[\"5\",\"3\",\"={단가} * {수량}\",\"={합계} + 1\"]")
+                .andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("15"))
+                .andExpect(jsonPath("$.data.rows[0].cells[3]").value("16"));
+    }
+
+    @Test
+    @DisplayName("SAME_ROW 전파는 행을 넘지 않는다 — 계산 열의 편집이 다른 행을 안 건드린다")
+    void sameRowPropagationStaysInRow() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\",\"\"]").andExpect(status().isOk());
+        patchRow(1, "[\"20\",\"2\",\"={단가} * {수량}\",\"\"]").andExpect(status().isOk());
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("30"))
+                .andExpect(jsonPath("$.data.rows[1].cells[2]").value("40"));
+
+        // 1행의 단가만 고친다.
+        patchRow(0, "[\"1\",\"3\",\"={단가} * {수량}\",\"\"]").andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("3"))
+                // 2행은 그대로여야 한다.
+                .andExpect(jsonPath("$.data.rows[1].cells[2]").value("40"));
+    }
+
+    @Test
+    @DisplayName("COLUMN_ALL 전파는 그 열의 아무 행이 바뀌어도 걸린다")
+    void columnAggregateRecomputesOnAnyRow() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"=SUM({단가})\",\"\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+
+        // 2행의 단가를 고치면 1행의 집계가 따라 바뀐다.
+        patchRow(1, "[\"5\",\"2\",\"\",\"\"]").andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("15"));
+    }
+
+    @Test
+    @DisplayName("절대 참조는 그 행이 바뀔 때 따라 바뀐다")
+    void absoluteRefRecomputes() throws Exception {
+        // 1행 비고가 2행 단가를 가리킨다.
+        patchRow(0, "[\"10\",\"3\",\"\",\"={단가}2\"]")
+                .andExpect(jsonPath("$.data.cells[3]").value("20"));
+
+        patchRow(1, "[\"99\",\"2\",\"\",\"\"]").andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[0].cells[3]").value("99"));
+    }
+
+    @Test
+    @DisplayName("에러도 전파된다 — 참조가 숫자가 아니게 되면 #VALUE!")
+    void errorPropagates() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\",\"\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+
+        patchRow(0, "[\"글자\",\"3\",\"={단가} * {수량}\",\"\"]").andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("#VALUE!"));
+
+        // 다시 숫자로 되돌리면 복구된다.
+        patchRow(0, "[\"4\",\"3\",\"={단가} * {수량}\",\"\"]").andExpect(status().isOk());
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("12"));
+        long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
+        assertThat(formulaRepository.findByRowIdAndColKey(rowId, "c2").orElseThrow().getError())
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("자기 자신을 참조하면 409")
+    void selfReferenceRejected() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={합계} + 1\",\"\"]")
+                .andExpect(status().isConflict());
+
+        long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
+        assertThat(formulaRepository.findByRowIdAndColKey(rowId, "c2")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("두 셀이 서로를 참조하면 409 — 두 번째를 저장할 때 막힌다")
+    void mutualReferenceRejected() throws Exception {
+        // c2 = c3 + 1 은 아직 순환이 아니다(c3엔 수식이 없다).
+        patchRow(0, "[\"10\",\"3\",\"={비고} + 1\",\"\"]").andExpect(status().isOk());
+        // c3 = c2 + 1 을 넣는 순간 c2 → c3 → c2 가 된다.
+        patchRow(0, "[\"10\",\"3\",\"={비고} + 1\",\"={합계} + 1\"]")
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("열 집계가 자기 열을 물면 409 — SUM이 그 열의 수식에 닿는다")
+    void aggregateOverOwnColumnRejected() throws Exception {
+        // c2 = SUM(c2) 는 c2의 수식(자기 자신)에 닿는다.
+        patchRow(0, "[\"10\",\"3\",\"=SUM({합계})\",\"\"]")
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("순환이 아니면 같은 열을 참조해도 통과한다")
+    void sameColumnAcrossRowsIsNotCycle() throws Exception {
+        // 1행 비고 = 2행 단가. 순환이 아니다.
+        patchRow(0, "[\"10\",\"3\",\"\",\"={단가}2\"]").andExpect(status().isOk());
+        // 2행 합계 = 같은 행 단가*수량. 위와 무관.
+        patchRow(1, "[\"20\",\"2\",\"={단가} * {수량}\",\"\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("40"));
+    }
+
+    @Test
+    @DisplayName("조회 응답의 수식을 그대로 돌려주면 살아남는다 — 값을 돌려주면 지워진다")
+    void formulaSurvivesEchoButNotValue() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\",\"\"]").andExpect(status().isOk());
+
+        // 조회 응답이 표시형 수식을 준다.
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("30"))
+                .andExpect(jsonPath("$.data.rows[0].formulas.c2").value("=({단가} * {수량})"))
+                // 수식 없는 셀은 담기지 않는다.
+                .andExpect(jsonPath("$.data.rows[0].formulas.c0").doesNotExist());
+
+        // 그 수식을 그대로 돌려주면 살아남는다.
+        patchRow(0, "[\"2\",\"3\",\"=({단가} * {수량})\",\"\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("6"));
+        rows().andExpect(jsonPath("$.data.rows[0].formulas.c2").exists());
+
+        // 계산된 값을 돌려주면 사용자가 직접 입력한 것으로 보고 수식을 지운다.
+        patchRow(0, "[\"2\",\"3\",\"6\",\"\"]").andExpect(status().isOk());
+        rows().andExpect(jsonPath("$.data.rows[0].formulas.c2").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("표시형 수식은 현재 열 이름을 따라간다")
+    void displayFormulaFollowsRename() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\",\"\"]").andExpect(status().isOk());
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}", datasetId, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"가격\"}"))
+                .andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[0].formulas.c2").value("=({가격} * {수량})"));
+    }
+
+    @Test
+    @DisplayName("행을 지우면 그 행을 참조하던 수식이 #REF!가 아니라 옛 값으로 남는다(#814 범위)")
+    void deletedRowLeavesStaleValueForNow() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"\",\"={단가}2\"]")
+                .andExpect(jsonPath("$.data.cells[3]").value("20"));
+
+        mockMvc.perform(delete("/api/datasets/{id}/rows/{i}", datasetId, 1)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNoContent());
+
+        // 삭제는 아직 전파를 일으키지 않는다 — #814가 #REF!로 바꾼다.
+        rows().andExpect(jsonPath("$.data.rows[0].cells[3]").value("20"));
+    }
+}

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     DUPLICATE_COLUMN_LABEL("SP-ERR-004", "이미 있는 열 이름입니다.", 409),
     FORMULA_SYNTAX_ERROR("SP-ERR-005", "수식을 이해할 수 없습니다.", 400),
     FORMULA_CIRCULAR_REFERENCE("SP-ERR-006", "수식이 자기 자신을 참조합니다.", 409),
+    FORMULA_PROPAGATION_TOO_WIDE("SP-ERR-007", "이 편집이 다시 계산할 수식이 너무 많습니다.", 409),
 
     // PLANNER (Google Calendar 연동)
     ROUTINE_INVALID_RULE("PLN-ERR-002", "유효하지 않은 반복 규칙입니다.", 400),

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -350,6 +350,101 @@ describe("DatasetGrid", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("다른 셀을 고칠 때 수식 셀엔 원본 수식을 돌려준다 — 값을 돌려주면 수식이 지워진다", async () => {
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "단가" },
+              { key: "c1", label: "합계" },
+            ],
+            rowCount: 1,
+          },
+        }),
+      ),
+      // c1은 수식 셀 — 화면엔 계산값 30, 원본은 formulas에.
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              {
+                id: 100,
+                rowIndex: 0,
+                cells: ["10", "30"],
+                formulas: { c1: "=({단가} * 3)" },
+              },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+    let sent: string[] | null = null;
+    server.use(
+      http.patch(`${API_BASE}/datasets/1/rows/:i`, async ({ request }) => {
+        const body = (await request.json()) as { cells: string[] };
+        sent = body.cells;
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 100,
+            rowIndex: 0,
+            cells: ["7", "21"],
+            formulas: { c1: "=({단가} * 3)" },
+          },
+        });
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    // 단가만 고친다.
+    await user.click(await screen.findByText("10"));
+    const input = await screen.findByLabelText("셀 1행 1열");
+    fireEvent.change(input, { target: { value: "7" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      // 합계 자리에 계산값 "30"이 아니라 원본 수식이 실려야 한다.
+      expect(sent).toEqual(["7", "=({단가} * 3)"]);
+    });
+    // 서버가 계산한 값으로 화면이 맞춰진다.
+    expect(await screen.findByText("21")).toBeInTheDocument();
+  });
+
+  it("수식을 입력하면 화면이 서버가 계산한 값으로 바뀐다", async () => {
+    mockDataset([["10", "3"]]);
+    server.use(
+      http.patch(`${API_BASE}/datasets/1/rows/:i`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 100,
+            rowIndex: 0,
+            cells: ["10", "30"],
+            formulas: { c1: "=({과목} * 3)" },
+          },
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    await user.click(await screen.findByText("3"));
+    const input = await screen.findByLabelText("셀 1행 2열");
+    fireEvent.change(input, { target: { value: "={과목} * 3" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // 입력한 수식이 아니라 계산 결과가 보인다.
+    expect(await screen.findByText("30")).toBeInTheDocument();
+    expect(screen.queryByText("={과목} * 3")).not.toBeInTheDocument();
+  });
+
   it("[열 추가]로 POST를 호출하고 새 열이 빈 칸으로 붙는다", async () => {
     mockDataset([["네트워크", "92"]]);
     let sentBody: Record<string, unknown> | null = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -40,7 +40,14 @@ interface Props {
 export function DatasetGrid({ datasetId }: Props) {
   const queryClient = useQueryClient();
   const { data: meta, isLoading, isError } = useDatasetMeta(datasetId);
-  const { getRow, ensureRange, setRowLocal, reset } = useDatasetRows(datasetId);
+  const {
+    getRow,
+    getFormulas,
+    ensureRange,
+    setRowLocal,
+    setFormulasLocal,
+    reset,
+  } = useDatasetRows(datasetId);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [editing, setEditing] = useState<{ row: number; col: number } | null>(
     null,
@@ -60,6 +67,12 @@ export function DatasetGrid({ datasetId }: Props) {
   const updateMut = useMutation({
     mutationFn: (v: { index: number; cells: string[] }) =>
       updateDatasetRow(datasetId, v.index, v.cells),
+    // 서버가 계산한 값과 수식으로 맞춘다 — '=1+2'를 치면 화면엔 3이 와야 하고,
+    // 전파가 같은 행의 다른 셀을 고쳤을 수도 있다.
+    onSuccess: (row) => {
+      setRowLocal(row.rowIndex, row.cells);
+      setFormulasLocal(row.rowIndex, row.formulas ?? {});
+    },
     onError: () => reset(),
   });
   const insertMut = useMutation({
@@ -161,11 +174,21 @@ export function DatasetGrid({ datasetId }: Props) {
       setEditing(null);
       return;
     }
-    const next = [...cells];
-    while (next.length < colCount) next.push("");
-    next[editing.col] = draft;
-    setRowLocal(editing.row, next);
-    updateMut.mutate({ index: editing.row, cells: next });
+    const rowFormulas = getFormulas(editing.row);
+
+    // 서버로는 수식 셀에 원본 수식을 돌려준다 — 계산된 값을 돌려주면 서버가
+    // 사용자가 직접 입력한 것으로 보고 수식을 지운다.
+    const sent = Array.from({ length: colCount }, (_, c) => {
+      if (c === editing.col) return draft;
+      return rowFormulas[meta.columns[c].key] ?? cells[c] ?? "";
+    });
+    // 화면엔 값을 유지한다(수식 원본이 잠깐 보이면 안 된다).
+    const shown = Array.from({ length: colCount }, (_, c) =>
+      c === editing.col ? draft : (cells[c] ?? ""),
+    );
+
+    setRowLocal(editing.row, shown);
+    updateMut.mutate({ index: editing.row, cells: sent });
     setEditing(null);
   };
 

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -18,7 +18,15 @@ export interface DatasetRow {
    */
   id: number;
   rowIndex: number;
+  /** 계산된 값. 수식 셀이면 계산 결과가 들어 있다. */
   cells: string[];
+  /**
+   * 수식 있는 셀의 원본(열 key → 표시형 수식). 수식 없는 셀은 없다.
+   *
+   * 행을 수정할 땐 수식 셀에 이걸 그대로 돌려줘야 한다 — 계산된 값을 돌려주면
+   * 서버가 사용자가 직접 입력한 것으로 보고 수식을 지운다.
+   */
+  formulas: Record<string, string>;
 }
 
 export interface RowsPage {

--- a/fe/src/features/note/dataset/hooks/useDatasetRows.ts
+++ b/fe/src/features/note/dataset/hooks/useDatasetRows.ts
@@ -14,6 +14,10 @@ export const DATASET_PAGE_SIZE = 100;
 export function useDatasetRows(datasetId: number) {
   const queryClient = useQueryClient();
   const [cache, setCache] = useState<Map<number, string[]>>(() => new Map());
+  // 수식은 값과 따로 캐시한다 — 화면엔 값을 그리고, 저장할 땐 수식을 돌려줘야 한다.
+  const [formulas, setFormulas] = useState<Map<number, Record<string, string>>>(
+    () => new Map(),
+  );
   const loadedPages = useRef<Set<number>>(new Set());
   const inflight = useRef<Set<number>>(new Set());
   // reset()이 스스로 재조회를 일으키기 위한 세대 번호. 호출자의 useEffect는 ensureRange를
@@ -44,6 +48,13 @@ export function useDatasetRows(datasetId: number) {
               pageData.rows.forEach((r) => next.set(r.rowIndex, r.cells));
               return next;
             });
+            setFormulas((prev) => {
+              const next = new Map(prev);
+              pageData.rows.forEach((r) =>
+                next.set(r.rowIndex, r.formulas ?? {}),
+              );
+              return next;
+            });
           })
           .catch(() => {})
           .finally(() => inflight.current.delete(page));
@@ -60,6 +71,14 @@ export function useDatasetRows(datasetId: number) {
     setCache((prev) => new Map(prev).set(index, cells));
   }, []);
 
+  /** 서버가 돌려준 수식으로 갱신. */
+  const setFormulasLocal = useCallback(
+    (index: number, next: Record<string, string>) => {
+      setFormulas((prev) => new Map(prev).set(index, next));
+    },
+    [],
+  );
+
   /**
    * 캐시를 비우고 다시 받아 온다. 행 인덱스가 밀리거나(행 추가·삭제) 열 구성이 바뀌어
    * 캐시된 위치 배열이 더 이상 유효하지 않을 때(열 삭제) 쓴다.
@@ -68,11 +87,23 @@ export function useDatasetRows(datasetId: number) {
     loadedPages.current.clear();
     inflight.current.clear();
     setCache(new Map());
+    setFormulas(new Map());
     queryClient.removeQueries({ queryKey: ["datasets", datasetId, "rows"] });
     setGeneration((g) => g + 1);
   }, [datasetId, queryClient]);
 
   const getRow = useCallback((index: number) => cache.get(index), [cache]);
+  const getFormulas = useCallback(
+    (index: number) => formulas.get(index) ?? {},
+    [formulas],
+  );
 
-  return { getRow, ensureRange, setRowLocal, reset };
+  return {
+    getRow,
+    getFormulas,
+    ensureRange,
+    setRowLocal,
+    setFormulasLocal,
+    reset,
+  };
 }


### PR DESCRIPTION
## 이슈
closes #813
## 작업 내용
의존성 전파와 순환 참조 거부. **여기서 `c0`을 고치면 `=c0*c1`이 따라 바뀐다** — 사용자가 체감하는 조각.

### 전파 범위는 참조 종류가 가른다 (D9)
| 종류 | 범위 |
|---|---|
| `SAME_ROW` | **같은 행 안에서만.** 계산 열(가장 흔한 패턴)의 편집이 다른 행을 안 건드린다 |
| `ABSOLUTE` | 그 셀을 가리키던 수식만 |
| `COLUMN_ALL` | 그 열의 아무 행이 바뀌어도 (집계라 불가피) |

D9에서 참조를 3종으로 나눈 값어치가 여기서 나온다. 전부 한 종류였다면 1행의 `c0`을 고칠 때 **모든 행의 계산 열**이 재계산됐을 것이다.

### 순환은 쓰기 시점에 거부 (O3)
저장 시 참조를 따라 앞으로 걸어 자기 셀에 닿으면 **409**. 읽기 시점 `#CIRC!`가 아닌 이유는 O1(쓸 때 계산)이라 **순환이 저장되면 재계산이 끝나지 않기** 때문이다.

### 전파 폭 상한 = 1000
모든 행이 `=SUM(c0)`인 병적인 표에선 셀 하나를 고치는 데 행 수만큼의 집계가 재계산되고 각 집계가 다시 전체 행을 훑어 폭발한다. 조용히 멈추면 값이 낡은 채 남으므로 **차라리 거부**한다(409). 실사용에서 걸리면 값을 올리기 전에 그 표의 설계를 먼저 볼 것.

---

## ⚠️ #812의 결함 수정 — 이슈 범위를 넘었다

**#813 테스트를 쓰다가 제가 #812에서 머지한 결함을 발견했다: 수식이 다음 편집 한 번에 사라진다.**

```
1. c2에 "={단가}*{수량}" 입력 → 저장, 응답 cells=["10","3","30"]
2. c0을 7로 고침 → FE가 행 전체를 보내야 하므로 ["7","3","30"] 전송
3. 서버: "30"은 "="로 시작 안 하니 리터럴 → c2 수식 삭제 ❌
```

**원인은 계약에 "이 셀은 그대로 두라"를 표현할 방법이 없다는 것.** 서버는 사용자가 진짜 `30`을 친 건지 FE가 계산값을 되돌려준 건지 구분할 수 없다.

**수정**:
- `RowView`에 **`formulas`**(열 key → 표시형 수식) 추가. 수식 없는 셀은 담기지 않아 대개 비어 있다
- FE가 수식 셀엔 **원본을 돌려주고**, 화면엔 계산값을 유지한다
- 표시형이 저장형과 같은 문법이라 그대로 돌려주면 다시 파싱된다 — #811의 왕복 성질이 여기서 쓰인다

원래 `RowView.formulas`는 #815(FE) 몫이었으나, **이슈 경계보다 main이 정상인 게 우선**이라 당겨왔다. #815엔 표시 토글 UX가 남는다.

## 테스트
BE 13건: **참조 셀 편집 → 재계산** / 연쇄 전파(2단계) / **SAME_ROW가 행을 안 넘음** / COLUMN_ALL이 아무 행에나 걸림 / ABSOLUTE / 에러 전파와 복구 / 자기 참조 409 / 상호 참조 409 / **집계가 자기 열을 물면 409** / 순환 아닌 경우 통과 / **수식 왕복(원본 돌려주면 생존, 값 돌려주면 삭제)** / 표시형이 rename을 따라감 / 행 삭제는 아직 `#REF!` 아님(#814 범위 명시)

FE 2건 추가: **다른 셀 편집 시 수식 셀엔 원본 전송** / 수식 입력하면 화면이 계산값으로

`./gradlew check` · FE 332건 · format · lint · tsc 통과.

## 로컬 확인
MySQL + bootRun + **브라우저**로 원래 버그 시나리오를 그대로 밟았다:
- 표에 `10`, `3`, `={열 1} * {열 2}` 입력 → **30**
- **열 1을 `10 → 7`로 수정 → 합계가 `30 → 21`로 따라 바뀜**
- DB 확인: 수식 `=({c0} * {c1})`이 **살아 있고** `cells`는 `{"c0":"7","c1":"3","c2":"21"}` — #812 상태였다면 이 자리에서 수식이 사라졌다
