### PR TITLE
feat : 데이터 그리드 선택 셀 얇은 테두리 강조

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -277,6 +277,9 @@ describe("DatasetGrid", () => {
     expect(input).toHaveValue("92");
     // 아직 편집이 아니므로 편집용 라벨(셀 N행 M열)은 없다.
     expect(screen.queryByLabelText("셀 1행 2열")).not.toBeInTheDocument();
+    // 어느 칸이 선택됐는지 보이도록 얇은 안쪽 테두리로 강조한다.
+    expect(input.className).toContain("ring-1");
+    expect(input.className).toContain("ring-primary");
   });
 
   it("셀 선택 후 한글을 조합해 입력하면 같은 입력창에서 편집돼 저장된다", async () => {

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -926,7 +926,8 @@ export function DatasetGrid({ datasetId }: Props) {
                 : `${rowIndex + 1}행 ${c + 1}열 셀 (입력하면 편집)`
             }
             className={cn(
-              "absolute inset-0 z-[6] h-full w-full px-2 py-1.5 outline-none",
+              // 활성(선택/편집) 셀은 얇은 안쪽 테두리로 강조해 어느 칸이 선택됐는지 보이게 한다.
+              "ring-primary absolute inset-0 z-[6] h-full w-full px-2 py-1.5 ring-1 outline-none ring-inset",
               ALIGN_CLASS[align],
               // 뒤 표시값을 가리도록 셀 배경색(없으면 카드색)으로 불투명하게 덮는다.
               !style?.bg && "bg-card",


### PR DESCRIPTION
## 이슈
closes #864

## 배경
셀을 한 번 클릭하면 활성 입력창이 셀을 불투명하게 덮어, 어느 칸이 선택됐는지 알 수 없었다.

## 작업 내용
- 활성(선택/편집) 셀 입력창에 **1px 안쪽 테두리**(`ring-1 ring-inset ring-primary`) 추가 → 클릭한 셀이 얇은 보라색(primary) 테두리로 강조된다

## 확인
- 유닛 테스트 47개 통과(테두리 클래스 검증 추가), `prettier`/`eslint`/`tsc -b` 통과
- 실제 에디터에서 확인: 셀 클릭 시 1px inset ring(primary) 렌더 확인(box-shadow: oklch primary 1px inset)

## 참고
- 이 PR은 활성 입력창 스타일만 건드려 우클릭 메뉴 통일 PR(#863)과 독립적입니다.