### PR TITLE
feat : 계산 열 (fill down · 행 추가 시 수식 승계)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -92,6 +92,17 @@ public class DatasetController {
         return ApiResponse.success(datasetService.reorderColumns(memberId, id, request));
     }
 
+    /** 한 셀의 수식을 그 열 전체에 채운다(계산 열 만들기). */
+    @PostMapping("/{id}/columns/{key}/fill")
+    public ApiResponse<DatasetResponse> fillDownColumn(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable String key,
+            @RequestParam int fromRowIndex) {
+        return ApiResponse.success(
+                datasetService.fillDownColumn(memberId, id, key, fromRowIndex));
+    }
+
     /** 열 이름 변경. key는 불변이며 label만 바꾼다. */
     @PatchMapping("/{id}/columns/{key}")
     public ApiResponse<DatasetResponse> renameColumn(

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
@@ -121,6 +121,11 @@ public class DatasetFormulaService {
      * @param seen 이미 다시 계산한 셀. 재귀 사이에 공유해 같은 셀을 두 번 계산하지 않는다.
      */
     void propagateFrom(Long datasetId, Long rowId, String colKey, Set<String> seen) {
+        propagateFrom(datasetId, rowId, colKey, seen, MAX_PROPAGATION);
+    }
+
+    /** 예산을 정해 전파한다. fill down처럼 <b>본래 행 수만큼</b> 번지는 작업은 상한이 달라야 한다. */
+    void propagateFrom(Long datasetId, Long rowId, String colKey, Set<String> seen, int budget) {
         for (Long formulaId : refRepository.findDependentFormulaIds(datasetId, rowId, colKey)) {
             DatasetFormula formula = formulaRepository.findById(formulaId).orElse(null);
             if (formula == null) {
@@ -130,13 +135,13 @@ public class DatasetFormulaService {
             if (!seen.add(cell)) {
                 continue;
             }
-            if (seen.size() > MAX_PROPAGATION) {
+            if (seen.size() > budget) {
                 throw new CustomException(ErrorCode.FORMULA_PROPAGATION_TOO_WIDE,
-                        "다시 계산할 수식이 " + MAX_PROPAGATION + "개를 넘습니다");
+                        "다시 계산할 수식이 " + budget + "개를 넘습니다");
             }
             recompute(datasetId, formula);
             // 이 수식의 셀도 값이 바뀌었으니 그걸 참조하던 것들로 계속 번진다.
-            propagateFrom(datasetId, formula.getRowId(), formula.getColKey(), seen);
+            propagateFrom(datasetId, formula.getRowId(), formula.getColKey(), seen, budget);
         }
     }
 
@@ -300,6 +305,95 @@ public class DatasetFormulaService {
         for (DatasetColumn column : columns) {
             propagateFrom(datasetId, rowId, column.key(), seen);
         }
+    }
+
+    /**
+     * 한 셀의 수식을 그 열의 모든 행에 채운다(fill down) — 계산 열을 만드는 방법.
+     *
+     * <p><b>복사가 그냥 되는 이유는 D9다.</b> 저장형의 같은 행 참조({@code {c0}})엔 행 id가 없어
+     * 각 행이 자기 행을 가리킨다. 절대 참조({@code {c0}@142})는 복사해도 그 행을 계속 가리킨다 —
+     * 엑셀의 {@code $A$1}과 같은 성질이라 저장형을 <b>글자 그대로</b> 옮기면 된다.
+     *
+     * <p><b>먼저 다 쓰고 나중에 전파한다.</b> 한 행씩 쓰면서 전파하면 열 집계가 반쯤 채워진
+     * 상태로 계산돼 틀린 값이 나오고, 행 수만큼 다시 계산된다.
+     *
+     * @return 채운 행 수
+     */
+    int fillDownColumn(Long datasetId, String colKey, DatasetRow source,
+                       List<DatasetColumn> columns) {
+        DatasetFormula origin = formulaRepository.findByRowIdAndColKey(source.getId(), colKey)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REQUEST,
+                        "채울 수식이 없는 셀입니다"));
+        String raw = origin.getRaw();
+
+        List<DatasetRow> rows = rowRepository.findByDatasetIdOrderByRowIndexAsc(datasetId);
+        int filled = 0;
+        // 1단계 — 전부 쓴다. 아직 전파하지 않는다.
+        for (DatasetRow row : rows) {
+            if (row.getId().equals(source.getId())) {
+                continue;
+            }
+            writeFormula(datasetId, row, colKey, raw, columns);
+            filled++;
+        }
+        // 2단계 — 값이 다 확정된 뒤에 한 번 전파한다. seen을 공유하므로 열 집계는
+        // 첫 행에서 한 번만(최종 값으로) 다시 계산된다.
+        Set<String> seen = new HashSet<>();
+        int budget = rows.size() + MAX_PROPAGATION;
+        for (DatasetRow row : rows) {
+            propagateFrom(datasetId, row.getId(), colKey, seen, budget);
+        }
+        return filled;
+    }
+
+    /**
+     * 행이 추가됐을 때 <b>계산 열</b>의 수식을 물려준다(D10).
+     *
+     * <p>그 열의 모든 셀이 같은 수식일 때만 물려준다 — 섞여 있으면 사용자가 의도한 게 아니다.
+     * 엑셀 표(ListObject)의 calculated column과 같은 규칙. "바로 윗 행 복사"는 윗 행만
+     * 예외적으로 수식을 가졌을 때 의도와 어긋난다.
+     */
+    void inheritFormulasForNewRow(Long datasetId, DatasetRow row, int rowCountBefore,
+                                  List<DatasetColumn> columns, Map<String, String> cells) {
+        for (DatasetColumn column : columns) {
+            String key = column.key();
+            // 균일 = 이전 모든 행에 수식이 있고, 그 수식이 하나뿐이다.
+            if (rowCountBefore == 0
+                    || formulaRepository.countByDatasetIdAndColKey(datasetId, key) != rowCountBefore
+                    || formulaRepository.countDistinctRawByColumn(datasetId, key) != 1) {
+                continue;
+            }
+            String raw = formulaRepository.findByDatasetIdAndColKey(datasetId, key)
+                    .getFirst().getRaw();
+            cells.put(key, writeFormula(datasetId, row, key, raw, columns));
+        }
+    }
+
+    /** 저장형 수식을 그 셀에 쓰고 계산해 값을 남긴다. 전파는 호출부가 정한다. */
+    private String writeFormula(Long datasetId, DatasetRow row, String colKey, String raw,
+                                List<DatasetColumn> columns) {
+        DatasetFormula formula = formulaRepository.findByRowIdAndColKey(row.getId(), colKey)
+                .orElseGet(() -> formulaRepository.save(
+                        new DatasetFormula(datasetId, row.getId(), colKey, raw)));
+        formula.updateRaw(raw);
+        formulaRepository.save(formula);
+
+        refRepository.deleteByFormulaId(formula.getId());
+        FormulaNode node = FormulaParser.parseStored(raw, new DbContext(datasetId, columns));
+        for (FormulaNode.Ref ref : FormulaParser.collectRefs(node)) {
+            refRepository.save(toEntity(formula.getId(), datasetId, ref));
+        }
+
+        Map<String, String> cells = DatasetCells.parse(row.getCells());
+        FormulaValue value = FormulaEvaluator.evaluate(node, new DbValues(datasetId, row, cells));
+        if (value instanceof FormulaValue.Err e) {
+            formula.markError(e.code());
+        } else {
+            formula.clearError();
+        }
+        cells.put(colKey, value.asCell());
+        row.updateCells(DatasetCells.serialize(cells));
+        return value.asCell();
     }
 
     /** 셀이 더 이상 수식이 아니면(리터럴로 덮어씀) 수식과 참조를 지운다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -268,6 +268,24 @@ public class DatasetService {
         return DatasetResponse.of(dataset, updated);
     }
 
+    /**
+     * 한 셀의 수식을 그 열 전체에 채운다 — 계산 열 만들기.
+     * 셀 단위 수식(D5)이라 계산 열을 만들려면 같은 수식을 모든 행에 두어야 한다.
+     */
+    @Transactional
+    public DatasetResponse fillDownColumn(Long memberId, Long datasetId, String colKey,
+                                          int fromRowIndex) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        if (columns.stream().noneMatch(c -> c.key().equals(colKey))) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+        DatasetRow source = rowRepository.findByDatasetIdAndRowIndex(datasetId, fromRowIndex)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        formulaService.fillDownColumn(datasetId, colKey, source, columns);
+        return DatasetResponse.of(dataset, columns);
+    }
+
     /** 행 벌크 추가(끝에 append). Import 청크에 사용. */
     @Transactional
     public DatasetResponse bulkAppend(Long memberId, Long datasetId, BulkRowsRequest request) {
@@ -372,8 +390,18 @@ public class DatasetService {
         if (at < rowCount) {
             rowRepository.shiftUp(datasetId, at); // 뒤 행을 밀어 자리 확보(flush)
         }
-        rowRepository.save(new DatasetRow(datasetId, at, toCellMap(request.cells(), columns)));
+        Map<String, String> cells = DatasetCells.toMap(request.cells(), columns);
+        DatasetRow row = rowRepository.save(new DatasetRow(datasetId, at,
+                DatasetCells.serialize(cells)));
         dataset.setRowCount(rowCount + 1);
+
+        // 계산 열이면 새 행도 수식을 물려받는다(D10) — 셀 단위 수식이라 안 물려주면 빈 칸이 된다.
+        formulaService.inheritFormulasForNewRow(datasetId, row, rowCount, columns, cells);
+        // 행이 하나 늘었으니 열 집계를 다시 계산한다.
+        Set<String> seen = new HashSet<>();
+        for (DatasetColumn column : columns) {
+            formulaService.propagateFrom(datasetId, row.getId(), column.key(), seen);
+        }
         return new InsertRowResponse(at);
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetCalculatedColumnTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetCalculatedColumnTest.java
@@ -1,0 +1,233 @@
+package ds.project.orino.planner.dataset.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.dataset.repository.DatasetFormulaRepository;
+import ds.project.orino.domain.planner.dataset.repository.DatasetRowRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** 계산 열 — fill down과 행 추가 시 수식 승계(D10). 셀 단위 수식(D5)의 직접적 귀결. */
+class DatasetCalculatedColumnTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DatasetFormulaRepository formulaRepository;
+    @Autowired
+    private DatasetRowRepository rowRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long datasetId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"단가"},{"key":"c1","label":"수량"},
+                                            {"key":"c2","label":"합계"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        datasetId = ((Number) JsonPath.read(body, "$.data.id")).longValue();
+        mockMvc.perform(post("/api/datasets/{id}/rows/bulk", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rows\":[[\"10\",\"3\",\"\"],[\"20\",\"2\",\"\"],[\"5\",\"4\",\"\"]]}"))
+                .andExpect(status().isOk());
+    }
+
+    private ResultActions patchRow(int rowIndex, String cells) throws Exception {
+        return mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", datasetId, rowIndex)
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cells\":" + cells + "}"));
+    }
+
+    private ResultActions rows() throws Exception {
+        return mockMvc.perform(get("/api/datasets/{id}/rows", datasetId)
+                .header(HttpHeaders.AUTHORIZATION, authHeader));
+    }
+
+    private ResultActions fillDown(String key, int fromRowIndex) throws Exception {
+        return mockMvc.perform(post("/api/datasets/{id}/columns/{key}/fill", datasetId, key)
+                .param("fromRowIndex", String.valueOf(fromRowIndex))
+                .header(HttpHeaders.AUTHORIZATION, authHeader));
+    }
+
+    @Test
+    @DisplayName("fill down — 한 셀의 수식이 그 열 전체에 채워지고 각 행이 자기 행을 계산한다")
+    void fillDownAppliesToWholeColumn() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+
+        fillDown("c2", 0).andExpect(status().isOk());
+
+        // 복사가 그냥 되는 이유가 D9 — 같은 행 참조엔 행 id가 없어 각 행이 자기 행을 본다.
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("30"))
+                .andExpect(jsonPath("$.data.rows[1].cells[2]").value("40"))
+                .andExpect(jsonPath("$.data.rows[2].cells[2]").value("20"));
+    }
+
+    @Test
+    @DisplayName("fill down 후 모든 행이 같은 저장형을 갖는다")
+    void fillDownStoresIdenticalRaw() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+        fillDown("c2", 0).andExpect(status().isOk());
+
+        assertThat(formulaRepository.countByDatasetIdAndColKey(datasetId, "c2")).isEqualTo(3);
+        assertThat(formulaRepository.countDistinctRawByColumn(datasetId, "c2")).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("fill down 후에도 각 행 편집이 그 행만 다시 계산한다")
+    void fillDownKeepsSameRowScoping() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+        fillDown("c2", 0).andExpect(status().isOk());
+
+        patchRow(1, "[\"100\",\"2\",\"=({단가} * {수량})\"]").andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("30"))
+                .andExpect(jsonPath("$.data.rows[1].cells[2]").value("200"))
+                .andExpect(jsonPath("$.data.rows[2].cells[2]").value("20"));
+    }
+
+    @Test
+    @DisplayName("fill down은 열 집계를 최종 값으로 한 번만 계산한다 — 반쯤 채워진 상태로 계산하면 안 된다")
+    void fillDownComputesAggregateOnce() throws Exception {
+        // 합계를 집계할 자리(총계)를 따로 만든다. 합계 열이 참조하는 단가·수량에 두면 순환이다.
+        mockMvc.perform(post("/api/datasets/{id}/columns", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"총계\"}"))
+                .andExpect(status().isCreated());
+
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\",\"=SUM({합계})\"]")
+                .andExpect(status().isOk());
+
+        // 1행만 30이던 상태에서 채우면 30+40+20=90이 돼야 한다.
+        fillDown("c2", 0).andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[0].cells[3]").value("90"));
+    }
+
+    @Test
+    @DisplayName("fill down — 수식 없는 셀에서 부르면 400")
+    void fillDownWithoutFormula() throws Exception {
+        fillDown("c2", 0).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("fill down — 없는 열·행이면 404")
+    void fillDownNotFound() throws Exception {
+        fillDown("c9", 0).andExpect(status().isNotFound());
+        fillDown("c2", 99).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("행을 추가하면 계산 열이 수식을 물려준다 — 균일할 때만")
+    void newRowInheritsUniformColumn() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+        fillDown("c2", 0).andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/datasets/{id}/rows", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"7\",\"2\",\"\"]}"))
+                .andExpect(status().isCreated());
+
+        // 새 행도 수식을 받아 계산된다(빈 칸이 아니다).
+        rows().andExpect(jsonPath("$.data.rows[3].cells[2]").value("14"))
+                .andExpect(jsonPath("$.data.rows[3].formulas.c2").value("=({단가} * {수량})"));
+    }
+
+    @Test
+    @DisplayName("열이 균일하지 않으면 물려주지 않는다 — 사용자가 의도한 게 아니다")
+    void newRowDoesNotInheritMixedColumn() throws Exception {
+        // 1행만 수식, 나머지는 값.
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/datasets/{id}/rows", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"7\",\"2\",\"\"]}"))
+                .andExpect(status().isCreated());
+
+        rows().andExpect(jsonPath("$.data.rows[3].cells[2]").value(""))
+                .andExpect(jsonPath("$.data.rows[3].formulas.c2").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("수식이 섞여 있으면 물려주지 않는다 — 같은 열이라도 다른 수식이면")
+    void mixedFormulasDoNotInherit() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+        patchRow(1, "[\"20\",\"2\",\"={단가} + {수량}\"]").andExpect(status().isOk());
+        patchRow(2, "[\"5\",\"4\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+        // 모든 행에 수식이 있지만 종류가 둘이다.
+        assertThat(formulaRepository.countDistinctRawByColumn(datasetId, "c2")).isEqualTo(2);
+
+        mockMvc.perform(post("/api/datasets/{id}/rows", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"7\",\"2\",\"\"]}"))
+                .andExpect(status().isCreated());
+
+        rows().andExpect(jsonPath("$.data.rows[3].formulas.c2").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("행을 추가하면 열 집계가 다시 계산된다")
+    void newRowRecomputesAggregate() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"=SUM({단가})\"]")
+                .andExpect(jsonPath("$.data.cells[2]").value("35")); // 10+20+5
+
+        mockMvc.perform(post("/api/datasets/{id}/rows", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"100\",\"1\",\"\"]}"))
+                .andExpect(status().isCreated());
+
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("135"));
+    }
+
+    @Test
+    @DisplayName("맨 앞에 행을 끼워도 승계가 동작한다 — 행 번호가 밀리는 것과 무관")
+    void inheritWorksOnInsertAtFront() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+        fillDown("c2", 0).andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/datasets/{id}/rows", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"atIndex\":0,\"cells\":[\"2\",\"5\",\"\"]}"))
+                .andExpect(status().isCreated());
+
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("10"))
+                // 밀려난 기존 행들도 그대로다.
+                .andExpect(jsonPath("$.data.rows[1].cells[2]").value("30"));
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetFormulaRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetFormulaRepository.java
@@ -2,6 +2,8 @@ package ds.project.orino.domain.planner.dataset.repository;
 
 import ds.project.orino.domain.planner.dataset.entity.DatasetFormula;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -20,6 +22,19 @@ public interface DatasetFormulaRepository extends JpaRepository<DatasetFormula, 
     List<DatasetFormula> findByDatasetIdAndColKey(Long datasetId, String colKey);
 
     long countByDatasetId(Long datasetId);
+
+    long countByDatasetIdAndColKey(Long datasetId, String colKey);
+
+    /**
+     * 그 열 수식들의 서로 다른 저장형 개수. 1이면 모든 행이 같은 수식 = 계산 열이다.
+     *
+     * <p>전부 읽어 비교하면 행 수만큼 비싸다 — 행을 추가할 때마다 하는 판정이라 쿼리로 센다.
+     * 저장형은 같은 행 참조에 행 id를 안 쓰므로(D9), 계산 열이면 모든 행의 raw가 글자까지 같다.
+     */
+    @Query("SELECT COUNT(DISTINCT f.raw) FROM DatasetFormula f "
+            + "WHERE f.datasetId = :datasetId AND f.colKey = :colKey")
+    long countDistinctRawByColumn(@Param("datasetId") Long datasetId,
+                                  @Param("colKey") String colKey);
 
     void deleteByRowIdAndColKey(Long rowId, String colKey);
 }


### PR DESCRIPTION
## 이슈
closes #816
## 작업 내용
계산 열. **[#799](https://github.com/wcorn/orino/issues/799) Epic의 마지막 구현 이슈.**

D5(셀 단위 수식)를 택한 대가를 갚는 작업이다 — 셀마다 독립적으로 수식을 가지므로 계산 열을 만들려면 같은 수식을 모든 행에 두어야 하고, 행을 추가하면 새 행엔 수식이 없어 빈 칸이 된다.

### fill down — `POST /columns/{key}/fill?fromRowIndex=`
**복사가 그냥 되는 이유는 D9다.** 저장형의 같은 행 참조(`{c0}`)엔 행 id가 없어 각 행이 자기 행을 가리킨다. 절대 참조(`{c0}@142`)는 복사해도 그 행을 계속 가리킨다 — 엑셀의 `$A$1`과 같은 성질이라 **저장형을 글자 그대로 옮기면 된다.**

**먼저 다 쓰고 나중에 한 번 전파한다.** 한 행씩 쓰면서 전파하면 열 집계가 **반쯤 채워진 상태로 계산돼 틀린 값**이 나오고, 행 수만큼 다시 계산된다. `seen`을 공유해 집계는 첫 행에서 한 번만(최종 값으로) 계산된다.

**전파 예산을 파라미터로 뺐다.** fill down은 본래 행 수만큼 번지므로 셀 하나 편집의 상한(`MAX_PROPAGATION`=1000)을 그대로 쓰면 1000행 넘는 표에서 정상 동작이 거부된다.

### 행 추가 시 승계 (D10)
그 열의 **모든 셀이 같은 수식일 때만** 물려준다. 섞여 있으면 사용자가 의도한 게 아니다 — 엑셀 표(ListObject)의 calculated column과 같은 규칙.

**균일성은 쿼리로 센다**(`COUNT(*)`, `COUNT(DISTINCT raw)`). 행마다 전체 수식을 읽어 비교하면 행 수만큼 비싸고, 이건 행을 추가할 때마다 하는 판정이다. 저장형이 같은 행 참조에 행 id를 안 쓰므로(D9) 계산 열이면 **모든 행의 raw가 글자까지 같다** — 그래서 `COUNT(DISTINCT raw) = 1`이 곧 균일이다.

## 테스트
11건: fill down 적용·각 행이 자기 행 계산 / 저장형 동일 / **fill down 후에도 행 편집이 그 행만 재계산** / **집계를 최종 값으로 한 번만 계산** / 수식 없는 셀 400 / 없는 열·행 404 / **균일할 때 승계** / 값만 있는 열은 승계 안 함 / **수식이 섞이면 승계 안 함** / 행 추가 시 집계 재계산 / 맨 앞 삽입에도 승계

> **순환 검출이 제 실수를 잡았다.** 집계 테스트를 `수량` 열에 `=SUM({합계})`로 썼는데, `합계 = 단가 * 수량`이라 `수량 → 합계 → 수량` 순환이었다. 409가 맞고, 집계를 참조되지 않는 열로 옮겼다.

`./gradlew check` · FE 336건 통과.

## 로컬 확인
MySQL + `bootRun`:
- 1행에만 `={단가} * {수량}` → `30`, 나머지 빈 칸
- **fill down** → `30 / 40 / 20` (각 행이 자기 행 기준)
- **행 추가 `["7","2",""]` → 수식을 물려받아 `14`** 자동 계산
- DB: `수식수=4, 서로다른수식=1` — 균일성 성립
