### PR TITLE
fix : 체크박스가 글자보다 아래로 치우치는 문제

### DIFF
--- a/fe/e2e/note-task-list.spec.ts
+++ b/fe/e2e/note-task-list.spec.ts
@@ -126,6 +126,29 @@ test.describe("노트 체크박스 목록", () => {
     expect(contentBox!.x).toBeGreaterThan(labelBox!.x);
   });
 
+  test("체크박스가 첫 줄 글자의 중심에 정렬된다", async ({ page }) => {
+    await page.getByLabel("노트 본문").click();
+    await page.keyboard.type("[] 우유 사기");
+    await expect(page.locator('ul[data-type="taskList"] > li')).toHaveCount(1);
+
+    // 체크박스 중심과 첫 줄 글자 중심의 세로 차이(px). 양수면 체크박스가 아래로 치우침.
+    const offset = await page.evaluate(() => {
+      const li = document.querySelector('ul[data-type="taskList"] > li')!;
+      const box = li
+        .querySelector('input[type="checkbox"]')!
+        .getBoundingClientRect();
+      const textNode = li.querySelector(":scope > div > p")!.firstChild!;
+      const range = document.createRange();
+      range.setStart(textNode, 0);
+      range.setEnd(textNode, 2);
+      const text = range.getBoundingClientRect();
+      return box.top + box.height / 2 - (text.top + text.height / 2);
+    });
+
+    // 회귀 대상: 문단 margin-top(0.15em)이 남아 체크박스가 위로 뜬 것처럼 보이던 문제.
+    expect(Math.abs(offset)).toBeLessThan(1.5);
+  });
+
   test("체크박스 목록엔 불릿 마커가 보이지 않는다", async ({ page }) => {
     await page.getByLabel("노트 본문").click();
     await page.keyboard.type("[] 우유 사기");

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -190,16 +190,20 @@
   gap: 0.5em;
 }
 
+/* label 높이를 글자 한 줄(1lh)로 잡고 그 안에서 중앙 정렬해,
+   체크박스 중심이 첫 줄 글자의 중심과 일치하게 한다.
+   (임의 보정값 대신 줄 높이에 맞추므로 글꼴/크기가 바뀌어도 따라간다.
+   여러 줄 항목에서도 체크박스는 첫 줄에 붙는다.) */
 .tiptap ul[data-type="taskList"] > li > label {
   flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  height: 1lh;
   user-select: none;
 }
 
-/* 체크박스를 첫 줄 글자의 시각 중심에 맞춘다(글자 line-height 기준). */
 .tiptap ul[data-type="taskList"] > li > label > input[type="checkbox"] {
   margin: 0;
-  vertical-align: middle;
-  translate: 0 0.25em;
   accent-color: var(--primary);
   cursor: pointer;
 }
@@ -208,6 +212,13 @@
 .tiptap ul[data-type="taskList"] > li > div {
   flex: 1 1 auto;
   min-width: 0;
+}
+
+/* 위 `.tiptap li > p` 규칙은 체크박스 항목(li > div > p)엔 걸리지 않아
+   문단만 margin-top(0.15em)만큼 내려가고, 그만큼 체크박스가 위로 뜬 것처럼 보인다. */
+.tiptap ul[data-type="taskList"] > li > div > p {
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 /* 체크 완료 항목은 흐리게 + 취소선. */


### PR DESCRIPTION
## 이슈
closes #825
## 작업 내용
- 체크박스 중심이 글자 중심보다 **2.7px 아래**에 놓이던 문제 수정 (#807 후속)
- #807에서 넣은 `translate: 0 0.25em` 보정을 제거하고, `label` 높이를 `1lh`로 잡아 중앙 정렬 → 글꼴/크기가 바뀌어도 따라간다
- **근본 원인은 정렬이 아니라 문단 여백이었다**: `.tiptap li > p { margin: 0 }`은 체크박스 항목(`li > div > p`)엔 걸리지 않아 문단만 `margin-top: 0.15em`(=2.1px)만큼 내려가 있었고, 그만큼 체크박스가 위로 뜬 것처럼 보였다. 밀린 건 체크박스가 아니라 글자 쪽이라 보정값은 증상을 가리는 처방이었다 → 원인을 제거했다
- 정렬 E2E 테스트 추가

### 왜 별도 PR인가
정렬 수정은 원래 #807에 넣으려 했으나, **#807이 이미 머지된 뒤에 푸시**해 main에 반영되지 않았다(squash 머지). 그래서 main에서 새로 브랜치를 따 올린다. 현재 main에는 과보정된 `translate: 0 0.25em`이 그대로 있다.

### 검증
폰트 메트릭(`actualBoundingBox*`)으로 글자의 실제 잉크 중심을 계산해 비교했다.

| | 체크박스 중심 − 글자 중심 |
|---|---|
| `translate: 0.25em` (현재 main) | +2.7px (아래로 치우침) ❌ |
| 보정 제거 + `1lh` 정렬만 | −2.1px (위로 치우침) ❌ |
| **문단 margin 제거까지 (이 PR)** | **±0.1px 이내** ✅ |

- 실제 노트 에디터(`/notes`)에서 `[] ` 입력 → 항목 3개 모두 오차 −0.03px 확인
- 여러 줄 항목에서도 체크박스가 첫 줄에 붙는 것 확인
- **main의 CSS로 되돌리면 추가한 정렬 테스트가 실패**함을 확인 → 회귀 가드 성립. #807의 기존 4건은 허용오차가 6px이라 이 어긋남을 못 잡는다
- `npm test` 336건 · lint · format:check · E2E 10건(auth 5 + 체크박스 5) 전부 통과

> 검증은 Chromium 기준이다. `height: 1lh`는 Chrome 111+ / Safari 16.4+ / Firefox 120+ 지원.