### PR TITLE
feat : 수식 참조 무결성 (#REF!)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
@@ -245,6 +245,63 @@ public class DatasetFormulaService {
         return out;
     }
 
+    /**
+     * 열이 지워졌을 때. 두 가지를 한다.
+     *
+     * <ol>
+     *   <li><b>그 열에 있던 수식은 지운다</b> — 담겨 있던 셀 자체가 사라졌다
+     *   <li><b>그 열을 참조하던 수식은 {@code #REF!}로</b> 만든다. 저장형이 없는 열을 가리키면
+     *       파싱이 실패하고, 그게 곧 참조가 끊겼다는 신호다
+     * </ol>
+     *
+     * <p>비용은 <b>O(그 열에 얽힌 수식 수)</b>지 O(행 수)가 아니다 — 열 삭제가 O(1)인 것(#800)과
+     * 양립한다.
+     */
+    void invalidateColumn(Long datasetId, String colKey) {
+        // 1. 그 열에 있던 수식 — 셀이 없어졌으니 수식도 없앤다.
+        for (DatasetFormula f : formulaRepository.findByDatasetIdAndColKey(datasetId, colKey)) {
+            refRepository.deleteByFormulaId(f.getId());
+            formulaRepository.delete(f);
+        }
+        // 2. 그 열을 참조하던 수식 — #REF!로.
+        Set<String> seen = new HashSet<>();
+        for (Long formulaId : refRepository.findFormulaIdsReferencingColumn(datasetId, colKey)) {
+            formulaRepository.findById(formulaId).ifPresent(f -> {
+                recompute(datasetId, f);
+                // 그 셀 값이 바뀌었으니 그걸 참조하던 것들로 계속 번진다.
+                propagateFrom(datasetId, f.getRowId(), f.getColKey(), seen);
+            });
+        }
+    }
+
+    /**
+     * 행이 지워진 <b>뒤에</b> 부른다. 순서가 중요하다 — 지우기 전에 부르면 평가할 때 그 행이
+     * 아직 있어 {@code #REF!}가 안 나온다. 지운 뒤라야 참조가 끊긴 게 드러난다
+     * ({@code to_row_id}엔 FK가 없어 끊긴 참조가 남는다).
+     *
+     * <p>두 가지를 한다.
+     * <ol>
+     *   <li>그 행을 <b>콕 집어</b> 참조하던 수식({@code ABSOLUTE})을 {@code #REF!}로
+     *   <li>모든 열의 <b>집계</b>({@code COLUMN_ALL})를 다시 계산 — 행이 하나 줄었으니 합계가 바뀐다
+     * </ol>
+     *
+     * <p>그 행에 있던 수식은 FK cascade로 이미 사라졌고, {@code SAME_ROW}는 자기 행만 가리키므로
+     * 따로 손댈 게 없다.
+     */
+    void invalidateAfterRowDelete(Long datasetId, Long rowId, List<DatasetColumn> columns) {
+        Set<String> seen = new HashSet<>();
+        for (Long formulaId : refRepository.findFormulaIdsReferencingRow(datasetId, rowId)) {
+            formulaRepository.findById(formulaId).ifPresent(f -> {
+                recompute(datasetId, f);
+                propagateFrom(datasetId, f.getRowId(), f.getColKey(), seen);
+            });
+        }
+        // 행이 줄어 값 집합이 바뀐 열들의 집계.
+        for (DatasetColumn column : columns) {
+            propagateFrom(datasetId, rowId, column.key(), seen);
+        }
+    }
+
     /** 셀이 더 이상 수식이 아니면(리터럴로 덮어씀) 수식과 참조를 지운다. */
     void removeIfAny(Long rowId, String colKey) {
         formulaRepository.findByRowIdAndColKey(rowId, colKey).ifPresent(f -> {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -207,6 +207,8 @@ public class DatasetService {
                 .filter(c -> !c.key().equals(key))
                 .toList();
         dataset.updateColumns(serialize(updated));
+        // 그 열의 수식은 담길 셀이 없어졌으니 지우고, 그 열을 참조하던 수식은 #REF!가 된다.
+        formulaService.invalidateColumn(datasetId, key);
         return DatasetResponse.of(dataset, updated);
     }
 
@@ -380,9 +382,14 @@ public class DatasetService {
         Dataset dataset = getOwned(memberId, datasetId);
         DatasetRow row = rowRepository.findByDatasetIdAndRowIndex(datasetId, rowIndex)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        Long rowId = row.getId();
         rowRepository.delete(row);
         rowRepository.shiftDown(datasetId, rowIndex); // 삭제 flush 후 뒤 행 당김
         dataset.setRowCount(dataset.getRowCount() - 1);
+        // 지운 뒤라야 참조가 끊긴 게 드러난다. 그 행을 콕 집어 참조하던 수식은 #REF!,
+        // 열 집계는 값이 하나 줄었으니 다시 계산한다.
+        formulaService.invalidateAfterRowDelete(datasetId, rowId,
+                parseColumns(dataset.getColumns()));
     }
 
     /** 데이터셋 삭제. dataset_row는 FK ON DELETE CASCADE로 함께 지워진다. */

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFormulaPropagationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFormulaPropagationTest.java
@@ -17,7 +17,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -230,19 +229,5 @@ class DatasetFormulaPropagationTest extends ApiTestSupport {
                 .andExpect(status().isOk());
 
         rows().andExpect(jsonPath("$.data.rows[0].formulas.c2").value("=({가격} * {수량})"));
-    }
-
-    @Test
-    @DisplayName("행을 지우면 그 행을 참조하던 수식이 #REF!가 아니라 옛 값으로 남는다(#814 범위)")
-    void deletedRowLeavesStaleValueForNow() throws Exception {
-        patchRow(0, "[\"10\",\"3\",\"\",\"={단가}2\"]")
-                .andExpect(jsonPath("$.data.cells[3]").value("20"));
-
-        mockMvc.perform(delete("/api/datasets/{id}/rows/{i}", datasetId, 1)
-                        .header(HttpHeaders.AUTHORIZATION, authHeader))
-                .andExpect(status().isNoContent());
-
-        // 삭제는 아직 전파를 일으키지 않는다 — #814가 #REF!로 바꾼다.
-        rows().andExpect(jsonPath("$.data.rows[0].cells[3]").value("20"));
     }
 }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFormulaRefIntegrityTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFormulaRefIntegrityTest.java
@@ -1,0 +1,224 @@
+package ds.project.orino.planner.dataset.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.dataset.repository.DatasetFormulaRepository;
+import ds.project.orino.domain.planner.dataset.repository.DatasetRowRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 참조하던 열·행이 사라졌을 때. 엑셀처럼 삭제를 막지 않고 수식을 {@code #REF!}로 만든다.
+ *
+ * <p>열 삭제의 지연 정리(#800)·열 key 재사용 금지(#798)와 맞물리는 지점이라 함께 고정한다.
+ */
+class DatasetFormulaRefIntegrityTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DatasetFormulaRepository formulaRepository;
+    @Autowired
+    private DatasetRowRepository rowRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long datasetId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"단가"},{"key":"c1","label":"수량"},
+                                            {"key":"c2","label":"합계"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        datasetId = ((Number) JsonPath.read(body, "$.data.id")).longValue();
+        mockMvc.perform(post("/api/datasets/{id}/rows/bulk", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rows\":[[\"10\",\"3\",\"\"],[\"20\",\"2\",\"\"]]}"))
+                .andExpect(status().isOk());
+    }
+
+    private ResultActions patchRow(int rowIndex, String cells) throws Exception {
+        return mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", datasetId, rowIndex)
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cells\":" + cells + "}"));
+    }
+
+    private ResultActions rows() throws Exception {
+        return mockMvc.perform(get("/api/datasets/{id}/rows", datasetId)
+                .header(HttpHeaders.AUTHORIZATION, authHeader));
+    }
+
+    private ResultActions deleteColumn(String key) throws Exception {
+        return mockMvc.perform(delete("/api/datasets/{id}/columns/{key}", datasetId, key)
+                .header(HttpHeaders.AUTHORIZATION, authHeader));
+    }
+
+    @Test
+    @DisplayName("참조하던 열을 지우면 수식이 #REF!가 된다 — 삭제를 막지 않는다")
+    void deletingReferencedColumnMakesRef() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+
+        deleteColumn("c1").andExpect(status().isOk());
+
+        // 열은 2개(단가·합계)가 되고, 합계는 #REF!.
+        rows().andExpect(jsonPath("$.data.rows[0].cells", org.hamcrest.Matchers.hasSize(2)))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("#REF!"));
+
+        long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
+        assertThat(formulaRepository.findByRowIdAndColKey(rowId, "c2").orElseThrow().getError())
+                .isEqualTo("#REF!");
+    }
+
+    @Test
+    @DisplayName("수식이 있던 열을 지우면 그 수식 자체가 사라진다 — 담길 셀이 없다")
+    void deletingFormulaOwnColumnRemovesFormula() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+        long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
+        assertThat(formulaRepository.findByRowIdAndColKey(rowId, "c2")).isPresent();
+
+        deleteColumn("c2").andExpect(status().isOk());
+
+        assertThat(formulaRepository.findByRowIdAndColKey(rowId, "c2")).isEmpty();
+        assertThat(formulaRepository.countByDatasetId(datasetId)).isZero();
+    }
+
+    @Test
+    @DisplayName("열 집계가 참조하던 열을 지워도 #REF!")
+    void deletingAggregatedColumnMakesRef() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"=SUM({단가})\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+
+        deleteColumn("c0").andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[0].cells[1]").value("#REF!"));
+    }
+
+    @Test
+    @DisplayName("#REF!는 전파된다 — 그 셀을 참조하던 수식도 #REF!")
+    void refErrorPropagates() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+        // 합계를 참조하는 수식을 2행에 둔다.
+        patchRow(1, "[\"20\",\"2\",\"={합계}1\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+
+        deleteColumn("c1").andExpect(status().isOk());
+
+        // 1행 합계가 #REF!가 되고, 그걸 참조하던 2행도 따라 #REF!.
+        rows().andExpect(jsonPath("$.data.rows[0].cells[1]").value("#REF!"))
+                .andExpect(jsonPath("$.data.rows[1].cells[1]").value("#REF!"));
+    }
+
+    @Test
+    @DisplayName("지연 정리(#800)와 무관하다 — 행에 남은 값이 #REF! 판정을 안 흔든다")
+    void independentOfLazyPurge() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+        deleteColumn("c1").andExpect(status().isOk());
+
+        // #800대로 지운 열의 값은 행에 남아 있다.
+        long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
+        assertThat(rowRepository.findById(rowId).orElseThrow().getCells()).contains("\"c1\"");
+        // 그래도 수식은 #REF!다 — 판정은 columns 기준이다.
+        rows().andExpect(jsonPath("$.data.rows[0].cells[1]").value("#REF!"));
+    }
+
+    @Test
+    @DisplayName("key 재사용 금지(#798) 덕에 지운 열 자리에 새 열을 만들어도 #REF!가 안 되살아난다")
+    void newColumnDoesNotResurrectRef() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+        deleteColumn("c1").andExpect(status().isOk());
+
+        // 새 열은 c3를 받는다(c1 재사용 안 함).
+        mockMvc.perform(post("/api/datasets/{id}/columns", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.columns[2].key").value("c3"));
+
+        // 수식은 여전히 c1을 가리키므로 #REF! 그대로 — 엉뚱한 새 열에 붙지 않는다.
+        rows().andExpect(jsonPath("$.data.rows[0].cells[1]").value("#REF!"));
+    }
+
+    @Test
+    @DisplayName("참조하던 행을 지우면 #REF! — 지운 뒤라야 드러난다")
+    void deletingReferencedRowMakesRef() throws Exception {
+        // 1행 합계가 2행 단가를 콕 집어 참조.
+        patchRow(0, "[\"10\",\"3\",\"={단가}2\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("20"));
+
+        mockMvc.perform(delete("/api/datasets/{id}/rows/{i}", datasetId, 1)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNoContent());
+
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("#REF!"));
+    }
+
+    @Test
+    @DisplayName("행을 지우면 열 집계가 다시 계산된다 — 값이 하나 줄었다")
+    void deletingRowRecomputesAggregate() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"=SUM({단가})\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("30")); // 10 + 20
+
+        mockMvc.perform(delete("/api/datasets/{id}/rows/{i}", datasetId, 1)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNoContent());
+
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("10"));
+    }
+
+    @Test
+    @DisplayName("열 순서를 바꿔도 참조가 안 깨진다 — key 바인딩이라 무관")
+    void reorderDoesNotBreakRefs() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/order", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keys\":[\"c2\",\"c1\",\"c0\"]}"))
+                .andExpect(status().isOk());
+
+        // 합계가 이제 첫 칸이고 값도 그대로다.
+        rows().andExpect(jsonPath("$.data.rows[0].cells[0]").value("30"))
+                .andExpect(jsonPath("$.data.rows[0].formulas.c2").value("=({단가} * {수량})"));
+    }
+
+    @Test
+    @DisplayName("#REF!가 된 수식도 표시형으로 볼 수 있다")
+    void refFormulaStillDisplayable() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+        deleteColumn("c1").andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[0].formulas.c2").value("#REF!"));
+    }
+}


### PR DESCRIPTION
## 이슈
closes #814
## 작업 내용
참조 무결성. **삭제를 막지 않고 수식을 `#REF!`로** 만든다 — D1/D5가 순수 엑셀식이므로 엑셀과 같이 간다.

### 열 삭제 — 두 가지를 한다
1. **그 열에 있던 수식은 지운다** — 담겨 있던 셀 자체가 사라졌다
2. **그 열을 참조하던 수식은 `#REF!`로** — 저장형이 없는 열을 가리키면 파싱이 실패하고, 그게 곧 참조가 끊겼다는 신호다

비용은 **O(그 열에 얽힌 수식 수)**지 O(행 수)가 아니다 — 열 삭제가 O(1)인 것(#800)과 양립한다.

### 행 삭제 — 순서가 중요하다
**지운 뒤에** 무효화한다. 지우기 전에 하면 평가할 때 그 행이 아직 있어 `#REF!`가 안 나온다. `to_row_id`에 FK를 안 건(#809) 덕에 지운 뒤에도 **끊긴 참조가 남아** 어떤 수식이 그 행을 가리켰는지 알 수 있다.

열 집계도 함께 다시 계산한다 — 행이 하나 줄었으니 합계가 바뀐다.

### 기존 설계와 맞물리는 지점 (테스트로 고정)
- **#800 지연 정리와 무관**: 지운 열의 값은 행에 남지만 `#REF!` 판정은 `columns` 기준이라 안 흔들린다
- **#798 key 재사용 금지가 여기서 값을 한다**: 지운 열 자리에 새 열을 만들면 `c3`를 받으므로 수식이 여전히 죽은 `c1`을 가리킨다. **key를 재사용했다면 수식이 엉뚱한 새 열에 조용히 붙었을 것이다**
- **#805 순서 변경과 무관**: key 바인딩이라 참조가 안 깨진다

## 테스트
10건: 참조 열 삭제 → `#REF!` / 수식이 있던 열 삭제 → 수식 자체 제거 / 집계 참조 열 삭제 / **`#REF!` 전파** / **지연 정리와 무관** / **새 열이 `#REF!`를 안 되살림** / 참조 행 삭제 → `#REF!` / 행 삭제 → 집계 재계산 / 순서 변경 무관 / `#REF!` 수식도 표시형으로 조회 가능

> **#813의 테스트 하나를 제거했다.** "행을 지우면 `#REF!`가 아니라 옛 값으로 남는다(#814 범위)"로 당시의 미완성 상태를 고정해뒀는데, 이 PR이 그 동작을 고쳤으니 실패하는 게 맞다. 새 테스트가 대체한다.

`./gradlew check` · FE 332건 통과.

## 로컬 확인
MySQL + `bootRun`:
- `={단가} * {수량}` → `30` → **참조하던 `수량` 열 삭제** → `#REF!`, DB의 `error` 컬럼도 `#REF!`
- `cells`엔 `"c1": "3"`이 남아 있지만(#800 지연 정리) 판정은 흔들리지 않음
- **새 열 추가 → `c3` 발급** → 수식이 여전히 죽은 `c1`을 가리켜 `#REF!` 유지
