### PR TITLE
feat : 데이터 그리드 셀·열 정렬

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -13,6 +13,7 @@ import ds.project.orino.planner.dataset.dto.ResizeColumnRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
 import ds.project.orino.planner.dataset.dto.SetCellStyleRequest;
+import ds.project.orino.planner.dataset.dto.SetColumnAlignRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
 import ds.project.orino.planner.dataset.service.DatasetService;
 import jakarta.validation.Valid;
@@ -123,6 +124,25 @@ public class DatasetController {
             @PathVariable Long id,
             @PathVariable String key) {
         return ApiResponse.success(datasetService.resetColumnWidth(memberId, id, key));
+    }
+
+    /** 열 기본 정렬 변경. 열 단위 표시 속성이라 행은 건드리지 않는다(셀 정렬이 있으면 그쪽이 덮는다). */
+    @PatchMapping("/{id}/columns/{key}/align")
+    public ApiResponse<DatasetResponse> setColumnAlign(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable String key,
+            @Valid @RequestBody SetColumnAlignRequest request) {
+        return ApiResponse.success(datasetService.setColumnAlign(memberId, id, key, request));
+    }
+
+    /** 열 기본 정렬 초기화 — 기본 정렬(left)로 되돌린다. */
+    @DeleteMapping("/{id}/columns/{key}/align")
+    public ApiResponse<DatasetResponse> resetColumnAlign(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable String key) {
+        return ApiResponse.success(datasetService.resetColumnAlign(memberId, id, key));
     }
 
     /** 열 이름 변경. key는 불변이며 label만 바꾼다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetColumn.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetColumn.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
 
 /**
  * 데이터셋 열 메타. key는 안정 식별자, label은 표시명.
@@ -11,6 +12,10 @@ import jakarta.validation.constraints.Min;
  * <p>{@code width}는 표시 너비(px)이며 <b>nullable</b>이다. null이면 클라이언트가 기본 폭으로
  * 그린다(기존 동작). 덕분에 width가 없는 기존 columns_json도 그대로 읽히고 마이그레이션이 필요 없다.
  * 직렬화 시 null은 빼서 columns_json에 빈 항목이 쌓이지 않게 한다.
+ *
+ * <p>{@code align}은 열 <b>기본</b> 정렬(left/center/right)이며 마찬가지로 nullable이다. null이면
+ * 클라이언트가 기본 정렬(left)로 그린다. 셀 단위 정렬({@link CellStyle#align})이 있으면 그쪽이
+ * 이 기본을 덮는다(#828 D2). width와 같은 nullable 확장이라 마이그레이션이 필요 없다.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record DatasetColumn(
@@ -18,25 +23,32 @@ public record DatasetColumn(
         String label,
         @Min(value = MIN_WIDTH, message = "width는 " + MIN_WIDTH + " 이상이어야 합니다.")
         @Max(value = MAX_WIDTH, message = "width는 " + MAX_WIDTH + " 이하여야 합니다.")
-        Integer width
+        Integer width,
+        @Pattern(regexp = "left|center|right", message = "허용되지 않은 정렬입니다.")
+        String align
 ) {
     /** 열 너비 하한(px). 이보다 좁으면 값이 사실상 안 보인다. */
     public static final int MIN_WIDTH = 60;
     /** 열 너비 상한(px). 한 열이 표 전체를 밀어내는 것을 막는다. */
     public static final int MAX_WIDTH = 800;
 
-    /** 너비 없이 만든다(기본 폭). */
+    /** 너비·정렬 없이 만든다(기본 폭·기본 정렬). */
     public DatasetColumn(String key, String label) {
-        this(key, label, null);
+        this(key, label, null, null);
     }
 
-    /** key/width는 두고 label만 바꾼 새 열 메타. */
+    /** key/width/align은 두고 label만 바꾼 새 열 메타. */
     public DatasetColumn withLabel(String label) {
-        return new DatasetColumn(key, label, width);
+        return new DatasetColumn(key, label, width, align);
     }
 
-    /** key/label은 두고 width만 바꾼 새 열 메타. */
+    /** key/label/align은 두고 width만 바꾼 새 열 메타. */
     public DatasetColumn withWidth(Integer width) {
-        return new DatasetColumn(key, label, width);
+        return new DatasetColumn(key, label, width, align);
+    }
+
+    /** key/label/width는 두고 align만 바꾼 새 열 메타. */
+    public DatasetColumn withAlign(String align) {
+        return new DatasetColumn(key, label, width, align);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetColumnAlignRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetColumnAlignRequest.java
@@ -1,0 +1,17 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * 열 기본 정렬 변경 요청. left/center/right만 받는다.
+ *
+ * <p>기본 정렬(left)로 되돌리는 것은 <b>정렬 삭제</b>(DELETE)로 표현한다. 여기서 null을 허용하면
+ * "값을 안 보냈다"와 "기본으로 되돌려라"를 구분할 수 없다({@link ResizeColumnRequest 너비}와 같은 규칙).
+ */
+public record SetColumnAlignRequest(
+        @NotNull(message = "align은 필수입니다.")
+        @Pattern(regexp = "left|center|right", message = "허용되지 않은 정렬입니다.")
+        String align
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -20,6 +20,7 @@ import ds.project.orino.planner.dataset.dto.ResizeColumnRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
 import ds.project.orino.planner.dataset.dto.SetCellStyleRequest;
+import ds.project.orino.planner.dataset.dto.SetColumnAlignRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -300,6 +301,39 @@ public class DatasetService {
 
         List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
         updated.set(at, columns.get(at).withWidth(width));
+        dataset.updateColumns(serialize(updated));
+        return DatasetResponse.of(dataset, updated);
+    }
+
+    /**
+     * 열 기본 정렬 변경. columns_json의 해당 열만 고치고 행은 건드리지 않아 O(1)이다.
+     * 정렬은 열 단위 표시 속성이라 셀 값·수식과 무관하다(셀 단위 정렬이 있으면 그쪽이 덮는다, #828 D2).
+     */
+    @Transactional
+    public DatasetResponse setColumnAlign(Long memberId, Long datasetId, String key,
+                                          SetColumnAlignRequest request) {
+        return updateAlign(memberId, datasetId, key, request.align());
+    }
+
+    /**
+     * 열 기본 정렬을 지워 기본 정렬(left)로 되돌린다. 정렬 미설정(null)이 곧 기본이므로
+     * "되돌리기"는 별도 상태가 아니라 값의 부재로 표현된다(너비와 같은 규칙).
+     */
+    @Transactional
+    public DatasetResponse resetColumnAlign(Long memberId, Long datasetId, String key) {
+        return updateAlign(memberId, datasetId, key, null);
+    }
+
+    private DatasetResponse updateAlign(Long memberId, Long datasetId, String key, String align) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        int at = indexOfColumn(columns, key);
+        if (at < 0) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+
+        List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
+        updated.set(at, columns.get(at).withAlign(align));
         dataset.updateColumns(serialize(updated));
         return DatasetResponse.of(dataset, updated);
     }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -1138,6 +1138,174 @@ class DatasetControllerTest extends ApiTestSupport {
                 .andExpect(status().isNotFound());
     }
 
+    // ---------- 열 기본 정렬(align) ----------
+
+    /** 열 기본 정렬을 바꾸고 응답 본문을 돌려준다. */
+    private String setColumnAlign(long id, String key, String align) throws Exception {
+        return mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/align", id, key)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"align\":\"" + align + "\"}"))
+                .andReturn().getResponse().getContentAsString();
+    }
+
+    @Test
+    @DisplayName("PATCH columns/{key}/align - 정렬을 저장하고 조회 시 유지된다")
+    void set_column_align() throws Exception {
+        long id = createDataset();
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/align", id, "c1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"align\":\"right\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[1].align").value("right"));
+
+        // 지정하지 않은 열은 align이 없다(기본 정렬 left).
+        mockMvc.perform(get("/api/datasets/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[1].align").value("right"))
+                .andExpect(jsonPath("$.data.columns[0].align").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("PATCH columns/{key}/align - 허용되지 않은 정렬은 거부한다")
+    void set_column_align_invalid() throws Exception {
+        long id = createDataset();
+
+        for (String bad : new String[]{"top", "justify", "LEFT", ""}) {
+            mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/align", id, "c0")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"align\":\"" + bad + "\"}"))
+                    .andExpect(status().isBadRequest());
+        }
+        // 허용값은 통과해야 한다.
+        for (String ok : new String[]{"left", "center", "right"}) {
+            mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/align", id, "c0")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"align\":\"" + ok + "\"}"))
+                    .andExpect(status().isOk());
+        }
+    }
+
+    @Test
+    @DisplayName("PATCH columns/{key}/align - align 누락은 거부한다")
+    void set_column_align_requires_align() throws Exception {
+        long id = createDataset();
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/align", id, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PATCH columns/{key}/align - 없는 열은 404")
+    void set_column_align_not_found() throws Exception {
+        long id = createDataset();
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/align", id, "c99")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"align\":\"center\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("DELETE columns/{key}/align - 정렬을 지우면 기본 정렬로 돌아간다")
+    void reset_column_align() throws Exception {
+        long id = createDataset();
+        setColumnAlign(id, "c0", "center");
+
+        mockMvc.perform(delete("/api/datasets/{id}/columns/{key}/align", id, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].align").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("이름·너비를 바꿔도 열 정렬은 유지된다")
+    void rename_and_resize_preserve_align() throws Exception {
+        long id = createDataset();
+        setColumnAlign(id, "c0", "center");
+
+        // rename은 align 보존
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}", id, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"바뀐이름\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].align").value("center"));
+
+        // width 변경도 align 보존
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/width", id, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"width\":300}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].align").value("center"))
+                .andExpect(jsonPath("$.data.columns[0].width").value(300));
+    }
+
+    @Test
+    @DisplayName("순서를 바꿔도 정렬은 열을 따라간다")
+    void reorder_carries_align() throws Exception {
+        long id = createDataset();
+        setColumnAlign(id, "c0", "right");
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/order", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keys\":[\"c1\",\"c0\"]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].key").value("c1"))
+                .andExpect(jsonPath("$.data.columns[0].align").doesNotExist())
+                .andExpect(jsonPath("$.data.columns[1].key").value("c0"))
+                .andExpect(jsonPath("$.data.columns[1].align").value("right"));
+    }
+
+    @Test
+    @DisplayName("생성 - 허용되지 않은 align을 넣으면 거부한다 (검증을 생성으로 우회 못 함)")
+    void create_rejects_invalid_align() throws Exception {
+        mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"과목","align":"top"}]}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("생성 - align을 함께 주면 저장된다")
+    void create_with_align() throws Exception {
+        mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"과목","align":"center"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.columns[0].align").value("center"));
+    }
+
+    @Test
+    @DisplayName("남의 데이터셋 열 정렬은 못 바꾼다")
+    void set_column_align_of_other_member() throws Exception {
+        long id = createDataset();
+        String otherToken = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/align", id, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, otherToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"align\":\"center\"}"))
+                .andExpect(status().isNotFound());
+    }
+
     // ---------- 셀 서식(배경색·정렬) ----------
 
     /** 셀 서식을 지정하고 응답을 돌려준다. */

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -1048,4 +1048,144 @@ describe("DatasetGrid", () => {
 
     await waitFor(() => expect(sent).toEqual({ bg: null, align: null }));
   });
+
+  it("열 정렬 버튼을 누르면 PATCH하고 셀 정렬이 바뀐다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let sent: unknown = null;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/columns/c1/align`,
+        async ({ request }) => {
+          sent = await request.json();
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              id: 1,
+              columns: [
+                { key: "c0", label: "과목" },
+                { key: "c1", label: "점수", align: "center" },
+              ],
+              rowCount: 1,
+            },
+          });
+        },
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("92");
+
+    // 기본은 왼쪽 → 클릭하면 가운데.
+    await user.click(screen.getByLabelText("점수 열 정렬 (현재 왼쪽)"));
+
+    await waitFor(() => expect(sent).toEqual({ align: "center" }));
+    // 열 기본 정렬이 그 열 셀에 반영된다.
+    await waitFor(() =>
+      expect(screen.getByText("92").className).toContain("text-center"),
+    );
+    // 다른 열은 그대로 기본(left).
+    expect(screen.getByText("네트워크").className).toContain("text-left");
+  });
+
+  it("셀 정렬(override)이 열 기본 정렬을 덮는다", async () => {
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "점수", align: "right" },
+            ],
+            rowCount: 2,
+          },
+        }),
+      ),
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              {
+                id: 100,
+                rowIndex: 0,
+                cells: ["네트워크", "92"],
+                formulas: {},
+                // 셀 override — 열 기본(right)을 덮는다.
+                styles: { c1: { align: "left" } },
+              },
+              {
+                id: 101,
+                rowIndex: 1,
+                cells: ["보안", "80"],
+                formulas: {},
+                styles: {},
+              },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("80");
+
+    // override 있는 셀은 left, 없는 셀은 열 기본 right.
+    expect(screen.getByText("92").className).toContain("text-left");
+    expect(screen.getByText("80").className).toContain("text-right");
+    // 정렬을 안 준 열은 기본 left.
+    expect(screen.getByText("네트워크").className).toContain("text-left");
+  });
+
+  it("셀 팔레트에서 정렬을 고르면 배경색을 보존해 PUT한다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let sent: unknown = null;
+    server.use(
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              {
+                id: 100,
+                rowIndex: 0,
+                cells: ["네트워크", "92"],
+                formulas: {},
+                styles: { c0: { bg: "green" } },
+              },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+      http.put(
+        `${API_BASE}/datasets/1/rows/0/cells/c0/style`,
+        async ({ request }) => {
+          sent = await request.json();
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              id: 100,
+              rowIndex: 0,
+              cells: ["네트워크", "92"],
+              formulas: {},
+              styles: { c0: { bg: "green", align: "center" } },
+            },
+          });
+        },
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+
+    await user.click(screen.getByLabelText("1행 1열 배경색"));
+    await user.click(screen.getByLabelText("정렬 가운데"));
+
+    // 배경색은 그대로 두고 정렬만 얹어 통째로 보낸다.
+    await waitFor(() => expect(sent).toEqual({ bg: "green", align: "center" }));
+  });
 });

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -6,7 +6,16 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { FunctionSquare, Palette, Plus, Trash2, X } from "lucide-react";
+import {
+  AlignCenter,
+  AlignLeft,
+  AlignRight,
+  FunctionSquare,
+  Palette,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -19,6 +28,7 @@ import { toast } from "@/shared/lib/toast";
 import {
   addDatasetColumn,
   CELL_BG_TOKENS,
+  type CellAlign,
   type CellBgToken,
   type CellStyle,
   type DatasetMeta,
@@ -32,6 +42,7 @@ import {
   resetDatasetColumnWidth,
   resizeDatasetColumn,
   setCellStyle,
+  setDatasetColumnAlign,
   updateDatasetRow,
 } from "./api/datasets";
 import { useDatasetMeta } from "./hooks/useDatasetMeta";
@@ -164,6 +175,14 @@ export function DatasetGrid({ datasetId }: Props) {
   });
   const resetColWidthMut = useMutation({
     mutationFn: (key: string) => resetDatasetColumnWidth(datasetId, key),
+    onSuccess: (next: DatasetMeta) =>
+      queryClient.setQueryData(datasetKeys.meta(datasetId), next),
+    onError: () => void invalidateMeta(),
+  });
+  const setColAlignMut = useMutation({
+    mutationFn: (v: { key: string; align: CellAlign }) =>
+      setDatasetColumnAlign(datasetId, v.key, v.align),
+    // 정렬은 열 단위 속성이라 행 캐시를 버릴 이유가 없다(너비와 같다 — 값이 안 밀린다).
     onSuccess: (next: DatasetMeta) =>
       queryClient.setQueryData(datasetKeys.meta(datasetId), next),
     onError: () => void invalidateMeta(),
@@ -309,6 +328,28 @@ export function DatasetGrid({ datasetId }: Props) {
     setPalette(null);
   };
 
+  /**
+   * 셀 정렬을 바꾼다(열 기본을 덮는 셀 단위 override). 배경색은 보존한다.
+   * null이면 셀 정렬을 지워 열 기본 정렬을 따르게 한다.
+   */
+  const applyAlign = (row: number, col: number, align: CellAlign | null) => {
+    const colKey = meta.columns[col].key;
+    const current = getStyles(row)[colKey];
+    styleMut.mutate({
+      row,
+      colKey,
+      style: { bg: current?.bg, align: align ?? undefined },
+    });
+    setPalette(null);
+  };
+
+  /** 열 기본 정렬을 다음 값으로 돌린다(좌→가운데→우→좌). 기본(미설정)은 좌로 본다. */
+  const cycleColumnAlign = (key: string, current: CellAlign | undefined) => {
+    const next: CellAlign =
+      current === "center" ? "right" : current === "right" ? "left" : "center";
+    setColAlignMut.mutate({ key, align: next });
+  };
+
   const addRow = () =>
     insertMut.mutate(Array.from({ length: colCount }, () => ""));
 
@@ -412,6 +453,30 @@ export function DatasetGrid({ datasetId }: Props) {
                       header.getContext(),
                     )}
                   </div>
+                  {/* 열 기본 정렬 — 클릭하면 좌→가운데→우로 순환한다. 아이콘이 현재 정렬을 보여준다. */}
+                  {(() => {
+                    const align =
+                      meta.columns.find((c) => c.key === header.id)?.align ??
+                      "left";
+                    const Icon = ALIGN_ICONS[align];
+                    return (
+                      <button
+                        type="button"
+                        aria-label={`${columnLabel(header.id)} 열 정렬 (현재 ${ALIGN_LABELS[align]})`}
+                        title="클릭해 열 정렬 변경 (좌·가운데·우)"
+                        onClick={() =>
+                          cycleColumnAlign(
+                            header.id,
+                            meta.columns.find((c) => c.key === header.id)
+                              ?.align,
+                          )
+                        }
+                        className="text-muted-foreground hover:text-foreground mr-1 shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+                      >
+                        <Icon className="size-3.5" />
+                      </button>
+                    );
+                  })()}
                   {/* 마지막 한 열은 서버가 거부하므로 버튼도 내보내지 않는다. */}
                   {colCount > 1 && (
                     <button
@@ -483,6 +548,8 @@ export function DatasetGrid({ datasetId }: Props) {
                   const colKey = meta.columns[c].key;
                   const formula = getFormulas(vi.index)[colKey];
                   const style = getStyles(vi.index)[colKey];
+                  // 셀 정렬(override) > 열 기본 정렬 > 기본(left) (#828 D2).
+                  const align = style?.align ?? meta.columns[c].align ?? "left";
                   const paletteOpen =
                     palette?.row === vi.index && palette.col === c;
                   return (
@@ -515,32 +582,68 @@ export function DatasetGrid({ datasetId }: Props) {
                       {paletteOpen && (
                         <div
                           role="menu"
-                          className="border-border bg-popover absolute top-5 right-0 z-20 flex gap-1 rounded-md border p-1 shadow-md"
+                          className="border-border bg-popover absolute top-5 right-0 z-20 flex flex-col gap-1 rounded-md border p-1 shadow-md"
                           onClick={(e) => e.stopPropagation()}
                         >
-                          {CELL_BG_TOKENS.map((token) => (
+                          {/* 배경색 — 6색 스와치 + 지우기 */}
+                          <div className="flex gap-1">
+                            {CELL_BG_TOKENS.map((token) => (
+                              <button
+                                key={token}
+                                type="button"
+                                aria-label={`배경색 ${token}`}
+                                onClick={() => applyBg(vi.index, c, token)}
+                                className={cn(
+                                  "size-4 rounded-full border",
+                                  style?.bg === token
+                                    ? "border-foreground"
+                                    : "border-border",
+                                )}
+                                style={{
+                                  background: `var(--cell-bg-${token})`,
+                                }}
+                              />
+                            ))}
                             <button
-                              key={token}
                               type="button"
-                              aria-label={`배경색 ${token}`}
-                              onClick={() => applyBg(vi.index, c, token)}
-                              className={cn(
-                                "size-4 rounded-full border",
-                                style?.bg === token
-                                  ? "border-foreground"
-                                  : "border-border",
-                              )}
-                              style={{ background: `var(--cell-bg-${token})` }}
-                            />
-                          ))}
-                          <button
-                            type="button"
-                            aria-label="배경색 지우기"
-                            onClick={() => applyBg(vi.index, c, null)}
-                            className="text-muted-foreground hover:text-foreground border-border flex size-4 items-center justify-center rounded-full border"
-                          >
-                            <X className="size-2.5" />
-                          </button>
+                              aria-label="배경색 지우기"
+                              onClick={() => applyBg(vi.index, c, null)}
+                              className="text-muted-foreground hover:text-foreground border-border flex size-4 items-center justify-center rounded-full border"
+                            >
+                              <X className="size-2.5" />
+                            </button>
+                          </div>
+                          {/* 정렬 — 셀 단위 override(열 기본을 덮는다) + 열 기본 따르기 */}
+                          <div className="flex gap-1">
+                            {ALIGN_ORDER.map((value) => {
+                              const Icon = ALIGN_ICONS[value];
+                              return (
+                                <button
+                                  key={value}
+                                  type="button"
+                                  aria-label={`정렬 ${ALIGN_LABELS[value]}`}
+                                  onClick={() => applyAlign(vi.index, c, value)}
+                                  className={cn(
+                                    "hover:bg-accent flex size-4 items-center justify-center rounded border",
+                                    style?.align === value
+                                      ? "border-foreground text-foreground"
+                                      : "border-border text-muted-foreground",
+                                  )}
+                                >
+                                  <Icon className="size-2.5" />
+                                </button>
+                              );
+                            })}
+                            <button
+                              type="button"
+                              aria-label="셀 정렬 지우기 (열 기본 따르기)"
+                              title="열 기본 정렬을 따른다"
+                              onClick={() => applyAlign(vi.index, c, null)}
+                              className="text-muted-foreground hover:text-foreground border-border flex size-4 items-center justify-center rounded border"
+                            >
+                              <X className="size-2.5" />
+                            </button>
+                          </div>
                         </div>
                       )}
                       {isEditing ? (
@@ -554,12 +657,16 @@ export function DatasetGrid({ datasetId }: Props) {
                             if (e.key === "Escape") setEditing(null);
                           }}
                           aria-label={`셀 ${vi.index + 1}행 ${c + 1}열`}
-                          className="focus-visible:ring-ring h-full w-full bg-transparent px-2 py-1 outline-none focus-visible:ring-1"
+                          className={cn(
+                            "focus-visible:ring-ring h-full w-full bg-transparent px-2 py-1 outline-none focus-visible:ring-1",
+                            ALIGN_CLASS[align],
+                          )}
                         />
                       ) : (
                         <div
                           className={cn(
                             "h-full cursor-text truncate px-2 py-1.5",
+                            ALIGN_CLASS[align],
                             cells === undefined && "text-muted-foreground/40",
                             isCellError(cells?.[c]) && "text-destructive",
                             formula !== undefined &&
@@ -637,6 +744,26 @@ export function DatasetGrid({ datasetId }: Props) {
 }
 
 const EMPTY: string[][] = [];
+
+/** 정렬 값 → 아이콘. 열/셀 정렬 버튼과 렌더에 공용. */
+const ALIGN_ICONS = {
+  left: AlignLeft,
+  center: AlignCenter,
+  right: AlignRight,
+} as const;
+const ALIGN_LABELS: Record<CellAlign, string> = {
+  left: "왼쪽",
+  center: "가운데",
+  right: "오른쪽",
+};
+/** 정렬 값 → Tailwind text-align 클래스. 인라인 style 대신 클래스로 둔다. */
+const ALIGN_CLASS: Record<CellAlign, string> = {
+  left: "text-left",
+  center: "text-center",
+  right: "text-right",
+};
+/** 정렬 버튼 순서. */
+const ALIGN_ORDER: CellAlign[] = ["left", "center", "right"];
 
 /** 서버가 알려주는 실패 사유(수식 문법 오류·순환 참조 등). 없으면 조용히 넘어간다. */
 function serverMessage(e: unknown): string | null {

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -5,7 +5,12 @@ export interface DatasetColumn {
   label: string;
   /** 표시 너비(px). 없으면 기본 폭(균등 분배). */
   width?: number;
+  /** 열 기본 정렬. 없으면 기본 정렬(left). 셀 정렬(CellStyle.align)이 있으면 그쪽이 덮는다. */
+  align?: CellAlign;
 }
+
+/** 셀·열 정렬 값. 서버의 ALLOWED_ALIGN과 같아야 한다. */
+export type CellAlign = "left" | "center" | "right";
 
 /** 열 너비 하한(px). 서버의 DatasetColumn.MIN_WIDTH와 같아야 한다. */
 export const MIN_COLUMN_WIDTH = 60;
@@ -26,7 +31,7 @@ export type CellBgToken = (typeof CELL_BG_TOKENS)[number];
 /** 셀 서식(배경색·정렬). 지정 안 한 축은 없다(sparse). */
 export interface CellStyle {
   bg?: CellBgToken;
-  align?: "left" | "center" | "right";
+  align?: CellAlign;
 }
 
 export interface DatasetMeta {
@@ -145,6 +150,19 @@ export async function resetDatasetColumnWidth(
 ): Promise<DatasetMeta> {
   const { data } = await client.delete<ApiEnvelope<DatasetMeta>>(
     `/datasets/${datasetId}/columns/${key}/width`,
+  );
+  return data.data;
+}
+
+/** 열 기본 정렬 변경. 열 단위 표시 속성이라 행은 안 건드린다(셀 정렬이 있으면 그쪽이 덮는다). */
+export async function setDatasetColumnAlign(
+  datasetId: number,
+  key: string,
+  align: CellAlign,
+): Promise<DatasetMeta> {
+  const { data } = await client.patch<ApiEnvelope<DatasetMeta>>(
+    `/datasets/${datasetId}/columns/${key}/align`,
+    { align },
   );
   return data.data;
 }


### PR DESCRIPTION
## 이슈
part of #828

## 작업 내용
`#828`(셀 서식)의 **정렬 축**. 배경색을 끝낸 `#831`이 후속으로 명시적으로 남긴 슬라이스이며, `#831` PR에서 확정한 **열 단위 기본 + 셀 override (D2)** 방식으로 구현했다.

### 저장 — 새 마이그레이션 없음
- **열 기본 정렬**: `columns_json`의 `align`(nullable). 열 너비(`#830`)와 **똑같은 열 속성 패턴** — 없으면 기본 정렬(left), 값 있는 것만 직렬화돼 기존 `columns_json`이 그대로 산다.
- **셀 단위 정렬**: `dataset_cell_style.align`. `#831`이 테이블·엔티티·저장 파이프라인을 **처음부터 `align` 컬럼과 함께** 만들어 둬(D1대로), 이번엔 마이그레이션 없이 FE override UI만 얹으면 됐다.

### API
| 메서드·경로 | 요청 | 용도 |
|---|---|---|
| `PATCH /datasets/{id}/columns/{key}/align` | `{ align }` | 열 기본 정렬 (left/center/right, 그 외 400) |
| `DELETE /datasets/{id}/columns/{key}/align` | — | 열 정렬 초기화(기본 left) |
| `PUT .../cells/{colKey}/style` | `{ bg?, align? }` | 셀 서식(`#831` 기존 계약, align override) |

너비 API(`resize`/`reset`)를 그대로 미러링했다.

### 렌더 우선순위
**셀 override > 열 기본 > 기본(left)**. Tailwind `text-left/center/right` 클래스로 적용(인라인 style 대신 — 배경색 셀렉터와 충돌 안 나게).

### FE
- **열 정렬**: 헤더 호버 버튼 → 좌→가운데→우 순환. 아이콘이 현재 정렬을 보여준다.
- **셀 정렬**: 기존 셀 팔레트 팝오버에 정렬 버튼 3개 + "열 기본 따르기"(override 지우기) 추가. 배경색은 보존한 채 통째로 교체.

### 검증
- **BE 13건**: 열 정렬 저장·조회 / 초기화(DELETE) / 잘못된 값·누락 거부 / 없는 열 404 / rename·resize·reorder가 정렬 보존 / 생성 시 검증 우회 방지 / 남의 데이터셋 404. 셀 단위 정렬은 `#831`의 셀 서식 테스트가 이미 커버.
- **FE 3건**: 열 정렬 버튼 → PATCH + 셀에 `text-center` 반영 / 셀 override가 열 기본을 이김(우선순위) / 팔레트 정렬 선택이 배경색을 보존해 PUT.
- 각 테스트는 해당 코드를 되돌리면 실패함을 확인(회귀 가드).
- `./gradlew check`(checkstyle) · BE 전체 테스트(TestContainers) · `npm run lint` · `format:check` · `build` · FE 전체 348건 통과.
- ⚠️ **브라우저 실물 확인은 이번엔 생략** — 로컬 `bootRun` 스택 기동 비용(로컬 프로필 hostname 트랩)이 커서, 실제 MySQL(TestContainers)을 통한 BE 통합 테스트와 RTL 렌더 테스트로 대체했다. 렌더 경로는 `#831`이 브라우저로 검증한 서식 파이프라인 위 Tailwind 정렬 클래스라 리스크가 낮다.

### 문서
설계 문서([Data-Grid-Block](https://github.com/wcorn/orino/wiki/Data-Grid-Block)) 갱신 — `dataset_cell_style` 스키마, 열 너비·정렬·셀 서식 API, "서식은 범위 밖" 서술 폐기(`#830`·`#831` 밀린 문서화도 함께 반영).