### PR TITLE
feat : 데이터 그리드 행/열 추가 버튼 notion식 통일

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -714,15 +714,18 @@ export function DatasetGrid({ datasetId }: Props) {
         </div>
       </div>
 
-      {/* 행/열 추가 — 공간을 차지하지 않게 절대 위치로 띄운다. 평소엔 없다가
-          표 호버(또는 키보드 포커스) 시 튀어나온다(notion 방식). */}
+      {/* 행/열 추가 — notion식 가장자리 바. 공간을 차지하지 않게 절대 위치로 두고
+          평소엔 숨겼다가 표 호버(또는 포커스) 시 나타난다. 둘 다 아이콘만(글자 없음):
+          행=하단 가로 바, 열=우측 세로 바. 같은 스타일로 통일. */}
       <button
         type="button"
+        aria-label="행 추가"
+        title="행 추가"
         onClick={() => addRow()}
         disabled={insertMut.isPending}
-        className="border-border bg-card text-muted-foreground hover:text-foreground absolute bottom-1 left-1 z-20 flex h-6 items-center gap-1 rounded-md border px-2 text-xs opacity-0 shadow-sm transition-opacity group-hover/grid:opacity-100 focus-visible:opacity-100 disabled:opacity-50"
+        className="bg-muted/60 text-muted-foreground hover:bg-muted hover:text-foreground absolute inset-x-0 bottom-0 z-20 flex h-5 items-center justify-center opacity-0 transition-opacity group-hover/grid:opacity-100 focus-visible:opacity-100 disabled:opacity-50"
       >
-        <Plus className="size-3.5" /> 행 추가
+        <Plus className="size-3.5" />
       </button>
       <button
         type="button"
@@ -730,7 +733,7 @@ export function DatasetGrid({ datasetId }: Props) {
         title="열 추가"
         onClick={() => addColumn()}
         disabled={addColMut.isPending}
-        className="border-border bg-card text-muted-foreground hover:text-foreground absolute top-1 right-1 z-20 flex size-6 items-center justify-center rounded-md border opacity-0 shadow-sm transition-opacity group-hover/grid:opacity-100 focus-visible:opacity-100 disabled:opacity-50"
+        className="bg-muted/60 text-muted-foreground hover:bg-muted hover:text-foreground absolute inset-y-0 right-0 z-20 flex w-5 items-center justify-center opacity-0 transition-opacity group-hover/grid:opacity-100 focus-visible:opacity-100 disabled:opacity-50"
       >
         <Plus className="size-3.5" />
       </button>


### PR DESCRIPTION
## 이슈
closes #849

## 작업 내용
행 추가·열 추가 버튼 디자인이 서로 달랐던 것을 notion식으로 통일했다.

- **Before**: 행 추가 = 아이콘 + "행 추가" 글자 알약(좌하단), 열 추가 = 아이콘 사각형(우상단) — 서로 다름
- **After**: 둘 다 **글자 없이 아이콘(+)만**, 같은 스타일의 **가장자리 바**
  - 행 추가 = 표 하단 가로 바 / 열 추가 = 표 우측 세로 바
  - `bg-muted` 반투명 + 호버 시 진해짐, 표 호버 시에만 노출
  - 공간을 차지하지 않는 절대 위치는 그대로 유지(레이아웃에서 빠짐)
- `aria-label`로 접근성 이름 유지 → 테스트 변경 불필요

## 검증
- FE: `vitest`(전체 349 통과) · `tsc` · `eslint` · `prettier` 모두 통과
- ⚠️ 실제 브라우저에서의 바 위치·마지막 열 리사이즈 핸들과의 겹침 등은 jsdom으로 확인 불가 — 눈으로 확인 후 조정 필요 시 알려주세요