### PR TITLE
feat : 데이터 그리드 행 높이 조정(가변)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -12,8 +12,10 @@ import ds.project.orino.planner.dataset.dto.ReorderColumnsRequest;
 import ds.project.orino.planner.dataset.dto.ResizeColumnRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.MergesResponse;
+import ds.project.orino.planner.dataset.dto.RowHeightsResponse;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
 import ds.project.orino.planner.dataset.dto.SetCellMergeRequest;
+import ds.project.orino.planner.dataset.dto.SetRowHeightRequest;
 import ds.project.orino.planner.dataset.dto.SetCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.SetColumnAlignRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
@@ -249,5 +251,33 @@ public class DatasetController {
             @PathVariable String colKey) {
         return ApiResponse.success(
                 datasetService.unmergeCell(memberId, id, rowIndex, colKey));
+    }
+
+    /** 기본이 아닌 행 높이 전체. 세로 병합은 앵커가 화면 밖이어도 덮인 행 높이를 알아야 해 통째로 준다. */
+    @GetMapping("/{id}/row-heights")
+    public ApiResponse<RowHeightsResponse> rowHeights(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id) {
+        return ApiResponse.success(datasetService.getRowHeights(memberId, id));
+    }
+
+    /** 행 높이 변경(px). 행 단위 표시 속성이라 값·수식은 건드리지 않는다. */
+    @PatchMapping("/{id}/rows/{rowIndex}/height")
+    public ApiResponse<RowHeightsResponse> setRowHeight(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable int rowIndex,
+            @Valid @RequestBody SetRowHeightRequest request) {
+        return ApiResponse.success(
+                datasetService.setRowHeight(memberId, id, rowIndex, request));
+    }
+
+    /** 행 높이 초기화 — 기본 높이로 되돌린다. */
+    @DeleteMapping("/{id}/rows/{rowIndex}/height")
+    public ApiResponse<RowHeightsResponse> resetRowHeight(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable int rowIndex) {
+        return ApiResponse.success(datasetService.resetRowHeight(memberId, id, rowIndex));
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowHeightView.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowHeightView.java
@@ -1,0 +1,11 @@
+package ds.project.orino.planner.dataset.dto;
+
+/**
+ * 기본이 아닌 행 높이 하나. 행을 <b>행 번호</b>로 가리킨다(저장은 row_id, 표시는 번호).
+ * 세로 병합 오버레이가 앵커 밖 행의 누적 높이를 알아야 해, 높이는 페이지가 아니라 dataset 단위로 온다.
+ */
+public record RowHeightView(
+        int rowIndex,
+        int height
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowHeightsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/RowHeightsResponse.java
@@ -1,0 +1,12 @@
+package ds.project.orino.planner.dataset.dto;
+
+import java.util.List;
+
+/**
+ * 한 dataset의 기본이 아닌 행 높이 전체. 세로 병합은 앵커 행이 화면 밖이어도 덮인 영역의 높이를
+ * 알아야 하므로, 병합처럼 페이지가 아니라 dataset 단위로 통째 내려간다(대개 sparse).
+ */
+public record RowHeightsResponse(
+        List<RowHeightView> heights
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetRowHeightRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetRowHeightRequest.java
@@ -1,0 +1,22 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 행 높이 변경 요청. px 정수만 받는다.
+ *
+ * <p>기본 높이로 되돌리는 것은 <b>높이 삭제</b>(DELETE)로 표현한다 — 열 너비와 같은 규칙.
+ */
+public record SetRowHeightRequest(
+        @NotNull(message = "height는 필수입니다.")
+        @Min(value = MIN_HEIGHT, message = "height는 " + MIN_HEIGHT + " 이상이어야 합니다.")
+        @Max(value = MAX_HEIGHT, message = "height는 " + MAX_HEIGHT + " 이하여야 합니다.")
+        Integer height
+) {
+    /** 행 높이 하한(px). 이보다 낮으면 값이 사실상 안 보인다. */
+    public static final int MIN_HEIGHT = 24;
+    /** 행 높이 상한(px). 한 행이 표를 다 밀어내는 것을 막는다. */
+    public static final int MAX_HEIGHT = 600;
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -16,11 +16,14 @@ import ds.project.orino.planner.dataset.dto.InsertRowRequest;
 import ds.project.orino.planner.dataset.dto.InsertRowResponse;
 import ds.project.orino.planner.dataset.dto.MergesResponse;
 import ds.project.orino.planner.dataset.dto.RenameColumnRequest;
+import ds.project.orino.planner.dataset.dto.RowHeightView;
+import ds.project.orino.planner.dataset.dto.RowHeightsResponse;
 import ds.project.orino.planner.dataset.dto.ReorderColumnsRequest;
 import ds.project.orino.planner.dataset.dto.ResizeColumnRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
 import ds.project.orino.planner.dataset.dto.SetCellMergeRequest;
+import ds.project.orino.planner.dataset.dto.SetRowHeightRequest;
 import ds.project.orino.planner.dataset.dto.SetCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.SetColumnAlignRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
@@ -523,6 +526,41 @@ public class DatasetService {
 
         mergeService.unmerge(row.getId(), colKey);
         return new MergesResponse(mergeService.allMerges(datasetId));
+    }
+
+    /** 기본이 아닌 행 높이 전체. 세로 병합을 그리려면 FE가 앵커 밖 행의 높이까지 알아야 해 통째로 준다. */
+    public RowHeightsResponse getRowHeights(Long memberId, Long datasetId) {
+        getOwned(memberId, datasetId);
+        return rowHeightsOf(datasetId);
+    }
+
+    /** 행 높이 변경. 열 너비처럼 표시 속성이라 값·수식과 무관하다. 갱신된 높이 전체를 돌려준다. */
+    @Transactional
+    public RowHeightsResponse setRowHeight(Long memberId, Long datasetId, int rowIndex,
+                                           SetRowHeightRequest request) {
+        getOwned(memberId, datasetId);
+        DatasetRow row = rowRepository.findByDatasetIdAndRowIndex(datasetId, rowIndex)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        row.updateHeight(request.height());
+        return rowHeightsOf(datasetId);
+    }
+
+    /** 행 높이를 지워 기본 높이로 되돌린다(값의 부재로 표현 — 열 너비와 같은 규칙). */
+    @Transactional
+    public RowHeightsResponse resetRowHeight(Long memberId, Long datasetId, int rowIndex) {
+        getOwned(memberId, datasetId);
+        DatasetRow row = rowRepository.findByDatasetIdAndRowIndex(datasetId, rowIndex)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        row.updateHeight(null);
+        return rowHeightsOf(datasetId);
+    }
+
+    private RowHeightsResponse rowHeightsOf(Long datasetId) {
+        List<RowHeightView> heights = rowRepository
+                .findByDatasetIdAndHeightIsNotNullOrderByRowIndexAsc(datasetId).stream()
+                .map(r -> new RowHeightView(r.getRowIndex(), r.getHeight()))
+                .toList();
+        return new RowHeightsResponse(heights);
     }
 
     /** 한 행의 현재 상태를 API 형태로 조립한다(값·수식·서식을 함께 싣는다). */

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/043-add-dataset-row-height.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/043-add-dataset-row-height.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  # 행 높이(px) 저장 (#839). 열 너비가 columns_json의 열 속성이듯, 행 높이는 dataset_row의 행 속성.
+  #
+  # nullable — 대부분 행은 기본 높이라 NULL이고, 사용자가 바꾼 행만 값을 갖는다(sparse).
+  # 세로 병합 오버레이가 앵커 밖 행의 누적 높이를 알아야 해, FE는 비기본 높이 전체를 통째로 받는다.
+  - changeSet:
+      id: 043-add-dataset-row-height
+      author: wcorn
+      comment: dataset_row에 height(px) 컬럼. 기본 높이인 행은 NULL.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: dataset_row
+                columnName: height
+      changes:
+        - addColumn:
+            tableName: dataset_row
+            columns:
+              - column:
+                  name: height
+                  type: INT

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -83,3 +83,5 @@ databaseChangeLog:
       file: db/changelog/changes/041-create-dataset-cell-style.yaml
   - include:
       file: db/changelog/changes/042-create-dataset-merge.yaml
+  - include:
+      file: db/changelog/changes/043-add-dataset-row-height.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -1838,4 +1838,100 @@ class DatasetControllerTest extends ApiTestSupport {
                         .content("{\"rowSpan\":1,\"colSpan\":2}"))
                 .andExpect(status().isNotFound());
     }
+
+    // ---------- 행 높이 ----------
+
+    @Test
+    @DisplayName("PATCH rows/{r}/height - 높이를 저장하고 GET /row-heights로 온다(sparse)")
+    void set_row_height() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"a\",\"1\"],[\"b\",\"2\"]]");
+
+        mockMvc.perform(patch("/api/datasets/{id}/rows/1/height", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"height\":120}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.heights", hasSize(1)))
+                .andExpect(jsonPath("$.data.heights[0].rowIndex").value(1))
+                .andExpect(jsonPath("$.data.heights[0].height").value(120));
+
+        // 기본 높이인 행(0)은 담기지 않는다(sparse).
+        mockMvc.perform(get("/api/datasets/{id}/row-heights", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.heights", hasSize(1)))
+                .andExpect(jsonPath("$.data.heights[0].rowIndex").value(1));
+    }
+
+    @Test
+    @DisplayName("DELETE rows/{r}/height - 높이를 지우면 기본 높이로 돌아간다")
+    void reset_row_height() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"a\",\"1\"]]");
+        mockMvc.perform(patch("/api/datasets/{id}/rows/0/height", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"height\":200}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(delete("/api/datasets/{id}/rows/0/height", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.heights", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("PATCH rows/{r}/height - 범위 밖 높이는 거부, 경계는 통과")
+    void set_row_height_bounds() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"a\",\"1\"]]");
+
+        for (String bad : new String[]{"23", "601", "0", "-5"}) {
+            mockMvc.perform(patch("/api/datasets/{id}/rows/0/height", id)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"height\":" + bad + "}"))
+                    .andExpect(status().isBadRequest());
+        }
+        for (String ok : new String[]{"24", "600"}) {
+            mockMvc.perform(patch("/api/datasets/{id}/rows/0/height", id)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"height\":" + ok + "}"))
+                    .andExpect(status().isOk());
+        }
+    }
+
+    @Test
+    @DisplayName("PATCH rows/{r}/height - height 누락은 거부, 없는 행은 404")
+    void set_row_height_invalid() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"a\",\"1\"]]");
+
+        mockMvc.perform(patch("/api/datasets/{id}/rows/0/height", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+        mockMvc.perform(patch("/api/datasets/{id}/rows/99/height", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"height\":100}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("남의 데이터셋 행 높이는 못 바꾼다")
+    void set_row_height_of_other_member() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"a\",\"1\"]]");
+        String otherToken = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+
+        mockMvc.perform(patch("/api/datasets/{id}/rows/0/height", id)
+                        .header(HttpHeaders.AUTHORIZATION, otherToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"height\":100}"))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetRow.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetRow.java
@@ -29,6 +29,10 @@ public class DatasetRow {
     @Column(columnDefinition = "JSON", nullable = false)
     private String cells;
 
+    /** 표시 높이(px). null이면 기본 높이. 열 너비처럼 값 있는 행만 담기는 sparse 속성. */
+    @Column
+    private Integer height;
+
     protected DatasetRow() {
     }
 
@@ -40,6 +44,11 @@ public class DatasetRow {
 
     public void updateCells(String cells) {
         this.cells = cells;
+    }
+
+    /** 행 높이를 바꾼다. null이면 기본 높이로 되돌린다. */
+    public void updateHeight(Integer height) {
+        this.height = height;
     }
 
     public void updateRowIndex(int rowIndex) {
@@ -60,5 +69,9 @@ public class DatasetRow {
 
     public String getCells() {
         return cells;
+    }
+
+    public Integer getHeight() {
+        return height;
     }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetRowRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetRowRepository.java
@@ -18,6 +18,9 @@ public interface DatasetRowRepository extends JpaRepository<DatasetRow, Long> {
 
     Optional<DatasetRow> findByDatasetIdAndRowIndex(Long datasetId, int rowIndex);
 
+    /** 높이를 바꾼 행만(sparse). 세로 병합 오버레이의 누적 오프셋 계산에 쓴다. */
+    List<DatasetRow> findByDatasetIdAndHeightIsNotNullOrderByRowIndexAsc(Long datasetId);
+
     /** 열 집계용 전체 조회. 수식이 열 전체를 참조할 때만 쓴다(비싸다). */
     List<DatasetRow> findByDatasetIdOrderByRowIndexAsc(Long datasetId);
 

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -44,6 +44,9 @@ function mockDataset(rows: string[][]) {
     http.get(`${API_BASE}/datasets/1/merges`, () =>
       HttpResponse.json({ code: "OK", data: { merges: [] } }),
     ),
+    http.get(`${API_BASE}/datasets/1/row-heights`, () =>
+      HttpResponse.json({ code: "OK", data: { heights: [] } }),
+    ),
   );
 }
 
@@ -52,6 +55,15 @@ function mockMerges(merges: unknown[]) {
   server.use(
     http.get(`${API_BASE}/datasets/1/merges`, () =>
       HttpResponse.json({ code: "OK", data: { merges } }),
+    ),
+  );
+}
+
+/** 그 dataset의 행 높이 리스트를 목킹한다(GET /row-heights). 기본이 아닌 행만 sparse. */
+function mockRowHeights(heights: unknown[]) {
+  server.use(
+    http.get(`${API_BASE}/datasets/1/row-heights`, () =>
+      HttpResponse.json({ code: "OK", data: { heights } }),
     ),
   );
 }
@@ -335,9 +347,10 @@ describe("DatasetGrid", () => {
       const row = document.querySelector(
         '[data-testid="dataset-grid"] div[style*="translateY(0px)"]',
       );
-      const cells = Array.from(row!.querySelectorAll(":scope > div")).map((c) =>
-        c.textContent?.trim(),
-      );
+      // 셀 div만 — 행 높이 리사이즈 핸들(role=separator)은 제외한다.
+      const cells = Array.from(
+        row!.querySelectorAll(":scope > div:not([role='separator'])"),
+      ).map((c) => c.textContent?.trim());
       expect(cells).toEqual(["재수강", "네트워크", "92"]);
     });
   });
@@ -1477,5 +1490,112 @@ describe("DatasetGrid", () => {
 
     // c0 오른쪽 = atIndex 1.
     await waitFor(() => expect(sent).toEqual({ atIndex: 1 }));
+  });
+
+  it("저장된 행 높이를 반영하고 아래 행은 그만큼 밀린다", async () => {
+    mockDataset([
+      ["네트워크", "92"],
+      ["보안", "80"],
+    ]);
+    mockRowHeights([{ rowIndex: 0, height: 120 }]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+
+    const row0 = document.querySelector(
+      '[data-testid="dataset-grid"] div[style*="translateY(0px)"]',
+    ) as HTMLElement;
+    expect(row0.style.height).toBe("120px");
+    // 0행이 120이라 1행은 120에서 시작(누적), 높이는 기본 36.
+    const row1 = document.querySelector(
+      'div[style*="translateY(120px)"]',
+    ) as HTMLElement;
+    expect(row1).toBeTruthy();
+    expect(row1.style.height).toBe("36px");
+  });
+
+  it("행 하단 핸들을 드래그하면 높이를 PATCH한다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let sent: unknown = null;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/rows/0/height`,
+        async ({ request }) => {
+          sent = await request.json();
+          return HttpResponse.json({
+            code: "OK",
+            data: { heights: [{ rowIndex: 0, height: 100 }] },
+          });
+        },
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+
+    const handle = screen.getByLabelText("1행 높이 조절");
+    fireEvent.pointerDown(handle, { clientY: 50 });
+    fireEvent.pointerMove(handle, { clientY: 114 }); // +64 → 36+64=100
+    fireEvent.pointerUp(handle, { clientY: 114 });
+
+    await waitFor(() => expect(sent).toEqual({ height: 100 }));
+  });
+
+  it("세로 병합 오버레이는 가변 행 높이의 누적 오프셋으로 그려진다", async () => {
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "점수" },
+            ],
+            rowCount: 3,
+          },
+        }),
+      ),
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              {
+                id: 100,
+                rowIndex: 0,
+                cells: ["네트워크", "92"],
+                formulas: {},
+                styles: {},
+              },
+              {
+                id: 101,
+                rowIndex: 1,
+                cells: ["보안", "80"],
+                formulas: {},
+                styles: {},
+              },
+              {
+                id: 102,
+                rowIndex: 2,
+                cells: ["암호", "70"],
+                formulas: {},
+                styles: {},
+              },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+    // 0행 높이 100 → 1행 오프셋 = 36 + (100-36) = 100. c0가 1..2행 세로 병합.
+    mockRowHeights([{ rowIndex: 0, height: 100 }]);
+    mockMerges([{ rowIndex: 1, colKey: "c0", rowSpan: 2, colSpan: 1 }]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("보안");
+
+    const box = screen.getByText("보안").closest("div[style]") as HTMLElement;
+    // top = 누적 오프셋(100), height = 1·2행 높이 합(36+36=72).
+    expect(box.style.top).toBe("100px");
+    expect(box.style.height).toBe("72px");
   });
 });

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -38,26 +38,33 @@ import {
   deleteCellMerge,
   deleteDatasetColumn,
   deleteDatasetRow,
+  deleteRowHeight,
   insertDatasetRow,
   MAX_COLUMN_WIDTH,
+  MAX_ROW_HEIGHT,
   type MergeSpan,
   type MergeView,
   MIN_COLUMN_WIDTH,
+  MIN_ROW_HEIGHT,
   renameDatasetColumn,
   reorderDatasetColumns,
   resetDatasetColumnWidth,
   resizeDatasetColumn,
+  type RowHeight,
   setCellMerge,
   setCellStyle,
   setDatasetColumnAlign,
+  setRowHeight,
   updateDatasetRow,
 } from "./api/datasets";
 import { useDatasetMerges } from "./hooks/useDatasetMerges";
 import { useDatasetMeta } from "./hooks/useDatasetMeta";
+import { useDatasetRowHeights } from "./hooks/useDatasetRowHeights";
 import { useDatasetRows } from "./hooks/useDatasetRows";
 import { datasetKeys } from "./queryKeys";
 
-const ROW_HEIGHT = 36;
+/** 기본 행 높이(px). 사용자가 행별로 조절하면 그 행만 달라진다(sparse, #839). */
+const DEFAULT_ROW_HEIGHT = 36;
 /** 표 뷰 높이(px) — 기본·하한·상한. 사용자가 하단 핸들로 이 범위에서 조절한다. */
 const DEFAULT_BODY_HEIGHT = 420;
 const MIN_BODY_HEIGHT = 120;
@@ -83,6 +90,8 @@ export function DatasetGrid({ datasetId }: Props) {
   } = useDatasetRows(datasetId);
   // 병합은 dataset 단위로 통째 받는다 — 세로 병합은 앵커가 화면 밖이어도 덮인 행을 그려야 한다.
   const { data: merges = [] } = useDatasetMerges(datasetId);
+  // 행 높이도 dataset 단위 — 병합 오버레이가 앵커 밖 행의 누적 높이를 알아야 한다(#839).
+  const { data: rowHeights = [] } = useDatasetRowHeights(datasetId);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [editing, setEditing] = useState<{ row: number; col: number } | null>(
     null,
@@ -120,6 +129,13 @@ export function DatasetGrid({ datasetId }: Props) {
     row: number;
     col: number;
   } | null>(null);
+  // 행 높이 리사이즈 중(대상 행·시작점·진행 높이). 드래그하는 동안만 값이 있다.
+  const [rowResize, setRowResize] = useState<{
+    index: number;
+    startY: number;
+    startHeight: number;
+    height: number;
+  } | null>(null);
 
   const colCount = meta?.columns.length ?? 0;
   const rowCount = meta?.rowCount ?? 0;
@@ -130,6 +146,11 @@ export function DatasetGrid({ datasetId }: Props) {
   // 병합을 다시 받는다.
   const invalidateMerges = () =>
     queryClient.invalidateQueries({ queryKey: datasetKeys.merges(datasetId) });
+  // 행 삽입·삭제로 행 번호가 밀리면 높이(번호 키)도 다시 받는다.
+  const invalidateRowHeights = () =>
+    queryClient.invalidateQueries({
+      queryKey: datasetKeys.rowHeights(datasetId),
+    });
 
   const updateMut = useMutation({
     mutationFn: (v: { index: number; cells: string[] }) =>
@@ -186,6 +207,7 @@ export function DatasetGrid({ datasetId }: Props) {
       reset();
       void invalidateMeta();
       void invalidateMerges(); // 뒤 행이 밀려 병합의 행 번호가 바뀌고, 안에 끼면 해제된다.
+      void invalidateRowHeights(); // 뒤 행 높이의 행 번호도 밀린다.
     },
   });
   const deleteMut = useMutation({
@@ -194,6 +216,7 @@ export function DatasetGrid({ datasetId }: Props) {
       reset();
       void invalidateMeta();
       void invalidateMerges(); // 앵커 행 삭제는 cascade, 뒤 행은 번호가 밀린다.
+      void invalidateRowHeights();
     },
   });
   const renameColMut = useMutation({
@@ -237,6 +260,23 @@ export function DatasetGrid({ datasetId }: Props) {
       queryClient.setQueryData(datasetKeys.meta(datasetId), next),
     onError: () => void invalidateMeta(),
   });
+  const setRowHeightMut = useMutation({
+    mutationFn: (v: { index: number; height: number }) =>
+      setRowHeight(datasetId, v.index, v.height),
+    // 높이는 행 단위 표시 속성이라 값 캐시는 그대로 두고 높이 리스트만 갱신한다(서버가 전체 반환).
+    onSuccess: (list: RowHeight[]) =>
+      queryClient.setQueryData(datasetKeys.rowHeights(datasetId), list),
+    onError: (e) => {
+      const message = serverMessage(e);
+      if (message) toast(message, "error");
+    },
+  });
+  const resetRowHeightMut = useMutation({
+    mutationFn: (index: number) => deleteRowHeight(datasetId, index),
+    onSuccess: (list: RowHeight[]) =>
+      queryClient.setQueryData(datasetKeys.rowHeights(datasetId), list),
+    onError: () => void invalidateRowHeights(),
+  });
   const setColAlignMut = useMutation({
     mutationFn: (v: { key: string; align: CellAlign }) =>
       setDatasetColumnAlign(datasetId, v.key, v.align),
@@ -276,10 +316,15 @@ export function DatasetGrid({ datasetId }: Props) {
     getCoreRowModel: getCoreRowModel(),
   });
 
+  // 확정된(드래그 제외) 행 높이 — 가상화 estimateSize·누적 오프셋의 기준. 값 있는 행만 sparse.
+  const heightMap = new Map(rowHeights.map((h) => [h.rowIndex, h.height]));
+  const committedHeightAt = (i: number) =>
+    heightMap.get(i) ?? DEFAULT_ROW_HEIGHT;
+
   const virtualizer = useVirtualizer({
     count: rowCount,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => ROW_HEIGHT,
+    estimateSize: (i) => committedHeightAt(i),
     overscan: 12,
   });
   const virtualItems = virtualizer.getVirtualItems();
@@ -325,6 +370,28 @@ export function DatasetGrid({ datasetId }: Props) {
 
   const clampWidth = (width: number) =>
     Math.round(Math.min(MAX_COLUMN_WIDTH, Math.max(MIN_COLUMN_WIDTH, width)));
+
+  /** 화면에 그릴 행 높이 — 드래그 중인 행은 진행 높이를 쓴다. */
+  const displayHeightAt = (i: number) =>
+    rowResize?.index === i ? rowResize.height : committedHeightAt(i);
+  /** i번 행 위쪽 누적 높이. override가 sparse라 합산이 저렴. 병합 오버레이 top에 쓴다. */
+  const rowOffset = (i: number) => {
+    let extra = 0;
+    for (const h of rowHeights) {
+      if (h.rowIndex < i) extra += h.height - DEFAULT_ROW_HEIGHT;
+    }
+    return i * DEFAULT_ROW_HEIGHT + extra;
+  };
+  /** [i, i+span) 행 높이 합. 병합 오버레이 height에 쓴다. */
+  const rowRangeHeight = (i: number, span: number) => {
+    let total = 0;
+    for (let k = i; k < i + span; k++) total += committedHeightAt(k);
+    return total;
+  };
+  // 드래그 중이면 그 아래 행들이 이만큼 밀린다(가상화 reflow 없이 시각만 반영, 놓을 때 확정).
+  const rowDragDelta = rowResize ? rowResize.height - rowResize.startHeight : 0;
+  const clampRowHeight = (h: number) =>
+    Math.round(Math.min(MAX_ROW_HEIGHT, Math.max(MIN_ROW_HEIGHT, h)));
 
   const startResize = (key: string, event: React.PointerEvent) => {
     // 헤더 셀의 실제 렌더 폭에서 시작한다. 너비 미지정(1fr) 열도 이 값으로 잡히므로
@@ -385,6 +452,40 @@ export function DatasetGrid({ datasetId }: Props) {
     if (!viewResize) return;
     setViewResize(null);
     writeBodyHeight(datasetId, bodyHeight);
+  };
+
+  // 행 높이 리사이즈 — 열 너비와 같은 pointer 패턴. 드래그 중엔 로컬 상태로 그리고(가상화 reflow 없이
+  // 아래 행을 밀어 시각 반영), 놓을 때 서버에 한 번 저장한다.
+  const startRowResize = (index: number, event: React.PointerEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    const startHeight = committedHeightAt(index);
+    setRowResize({
+      index,
+      startY: event.clientY,
+      startHeight,
+      height: startHeight,
+    });
+  };
+
+  const moveRowResize = (event: React.PointerEvent) => {
+    if (!rowResize) return;
+    setRowResize({
+      ...rowResize,
+      height: clampRowHeight(
+        rowResize.startHeight + (event.clientY - rowResize.startY),
+      ),
+    });
+  };
+
+  const endRowResize = () => {
+    if (!rowResize) return;
+    const { index, height, startHeight } = rowResize;
+    setRowResize(null);
+    // 높이가 그대로면 저장하지 않는다 — 핸들을 그냥 누르기만 한 경우.
+    if (Math.round(startHeight) === height) return;
+    setRowHeightMut.mutate({ index, height });
   };
 
   const startEdit = (row: number, col: number) => {
@@ -560,6 +661,8 @@ export function DatasetGrid({ datasetId }: Props) {
     // 셀 정렬(override) > 열 기본 정렬 > 기본(left) (#828 D2).
     const align = style?.align ?? meta.columns[c].align ?? "left";
     const paletteOpen = palette?.row === rowIndex && palette.col === c;
+    // 높이를 늘린 행은 truncate 대신 줄바꿈해 여러 줄 표시(안 그러면 빈 여백만).
+    const tall = displayHeightAt(rowIndex) > DEFAULT_ROW_HEIGHT;
     return (
       <>
         {/* 셀 서식·병합 버튼 — 호버 시 나타난다. */}
@@ -659,7 +762,10 @@ export function DatasetGrid({ datasetId }: Props) {
         ) : (
           <div
             className={cn(
-              "h-full cursor-text truncate px-2 py-1.5",
+              "h-full cursor-text px-2 py-1.5",
+              tall
+                ? "overflow-hidden break-words whitespace-pre-wrap"
+                : "truncate",
               ALIGN_CLASS[align],
               cells === undefined && "text-muted-foreground/40",
               isCellError(cells?.[c]) && "text-destructive",
@@ -818,7 +924,10 @@ export function DatasetGrid({ datasetId }: Props) {
 
         {/* 본문 (가상화) */}
         <div
-          style={{ height: virtualizer.getTotalSize(), position: "relative" }}
+          style={{
+            height: virtualizer.getTotalSize() + rowDragDelta,
+            position: "relative",
+          }}
         >
           {virtualItems.map((vi) => {
             // 그 행에 앵커가 있는 가로 전용 병합(rowSpan===1). 덮인 칸은 스킵하고 앵커가 span으로 넓게.
@@ -834,10 +943,14 @@ export function DatasetGrid({ datasetId }: Props) {
             return (
               <div
                 key={vi.key}
-                className="border-border absolute top-0 left-0 grid w-full border-b text-sm"
+                className="border-border group/row absolute top-0 left-0 grid w-full border-b text-sm"
                 style={{
-                  height: ROW_HEIGHT,
-                  transform: `translateY(${vi.start}px)`,
+                  height: displayHeightAt(vi.index),
+                  // 드래그 중이면 그 아래 행들을 delta만큼 민다(가상화 reflow 없이 시각만).
+                  transform: `translateY(${
+                    vi.start +
+                    (rowResize && vi.index > rowResize.index ? rowDragDelta : 0)
+                  }px)`,
                   gridTemplateColumns,
                 }}
               >
@@ -878,6 +991,23 @@ export function DatasetGrid({ datasetId }: Props) {
                 >
                   <Trash2 className="size-3.5" />
                 </button>
+                {/* 행 하단 경계 드래그 핸들 — 열 너비의 세로판. 호버 시 나타난다. */}
+                <div
+                  role="separator"
+                  aria-orientation="horizontal"
+                  aria-label={`${vi.index + 1}행 높이 조절`}
+                  title="드래그해 행 높이 조절 · 더블클릭해 기본 높이로"
+                  onPointerDown={(e) => startRowResize(vi.index, e)}
+                  onPointerMove={moveRowResize}
+                  onPointerUp={endRowResize}
+                  onPointerCancel={endRowResize}
+                  onDoubleClick={() => resetRowHeightMut.mutate(vi.index)}
+                  className={cn(
+                    "hover:bg-primary/60 absolute bottom-0 left-0 z-10 -mb-[3px] h-[6px] w-full cursor-row-resize touch-none opacity-0 group-hover/row:opacity-100",
+                    rowResize?.index === vi.index &&
+                      "bg-primary/60 opacity-100",
+                  )}
+                />
               </div>
             );
           })}
@@ -887,7 +1017,10 @@ export function DatasetGrid({ datasetId }: Props) {
               고정 행 높이라 세로는 top·height를 px로 계산한다(측정 불필요). */}
           <div
             className="pointer-events-none absolute top-0 left-0 grid w-full"
-            style={{ gridTemplateColumns, height: virtualizer.getTotalSize() }}
+            style={{
+              gridTemplateColumns,
+              height: virtualizer.getTotalSize() + rowDragDelta,
+            }}
           >
             {overlayMerges
               .filter(
@@ -908,8 +1041,9 @@ export function DatasetGrid({ datasetId }: Props) {
                     <div
                       className="border-border bg-card group/cell pointer-events-auto absolute right-0 left-0 truncate border-r border-b text-sm"
                       style={{
-                        top: m.rowIndex * ROW_HEIGHT,
-                        height: m.rowSpan * ROW_HEIGHT,
+                        // 누적 오프셋 — 가변 행 높이에서도 정확(고정 높이면 rowIndex×36과 같다).
+                        top: rowOffset(m.rowIndex),
+                        height: rowRangeHeight(m.rowIndex, m.rowSpan),
                         ...(style?.bg
                           ? { background: `var(--cell-bg-${style.bg})` }
                           : {}),

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -17,6 +17,19 @@ export const MIN_COLUMN_WIDTH = 60;
 /** 열 너비 상한(px). 서버의 DatasetColumn.MAX_WIDTH와 같아야 한다. */
 export const MAX_COLUMN_WIDTH = 800;
 
+/** 행 높이 하한·상한(px). 서버의 SetRowHeightRequest.MIN/MAX_HEIGHT와 같아야 한다. */
+export const MIN_ROW_HEIGHT = 24;
+export const MAX_ROW_HEIGHT = 600;
+
+/**
+ * 기본이 아닌 행 높이 하나(행 번호 → px). 병합처럼 dataset 단위로 통째 받는다 —
+ * 세로 병합 오버레이가 앵커 밖 행의 누적 높이를 알아야 한다.
+ */
+export interface RowHeight {
+  rowIndex: number;
+  height: number;
+}
+
 /** 셀 배경 팔레트 토큰. 서버의 CellStyle.ALLOWED_BG·index.css의 --cell-bg-*와 같아야 한다. */
 export const CELL_BG_TOKENS = [
   "red",
@@ -292,6 +305,38 @@ export async function deleteCellMerge(
     `/datasets/${datasetId}/rows/${rowIndex}/cells/${colKey}/merge`,
   );
   return data.data.merges;
+}
+
+/** 그 dataset의 기본이 아닌 행 높이 전체. 세로 병합 오버레이의 누적 높이 계산에 필요해 통째로 받는다. */
+export async function fetchRowHeights(datasetId: number): Promise<RowHeight[]> {
+  const { data } = await client.get<ApiEnvelope<{ heights: RowHeight[] }>>(
+    `/datasets/${datasetId}/row-heights`,
+  );
+  return data.data.heights;
+}
+
+/** 행 높이 변경(px). 갱신된 높이 전체를 돌려준다. */
+export async function setRowHeight(
+  datasetId: number,
+  rowIndex: number,
+  height: number,
+): Promise<RowHeight[]> {
+  const { data } = await client.patch<ApiEnvelope<{ heights: RowHeight[] }>>(
+    `/datasets/${datasetId}/rows/${rowIndex}/height`,
+    { height },
+  );
+  return data.data.heights;
+}
+
+/** 행 높이 초기화 — 기본 높이로 되돌린다. 갱신된 높이 전체를 돌려준다. */
+export async function deleteRowHeight(
+  datasetId: number,
+  rowIndex: number,
+): Promise<RowHeight[]> {
+  const { data } = await client.delete<ApiEnvelope<{ heights: RowHeight[] }>>(
+    `/datasets/${datasetId}/rows/${rowIndex}/height`,
+  );
+  return data.data.heights;
 }
 
 export async function insertDatasetRow(

--- a/fe/src/features/note/dataset/hooks/useDatasetRowHeights.ts
+++ b/fe/src/features/note/dataset/hooks/useDatasetRowHeights.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchRowHeights } from "../api/datasets";
+import { datasetKeys } from "../queryKeys";
+
+/**
+ * 그 dataset의 기본이 아닌 행 높이 전체를 조회한다. 세로 병합 오버레이가 앵커 밖 행의 누적 높이를
+ * 알아야 하므로, 높이는 페이지가 아니라 dataset 단위로 통째 가져온다(대개 sparse).
+ */
+export function useDatasetRowHeights(datasetId: number) {
+  return useQuery({
+    queryKey: datasetKeys.rowHeights(datasetId),
+    queryFn: () => fetchRowHeights(datasetId),
+    staleTime: 60 * 1000,
+  });
+}

--- a/fe/src/features/note/dataset/queryKeys.ts
+++ b/fe/src/features/note/dataset/queryKeys.ts
@@ -4,4 +4,5 @@ export const datasetKeys = {
   rows: (id: number, offset: number, limit: number) =>
     ["datasets", id, "rows", offset, limit] as const,
   merges: (id: number) => ["datasets", id, "merges"] as const,
+  rowHeights: (id: number) => ["datasets", id, "rowHeights"] as const,
 };


### PR DESCRIPTION
## 이슈
closes #839

## 작업 내용
행 높이를 **하단 핸들 드래그**로 조절 가능하게 했다(열 너비의 세로판). 설계는 [Data-Grid-Cell-Merge](https://github.com/wcorn/orino/wiki/Data-Grid-Cell-Merge) §7·[Data-Grid-Block](https://github.com/wcorn/orino/wiki/Data-Grid-Block).

### 저장 — sparse override
- `dataset_row.height`(nullable). 열 너비가 `columns_json`(열 속성)이듯 **행 속성은 `dataset_row`에**. 바꾼 행만 값 → sparse.
- 세로 병합 오버레이가 앵커 밖(미로드) 행의 누적 높이를 알아야 해, **비기본 높이 전체를 `GET /row-heights`로 통째** 받는다(병합과 같은 load-all). row_id 저장, rowIndex로 변환.
- API: `PATCH`/`DELETE /rows/{r}/height`(24~600px), `GET /row-heights`. 갱신된 전체 반환.

### 렌더
- **가상화**: `estimateSize`를 가변으로 — known 높이라 `measureElement` 불필요. `vi.start` 누적 자동.
- **병합 오버레이(핵심 재작업)**: `top`/`height`를 `rowIndex×36`에서 **누적 오프셋**으로 —
  `rowOffset(i) = i×36 + Σ_{j<i,override}(h[j]−36)`, span 높이 `= Σ 덮는 행 높이`. override sparse라 저렴. 고정 높이면 `i×36`과 동일.
- **정합성 보장**: 이 누적이 가상화 `vi.start`와 일치함을 테스트로 확인 — `row0=120` → `row1`이 `translateY(120px)`에 위치(가상화)하고 `rowOffset(1)=120`(오버레이)로 맞아떨어진다. 둘 다 같은 estimateSize의 누적이라 어긋날 수 없다.
- **드래그 UX**: 드래그 중엔 가상화 reflow 없이 아래 행을 delta만큼 밀어 시각 반영, 놓을 때 저장.
- **줄바꿈**: 높이 늘린 행은 `truncate` 대신 wrap(안 그러면 빈 여백만).

### 구조 변경
- 행 삽입·삭제 시 병합처럼 높이도 다시 받는다(행 번호가 밀린다). covered 행 리사이즈 → 병합 총 높이=합이라 자동 반영.

### 검증
- **BE 5건**: 높이 저장·조회(sparse) / 초기화 / 범위(24~600) / 누락·없는 행 / 남의 데이터셋.
- **FE 3건**: 저장 높이 반영 + 아래 행 누적 밀림 / 핸들 드래그 → PATCH / **세로 병합 오버레이가 가변 높이 누적 오프셋으로**(top 100·height 72).
- `./gradlew checkstyle`·BE 전체(TestContainers) · `npm run lint`·`format:check`·`build`·FE 전체 360건 통과.
- ⚠️ 오버레이 누적 오프셋은 순수 산술이라 jsdom이 값(top/height)과 **가상화 vi.start와의 일치**를 검증. 앞선 오버레이 x/폭 기법은 이전 PR에서 브라우저 실증.

### 문서
Data-Grid-Block(`dataset_row.height`·row-heights API) · Data-Grid-Cell-Merge(누적 오프셋) 갱신.

이로써 사용자 제안 개선(뷰 크기·행/열 조작·우클릭 메뉴·행/열 크기 조정)이 모두 반영됐다.