### PR TITLE
feat : 데이터 그리드 notion 스타일 값-중심 표

### DIFF
--- a/fe/src/features/note/components/NoteTab.test.tsx
+++ b/fe/src/features/note/components/NoteTab.test.tsx
@@ -368,8 +368,9 @@ describe("NoteTab", () => {
     await user.click(screen.getByRole("button", { name: "표 삽입" }));
 
     // dataset 생성 → datasetTable 노드 → NodeView → DatasetGrid 렌더
+    // 제목 행이 없는 값-중심 표라 열 라벨 대신 그리드 컨트롤(행 추가)로 확인한다.
     expect(await screen.findByTestId("dataset-grid")).toBeInTheDocument();
-    expect(screen.getByText("열 1")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "행 추가" })).toBeInTheDocument();
   });
 
   it("툴바 [이미지 추가]로 파일 선택 시 presign→PUT 후 본문에 이미지가 삽입된다", async () => {
@@ -469,9 +470,10 @@ describe("NoteTab", () => {
     await screen.findByText("총 1행 × 2열");
     await user.click(screen.getByRole("button", { name: "표로 가져오기" }));
 
-    // 본문에 datasetTable → DatasetGrid가 렌더되고 헤더 라벨이 보인다
+    // 본문에 datasetTable → DatasetGrid가 렌더되고 가져온 값 셀이 보인다
+    // (제목 행이 없어 헤더 라벨 대신 데이터 값 "A"로 확인 — 셀은 지연 로드라 findByText로 기다린다)
     expect(await screen.findByTestId("dataset-grid")).toBeInTheDocument();
-    expect(screen.getByText("항목")).toBeInTheDocument();
+    expect(await screen.findByText("A")).toBeInTheDocument();
   });
 
   it("자손이 있는 노트 삭제 시 확인 문구에 하위 개수를 표시한다", async () => {
@@ -543,8 +545,9 @@ describe("NoteTab", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("노트 제목")).toHaveValue("표노트");
     });
-    // 노드 → NodeView → DatasetGrid(헤더) 렌더
+    // 노드 → NodeView → DatasetGrid 렌더 (제목 행 없는 값-중심 표 —
+    // rowCount 0이라 값도 없어 그리드 컨트롤(행 추가)로 확인한다)
     expect(await screen.findByTestId("dataset-grid")).toBeInTheDocument();
-    expect(screen.getByText("과목")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "행 추가" })).toBeInTheDocument();
   });
 });

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -83,17 +83,20 @@ describe("DatasetGrid", () => {
     vi.restoreAllMocks();
   });
 
-  it("헤더와 행을 지연 로드해 렌더한다", async () => {
+  it("제목 행 없이 값 셀만 지연 로드해 렌더한다", async () => {
     mockDataset([
       ["네트워크", "92"],
       ["운영체제", "78"],
     ]);
     renderWithRouter(<DatasetGrid datasetId={1} />);
 
-    expect(await screen.findByText("과목")).toBeInTheDocument();
-    expect(screen.getByText("점수")).toBeInTheDocument();
     expect(await screen.findByText("네트워크")).toBeInTheDocument();
+    expect(screen.getByText("92")).toBeInTheDocument();
+    expect(screen.getByText("운영체제")).toBeInTheDocument();
     expect(screen.getByText("78")).toBeInTheDocument();
+    // 열 제목(과목·점수)은 렌더되지 않는다 — 값만 있는 표.
+    expect(screen.queryByText("과목")).not.toBeInTheDocument();
+    expect(screen.queryByText("점수")).not.toBeInTheDocument();
   });
 
   it("세로 뷰포트 없이 행 수만큼 자란다 — 높이 상한이 없고 가로만 스크롤한다", async () => {
@@ -112,8 +115,9 @@ describe("DatasetGrid", () => {
     // 뷰 높이 조절 핸들은 사라졌다.
     expect(screen.queryByLabelText("표 높이 조절")).toBeNull();
 
-    // 본문 목록 높이 = 행 수 × 고정 행 높이(36).
-    const body = scroll.children[1] as HTMLElement;
+    // 제목 행이 없어 본문 목록이 스크롤의 첫 자식이다.
+    // 높이 = 행 수 × 고정 행 높이(36).
+    const body = scroll.children[0] as HTMLElement;
     expect(body.style.height).toBe("108px");
   });
 
@@ -122,13 +126,14 @@ describe("DatasetGrid", () => {
     renderWithRouter(<DatasetGrid datasetId={1} />);
     await screen.findByText("네트워크");
 
+    // 행 추가 버튼 자체가 기본 opacity-0, 표(group/grid) 호버 시 드러난다.
     const addRow = screen.getByRole("button", { name: "행 추가" });
-    const addCol = screen.getByLabelText("열 추가");
-    // 기본은 opacity-0, 표(group/grid) 호버 시 opacity-100로 드러난다.
-    for (const btn of [addRow, addCol]) {
-      expect(btn.className).toContain("opacity-0");
-      expect(btn.className).toContain("group-hover/grid:opacity-100");
-    }
+    expect(addRow.className).toContain("opacity-0");
+    expect(addRow.className).toContain("group-hover/grid:opacity-100");
+    // 열 추가 버튼은 오른쪽 가장자리 스트립 안에 있고, 스트립이 호버 시 드러난다.
+    const strip = screen.getByLabelText("열 추가").parentElement as HTMLElement;
+    expect(strip.className).toContain("opacity-0");
+    expect(strip.className).toContain("group-hover/grid:opacity-100");
   });
 
   it("셀을 클릭해 편집하면 PATCH로 저장한다", async () => {
@@ -243,7 +248,9 @@ describe("DatasetGrid", () => {
       ),
     );
 
-    await user.click(screen.getByRole("button", { name: "점수 열 삭제" }));
+    // 헤더가 없어 열 삭제는 셀 우클릭 메뉴로 한다 — c1(점수) 값 "92" 셀을 우클릭.
+    fireEvent.contextMenu(screen.getByText("92"));
+    await user.click(await screen.findByRole("menuitem", { name: "열 삭제" }));
     // 확인 전엔 요청이 나가지 않는다.
     expect(deletedKey).toBeNull();
     await user.click(screen.getByRole("button", { name: "삭제" }));
@@ -255,148 +262,6 @@ describe("DatasetGrid", () => {
     // 재조회가 안 되면 여기서 "92"가 남아 실패한다.
     expect(await screen.findByText("재수강")).toBeInTheDocument();
     expect(screen.queryByText("92")).not.toBeInTheDocument();
-  });
-
-  it("헤더를 드래그해 순서를 바꾸면 PATCH하고 값이 열을 따라간다", async () => {
-    // 3열 과목/점수/비고 — 비고(c2)를 맨 앞으로 끈다.
-    server.use(
-      http.get(`${API_BASE}/datasets/1`, () =>
-        HttpResponse.json({
-          code: "OK",
-          data: {
-            id: 1,
-            columns: [
-              { key: "c0", label: "과목" },
-              { key: "c1", label: "점수" },
-              { key: "c2", label: "비고" },
-            ],
-            rowCount: 1,
-          },
-        }),
-      ),
-      http.get(`${API_BASE}/datasets/1/rows`, () =>
-        HttpResponse.json({
-          code: "OK",
-          data: {
-            rows: [
-              { id: 100, rowIndex: 0, cells: ["네트워크", "92", "재수강"] },
-            ],
-            offset: 0,
-            limit: 100,
-          },
-        }),
-      ),
-    );
-    renderWithRouter(<DatasetGrid datasetId={1} />);
-    await screen.findByText("네트워크");
-
-    let sentKeys: string[] | null = null;
-    server.use(
-      http.patch(
-        `${API_BASE}/datasets/1/columns/order`,
-        async ({ request }) => {
-          const body = (await request.json()) as { keys: string[] };
-          sentKeys = body.keys;
-          return HttpResponse.json({
-            code: "OK",
-            data: {
-              id: 1,
-              columns: [
-                { key: "c2", label: "비고" },
-                { key: "c0", label: "과목" },
-                { key: "c1", label: "점수" },
-              ],
-              rowCount: 1,
-            },
-          });
-        },
-      ),
-      // 서버는 새 열 순서로 투영해 준다.
-      http.get(`${API_BASE}/datasets/1/rows`, () =>
-        HttpResponse.json({
-          code: "OK",
-          data: {
-            rows: [
-              { id: 100, rowIndex: 0, cells: ["재수강", "네트워크", "92"] },
-            ],
-            offset: 0,
-            limit: 100,
-          },
-        }),
-      ),
-    );
-
-    const headers = document.querySelectorAll(
-      '[data-testid="dataset-grid"] .sticky > div',
-    );
-    fireEvent.dragStart(headers[2]); // 비고
-    fireEvent.dragOver(headers[0]);
-    fireEvent.drop(headers[0]); // 과목 자리에 놓기
-
-    await waitFor(() => expect(sentKeys).toEqual(["c2", "c0", "c1"]));
-    expect(await screen.findByText("비고")).toBeInTheDocument();
-    // 재조회가 안 되면 여기서 옛 순서(네트워크가 첫 칸)가 남아 실패한다.
-    await waitFor(() => {
-      const row = document.querySelector(
-        '[data-testid="dataset-grid"] div[style*="translateY(0px)"]',
-      );
-      const cells = Array.from(row!.querySelectorAll(":scope > div")).map((c) =>
-        c.textContent?.trim(),
-      );
-      expect(cells).toEqual(["재수강", "네트워크", "92"]);
-    });
-  });
-
-  it("같은 자리에 놓으면 PATCH하지 않는다", async () => {
-    mockDataset([["네트워크", "92"]]);
-    let called = false;
-    server.use(
-      http.patch(`${API_BASE}/datasets/1/columns/order`, () => {
-        called = true;
-        return new HttpResponse(null, { status: 400 });
-      }),
-    );
-    renderWithRouter(<DatasetGrid datasetId={1} />);
-    await screen.findByText("네트워크");
-
-    const headers = document.querySelectorAll(
-      '[data-testid="dataset-grid"] .sticky > div',
-    );
-    fireEvent.dragStart(headers[0]);
-    fireEvent.drop(headers[0]);
-
-    expect(called).toBe(false);
-  });
-
-  it("마지막 한 열만 남으면 삭제 버튼을 내보내지 않는다", async () => {
-    server.use(
-      http.get(`${API_BASE}/datasets/1`, () =>
-        HttpResponse.json({
-          code: "OK",
-          data: {
-            id: 1,
-            columns: [{ key: "c0", label: "과목" }],
-            rowCount: 1,
-          },
-        }),
-      ),
-      http.get(`${API_BASE}/datasets/1/rows`, () =>
-        HttpResponse.json({
-          code: "OK",
-          data: {
-            rows: [{ id: 100, rowIndex: 0, cells: ["네트워크"] }],
-            offset: 0,
-            limit: 100,
-          },
-        }),
-      ),
-    );
-    renderWithRouter(<DatasetGrid datasetId={1} />);
-
-    expect(await screen.findByText("과목")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "과목 열 삭제" }),
-    ).not.toBeInTheDocument();
   });
 
   it("다른 셀을 고칠 때 수식 셀엔 원본 수식을 돌려준다 — 값을 돌려주면 수식이 지워진다", async () => {
@@ -551,24 +416,6 @@ describe("DatasetGrid", () => {
     expect(await screen.findByLabelText("셀 1행 1열")).toHaveValue("10");
   });
 
-  it("[수식 보기]를 켜면 계산값 대신 수식이 보인다", async () => {
-    mockFormulaRow();
-    const user = userEvent.setup();
-    renderWithRouter(<DatasetGrid datasetId={1} />);
-    await screen.findByText("30");
-
-    await user.click(screen.getByRole("button", { name: "수식 보기" }));
-
-    expect(await screen.findByText("=({단가} * 3)")).toBeInTheDocument();
-    expect(screen.queryByText("30")).not.toBeInTheDocument();
-    // 수식 없는 셀은 그대로 값.
-    expect(screen.getByText("10")).toBeInTheDocument();
-
-    // 다시 끄면 값으로 돌아온다.
-    await user.click(screen.getByRole("button", { name: "수식 보기" }));
-    expect(await screen.findByText("30")).toBeInTheDocument();
-  });
-
   it("서버가 알려준 수식 오류를 그대로 보여준다", async () => {
     mockDataset([["10", "3"]]);
     server.use(
@@ -625,9 +472,16 @@ describe("DatasetGrid", () => {
     await screen.findByText("네트워크");
     await user.click(screen.getByRole("button", { name: "열 추가" }));
 
-    expect(await screen.findByText("열 3")).toBeInTheDocument();
-    // 클라이언트는 이름을 짓지 않는다 — 열 개수 기반 규칙이 삭제 후 중복을 만들었다.
-    expect(sentBody).toEqual({});
+    // 클라이언트는 이름을 짓지 않는다(서버가 붙인다) — 빈 body로 POST한다.
+    await waitFor(() => expect(sentBody).toEqual({}));
+    // 새 열이 붙어 행에 빈 3번째 값 셀이 생긴다(제목이 없어 셀 개수로 확인).
+    await waitFor(() => {
+      expect(
+        document.querySelector(
+          '[data-testid="dataset-grid"] div[style*="translateY(0px)"] > div:nth-child(3)',
+        ),
+      ).not.toBeNull();
+    });
     // 행을 다시 받지 않으므로 기존 값이 깜빡임 없이 그대로 남는다.
     expect(screen.getByText("네트워크")).toBeInTheDocument();
     expect(screen.getByText("92")).toBeInTheDocument();
@@ -666,7 +520,14 @@ describe("DatasetGrid", () => {
 
     await screen.findByText("네트워크");
     await user.click(screen.getByRole("button", { name: "열 추가" }));
-    await screen.findByText("열 3");
+    // 새 3번째 셀이 붙을 때까지 기다린다(제목이 없어 셀 개수로 확인).
+    await waitFor(() => {
+      expect(
+        document.querySelector(
+          '[data-testid="dataset-grid"] div[style*="translateY(0px)"] > div:nth-child(3)',
+        ),
+      ).not.toBeNull();
+    });
 
     // 편집 전엔 input이 없어 라벨로 못 찾는다 — 행의 3번째 셀 div를 눌러 편집을 연다.
     const thirdCell = document.querySelector(
@@ -680,63 +541,6 @@ describe("DatasetGrid", () => {
     await waitFor(() => {
       expect(patched).toEqual(["네트워크", "92", "재수강"]);
     });
-  });
-
-  it("열 헤더를 더블클릭해 편집하면 PATCH로 저장하고 새 이름을 보여준다", async () => {
-    mockDataset([["네트워크", "92"]]);
-    let renamed: { key: string; label: string } | null = null;
-    server.use(
-      http.patch(
-        `${API_BASE}/datasets/1/columns/:key`,
-        async ({ params, request }) => {
-          const body = (await request.json()) as { label: string };
-          renamed = { key: String(params.key), label: body.label };
-          return HttpResponse.json({
-            code: "OK",
-            data: {
-              id: 1,
-              columns: [
-                { key: "c0", label: "과목" },
-                { key: "c1", label: body.label },
-              ],
-              rowCount: 1,
-            },
-          });
-        },
-      ),
-    );
-    renderWithRouter(<DatasetGrid datasetId={1} />);
-
-    fireEvent.doubleClick(await screen.findByText("점수"));
-    const input = await screen.findByLabelText("열 이름 c1");
-    fireEvent.change(input, { target: { value: "최종점수" } });
-    fireEvent.keyDown(input, { key: "Enter" });
-
-    await waitFor(() => {
-      expect(renamed).toEqual({ key: "c1", label: "최종점수" });
-    });
-    expect(await screen.findByText("최종점수")).toBeInTheDocument();
-  });
-
-  it("열 이름을 비우면 PATCH를 보내지 않는다", async () => {
-    mockDataset([["네트워크", "92"]]);
-    let called = false;
-    server.use(
-      http.patch(`${API_BASE}/datasets/1/columns/:key`, () => {
-        called = true;
-        return new HttpResponse(null, { status: 400 });
-      }),
-    );
-    renderWithRouter(<DatasetGrid datasetId={1} />);
-
-    fireEvent.doubleClick(await screen.findByText("점수"));
-    const input = await screen.findByLabelText("열 이름 c1");
-    fireEvent.change(input, { target: { value: "   " } });
-    fireEvent.keyDown(input, { key: "Enter" });
-
-    // 편집이 닫히고 원래 이름이 남는다
-    expect(await screen.findByText("점수")).toBeInTheDocument();
-    expect(called).toBe(false);
   });
 
   it("행 삭제 버튼으로 DELETE를 호출한다", async () => {
@@ -782,9 +586,9 @@ describe("DatasetGrid", () => {
       ),
     );
     renderWithRouter(<DatasetGrid datasetId={1} />);
-    await screen.findByText("과목");
+    await screen.findByText("네트워크");
 
-    const handle = screen.getByLabelText("과목 열 너비 조절");
+    const handle = screen.getByLabelText("1열 너비 조절");
     // getBoundingClientRect가 800으로 목킹돼 있으므로 시작 폭은 800이다.
     fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 });
     fireEvent.pointerMove(handle, { clientX: -100, pointerId: 1 });
@@ -804,26 +608,29 @@ describe("DatasetGrid", () => {
               { key: "c0", label: "과목", width: 300 },
               { key: "c1", label: "점수" },
             ],
-            rowCount: 0,
+            rowCount: 1,
           },
         }),
       ),
       http.get(`${API_BASE}/datasets/1/rows`, () =>
         HttpResponse.json({
           code: "OK",
-          data: { rows: [], offset: 0, limit: 100 },
+          data: {
+            rows: [{ id: 100, rowIndex: 0, cells: ["네트워크", "92"] }],
+            offset: 0,
+            limit: 100,
+          },
         }),
       ),
     );
     renderWithRouter(<DatasetGrid datasetId={1} />);
-    await screen.findByText("과목");
+    await screen.findByText("네트워크");
 
-    const header = screen
-      .getByText("과목")
-      .closest("div[style]") as HTMLElement;
-    expect(header.style.gridTemplateColumns).toBe(
-      "300px minmax(120px, 1fr) 44px",
-    );
+    // 제목 행이 없어졌으므로 값 행의 그리드 열 정의로 확인한다.
+    const row = document.querySelector(
+      '[data-testid="dataset-grid"] div[style*="translateY(0px)"]',
+    ) as HTMLElement;
+    expect(row.style.gridTemplateColumns).toBe("300px minmax(120px, 1fr) 44px");
   });
 
   it("하한보다 좁게 끌어도 하한에서 멈춘다", async () => {
@@ -849,9 +656,9 @@ describe("DatasetGrid", () => {
       ),
     );
     renderWithRouter(<DatasetGrid datasetId={1} />);
-    await screen.findByText("과목");
+    await screen.findByText("네트워크");
 
-    const handle = screen.getByLabelText("과목 열 너비 조절");
+    const handle = screen.getByLabelText("1열 너비 조절");
     fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 });
     fireEvent.pointerMove(handle, { clientX: -5000, pointerId: 1 });
     fireEvent.pointerUp(handle, { clientX: -5000, pointerId: 1 });
@@ -870,9 +677,9 @@ describe("DatasetGrid", () => {
       }),
     );
     renderWithRouter(<DatasetGrid datasetId={1} />);
-    await screen.findByText("과목");
+    await screen.findByText("네트워크");
 
-    const handle = screen.getByLabelText("과목 열 너비 조절");
+    const handle = screen.getByLabelText("1열 너비 조절");
     fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 });
     fireEvent.pointerUp(handle, { clientX: 0, pointerId: 1 });
 
@@ -900,52 +707,11 @@ describe("DatasetGrid", () => {
       }),
     );
     renderWithRouter(<DatasetGrid datasetId={1} />);
-    await screen.findByText("과목");
+    await screen.findByText("네트워크");
 
-    fireEvent.doubleClick(screen.getByLabelText("과목 열 너비 조절"));
+    fireEvent.doubleClick(screen.getByLabelText("1열 너비 조절"));
 
     await waitFor(() => expect(deleted).toHaveBeenCalled());
-  });
-
-  it("너비 조절 드래그가 열 순서 변경으로 새지 않는다", async () => {
-    mockDataset([["네트워크", "92"]]);
-    const reordered = vi.fn();
-    server.use(
-      http.patch(`${API_BASE}/datasets/1/columns/order`, () => {
-        reordered();
-        return HttpResponse.json({ code: "OK", data: null });
-      }),
-      http.patch(`${API_BASE}/datasets/1/columns/c0/width`, () =>
-        HttpResponse.json({
-          code: "OK",
-          data: {
-            id: 1,
-            columns: [
-              { key: "c0", label: "과목", width: 700 },
-              { key: "c1", label: "점수" },
-            ],
-            rowCount: 1,
-          },
-        }),
-      ),
-    );
-    renderWithRouter(<DatasetGrid datasetId={1} />);
-    await screen.findByText("과목");
-
-    const handle = screen.getByLabelText("과목 열 너비 조절");
-    // 리사이즈 시작 전엔 헤더를 끌어 순서를 바꿀 수 있다.
-    const header = screen.getByText("과목").closest("[draggable]");
-    expect(header).toHaveAttribute("draggable", "true");
-
-    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 });
-    // 리사이즈 중엔 draggable이 꺼져 HTML5 드래그가 시작되지 않는다.
-    expect(header).toHaveAttribute("draggable", "false");
-
-    fireEvent.pointerMove(handle, { clientX: -100, pointerId: 1 });
-    fireEvent.pointerUp(handle, { clientX: -100, pointerId: 1 });
-
-    await new Promise((r) => setTimeout(r, 50));
-    expect(reordered).not.toHaveBeenCalled();
   });
 
   // ---------- 셀 배경색 ----------
@@ -1095,44 +861,6 @@ describe("DatasetGrid", () => {
     await user.click(screen.getByLabelText("배경색 지우기"));
 
     await waitFor(() => expect(sent).toEqual({ bg: null, align: null }));
-  });
-
-  it("열 정렬 버튼을 누르면 PATCH하고 셀 정렬이 바뀐다", async () => {
-    mockDataset([["네트워크", "92"]]);
-    let sent: unknown = null;
-    server.use(
-      http.patch(
-        `${API_BASE}/datasets/1/columns/c1/align`,
-        async ({ request }) => {
-          sent = await request.json();
-          return HttpResponse.json({
-            code: "OK",
-            data: {
-              id: 1,
-              columns: [
-                { key: "c0", label: "과목" },
-                { key: "c1", label: "점수", align: "center" },
-              ],
-              rowCount: 1,
-            },
-          });
-        },
-      ),
-    );
-    const user = userEvent.setup();
-    renderWithRouter(<DatasetGrid datasetId={1} />);
-    await screen.findByText("92");
-
-    // 기본은 왼쪽 → 클릭하면 가운데.
-    await user.click(screen.getByLabelText("점수 열 정렬 (현재 왼쪽)"));
-
-    await waitFor(() => expect(sent).toEqual({ align: "center" }));
-    // 열 기본 정렬이 그 열 셀에 반영된다.
-    await waitFor(() =>
-      expect(screen.getByText("92").className).toContain("text-center"),
-    );
-    // 다른 열은 그대로 기본(left).
-    expect(screen.getByText("네트워크").className).toContain("text-left");
   });
 
   it("셀 정렬(override)이 열 기본 정렬을 덮는다", async () => {

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -1,16 +1,9 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  type ColumnDef,
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from "@tanstack/react-table";
 import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import {
   AlignCenter,
   AlignLeft,
   AlignRight,
-  FunctionSquare,
   Palette,
   Plus,
   TableCellsMerge,
@@ -18,7 +11,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Button } from "@/components/ui/button";
@@ -42,13 +35,10 @@ import {
   type MergeSpan,
   type MergeView,
   MIN_COLUMN_WIDTH,
-  renameDatasetColumn,
-  reorderDatasetColumns,
   resetDatasetColumnWidth,
   resizeDatasetColumn,
   setCellMerge,
   setCellStyle,
-  setDatasetColumnAlign,
   updateDatasetRow,
 } from "./api/datasets";
 import { useDatasetMerges } from "./hooks/useDatasetMerges";
@@ -64,9 +54,9 @@ interface Props {
 }
 
 /**
- * 대용량 편집 표. TanStack Table(열/헤더) + 윈도우 가상화(행) + 지연 로드 + 셀/행 편집.
- * 세로는 노트 페이지 흐름을 따라 무한히 자라고(자체 스크롤 뷰포트 없음),
- * 가로는 열이 화면을 넘으면 스크롤한다.
+ * notion 스타일 값-중심 표. 제목(헤더) 행 없이 값 셀만 그린다 + 윈도우 가상화(행) +
+ * 지연 로드 + 셀 편집. 세로는 노트 페이지 흐름을 따라 무한히 자라고(자체 스크롤 뷰포트 없음),
+ * 가로는 열이 화면을 넘으면 스크롤한다. 열 너비는 셀 오른쪽 경계 드래그로 조절한다.
  */
 export function DatasetGrid({ datasetId }: Props) {
   const queryClient = useQueryClient();
@@ -89,10 +79,7 @@ export function DatasetGrid({ datasetId }: Props) {
     null,
   );
   const [draft, setDraft] = useState("");
-  const [editingCol, setEditingCol] = useState<string | null>(null);
-  const [colDraft, setColDraft] = useState("");
   const [pendingColDelete, setPendingColDelete] = useState<string | null>(null);
-  const [dragKey, setDragKey] = useState<string | null>(null);
   // 리사이즈 중인 열과 진행 중 너비. 드래그하는 동안엔 여기 값으로 그리고,
   // 저장은 놓을 때 한 번만 한다(mousemove마다 PATCH를 보내지 않는다).
   const [resizing, setResizing] = useState<{
@@ -101,8 +88,6 @@ export function DatasetGrid({ datasetId }: Props) {
     startWidth: number;
     width: number;
   } | null>(null);
-  // D6 — 수식은 평소 숨기고 선택 시에만 보여준다. 이 토글은 상시 표시.
-  const [showFormulas, setShowFormulas] = useState(false);
   // 색 팔레트를 연 셀(행 index·열 index). null이면 닫힘.
   const [palette, setPalette] = useState<{ row: number; col: number } | null>(
     null,
@@ -193,23 +178,6 @@ export function DatasetGrid({ datasetId }: Props) {
       void invalidateMerges(); // 앵커 행 삭제는 cascade, 뒤 행은 번호가 밀린다.
     },
   });
-  const renameColMut = useMutation({
-    mutationFn: (v: { key: string; label: string }) =>
-      renameDatasetColumn(datasetId, v.key, v.label),
-    onSuccess: (next: DatasetMeta) =>
-      queryClient.setQueryData(datasetKeys.meta(datasetId), next),
-    onError: () => void invalidateMeta(),
-  });
-  const reorderColMut = useMutation({
-    mutationFn: (keys: string[]) => reorderDatasetColumns(datasetId, keys),
-    onSuccess: (next: DatasetMeta) => {
-      queryClient.setQueryData(datasetKeys.meta(datasetId), next);
-      // 캐시된 cells는 이전 열 순서 기준이라 그대로 쓰면 값이 어긋난다.
-      reset();
-      void invalidateMerges(); // 순서 변경 시 서버가 병합을 해제한다(v1 보수적).
-    },
-    onError: () => void invalidateMeta(),
-  });
   const deleteColMut = useMutation({
     mutationFn: (key: string) => deleteDatasetColumn(datasetId, key),
     onSuccess: (next: DatasetMeta) => {
@@ -234,14 +202,6 @@ export function DatasetGrid({ datasetId }: Props) {
       queryClient.setQueryData(datasetKeys.meta(datasetId), next),
     onError: () => void invalidateMeta(),
   });
-  const setColAlignMut = useMutation({
-    mutationFn: (v: { key: string; align: CellAlign }) =>
-      setDatasetColumnAlign(datasetId, v.key, v.align),
-    // 정렬은 열 단위 속성이라 행 캐시를 버릴 이유가 없다(너비와 같다 — 값이 안 밀린다).
-    onSuccess: (next: DatasetMeta) =>
-      queryClient.setQueryData(datasetKeys.meta(datasetId), next),
-    onError: () => void invalidateMeta(),
-  });
   const addColMut = useMutation({
     mutationFn: (v: { atIndex?: number }) =>
       addDatasetColumn(datasetId, v.atIndex),
@@ -255,22 +215,6 @@ export function DatasetGrid({ datasetId }: Props) {
       }
     },
     onError: () => void invalidateMeta(),
-  });
-
-  // TanStack Table — 열/헤더 모델만(본문은 가상화로 직접 렌더).
-  const columns = useMemo<ColumnDef<string[]>[]>(
-    () =>
-      (meta?.columns ?? []).map((col, c) => ({
-        id: col.key,
-        header: col.label,
-        accessorFn: (row) => row[c] ?? "",
-      })),
-    [meta],
-  );
-  const table = useReactTable({
-    data: EMPTY,
-    columns,
-    getCoreRowModel: getCoreRowModel(),
   });
 
   const virtualizer = useWindowVirtualizer({
@@ -343,11 +287,11 @@ export function DatasetGrid({ datasetId }: Props) {
     Math.round(Math.min(MAX_COLUMN_WIDTH, Math.max(MIN_COLUMN_WIDTH, width)));
 
   const startResize = (key: string, event: React.PointerEvent) => {
-    // 헤더 셀의 실제 렌더 폭에서 시작한다. 너비 미지정(1fr) 열도 이 값으로 잡히므로
+    // 핸들의 부모 셀 실제 렌더 폭에서 시작한다. 너비 미지정(1fr) 열도 이 값으로 잡히므로
     // 첫 드래그가 기본 폭에서 자연스럽게 이어진다.
-    const headerCell = event.currentTarget.parentElement;
-    if (!headerCell) return;
-    const startWidth = headerCell.getBoundingClientRect().width;
+    const cell = event.currentTarget.parentElement;
+    if (!cell) return;
+    const startWidth = cell.getBoundingClientRect().width;
     event.preventDefault();
     event.stopPropagation();
     // 포인터를 잡아 두면 핸들 밖으로 벗어나도 move/up이 계속 온다.
@@ -441,13 +385,6 @@ export function DatasetGrid({ datasetId }: Props) {
     setPalette(null);
   };
 
-  /** 열 기본 정렬을 다음 값으로 돌린다(좌→가운데→우→좌). 기본(미설정)은 좌로 본다. */
-  const cycleColumnAlign = (key: string, current: CellAlign | undefined) => {
-    const next: CellAlign =
-      current === "center" ? "right" : current === "right" ? "left" : "center";
-    setColAlignMut.mutate({ key, align: next });
-  };
-
   /** (row,col)이 앵커인 병합. 없으면 undefined. */
   const mergeAt = (row: number, col: number): MergeView | undefined =>
     merges.find(
@@ -510,35 +447,6 @@ export function DatasetGrid({ datasetId }: Props) {
 
   const columnLabel = (key: string) =>
     meta.columns.find((c) => c.key === key)?.label ?? key;
-
-  /** 끌던 열을 대상 열 자리에 놓는다. */
-  const dropColumnOn = (targetKey: string) => {
-    const from = dragKey;
-    setDragKey(null);
-    if (!from || from === targetKey) return;
-    const keys = meta.columns.map((c) => c.key);
-    const at = keys.indexOf(from);
-    const to = keys.indexOf(targetKey);
-    if (at < 0 || to < 0) return;
-    keys.splice(to, 0, keys.splice(at, 1)[0]);
-    reorderColMut.mutate(keys);
-  };
-
-  const startColEdit = (key: string, label: string) => {
-    setEditingCol(key);
-    setColDraft(label);
-  };
-
-  const commitColEdit = () => {
-    if (!editingCol) return;
-    const key = editingCol;
-    const label = colDraft.trim();
-    const current = meta.columns.find((c) => c.key === key);
-    setEditingCol(null);
-    // 빈 이름은 서버가 거부하므로 보내지 않고, 변경 없으면 요청 자체를 생략한다.
-    if (!label || label === current?.label) return;
-    renameColMut.mutate({ key, label });
-  };
 
   /**
    * 셀 내부(서식 버튼·팝오버·값/입력). base 그리드 셀과 세로 병합 오버레이 박스가 함께 쓴다 —
@@ -656,15 +564,10 @@ export function DatasetGrid({ datasetId }: Props) {
               ALIGN_CLASS[align],
               cells === undefined && "text-muted-foreground/40",
               isCellError(cells?.[c]) && "text-destructive",
-              formula !== undefined &&
-                showFormulas &&
-                "text-muted-foreground font-mono text-xs",
             )}
             title={formula}
           >
-            {cells === undefined
-              ? "…"
-              : (showFormulas && formula) || (cells[c] ?? "")}
+            {cells === undefined ? "…" : (cells[c] ?? "")}
           </div>
         )}
       </>
@@ -676,250 +579,169 @@ export function DatasetGrid({ datasetId }: Props) {
       className="border-border bg-card group/grid my-2 flex flex-col overflow-hidden rounded-md border"
       data-testid="dataset-grid"
     >
-      {/* 헤더+본문을 한 컨테이너에 둔다. 가로는 열이 넘치면 스크롤하고(overflow-x-auto),
-          세로는 뷰포트를 두지 않아 행이 늘수록 페이지 흐름대로 자란다. */}
-      <div className="overflow-x-auto">
-        {/* 헤더 (TanStack Table) — sticky로 상단 고정 */}
-        <div
-          className="bg-muted text-muted-foreground sticky top-0 z-10 grid border-b text-sm font-semibold"
-          style={{ gridTemplateColumns }}
-        >
-          {table.getFlatHeaders().map((header) => (
-            <div
-              key={header.id}
-              // 이름 편집 중엔 텍스트 선택을 막지 않도록 드래그를 끈다.
-              // 리사이즈 중에도 꺼야 한다 — 켜두면 핸들을 끄는 순간 HTML5 드래그가
-              // 시작돼 열 순서 변경으로 새어 나간다.
-              draggable={editingCol !== header.id && resizing === null}
-              onDragStart={() => setDragKey(header.id)}
-              onDragEnd={() => setDragKey(null)}
-              onDragOver={(e) => e.preventDefault()}
-              onDrop={() => dropColumnOn(header.id)}
-              data-dragging={dragKey === header.id || undefined}
-              className={cn(
-                "border-border group flex items-center border-r",
-                editingCol !== header.id && "cursor-grab",
-                dragKey === header.id && "opacity-50",
-              )}
-            >
-              {editingCol === header.id ? (
-                <input
-                  autoFocus
-                  value={colDraft}
-                  onChange={(e) => setColDraft(e.target.value)}
-                  onBlur={commitColEdit}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") commitColEdit();
-                    if (e.key === "Escape") setEditingCol(null);
-                  }}
-                  aria-label={`열 이름 ${header.id}`}
-                  className="focus-visible:ring-ring h-full w-full bg-transparent px-2 py-1.5 font-semibold outline-none focus-visible:ring-1"
-                />
-              ) : (
-                <>
-                  <div
-                    className="min-w-0 flex-1 cursor-text truncate px-2 py-1.5"
-                    title="더블클릭해 열 이름 변경"
-                    onDoubleClick={() =>
-                      startColEdit(
-                        header.id,
-                        meta.columns.find((c) => c.key === header.id)?.label ??
-                          "",
-                      )
-                    }
-                  >
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext(),
-                    )}
-                  </div>
-                  {/* 열 기본 정렬 — 클릭하면 좌→가운데→우로 순환한다. 아이콘이 현재 정렬을 보여준다. */}
-                  {(() => {
-                    const align =
-                      meta.columns.find((c) => c.key === header.id)?.align ??
-                      "left";
-                    const Icon = ALIGN_ICONS[align];
-                    return (
-                      <button
-                        type="button"
-                        aria-label={`${columnLabel(header.id)} 열 정렬 (현재 ${ALIGN_LABELS[align]})`}
-                        title="클릭해 열 정렬 변경 (좌·가운데·우)"
-                        onClick={() =>
-                          cycleColumnAlign(
-                            header.id,
-                            meta.columns.find((c) => c.key === header.id)
-                              ?.align,
-                          )
-                        }
-                        className="text-muted-foreground hover:text-foreground mr-1 shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-                      >
-                        <Icon className="size-3.5" />
-                      </button>
-                    );
-                  })()}
-                  {/* 마지막 한 열은 서버가 거부하므로 버튼도 내보내지 않는다. */}
-                  {colCount > 1 && (
-                    <button
-                      type="button"
-                      aria-label={`${columnLabel(header.id)} 열 삭제`}
-                      onClick={() => setPendingColDelete(header.id)}
-                      className="text-muted-foreground hover:text-destructive mr-1 shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-                    >
-                      <X className="size-3.5" />
-                    </button>
-                  )}
-                </>
-              )}
-              {/* 열 경계 리사이즈 핸들. 이름 편집 중엔 내보내지 않는다. */}
-              {editingCol !== header.id && (
+      {/* 값 셀만(제목 행 없음). 가로는 열이 넘치면 스크롤하고(overflow-x-auto),
+          세로는 뷰포트를 두지 않아 행이 늘수록 페이지 흐름대로 자란다.
+          오른쪽 얇은 칸은 표 호버 시 나타나는 [열 추가]. */}
+      <div className="flex items-stretch">
+        <div className="min-w-0 flex-1 overflow-x-auto">
+          {/* 본문 (윈도우 가상화) */}
+          <div
+            ref={listRef}
+            style={{ height: virtualizer.getTotalSize(), position: "relative" }}
+          >
+            {virtualItems.map((vi) => {
+              // 그 행에 앵커가 있는 가로 전용 병합(rowSpan===1). 덮인 칸은 스킵하고 앵커가 span으로 넓게.
+              const hCovered = new Set<number>();
+              const hAnchor = new Map<number, MergeView>();
+              for (const m of merges) {
+                if (m.rowIndex !== vi.index || m.rowSpan !== 1) continue;
+                const ai = colOf(m.colKey);
+                if (ai < 0) continue;
+                hAnchor.set(ai, m);
+                for (let k = 1; k < m.colSpan; k++) hCovered.add(ai + k);
+              }
+              return (
                 <div
-                  role="separator"
-                  aria-orientation="vertical"
-                  aria-label={`${columnLabel(header.id)} 열 너비 조절`}
-                  title="드래그해 너비 조절 · 더블클릭해 기본 폭으로"
-                  onPointerDown={(e) => startResize(header.id, e)}
-                  onPointerMove={moveResize}
-                  onPointerUp={endResize}
-                  onPointerCancel={endResize}
-                  onDoubleClick={() => resetColWidthMut.mutate(header.id)}
-                  // 부모가 draggable이라 핸들에서 시작한 드래그가 순서 변경으로 새는 것을 막는다.
-                  draggable={false}
-                  onDragStart={(e) => e.preventDefault()}
-                  className={cn(
-                    "hover:bg-primary/60 -mr-[3px] h-full w-[6px] shrink-0 cursor-col-resize touch-none",
-                    resizing?.key === header.id && "bg-primary/60",
-                  )}
-                />
-              )}
+                  key={vi.key}
+                  className="border-border group/row absolute top-0 left-0 grid w-full border-b text-sm"
+                  style={{
+                    height: ROW_HEIGHT,
+                    // vi.start는 문서 좌표(scrollMargin 포함)라 목록 기준으로 되돌린다.
+                    transform: `translateY(${vi.start - scrollMargin}px)`,
+                    gridTemplateColumns,
+                  }}
+                >
+                  {Array.from({ length: colCount }, (_, c) => {
+                    // 세로·블록 병합이 덮는 칸은 오버레이가 그리므로 base엔 자리만 둔다(정렬 유지).
+                    if (overlayCovering(vi.index, c)) {
+                      return <div key={c} aria-hidden className="border-r" />;
+                    }
+                    // 가로 병합에 덮인 칸은 앵커가 span으로 차지하므로 렌더하지 않는다.
+                    if (hCovered.has(c)) return null;
+                    const anchor = hAnchor.get(c);
+                    const style = getStyles(vi.index)[meta.columns[c].key];
+                    return (
+                      <div
+                        key={c}
+                        className="border-border group/cell relative truncate border-r"
+                        style={{
+                          ...(style?.bg
+                            ? { background: `var(--cell-bg-${style.bg})` }
+                            : {}),
+                          // 가로 병합 앵커는 colSpan만큼 그리드 열을 차지한다(덮인 칸 스킵과 짝).
+                          ...(anchor
+                            ? { gridColumn: `span ${anchor.colSpan}` }
+                            : {}),
+                        }}
+                        onClick={() => startEdit(vi.index, c)}
+                        onContextMenu={(e) => openContextMenu(e, vi.index, c)}
+                      >
+                        {renderCellInner(vi.index, c)}
+                        {/* 열 너비 조절 — 셀 오른쪽 경계 드래그(제목 행이 없어 셀로 옮겼다).
+                          셀 호버 시 나타난다. 가로 병합 앵커엔 경계가 모호해 달지 않는다. */}
+                        {!anchor && (
+                          <div
+                            role="separator"
+                            aria-orientation="vertical"
+                            aria-label={`${c + 1}열 너비 조절`}
+                            title="드래그해 너비 조절 · 더블클릭해 기본 폭으로"
+                            onPointerDown={(e) =>
+                              startResize(meta.columns[c].key, e)
+                            }
+                            onPointerMove={moveResize}
+                            onPointerUp={endResize}
+                            onPointerCancel={endResize}
+                            onClick={(e) => e.stopPropagation()}
+                            onDoubleClick={(e) => {
+                              e.stopPropagation();
+                              resetColWidthMut.mutate(meta.columns[c].key);
+                            }}
+                            className={cn(
+                              "hover:bg-primary/60 absolute top-0 right-0 z-10 -mr-[3px] h-full w-[6px] cursor-col-resize touch-none opacity-0 group-hover/cell:opacity-100",
+                              resizing?.key === meta.columns[c].key &&
+                                "bg-primary/60 opacity-100",
+                            )}
+                          />
+                        )}
+                      </div>
+                    );
+                  })}
+                  <button
+                    type="button"
+                    aria-label={`${vi.index + 1}행 삭제`}
+                    onClick={() => deleteMut.mutate(vi.index)}
+                    className="text-muted-foreground hover:text-destructive flex items-center justify-center opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100"
+                  >
+                    <Trash2 className="size-3.5" />
+                  </button>
+                </div>
+              );
+            })}
+
+            {/* 세로·블록 병합(rowSpan>1) 오버레이 — 가상화가 앵커 행을 안 그려도 덮인 영역을 그린다.
+              같은 gridTemplateColumns를 쓰는 grid에 열 배치로 x·폭을 맞추고(유연폭 대응),
+              고정 행 높이라 세로는 top·height를 px로 계산한다(측정 불필요). */}
+            <div
+              className="pointer-events-none absolute top-0 left-0 grid w-full"
+              style={{
+                gridTemplateColumns,
+                height: virtualizer.getTotalSize(),
+              }}
+            >
+              {overlayMerges
+                .filter(
+                  (m) =>
+                    m.rowIndex <= lastIndex &&
+                    m.rowIndex + m.rowSpan > firstIndex,
+                )
+                .map((m) => {
+                  const ai = colOf(m.colKey);
+                  if (ai < 0) return null;
+                  const style = getStyles(m.rowIndex)[m.colKey];
+                  return (
+                    <div
+                      key={`${m.rowIndex}:${m.colKey}`}
+                      style={{ gridColumn: `${ai + 1} / span ${m.colSpan}` }}
+                      className="relative"
+                    >
+                      <div
+                        className="border-border bg-card group/cell pointer-events-auto absolute right-0 left-0 truncate border-r border-b text-sm"
+                        style={{
+                          top: m.rowIndex * ROW_HEIGHT,
+                          height: m.rowSpan * ROW_HEIGHT,
+                          ...(style?.bg
+                            ? { background: `var(--cell-bg-${style.bg})` }
+                            : {}),
+                        }}
+                        onClick={() => startEdit(m.rowIndex, ai)}
+                        onContextMenu={(e) =>
+                          openContextMenu(e, m.rowIndex, ai)
+                        }
+                      >
+                        {renderCellInner(m.rowIndex, ai)}
+                      </div>
+                    </div>
+                  );
+                })}
             </div>
-          ))}
-          {/* 행 삭제 버튼 열(44px) 위 자리 — 열 추가 버튼을 둔다.
-              표에 마우스를 올렸을 때(또는 키보드 포커스 시)만 보인다. */}
+          </div>
+        </div>
+        {/* 열 추가 — 표 오른쪽 가장자리. 표 호버(또는 키보드 포커스) 시 나타난다. */}
+        <div className="border-border flex w-7 shrink-0 justify-center border-l pt-1.5 opacity-0 transition-opacity group-hover/grid:opacity-100 focus-within:opacity-100">
           <button
             type="button"
             aria-label="열 추가"
             title="열 추가"
             onClick={() => addColumn()}
             disabled={addColMut.isPending}
-            className="text-muted-foreground hover:text-foreground flex items-center justify-center opacity-0 transition-opacity group-hover/grid:opacity-100 focus-visible:opacity-100 disabled:opacity-50"
+            className="text-muted-foreground hover:text-foreground disabled:opacity-50"
           >
             <Plus className="size-3.5" />
           </button>
         </div>
-
-        {/* 본문 (윈도우 가상화) */}
-        <div
-          ref={listRef}
-          style={{ height: virtualizer.getTotalSize(), position: "relative" }}
-        >
-          {virtualItems.map((vi) => {
-            // 그 행에 앵커가 있는 가로 전용 병합(rowSpan===1). 덮인 칸은 스킵하고 앵커가 span으로 넓게.
-            const hCovered = new Set<number>();
-            const hAnchor = new Map<number, MergeView>();
-            for (const m of merges) {
-              if (m.rowIndex !== vi.index || m.rowSpan !== 1) continue;
-              const ai = colOf(m.colKey);
-              if (ai < 0) continue;
-              hAnchor.set(ai, m);
-              for (let k = 1; k < m.colSpan; k++) hCovered.add(ai + k);
-            }
-            return (
-              <div
-                key={vi.key}
-                className="border-border absolute top-0 left-0 grid w-full border-b text-sm"
-                style={{
-                  height: ROW_HEIGHT,
-                  // vi.start는 문서 좌표(scrollMargin 포함)라 목록 기준으로 되돌린다.
-                  transform: `translateY(${vi.start - scrollMargin}px)`,
-                  gridTemplateColumns,
-                }}
-              >
-                {Array.from({ length: colCount }, (_, c) => {
-                  // 세로·블록 병합이 덮는 칸은 오버레이가 그리므로 base엔 자리만 둔다(정렬 유지).
-                  if (overlayCovering(vi.index, c)) {
-                    return <div key={c} aria-hidden className="border-r" />;
-                  }
-                  // 가로 병합에 덮인 칸은 앵커가 span으로 차지하므로 렌더하지 않는다.
-                  if (hCovered.has(c)) return null;
-                  const anchor = hAnchor.get(c);
-                  const style = getStyles(vi.index)[meta.columns[c].key];
-                  return (
-                    <div
-                      key={c}
-                      className="border-border group/cell relative truncate border-r"
-                      style={{
-                        ...(style?.bg
-                          ? { background: `var(--cell-bg-${style.bg})` }
-                          : {}),
-                        // 가로 병합 앵커는 colSpan만큼 그리드 열을 차지한다(덮인 칸 스킵과 짝).
-                        ...(anchor
-                          ? { gridColumn: `span ${anchor.colSpan}` }
-                          : {}),
-                      }}
-                      onClick={() => startEdit(vi.index, c)}
-                      onContextMenu={(e) => openContextMenu(e, vi.index, c)}
-                    >
-                      {renderCellInner(vi.index, c)}
-                    </div>
-                  );
-                })}
-                <button
-                  type="button"
-                  aria-label={`${vi.index + 1}행 삭제`}
-                  onClick={() => deleteMut.mutate(vi.index)}
-                  className="text-muted-foreground hover:text-destructive flex items-center justify-center"
-                >
-                  <Trash2 className="size-3.5" />
-                </button>
-              </div>
-            );
-          })}
-
-          {/* 세로·블록 병합(rowSpan>1) 오버레이 — 가상화가 앵커 행을 안 그려도 덮인 영역을 그린다.
-              같은 gridTemplateColumns를 쓰는 grid에 열 배치로 x·폭을 맞추고(유연폭 대응),
-              고정 행 높이라 세로는 top·height를 px로 계산한다(측정 불필요). */}
-          <div
-            className="pointer-events-none absolute top-0 left-0 grid w-full"
-            style={{ gridTemplateColumns, height: virtualizer.getTotalSize() }}
-          >
-            {overlayMerges
-              .filter(
-                (m) =>
-                  m.rowIndex <= lastIndex &&
-                  m.rowIndex + m.rowSpan > firstIndex,
-              )
-              .map((m) => {
-                const ai = colOf(m.colKey);
-                if (ai < 0) return null;
-                const style = getStyles(m.rowIndex)[m.colKey];
-                return (
-                  <div
-                    key={`${m.rowIndex}:${m.colKey}`}
-                    style={{ gridColumn: `${ai + 1} / span ${m.colSpan}` }}
-                    className="relative"
-                  >
-                    <div
-                      className="border-border bg-card group/cell pointer-events-auto absolute right-0 left-0 truncate border-r border-b text-sm"
-                      style={{
-                        top: m.rowIndex * ROW_HEIGHT,
-                        height: m.rowSpan * ROW_HEIGHT,
-                        ...(style?.bg
-                          ? { background: `var(--cell-bg-${style.bg})` }
-                          : {}),
-                      }}
-                      onClick={() => startEdit(m.rowIndex, ai)}
-                      onContextMenu={(e) => openContextMenu(e, m.rowIndex, ai)}
-                    >
-                      {renderCellInner(m.rowIndex, ai)}
-                    </div>
-                  </div>
-                );
-              })}
-          </div>
-        </div>
       </div>
 
-      {/* 행 추가 — 표에 마우스를 올렸을 때(또는 키보드 포커스 시)만 [행 추가]가 보인다. */}
+      {/* 행 추가 — 표에 마우스를 올렸을 때(또는 키보드 포커스 시)만 보인다. */}
       <div className="border-border flex items-center gap-1 border-t p-1">
         <Button
           type="button"
@@ -930,16 +752,6 @@ export function DatasetGrid({ datasetId }: Props) {
           className="opacity-0 transition-opacity group-hover/grid:opacity-100 focus-visible:opacity-100"
         >
           <Plus className="size-4" /> 행 추가
-        </Button>
-        <Button
-          type="button"
-          variant={showFormulas ? "secondary" : "ghost"}
-          size="sm"
-          aria-pressed={showFormulas}
-          onClick={() => setShowFormulas((v) => !v)}
-          title="수식 셀에 계산 결과 대신 수식을 보여준다"
-        >
-          <FunctionSquare className="size-4" /> 수식 보기
         </Button>
       </div>
 
@@ -1061,9 +873,7 @@ export function DatasetGrid({ datasetId }: Props) {
   );
 }
 
-const EMPTY: string[][] = [];
-
-/** 정렬 값 → 아이콘. 열/셀 정렬 버튼과 렌더에 공용. */
+/** 정렬 값 → 아이콘. 셀 정렬 팔레트와 렌더에 공용. */
 const ALIGN_ICONS = {
   left: AlignLeft,
   center: AlignCenter,


### PR DESCRIPTION
## 이슈
closes #845

## 작업 내용
notion 스타일 값-중심 표로 정리. 상시 노출 조작 UI를 걷어내고 열 제목 행을 없앴다.

- **열 제목(헤더) 행 완전 제거** — 값 셀만 그린다. 열 이름 표시·rename·정렬·순서변경 헤더 UI 제거
- **열 너비 조절 유지** — 헤더가 없어졌으므로 **셀 오른쪽 경계 드래그**로 이동(셀 호버 시 핸들, 더블클릭 시 기본 폭)
- **수식 보기 토글 제거** — 표시는 항상 계산값
- **헤더 열 삭제 X 버튼 제거** — 열 삭제는 셀 우클릭 메뉴로 유지
- **추가 버튼 미니멀화(notion 방식)** — 하단 바·우측 스트립(빈 테두리)이 공간을 차지하던 것을 없애고, **절대 위치 플로팅 버튼**으로 전환. 평소엔 공간을 전혀 차지하지 않다가 표 호버(또는 포커스) 시에만 나타난다
- **우측 44px 빈 삭제 열 제거** — 인라인 행 삭제 버튼도 없애고 **행 삭제는 셀 우클릭 메뉴로 일원화**(열 삭제와 동일)
- 정리: `@tanstack/react-table`·rename/reorder/colAlign mutation·수식 보기 상태·미사용 Button import 제거로 컴포넌트 단순화
  - BE 엔드포인트(rename/reorder/align)는 존치(향후 재사용 여지 — 이번엔 FE 미사용)

## 검증
- FE: `vitest`(전체 349 통과) · `tsc --noEmit` · `eslint .` · `prettier --check` · `vite build` 모두 통과
- 테스트 갱신: 제목 라벨 대신 값 셀·컨트롤로 확인, 리사이즈는 셀 경계 핸들, 행/열 삭제·추가는 우클릭 메뉴/플로팅 버튼 기준으로
- ⚠️ 셀 경계 리사이즈·플로팅 버튼의 실제 레이아웃은 jsdom으로 완전 검증 불가 — 풀스택 브라우저 확인 별도 필요