### PR TITLE
fix : E2E auth 목킹이 실제 호출 주소와 어긋나던 문제

### DIFF
--- a/fe/e2e/auth.spec.ts
+++ b/fe/e2e/auth.spec.ts
@@ -1,10 +1,16 @@
 import { expect, test } from "@playwright/test";
 
-const API_BASE = "https://api.orino.dev/api";
-
+/**
+ * 앱이 실제로 부르는 주소로 가로챈다.
+ *
+ * 호스트를 하드코딩하면(`https://api.orino.dev/api`) dev에서 매치되지 않는다 —
+ * `.env.development`가 `VITE_API_URL=/api`라 앱은 Vite 프록시(`/api/...`)로 부른다.
+ * 매치가 안 되면 요청이 프록시를 타고 실제 BE로 나가고, BE가 없으면 500이 온다.
+ * 경로 패턴은 dev·배포 양쪽에 다 걸린다.
+ */
 function mockAuthApi(page: import("@playwright/test").Page) {
   return Promise.all([
-    page.route(`${API_BASE}/auth/login`, async (route) => {
+    page.route("**/api/auth/login", async (route) => {
       const body = route.request().postDataJSON();
       if (body.loginId === "admin" && body.password === "password") {
         await route.fulfill({
@@ -27,7 +33,7 @@ function mockAuthApi(page: import("@playwright/test").Page) {
       }
     }),
 
-    page.route(`${API_BASE}/auth/reissue`, async (route) => {
+    page.route("**/api/auth/reissue", async (route) => {
       await route.fulfill({
         status: 401,
         contentType: "application/json",
@@ -38,7 +44,27 @@ function mockAuthApi(page: import("@playwright/test").Page) {
       });
     }),
 
-    page.route(`${API_BASE}/auth/logout`, async (route) => {
+    // 로그인 후 화면엔 Sidebar가 딸려 오고 복습 요약을 부른다. 안 막아두면
+    // 실제 BE가 가짜 토큰을 401로 거부하고 앱이 정상적으로 자동 로그아웃해 버린다
+    // (= BE가 떠 있으면 실패하는 테스트가 된다).
+    page.route("**/api/planner/reviews/summary*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        // 형태는 src/test/mocks/handlers.ts의 것을 따른다 — 지어내면 Sidebar가 깨진다.
+        body: JSON.stringify({
+          code: "OK",
+          data: {
+            today: "2026-05-18",
+            counts: { now: 0, overdue: 0, upcoming: 0, doneToday: 0 },
+            estimatedMinutes: 0,
+            materials: [],
+          },
+        }),
+      });
+    }),
+
+    page.route("**/api/auth/logout", async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -77,7 +103,10 @@ test.describe("인증 흐름", () => {
     await page.getByRole("button", { name: "로그인" }).click();
 
     await expect(page).toHaveURL(/\/home/);
-    await expect(page.getByText("orino")).toBeVisible();
+    // 워드마크가 글자를 쪼개 놓아(or + ı + no) getByText로는 안 잡힌다. 접근성 이름으로 찾는다.
+    await expect(
+      page.getByRole("img", { name: "orino" }).first(),
+    ).toBeVisible();
     await expect(page.getByRole("button", { name: /로그아웃/ })).toBeVisible();
   });
 
@@ -104,6 +133,7 @@ test.describe("인증 흐름", () => {
 
     // 로그아웃 후 인증이 필요 없는 페이지로 이동
     await page.waitForURL(/\/(login)?$/);
-    await expect(page.getByText("orino")).toBeVisible();
+    // 로고가 보이는지보다 "로그아웃됐는지"가 이 테스트가 확인할 것이다.
+    await expect(page.getByRole("button", { name: /로그아웃/ })).toBeHidden();
   });
 });


### PR DESCRIPTION
## 이슈
closes #808
## 작업 내용
`page.route`가 호스트를 하드코딩(`https://api.orino.dev/api`)해 dev에서 매치되지 않던 문제. 경로 패턴(`**/api/auth/login`)으로 교체했다 — #807의 `note-task-list.spec.ts`가 쓰는 방식.

### False green을 실증하고 없앤 걸 확인했다
이슈가 지적한 "통과하지만 이유가 틀린" 테스트를 **직접 재현**했다:

```
MOCK_HIT=false                              ← 401 목킹이 한 번도 안 탐
REQ=[..., "POST http://localhost:3000/api/auth/login"]
RES=[...]                                   ← 그 POST엔 응답 로그조차 없음(프록시 죽음)
1 passed                                    ← 그런데도 통과
```

수정 후 같은 방식으로 확인:
- `MOCK_HIT=true` — 목킹이 실제로 탄다
- **목킹을 200으로 바꾸면 `/home`으로 간다** — 테스트가 목킹 응답에 진짜로 반응한다는 뜻. 예전엔 무엇을 주든 결과가 같았다

## 이슈에 없던 원인 두 개를 더 찾았다
경로 패턴만 고쳤을 때 **여전히 2건이 실패**해서 파봤다.

**1. `getByText("orino")`가 `/home`에서 매치 불가**
로고가 워드마크라 글자를 쪼개 놓았다 — `role="img" aria-label="orino"`인데 텍스트는 `"or"` + `"ı"`(U+0131) + `"no"`다. 랜딩 페이지만 진짜 `h1` 텍스트라 통과했던 것. 접근성 이름으로 찾도록 바꿨고, 로그아웃 테스트는 로고 대신 **"로그아웃됐는지"**를 단언한다.

**2. 테스트가 "BE가 꺼져 있음"에 의존하고 있었다**
BE를 띄우고 돌리면 실패했다. 목킹한 가짜 토큰으로 `/home`에 가면 Sidebar가 복습 요약을 부르고, **실제 BE가 401로 거부하자 앱이 정상적으로 자동 로그아웃**한다. BE가 없을 땐 그 호출이 500이라 로그아웃이 안 일어나 우연히 통과했다.

Sidebar의 요약 API를 목킹해 격리했다. 응답 형태는 지어내지 않고 `src/test/mocks/handlers.ts`의 것을 따랐다 — 처음에 형태를 추측했다가 Sidebar가 깨져 오히려 실패가 늘었다.

## 확인
| 환경 | 결과 |
|---|---|
| **BE 없음** (CI 조건) | **9 passed** |
| **BE 있음** | **9 passed** |

수정 전엔 BE 없음에서 2 failed / 3 passed(그중 1건 false green)였고, BE 있음에선 더 많이 실패했다. 실행 시간도 13.5초 → 4.8초로 줄었다(죽은 프록시 타임아웃이 사라져서).

`npm test`(336건) · format · lint 통과.
