### PR TITLE
feat : 데이터 그리드 열 너비 조절(resize)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -9,6 +9,7 @@ import ds.project.orino.planner.dataset.dto.InsertRowRequest;
 import ds.project.orino.planner.dataset.dto.InsertRowResponse;
 import ds.project.orino.planner.dataset.dto.RenameColumnRequest;
 import ds.project.orino.planner.dataset.dto.ReorderColumnsRequest;
+import ds.project.orino.planner.dataset.dto.ResizeColumnRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
@@ -101,6 +102,25 @@ public class DatasetController {
             @RequestParam int fromRowIndex) {
         return ApiResponse.success(
                 datasetService.fillDownColumn(memberId, id, key, fromRowIndex));
+    }
+
+    /** 열 너비 변경(px). 열 단위 표시 속성이라 행은 건드리지 않는다. */
+    @PatchMapping("/{id}/columns/{key}/width")
+    public ApiResponse<DatasetResponse> resizeColumn(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable String key,
+            @Valid @RequestBody ResizeColumnRequest request) {
+        return ApiResponse.success(datasetService.resizeColumn(memberId, id, key, request));
+    }
+
+    /** 열 너비 초기화 — 기본 폭으로 되돌린다. */
+    @DeleteMapping("/{id}/columns/{key}/width")
+    public ApiResponse<DatasetResponse> resetColumnWidth(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable String key) {
+        return ApiResponse.success(datasetService.resetColumnWidth(memberId, id, key));
     }
 
     /** 열 이름 변경. key는 불변이며 label만 바꾼다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/CreateDatasetRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/CreateDatasetRequest.java
@@ -1,11 +1,15 @@
 package ds.project.orino.planner.dataset.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 
 public record CreateDatasetRequest(
+        // @Valid — 생성 시에도 열의 width 범위를 검증한다. 없으면 resize API의 상·하한을
+        // 생성 경로로 우회할 수 있다.
         @NotEmpty(message = "columns는 최소 1개여야 합니다.")
+        @Valid
         List<DatasetColumn> columns
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetColumn.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetColumn.java
@@ -1,5 +1,42 @@
 package ds.project.orino.planner.dataset.dto;
 
-/** 데이터셋 열 메타. key는 안정 식별자, label은 표시명. */
-public record DatasetColumn(String key, String label) {
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+/**
+ * 데이터셋 열 메타. key는 안정 식별자, label은 표시명.
+ *
+ * <p>{@code width}는 표시 너비(px)이며 <b>nullable</b>이다. null이면 클라이언트가 기본 폭으로
+ * 그린다(기존 동작). 덕분에 width가 없는 기존 columns_json도 그대로 읽히고 마이그레이션이 필요 없다.
+ * 직렬화 시 null은 빼서 columns_json에 빈 항목이 쌓이지 않게 한다.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DatasetColumn(
+        String key,
+        String label,
+        @Min(value = MIN_WIDTH, message = "width는 " + MIN_WIDTH + " 이상이어야 합니다.")
+        @Max(value = MAX_WIDTH, message = "width는 " + MAX_WIDTH + " 이하여야 합니다.")
+        Integer width
+) {
+    /** 열 너비 하한(px). 이보다 좁으면 값이 사실상 안 보인다. */
+    public static final int MIN_WIDTH = 60;
+    /** 열 너비 상한(px). 한 열이 표 전체를 밀어내는 것을 막는다. */
+    public static final int MAX_WIDTH = 800;
+
+    /** 너비 없이 만든다(기본 폭). */
+    public DatasetColumn(String key, String label) {
+        this(key, label, null);
+    }
+
+    /** key/width는 두고 label만 바꾼 새 열 메타. */
+    public DatasetColumn withLabel(String label) {
+        return new DatasetColumn(key, label, width);
+    }
+
+    /** key/label은 두고 width만 바꾼 새 열 메타. */
+    public DatasetColumn withWidth(Integer width) {
+        return new DatasetColumn(key, label, width);
+    }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/ResizeColumnRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/ResizeColumnRequest.java
@@ -1,0 +1,19 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 열 너비 변경 요청. px 정수만 받는다.
+ *
+ * <p>기본 폭으로 되돌리는 것은 <b>너비 삭제</b>(DELETE)로 표현한다. 여기서 null을 허용하면
+ * "값을 안 보냈다"와 "기본으로 되돌려라"를 구분할 수 없다.
+ */
+public record ResizeColumnRequest(
+        @NotNull(message = "width는 필수입니다.")
+        @Min(value = DatasetColumn.MIN_WIDTH, message = "width는 " + DatasetColumn.MIN_WIDTH + " 이상이어야 합니다.")
+        @Max(value = DatasetColumn.MAX_WIDTH, message = "width는 " + DatasetColumn.MAX_WIDTH + " 이하여야 합니다.")
+        Integer width
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -15,6 +15,7 @@ import ds.project.orino.planner.dataset.dto.InsertRowRequest;
 import ds.project.orino.planner.dataset.dto.InsertRowResponse;
 import ds.project.orino.planner.dataset.dto.RenameColumnRequest;
 import ds.project.orino.planner.dataset.dto.ReorderColumnsRequest;
+import ds.project.orino.planner.dataset.dto.ResizeColumnRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
@@ -104,7 +105,7 @@ public class DatasetService {
             for (int n = 2; !taken.add(label); n++) {
                 label = column.label() + " (" + n + ")";
             }
-            result.add(new DatasetColumn(column.key(), label));
+            result.add(column.withLabel(label));
         }
         return result;
     }
@@ -249,13 +250,7 @@ public class DatasetService {
                                         RenameColumnRequest request) {
         Dataset dataset = getOwned(memberId, datasetId);
         List<DatasetColumn> columns = parseColumns(dataset.getColumns());
-        int at = -1;
-        for (int i = 0; i < columns.size(); i++) {
-            if (columns.get(i).key().equals(key)) {
-                at = i;
-                break;
-            }
-        }
+        int at = indexOfColumn(columns, key);
         if (at < 0) {
             throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
         }
@@ -263,9 +258,52 @@ public class DatasetService {
         requireLabelFree(columns, request.label(), key);
 
         List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
-        updated.set(at, new DatasetColumn(key, request.label()));
+        // withLabel — 이름만 바꾸고 width는 보존한다. 새로 만들면 설정한 너비가 날아간다.
+        updated.set(at, columns.get(at).withLabel(request.label()));
         dataset.updateColumns(serialize(updated));
         return DatasetResponse.of(dataset, updated);
+    }
+
+    /**
+     * 열 너비 변경. columns_json의 해당 열만 고치고 행은 건드리지 않아 O(1)이다.
+     * 너비는 열 단위 표시 속성이라 셀 값·수식과 무관하다.
+     */
+    @Transactional
+    public DatasetResponse resizeColumn(Long memberId, Long datasetId, String key,
+                                        ResizeColumnRequest request) {
+        return updateWidth(memberId, datasetId, key, request.width());
+    }
+
+    /**
+     * 열 너비를 지워 기본 폭으로 되돌린다. 너비 미설정(null)이 곧 기본 폭이므로
+     * "되돌리기"는 별도 상태가 아니라 값의 부재로 표현된다.
+     */
+    @Transactional
+    public DatasetResponse resetColumnWidth(Long memberId, Long datasetId, String key) {
+        return updateWidth(memberId, datasetId, key, null);
+    }
+
+    private DatasetResponse updateWidth(Long memberId, Long datasetId, String key, Integer width) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        int at = indexOfColumn(columns, key);
+        if (at < 0) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+
+        List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
+        updated.set(at, columns.get(at).withWidth(width));
+        dataset.updateColumns(serialize(updated));
+        return DatasetResponse.of(dataset, updated);
+    }
+
+    private int indexOfColumn(List<DatasetColumn> columns, String key) {
+        for (int i = 0; i < columns.size(); i++) {
+            if (columns.get(i).key().equals(key)) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     /**

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -959,4 +959,178 @@ class DatasetControllerTest extends ApiTestSupport {
                 .assertThat(datasetRowRepository.countByDatasetId(id))
                 .isZero();
     }
+
+    // ---------- 열 너비(resize) ----------
+
+    /** 열 너비를 바꾸고 응답 본문을 돌려준다. */
+    private String resize(long id, String key, String widthJson) throws Exception {
+        return mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/width", id, key)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"width\":" + widthJson + "}"))
+                .andReturn().getResponse().getContentAsString();
+    }
+
+    @Test
+    @DisplayName("PATCH columns/{key}/width - 너비를 저장하고 조회 시 유지된다")
+    void resize_column() throws Exception {
+        long id = createDataset();
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/width", id, "c1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"width\":240}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[1].width").value(240));
+
+        // 지정하지 않은 열은 width가 없다(기본 폭).
+        mockMvc.perform(get("/api/datasets/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[1].width").value(240))
+                .andExpect(jsonPath("$.data.columns[0].width").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("PATCH columns/{key}/width - 범위 밖 너비는 거부한다")
+    void resize_column_out_of_range() throws Exception {
+        long id = createDataset();
+
+        for (String bad : new String[]{"59", "801", "0", "-10"}) {
+            mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/width", id, "c0")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"width\":" + bad + "}"))
+                    .andExpect(status().isBadRequest());
+        }
+        // 경계값은 통과해야 한다.
+        for (String ok : new String[]{"60", "800"}) {
+            mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/width", id, "c0")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"width\":" + ok + "}"))
+                    .andExpect(status().isOk());
+        }
+    }
+
+    @Test
+    @DisplayName("PATCH columns/{key}/width - width 누락은 거부한다")
+    void resize_column_requires_width() throws Exception {
+        long id = createDataset();
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/width", id, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PATCH columns/{key}/width - 없는 열은 404")
+    void resize_column_not_found() throws Exception {
+        long id = createDataset();
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/width", id, "c99")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"width\":200}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("DELETE columns/{key}/width - 너비를 지우면 기본 폭으로 돌아간다")
+    void reset_column_width() throws Exception {
+        long id = createDataset();
+        resize(id, "c0", "300");
+
+        mockMvc.perform(delete("/api/datasets/{id}/columns/{key}/width", id, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].width").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("이름을 바꿔도 열 너비는 유지된다")
+    void rename_preserves_width() throws Exception {
+        long id = createDataset();
+        resize(id, "c0", "300");
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}", id, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"바뀐이름\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].label").value("바뀐이름"))
+                .andExpect(jsonPath("$.data.columns[0].width").value(300));
+    }
+
+    @Test
+    @DisplayName("순서를 바꿔도 너비는 열을 따라간다")
+    void reorder_carries_width() throws Exception {
+        long id = createDataset();
+        resize(id, "c0", "300");
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/order", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keys\":[\"c1\",\"c0\"]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].key").value("c1"))
+                .andExpect(jsonPath("$.data.columns[0].width").doesNotExist())
+                .andExpect(jsonPath("$.data.columns[1].key").value("c0"))
+                .andExpect(jsonPath("$.data.columns[1].width").value(300));
+    }
+
+    @Test
+    @DisplayName("너비를 바꿔도 행 값은 그대로다 - 열 단위 표시 속성이라 행을 안 건드린다")
+    void resize_does_not_touch_rows() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        resize(id, "c0", "300");
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value("네트워크"))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("92"));
+    }
+
+    @Test
+    @DisplayName("생성 - 범위 밖 width를 넣으면 거부한다 (resize 상·하한을 생성으로 우회 못 함)")
+    void create_rejects_out_of_range_width() throws Exception {
+        mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"과목","width":9999}]}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("생성 - width를 함께 주면 저장된다")
+    void create_with_width() throws Exception {
+        mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"과목","width":150}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.columns[0].width").value(150));
+    }
+
+    @Test
+    @DisplayName("남의 데이터셋 열 너비는 못 바꾼다")
+    void resize_column_of_other_member() throws Exception {
+        long id = createDataset();
+        String otherToken = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/width", id, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, otherToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"width\":200}"))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -708,4 +708,195 @@ describe("DatasetGrid", () => {
 
     await waitFor(() => expect(deleted).toBe(0));
   });
+
+  // ---------- 열 너비(resize) ----------
+
+  it("헤더 경계를 드래그하면 너비를 PATCH하고 그 폭으로 그린다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let sent: unknown = null;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/columns/c0/width`,
+        async ({ request }) => {
+          sent = await request.json();
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              id: 1,
+              columns: [
+                { key: "c0", label: "과목", width: 700 },
+                { key: "c1", label: "점수" },
+              ],
+              rowCount: 1,
+            },
+          });
+        },
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("과목");
+
+    const handle = screen.getByLabelText("과목 열 너비 조절");
+    // getBoundingClientRect가 800으로 목킹돼 있으므로 시작 폭은 800이다.
+    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: -100, pointerId: 1 });
+    fireEvent.pointerUp(handle, { clientX: -100, pointerId: 1 });
+
+    await waitFor(() => expect(sent).toEqual({ width: 700 }));
+  });
+
+  it("너비를 지정한 열은 고정 폭, 나머지는 기본 폭으로 그린다", async () => {
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목", width: 300 },
+              { key: "c1", label: "점수" },
+            ],
+            rowCount: 0,
+          },
+        }),
+      ),
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: { rows: [], offset: 0, limit: 100 },
+        }),
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("과목");
+
+    const header = screen
+      .getByText("과목")
+      .closest("div[style]") as HTMLElement;
+    expect(header.style.gridTemplateColumns).toBe(
+      "300px minmax(120px, 1fr) 44px",
+    );
+  });
+
+  it("하한보다 좁게 끌어도 하한에서 멈춘다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let sent: unknown = null;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/columns/c0/width`,
+        async ({ request }) => {
+          sent = await request.json();
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              id: 1,
+              columns: [
+                { key: "c0", label: "과목", width: 60 },
+                { key: "c1", label: "점수" },
+              ],
+              rowCount: 1,
+            },
+          });
+        },
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("과목");
+
+    const handle = screen.getByLabelText("과목 열 너비 조절");
+    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: -5000, pointerId: 1 });
+    fireEvent.pointerUp(handle, { clientX: -5000, pointerId: 1 });
+
+    // 서버가 400을 내기 전에 클라이언트가 먼저 하한으로 붙인다.
+    await waitFor(() => expect(sent).toEqual({ width: 60 }));
+  });
+
+  it("폭이 그대로면 PATCH하지 않는다 - 핸들을 누르기만 한 경우", async () => {
+    mockDataset([["네트워크", "92"]]);
+    const patched = vi.fn();
+    server.use(
+      http.patch(`${API_BASE}/datasets/1/columns/c0/width`, () => {
+        patched();
+        return HttpResponse.json({ code: "OK", data: null });
+      }),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("과목");
+
+    const handle = screen.getByLabelText("과목 열 너비 조절");
+    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 });
+    fireEvent.pointerUp(handle, { clientX: 0, pointerId: 1 });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(patched).not.toHaveBeenCalled();
+  });
+
+  it("핸들을 더블클릭하면 너비를 지워 기본 폭으로 되돌린다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    const deleted = vi.fn();
+    server.use(
+      http.delete(`${API_BASE}/datasets/1/columns/c0/width`, () => {
+        deleted();
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "점수" },
+            ],
+            rowCount: 1,
+          },
+        });
+      }),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("과목");
+
+    fireEvent.doubleClick(screen.getByLabelText("과목 열 너비 조절"));
+
+    await waitFor(() => expect(deleted).toHaveBeenCalled());
+  });
+
+  it("너비 조절 드래그가 열 순서 변경으로 새지 않는다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    const reordered = vi.fn();
+    server.use(
+      http.patch(`${API_BASE}/datasets/1/columns/order`, () => {
+        reordered();
+        return HttpResponse.json({ code: "OK", data: null });
+      }),
+      http.patch(`${API_BASE}/datasets/1/columns/c0/width`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목", width: 700 },
+              { key: "c1", label: "점수" },
+            ],
+            rowCount: 1,
+          },
+        }),
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("과목");
+
+    const handle = screen.getByLabelText("과목 열 너비 조절");
+    // 리사이즈 시작 전엔 헤더를 끌어 순서를 바꿀 수 있다.
+    const header = screen.getByText("과목").closest("[draggable]");
+    expect(header).toHaveAttribute("draggable", "true");
+
+    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 });
+    // 리사이즈 중엔 draggable이 꺼져 HTML5 드래그가 시작되지 않는다.
+    expect(header).toHaveAttribute("draggable", "false");
+
+    fireEvent.pointerMove(handle, { clientX: -100, pointerId: 1 });
+    fireEvent.pointerUp(handle, { clientX: -100, pointerId: 1 });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(reordered).not.toHaveBeenCalled();
+  });
 });

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -22,8 +22,12 @@ import {
   deleteDatasetColumn,
   deleteDatasetRow,
   insertDatasetRow,
+  MAX_COLUMN_WIDTH,
+  MIN_COLUMN_WIDTH,
   renameDatasetColumn,
   reorderDatasetColumns,
+  resetDatasetColumnWidth,
+  resizeDatasetColumn,
   updateDatasetRow,
 } from "./api/datasets";
 import { useDatasetMeta } from "./hooks/useDatasetMeta";
@@ -58,6 +62,14 @@ export function DatasetGrid({ datasetId }: Props) {
   const [colDraft, setColDraft] = useState("");
   const [pendingColDelete, setPendingColDelete] = useState<string | null>(null);
   const [dragKey, setDragKey] = useState<string | null>(null);
+  // 리사이즈 중인 열과 진행 중 너비. 드래그하는 동안엔 여기 값으로 그리고,
+  // 저장은 놓을 때 한 번만 한다(mousemove마다 PATCH를 보내지 않는다).
+  const [resizing, setResizing] = useState<{
+    key: string;
+    startX: number;
+    startWidth: number;
+    width: number;
+  } | null>(null);
   // D6 — 수식은 평소 숨기고 선택 시에만 보여준다. 이 토글은 상시 표시.
   const [showFormulas, setShowFormulas] = useState(false);
 
@@ -122,6 +134,20 @@ export function DatasetGrid({ datasetId }: Props) {
     },
     onError: () => void invalidateMeta(),
   });
+  const resizeColMut = useMutation({
+    mutationFn: (v: { key: string; width: number }) =>
+      resizeDatasetColumn(datasetId, v.key, v.width),
+    // 너비는 열 단위 속성이라 행 캐시를 버릴 이유가 없다(reorder/delete와 달리 값이 안 밀린다).
+    onSuccess: (next: DatasetMeta) =>
+      queryClient.setQueryData(datasetKeys.meta(datasetId), next),
+    onError: () => void invalidateMeta(),
+  });
+  const resetColWidthMut = useMutation({
+    mutationFn: (key: string) => resetDatasetColumnWidth(datasetId, key),
+    onSuccess: (next: DatasetMeta) =>
+      queryClient.setQueryData(datasetKeys.meta(datasetId), next),
+    onError: () => void invalidateMeta(),
+  });
   const addColMut = useMutation({
     mutationFn: () => addDatasetColumn(datasetId),
     // 행은 다시 받지 않는다. 새 열의 key는 방금 발급돼 어느 행에도 값이 없으므로,
@@ -166,7 +192,56 @@ export function DatasetGrid({ datasetId }: Props) {
     return <FieldError>표를 불러오지 못했어요.</FieldError>;
   }
 
-  const gridTemplateColumns = `repeat(${colCount}, minmax(120px, 1fr)) 44px`;
+  // 너비를 지정한 열은 고정 px, 안 한 열은 기존대로 남는 폭을 나눠 갖는다.
+  // 드래그 중인 열은 아직 저장 전이므로 진행 중 너비로 그린다.
+  const gridTemplateColumns =
+    meta.columns
+      .map((col) => {
+        const width = resizing?.key === col.key ? resizing.width : col.width;
+        return width != null ? `${width}px` : "minmax(120px, 1fr)";
+      })
+      .join(" ") + " 44px";
+
+  const clampWidth = (width: number) =>
+    Math.round(Math.min(MAX_COLUMN_WIDTH, Math.max(MIN_COLUMN_WIDTH, width)));
+
+  const startResize = (key: string, event: React.PointerEvent) => {
+    // 헤더 셀의 실제 렌더 폭에서 시작한다. 너비 미지정(1fr) 열도 이 값으로 잡히므로
+    // 첫 드래그가 기본 폭에서 자연스럽게 이어진다.
+    const headerCell = event.currentTarget.parentElement;
+    if (!headerCell) return;
+    const startWidth = headerCell.getBoundingClientRect().width;
+    event.preventDefault();
+    event.stopPropagation();
+    // 포인터를 잡아 두면 핸들 밖으로 벗어나도 move/up이 계속 온다.
+    // (jsdom엔 없어서 옵셔널 호출 — 없으면 캡처만 못 할 뿐 동작은 같다)
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    setResizing({
+      key,
+      startX: event.clientX,
+      startWidth,
+      width: clampWidth(startWidth),
+    });
+  };
+
+  const moveResize = (event: React.PointerEvent) => {
+    if (!resizing) return;
+    setResizing({
+      ...resizing,
+      width: clampWidth(
+        resizing.startWidth + (event.clientX - resizing.startX),
+      ),
+    });
+  };
+
+  const endResize = () => {
+    if (!resizing) return;
+    const { key, width, startWidth } = resizing;
+    setResizing(null);
+    // 폭이 그대로면 저장하지 않는다 — 핸들을 그냥 누르기만 한 경우.
+    if (Math.round(startWidth) === width) return;
+    resizeColMut.mutate({ key, width });
+  };
 
   const startEdit = (row: number, col: number) => {
     const cells = getRow(row);
@@ -260,7 +335,9 @@ export function DatasetGrid({ datasetId }: Props) {
             <div
               key={header.id}
               // 이름 편집 중엔 텍스트 선택을 막지 않도록 드래그를 끈다.
-              draggable={editingCol !== header.id}
+              // 리사이즈 중에도 꺼야 한다 — 켜두면 핸들을 끄는 순간 HTML5 드래그가
+              // 시작돼 열 순서 변경으로 새어 나간다.
+              draggable={editingCol !== header.id && resizing === null}
               onDragStart={() => setDragKey(header.id)}
               onDragEnd={() => setDragKey(null)}
               onDragOver={(e) => e.preventDefault()}
@@ -315,6 +392,27 @@ export function DatasetGrid({ datasetId }: Props) {
                     </button>
                   )}
                 </>
+              )}
+              {/* 열 경계 리사이즈 핸들. 이름 편집 중엔 내보내지 않는다. */}
+              {editingCol !== header.id && (
+                <div
+                  role="separator"
+                  aria-orientation="vertical"
+                  aria-label={`${columnLabel(header.id)} 열 너비 조절`}
+                  title="드래그해 너비 조절 · 더블클릭해 기본 폭으로"
+                  onPointerDown={(e) => startResize(header.id, e)}
+                  onPointerMove={moveResize}
+                  onPointerUp={endResize}
+                  onPointerCancel={endResize}
+                  onDoubleClick={() => resetColWidthMut.mutate(header.id)}
+                  // 부모가 draggable이라 핸들에서 시작한 드래그가 순서 변경으로 새는 것을 막는다.
+                  draggable={false}
+                  onDragStart={(e) => e.preventDefault()}
+                  className={cn(
+                    "hover:bg-primary/60 -mr-[3px] h-full w-[6px] shrink-0 cursor-col-resize touch-none",
+                    resizing?.key === header.id && "bg-primary/60",
+                  )}
+                />
               )}
             </div>
           ))}

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -3,7 +3,14 @@ import { client } from "@/shared/api";
 export interface DatasetColumn {
   key: string;
   label: string;
+  /** 표시 너비(px). 없으면 기본 폭(균등 분배). */
+  width?: number;
 }
+
+/** 열 너비 하한(px). 서버의 DatasetColumn.MIN_WIDTH와 같아야 한다. */
+export const MIN_COLUMN_WIDTH = 60;
+/** 열 너비 상한(px). 서버의 DatasetColumn.MAX_WIDTH와 같아야 한다. */
+export const MAX_COLUMN_WIDTH = 800;
 
 export interface DatasetMeta {
   id: number;
@@ -95,6 +102,30 @@ export async function reorderDatasetColumns(
   const { data } = await client.patch<ApiEnvelope<DatasetMeta>>(
     `/datasets/${datasetId}/columns/order`,
     { keys },
+  );
+  return data.data;
+}
+
+/** 열 너비 변경(px). 열 단위 표시 속성이라 행은 안 건드린다. */
+export async function resizeDatasetColumn(
+  datasetId: number,
+  key: string,
+  width: number,
+): Promise<DatasetMeta> {
+  const { data } = await client.patch<ApiEnvelope<DatasetMeta>>(
+    `/datasets/${datasetId}/columns/${key}/width`,
+    { width },
+  );
+  return data.data;
+}
+
+/** 열 너비 초기화 — 기본 폭으로 되돌린다. */
+export async function resetDatasetColumnWidth(
+  datasetId: number,
+  key: string,
+): Promise<DatasetMeta> {
+  const { data } = await client.delete<ApiEnvelope<DatasetMeta>>(
+    `/datasets/${datasetId}/columns/${key}/width`,
   );
   return data.data;
 }


### PR DESCRIPTION
## 이슈
closes #827
## 작업 내용
- 열 너비를 저장·조절할 수 있게 했다. `#760` 백로그 "셀 크기 제어 최적화"에서 승격한 첫 항목
- **저장 위치**: `columns_json`. 너비는 열 단위 속성이라 행을 안 건드리고 O(1)로 끝난다
- **하위호환**: `width`는 nullable이고 null이면 기본 폭(현행 동작). 직렬화 시 null을 빼므로 기존 `columns_json`이 그대로 읽히고 **마이그레이션이 없다**
- **API**
  - `PATCH /datasets/{id}/columns/{key}/width` — 너비 지정(px)
  - `DELETE /datasets/{id}/columns/{key}/width` — 기본 폭 복귀
  - PATCH에서 null을 허용하지 않고 삭제로 분리했다. null을 받으면 "값을 안 보냈다"와 "기본으로 되돌려라"를 구분할 수 없다
- **FE**: 헤더 경계 드래그로 조절, 더블클릭으로 기본 폭 복귀. 드래그 중엔 로컬 상태로 그리고 **놓을 때 한 번만** PATCH한다(mousemove마다 요청하지 않음)
- 범위(60~800px)는 BE/FE 양쪽에 상수로 두고 서로 맞췄다

### 구현 중 발견한 함정 두 가지
둘 다 테스트로 막았고, 해당 코드를 되돌리면 그 테스트만 실패하는 것을 확인했다.

1. **rename이 너비를 날린다** — `renameColumn`이 `new DatasetColumn(key, label)`로 열을 새로 만들어 교체하고 있었다. width를 추가하면 이름만 바꿔도 너비가 사라진다. `withLabel()`로 바꿔 보존한다
2. **생성 경로로 검증 우회** — `CreateDatasetRequest`가 `DatasetColumn`을 그대로 받아서, `@Valid`가 없으면 `POST /datasets`로 `width: 9999`를 심어 resize의 상·하한을 우회할 수 있었다

### 리사이즈 × 열 순서 변경 충돌
헤더는 이미 HTML5 `draggable`(순서 변경)이 걸려 있어, 핸들에서 드래그를 시작하면 순서 변경으로 샌다. 리사이즈 중엔 `draggable`을 꺼서 막았다.

### 검증
- **BE 54건 통과** (열 너비 11건 신규). 너비 저장·조회 / 경계값(60·800 통과, 59·801·0·-10 거부) / width 누락 / 없는 열 404 / 남의 데이터셋 404 / 기본 폭 복귀 / **rename·reorder 후 너비 유지** / 너비 변경이 행 값을 안 건드림 / 생성 시 범위 검증
- **FE 342건 통과** (그리드 24건). 드래그 → PATCH / 고정 폭 렌더 / 하한 클램프 / 폭 그대로면 미전송 / 더블클릭 초기화 / 순서 변경으로 안 샘
- **실제 브라우저 확인**(Playwright): 328px → 120px 끌어 **208px**, 서버로 간 값 208, 본문 셀 폭도 208로 헤더와 일치

| | 헤더 폭 | 본문 셀 폭 | 저장된 width |
|---|---|---|---|
| 드래그 전 | 328 | — | 없음(기본) |
| 120px 좁힌 후 | 208 | 208 | 208 |

- `./gradlew check`(checkstyle) · `npm run lint` · `format:check` · `build` 통과

### 범위 밖
행 높이, 자동 맞춤(auto-fit), 셀 병합(#829), 셀 서식(#828).

> 설계 문서(Data-Grid-Block)에 열 너비 서술이 없다. 머지되면 위키에 API와 `width` 필드를 추가하겠다.