### PR TITLE
feat : 데이터 그리드 옵션을 우클릭 메뉴로 통일

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -1370,19 +1370,22 @@ describe("DatasetGrid", () => {
 
   // ---------- 선택(selection) ----------
 
-  it("셀을 한 번 클릭하면 편집이 아니라 선택되고 툴바가 뜬다", async () => {
+  it("셀을 한 번 클릭하면 선택되고, 우클릭하면 '셀 1개' 메뉴가 뜬다", async () => {
     mockDataset([["네트워크", "92"]]);
     renderWithRouter(<DatasetGrid datasetId={1} />);
     const cell = (await screen.findByText("92")).parentElement as HTMLElement;
     fireEvent.pointerDown(cell, { button: 0 });
 
-    // 편집 input은 뜨지 않는다.
+    // 편집 input(셀 N행 M열)은 아직 뜨지 않는다(선택일 뿐).
     expect(screen.queryByLabelText("셀 1행 2열")).not.toBeInTheDocument();
-    const toolbar = await screen.findByRole("toolbar", { name: "선택 도구" });
-    expect(within(toolbar).getByText("셀 1개")).toBeInTheDocument();
+
+    // 옵션은 플로팅 툴바 없이 우클릭 메뉴 하나로 통일 — 선택 범위가 '셀 1개'로 표시된다.
+    fireEvent.contextMenu(cell);
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    expect(within(menu).getByText("셀 1개")).toBeInTheDocument();
   });
 
-  it("shift+클릭으로 셀 범위를 선택한다", async () => {
+  it("shift+클릭으로 셀 범위를 선택하고, 우클릭 메뉴가 '셀 4개'를 보여준다", async () => {
     mockDataset([
       ["네트워크", "92"],
       ["운영체제", "78"],
@@ -1394,51 +1397,55 @@ describe("DatasetGrid", () => {
     const b = screen.getByText("78").parentElement as HTMLElement;
     fireEvent.pointerDown(b, { button: 0, shiftKey: true });
 
-    // (0,0)~(1,1) = 4칸.
-    const toolbar = await screen.findByRole("toolbar", { name: "선택 도구" });
-    expect(within(toolbar).getByText("셀 4개")).toBeInTheDocument();
+    // (0,0)~(1,1) = 4칸. 선택 안을 우클릭하면 선택이 유지된다.
+    fireEvent.contextMenu(a);
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    expect(within(menu).getByText("셀 4개")).toBeInTheDocument();
   });
 
-  it("행 핸들을 누르면 행이 선택되고 툴바에 행 옵션이 뜬다", async () => {
+  it("행 핸들로 행을 선택하고 우클릭하면 '1행'과 행 삽입 옵션이 나온다", async () => {
     mockDataset([["네트워크", "92"]]);
     renderWithRouter(<DatasetGrid datasetId={1} />);
     await screen.findByText("네트워크");
     fireEvent.pointerDown(screen.getByRole("button", { name: "1행 선택" }));
 
-    const toolbar = await screen.findByRole("toolbar", { name: "선택 도구" });
-    expect(within(toolbar).getByText("1행")).toBeInTheDocument();
+    fireEvent.contextMenu(screen.getByText("네트워크"));
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    expect(within(menu).getByText("1행")).toBeInTheDocument();
     expect(
-      within(toolbar).getByRole("button", { name: "위 삽입" }),
+      within(menu).getByRole("menuitem", { name: "위에 행 삽입" }),
     ).toBeInTheDocument();
     expect(
-      within(toolbar).getByRole("button", { name: "아래 삽입" }),
+      within(menu).getByRole("menuitem", { name: "아래에 행 삽입" }),
     ).toBeInTheDocument();
   });
 
-  it("열 핸들을 누르면 열이 선택되고 툴바에 열 옵션이 뜬다", async () => {
+  it("열 핸들로 열을 선택하고 우클릭하면 '1열'과 열 삽입 옵션이 나온다", async () => {
     mockDataset([["네트워크", "92"]]);
     renderWithRouter(<DatasetGrid datasetId={1} />);
     await screen.findByText("네트워크");
     fireEvent.pointerDown(screen.getByRole("button", { name: "1열 선택" }));
 
-    const toolbar = await screen.findByRole("toolbar", { name: "선택 도구" });
-    expect(within(toolbar).getByText("1열")).toBeInTheDocument();
+    fireEvent.contextMenu(screen.getByText("네트워크"));
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    expect(within(menu).getByText("1열")).toBeInTheDocument();
     expect(
-      within(toolbar).getByRole("button", { name: "왼쪽 삽입" }),
+      within(menu).getByRole("menuitem", { name: "왼쪽에 열 삽입" }),
     ).toBeInTheDocument();
   });
 
-  it("코너를 누르면 표 전체가 선택된다", async () => {
+  it("코너로 표 전체를 선택하고 우클릭하면 '표 전체'가 나온다", async () => {
     mockDataset([["네트워크", "92"]]);
     renderWithRouter(<DatasetGrid datasetId={1} />);
     await screen.findByText("네트워크");
     fireEvent.pointerDown(screen.getByRole("button", { name: "표 전체 선택" }));
 
-    const toolbar = await screen.findByRole("toolbar", { name: "선택 도구" });
-    expect(within(toolbar).getByText("표 전체")).toBeInTheDocument();
+    fireEvent.contextMenu(screen.getByText("네트워크"));
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    expect(within(menu).getByText("표 전체")).toBeInTheDocument();
   });
 
-  it("선택 툴바에서 배경색을 고르면 선택한 셀에 일괄 PUT한다", async () => {
+  it("우클릭 메뉴에서 배경색을 고르면 선택한 셀에 일괄 PUT한다", async () => {
     mockDataset([["네트워크", "92"]]);
     let sentCells: unknown = null;
     server.use(
@@ -1463,8 +1470,9 @@ describe("DatasetGrid", () => {
     const cell = (await screen.findByText("92")).parentElement as HTMLElement; // (0,1)=c1
     fireEvent.pointerDown(cell, { button: 0 });
 
-    const toolbar = await screen.findByRole("toolbar", { name: "선택 도구" });
-    await user.click(within(toolbar).getByLabelText("배경색 green"));
+    fireEvent.contextMenu(cell);
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    await user.click(within(menu).getByLabelText("배경색 green"));
 
     // 선택 셀 하나를 일괄 엔드포인트로 보낸다(정렬은 기존값 없음 → null).
     await waitFor(() =>
@@ -1474,7 +1482,7 @@ describe("DatasetGrid", () => {
     );
   });
 
-  it("범위를 선택해 배경색을 고르면 한 번의 요청으로 모든 셀에 적용한다", async () => {
+  it("범위를 선택해 우클릭 배경색을 고르면 한 번의 요청으로 모든 셀에 적용한다", async () => {
     mockDataset([
       ["네트워크", "92"],
       ["운영체제", "78"],
@@ -1496,8 +1504,9 @@ describe("DatasetGrid", () => {
     const b = screen.getByText("78").parentElement as HTMLElement; // (1,1)
     fireEvent.pointerDown(b, { button: 0, shiftKey: true });
 
-    const toolbar = await screen.findByRole("toolbar", { name: "선택 도구" });
-    await user.click(within(toolbar).getByLabelText("배경색 blue"));
+    fireEvent.contextMenu(a);
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    await user.click(within(menu).getByLabelText("배경색 blue"));
 
     // 4칸(2×2)을 한 요청으로 보낸다.
     await waitFor(() => expect(requestCount).toBe(1));
@@ -1509,13 +1518,92 @@ describe("DatasetGrid", () => {
     renderWithRouter(<DatasetGrid datasetId={1} />);
     const cell = (await screen.findByText("92")).parentElement as HTMLElement;
     fireEvent.pointerDown(cell, { button: 0 });
-    await screen.findByRole("toolbar", { name: "선택 도구" });
+    // 선택되면 활성 입력창(선택 모드)이 뜬다.
+    expect(
+      screen.getByLabelText("1행 2열 셀 (입력하면 편집)"),
+    ).toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: "Escape" });
     await waitFor(() =>
       expect(
-        screen.queryByRole("toolbar", { name: "선택 도구" }),
+        screen.queryByLabelText("1행 2열 셀 (입력하면 편집)"),
       ).not.toBeInTheDocument(),
     );
+  });
+
+  it("셀 범위를 우클릭해 '병합'하면 앵커 셀에 rowSpan·colSpan으로 PUT한다", async () => {
+    mockDataset([
+      ["네트워크", "92"],
+      ["운영체제", "78"],
+    ]);
+    let sent: unknown = null;
+    server.use(
+      http.put(
+        `${API_BASE}/datasets/1/rows/0/cells/c0/merge`,
+        async ({ request }) => {
+          sent = await request.json();
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              merges: [{ rowIndex: 0, colKey: "c0", rowSpan: 2, colSpan: 2 }],
+            },
+          });
+        },
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const a = (await screen.findByText("네트워크"))
+      .parentElement as HTMLElement; // (0,0)
+    fireEvent.pointerDown(a, { button: 0 });
+    const b = screen.getByText("78").parentElement as HTMLElement; // (1,1)
+    fireEvent.pointerDown(b, { button: 0, shiftKey: true });
+
+    fireEvent.contextMenu(a);
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    await user.click(within(menu).getByRole("menuitem", { name: "병합" }));
+
+    // 2×2 사각 범위를 앵커(0,0=c0)에 한 병합으로 보낸다.
+    await waitFor(() => expect(sent).toEqual({ rowSpan: 2, colSpan: 2 }));
+  });
+
+  it("셀 범위를 우클릭해 '내용 지우기'하면 값이 비워져 저장된다", async () => {
+    mockDataset([
+      ["네트워크", "92"],
+      ["운영체제", "78"],
+    ]);
+    const patched: Record<number, string[]> = {};
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/rows/:i`,
+        async ({ params, request }) => {
+          const body = (await request.json()) as { cells: string[] };
+          patched[Number(params.i)] = body.cells;
+          return HttpResponse.json({
+            code: "OK",
+            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+          });
+        },
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const a = (await screen.findByText("네트워크"))
+      .parentElement as HTMLElement; // (0,0)
+    fireEvent.pointerDown(a, { button: 0 });
+    const b = screen.getByText("78").parentElement as HTMLElement; // (1,1)
+    fireEvent.pointerDown(b, { button: 0, shiftKey: true });
+
+    fireEvent.contextMenu(a);
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    await user.click(
+      within(menu).getByRole("menuitem", { name: "내용 지우기" }),
+    );
+
+    // 두 행의 두 열 모두 빈 값으로 저장된다.
+    await waitFor(() => {
+      expect(patched[0]).toEqual(["", ""]);
+      expect(patched[1]).toEqual(["", ""]);
+    });
   });
 });

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -202,14 +202,6 @@ export function DatasetGrid({ datasetId }: Props) {
       void invalidateMerges(); // 뒤 행이 밀려 병합의 행 번호가 바뀌고, 안에 끼면 해제된다.
     },
   });
-  const deleteMut = useMutation({
-    mutationFn: (index: number) => deleteDatasetRow(datasetId, index),
-    onSuccess: () => {
-      reset();
-      void invalidateMeta();
-      void invalidateMerges(); // 앵커 행 삭제는 cascade, 뒤 행은 번호가 밀린다.
-    },
-  });
   const deleteColMut = useMutation({
     mutationFn: (key: string) => deleteDatasetColumn(datasetId, key),
     onSuccess: (next: DatasetMeta) => {
@@ -502,7 +494,10 @@ export function DatasetGrid({ datasetId }: Props) {
     setPalette(null);
   };
 
-  /** 셀 우클릭 → 그 자리에 컨텍스트 메뉴를 연다(행/열 삽입·삭제·병합). */
+  /**
+   * 셀 우클릭 → 그 자리에 컨텍스트 메뉴를 연다(선택 범위에 맞춰 서식·병합·행/열 옵션을 모두 담는다).
+   * 클릭한 셀이 현재 선택 밖이면 그 셀을 단일 선택으로 잡고(엑셀식), 선택 안이면 선택을 유지한다.
+   */
   const openContextMenu = (
     event: React.MouseEvent,
     row: number,
@@ -510,6 +505,11 @@ export function DatasetGrid({ datasetId }: Props) {
   ) => {
     event.preventDefault();
     setPalette(null);
+    if (!inSel(row, col)) {
+      setEditing(null);
+      selDrag.current = null;
+      setSel({ kind: "cells", a: [row, col], b: [row, col] });
+    }
     setCtxMenu({ x: event.clientX, y: event.clientY, row, col });
   };
 
@@ -753,9 +753,9 @@ export function DatasetGrid({ datasetId }: Props) {
       span: { rowSpan, colSpan },
     });
   };
-  /** 선택한 행들을 뒤 인덱스부터 순서대로 지운다(인덱스가 밀리지 않게). */
+  /** 선택이 걸친 행들을 뒤 인덱스부터 순서대로 지운다(인덱스가 밀리지 않게). */
   const deleteRowsSel = async () => {
-    if (!selRect || sel?.kind !== "rows") return;
+    if (!selRect) return;
     for (let r = selRect.r1; r >= selRect.r0; r--) {
       await deleteDatasetRow(datasetId, r);
     }
@@ -764,9 +764,9 @@ export function DatasetGrid({ datasetId }: Props) {
     void invalidateMerges();
     setSel(null);
   };
-  /** 선택한 열들을 지운다(key 기준이라 순서 무관). 최소 한 열은 남긴다. */
+  /** 선택이 걸친 열들을 지운다(key 기준이라 순서 무관). 최소 한 열은 남긴다. */
   const deleteColsSel = async () => {
-    if (!selRect || sel?.kind !== "cols") return;
+    if (!selRect) return;
     const keys = meta.columns
       .slice(selRect.c0, selRect.c1 + 1)
       .map((c) => c.key);
@@ -1177,177 +1177,6 @@ export function DatasetGrid({ datasetId }: Props) {
           </div>
         </div>
 
-        {/* 선택 위 플로팅 툴바 — 선택 범위(표/행/열/셀)에 맞는 옵션을 보여준다.
-          세로는 선택을 따라붙는다: 기본은 선택 바로 위, 위 공간이 부족하면(표·뷰포트 상단)
-          아래로 뒤집는다. 가로는 표 중앙 유지. */}
-        {sel &&
-          selRect &&
-          (() => {
-            const area =
-              (selRect.r1 - selRect.r0 + 1) * (selRect.c1 - selRect.c0 + 1);
-            const scopeLabel =
-              sel.kind === "table"
-                ? "표 전체"
-                : sel.kind === "rows"
-                  ? `${selRect.r1 - selRect.r0 + 1}행`
-                  : sel.kind === "cols"
-                    ? `${selRect.c1 - selRect.c0 + 1}열`
-                    : `셀 ${area}개`;
-            const divider = <div className="bg-border mx-0.5 h-5 w-px" />;
-            // 선택 첫 행 위(뷰포트 기준)에 툴바가 들어갈 자리가 있으면 위, 없으면 아래.
-            // scrollMargin=본문의 문서 오프셋, ROW_HEIGHT=고정 행 높이.
-            const selTopViewport =
-              scrollMargin + selRect.r0 * ROW_HEIGHT - window.scrollY;
-            const above = selTopViewport >= 48;
-            const anchorTop = above
-              ? selRect.r0 * ROW_HEIGHT
-              : (selRect.r1 + 1) * ROW_HEIGHT;
-            return (
-              <div
-                role="toolbar"
-                aria-label="선택 도구"
-                onPointerDown={(e) => e.stopPropagation()}
-                style={{
-                  top: anchorTop,
-                  transform: above
-                    ? "translate(-50%, calc(-100% - 6px))"
-                    : "translate(-50%, 6px)",
-                }}
-                className="border-border bg-popover absolute left-1/2 z-30 flex items-center gap-1 rounded-md border p-1 whitespace-nowrap shadow-md"
-              >
-                <span className="text-muted-foreground px-1 text-xs whitespace-nowrap">
-                  {scopeLabel}
-                </span>
-                {divider}
-                {/* 배경색 — 모든 선택 공통 */}
-                {CELL_BG_TOKENS.map((token) => (
-                  <button
-                    key={token}
-                    type="button"
-                    aria-label={`배경색 ${token}`}
-                    onClick={() => applyBgSel(token)}
-                    className="border-border size-4 rounded-full border"
-                    style={{ background: `var(--cell-bg-${token})` }}
-                  />
-                ))}
-                <button
-                  type="button"
-                  aria-label="배경색 지우기"
-                  onClick={() => applyBgSel(null)}
-                  className="text-muted-foreground hover:text-foreground border-border flex size-5 items-center justify-center rounded border"
-                >
-                  <X className="size-3" />
-                </button>
-                {divider}
-                {/* 정렬 */}
-                {ALIGN_ORDER.map((value) => {
-                  const Icon = ALIGN_ICONS[value];
-                  return (
-                    <button
-                      key={value}
-                      type="button"
-                      aria-label={`정렬 ${ALIGN_LABELS[value]}`}
-                      onClick={() => applyAlignSel(value)}
-                      className="text-muted-foreground hover:bg-accent hover:text-foreground flex size-5 items-center justify-center rounded"
-                    >
-                      <Icon className="size-3.5" />
-                    </button>
-                  );
-                })}
-                {/* 서식 지우기 */}
-                <button
-                  type="button"
-                  aria-label="서식 지우기"
-                  title="배경·정렬 초기화"
-                  onClick={clearFormatSel}
-                  className="text-muted-foreground hover:bg-accent hover:text-foreground flex size-5 items-center justify-center rounded"
-                >
-                  <Eraser className="size-3.5" />
-                </button>
-                {/* 병합 — 셀 사각 2칸 이상 */}
-                {sel.kind === "cells" && area > 1 && (
-                  <button
-                    type="button"
-                    aria-label="병합"
-                    title="선택 범위 병합"
-                    onClick={mergeSel}
-                    className="text-muted-foreground hover:bg-accent hover:text-foreground flex size-5 items-center justify-center rounded"
-                  >
-                    <TableCellsMerge className="size-3.5" />
-                  </button>
-                )}
-                {/* 행 옵션 */}
-                {sel.kind === "rows" && (
-                  <>
-                    {divider}
-                    <button
-                      type="button"
-                      onClick={() => addRow(selRect.r0)}
-                      className="hover:bg-accent rounded px-1.5 py-0.5 text-xs whitespace-nowrap"
-                    >
-                      위 삽입
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => addRow(selRect.r1 + 1)}
-                      className="hover:bg-accent rounded px-1.5 py-0.5 text-xs whitespace-nowrap"
-                    >
-                      아래 삽입
-                    </button>
-                    <button
-                      type="button"
-                      aria-label="행 삭제"
-                      onClick={() => void deleteRowsSel()}
-                      className="text-destructive hover:bg-accent flex size-5 items-center justify-center rounded"
-                    >
-                      <Trash2 className="size-3.5" />
-                    </button>
-                  </>
-                )}
-                {/* 열 옵션 */}
-                {sel.kind === "cols" && (
-                  <>
-                    {divider}
-                    <button
-                      type="button"
-                      onClick={() => addColumn(selRect.c0)}
-                      className="hover:bg-accent rounded px-1.5 py-0.5 text-xs whitespace-nowrap"
-                    >
-                      왼쪽 삽입
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => addColumn(selRect.c1 + 1)}
-                      className="hover:bg-accent rounded px-1.5 py-0.5 text-xs whitespace-nowrap"
-                    >
-                      오른쪽 삽입
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        for (let c = selRect.c0; c <= selRect.c1; c++)
-                          resetColWidthMut.mutate(meta.columns[c].key);
-                      }}
-                      className="hover:bg-accent rounded px-1.5 py-0.5 text-xs whitespace-nowrap"
-                    >
-                      너비 초기화
-                    </button>
-                    {colCount > selRect.c1 - selRect.c0 + 1 && (
-                      <button
-                        type="button"
-                        aria-label="열 삭제"
-                        onClick={() => void deleteColsSel()}
-                        className="text-destructive hover:bg-accent flex size-5 items-center justify-center rounded"
-                      >
-                        <Trash2 className="size-3.5" />
-                      </button>
-                    )}
-                  </>
-                )}
-              </div>
-            );
-          })()}
-
         <ConfirmDialog
           open={pendingColDelete !== null}
           onOpenChange={(open) => {
@@ -1368,15 +1197,39 @@ export function DatasetGrid({ datasetId }: Props) {
           pending={deleteColMut.isPending}
         />
 
-        {/* 셀 우클릭 컨텍스트 메뉴 — 행/열 삽입·삭제·병합을 한 곳에 모은다. */}
+        {/* 우클릭 컨텍스트 메뉴 — 선택 범위에 맞춰 서식·병합·행/열 옵션을 한 곳에 모은다.
+          (별도 플로팅 툴바 없이 우클릭 하나로 통일한다.) */}
         {ctxMenu &&
           (() => {
             const { row, col } = ctxMenu;
             const cm = mergeAt(row, col);
             const colSpan = cm?.colSpan ?? 1;
             const rowSpan = cm?.rowSpan ?? 1;
-            const colKey = meta.columns[col].key;
+            // 선택이 있으면 그 범위, 없으면 우클릭한 셀 1칸을 대상으로 한다.
+            const rect = selRect ?? { r0: row, c0: col, r1: row, c1: col };
+            const kind = sel?.kind ?? "cells";
+            const rowN = rect.r1 - rect.r0 + 1;
+            const colN = rect.c1 - rect.c0 + 1;
+            const area = rowN * colN;
+            const scopeLabel =
+              kind === "table"
+                ? "표 전체"
+                : kind === "rows"
+                  ? `${rowN}행`
+                  : kind === "cols"
+                    ? `${colN}열`
+                    : `셀 ${area}개`;
+            const singleCell = kind === "cells" && area === 1;
+            const canMergeRight = col + colSpan < colCount;
+            const canMergeDown = row + rowSpan < rowCount;
+            const showMergeSection =
+              (kind === "cells" && area > 1) ||
+              (singleCell && (canMergeRight || canMergeDown || Boolean(cm)));
             const close = () => setCtxMenu(null);
+            const run = (fn: () => void) => () => {
+              fn();
+              close();
+            };
             const item = (
               label: string,
               onClick: () => void,
@@ -1385,10 +1238,7 @@ export function DatasetGrid({ datasetId }: Props) {
               <button
                 type="button"
                 role="menuitem"
-                onClick={() => {
-                  onClick();
-                  close();
-                }}
+                onClick={run(onClick)}
                 className={cn(
                   "hover:bg-accent flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm",
                   opts.destructive && "text-destructive",
@@ -1398,8 +1248,7 @@ export function DatasetGrid({ datasetId }: Props) {
                 {label}
               </button>
             );
-            const canMergeRight = col + colSpan < colCount;
-            const canMergeDown = row + rowSpan < rowCount;
+            const divider = <div className="bg-border my-1 h-px" />;
             return (
               <>
                 {/* 바깥 클릭·우클릭으로 닫는다. */}
@@ -1414,50 +1263,126 @@ export function DatasetGrid({ datasetId }: Props) {
                 <div
                   role="menu"
                   aria-label="셀 메뉴"
-                  className="border-border bg-popover fixed z-50 min-w-40 rounded-md border p-1 shadow-md"
+                  className="border-border bg-popover fixed z-50 min-w-44 rounded-md border p-1 shadow-md"
                   // 뷰포트 오른쪽·아래로 넘치지 않게 대략 클램프한다(메뉴 크기 여유분).
                   style={{
-                    left: Math.min(ctxMenu.x, window.innerWidth - 176),
-                    top: Math.min(ctxMenu.y, window.innerHeight - 340),
+                    left: Math.min(ctxMenu.x, window.innerWidth - 192),
+                    top: Math.min(ctxMenu.y, window.innerHeight - 420),
                   }}
                 >
-                  {item("위에 행 삽입", () => addRow(row), {
-                    icon: <Plus className="size-3.5" />,
-                  })}
-                  {item("아래에 행 삽입", () => addRow(row + 1), {
-                    icon: <Plus className="size-3.5" />,
-                  })}
-                  {item("왼쪽에 열 삽입", () => addColumn(col), {
-                    icon: <Plus className="size-3.5" />,
-                  })}
-                  {item("오른쪽에 열 삽입", () => addColumn(col + 1), {
-                    icon: <Plus className="size-3.5" />,
-                  })}
-                  {(canMergeRight || canMergeDown || cm) && (
-                    <div className="bg-border my-1 h-px" />
-                  )}
-                  {canMergeRight &&
+                  {/* 선택 범위 표시 */}
+                  <div className="text-muted-foreground px-2 py-1 text-xs">
+                    {scopeLabel}
+                  </div>
+                  {/* 배경색 — 스와치 + 지우기 */}
+                  <div className="flex items-center gap-1 px-2 py-1">
+                    {CELL_BG_TOKENS.map((token) => (
+                      <button
+                        key={token}
+                        type="button"
+                        aria-label={`배경색 ${token}`}
+                        onClick={run(() => applyBgSel(token))}
+                        className="border-border size-5 rounded-full border"
+                        style={{ background: `var(--cell-bg-${token})` }}
+                      />
+                    ))}
+                    <button
+                      type="button"
+                      aria-label="배경색 지우기"
+                      onClick={run(() => applyBgSel(null))}
+                      className="text-muted-foreground hover:text-foreground border-border flex size-5 items-center justify-center rounded-full border"
+                    >
+                      <X className="size-3" />
+                    </button>
+                  </div>
+                  {/* 정렬 + 서식 지우기 */}
+                  <div className="flex items-center gap-1 px-2 py-1">
+                    {ALIGN_ORDER.map((value) => {
+                      const Icon = ALIGN_ICONS[value];
+                      return (
+                        <button
+                          key={value}
+                          type="button"
+                          aria-label={`정렬 ${ALIGN_LABELS[value]}`}
+                          onClick={run(() => applyAlignSel(value))}
+                          className="text-muted-foreground hover:bg-accent hover:text-foreground flex size-6 items-center justify-center rounded"
+                        >
+                          <Icon className="size-4" />
+                        </button>
+                      );
+                    })}
+                    <button
+                      type="button"
+                      aria-label="서식 지우기"
+                      title="배경·정렬 초기화"
+                      onClick={run(clearFormatSel)}
+                      className="text-muted-foreground hover:bg-accent hover:text-foreground ml-auto flex size-6 items-center justify-center rounded"
+                    >
+                      <Eraser className="size-4" />
+                    </button>
+                  </div>
+                  {divider}
+                  {/* 병합 — 셀 범위(2칸+)는 통합 병합, 단일 셀은 방향 병합·해제 */}
+                  {kind === "cells" &&
+                    area > 1 &&
+                    item("병합", mergeSel, {
+                      icon: <TableCellsMerge className="size-3.5" />,
+                    })}
+                  {singleCell &&
+                    canMergeRight &&
                     item("오른쪽과 병합", () => mergeRight(row, col), {
                       icon: <TableCellsMerge className="size-3.5" />,
                     })}
-                  {canMergeDown &&
+                  {singleCell &&
+                    canMergeDown &&
                     item("아래와 병합", () => mergeDown(row, col), {
                       icon: <TableCellsMerge className="size-3.5 rotate-90" />,
                     })}
-                  {cm &&
+                  {singleCell &&
+                    cm &&
                     item("병합 해제", () => unmerge(row, col), {
                       icon: <TableCellsSplit className="size-3.5" />,
                     })}
-                  <div className="bg-border my-1 h-px" />
-                  {item("행 삭제", () => deleteMut.mutate(row), {
+                  {showMergeSection && divider}
+                  {/* 행/열 삽입 + 너비 초기화 */}
+                  {item("위에 행 삽입", () => addRow(rect.r0), {
+                    icon: <Plus className="size-3.5" />,
+                  })}
+                  {item("아래에 행 삽입", () => addRow(rect.r1 + 1), {
+                    icon: <Plus className="size-3.5" />,
+                  })}
+                  {item("왼쪽에 열 삽입", () => addColumn(rect.c0), {
+                    icon: <Plus className="size-3.5" />,
+                  })}
+                  {item("오른쪽에 열 삽입", () => addColumn(rect.c1 + 1), {
+                    icon: <Plus className="size-3.5" />,
+                  })}
+                  {item("열 너비 초기화", () => {
+                    for (let c = rect.c0; c <= rect.c1; c++)
+                      resetColWidthMut.mutate(meta.columns[c].key);
+                  })}
+                  {divider}
+                  {/* 내용 지우기(값만) */}
+                  {item("내용 지우기", clearSelValues, {
+                    icon: <Eraser className="size-3.5" />,
+                  })}
+                  {divider}
+                  {/* 삭제 */}
+                  {item("행 삭제", () => void deleteRowsSel(), {
                     icon: <Trash2 className="size-3.5" />,
                     destructive: true,
                   })}
                   {colCount > 1 &&
-                    item("열 삭제", () => setPendingColDelete(colKey), {
-                      icon: <X className="size-3.5" />,
-                      destructive: true,
-                    })}
+                    item(
+                      "열 삭제",
+                      () => {
+                        // 한 열이면 데이터 손실 확인 다이얼로그, 여러 열이면 바로 지운다.
+                        if (colN === 1)
+                          setPendingColDelete(meta.columns[rect.c0].key);
+                        else void deleteColsSel();
+                      },
+                      { icon: <X className="size-3.5" />, destructive: true },
+                    )}
                 </div>
               </>
             );


### PR DESCRIPTION
## 이슈
closes #862

## 배경
셀을 드래그 선택하면 **선택 위 플로팅 툴바**와 **우클릭 메뉴**가 동시에 존재해 옵션이 두 곳으로 갈렸다. 우클릭 하나로 통일한다.

## 작업 내용
- 선택 위 플로팅 툴바(`role="toolbar"`) **제거**
- 우클릭 메뉴를 **선택 범위 인식형**으로 개선:
  - 선택 **밖** 셀 우클릭 → 그 셀을 단일 선택(엑셀식)
  - 선택 **안** 우클릭 → 현재 선택 유지
- 메뉴에 **모든 옵션 집약**: 선택 범위 표시(셀 N개/N행/N열/표 전체) · 배경색 · 정렬 · 서식 지우기 · 병합(범위)/오른쪽·아래 병합(단일)/병합 해제 · 행/열 삽입 · 열 너비 초기화 · 내용 지우기 · 행/열 삭제
- `deleteRowsSel`/`deleteColsSel`를 선택 범위 기준으로 일반화, 미사용 `deleteMut` 제거

## 확인
- 유닛 테스트 47개 통과(툴바 테스트 → 우클릭 메뉴로 전환, 병합·내용 지우기 메뉴 테스트 추가), `prettier`/`eslint`/`tsc -b` 통과
- **실제 Tiptap 에디터 안에서** 브라우저 직접 확인:
  - 드래그 선택 직후 **플로팅 툴바 없음**, 우클릭 시 '셀 4개' + 전체 옵션 메뉴
  - 메뉴에서 배경색 적용 → 선택 4칸에만 반영, 메뉴 닫힘
  - 선택 밖 셀 우클릭 → '셀 1개'로 재선택
  - 기존 편집/타이핑·행/열 삽입·삭제·병합 동작 유지