### PR TITLE
feat : 데이터 그리드 셀 가로 병합(colspan)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -12,6 +12,7 @@ import ds.project.orino.planner.dataset.dto.ReorderColumnsRequest;
 import ds.project.orino.planner.dataset.dto.ResizeColumnRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
+import ds.project.orino.planner.dataset.dto.SetCellMergeRequest;
 import ds.project.orino.planner.dataset.dto.SetCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.SetColumnAlignRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
@@ -213,5 +214,31 @@ public class DatasetController {
             @Valid @RequestBody SetCellStyleRequest request) {
         return ApiResponse.success(
                 datasetService.setCellStyle(memberId, id, rowIndex, colKey, request));
+    }
+
+    /**
+     * 셀 병합. 앵커(rowIndex·colKey) 기준으로 {@code rowSpan × colSpan} 영역을 병합한다.
+     * 표시 오버레이라 cells를 건드리지 않는다(덮인 셀 값 보존). 슬라이스 1은 가로 병합만.
+     */
+    @PutMapping("/{id}/rows/{rowIndex}/cells/{colKey}/merge")
+    public ApiResponse<RowView> setCellMerge(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable int rowIndex,
+            @PathVariable String colKey,
+            @Valid @RequestBody SetCellMergeRequest request) {
+        return ApiResponse.success(
+                datasetService.setCellMerge(memberId, id, rowIndex, colKey, request));
+    }
+
+    /** 병합 해제. 덮여 있던 셀 값은 그 자리에 되살아난다. */
+    @DeleteMapping("/{id}/rows/{rowIndex}/cells/{colKey}/merge")
+    public ApiResponse<RowView> unmergeCell(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable int rowIndex,
+            @PathVariable String colKey) {
+        return ApiResponse.success(
+                datasetService.unmergeCell(memberId, id, rowIndex, colKey));
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/MergeSpec.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/MergeSpec.java
@@ -1,0 +1,14 @@
+package ds.project.orino.planner.dataset.dto;
+
+/**
+ * 한 앵커 셀의 병합 범위. {@code RowView.merges}에 앵커 열 key로 담기며, 병합 있는 셀만 들어간다
+ * ({@code formulas}·{@code styles}와 같은 sparse 맵).
+ *
+ * <p>{@code rowSpan}·{@code colSpan}은 각 &ge;1이고 {@code (1,1)}은 병합이 아니라 담기지 않는다.
+ * 슬라이스 1(가로 병합)에선 {@code rowSpan}이 항상 1이다.
+ */
+public record MergeSpec(
+        int rowSpan,
+        int colSpan
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowView.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowView.java
@@ -19,12 +19,17 @@ import java.util.Map;
  *
  * <p>{@code styles}엔 서식(배경색·정렬)이 있는 셀만 열 key로 담긴다({@code formulas}와 같은
  * sparse 맵). 서식 없는 셀은 아예 없다.
+ *
+ * <p>{@code merges}엔 병합된 <b>앵커</b> 셀만 열 key로 담긴다({@code styles}와 같은 sparse 맵).
+ * 병합은 표시 오버레이라 {@code cells}는 직사각형 그대로다 — 클라이언트가 앵커를 span으로 넓게
+ * 그리고 덮인 칸을 렌더에서 건너뛴다.
  */
 public record RowView(
         Long id,
         int rowIndex,
         List<String> cells,
         Map<String, String> formulas,
-        Map<String, CellStyle> styles
+        Map<String, CellStyle> styles,
+        Map<String, MergeSpec> merges
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetCellMergeRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetCellMergeRequest.java
@@ -1,0 +1,26 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 셀 병합 요청. 앵커(경로의 {@code rowIndex}·{@code colKey}) 기준으로 {@code rowSpan × colSpan}
+ * 영역을 병합한다. 병합 해제는 별도 API(DELETE)다.
+ *
+ * <p>슬라이스 1은 가로 병합만이라 {@code rowSpan}은 1이어야 한다(그 외는 서비스가 400).
+ * 상한(경계 초과·겹침)은 열 구성을 알아야 하므로 서비스에서 검증한다.
+ */
+public record SetCellMergeRequest(
+        @NotNull(message = "rowSpan은 필수입니다.")
+        @Min(value = 1, message = "rowSpan은 1 이상이어야 합니다.")
+        @Max(value = MAX_SPAN, message = "rowSpan이 너무 큽니다.")
+        Integer rowSpan,
+        @NotNull(message = "colSpan은 필수입니다.")
+        @Min(value = 1, message = "colSpan은 1 이상이어야 합니다.")
+        @Max(value = MAX_SPAN, message = "colSpan이 너무 큽니다.")
+        Integer colSpan
+) {
+    /** span 상한(폭주 방지). 실제 경계는 열/행 수로 서비스가 다시 막는다. */
+    public static final int MAX_SPAN = 1000;
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetMergeService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetMergeService.java
@@ -1,0 +1,140 @@
+package ds.project.orino.planner.dataset.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.dataset.entity.DatasetMerge;
+import ds.project.orino.domain.planner.dataset.repository.DatasetMergeRepository;
+import ds.project.orino.planner.dataset.dto.DatasetColumn;
+import ds.project.orino.planner.dataset.dto.MergeSpec;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 셀 병합 저장·조회. 값은 {@code dataset_row.cells}에 직사각형 그대로 두고 span만
+ * {@code dataset_merge}에 담는다 — 수식·서식과 같은 sparse 오버레이 전략이라 읽기 경로가 안 바뀐다.
+ *
+ * <p>슬라이스 1은 <b>가로 병합만</b>(rowSpan=1). 세로 병합은 슬라이스 2에서 이 서비스의 검증만
+ * 완화하면 된다(스키마는 이미 rowSpan을 담는다).
+ */
+@Service
+public class DatasetMergeService {
+
+    private final DatasetMergeRepository mergeRepository;
+
+    public DatasetMergeService(DatasetMergeRepository mergeRepository) {
+        this.mergeRepository = mergeRepository;
+    }
+
+    /**
+     * 앵커 기준으로 영역을 병합한다(통째 교체). 이미 병합이 있으면 span을 갱신한다.
+     *
+     * <p>검증: 앵커 열 존재(404) · 슬라이스 1은 rowSpan=1 · 실제 병합이 되도록 colSpan&ge;2 ·
+     * 오른쪽 경계 초과 금지 · 같은 행의 다른 병합과 겹침 금지(모두 400).
+     */
+    public void setMerge(Long datasetId, Long anchorRowId, String anchorColKey,
+                         int rowSpan, int colSpan, List<DatasetColumn> columns) {
+        int at = indexOf(columns, anchorColKey);
+        if (at < 0) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+        // 슬라이스 1 — 가로 병합만. 스키마는 세로 span을 담지만 아직 렌더가 없다.
+        if (rowSpan != 1) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST, "세로 병합은 아직 지원하지 않습니다.");
+        }
+        // (1,1)은 병합이 아니다 — 해제는 별도 DELETE로 표현한다.
+        if (colSpan < 2) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST, "병합할 범위가 없습니다.");
+        }
+        // 오른쪽 끝을 넘으면 담을 열이 없다.
+        if (at + colSpan > columns.size()) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST, "병합 범위가 열 수를 넘습니다.");
+        }
+        // 같은 행의 다른 병합과 겹치면 거부한다(가로 병합이라 겹침=열 구간 교차).
+        int newEnd = at + colSpan;
+        for (DatasetMerge other : mergeRepository.findByAnchorRowIdIn(List.of(anchorRowId))) {
+            if (other.getAnchorColKey().equals(anchorColKey)) {
+                continue; // 자기 자신(범위 갱신)은 겹침이 아니다.
+            }
+            int otherAt = indexOf(columns, other.getAnchorColKey());
+            if (otherAt < 0) {
+                continue;
+            }
+            int otherEnd = otherAt + other.getColSpan();
+            if (at < otherEnd && otherAt < newEnd) {
+                throw new CustomException(ErrorCode.INVALID_REQUEST, "다른 병합과 겹칩니다.");
+            }
+        }
+
+        DatasetMerge existing = mergeRepository
+                .findByAnchorRowIdAndAnchorColKey(anchorRowId, anchorColKey).orElse(null);
+        if (existing == null) {
+            mergeRepository.save(new DatasetMerge(datasetId, anchorRowId, anchorColKey, rowSpan, colSpan));
+        } else {
+            existing.update(rowSpan, colSpan);
+        }
+    }
+
+    /** 병합 해제. 없으면 아무 일도 안 한다(멱등). */
+    public void unmerge(Long anchorRowId, String anchorColKey) {
+        mergeRepository.findByAnchorRowIdAndAnchorColKey(anchorRowId, anchorColKey)
+                .ifPresent(mergeRepository::delete);
+    }
+
+    /** 페이지의 병합을 앵커 행 id별로 모은다. 병합 있는 앵커만 담기므로 대개 비어 있다. */
+    public Map<Long, Map<String, MergeSpec>> mergesByRow(List<Long> rowIds) {
+        if (rowIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, Map<String, MergeSpec>> result = new HashMap<>();
+        for (DatasetMerge merge : mergeRepository.findByAnchorRowIdIn(rowIds)) {
+            result.computeIfAbsent(merge.getAnchorRowId(), k -> new HashMap<>())
+                    .put(merge.getAnchorColKey(), new MergeSpec(merge.getRowSpan(), merge.getColSpan()));
+        }
+        return result;
+    }
+
+    /**
+     * 열이 지워졌을 때 그 열에 걸친 병합을 해제한다 — 영역이 온전할 수 없어졌다(#829 O3 "깨지면 해제").
+     * 앵커가 그 열이거나, 다른 열 앵커의 span이 그 열을 덮는 경우 모두 지운다.
+     * 서식·수식의 {@code invalidateColumn}과 같은 자리에서 부른다.
+     */
+    public void invalidateColumn(Long datasetId, String colKey, List<DatasetColumn> columns) {
+        int gone = indexOf(columns, colKey);
+        for (DatasetMerge merge : mergeRepository.findByDatasetId(datasetId)) {
+            if (merge.getAnchorColKey().equals(colKey)) {
+                mergeRepository.delete(merge);
+                continue;
+            }
+            if (gone < 0) {
+                continue;
+            }
+            int at = indexOf(columns, merge.getAnchorColKey());
+            if (at >= 0 && at < gone && gone < at + merge.getColSpan()) {
+                mergeRepository.delete(merge); // 이 병합의 span이 지워질 열을 덮는다.
+            }
+        }
+    }
+
+    /**
+     * 열 순서가 바뀌면 병합 영역이 불연속이 될 수 있어 그 dataset의 병합을 모두 해제한다
+     * (#829 O3, v1 보수적 처리). 병합은 sparse라 대개 없거나 적다.
+     */
+    public void invalidateAllOnReorder(Long datasetId) {
+        List<DatasetMerge> merges = mergeRepository.findByDatasetId(datasetId);
+        if (!merges.isEmpty()) {
+            mergeRepository.deleteAll(merges);
+        }
+    }
+
+    private int indexOf(List<DatasetColumn> columns, String key) {
+        for (int i = 0; i < columns.size(); i++) {
+            if (columns.get(i).key().equals(key)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -14,11 +14,13 @@ import ds.project.orino.planner.dataset.dto.DatasetColumn;
 import ds.project.orino.planner.dataset.dto.DatasetResponse;
 import ds.project.orino.planner.dataset.dto.InsertRowRequest;
 import ds.project.orino.planner.dataset.dto.InsertRowResponse;
+import ds.project.orino.planner.dataset.dto.MergeSpec;
 import ds.project.orino.planner.dataset.dto.RenameColumnRequest;
 import ds.project.orino.planner.dataset.dto.ReorderColumnsRequest;
 import ds.project.orino.planner.dataset.dto.ResizeColumnRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
+import ds.project.orino.planner.dataset.dto.SetCellMergeRequest;
 import ds.project.orino.planner.dataset.dto.SetCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.SetColumnAlignRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
@@ -71,14 +73,17 @@ public class DatasetService {
     private final DatasetRowRepository rowRepository;
     private final DatasetFormulaService formulaService;
     private final DatasetCellStyleService styleService;
+    private final DatasetMergeService mergeService;
 
     public DatasetService(DatasetRepository datasetRepository, DatasetRowRepository rowRepository,
                           DatasetFormulaService formulaService,
-                          DatasetCellStyleService styleService) {
+                          DatasetCellStyleService styleService,
+                          DatasetMergeService mergeService) {
         this.datasetRepository = datasetRepository;
         this.rowRepository = rowRepository;
         this.formulaService = formulaService;
         this.styleService = styleService;
+        this.mergeService = mergeService;
     }
 
     /**
@@ -218,6 +223,8 @@ public class DatasetService {
         formulaService.invalidateColumn(datasetId, key);
         // 그 열의 서식도 담길 셀이 없어졌으니 지운다(col_key는 FK가 아니라 cascade가 없다).
         styleService.invalidateColumn(datasetId, key);
+        // 그 열에 걸친 병합은 영역이 온전할 수 없어 해제한다(삭제 전 열 순서로 덮는 열을 계산해야 한다).
+        mergeService.invalidateColumn(datasetId, key, columns);
         return DatasetResponse.of(dataset, updated);
     }
 
@@ -246,6 +253,8 @@ public class DatasetService {
 
         List<DatasetColumn> updated = request.keys().stream().map(byKey::get).toList();
         dataset.updateColumns(serialize(updated));
+        // 순서가 바뀌면 병합 영역이 불연속이 될 수 있어 그 dataset의 병합을 모두 해제한다(#829 O3, v1 보수적).
+        mergeService.invalidateAllOnReorder(datasetId);
         return DatasetResponse.of(dataset, updated);
     }
 
@@ -397,15 +406,17 @@ public class DatasetService {
         List<DatasetRow> found = rowRepository
                 .findByDatasetIdAndRowIndexGreaterThanEqualAndRowIndexLessThanOrderByRowIndexAsc(
                         datasetId, off, off + lim);
-        // 페이지의 수식·서식을 한 번에 가져온다. 있는 셀만 담기므로 대개 비어 있다.
+        // 페이지의 수식·서식·병합을 한 번에 가져온다. 있는 셀만 담기므로 대개 비어 있다.
         List<Long> rowIds = found.stream().map(DatasetRow::getId).toList();
         Map<Long, Map<String, String>> formulas =
                 formulaService.displayFormulas(datasetId, rowIds, columns);
         Map<Long, Map<String, CellStyle>> styles = styleService.stylesByRow(rowIds);
+        Map<Long, Map<String, MergeSpec>> merges = mergeService.mergesByRow(rowIds);
         List<RowView> rows = found.stream()
                 .map(r -> new RowView(r.getId(), r.getRowIndex(), toCellList(r.getCells(), columns),
                         formulas.getOrDefault(r.getId(), Map.of()),
-                        styles.getOrDefault(r.getId(), Map.of())))
+                        styles.getOrDefault(r.getId(), Map.of()),
+                        merges.getOrDefault(r.getId(), Map.of())))
                 .toList();
         return new RowsResponse(rows, off, lim);
     }
@@ -473,13 +484,43 @@ public class DatasetService {
         return buildRowView(datasetId, row, rowIndex, columns);
     }
 
-    /** 한 행의 현재 상태를 API 형태로 조립한다(값·수식·서식을 함께 싣는다). */
+    /**
+     * 셀 병합. 앵커(rowIndex·colKey) 기준으로 영역을 병합한다. 값·수식과 무관한 표시 오버레이라
+     * cells를 건드리지 않는다 — 덮인 셀의 값은 보존되고 분할하면 되살아난다.
+     */
+    @Transactional
+    public RowView setCellMerge(Long memberId, Long datasetId, int rowIndex, String colKey,
+                                SetCellMergeRequest request) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        DatasetRow row = rowRepository.findByDatasetIdAndRowIndex(datasetId, rowIndex)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        mergeService.setMerge(datasetId, row.getId(), colKey,
+                request.rowSpan(), request.colSpan(), columns);
+        return buildRowView(datasetId, row, rowIndex, columns);
+    }
+
+    /** 병합 해제. 덮여 있던 셀 값은 cells에 그대로 있었으므로 그 자리에 되살아난다. */
+    @Transactional
+    public RowView unmergeCell(Long memberId, Long datasetId, int rowIndex, String colKey) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        DatasetRow row = rowRepository.findByDatasetIdAndRowIndex(datasetId, rowIndex)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        mergeService.unmerge(row.getId(), colKey);
+        return buildRowView(datasetId, row, rowIndex, columns);
+    }
+
+    /** 한 행의 현재 상태를 API 형태로 조립한다(값·수식·서식·병합을 함께 싣는다). */
     private RowView buildRowView(Long datasetId, DatasetRow row, int rowIndex,
                                  List<DatasetColumn> columns) {
         List<Long> ids = List.of(row.getId());
         return new RowView(row.getId(), rowIndex, toCellList(row.getCells(), columns),
                 formulaService.displayFormulas(datasetId, ids, columns).getOrDefault(row.getId(), Map.of()),
-                styleService.stylesByRow(ids).getOrDefault(row.getId(), Map.of()));
+                styleService.stylesByRow(ids).getOrDefault(row.getId(), Map.of()),
+                mergeService.mergesByRow(ids).getOrDefault(row.getId(), Map.of()));
     }
 
     @Transactional

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/042-create-dataset-merge.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/042-create-dataset-merge.yaml
@@ -1,0 +1,91 @@
+databaseChangeLog:
+  # 셀 병합 저장 스키마 (Epic #829, 슬라이스 1 가로 병합).
+  #
+  # 수식(dataset_formula)·서식(dataset_cell_style)과 같은 오버레이 전략: 값은 dataset_row.cells에
+  # 직사각형 그대로 두고, 여기엔 "어느 앵커가 몇 칸을 덮는가"만 담는다. 덮인 셀의 값은 보존되므로
+  # 분할하면 되살아나고, 투영·수식 읽기 경로가 바뀌지 않는다. 병합 있는 앵커만 행이 생겨 sparse하다.
+  #
+  # 슬라이스 1은 가로 병합만(row_span=1). row_span 컬럼을 처음부터 둬 슬라이스 2(세로 병합)가
+  # 마이그레이션 없이 얹히게 한다.
+  - changeSet:
+      id: 042-create-dataset-merge
+      author: wcorn
+      comment: 셀 병합 테이블. 앵커(row_id,col_key) 기준 span만 담고 값은 dataset_row.cells에 남는다.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: dataset_merge
+      changes:
+        - createTable:
+            tableName: dataset_merge
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: dataset_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_dataset_merge_dataset
+                    references: dataset(id)
+                    deleteCascade: true
+              # 앵커 = 좌상단 셀. 행 정체성은 row_index가 아니라 id다(행이 밀려도 병합이 따라다닌다).
+              # 앵커 행이 지워지면 cascade로 병합도 함께 사라진다.
+              - column:
+                  name: anchor_row_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_dataset_merge_row
+                    references: dataset_row(id)
+                    deleteCascade: true
+              - column:
+                  name: anchor_col_key
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+              # 세로 span(>=1). 슬라이스 1은 항상 1(가로 병합만). 슬라이스 2에서 >1 허용.
+              - column:
+                  name: row_span
+                  type: INT
+                  constraints:
+                    nullable: false
+              # 가로 span(>=1).
+              - column:
+                  name: col_span
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        # 한 앵커에 병합은 하나. 조회 키이자 중복 방지.
+        - createIndex:
+            tableName: dataset_merge
+            indexName: uq_dataset_merge_anchor
+            unique: true
+            columns:
+              - column:
+                  name: anchor_row_id
+              - column:
+                  name: anchor_col_key
+        # 페이지 조회 시 그 dataset의 병합을 한 번에 가져오기 위한 인덱스.
+        - createIndex:
+            tableName: dataset_merge
+            indexName: idx_dataset_merge_dataset
+            columns:
+              - column:
+                  name: dataset_id

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -81,3 +81,5 @@ databaseChangeLog:
       file: db/changelog/changes/040-create-dataset-formula.yaml
   - include:
       file: db/changelog/changes/041-create-dataset-cell-style.yaml
+  - include:
+      file: db/changelog/changes/042-create-dataset-merge.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -5,6 +5,7 @@ import ds.project.orino.domain.member.repository.MemberRepository;
 import ds.project.orino.domain.planner.dataset.entity.DatasetFormula;
 import ds.project.orino.domain.planner.dataset.repository.DatasetCellStyleRepository;
 import ds.project.orino.domain.planner.dataset.repository.DatasetFormulaRepository;
+import ds.project.orino.domain.planner.dataset.repository.DatasetMergeRepository;
 import ds.project.orino.domain.planner.dataset.repository.DatasetRowRepository;
 import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.AuthFixture;
@@ -36,6 +37,8 @@ class DatasetControllerTest extends ApiTestSupport {
     private DatasetFormulaRepository datasetFormulaRepository;
     @Autowired
     private DatasetCellStyleRepository datasetCellStyleRepository;
+    @Autowired
+    private DatasetMergeRepository datasetMergeRepository;
     @Autowired
     private DbCleaner dbCleaner;
 
@@ -1481,6 +1484,222 @@ class DatasetControllerTest extends ApiTestSupport {
                         .header(HttpHeaders.AUTHORIZATION, otherToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"bg\":\"green\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    // ---------- 셀 병합(가로) ----------
+
+    /** 3열 dataset(c0/c1/c2)을 만들고 id를 반환한다 — colspan 검증엔 열이 3개 필요하다. */
+    private long createDataset3() throws Exception {
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[
+                                  {"key":"c0","label":"과목"},
+                                  {"key":"c1","label":"점수"},
+                                  {"key":"c2","label":"비고"}
+                                ]}
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    /** 앵커 셀을 병합하고 응답을 돌려준다. */
+    private String merge(long id, int rowIndex, String colKey, int rowSpan, int colSpan)
+            throws Exception {
+        return mockMvc.perform(put("/api/datasets/{id}/rows/{r}/cells/{c}/merge", id, rowIndex, colKey)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rowSpan\":" + rowSpan + ",\"colSpan\":" + colSpan + "}"))
+                .andReturn().getResponse().getContentAsString();
+    }
+
+    @Test
+    @DisplayName("PUT cells/{col}/merge - 병합을 저장하고 행 조회 시 merges로 온다")
+    void set_cell_merge() throws Exception {
+        long id = createDataset3();
+        bulk(id, "[[\"네트워크\",\"92\",\"재수강\"]]");
+
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c0/merge", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rowSpan\":1,\"colSpan\":2}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.merges.c0.rowSpan").value(1))
+                .andExpect(jsonPath("$.data.merges.c0.colSpan").value(2));
+
+        // 페이지 조회에도 merges가 실려 온다. 병합 없는 앵커는 담기지 않는다.
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rows[0].merges.c0.colSpan").value(2))
+                .andExpect(jsonPath("$.data.rows[0].merges.c1").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("병합해도 덮인 셀의 값은 cells에 보존된다(오버레이)")
+    void merge_preserves_covered_values() throws Exception {
+        long id = createDataset3();
+        bulk(id, "[[\"네트워크\",\"92\",\"재수강\"]]");
+
+        merge(id, 0, "c0", 1, 2); // c0가 c0..c1을 덮는다
+
+        // 값은 직사각형 그대로 — 덮인 c1(92)도 남아 있다.
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value("네트워크"))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("92"))
+                .andExpect(jsonPath("$.data.rows[0].cells[2]").value("재수강"));
+    }
+
+    @Test
+    @DisplayName("DELETE merge - 분할하면 merges가 사라진다(값은 원래대로)")
+    void unmerge_cell() throws Exception {
+        long id = createDataset3();
+        bulk(id, "[[\"네트워크\",\"92\",\"재수강\"]]");
+        merge(id, 0, "c0", 1, 2);
+
+        mockMvc.perform(delete("/api/datasets/{id}/rows/0/cells/c0/merge", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.merges.c0").doesNotExist());
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rows[0].merges.c0").doesNotExist())
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("92"));
+    }
+
+    @Test
+    @DisplayName("병합 - 오른쪽 경계를 넘으면 400")
+    void merge_out_of_bounds() throws Exception {
+        long id = createDataset3(); // c0/c1/c2
+        bulk(id, "[[\"a\",\"b\",\"c\"]]");
+
+        // c1에서 colSpan=3이면 c1..c3인데 c3가 없다.
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c1/merge", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rowSpan\":1,\"colSpan\":3}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("병합 - colSpan 1은 병합이 아니라 400, 세로 병합(rowSpan>1)도 400")
+    void merge_rejects_noop_and_vertical() throws Exception {
+        long id = createDataset3();
+        bulk(id, "[[\"a\",\"b\",\"c\"]]");
+
+        // colSpan=1, rowSpan=1 → 병합할 범위 없음
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c0/merge", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rowSpan\":1,\"colSpan\":1}"))
+                .andExpect(status().isBadRequest());
+        // 세로 병합은 슬라이스 1 미지원
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c0/merge", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rowSpan\":2,\"colSpan\":1}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("병합 - 다른 병합과 겹치면 400")
+    void merge_overlap_rejected() throws Exception {
+        long id = createDataset3();
+        bulk(id, "[[\"a\",\"b\",\"c\"]]");
+        merge(id, 0, "c0", 1, 2); // c0..c1
+
+        // c1에서 병합 시도 → c0의 영역과 겹친다.
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c1/merge", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rowSpan\":1,\"colSpan\":2}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("병합 - 없는 열은 404")
+    void merge_column_not_found() throws Exception {
+        long id = createDataset3();
+        bulk(id, "[[\"a\",\"b\",\"c\"]]");
+
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c99/merge", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rowSpan\":1,\"colSpan\":2}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("병합에 걸친 열을 삭제하면 병합이 해제된다")
+    void delete_column_dissolves_merge() throws Exception {
+        long id = createDataset3();
+        bulk(id, "[[\"a\",\"b\",\"c\"]]");
+        merge(id, 0, "c0", 1, 2); // c0가 c0..c1을 덮는다
+
+        // 덮인 열 c1을 삭제 → 병합 해제.
+        mockMvc.perform(delete("/api/datasets/{id}/columns/{key}", id, "c1")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rows[0].merges.c0").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("열 순서를 바꾸면 병합이 해제된다(v1 보수적 처리)")
+    void reorder_dissolves_merge() throws Exception {
+        long id = createDataset3();
+        bulk(id, "[[\"a\",\"b\",\"c\"]]");
+        merge(id, 0, "c0", 1, 2);
+
+        mockMvc.perform(patch("/api/datasets/{id}/columns/order", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keys\":[\"c2\",\"c1\",\"c0\"]}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rows[0].merges.c0").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("앵커 행을 삭제하면 병합도 cascade로 사라진다")
+    void delete_row_cascades_merge() throws Exception {
+        long id = createDataset3();
+        bulk(id, "[[\"a\",\"b\",\"c\"],[\"d\",\"e\",\"f\"]]");
+        merge(id, 0, "c0", 1, 2);
+
+        mockMvc.perform(delete("/api/datasets/{id}/rows/0", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNoContent());
+
+        org.assertj.core.api.Assertions
+                .assertThat(datasetMergeRepository.findByDatasetId(id))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("남의 데이터셋 셀은 못 병합한다")
+    void merge_of_other_member() throws Exception {
+        long id = createDataset3();
+        bulk(id, "[[\"a\",\"b\",\"c\"]]");
+        String otherToken = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c0/merge", id)
+                        .header(HttpHeaders.AUTHORIZATION, otherToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rowSpan\":1,\"colSpan\":2}"))
                 .andExpect(status().isNotFound());
     }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetMerge.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetMerge.java
@@ -1,0 +1,101 @@
+package ds.project.orino.domain.planner.dataset.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+/**
+ * 병합된 셀 영역. 값이 아니라 <b>span만</b> 담는다 — 덮인 셀의 값은
+ * {@link DatasetRow#getCells()}에 그대로 남아 분할하면 되살아나고 읽기 경로가 바뀌지 않는다.
+ * 병합 있는 앵커만 행이 생기므로 sparse하다({@link DatasetFormula 수식}·{@link DatasetCellStyle 서식}과
+ * 같은 오버레이 전략).
+ *
+ * <p>앵커는 <b>좌상단</b> 셀이고 주소는 {@code (anchorRowId, anchorColKey)}다. 행은 {@code row_index}가
+ * 아니라 {@code id}로 가리킨다 — 순번은 삽입·삭제 때 밀려 정체성이 될 수 없다.
+ *
+ * <p>{@code rowSpan}·{@code colSpan}은 앵커가 덮는 칸 수(각 &ge;1). 슬라이스 1(가로 병합)은
+ * {@code rowSpan}이 항상 1이다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "dataset_merge")
+public class DatasetMerge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "dataset_id", nullable = false)
+    private Long datasetId;
+
+    @Column(name = "anchor_row_id", nullable = false)
+    private Long anchorRowId;
+
+    @Column(name = "anchor_col_key", nullable = false, length = 64)
+    private String anchorColKey;
+
+    @Column(name = "row_span", nullable = false)
+    private int rowSpan;
+
+    @Column(name = "col_span", nullable = false)
+    private int colSpan;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected DatasetMerge() {
+    }
+
+    public DatasetMerge(Long datasetId, Long anchorRowId, String anchorColKey,
+                        int rowSpan, int colSpan) {
+        this.datasetId = datasetId;
+        this.anchorRowId = anchorRowId;
+        this.anchorColKey = anchorColKey;
+        this.rowSpan = rowSpan;
+        this.colSpan = colSpan;
+    }
+
+    /** span을 덮어쓴다(병합 범위 변경). */
+    public void update(int rowSpan, int colSpan) {
+        this.rowSpan = rowSpan;
+        this.colSpan = colSpan;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getDatasetId() {
+        return datasetId;
+    }
+
+    public Long getAnchorRowId() {
+        return anchorRowId;
+    }
+
+    public String getAnchorColKey() {
+        return anchorColKey;
+    }
+
+    public int getRowSpan() {
+        return rowSpan;
+    }
+
+    public int getColSpan() {
+        return colSpan;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetMergeRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetMergeRepository.java
@@ -1,0 +1,19 @@
+package ds.project.orino.domain.planner.dataset.repository;
+
+import ds.project.orino.domain.planner.dataset.entity.DatasetMerge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DatasetMergeRepository extends JpaRepository<DatasetMerge, Long> {
+
+    /** 앵커 하나의 병합. 한 앵커에 병합은 하나(UNIQUE). */
+    Optional<DatasetMerge> findByAnchorRowIdAndAnchorColKey(Long anchorRowId, String anchorColKey);
+
+    /** 페이지 조회 시 그 행들의 병합을 한 번에. */
+    List<DatasetMerge> findByAnchorRowIdIn(List<Long> anchorRowIds);
+
+    /** 열 삭제·순서 변경 시 정리를 위해 그 dataset의 병합을 전부. sparse라 대개 적다. */
+    List<DatasetMerge> findByDatasetId(Long datasetId);
+}

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -1188,4 +1188,165 @@ describe("DatasetGrid", () => {
     // 배경색은 그대로 두고 정렬만 얹어 통째로 보낸다.
     await waitFor(() => expect(sent).toEqual({ bg: "green", align: "center" }));
   });
+
+  it("병합된 앵커는 colSpan으로 넓게, 덮인 셀은 렌더하지 않는다", async () => {
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "점수" },
+              { key: "c2", label: "비고" },
+            ],
+            rowCount: 1,
+          },
+        }),
+      ),
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              {
+                id: 100,
+                rowIndex: 0,
+                cells: ["네트워크", "92", "재수강"],
+                formulas: {},
+                styles: {},
+                // c0가 c0..c1을 덮는다(가로 병합).
+                merges: { c0: { rowSpan: 1, colSpan: 2 } },
+              },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+
+    // 앵커는 2칸을 차지한다.
+    const anchor = screen
+      .getByText("네트워크")
+      .closest("div[style]") as HTMLElement;
+    expect(anchor.style.gridColumn).toContain("span 2");
+    // 덮인 셀(c1="92")은 렌더되지 않는다. 값은 서버에 보존되지만 화면엔 앵커가 대신 그려진다.
+    expect(screen.queryByText("92")).not.toBeInTheDocument();
+    // 병합 밖의 셀은 그대로 보인다.
+    expect(screen.getByText("재수강")).toBeInTheDocument();
+  });
+
+  it("오른쪽과 병합을 누르면 colSpan 2로 PUT한다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let sent: unknown = null;
+    server.use(
+      http.put(
+        `${API_BASE}/datasets/1/rows/0/cells/c0/merge`,
+        async ({ request }) => {
+          sent = await request.json();
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              id: 100,
+              rowIndex: 0,
+              cells: ["네트워크", "92"],
+              formulas: {},
+              styles: {},
+              merges: { c0: { rowSpan: 1, colSpan: 2 } },
+            },
+          });
+        },
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+
+    await user.click(screen.getByLabelText("1행 1열 배경색"));
+    await user.click(screen.getByLabelText("1행 1열 오른쪽과 병합"));
+
+    await waitFor(() => expect(sent).toEqual({ rowSpan: 1, colSpan: 2 }));
+    // 병합 응답으로 덮인 c1("92")이 화면에서 사라진다.
+    await waitFor(() =>
+      expect(screen.queryByText("92")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("병합 해제를 누르면 DELETE하고 덮였던 셀이 되살아난다", async () => {
+    server.use(
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              {
+                id: 100,
+                rowIndex: 0,
+                cells: ["네트워크", "92"],
+                formulas: {},
+                styles: {},
+                merges: { c0: { rowSpan: 1, colSpan: 2 } },
+              },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+    mockDataset([["네트워크", "92"]]);
+    let deleted = false;
+    server.use(
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              {
+                id: 100,
+                rowIndex: 0,
+                cells: ["네트워크", "92"],
+                formulas: {},
+                styles: {},
+                merges: { c0: { rowSpan: 1, colSpan: 2 } },
+              },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+      http.delete(`${API_BASE}/datasets/1/rows/0/cells/c0/merge`, () => {
+        deleted = true;
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 100,
+            rowIndex: 0,
+            cells: ["네트워크", "92"],
+            formulas: {},
+            styles: {},
+            merges: {},
+          },
+        });
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+
+    // 병합 상태라 덮인 "92"는 처음엔 안 보인다.
+    expect(screen.queryByText("92")).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("1행 1열 배경색"));
+    await user.click(screen.getByLabelText("1행 1열 병합 해제"));
+
+    await waitFor(() => expect(deleted).toBe(true));
+    // 해제되면 덮였던 셀이 되살아난다.
+    await waitFor(() => expect(screen.getByText("92")).toBeInTheDocument());
+  });
 });

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -13,6 +13,8 @@ import {
   FunctionSquare,
   Palette,
   Plus,
+  TableCellsMerge,
+  TableCellsSplit,
   Trash2,
   X,
 } from "lucide-react";
@@ -32,15 +34,18 @@ import {
   type CellBgToken,
   type CellStyle,
   type DatasetMeta,
+  deleteCellMerge,
   deleteDatasetColumn,
   deleteDatasetRow,
   insertDatasetRow,
   MAX_COLUMN_WIDTH,
+  type MergeSpec,
   MIN_COLUMN_WIDTH,
   renameDatasetColumn,
   reorderDatasetColumns,
   resetDatasetColumnWidth,
   resizeDatasetColumn,
+  setCellMerge,
   setCellStyle,
   setDatasetColumnAlign,
   updateDatasetRow,
@@ -64,10 +69,12 @@ export function DatasetGrid({ datasetId }: Props) {
     getRow,
     getFormulas,
     getStyles,
+    getMerges,
     ensureRange,
     setRowLocal,
     setFormulasLocal,
     setStylesLocal,
+    setMergesLocal,
     reset,
   } = useDatasetRows(datasetId);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -121,6 +128,26 @@ export function DatasetGrid({ datasetId }: Props) {
       setCellStyle(datasetId, v.row, v.colKey, v.style),
     // 서식만 바뀌므로 값·수식 캐시는 건드리지 않고 styles만 갱신한다.
     onSuccess: (row) => setStylesLocal(row.rowIndex, row.styles ?? {}),
+    onError: (e) => {
+      const message = serverMessage(e);
+      if (message) toast(message, "error");
+    },
+  });
+  const mergeMut = useMutation({
+    mutationFn: (v: { row: number; colKey: string; spec: MergeSpec }) =>
+      setCellMerge(datasetId, v.row, v.colKey, v.spec),
+    // 병합은 표시 오버레이라 값 캐시는 그대로 두고 merges만 갱신한다.
+    onSuccess: (row) => setMergesLocal(row.rowIndex, row.merges ?? {}),
+    onError: (e) => {
+      // 경계 초과·겹침 등은 서버가 사유를 알려준다.
+      const message = serverMessage(e);
+      if (message) toast(message, "error");
+    },
+  });
+  const unmergeMut = useMutation({
+    mutationFn: (v: { row: number; colKey: string }) =>
+      deleteCellMerge(datasetId, v.row, v.colKey),
+    onSuccess: (row) => setMergesLocal(row.rowIndex, row.merges ?? {}),
     onError: (e) => {
       const message = serverMessage(e);
       if (message) toast(message, "error");
@@ -350,6 +377,23 @@ export function DatasetGrid({ datasetId }: Props) {
     setColAlignMut.mutate({ key, align: next });
   };
 
+  /** 앵커 셀을 오른쪽 열과 한 칸 더 병합한다(가로 병합, 슬라이스 1). 이미 병합이면 span+1. */
+  const mergeRight = (row: number, col: number) => {
+    const colKey = meta.columns[col].key;
+    const current = getMerges(row)[colKey];
+    const nextSpan = (current?.colSpan ?? 1) + 1;
+    // 오른쪽 끝을 넘으면 담을 열이 없다(서버도 막지만 헛요청을 줄인다).
+    if (col + nextSpan > colCount) return;
+    mergeMut.mutate({ row, colKey, spec: { rowSpan: 1, colSpan: nextSpan } });
+    setPalette(null);
+  };
+
+  /** 병합 해제. 덮여 있던 셀 값이 그 자리에 되살아난다. */
+  const unmerge = (row: number, col: number) => {
+    unmergeMut.mutate({ row, colKey: meta.columns[col].key });
+    setPalette(null);
+  };
+
   const addRow = () =>
     insertMut.mutate(Array.from({ length: colCount }, () => ""));
 
@@ -532,6 +576,14 @@ export function DatasetGrid({ datasetId }: Props) {
         >
           {virtualItems.map((vi) => {
             const cells = getRow(vi.index);
+            const rowMerges = getMerges(vi.index);
+            // 앵커가 덮는 열(앵커 다음 칸부터)은 렌더에서 건너뛴다. 앵커는 span으로 넓게 그린다.
+            const covered = new Set<number>();
+            for (const [anchorKey, spec] of Object.entries(rowMerges)) {
+              const ai = meta.columns.findIndex((col) => col.key === anchorKey);
+              if (ai < 0) continue;
+              for (let k = 1; k < spec.colSpan; k++) covered.add(ai + k);
+            }
             return (
               <div
                 key={vi.key}
@@ -543,11 +595,14 @@ export function DatasetGrid({ datasetId }: Props) {
                 }}
               >
                 {Array.from({ length: colCount }, (_, c) => {
+                  // 병합에 덮인 칸은 앵커가 span으로 차지하므로 렌더하지 않는다.
+                  if (covered.has(c)) return null;
                   const isEditing =
                     editing?.row === vi.index && editing.col === c;
                   const colKey = meta.columns[c].key;
                   const formula = getFormulas(vi.index)[colKey];
                   const style = getStyles(vi.index)[colKey];
+                  const merge = rowMerges[colKey];
                   // 셀 정렬(override) > 열 기본 정렬 > 기본(left) (#828 D2).
                   const align = style?.align ?? meta.columns[c].align ?? "left";
                   const paletteOpen =
@@ -556,11 +611,15 @@ export function DatasetGrid({ datasetId }: Props) {
                     <div
                       key={c}
                       className="border-border group/cell relative truncate border-r"
-                      style={
-                        style?.bg
+                      style={{
+                        ...(style?.bg
                           ? { background: `var(--cell-bg-${style.bg})` }
-                          : undefined
-                      }
+                          : {}),
+                        // 앵커는 colSpan만큼 그리드 열을 차지한다 — 덮인 칸을 스킵한 만큼 정렬이 맞는다.
+                        ...(merge && merge.colSpan > 1
+                          ? { gridColumn: `span ${merge.colSpan}` }
+                          : {}),
+                      }}
                       onClick={() => startEdit(vi.index, c)}
                     >
                       {/* 셀 배경색 버튼 — 호버 시 나타난다. */}
@@ -643,6 +702,31 @@ export function DatasetGrid({ datasetId }: Props) {
                             >
                               <X className="size-2.5" />
                             </button>
+                          </div>
+                          {/* 병합 — 앵커를 오른쪽으로 넓히거나 해제한다(가로 병합, 슬라이스 1) */}
+                          <div className="flex gap-1">
+                            {c + (merge?.colSpan ?? 1) < colCount && (
+                              <button
+                                type="button"
+                                aria-label={`${vi.index + 1}행 ${c + 1}열 오른쪽과 병합`}
+                                title="오른쪽 열과 병합"
+                                onClick={() => mergeRight(vi.index, c)}
+                                className="text-muted-foreground hover:text-foreground border-border flex size-4 items-center justify-center rounded border"
+                              >
+                                <TableCellsMerge className="size-2.5" />
+                              </button>
+                            )}
+                            {merge && merge.colSpan > 1 && (
+                              <button
+                                type="button"
+                                aria-label={`${vi.index + 1}행 ${c + 1}열 병합 해제`}
+                                title="병합 해제"
+                                onClick={() => unmerge(vi.index, c)}
+                                className="text-muted-foreground hover:text-foreground border-border flex size-4 items-center justify-center rounded border"
+                              >
+                                <TableCellsSplit className="size-2.5" />
+                              </button>
+                            )}
                           </div>
                         </div>
                       )}

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -34,6 +34,15 @@ export interface CellStyle {
   align?: CellAlign;
 }
 
+/**
+ * 한 앵커 셀의 병합 범위. 병합은 표시 오버레이라 cells는 직사각형 그대로다 —
+ * 앵커를 span으로 넓게 그리고 덮인 칸을 렌더에서 건너뛴다. 슬라이스 1은 rowSpan=1(가로 병합).
+ */
+export interface MergeSpec {
+  rowSpan: number;
+  colSpan: number;
+}
+
 export interface DatasetMeta {
   id: number;
   columns: DatasetColumn[];
@@ -58,6 +67,8 @@ export interface DatasetRow {
   formulas: Record<string, string>;
   /** 서식 있는 셀의 배경색·정렬(열 key → CellStyle). 서식 없는 셀은 없다. */
   styles: Record<string, CellStyle>;
+  /** 병합된 앵커 셀의 span(열 key → MergeSpec). 병합 없는 앵커는 없다(sparse). */
+  merges: Record<string, MergeSpec>;
 }
 
 export interface RowsPage {
@@ -228,6 +239,35 @@ export async function setCellStyle(
   const { data } = await client.put<ApiEnvelope<DatasetRow>>(
     `/datasets/${datasetId}/rows/${rowIndex}/cells/${colKey}/style`,
     { bg: style.bg ?? null, align: style.align ?? null },
+  );
+  return data.data;
+}
+
+/**
+ * 셀 병합. 앵커(rowIndex·colKey) 기준으로 rowSpan×colSpan 영역을 병합한다. 표시 오버레이라
+ * 덮인 셀의 값은 보존되고 분할하면 되살아난다. 슬라이스 1은 가로 병합만(rowSpan=1).
+ */
+export async function setCellMerge(
+  datasetId: number,
+  rowIndex: number,
+  colKey: string,
+  spec: MergeSpec,
+): Promise<DatasetRow> {
+  const { data } = await client.put<ApiEnvelope<DatasetRow>>(
+    `/datasets/${datasetId}/rows/${rowIndex}/cells/${colKey}/merge`,
+    { rowSpan: spec.rowSpan, colSpan: spec.colSpan },
+  );
+  return data.data;
+}
+
+/** 병합 해제. 덮여 있던 셀 값은 그 자리에 되살아난다. */
+export async function deleteCellMerge(
+  datasetId: number,
+  rowIndex: number,
+  colKey: string,
+): Promise<DatasetRow> {
+  const { data } = await client.delete<ApiEnvelope<DatasetRow>>(
+    `/datasets/${datasetId}/rows/${rowIndex}/cells/${colKey}/merge`,
   );
   return data.data;
 }

--- a/fe/src/features/note/dataset/hooks/useDatasetRows.ts
+++ b/fe/src/features/note/dataset/hooks/useDatasetRows.ts
@@ -1,7 +1,11 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
 
-import { type CellStyle, fetchDatasetRows } from "../api/datasets";
+import {
+  type CellStyle,
+  fetchDatasetRows,
+  type MergeSpec,
+} from "../api/datasets";
 import { datasetKeys } from "../queryKeys";
 
 /** 가상화 스크롤에 맞춰 페이지 단위로 행을 지연 로드하는 크기. */
@@ -20,6 +24,10 @@ export function useDatasetRows(datasetId: number) {
   );
   // 서식(배경색·정렬)도 값과 따로 캐시한다 — 수식과 같은 방식.
   const [styles, setStyles] = useState<Map<number, Record<string, CellStyle>>>(
+    () => new Map(),
+  );
+  // 병합(앵커 span)도 값과 따로 캐시한다 — 서식과 같은 방식.
+  const [merges, setMerges] = useState<Map<number, Record<string, MergeSpec>>>(
     () => new Map(),
   );
   const loadedPages = useRef<Set<number>>(new Set());
@@ -66,6 +74,13 @@ export function useDatasetRows(datasetId: number) {
               );
               return next;
             });
+            setMerges((prev) => {
+              const next = new Map(prev);
+              pageData.rows.forEach((r) =>
+                next.set(r.rowIndex, r.merges ?? {}),
+              );
+              return next;
+            });
           })
           .catch(() => {})
           .finally(() => inflight.current.delete(page));
@@ -98,6 +113,14 @@ export function useDatasetRows(datasetId: number) {
     [],
   );
 
+  /** 서버가 돌려준 병합으로 갱신. */
+  const setMergesLocal = useCallback(
+    (index: number, next: Record<string, MergeSpec>) => {
+      setMerges((prev) => new Map(prev).set(index, next));
+    },
+    [],
+  );
+
   /**
    * 캐시를 비우고 다시 받아 온다. 행 인덱스가 밀리거나(행 추가·삭제) 열 구성이 바뀌어
    * 캐시된 위치 배열이 더 이상 유효하지 않을 때(열 삭제) 쓴다.
@@ -108,6 +131,7 @@ export function useDatasetRows(datasetId: number) {
     setCache(new Map());
     setFormulas(new Map());
     setStyles(new Map());
+    setMerges(new Map());
     queryClient.removeQueries({ queryKey: ["datasets", datasetId, "rows"] });
     setGeneration((g) => g + 1);
   }, [datasetId, queryClient]);
@@ -121,15 +145,21 @@ export function useDatasetRows(datasetId: number) {
     (index: number) => styles.get(index) ?? {},
     [styles],
   );
+  const getMerges = useCallback(
+    (index: number) => merges.get(index) ?? {},
+    [merges],
+  );
 
   return {
     getRow,
     getFormulas,
     getStyles,
+    getMerges,
     ensureRange,
     setRowLocal,
     setFormulasLocal,
     setStylesLocal,
+    setMergesLocal,
     reset,
   };
 }


### PR DESCRIPTION
## 이슈
closes #833

## 작업 내용
셀 병합 Epic(#829)의 **슬라이스 1 — 가로 병합(colspan)**. 설계 문서 [Data-Grid-Cell-Merge](https://github.com/wcorn/orino/wiki/Data-Grid-Cell-Merge)에서 확정한 **오버레이 모델**로 구현했다.

### 핵심 — 병합은 값을 안 건드리는 sparse 표시 오버레이
`dataset_merge` 테이블에 앵커의 span만 담고, `dataset_row.cells`는 **직사각형 그대로** 둔다. 덮인 셀의 값이 보존되므로 분할하면 되살아나고, 투영·수식 읽기 경로가 안 바뀐다(수식 `dataset_formula`·서식 `dataset_cell_style`과 같은 sparse 전략).

- **스키마**: `dataset_merge(dataset_id, anchor_row_id, anchor_col_key, row_span, col_span)`, FK cascade, UNIQUE 앵커. `row_span`을 처음부터 둬 슬라이스 2(세로 병합)가 마이그레이션 없이 얹힌다(#831이 align 컬럼을 미리 둔 방식).
- **API**: `PUT/DELETE /datasets/{id}/rows/{rowIndex}/cells/{colKey}/merge`. `RowView`에 `merges` sparse 맵을 `formulas`·`styles`처럼 얹었다.
- **검증**: 앵커 열 존재(404) · rowSpan=1(세로 병합 미지원 400) · colSpan≥2(colSpan 1은 병합 아님) · 오른쪽 경계 초과 · 다른 병합과 겹침(모두 400).

### 렌더 — 가상화 무손상
앵커를 `grid-column: span N`으로 넓게 그리고 덮인 열은 렌더에서 스킵. 각 행이 고정 높이 absolute div인 가상화 구조를 그대로 유지한다(설계에서 정정한 "가로 병합은 가상화와 완전 양립"). 병합 UI는 기존 셀 팝오버에 "오른쪽과 병합"(span+1)·"병합 해제"를 추가.

### 삭제 정리
- **열 삭제**: 그 열에 걸친 병합 해제(`mergeService.invalidateColumn`, 서식/수식의 `invalidateColumn`과 같은 자리).
- **열 순서 변경**: 그 dataset 병합 전부 해제(v1 보수적, #829 O3).
- **행·데이터셋 삭제**: FK cascade. 가로 병합이라 다른 행의 삽입·삭제엔 영향 없음.

### 수식 × 병합
무변경 — 병합은 표시 오버레이라 수식은 밑의 직사각형 값을 그대로 읽는다. 병합이 `#REF!`를 만들 일이 없다.

### 검증
- **BE 12건**: 병합 저장·조회(merges) / 덮인 값 보존 / 분할 / 경계 초과·colSpan 1·세로 병합·겹침 거부 / 없는 열 404 / 열 삭제·순서변경 시 정리 / 행 삭제 cascade / 남의 데이터셋 404.
- **FE 3건**: colSpan 렌더(앵커 span + 덮인 셀 미렌더) / "오른쪽과 병합" → PUT / "병합 해제" → DELETE + 되살아남.
- 각 테스트는 해당 코드를 되돌리면 실패함을 확인(회귀 가드).
- `./gradlew checkstyleMain·checkstyleTest` · BE DatasetControllerTest(TestContainers) · `npm run lint` · `format:check` · `build` · FE 전체 351건 통과.
- ⚠️ **브라우저 실물 확인은 생략** — 로컬 bootRun 스택 기동 비용(로컬 프로필 hostname 트랩) 때문에, 실제 MySQL(TestContainers) BE 통합 테스트 + RTL 렌더 테스트로 대체. 렌더는 Tailwind/grid-column 기반이라 리스크가 낮다.

### 문서
[Data-Grid-Cell-Merge](https://github.com/wcorn/orino/wiki/Data-Grid-Cell-Merge) 갱신 — 구현된 API·스키마·검증·정리 정책 반영, 슬라이스 1 완료 표시.

### 다음
슬라이스 2 — 세로 병합(rowspan): 고정 높이 오버레이 레이어.