### PR TITLE
feat : 데이터 그리드 우클릭 컨텍스트 메뉴 + 행·열 중간 삽입

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/AddColumnRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/AddColumnRequest.java
@@ -8,9 +8,13 @@ import jakarta.validation.constraints.Size;
  * <p>{@code label}은 선택이다. 비우면 서버가 유일한 기본 이름을 발급한다 —
  * 클라이언트가 열 개수로 이름을 지으면 열을 지운 뒤 중복이 생긴다.
  * 값을 주면 기존 열과 겹칠 때 거부한다.
+ *
+ * <p>{@code atIndex}는 선택이다. 주면 그 위치에 삽입하고(범위를 넘으면 클램프), 비우면 끝에 추가한다.
+ * cells가 key 맵이라 위치 삽입도 columns_json 순서만 바꾸는 O(1)이다(기존 행 무손상).
  */
 public record AddColumnRequest(
         @Size(max = 255, message = "label은 255자 이하여야 합니다.")
-        String label
+        String label,
+        Integer atIndex
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetMergeService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetMergeService.java
@@ -142,6 +142,34 @@ public class DatasetMergeService {
         }
     }
 
+    /**
+     * 행이 {@code atRow}에 삽입될 때, 그 위치를 세로 span이 가로지르는 병합을 해제한다(#829 O3).
+     * 삽입 위쪽·아래쪽 병합은 함께 밀리므로 온전하다 — 영역 <b>안</b>에 끼는 것만 깨진다.
+     * 삽입으로 인덱스가 밀리기 <b>전</b>에 부른다.
+     */
+    public void invalidateOnRowInsert(Long datasetId, int atRow) {
+        for (DatasetMerge merge : mergeRepository.findByDatasetId(datasetId)) {
+            Integer anchorRow = rowRepository.findById(merge.getAnchorRowId())
+                    .map(DatasetRow::getRowIndex).orElse(null);
+            if (anchorRow != null && anchorRow < atRow && atRow < anchorRow + merge.getRowSpan()) {
+                mergeRepository.delete(merge);
+            }
+        }
+    }
+
+    /**
+     * 열이 {@code atCol}에 삽입될 때, 그 위치를 가로 span이 가로지르는 병합을 해제한다(#829 O3).
+     * {@code columns}는 삽입 <b>전</b> 순서.
+     */
+    public void invalidateOnColumnInsert(Long datasetId, int atCol, List<DatasetColumn> columns) {
+        for (DatasetMerge merge : mergeRepository.findByDatasetId(datasetId)) {
+            int anchorCol = indexOf(columns, merge.getAnchorColKey());
+            if (anchorCol >= 0 && anchorCol < atCol && atCol < anchorCol + merge.getColSpan()) {
+                mergeRepository.delete(merge);
+            }
+        }
+    }
+
     /** 병합들의 앵커 행 번호를 한 번에 조회한다. */
     private Map<Long, Integer> rowIndexById(List<DatasetMerge> merges) {
         List<Long> ids = merges.stream().map(DatasetMerge::getAnchorRowId).distinct().toList();

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -184,7 +184,14 @@ public class DatasetService {
         requireLabelFree(columns, label, null);
 
         List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
-        updated.add(new DatasetColumn("c" + dataset.issueColumnSeq(), label));
+        DatasetColumn added = new DatasetColumn("c" + dataset.issueColumnSeq(), label);
+        // atIndex를 주면 그 위치에 끼우고(범위 밖은 클램프), 없으면 끝에 붙인다.
+        int at = request.atIndex() == null
+                ? updated.size()
+                : Math.max(0, Math.min(request.atIndex(), updated.size()));
+        // 삽입 위치를 가로 span이 가로지르는 병합은 해제한다(삽입 전 순서로 판정). 끝에 추가면 no-op.
+        mergeService.invalidateOnColumnInsert(datasetId, at, columns);
+        updated.add(at, added);
         dataset.updateColumns(serialize(updated));
         return DatasetResponse.of(dataset, updated);
     }
@@ -540,6 +547,8 @@ public class DatasetService {
             throw new CustomException(ErrorCode.INVALID_REQUEST);
         }
 
+        // 삽입 위치를 세로 span이 가로지르는 병합은 해제한다(행 인덱스가 밀리기 전에). 끝에 추가면 no-op.
+        mergeService.invalidateOnRowInsert(datasetId, at);
         if (at < rowCount) {
             rowRepository.shiftUp(datasetId, at); // 뒤 행을 밀어 자리 확보(flush)
         }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -611,6 +611,32 @@ class DatasetControllerTest extends ApiTestSupport {
     }
 
     @Test
+    @DisplayName("POST column - atIndex를 주면 그 위치에 끼우고 기존 행 값은 그대로")
+    void add_column_at_index() throws Exception {
+        long id = createDataset(); // c0(과목), c1(점수)
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        // 0번 자리에 삽입 → 새 열이 맨 앞, 기존 열은 뒤로 밀린다(key는 불변).
+        mockMvc.perform(post("/api/datasets/{id}/columns", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"label\":\"비고\",\"atIndex\":0}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.columns", hasSize(3)))
+                .andExpect(jsonPath("$.data.columns[0].key").value("c2"))
+                .andExpect(jsonPath("$.data.columns[0].label").value("비고"))
+                .andExpect(jsonPath("$.data.columns[1].key").value("c0"))
+                .andExpect(jsonPath("$.data.columns[2].key").value("c1"));
+
+        // cells는 새 열 순서로 투영된다 — 새 열은 빈 값, 기존 값은 뒤 자리로.
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].cells[0]").value(""))
+                .andExpect(jsonPath("$.data.rows[0].cells[1]").value("네트워크"))
+                .andExpect(jsonPath("$.data.rows[0].cells[2]").value("92"));
+    }
+
+    @Test
     @DisplayName("열 추가는 행을 건드리지 않는다(저장된 맵에 새 key가 안 생김)")
     void add_column_does_not_touch_rows() throws Exception {
         long id = createDataset();
@@ -1715,6 +1741,67 @@ class DatasetControllerTest extends ApiTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"keys\":[\"c2\",\"c1\",\"c0\"]}"))
                 .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/datasets/{id}/merges", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.merges", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("가로 병합 안에 열을 삽입하면 그 병합이 해제된다(#829 O3)")
+    void insert_column_inside_merge_dissolves_it() throws Exception {
+        long id = createDataset3(); // c0/c1/c2
+        bulk(id, "[[\"a\",\"b\",\"c\"]]");
+        merge(id, 0, "c0", 1, 2); // c0..c1
+
+        // c0와 c1 사이(index 1)에 열 삽입 → 그 병합은 온전할 수 없어 해제.
+        mockMvc.perform(post("/api/datasets/{id}/columns", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"atIndex\":1}"))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/datasets/{id}/merges", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.merges", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("가로 병합 밖(앞)에 열을 삽입하면 병합은 유지된다")
+    void insert_column_outside_merge_keeps_it() throws Exception {
+        long id = createDataset3();
+        bulk(id, "[[\"a\",\"b\",\"c\"]]");
+        merge(id, 0, "c1", 1, 2); // c1..c2
+
+        // 맨 앞(index 0)에 삽입 → c1..c2 병합은 함께 밀리고 온전.
+        mockMvc.perform(post("/api/datasets/{id}/columns", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"atIndex\":0}"))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/datasets/{id}/merges", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.merges", hasSize(1)))
+                .andExpect(jsonPath("$.data.merges[0].colKey").value("c1"));
+    }
+
+    @Test
+    @DisplayName("세로 병합 안에 행을 삽입하면 그 병합이 해제된다(#829 O3)")
+    void insert_row_inside_vertical_merge_dissolves_it() throws Exception {
+        long id = createDataset3();
+        bulk(id, "[[\"a\",\"b\",\"c\"],[\"d\",\"e\",\"f\"],[\"g\",\"h\",\"i\"]]");
+        merge(id, 0, "c0", 2, 1); // 0..1행 세로 병합
+
+        // 0행과 1행 사이(index 1)에 행 삽입 → 세로 병합 해제.
+        mockMvc.perform(post("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"atIndex\":1,\"cells\":[\"x\",\"y\",\"z\"]}"))
+                .andExpect(status().isCreated());
 
         mockMvc.perform(get("/api/datasets/{id}/merges", id)
                         .header(HttpHeaders.AUTHORIZATION, authHeader))

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -1358,8 +1358,8 @@ describe("DatasetGrid", () => {
     renderWithRouter(<DatasetGrid datasetId={1} />);
     await screen.findByText("네트워크");
 
-    await user.click(screen.getByLabelText("1행 1열 서식"));
-    await user.click(screen.getByLabelText("1행 1열 오른쪽과 병합"));
+    fireEvent.contextMenu(screen.getByText("네트워크"));
+    await user.click(screen.getByRole("menuitem", { name: "오른쪽과 병합" }));
 
     await waitFor(() => expect(sent).toEqual({ rowSpan: 1, colSpan: 2 }));
     // 응답 리스트로 갱신돼 덮인 c1("92")이 화면에서 사라진다.
@@ -1392,8 +1392,8 @@ describe("DatasetGrid", () => {
     renderWithRouter(<DatasetGrid datasetId={1} />);
     await screen.findByText("네트워크");
 
-    await user.click(screen.getByLabelText("1행 1열 서식"));
-    await user.click(screen.getByLabelText("1행 1열 아래와 병합"));
+    fireEvent.contextMenu(screen.getByText("네트워크"));
+    await user.click(screen.getByRole("menuitem", { name: "아래와 병합" }));
 
     await waitFor(() => expect(sent).toEqual({ rowSpan: 2, colSpan: 1 }));
   });
@@ -1415,11 +1415,67 @@ describe("DatasetGrid", () => {
     // 병합 상태라 덮인 "92"는 처음엔 안 보인다.
     expect(screen.queryByText("92")).not.toBeInTheDocument();
 
-    await user.click(screen.getByLabelText("1행 1열 서식"));
-    await user.click(screen.getByLabelText("1행 1열 병합 해제"));
+    fireEvent.contextMenu(screen.getByText("네트워크"));
+    await user.click(screen.getByRole("menuitem", { name: "병합 해제" }));
 
     await waitFor(() => expect(deleted).toBe(true));
     // 해제되면 덮였던 셀이 되살아난다.
     await waitFor(() => expect(screen.getByText("92")).toBeInTheDocument());
+  });
+
+  it("우클릭 메뉴에서 '아래에 행 삽입'하면 atIndex로 POST한다", async () => {
+    mockDataset([
+      ["네트워크", "92"],
+      ["보안", "80"],
+    ]);
+    let sent: { atIndex?: number } | null = null;
+    server.use(
+      http.post(`${API_BASE}/datasets/1/rows`, async ({ request }) => {
+        sent = (await request.json()) as { atIndex?: number };
+        return HttpResponse.json({ code: "OK", data: { rowIndex: 1 } });
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+
+    fireEvent.contextMenu(screen.getByText("네트워크")); // 0행
+    await user.click(screen.getByRole("menuitem", { name: "아래에 행 삽입" }));
+
+    // 0행 아래 = atIndex 1.
+    await waitFor(() => expect(sent?.atIndex).toBe(1));
+  });
+
+  it("우클릭 메뉴에서 '오른쪽에 열 삽입'하면 atIndex로 POST한다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let sent: unknown = null;
+    server.use(
+      http.post(`${API_BASE}/datasets/1/columns`, async ({ request }) => {
+        sent = await request.json();
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c2", label: "새 열" },
+              { key: "c1", label: "점수" },
+            ],
+            rowCount: 1,
+          },
+        });
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+
+    fireEvent.contextMenu(screen.getByText("네트워크")); // c0
+    await user.click(
+      screen.getByRole("menuitem", { name: "오른쪽에 열 삽입" }),
+    );
+
+    // c0 오른쪽 = atIndex 1.
+    await waitFor(() => expect(sent).toEqual({ atIndex: 1 }));
   });
 });

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -113,6 +113,13 @@ export function DatasetGrid({ datasetId }: Props) {
     startY: number;
     startHeight: number;
   } | null>(null);
+  // 우클릭 컨텍스트 메뉴(뷰포트 좌표 + 대상 셀). null이면 닫힘.
+  const [ctxMenu, setCtxMenu] = useState<{
+    x: number;
+    y: number;
+    row: number;
+    col: number;
+  } | null>(null);
 
   const colCount = meta?.columns.length ?? 0;
   const rowCount = meta?.rowCount ?? 0;
@@ -173,11 +180,12 @@ export function DatasetGrid({ datasetId }: Props) {
     },
   });
   const insertMut = useMutation({
-    mutationFn: (cells: string[]) => insertDatasetRow(datasetId, cells),
+    mutationFn: (v: { cells: string[]; atIndex?: number }) =>
+      insertDatasetRow(datasetId, v.cells, v.atIndex),
     onSuccess: () => {
       reset();
       void invalidateMeta();
-      void invalidateMerges(); // 뒤 행이 밀려 병합의 행 번호가 바뀐다.
+      void invalidateMerges(); // 뒤 행이 밀려 병합의 행 번호가 바뀌고, 안에 끼면 해제된다.
     },
   });
   const deleteMut = useMutation({
@@ -238,11 +246,17 @@ export function DatasetGrid({ datasetId }: Props) {
     onError: () => void invalidateMeta(),
   });
   const addColMut = useMutation({
-    mutationFn: () => addDatasetColumn(datasetId),
-    // 행은 다시 받지 않는다. 새 열의 key는 방금 발급돼 어느 행에도 값이 없으므로,
-    // 캐시된 짧은 cells를 그대로 두면 렌더가 새 열을 빈 칸으로 그린다(편집 시 패딩됨).
-    onSuccess: (next: DatasetMeta) =>
-      queryClient.setQueryData(datasetKeys.meta(datasetId), next),
+    mutationFn: (v: { atIndex?: number }) =>
+      addDatasetColumn(datasetId, v.atIndex),
+    onSuccess: (next: DatasetMeta, v) => {
+      queryClient.setQueryData(datasetKeys.meta(datasetId), next);
+      // 끝에 추가면 새 열 key는 어느 행에도 값이 없어 캐시된 짧은 cells를 그대로 둬도 된다.
+      // 중간 삽입이면 뒤 열이 밀려 위치 배열이 어긋나고, 안에 끼면 병합이 해제됐을 수 있다 → 다시 받는다.
+      if (v.atIndex != null) {
+        reset();
+        void invalidateMerges();
+      }
+    },
     onError: () => void invalidateMeta(),
   });
 
@@ -482,11 +496,24 @@ export function DatasetGrid({ datasetId }: Props) {
     setPalette(null);
   };
 
-  const addRow = () =>
-    insertMut.mutate(Array.from({ length: colCount }, () => ""));
+  /** 셀 우클릭 → 그 자리에 컨텍스트 메뉴를 연다(행/열 삽입·삭제·병합). */
+  const openContextMenu = (
+    event: React.MouseEvent,
+    row: number,
+    col: number,
+  ) => {
+    event.preventDefault();
+    setPalette(null);
+    setCtxMenu({ x: event.clientX, y: event.clientY, row, col });
+  };
+
+  const emptyRow = () => Array.from({ length: colCount }, () => "");
+  // atIndex를 주면 그 위치에 삽입(위/아래), 없으면 끝에 추가.
+  const addRow = (atIndex?: number) =>
+    insertMut.mutate({ cells: emptyRow(), atIndex });
 
   // 이름은 서버가 붙인다 — 열 개수로 지으면 삭제 후 중복된다.
-  const addColumn = () => addColMut.mutate();
+  const addColumn = (atIndex?: number) => addColMut.mutate({ atIndex });
 
   const columnLabel = (key: string) =>
     meta.columns.find((c) => c.key === key)?.label ?? key;
@@ -530,12 +557,9 @@ export function DatasetGrid({ datasetId }: Props) {
     const cells = getRow(rowIndex);
     const formula = getFormulas(rowIndex)[colKey];
     const style = getStyles(rowIndex)[colKey];
-    const merge = mergeAt(rowIndex, c);
     // 셀 정렬(override) > 열 기본 정렬 > 기본(left) (#828 D2).
     const align = style?.align ?? meta.columns[c].align ?? "left";
     const paletteOpen = palette?.row === rowIndex && palette.col === c;
-    const colSpan = merge?.colSpan ?? 1;
-    const rowSpan = merge?.rowSpan ?? 1;
     return (
       <>
         {/* 셀 서식·병합 버튼 — 호버 시 나타난다. */}
@@ -613,42 +637,7 @@ export function DatasetGrid({ datasetId }: Props) {
                 <X className="size-2.5" />
               </button>
             </div>
-            {/* 병합 — 오른쪽·아래로 넓히거나 해제한다 */}
-            <div className="flex gap-1">
-              {c + colSpan < colCount && (
-                <button
-                  type="button"
-                  aria-label={`${rowIndex + 1}행 ${c + 1}열 오른쪽과 병합`}
-                  title="오른쪽 열과 병합"
-                  onClick={() => mergeRight(rowIndex, c)}
-                  className="text-muted-foreground hover:text-foreground border-border flex size-4 items-center justify-center rounded border"
-                >
-                  <TableCellsMerge className="size-2.5" />
-                </button>
-              )}
-              {rowIndex + rowSpan < rowCount && (
-                <button
-                  type="button"
-                  aria-label={`${rowIndex + 1}행 ${c + 1}열 아래와 병합`}
-                  title="아래 행과 병합"
-                  onClick={() => mergeDown(rowIndex, c)}
-                  className="text-muted-foreground hover:text-foreground border-border flex size-4 rotate-90 items-center justify-center rounded border"
-                >
-                  <TableCellsMerge className="size-2.5" />
-                </button>
-              )}
-              {merge && (
-                <button
-                  type="button"
-                  aria-label={`${rowIndex + 1}행 ${c + 1}열 병합 해제`}
-                  title="병합 해제"
-                  onClick={() => unmerge(rowIndex, c)}
-                  className="text-muted-foreground hover:text-foreground border-border flex size-4 items-center justify-center rounded border"
-                >
-                  <TableCellsSplit className="size-2.5" />
-                </button>
-              )}
-            </div>
+            {/* 삽입·삭제·병합은 셀 우클릭 메뉴로. */}
           </div>
         )}
         {isEditing ? (
@@ -819,7 +808,7 @@ export function DatasetGrid({ datasetId }: Props) {
             type="button"
             aria-label="열 추가"
             title="열 추가"
-            onClick={addColumn}
+            onClick={() => addColumn()}
             disabled={addColMut.isPending}
             className="text-muted-foreground hover:text-foreground flex items-center justify-center disabled:opacity-50"
           >
@@ -875,6 +864,7 @@ export function DatasetGrid({ datasetId }: Props) {
                           : {}),
                       }}
                       onClick={() => startEdit(vi.index, c)}
+                      onContextMenu={(e) => openContextMenu(e, vi.index, c)}
                     >
                       {renderCellInner(vi.index, c)}
                     </div>
@@ -925,6 +915,7 @@ export function DatasetGrid({ datasetId }: Props) {
                           : {}),
                       }}
                       onClick={() => startEdit(m.rowIndex, ai)}
+                      onContextMenu={(e) => openContextMenu(e, m.rowIndex, ai)}
                     >
                       {renderCellInner(m.rowIndex, ai)}
                     </div>
@@ -959,7 +950,7 @@ export function DatasetGrid({ datasetId }: Props) {
           type="button"
           variant="ghost"
           size="sm"
-          onClick={addRow}
+          onClick={() => addRow()}
           disabled={insertMut.isPending}
         >
           <Plus className="size-4" /> 행 추가
@@ -995,6 +986,101 @@ export function DatasetGrid({ datasetId }: Props) {
         }}
         pending={deleteColMut.isPending}
       />
+
+      {/* 셀 우클릭 컨텍스트 메뉴 — 행/열 삽입·삭제·병합을 한 곳에 모은다. */}
+      {ctxMenu &&
+        (() => {
+          const { row, col } = ctxMenu;
+          const cm = mergeAt(row, col);
+          const colSpan = cm?.colSpan ?? 1;
+          const rowSpan = cm?.rowSpan ?? 1;
+          const colKey = meta.columns[col].key;
+          const close = () => setCtxMenu(null);
+          const item = (
+            label: string,
+            onClick: () => void,
+            opts: { icon?: React.ReactNode; destructive?: boolean } = {},
+          ) => (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                onClick();
+                close();
+              }}
+              className={cn(
+                "hover:bg-accent flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm",
+                opts.destructive && "text-destructive",
+              )}
+            >
+              {opts.icon}
+              {label}
+            </button>
+          );
+          const canMergeRight = col + colSpan < colCount;
+          const canMergeDown = row + rowSpan < rowCount;
+          return (
+            <>
+              {/* 바깥 클릭·우클릭으로 닫는다. */}
+              <div
+                className="fixed inset-0 z-40"
+                onClick={close}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  close();
+                }}
+              />
+              <div
+                role="menu"
+                aria-label="셀 메뉴"
+                className="border-border bg-popover fixed z-50 min-w-40 rounded-md border p-1 shadow-md"
+                // 뷰포트 오른쪽·아래로 넘치지 않게 대략 클램프한다(메뉴 크기 여유분).
+                style={{
+                  left: Math.min(ctxMenu.x, window.innerWidth - 176),
+                  top: Math.min(ctxMenu.y, window.innerHeight - 340),
+                }}
+              >
+                {item("위에 행 삽입", () => addRow(row), {
+                  icon: <Plus className="size-3.5" />,
+                })}
+                {item("아래에 행 삽입", () => addRow(row + 1), {
+                  icon: <Plus className="size-3.5" />,
+                })}
+                {item("왼쪽에 열 삽입", () => addColumn(col), {
+                  icon: <Plus className="size-3.5" />,
+                })}
+                {item("오른쪽에 열 삽입", () => addColumn(col + 1), {
+                  icon: <Plus className="size-3.5" />,
+                })}
+                {(canMergeRight || canMergeDown || cm) && (
+                  <div className="bg-border my-1 h-px" />
+                )}
+                {canMergeRight &&
+                  item("오른쪽과 병합", () => mergeRight(row, col), {
+                    icon: <TableCellsMerge className="size-3.5" />,
+                  })}
+                {canMergeDown &&
+                  item("아래와 병합", () => mergeDown(row, col), {
+                    icon: <TableCellsMerge className="size-3.5 rotate-90" />,
+                  })}
+                {cm &&
+                  item("병합 해제", () => unmerge(row, col), {
+                    icon: <TableCellsSplit className="size-3.5" />,
+                  })}
+                <div className="bg-border my-1 h-px" />
+                {item("행 삭제", () => deleteMut.mutate(row), {
+                  icon: <Trash2 className="size-3.5" />,
+                  destructive: true,
+                })}
+                {colCount > 1 &&
+                  item("열 삭제", () => setPendingColDelete(colKey), {
+                    icon: <X className="size-3.5" />,
+                    destructive: true,
+                  })}
+              </div>
+            </>
+          );
+        })()}
     </div>
   );
 }

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -122,15 +122,18 @@ export async function fetchDatasetMeta(
 }
 
 /**
- * 열 추가(끝에). key와 기본 이름을 서버가 발급한다 — 클라이언트가 열 개수로 이름을 지으면
+ * 열 추가. key와 기본 이름을 서버가 발급한다 — 클라이언트가 열 개수로 이름을 지으면
  * 열을 지운 뒤 중복이 생긴다. 기존 행은 서버에서 건드리지 않는다.
+ *
+ * `atIndex`를 주면 그 위치에 삽입하고, 없으면 끝에 추가한다.
  */
 export async function addDatasetColumn(
   datasetId: number,
+  atIndex?: number,
 ): Promise<DatasetMeta> {
   const { data } = await client.post<ApiEnvelope<DatasetMeta>>(
     `/datasets/${datasetId}/columns`,
-    {},
+    atIndex == null ? {} : { atIndex },
   );
   return data.data;
 }


### PR DESCRIPTION
## 이슈
closes #838

## 작업 내용
셀 **우클릭(onContextMenu)** → 행/열 삽입·삭제·병합을 한 메뉴에 통합했다. 흩어져 있던 진입점을 모으고 **병합 조작을 셀 팔레트 → 컨텍스트 메뉴로 이동**했다(팔레트는 배경색·정렬만).

- **행 중간 삽입**(위/아래)은 기존 `insertRow atIndex` 활용. **열 중간 삽입**(좌/우)은 `AddColumnRequest.atIndex` 신규 — cells가 key 맵이라 O(1)(기존 행 무손상).
- **중간 삽입이 병합 영역을 가로지르면 그 병합을 해제**(#829 O3): `mergeService.invalidateOnRowInsert`·`invalidateOnColumnInsert`. 삽입 밖(앞/뒤)의 병합은 함께 밀려 온전 — 순서 변경의 전체 해제보다 정밀.
- 컨텍스트 메뉴는 뷰포트 밖으로 넘치지 않게 클램프.

## 검증
- **BE 4건 신규**: 열 atIndex 삽입 / 가로 병합 안에 열 삽입 시 해제 / 밖에 삽입 시 유지 / 세로 병합 안에 행 삽입 시 해제.
- **FE 4건 신규**: 우클릭 '아래에 행 삽입'·'오른쪽에 열 삽입' atIndex POST / 병합 조작이 컨텍스트 메뉴에서 동작(기존 3건 갱신).
- `./gradlew checkstyle`·BE 전체 테스트(TestContainers) · `npm run lint`·`format:check`·`build`·FE 전체 357건 통과.
- ⚠️ 컨텍스트 메뉴는 표준 UI 상호작용이라 jsdom으로 구조·로직 검증(병합 오버레이 같은 novel geometry가 아님).

## 문서
[Data-Grid-Block](https://github.com/wcorn/orino/wiki/Data-Grid-Block)(열 atIndex) · [Data-Grid-Cell-Merge](https://github.com/wcorn/orino/wiki/Data-Grid-Cell-Merge)(O3 중간 삽입 해제) 갱신.

## 남은 후속
#839(행 높이 조정 — 병합 오버레이 상호작용 검토 선행).