### PR TITLE
feat : 데이터 그리드 셀 서식 일괄 적용(Phase 2) — 선택 범위 1요청

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -2,6 +2,7 @@ package ds.project.orino.planner.dataset.controller;
 
 import ds.project.orino.common.response.ApiResponse;
 import ds.project.orino.planner.dataset.dto.AddColumnRequest;
+import ds.project.orino.planner.dataset.dto.BulkCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.BulkRowsRequest;
 import ds.project.orino.planner.dataset.dto.CreateDatasetRequest;
 import ds.project.orino.planner.dataset.dto.DatasetResponse;
@@ -19,6 +20,7 @@ import ds.project.orino.planner.dataset.dto.SetColumnAlignRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
 import ds.project.orino.planner.dataset.service.DatasetService;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -215,6 +217,19 @@ public class DatasetController {
             @Valid @RequestBody SetCellStyleRequest request) {
         return ApiResponse.success(
                 datasetService.setCellStyle(memberId, id, rowIndex, colKey, request));
+    }
+
+    /**
+     * 여러 셀 서식을 한 번에 지정한다(선택 범위·행·열·표 전체 적용). 셀마다 서식을 통째로
+     * 교체하며, 영향받은 행들의 최신 상태를 rowIndex 오름차순으로 돌려준다.
+     */
+    @PutMapping("/{id}/cells/style")
+    public ApiResponse<List<RowView>> setCellStylesBulk(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @Valid @RequestBody BulkCellStyleRequest request) {
+        return ApiResponse.success(
+                datasetService.setCellStylesBulk(memberId, id, request));
     }
 
     /** 그 dataset의 병합 전체. 세로 병합은 앵커가 화면 밖이어도 덮인 행을 그려야 해 통째로 준다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/BulkCellStyleRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/BulkCellStyleRequest.java
@@ -1,0 +1,33 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import java.util.List;
+
+/**
+ * 여러 셀에 서식을 한 번에 지정한다(선택 범위·행·열·표 전체 적용용). 셀마다 서식을 통째로
+ * 교체하며(부분 갱신 아님), 한 셀의 bg·align이 모두 null이면 그 셀 서식을 지운다 —
+ * 단건 {@link SetCellStyleRequest}와 같은 의미를 목록으로 확장한 것.
+ *
+ * <p>같은 배경색을 칠해도 셀마다 정렬이 다를 수 있어(그 반대도) 하나의 공통 style이 아니라
+ * 셀별 전체 서식을 담는다. 클라이언트가 각 셀의 보존할 속성을 채워 보낸다.
+ */
+public record BulkCellStyleRequest(
+        @NotEmpty(message = "대상 셀이 비어 있습니다.")
+        @Valid
+        List<Target> cells
+) {
+    public record Target(
+            @NotNull(message = "행 인덱스가 필요합니다.")
+            Integer rowIndex,
+            @NotNull(message = "열 key가 필요합니다.")
+            String colKey,
+            @Pattern(regexp = "red|orange|yellow|green|blue|purple", message = "허용되지 않은 배경색입니다.")
+            String bg,
+            @Pattern(regexp = "left|center|right", message = "허용되지 않은 정렬입니다.")
+            String align
+    ) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -18,6 +18,7 @@ import ds.project.orino.planner.dataset.dto.MergesResponse;
 import ds.project.orino.planner.dataset.dto.RenameColumnRequest;
 import ds.project.orino.planner.dataset.dto.ReorderColumnsRequest;
 import ds.project.orino.planner.dataset.dto.ResizeColumnRequest;
+import ds.project.orino.planner.dataset.dto.BulkCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.RowView;
 import ds.project.orino.planner.dataset.dto.RowsResponse;
 import ds.project.orino.planner.dataset.dto.SetCellMergeRequest;
@@ -488,6 +489,32 @@ public class DatasetService {
 
         styleService.setStyle(datasetId, row.getId(), colKey, request.bg(), request.align());
         return buildRowView(datasetId, row, rowIndex, columns);
+    }
+
+    /**
+     * 여러 셀 서식을 한 번에 지정한다(선택 범위·행·열·표 전체 적용). 소유권은 한 번만 확인하고
+     * 대상마다 서식을 통째로 교체한다(단건과 같은 의미). 영향받은 행들의 최신 상태를
+     * rowIndex 오름차순으로 돌려준다 — FE가 행별로 styles 캐시를 갱신한다.
+     */
+    @Transactional
+    public List<RowView> setCellStylesBulk(Long memberId, Long datasetId,
+                                           BulkCellStyleRequest request) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        Map<Integer, DatasetRow> rowByIndex = new LinkedHashMap<>();
+        for (BulkCellStyleRequest.Target t : request.cells()) {
+            if (indexOfColumn(columns, t.colKey()) < 0) {
+                throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+            }
+            DatasetRow row = rowByIndex.computeIfAbsent(t.rowIndex(), idx ->
+                    rowRepository.findByDatasetIdAndRowIndex(datasetId, idx)
+                            .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND)));
+            styleService.setStyle(datasetId, row.getId(), t.colKey(), t.bg(), t.align());
+        }
+        return rowByIndex.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> buildRowView(datasetId, e.getValue(), e.getKey(), columns))
+                .toList();
     }
 
     /** 그 dataset의 병합 전체. 세로 병합을 그리려면 FE가 앵커 밖 행까지 알아야 해서 통째로 준다. */

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -1513,6 +1513,108 @@ class DatasetControllerTest extends ApiTestSupport {
                 .andExpect(status().isNotFound());
     }
 
+    // ---------- 셀 서식 일괄(선택 범위·행·열·표 전체) ----------
+
+    @Test
+    @DisplayName("PUT cells/style(bulk) - 여러 셀 서식을 한 번에 지정하고 영향 행을 돌려준다")
+    void set_cell_styles_bulk() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"a\",\"1\"],[\"b\",\"2\"]]");
+
+        mockMvc.perform(put("/api/datasets/{id}/cells/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":["
+                                + "{\"rowIndex\":0,\"colKey\":\"c1\",\"bg\":\"green\"},"
+                                + "{\"rowIndex\":1,\"colKey\":\"c1\",\"bg\":\"green\",\"align\":\"center\"}]}"))
+                .andExpect(status().isOk())
+                // 영향받은 행이 rowIndex 오름차순으로 온다.
+                .andExpect(jsonPath("$.data[0].rowIndex").value(0))
+                .andExpect(jsonPath("$.data[0].styles.c1.bg").value("green"))
+                .andExpect(jsonPath("$.data[1].rowIndex").value(1))
+                .andExpect(jsonPath("$.data[1].styles.c1.bg").value("green"))
+                .andExpect(jsonPath("$.data[1].styles.c1.align").value("center"));
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.rows[0].styles.c1.bg").value("green"))
+                .andExpect(jsonPath("$.data.rows[1].styles.c1.align").value("center"))
+                // 서식 없는 셀은 sparse.
+                .andExpect(jsonPath("$.data.rows[0].styles.c0").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("PUT cells/style(bulk) - bg·align 모두 빈 대상은 그 셀 서식을 지운다")
+    void bulk_style_clears_empty_target() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"a\",\"1\"]]");
+        setStyle(id, 0, "c1", "{\"bg\":\"green\"}");
+
+        mockMvc.perform(put("/api/datasets/{id}/cells/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[{\"rowIndex\":0,\"colKey\":\"c1\"}]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].styles.c1").doesNotExist());
+
+        org.assertj.core.api.Assertions
+                .assertThat(datasetCellStyleRepository.findByRowIdAndColKey(rowIds(id).get(0), "c1"))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("PUT cells/style(bulk) - 허용되지 않은 색은 거부한다")
+    void bulk_style_rejects_invalid() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"a\",\"1\"]]");
+
+        mockMvc.perform(put("/api/datasets/{id}/cells/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[{\"rowIndex\":0,\"colKey\":\"c1\",\"bg\":\"pink\"}]}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PUT cells/style(bulk) - 대상이 비면 400")
+    void bulk_style_rejects_empty() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"a\",\"1\"]]");
+
+        mockMvc.perform(put("/api/datasets/{id}/cells/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[]}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PUT cells/style(bulk) - 없는 열이 섞이면 404")
+    void bulk_style_unknown_column() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"a\",\"1\"]]");
+
+        mockMvc.perform(put("/api/datasets/{id}/cells/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[{\"rowIndex\":0,\"colKey\":\"c99\",\"bg\":\"green\"}]}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("PUT cells/style(bulk) - 남의 데이터셋은 못 바꾼다")
+    void bulk_style_of_other_member() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"a\",\"1\"]]");
+        String otherToken = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+
+        mockMvc.perform(put("/api/datasets/{id}/cells/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, otherToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[{\"rowIndex\":0,\"colKey\":\"c1\",\"bg\":\"green\"}]}"))
+                .andExpect(status().isNotFound());
+    }
+
     // ---------- 셀 병합(가로·세로) ----------
 
     /** 3열 dataset(c0/c1/c2)을 만들고 id를 반환한다 — colspan 검증엔 열이 3개 필요하다. */

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -1285,20 +1285,25 @@ describe("DatasetGrid", () => {
     expect(within(toolbar).getByText("표 전체")).toBeInTheDocument();
   });
 
-  it("선택 툴바에서 배경색을 고르면 선택한 셀에 PUT한다", async () => {
+  it("선택 툴바에서 배경색을 고르면 선택한 셀에 일괄 PUT한다", async () => {
     mockDataset([["네트워크", "92"]]);
-    let sentTo: string | null = null;
+    let sentCells: unknown = null;
     server.use(
-      http.put(
-        `${API_BASE}/datasets/1/rows/:r/cells/:key/style`,
-        ({ params }) => {
-          sentTo = `${params.r}/${params.key}`;
-          return HttpResponse.json({
-            code: "OK",
-            data: { id: 100, rowIndex: Number(params.r), styles: {} },
-          });
-        },
-      ),
+      http.put(`${API_BASE}/datasets/1/cells/style`, async ({ request }) => {
+        sentCells = ((await request.json()) as { cells: unknown }).cells;
+        return HttpResponse.json({
+          code: "OK",
+          data: [
+            {
+              id: 100,
+              rowIndex: 0,
+              cells: ["네트워크", "92"],
+              formulas: {},
+              styles: { c1: { bg: "green" } },
+            },
+          ],
+        });
+      }),
     );
     const user = userEvent.setup();
     renderWithRouter(<DatasetGrid datasetId={1} />);
@@ -1308,7 +1313,42 @@ describe("DatasetGrid", () => {
     const toolbar = await screen.findByRole("toolbar", { name: "선택 도구" });
     await user.click(within(toolbar).getByLabelText("배경색 green"));
 
-    await waitFor(() => expect(sentTo).toBe("0/c1"));
+    // 선택 셀 하나를 일괄 엔드포인트로 보낸다(정렬은 기존값 없음 → null).
+    await waitFor(() =>
+      expect(sentCells).toEqual([
+        { rowIndex: 0, colKey: "c1", bg: "green", align: null },
+      ]),
+    );
+  });
+
+  it("범위를 선택해 배경색을 고르면 한 번의 요청으로 모든 셀에 적용한다", async () => {
+    mockDataset([
+      ["네트워크", "92"],
+      ["운영체제", "78"],
+    ]);
+    let requestCount = 0;
+    let count = 0;
+    server.use(
+      http.put(`${API_BASE}/datasets/1/cells/style`, async ({ request }) => {
+        requestCount++;
+        count = ((await request.json()) as { cells: unknown[] }).cells.length;
+        return HttpResponse.json({ code: "OK", data: [] });
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const a = (await screen.findByText("네트워크"))
+      .parentElement as HTMLElement; // (0,0)
+    fireEvent.pointerDown(a, { button: 0 });
+    const b = screen.getByText("78").parentElement as HTMLElement; // (1,1)
+    fireEvent.pointerDown(b, { button: 0, shiftKey: true });
+
+    const toolbar = await screen.findByRole("toolbar", { name: "선택 도구" });
+    await user.click(within(toolbar).getByLabelText("배경색 blue"));
+
+    // 4칸(2×2)을 한 요청으로 보낸다.
+    await waitFor(() => expect(requestCount).toBe(1));
+    expect(count).toBe(4);
   });
 
   it("Esc로 선택을 해제한다", async () => {

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -39,6 +39,7 @@ import {
   resizeDatasetColumn,
   setCellMerge,
   setCellStyle,
+  setCellStylesBulk,
   updateDatasetRow,
 } from "./api/datasets";
 import { useDatasetMerges } from "./hooks/useDatasetMerges";
@@ -149,6 +150,19 @@ export function DatasetGrid({ datasetId }: Props) {
       setCellStyle(datasetId, v.row, v.colKey, v.style),
     // 서식만 바뀌므로 값·수식 캐시는 건드리지 않고 styles만 갱신한다.
     onSuccess: (row) => setStylesLocal(row.rowIndex, row.styles ?? {}),
+    onError: (e) => {
+      const message = serverMessage(e);
+      if (message) toast(message, "error");
+    },
+  });
+  // 선택 범위 서식을 한 요청으로 적용(표 전체도 1회). 영향 행마다 styles 캐시를 갱신한다.
+  const bulkStyleMut = useMutation({
+    mutationFn: (
+      cells: Array<{ rowIndex: number; colKey: string; style: CellStyle }>,
+    ) => setCellStylesBulk(datasetId, cells),
+    onSuccess: (rows) => {
+      for (const row of rows) setStylesLocal(row.rowIndex, row.styles ?? {});
+    },
     onError: (e) => {
       const message = serverMessage(e);
       if (message) toast(message, "error");
@@ -573,31 +587,31 @@ export function DatasetGrid({ datasetId }: Props) {
     }
     return refs;
   };
-  // 서식 적용은 지금은 셀 단위 반복(표 전체는 요청이 많을 수 있다 → Phase 2에서 일괄 엔드포인트).
+  // 서식 적용은 선택 전체를 한 요청으로 보낸다(표 전체도 1회). 각 셀은 통째 교체라
+  // 바꾸지 않는 속성(정렬/배경)은 그 셀의 현재값을 채워 보존한다.
   const applyBgSel = (bg: CellBgToken | null) => {
-    for (const { row, colKey } of selCellRefs()) {
-      const cur = getStyles(row)[colKey];
-      styleMut.mutate({
-        row,
-        colKey,
-        style: { bg: bg ?? undefined, align: cur?.align },
-      });
-    }
+    const cells = selCellRefs().map(({ row, colKey }) => ({
+      rowIndex: row,
+      colKey,
+      style: { bg: bg ?? undefined, align: getStyles(row)[colKey]?.align },
+    }));
+    if (cells.length) bulkStyleMut.mutate(cells);
   };
   const applyAlignSel = (align: CellAlign | null) => {
-    for (const { row, colKey } of selCellRefs()) {
-      const cur = getStyles(row)[colKey];
-      styleMut.mutate({
-        row,
-        colKey,
-        style: { bg: cur?.bg, align: align ?? undefined },
-      });
-    }
+    const cells = selCellRefs().map(({ row, colKey }) => ({
+      rowIndex: row,
+      colKey,
+      style: { bg: getStyles(row)[colKey]?.bg, align: align ?? undefined },
+    }));
+    if (cells.length) bulkStyleMut.mutate(cells);
   };
   const clearFormatSel = () => {
-    for (const { row, colKey } of selCellRefs()) {
-      styleMut.mutate({ row, colKey, style: {} });
-    }
+    const cells = selCellRefs().map(({ row, colKey }) => ({
+      rowIndex: row,
+      colKey,
+      style: {} as CellStyle,
+    }));
+    if (cells.length) bulkStyleMut.mutate(cells);
   };
   /** 셀 사각 범위를 하나의 병합으로(2칸 이상일 때만). */
   const mergeSel = () => {

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -255,6 +255,28 @@ export async function setCellStyle(
   return data.data;
 }
 
+/**
+ * 여러 셀 서식을 한 번에 지정한다(선택 범위·행·열·표 전체 적용). 셀마다 서식을 통째로
+ * 교체하며(각 셀의 보존할 속성은 호출자가 채운다), 영향받은 행들을 돌려준다.
+ */
+export async function setCellStylesBulk(
+  datasetId: number,
+  cells: Array<{ rowIndex: number; colKey: string; style: CellStyle }>,
+): Promise<DatasetRow[]> {
+  const { data } = await client.put<ApiEnvelope<DatasetRow[]>>(
+    `/datasets/${datasetId}/cells/style`,
+    {
+      cells: cells.map((c) => ({
+        rowIndex: c.rowIndex,
+        colKey: c.colKey,
+        bg: c.style.bg ?? null,
+        align: c.style.align ?? null,
+      })),
+    },
+  );
+  return data.data;
+}
+
 /** 그 dataset의 병합 전체. 세로 병합은 앵커가 화면 밖이어도 덮인 행을 그려야 해 통째로 받는다. */
 export async function fetchDatasetMerges(
   datasetId: number,


### PR DESCRIPTION
## 이슈
Epic #851 (Phase 2)

## 배경
Phase 1(#852)에서 선택 툴바의 서식 적용은 **셀 단위 반복 요청**이었다. "표 전체 적용"은 셀 수만큼 PUT이 나가 비효율. 이를 **일괄 엔드포인트 1요청**으로 최적화한다.

## 작업 내용
### BE — 셀 서식 일괄 엔드포인트
- `PUT /api/datasets/{id}/cells/style`
- 요청: `{ cells: [{ rowIndex, colKey, bg, align }] }` — 셀마다 **전체 서식 교체**(단건 `SetCellStyleRequest`와 같은 의미를 목록으로 확장). bg·align 모두 비면 그 셀 서식 삭제
- 응답: 영향받은 행들의 `RowView` 리스트(rowIndex 오름차순)
- `DatasetService.setCellStylesBulk`: 소유권 1회 확인, 행 재조회 최소화(LinkedHashMap 캐시), 대상별 `styleService.setStyle`
- 검증: `@NotEmpty` cells · `@Pattern` bg/align · 없는 열/타인 데이터셋 404
- 컨트롤러 테스트 6건 추가

### FE — 선택 툴바가 일괄 엔드포인트 사용
- 선택 범위의 **배경색·정렬·서식 지우기**를 셀 단위 반복 → `setCellStylesBulk` **1요청**으로 전환
- 표 전체 적용도 요청 1회. 응답 행별로 styles 캐시 갱신
- 각 셀 전체교체라 바꾸지 않는 속성(정렬/배경)은 현재값을 채워 보존
- 테스트: 단일·범위(2×2=4칸을 1요청으로) 검증

## 검증
- BE: `compileJava`/`compileTestJava` · `checkstyle` · `DatasetControllerTest`(TestContainers, bulk 6건 포함) 통과
- FE: `vitest`(전체 357 통과) · `tsc` · `eslint` · `prettier` · `vite build` 통과

이로써 Epic #851의 계획된 범위(Phase 1 선택 시스템 + Phase 2 일괄 적용)가 완료됩니다.