### PR TITLE
feat : 수식 FE 입력·표시 (선택 시 노출)

### DIFF
--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorResponse.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorResponse.java
@@ -14,6 +14,15 @@ public class ErrorResponse {
         return new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
     }
 
+    /**
+     * 예외가 들고 있는 메시지를 그대로 쓴다. {@code CustomException(errorCode, detail)}로
+     * 덧붙인 상세(예: "없는 열: 점수")를 사용자에게 전하기 위한 경로 —
+     * {@link #of(ErrorCode)}만 쓰면 그 상세가 응답에서 사라진다.
+     */
+    public static ErrorResponse of(CustomException e) {
+        return new ErrorResponse(e.getErrorCode().getCode(), e.getMessage());
+    }
+
     public static ErrorResponse of(ErrorCode errorCode, Exception e) {
         return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(e));
     }

--- a/be/orino-core-web/src/main/java/ds/project/orino/core/web/GlobalExceptionHandler.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/web/GlobalExceptionHandler.java
@@ -31,7 +31,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
         log.error("handleCustomException: {}", e.getErrorCode().toString());
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
-                .body(ErrorResponse.of(e.getErrorCode()));
+                .body(ErrorResponse.of(e));
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useAuthStore } from "@/features/auth/store/authStore";
+import { useToastStore } from "@/shared/lib/toast";
 import { server } from "@/test/mocks/server";
 import { renderWithRouter } from "@/test/render";
 
@@ -443,6 +444,110 @@ describe("DatasetGrid", () => {
     // 입력한 수식이 아니라 계산 결과가 보인다.
     expect(await screen.findByText("30")).toBeInTheDocument();
     expect(screen.queryByText("={과목} * 3")).not.toBeInTheDocument();
+  });
+
+  /** c1이 수식 셀인 표 — 화면엔 30, 원본은 formulas에. */
+  function mockFormulaRow() {
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "단가" },
+              { key: "c1", label: "합계" },
+            ],
+            rowCount: 1,
+          },
+        }),
+      ),
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              {
+                id: 100,
+                rowIndex: 0,
+                cells: ["10", "30"],
+                formulas: { c1: "=({단가} * 3)" },
+              },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+  }
+
+  it("수식 셀을 고르면 계산값이 아니라 수식이 보인다 — 안 그러면 자기 수식을 다시 볼 수 없다", async () => {
+    mockFormulaRow();
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    await user.click(await screen.findByText("30"));
+
+    const input = await screen.findByLabelText("셀 1행 2열");
+    expect(input).toHaveValue("=({단가} * 3)");
+  });
+
+  it("수식 없는 셀은 값 그대로 편집한다", async () => {
+    mockFormulaRow();
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    await user.click(await screen.findByText("10"));
+
+    expect(await screen.findByLabelText("셀 1행 1열")).toHaveValue("10");
+  });
+
+  it("[수식 보기]를 켜면 계산값 대신 수식이 보인다", async () => {
+    mockFormulaRow();
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("30");
+
+    await user.click(screen.getByRole("button", { name: "수식 보기" }));
+
+    expect(await screen.findByText("=({단가} * 3)")).toBeInTheDocument();
+    expect(screen.queryByText("30")).not.toBeInTheDocument();
+    // 수식 없는 셀은 그대로 값.
+    expect(screen.getByText("10")).toBeInTheDocument();
+
+    // 다시 끄면 값으로 돌아온다.
+    await user.click(screen.getByRole("button", { name: "수식 보기" }));
+    expect(await screen.findByText("30")).toBeInTheDocument();
+  });
+
+  it("서버가 알려준 수식 오류를 그대로 보여준다", async () => {
+    mockDataset([["10", "3"]]);
+    server.use(
+      http.patch(`${API_BASE}/datasets/1/rows/:i`, () =>
+        HttpResponse.json(
+          {
+            code: "SP-ERR-005",
+            message: "수식을 이해할 수 없습니다. - 없는 열: 무엇",
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    await user.click(await screen.findByText("3"));
+    const input = await screen.findByLabelText("셀 1행 2열");
+    fireEvent.change(input, { target: { value: "={무엇}" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // Toaster는 앱 레이아웃에 있어 이 렌더 트리엔 없다. 스토어에 실렸는지로 본다.
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts.map((t) => t.message)).toContain(
+        "수식을 이해할 수 없습니다. - 없는 열: 무엇",
+      );
+    });
   });
 
   it("[열 추가]로 POST를 호출하고 새 열이 빈 칸으로 붙는다", async () => {

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -6,7 +6,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { Plus, Trash2, X } from "lucide-react";
+import { FunctionSquare, Plus, Trash2, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { FieldError } from "@/components/ui/field-error";
 import { LoadingText } from "@/components/ui/loading-text";
 import { cn } from "@/lib/utils";
+import { toast } from "@/shared/lib/toast";
 
 import {
   addDatasetColumn,
@@ -57,6 +58,8 @@ export function DatasetGrid({ datasetId }: Props) {
   const [colDraft, setColDraft] = useState("");
   const [pendingColDelete, setPendingColDelete] = useState<string | null>(null);
   const [dragKey, setDragKey] = useState<string | null>(null);
+  // D6 — 수식은 평소 숨기고 선택 시에만 보여준다. 이 토글은 상시 표시.
+  const [showFormulas, setShowFormulas] = useState(false);
 
   const colCount = meta?.columns.length ?? 0;
   const rowCount = meta?.rowCount ?? 0;
@@ -73,7 +76,12 @@ export function DatasetGrid({ datasetId }: Props) {
       setRowLocal(row.rowIndex, row.cells);
       setFormulasLocal(row.rowIndex, row.formulas ?? {});
     },
-    onError: () => reset(),
+    onError: (e) => {
+      // 수식 문법 오류·순환 참조는 서버가 무엇이 틀렸는지 알려준다. 그대로 보여준다.
+      const message = serverMessage(e);
+      if (message) toast(message, "error");
+      reset();
+    },
   });
   const insertMut = useMutation({
     mutationFn: (cells: string[]) => insertDatasetRow(datasetId, cells),
@@ -164,7 +172,9 @@ export function DatasetGrid({ datasetId }: Props) {
     const cells = getRow(row);
     if (!cells) return;
     setEditing({ row, col });
-    setDraft(cells[col] ?? "");
+    // 수식 셀을 고를 땐 계산된 값이 아니라 수식을 보여준다 — 값을 보여주면
+    // 자기가 쓴 수식을 다시 볼 방법이 없다.
+    setDraft(getFormulas(row)[meta.columns[col].key] ?? cells[col] ?? "");
   };
 
   const commitEdit = () => {
@@ -340,6 +350,7 @@ export function DatasetGrid({ datasetId }: Props) {
                 {Array.from({ length: colCount }, (_, c) => {
                   const isEditing =
                     editing?.row === vi.index && editing.col === c;
+                  const formula = getFormulas(vi.index)[meta.columns[c].key];
                   return (
                     <div
                       key={c}
@@ -364,9 +375,16 @@ export function DatasetGrid({ datasetId }: Props) {
                           className={cn(
                             "h-full cursor-text truncate px-2 py-1.5",
                             cells === undefined && "text-muted-foreground/40",
+                            isCellError(cells?.[c]) && "text-destructive",
+                            formula !== undefined &&
+                              showFormulas &&
+                              "text-muted-foreground font-mono text-xs",
                           )}
+                          title={formula}
                         >
-                          {cells === undefined ? "…" : (cells[c] ?? "")}
+                          {cells === undefined
+                            ? "…"
+                            : (showFormulas && formula) || (cells[c] ?? "")}
                         </div>
                       )}
                     </div>
@@ -387,7 +405,7 @@ export function DatasetGrid({ datasetId }: Props) {
       </div>
 
       {/* 행 추가 */}
-      <div className="border-border border-t p-1">
+      <div className="border-border flex items-center gap-1 border-t p-1">
         <Button
           type="button"
           variant="ghost"
@@ -396,6 +414,16 @@ export function DatasetGrid({ datasetId }: Props) {
           disabled={insertMut.isPending}
         >
           <Plus className="size-4" /> 행 추가
+        </Button>
+        <Button
+          type="button"
+          variant={showFormulas ? "secondary" : "ghost"}
+          size="sm"
+          aria-pressed={showFormulas}
+          onClick={() => setShowFormulas((v) => !v)}
+          title="수식 셀에 계산 결과 대신 수식을 보여준다"
+        >
+          <FunctionSquare className="size-4" /> 수식 보기
         </Button>
       </div>
 
@@ -423,3 +451,15 @@ export function DatasetGrid({ datasetId }: Props) {
 }
 
 const EMPTY: string[][] = [];
+
+/** 서버가 알려주는 실패 사유(수식 문법 오류·순환 참조 등). 없으면 조용히 넘어간다. */
+function serverMessage(e: unknown): string | null {
+  const data = (e as { response?: { data?: { message?: string } } })?.response
+    ?.data;
+  return typeof data?.message === "string" ? data.message : null;
+}
+
+/** 서버가 계산 대신 넣은 셀 에러(#REF! #VALUE! #DIV/0!). 쿼리의 isError와 헷갈리지 않게 이름을 구분한다. */
+function isCellError(value: string | undefined): boolean {
+  return value !== undefined && value.startsWith("#");
+}


### PR DESCRIPTION
## 이슈
closes #815
## 작업 내용
수식 입력·표시. **여기까지 오면 수식을 실제로 쓸 수 있다.**

### 노출 정책 (D6)
| 상황 | 보이는 것 |
|---|---|
| 평소 | **값** (`30`) |
| 셀 선택 | **수식** (`=({단가} * {수량})`) |
| [수식 보기] 토글 | 상시 수식 |

**셀을 고르면 수식이 뜨는 게 핵심이다.** 지금까진 계산값이 떠서 **자기가 쓴 수식을 다시 볼 방법이 없었다.**

- 에러 셀(`#REF!` `#VALUE!` `#DIV/0!`)은 destructive 색
- 수식 오류·순환 참조는 서버 메시지를 그대로 토스트

### 함께 고친 것 — 에러 상세가 응답에서 사라지고 있었다
브라우저 확인 중 토스트에 **`"수식을 이해할 수 없습니다."`만** 뜨고 `- 없는 열: 없는열`이 빠진 걸 발견했다.

`GlobalExceptionHandler`가 `ErrorResponse.of(e.getErrorCode())`를 써서 **ErrorCode의 고정 메시지만** 실었다. `CustomException(errorCode, detail)`로 덧붙인 상세가 통째로 버려진다 — #811에서 파서에 넣은 안내(`없는 열: 점수`, `집계 함수 안에서는 행을 지정할 수 없습니다` 등)가 **사용자에게 영영 안 갔다.**

예외 메시지를 쓰는 경로(`ErrorResponse.of(CustomException)`)를 추가했다. 기존 에러들은 detail이 없어 동작이 그대로다(회귀 테스트로 확인).

## 테스트
FE 4건 추가: **수식 셀 선택 시 수식 표시** / 수식 없는 셀은 값 그대로 / **[수식 보기] 토글 켜고 끄기** / 서버 오류 메시지 표시

전체: FE 336건 · `./gradlew check` · format · lint 통과.

> **런타임 버그를 tsc가 못 잡았다.** 헬퍼 이름을 `isError`로 지었는데 `useDatasetMeta`가 구조분해하는 `isError`(boolean)와 충돌해 모든 렌더가 깨졌다. `tsc --noEmit`은 충돌 상태에서도 **exit 0**이었고, 테스트가 잡았다. `isCellError`로 바꿨다.

## 로컬 확인
MySQL + bootRun + 브라우저:
- 표에 `10`, `3`, `={열 1} * {열 2}` → 평소 화면 **`30`**
- **셀 선택 → 편집창에 `=({열 1} * {열 2})`**
- **[수식 보기] 켬 → `=({열 1} * {열 2})` 표시, 끔 → `30`**
- `={없는열} + 1` 입력 → 토스트에 **`수식을 이해할 수 없습니다. - 없는 열: 없는열`**
- 순환 참조 → `수식이 자기 자신을 참조합니다.` / 기존 에러(`존재하지 않는 리소스입니다`)도 그대로
