### PR TITLE
feat : 데이터 그리드 셀 배경색

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -12,6 +12,7 @@ import ds.project.orino.planner.dataset.dto.ReorderColumnsRequest;
 import ds.project.orino.planner.dataset.dto.ResizeColumnRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
+import ds.project.orino.planner.dataset.dto.SetCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
 import ds.project.orino.planner.dataset.service.DatasetService;
 import jakarta.validation.Valid;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -176,5 +178,20 @@ public class DatasetController {
             @PathVariable int rowIndex) {
         datasetService.deleteRow(memberId, id, rowIndex);
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 셀 서식(배경색·정렬) 지정. 서식을 통째로 교체하며, 빈 요청({@code {}})이면 그 셀 서식을 지운다.
+     * 값·수식과 무관한 표시 속성이라 cells를 건드리지 않는다.
+     */
+    @PutMapping("/{id}/rows/{rowIndex}/cells/{colKey}/style")
+    public ApiResponse<RowView> setCellStyle(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable int rowIndex,
+            @PathVariable String colKey,
+            @Valid @RequestBody SetCellStyleRequest request) {
+        return ApiResponse.success(
+                datasetService.setCellStyle(memberId, id, rowIndex, colKey, request));
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/CellStyle.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/CellStyle.java
@@ -1,0 +1,23 @@
+package ds.project.orino.planner.dataset.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * 한 셀의 서식. {@code RowView.styles}에 열 key로 담기며, 서식 있는 셀만 들어간다
+ * ({@code formulas}와 같은 sparse 맵).
+ *
+ * <p>{@code bg}는 팔레트 토큰명(hex 아님)이라 다크모드는 클라이언트가 토큰으로 해결한다.
+ * null 필드는 직렬화에서 빠진다.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CellStyle(
+        String bg,
+        String align
+) {
+    /** 허용 배경색 토큰. 디자인 시스템의 셀 하이라이트 팔레트와 맞춘다. */
+    public static final java.util.Set<String> ALLOWED_BG =
+            java.util.Set.of("red", "orange", "yellow", "green", "blue", "purple");
+    /** 허용 정렬 값. */
+    public static final java.util.Set<String> ALLOWED_ALIGN =
+            java.util.Set.of("left", "center", "right");
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowView.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowView.java
@@ -16,11 +16,15 @@ import java.util.Map;
  * 수식을 지운다.
  *
  * <p>{@code formulas}는 <b>표시형</b>(열 이름·행 번호)이다. 저장형(key·행 id)은 서버 안에만 있다.
+ *
+ * <p>{@code styles}엔 서식(배경색·정렬)이 있는 셀만 열 key로 담긴다({@code formulas}와 같은
+ * sparse 맵). 서식 없는 셀은 아예 없다.
  */
 public record RowView(
         Long id,
         int rowIndex,
         List<String> cells,
-        Map<String, String> formulas
+        Map<String, String> formulas,
+        Map<String, CellStyle> styles
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetCellStyleRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetCellStyleRequest.java
@@ -1,0 +1,17 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * 셀 서식 지정 요청. 필드가 null이면 "그 서식 없음"으로 저장한다(부분 갱신이 아니라 전체 교체).
+ *
+ * <p>둘 다 null이면 서식이 없어진 것이므로 서버가 그 셀의 서식 행을 지운다 — 서식 초기화는
+ * 별도 API가 아니라 빈 요청으로 표현된다.
+ */
+public record SetCellStyleRequest(
+        @Pattern(regexp = "red|orange|yellow|green|blue|purple", message = "허용되지 않은 배경색입니다.")
+        String bg,
+        @Pattern(regexp = "left|center|right", message = "허용되지 않은 정렬입니다.")
+        String align
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetCellStyleService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetCellStyleService.java
@@ -1,0 +1,62 @@
+package ds.project.orino.planner.dataset.service;
+
+import ds.project.orino.domain.planner.dataset.entity.DatasetCellStyle;
+import ds.project.orino.domain.planner.dataset.repository.DatasetCellStyleRepository;
+import ds.project.orino.planner.dataset.dto.CellStyle;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 셀 서식(배경색·정렬) 저장·조회. 값은 {@code dataset_row.cells}에 그대로 두고 서식만
+ * {@code dataset_cell_style}에 담는다 — 수식({@link DatasetFormulaService})과 같은 sparse 전략이라
+ * 읽기 경로가 바뀌지 않는다.
+ */
+@Service
+public class DatasetCellStyleService {
+
+    private final DatasetCellStyleRepository styleRepository;
+
+    public DatasetCellStyleService(DatasetCellStyleRepository styleRepository) {
+        this.styleRepository = styleRepository;
+    }
+
+    /**
+     * 셀 서식을 통째로 교체한다(부분 갱신 아님). 둘 다 null이면 서식이 없어진 것이므로 행을 지운다 —
+     * 빈 행을 남기면 sparse가 깨진다.
+     */
+    public void setStyle(Long datasetId, Long rowId, String colKey, String bg, String align) {
+        DatasetCellStyle existing = styleRepository.findByRowIdAndColKey(rowId, colKey).orElse(null);
+        if (bg == null && align == null) {
+            if (existing != null) {
+                styleRepository.delete(existing);
+            }
+            return;
+        }
+        if (existing == null) {
+            styleRepository.save(new DatasetCellStyle(datasetId, rowId, colKey, bg, align));
+        } else {
+            existing.update(bg, align);
+        }
+    }
+
+    /** 페이지의 서식을 행 id별로 모은다. 서식 있는 셀만 담기므로 대개 비어 있다. */
+    public Map<Long, Map<String, CellStyle>> stylesByRow(List<Long> rowIds) {
+        if (rowIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, Map<String, CellStyle>> result = new HashMap<>();
+        for (DatasetCellStyle style : styleRepository.findByRowIdIn(rowIds)) {
+            result.computeIfAbsent(style.getRowId(), k -> new HashMap<>())
+                    .put(style.getColKey(), new CellStyle(style.getBg(), style.getAlign()));
+        }
+        return result;
+    }
+
+    /** 열 삭제 시 그 열의 서식을 정리한다. 담길 셀이 없어졌으니 남길 이유가 없다. */
+    public void invalidateColumn(Long datasetId, String colKey) {
+        styleRepository.deleteByDatasetIdAndColKey(datasetId, colKey);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -8,6 +8,7 @@ import ds.project.orino.domain.planner.dataset.repository.DatasetRepository;
 import ds.project.orino.domain.planner.dataset.repository.DatasetRowRepository;
 import ds.project.orino.planner.dataset.dto.AddColumnRequest;
 import ds.project.orino.planner.dataset.dto.BulkRowsRequest;
+import ds.project.orino.planner.dataset.dto.CellStyle;
 import ds.project.orino.planner.dataset.dto.CreateDatasetRequest;
 import ds.project.orino.planner.dataset.dto.DatasetColumn;
 import ds.project.orino.planner.dataset.dto.DatasetResponse;
@@ -18,6 +19,7 @@ import ds.project.orino.planner.dataset.dto.ReorderColumnsRequest;
 import ds.project.orino.planner.dataset.dto.ResizeColumnRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
+import ds.project.orino.planner.dataset.dto.SetCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,12 +69,15 @@ public class DatasetService {
     private final DatasetRepository datasetRepository;
     private final DatasetRowRepository rowRepository;
     private final DatasetFormulaService formulaService;
+    private final DatasetCellStyleService styleService;
 
     public DatasetService(DatasetRepository datasetRepository, DatasetRowRepository rowRepository,
-                          DatasetFormulaService formulaService) {
+                          DatasetFormulaService formulaService,
+                          DatasetCellStyleService styleService) {
         this.datasetRepository = datasetRepository;
         this.rowRepository = rowRepository;
         this.formulaService = formulaService;
+        this.styleService = styleService;
     }
 
     /**
@@ -210,6 +215,8 @@ public class DatasetService {
         dataset.updateColumns(serialize(updated));
         // 그 열의 수식은 담길 셀이 없어졌으니 지우고, 그 열을 참조하던 수식은 #REF!가 된다.
         formulaService.invalidateColumn(datasetId, key);
+        // 그 열의 서식도 담길 셀이 없어졌으니 지운다(col_key는 FK가 아니라 cascade가 없다).
+        styleService.invalidateColumn(datasetId, key);
         return DatasetResponse.of(dataset, updated);
     }
 
@@ -356,12 +363,15 @@ public class DatasetService {
         List<DatasetRow> found = rowRepository
                 .findByDatasetIdAndRowIndexGreaterThanEqualAndRowIndexLessThanOrderByRowIndexAsc(
                         datasetId, off, off + lim);
-        // 페이지의 수식을 한 번에 가져온다. 수식 있는 셀만 담기므로 대개 비어 있다.
-        Map<Long, Map<String, String>> formulas = formulaService.displayFormulas(
-                datasetId, found.stream().map(DatasetRow::getId).toList(), columns);
+        // 페이지의 수식·서식을 한 번에 가져온다. 있는 셀만 담기므로 대개 비어 있다.
+        List<Long> rowIds = found.stream().map(DatasetRow::getId).toList();
+        Map<Long, Map<String, String>> formulas =
+                formulaService.displayFormulas(datasetId, rowIds, columns);
+        Map<Long, Map<String, CellStyle>> styles = styleService.stylesByRow(rowIds);
         List<RowView> rows = found.stream()
                 .map(r -> new RowView(r.getId(), r.getRowIndex(), toCellList(r.getCells(), columns),
-                        formulas.getOrDefault(r.getId(), Map.of())))
+                        formulas.getOrDefault(r.getId(), Map.of()),
+                        styles.getOrDefault(r.getId(), Map.of())))
                 .toList();
         return new RowsResponse(rows, off, lim);
     }
@@ -407,9 +417,35 @@ public class DatasetService {
         }
 
         // 전파가 이 행의 다른 셀을 고쳤을 수 있어 다시 읽는다.
+        return buildRowView(datasetId, row, rowIndex, columns);
+    }
+
+    /**
+     * 셀 서식(배경색·정렬) 지정. 값·수식과 무관한 표시 속성이라 cells를 건드리지 않는다.
+     * 서식을 통째로 교체하며, 둘 다 비면 그 셀 서식을 지운다.
+     */
+    @Transactional
+    public RowView setCellStyle(Long memberId, Long datasetId, int rowIndex, String colKey,
+                                SetCellStyleRequest request) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        if (indexOfColumn(columns, colKey) < 0) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+        DatasetRow row = rowRepository.findByDatasetIdAndRowIndex(datasetId, rowIndex)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        styleService.setStyle(datasetId, row.getId(), colKey, request.bg(), request.align());
+        return buildRowView(datasetId, row, rowIndex, columns);
+    }
+
+    /** 한 행의 현재 상태를 API 형태로 조립한다(값·수식·서식을 함께 싣는다). */
+    private RowView buildRowView(Long datasetId, DatasetRow row, int rowIndex,
+                                 List<DatasetColumn> columns) {
+        List<Long> ids = List.of(row.getId());
         return new RowView(row.getId(), rowIndex, toCellList(row.getCells(), columns),
-                formulaService.displayFormulas(datasetId, List.of(row.getId()), columns)
-                        .getOrDefault(row.getId(), Map.of()));
+                formulaService.displayFormulas(datasetId, ids, columns).getOrDefault(row.getId(), Map.of()),
+                styleService.stylesByRow(ids).getOrDefault(row.getId(), Map.of()));
     }
 
     @Transactional

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/041-create-dataset-cell-style.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/041-create-dataset-cell-style.yaml
@@ -1,0 +1,84 @@
+databaseChangeLog:
+  # 셀 서식(배경색·정렬) 저장 스키마 (#828).
+  #
+  # 수식(dataset_formula)과 같은 전략: 값은 dataset_row.cells에 그대로 두고 서식만 여기 담는다.
+  # 서식 있는 셀만 행이 생기므로 sparse하고, cells의 포맷·투영·API 읽기 경로가 바뀌지 않는다.
+  # bg/align 둘 다 NULL이면 이 행 자체가 없다(서식 없는 셀).
+  - changeSet:
+      id: 041-create-dataset-cell-style
+      author: wcorn
+      comment: 셀 서식 테이블. 값은 dataset_row.cells에 남고 여기엔 배경색·정렬만.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: dataset_cell_style
+      changes:
+        - createTable:
+            tableName: dataset_cell_style
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: dataset_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_dataset_cell_style_dataset
+                    references: dataset(id)
+                    deleteCascade: true
+              # 행 정체성은 row_index가 아니라 id다. 행이 밀려도 서식이 따라다닌다.
+              # 행이 지워지면 cascade로 서식도 함께 사라진다(수식과 달리 끊긴 참조를 남길 이유가 없다).
+              - column:
+                  name: row_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_dataset_cell_style_row
+                    references: dataset_row(id)
+                    deleteCascade: true
+              - column:
+                  name: col_key
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+              # 배경색 토큰명(red/yellow/… — hex 아님). 다크모드는 렌더 시 토큰이 해결한다.
+              - column:
+                  name: bg
+                  type: VARCHAR(32)
+              # left/center/right. NULL이면 열 기본 정렬(columns_json)이나 셀 기본을 따른다.
+              - column:
+                  name: align
+                  type: VARCHAR(16)
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        # 한 셀에 서식은 하나. 조회 키이자 중복 방지.
+        - createIndex:
+            tableName: dataset_cell_style
+            indexName: uq_dataset_cell_style_cell
+            unique: true
+            columns:
+              - column:
+                  name: row_id
+              - column:
+                  name: col_key
+        # 페이지 조회 시 그 dataset의 서식을 한 번에 가져오기 위한 인덱스.
+        - createIndex:
+            tableName: dataset_cell_style
+            indexName: idx_dataset_cell_style_dataset
+            columns:
+              - column:
+                  name: dataset_id

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -79,3 +79,5 @@ databaseChangeLog:
       file: db/changelog/changes/039-dataset-next-column-seq.yaml
   - include:
       file: db/changelog/changes/040-create-dataset-formula.yaml
+  - include:
+      file: db/changelog/changes/041-create-dataset-cell-style.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -3,6 +3,7 @@ package ds.project.orino.planner.dataset.controller;
 import com.jayway.jsonpath.JsonPath;
 import ds.project.orino.domain.member.repository.MemberRepository;
 import ds.project.orino.domain.planner.dataset.entity.DatasetFormula;
+import ds.project.orino.domain.planner.dataset.repository.DatasetCellStyleRepository;
 import ds.project.orino.domain.planner.dataset.repository.DatasetFormulaRepository;
 import ds.project.orino.domain.planner.dataset.repository.DatasetRowRepository;
 import ds.project.orino.support.ApiTestSupport;
@@ -21,6 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -32,6 +34,8 @@ class DatasetControllerTest extends ApiTestSupport {
     private DatasetRowRepository datasetRowRepository;
     @Autowired
     private DatasetFormulaRepository datasetFormulaRepository;
+    @Autowired
+    private DatasetCellStyleRepository datasetCellStyleRepository;
     @Autowired
     private DbCleaner dbCleaner;
 
@@ -1131,6 +1135,184 @@ class DatasetControllerTest extends ApiTestSupport {
                         .header(HttpHeaders.AUTHORIZATION, otherToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"width\":200}"))
+                .andExpect(status().isNotFound());
+    }
+
+    // ---------- 셀 서식(배경색·정렬) ----------
+
+    /** 셀 서식을 지정하고 응답을 돌려준다. */
+    private String setStyle(long id, int rowIndex, String colKey, String bodyJson) throws Exception {
+        return mockMvc.perform(put("/api/datasets/{id}/rows/{r}/cells/{c}/style", id, rowIndex, colKey)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(bodyJson))
+                .andReturn().getResponse().getContentAsString();
+    }
+
+    @Test
+    @DisplayName("PUT cells/{col}/style - 배경색·정렬을 저장하고 행 조회 시 styles로 온다")
+    void set_cell_style() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c1/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"bg\":\"green\",\"align\":\"right\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.styles.c1.bg").value("green"))
+                .andExpect(jsonPath("$.data.styles.c1.align").value("right"));
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rows[0].styles.c1.bg").value("green"))
+                .andExpect(jsonPath("$.data.rows[0].styles.c1.align").value("right"))
+                // 서식 없는 셀은 styles에 아예 없다(sparse).
+                .andExpect(jsonPath("$.data.rows[0].styles.c0").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("PUT cells/{col}/style - 빈 요청이면 서식을 지운다")
+    void clear_cell_style() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+        setStyle(id, 0, "c1", "{\"bg\":\"green\"}");
+
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c1/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.styles.c1").doesNotExist());
+
+        // 빈 서식 행이 남지 않아야 한다(sparse 유지).
+        org.assertj.core.api.Assertions
+                .assertThat(datasetCellStyleRepository.findByRowIdAndColKey(rowIds(id).get(0), "c1"))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("PUT cells/{col}/style - 통째로 교체한다(부분 갱신 아님)")
+    void set_cell_style_replaces() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+        setStyle(id, 0, "c1", "{\"bg\":\"green\",\"align\":\"right\"}");
+
+        // align만 보내면 bg는 사라진다.
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c1/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"align\":\"center\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.styles.c1.align").value("center"))
+                .andExpect(jsonPath("$.data.styles.c1.bg").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("PUT cells/{col}/style - 허용되지 않은 색/정렬은 거부한다")
+    void set_cell_style_rejects_invalid() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c1/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"bg\":\"#ff0000\"}"))
+                .andExpect(status().isBadRequest());
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c1/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"align\":\"justify\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PUT cells/{col}/style - 없는 열은 404")
+    void set_cell_style_unknown_column() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c99/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"bg\":\"green\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("셀 서식을 바꿔도 값·수식은 그대로다 - 표시 속성이라 cells를 안 건드린다")
+    void set_cell_style_keeps_value_and_formula() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"3\",\"4\"]]");
+        // c1을 수식으로 만든다. 참조는 label(과목) 기반이고 열 이름은 중괄호로 감싼다.
+        mockMvc.perform(patch("/api/datasets/{id}/rows/0", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"3\",\"={과목}*2\"]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.cells[1]").value("6"));
+
+        setStyle(id, 0, "c1", "{\"bg\":\"yellow\"}");
+
+        // 값(6)과 수식이 유지돼야 한다.
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("6"))
+                .andExpect(jsonPath("$.data.rows[0].formulas.c1").exists())
+                .andExpect(jsonPath("$.data.rows[0].styles.c1.bg").value("yellow"));
+    }
+
+    @Test
+    @DisplayName("열을 지우면 그 열의 셀 서식도 함께 정리된다")
+    void delete_column_clears_styles() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+        setStyle(id, 0, "c1", "{\"bg\":\"green\"}");
+        long rowId = rowIds(id).get(0);
+        org.assertj.core.api.Assertions
+                .assertThat(datasetCellStyleRepository.findByRowIdAndColKey(rowId, "c1"))
+                .isPresent();
+
+        mockMvc.perform(delete("/api/datasets/{id}/columns/c1", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+
+        // 지연 정리가 아니라 즉시 정리다(수식과 같은 방식).
+        org.assertj.core.api.Assertions
+                .assertThat(datasetCellStyleRepository.findByRowIdAndColKey(rowId, "c1"))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("행을 지우면 그 행의 셀 서식도 cascade로 사라진다")
+    void delete_row_cascades_styles() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+        setStyle(id, 0, "c1", "{\"bg\":\"green\"}");
+        long rowId = rowIds(id).get(0);
+
+        mockMvc.perform(delete("/api/datasets/{id}/rows/0", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNoContent());
+
+        org.assertj.core.api.Assertions
+                .assertThat(datasetCellStyleRepository.findByRowIdAndColKey(rowId, "c1"))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("남의 데이터셋 셀 서식은 못 바꾼다")
+    void set_cell_style_of_other_member() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+        String otherToken = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c1/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, otherToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"bg\":\"green\"}"))
                 .andExpect(status().isNotFound());
     }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetCellStyle.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetCellStyle.java
@@ -1,0 +1,106 @@
+package ds.project.orino.domain.planner.dataset.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+/**
+ * 서식(배경색·정렬)이 지정된 셀. 값이 아니라 <b>서식만</b> 담는다 — 값은
+ * {@link DatasetRow#getCells()}에 그대로 남아 읽기 경로가 바뀌지 않는다. 서식 있는 셀만
+ * 행이 생기므로 sparse하다({@link DatasetFormula 수식}과 같은 전략).
+ *
+ * <p>셀 주소는 {@code (rowId, colKey)}다. 행은 {@code row_index}가 아니라 {@code id}로 가리킨다 —
+ * 순번은 삽입·삭제 때 밀려 정체성이 될 수 없다.
+ *
+ * <p>{@code bg}는 팔레트 토큰명(hex 아님)이라 다크모드는 렌더 시 토큰이 해결한다.
+ * {@code align}이 null이면 열 기본 정렬을 따른다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "dataset_cell_style")
+public class DatasetCellStyle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "dataset_id", nullable = false)
+    private Long datasetId;
+
+    @Column(name = "row_id", nullable = false)
+    private Long rowId;
+
+    @Column(name = "col_key", nullable = false, length = 64)
+    private String colKey;
+
+    /** 배경색 토큰명(red/yellow/…). 없으면 null. */
+    @Column(length = 32)
+    private String bg;
+
+    /** left/center/right. 없으면 null(열 기본 정렬을 따른다). */
+    @Column(length = 16)
+    private String align;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected DatasetCellStyle() {
+    }
+
+    public DatasetCellStyle(Long datasetId, Long rowId, String colKey, String bg, String align) {
+        this.datasetId = datasetId;
+        this.rowId = rowId;
+        this.colKey = colKey;
+        this.bg = bg;
+        this.align = align;
+    }
+
+    /** 서식을 덮어쓴다. 둘 다 null이면 서식 없는 셀 — 호출부가 이 행을 지운다. */
+    public void update(String bg, String align) {
+        this.bg = bg;
+        this.align = align;
+    }
+
+    /** 지정된 서식이 하나도 없으면 true. 이 상태면 행을 남길 이유가 없다. */
+    public boolean isEmpty() {
+        return bg == null && align == null;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getDatasetId() {
+        return datasetId;
+    }
+
+    public Long getRowId() {
+        return rowId;
+    }
+
+    public String getColKey() {
+        return colKey;
+    }
+
+    public String getBg() {
+        return bg;
+    }
+
+    public String getAlign() {
+        return align;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetCellStyleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetCellStyleRepository.java
@@ -1,0 +1,21 @@
+package ds.project.orino.domain.planner.dataset.repository;
+
+import ds.project.orino.domain.planner.dataset.entity.DatasetCellStyle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DatasetCellStyleRepository extends JpaRepository<DatasetCellStyle, Long> {
+
+    /** 셀 하나의 서식. 한 셀에 서식은 하나(UNIQUE). */
+    Optional<DatasetCellStyle> findByRowIdAndColKey(Long rowId, String colKey);
+
+    /** 페이지 조회 시 그 행들의 서식을 한 번에. */
+    List<DatasetCellStyle> findByRowIdIn(List<Long> rowIds);
+
+    /** 열 삭제 시 그 열의 서식 정리에 사용. */
+    List<DatasetCellStyle> findByDatasetIdAndColKey(Long datasetId, String colKey);
+
+    void deleteByDatasetIdAndColKey(Long datasetId, String colKey);
+}

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -899,4 +899,153 @@ describe("DatasetGrid", () => {
     await new Promise((r) => setTimeout(r, 50));
     expect(reordered).not.toHaveBeenCalled();
   });
+
+  // ---------- 셀 배경색 ----------
+
+  it("팔레트에서 색을 고르면 PUT하고 셀 배경이 칠해진다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let sent: unknown = null;
+    server.use(
+      http.put(
+        `${API_BASE}/datasets/1/rows/0/cells/c0/style`,
+        async ({ request }) => {
+          sent = await request.json();
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              id: 100,
+              rowIndex: 0,
+              cells: ["네트워크", "92"],
+              formulas: {},
+              styles: { c0: { bg: "green" } },
+            },
+          });
+        },
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+
+    // 셀 호버 버튼 → 팔레트 → green
+    await user.click(screen.getByLabelText("1행 1열 배경색"));
+    await user.click(screen.getByLabelText("배경색 green"));
+
+    await waitFor(() => expect(sent).toEqual({ bg: "green", align: null }));
+    const cell = screen
+      .getByText("네트워크")
+      .closest("div[style]") as HTMLElement;
+    await waitFor(() =>
+      expect(cell.style.background).toContain("--cell-bg-green"),
+    );
+  });
+
+  it("서버가 준 styles로 셀 배경을 그린다", async () => {
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "점수" },
+            ],
+            rowCount: 1,
+          },
+        }),
+      ),
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              {
+                id: 100,
+                rowIndex: 0,
+                cells: ["네트워크", "92"],
+                formulas: {},
+                styles: { c1: { bg: "yellow" } },
+              },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("92");
+
+    const colored = screen.getByText("92").closest("div[style]") as HTMLElement;
+    expect(colored.style.background).toContain("--cell-bg-yellow");
+    // 서식 없는 셀은 배경이 없다.
+    const plain = screen
+      .getByText("네트워크")
+      .closest("div[style]") as HTMLElement;
+    expect(plain.style.background).toBe("");
+  });
+
+  it("지우기를 누르면 bg를 비워 PUT한다", async () => {
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "점수" },
+            ],
+            rowCount: 1,
+          },
+        }),
+      ),
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              {
+                id: 100,
+                rowIndex: 0,
+                cells: ["네트워크", "92"],
+                formulas: {},
+                styles: { c0: { bg: "green" } },
+              },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+    let sent: unknown = null;
+    server.use(
+      http.put(
+        `${API_BASE}/datasets/1/rows/0/cells/c0/style`,
+        async ({ request }) => {
+          sent = await request.json();
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              id: 100,
+              rowIndex: 0,
+              cells: ["네트워크", "92"],
+              formulas: {},
+              styles: {},
+            },
+          });
+        },
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+
+    await user.click(screen.getByLabelText("1행 1열 배경색"));
+    await user.click(screen.getByLabelText("배경색 지우기"));
+
+    await waitFor(() => expect(sent).toEqual({ bg: null, align: null }));
+  });
 });

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -6,7 +6,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { FunctionSquare, Plus, Trash2, X } from "lucide-react";
+import { FunctionSquare, Palette, Plus, Trash2, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -18,6 +18,9 @@ import { toast } from "@/shared/lib/toast";
 
 import {
   addDatasetColumn,
+  CELL_BG_TOKENS,
+  type CellBgToken,
+  type CellStyle,
   type DatasetMeta,
   deleteDatasetColumn,
   deleteDatasetRow,
@@ -28,6 +31,7 @@ import {
   reorderDatasetColumns,
   resetDatasetColumnWidth,
   resizeDatasetColumn,
+  setCellStyle,
   updateDatasetRow,
 } from "./api/datasets";
 import { useDatasetMeta } from "./hooks/useDatasetMeta";
@@ -48,9 +52,11 @@ export function DatasetGrid({ datasetId }: Props) {
   const {
     getRow,
     getFormulas,
+    getStyles,
     ensureRange,
     setRowLocal,
     setFormulasLocal,
+    setStylesLocal,
     reset,
   } = useDatasetRows(datasetId);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -72,6 +78,10 @@ export function DatasetGrid({ datasetId }: Props) {
   } | null>(null);
   // D6 — 수식은 평소 숨기고 선택 시에만 보여준다. 이 토글은 상시 표시.
   const [showFormulas, setShowFormulas] = useState(false);
+  // 색 팔레트를 연 셀(행 index·열 index). null이면 닫힘.
+  const [palette, setPalette] = useState<{ row: number; col: number } | null>(
+    null,
+  );
 
   const colCount = meta?.columns.length ?? 0;
   const rowCount = meta?.rowCount ?? 0;
@@ -93,6 +103,16 @@ export function DatasetGrid({ datasetId }: Props) {
       const message = serverMessage(e);
       if (message) toast(message, "error");
       reset();
+    },
+  });
+  const styleMut = useMutation({
+    mutationFn: (v: { row: number; colKey: string; style: CellStyle }) =>
+      setCellStyle(datasetId, v.row, v.colKey, v.style),
+    // 서식만 바뀌므로 값·수식 캐시는 건드리지 않고 styles만 갱신한다.
+    onSuccess: (row) => setStylesLocal(row.rowIndex, row.styles ?? {}),
+    onError: (e) => {
+      const message = serverMessage(e);
+      if (message) toast(message, "error");
     },
   });
   const insertMut = useMutation({
@@ -277,6 +297,18 @@ export function DatasetGrid({ datasetId }: Props) {
     setEditing(null);
   };
 
+  /** 셀 배경색을 바꾼다. 정렬 등 다른 서식은 보존한다(서버는 통째로 교체하므로). */
+  const applyBg = (row: number, col: number, bg: CellBgToken | null) => {
+    const colKey = meta.columns[col].key;
+    const current = getStyles(row)[colKey];
+    styleMut.mutate({
+      row,
+      colKey,
+      style: { bg: bg ?? undefined, align: current?.align },
+    });
+    setPalette(null);
+  };
+
   const addRow = () =>
     insertMut.mutate(Array.from({ length: colCount }, () => ""));
 
@@ -448,13 +480,69 @@ export function DatasetGrid({ datasetId }: Props) {
                 {Array.from({ length: colCount }, (_, c) => {
                   const isEditing =
                     editing?.row === vi.index && editing.col === c;
-                  const formula = getFormulas(vi.index)[meta.columns[c].key];
+                  const colKey = meta.columns[c].key;
+                  const formula = getFormulas(vi.index)[colKey];
+                  const style = getStyles(vi.index)[colKey];
+                  const paletteOpen =
+                    palette?.row === vi.index && palette.col === c;
                   return (
                     <div
                       key={c}
-                      className="border-border truncate border-r"
+                      className="border-border group/cell relative truncate border-r"
+                      style={
+                        style?.bg
+                          ? { background: `var(--cell-bg-${style.bg})` }
+                          : undefined
+                      }
                       onClick={() => startEdit(vi.index, c)}
                     >
+                      {/* 셀 배경색 버튼 — 호버 시 나타난다. */}
+                      {!isEditing && (
+                        <button
+                          type="button"
+                          aria-label={`${vi.index + 1}행 ${c + 1}열 배경색`}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setPalette(
+                              paletteOpen ? null : { row: vi.index, col: c },
+                            );
+                          }}
+                          className="text-muted-foreground hover:text-foreground absolute top-0.5 right-0.5 z-10 opacity-0 group-hover/cell:opacity-100 focus-visible:opacity-100"
+                        >
+                          <Palette className="size-3" />
+                        </button>
+                      )}
+                      {paletteOpen && (
+                        <div
+                          role="menu"
+                          className="border-border bg-popover absolute top-5 right-0 z-20 flex gap-1 rounded-md border p-1 shadow-md"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {CELL_BG_TOKENS.map((token) => (
+                            <button
+                              key={token}
+                              type="button"
+                              aria-label={`배경색 ${token}`}
+                              onClick={() => applyBg(vi.index, c, token)}
+                              className={cn(
+                                "size-4 rounded-full border",
+                                style?.bg === token
+                                  ? "border-foreground"
+                                  : "border-border",
+                              )}
+                              style={{ background: `var(--cell-bg-${token})` }}
+                            />
+                          ))}
+                          <button
+                            type="button"
+                            aria-label="배경색 지우기"
+                            onClick={() => applyBg(vi.index, c, null)}
+                            className="text-muted-foreground hover:text-foreground border-border flex size-4 items-center justify-center rounded-full border"
+                          >
+                            <X className="size-2.5" />
+                          </button>
+                        </div>
+                      )}
                       {isEditing ? (
                         <input
                           autoFocus

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -12,6 +12,23 @@ export const MIN_COLUMN_WIDTH = 60;
 /** 열 너비 상한(px). 서버의 DatasetColumn.MAX_WIDTH와 같아야 한다. */
 export const MAX_COLUMN_WIDTH = 800;
 
+/** 셀 배경 팔레트 토큰. 서버의 CellStyle.ALLOWED_BG·index.css의 --cell-bg-*와 같아야 한다. */
+export const CELL_BG_TOKENS = [
+  "red",
+  "orange",
+  "yellow",
+  "green",
+  "blue",
+  "purple",
+] as const;
+export type CellBgToken = (typeof CELL_BG_TOKENS)[number];
+
+/** 셀 서식(배경색·정렬). 지정 안 한 축은 없다(sparse). */
+export interface CellStyle {
+  bg?: CellBgToken;
+  align?: "left" | "center" | "right";
+}
+
 export interface DatasetMeta {
   id: number;
   columns: DatasetColumn[];
@@ -34,6 +51,8 @@ export interface DatasetRow {
    * 서버가 사용자가 직접 입력한 것으로 보고 수식을 지운다.
    */
   formulas: Record<string, string>;
+  /** 서식 있는 셀의 배경색·정렬(열 key → CellStyle). 서식 없는 셀은 없다. */
+  styles: Record<string, CellStyle>;
 }
 
 export interface RowsPage {
@@ -174,6 +193,23 @@ export async function updateDatasetRow(
   const { data } = await client.patch<ApiEnvelope<DatasetRow>>(
     `/datasets/${datasetId}/rows/${rowIndex}`,
     { cells },
+  );
+  return data.data;
+}
+
+/**
+ * 셀 서식(배경색·정렬)을 통째로 교체한다. 빈 style이면 그 셀 서식을 지운다.
+ * 값·수식과 무관한 표시 속성이라 cells는 안 바뀐다.
+ */
+export async function setCellStyle(
+  datasetId: number,
+  rowIndex: number,
+  colKey: string,
+  style: CellStyle,
+): Promise<DatasetRow> {
+  const { data } = await client.put<ApiEnvelope<DatasetRow>>(
+    `/datasets/${datasetId}/rows/${rowIndex}/cells/${colKey}/style`,
+    { bg: style.bg ?? null, align: style.align ?? null },
   );
   return data.data;
 }

--- a/fe/src/features/note/dataset/hooks/useDatasetRows.ts
+++ b/fe/src/features/note/dataset/hooks/useDatasetRows.ts
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
 
-import { fetchDatasetRows } from "../api/datasets";
+import { type CellStyle, fetchDatasetRows } from "../api/datasets";
 import { datasetKeys } from "../queryKeys";
 
 /** 가상화 스크롤에 맞춰 페이지 단위로 행을 지연 로드하는 크기. */
@@ -16,6 +16,10 @@ export function useDatasetRows(datasetId: number) {
   const [cache, setCache] = useState<Map<number, string[]>>(() => new Map());
   // 수식은 값과 따로 캐시한다 — 화면엔 값을 그리고, 저장할 땐 수식을 돌려줘야 한다.
   const [formulas, setFormulas] = useState<Map<number, Record<string, string>>>(
+    () => new Map(),
+  );
+  // 서식(배경색·정렬)도 값과 따로 캐시한다 — 수식과 같은 방식.
+  const [styles, setStyles] = useState<Map<number, Record<string, CellStyle>>>(
     () => new Map(),
   );
   const loadedPages = useRef<Set<number>>(new Set());
@@ -55,6 +59,13 @@ export function useDatasetRows(datasetId: number) {
               );
               return next;
             });
+            setStyles((prev) => {
+              const next = new Map(prev);
+              pageData.rows.forEach((r) =>
+                next.set(r.rowIndex, r.styles ?? {}),
+              );
+              return next;
+            });
           })
           .catch(() => {})
           .finally(() => inflight.current.delete(page));
@@ -79,6 +90,14 @@ export function useDatasetRows(datasetId: number) {
     [],
   );
 
+  /** 서버가 돌려준 서식으로 갱신. */
+  const setStylesLocal = useCallback(
+    (index: number, next: Record<string, CellStyle>) => {
+      setStyles((prev) => new Map(prev).set(index, next));
+    },
+    [],
+  );
+
   /**
    * 캐시를 비우고 다시 받아 온다. 행 인덱스가 밀리거나(행 추가·삭제) 열 구성이 바뀌어
    * 캐시된 위치 배열이 더 이상 유효하지 않을 때(열 삭제) 쓴다.
@@ -88,6 +107,7 @@ export function useDatasetRows(datasetId: number) {
     inflight.current.clear();
     setCache(new Map());
     setFormulas(new Map());
+    setStyles(new Map());
     queryClient.removeQueries({ queryKey: ["datasets", datasetId, "rows"] });
     setGeneration((g) => g + 1);
   }, [datasetId, queryClient]);
@@ -97,13 +117,19 @@ export function useDatasetRows(datasetId: number) {
     (index: number) => formulas.get(index) ?? {},
     [formulas],
   );
+  const getStyles = useCallback(
+    (index: number) => styles.get(index) ?? {},
+    [styles],
+  );
 
   return {
     getRow,
     getFormulas,
+    getStyles,
     ensureRange,
     setRowLocal,
     setFormulasLocal,
+    setStylesLocal,
     reset,
   };
 }

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -87,6 +87,14 @@
   --warning-foreground: oklch(0.22 0.03 75);
   --info: oklch(0.58 0.15 250);
   --info-foreground: oklch(0.99 0 0);
+  /* 셀 배경 팔레트(라이트). 옅은 틴트라 본문 글자(--foreground)가 대비를 유지한다.
+     저장값은 토큰명(red/…)이고 렌더는 var(--cell-bg-<토큰>)으로 해결한다 — 다크는 .dark가 덮는다. */
+  --cell-bg-red: oklch(0.94 0.04 25);
+  --cell-bg-orange: oklch(0.95 0.045 60);
+  --cell-bg-yellow: oklch(0.96 0.05 95);
+  --cell-bg-green: oklch(0.94 0.04 150);
+  --cell-bg-blue: oklch(0.94 0.035 240);
+  --cell-bg-purple: oklch(0.94 0.04 300);
   --border: oklch(0.925 0 0);
   --input: oklch(0.925 0 0);
   /* 포커스 링·브랜드는 primary를 단일 진실원천으로 별칭(같은 의미=같은 값). */
@@ -121,6 +129,13 @@
   --warning-foreground: oklch(0.2 0.03 75);
   --info: oklch(0.66 0.15 250);
   --info-foreground: oklch(0.13 0 0);
+  /* 셀 배경 팔레트(다크). 낮은 명도라 밝은 본문 글자가 대비를 유지한다. */
+  --cell-bg-red: oklch(0.32 0.06 25);
+  --cell-bg-orange: oklch(0.33 0.055 60);
+  --cell-bg-yellow: oklch(0.34 0.05 95);
+  --cell-bg-green: oklch(0.32 0.05 150);
+  --cell-bg-blue: oklch(0.33 0.06 240);
+  --cell-bg-purple: oklch(0.32 0.06 300);
   --border: oklch(0.22 0 0);
   --input: oklch(0.22 0 0);
 }


### PR DESCRIPTION
## 이슈
part of #828
## 작업 내용
- 셀 배경색 지정 기능. `#760` 백로그 "셀 색깔 지정"에서 승격한 첫 슬라이스
- **저장**: `dataset_cell_style` sparse 테이블. 값은 `dataset_row.cells`에 그대로 두고 서식만 담는다 → `#797`의 값 스키마·투영·API·수식 읽기 경로가 **그대로 산다**. `#799`의 수식(`dataset_formula`)이 쓴 패턴 그대로라 새로 증명할 게 없다
- **API**: `PUT /datasets/{id}/rows/{rowIndex}/cells/{colKey}/style` — 서식을 통째로 교체, 빈 요청(`{}`)이면 그 셀 서식을 지운다. `RowView`에 `styles`(열key→`{bg,align}`) sparse 맵을 `formulas`처럼 얹었다
- **색**: 팔레트 토큰명(`red`/`orange`/`yellow`/`green`/`blue`/`purple`) 저장, 렌더는 `var(--cell-bg-<토큰>)`. **라이트/다크 토큰을 따로 둬 다크모드 대비가 자동 해결**된다(자유 hex라면 어두운 테마에서 글자를 삼키는 문제를 따로 보정해야 함)
- **FE**: 셀 호버 시 나타나는 팔레트 버튼 → 6색 스와치 + 지우기

### 왜 배경색만 (정렬은 후속)
`#828`은 배경색 + 정렬 두 축이고 둘 다 같은 sparse 테이블을 쓴다. 한 PR에 다 넣으면 15+ 파일이라, 지금까지의 dataset 작업(#796·#798·#800…) 흐름에 맞춰 쪼갰다. **테이블·엔티티에 `align` 컬럼을 처음부터 함께 뒀으므로**(D1대로) 정렬 PR은 로직만 얹으면 되고 마이그레이션 추가가 없다.

### 삭제 시 정리 (검증한 함정)
- **열 삭제**: `col_key`는 FK가 아니라 문자열이라 cascade가 안 걸린다. 수식이 `formulaService.invalidateColumn`으로 즉시 정리하는 것과 똑같이 `styleService.invalidateColumn`으로 즉시 지운다
- **행·데이터셋 삭제**: `row_id`·`dataset_id`에 FK `deleteCascade`를 걸어 함께 사라진다

### 검증
- **BE 63건 통과**(셀 서식 9건 신규): 저장·조회(styles sparse) / 빈 요청으로 삭제 / 통째 교체(부분 갱신 아님) / 잘못된 색·정렬 거부 / 없는 열 404 / 남의 데이터셋 404 / 값·수식 보존 / **열 삭제 시 즉시 정리** / **행 삭제 시 cascade**
- **FE 345건 통과**(배경색 3건): 팔레트 선택 → PUT + 배경 렌더 / 서버 styles로 렌더 / 지우기
- 각 테스트는 해당 코드를 되돌리면 실패함을 확인(회귀 가드 성립)
- **실제 브라우저 확인**(Playwright): 팔레트에서 green 선택 → 셀 배경이 `oklch(0.94 0.04 150)`(= `--cell-bg-green`)로 칠해짐
- `./gradlew check`(checkstyle) · `npm run lint` · `format:check` · `build` 통과

### 다음
- **정렬**(열 단위 기본 + 셀 override, D2) — 별도 PR
- 머지되면 위키(Data-Grid-Block)에 `dataset_cell_style` 스키마와 API를 추가하겠다