### PR TITLE
feat : 데이터 그리드 셀 범위 복사/붙여넣기(엑셀식)

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -244,6 +244,98 @@ describe("DatasetGrid", () => {
     });
   });
 
+  it("셀 범위를 복사하면 TSV(탭·줄바꿈)로 클립보드에 담는다", async () => {
+    mockDataset([
+      ["네트워크", "92"],
+      ["운영체제", "78"],
+    ]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const a = (await screen.findByText("네트워크"))
+      .parentElement as HTMLElement; // (0,0)
+    fireEvent.pointerDown(a, { button: 0 });
+    const b = screen.getByText("78").parentElement as HTMLElement; // (1,1)
+    fireEvent.pointerDown(b, { button: 0, shiftKey: true });
+
+    const setData = vi.fn();
+    fireEvent.copy(screen.getByTestId("dataset-grid"), {
+      clipboardData: { setData, getData: () => "" },
+    });
+
+    // 2×2 범위를 엑셀 호환 TSV로 담는다.
+    expect(setData).toHaveBeenCalledWith(
+      "text/plain",
+      "네트워크\t92\n운영체제\t78",
+    );
+  });
+
+  it("셀을 선택하고 붙여넣으면 좌상단부터 값이 채워져 저장된다", async () => {
+    mockDataset([
+      ["네트워크", "92"],
+      ["운영체제", "78"],
+    ]);
+    const patched: Record<number, string[]> = {};
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/rows/:i`,
+        async ({ params, request }) => {
+          const body = (await request.json()) as { cells: string[] };
+          patched[Number(params.i)] = body.cells;
+          return HttpResponse.json({
+            code: "OK",
+            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+          });
+        },
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const a = (await screen.findByText("네트워크"))
+      .parentElement as HTMLElement; // (0,0) 선택
+    fireEvent.pointerDown(a, { button: 0 });
+
+    // 2×2 TSV를 (0,0)부터 붙여넣는다.
+    fireEvent.paste(screen.getByTestId("dataset-grid"), {
+      clipboardData: { getData: () => "가\t나\n다\t라", setData: () => {} },
+    });
+
+    await waitFor(() => {
+      expect(patched[0]).toEqual(["가", "나"]);
+      expect(patched[1]).toEqual(["다", "라"]);
+    });
+  });
+
+  it("붙여넣기가 표 경계를 넘으면 넘치는 부분은 잘라낸다(행 자동 추가 없음)", async () => {
+    mockDataset([["네트워크", "92"]]); // 1행 2열뿐
+    const patched: Record<number, string[]> = {};
+    let rowCalls = 0;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/rows/:i`,
+        async ({ params, request }) => {
+          rowCalls++;
+          const body = (await request.json()) as { cells: string[] };
+          patched[Number(params.i)] = body.cells;
+          return HttpResponse.json({
+            code: "OK",
+            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+          });
+        },
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const a = (await screen.findByText("92")).parentElement as HTMLElement; // (0,1)
+    fireEvent.pointerDown(a, { button: 0 });
+
+    // 3열·2행짜리를 (0,1)에 붙여도, 표는 1행 2열이라 (0,1) 한 칸만 채워진다.
+    fireEvent.paste(screen.getByTestId("dataset-grid"), {
+      clipboardData: { getData: () => "A\tB\tC\nD\tE\tF", setData: () => {} },
+    });
+
+    await waitFor(() => expect(patched[0]).toEqual(["네트워크", "A"]));
+    // 두 번째 행은 존재하지 않아 요청조차 나가지 않는다.
+    expect(rowCalls).toBe(1);
+    expect(patched[1]).toBeUndefined();
+  });
+
   it("선택 상태에서 글자를 누르면 이벤트가 상위(에디터)로 전파되지 않는다", async () => {
     mockDataset([["네트워크", "92"]]);
     const user = userEvent.setup();

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -667,6 +667,78 @@ export function DatasetGrid({ datasetId }: Props) {
     }
   };
 
+  /** 선택 범위를 TSV(탭 구분·줄바꿈)로 만든다 — 엑셀·구글시트와 호환되는 클립보드 형식. */
+  const selectionToTSV = (): string => {
+    if (!selRect) return "";
+    const lines: string[] = [];
+    for (let r = selRect.r0; r <= selRect.r1; r++) {
+      const cells = getRow(r);
+      const cols: string[] = [];
+      for (let c = selRect.c0; c <= selRect.c1; c++)
+        cols.push(cells?.[c] ?? "");
+      lines.push(cols.join("\t"));
+    }
+    return lines.join("\n");
+  };
+
+  /** 선택 범위 복사(Cmd/Ctrl+C). 편집 중엔 입력창 기본 복사에 맡긴다. */
+  const onGridCopy = (e: React.ClipboardEvent) => {
+    if (editing || !selRect) return;
+    e.preventDefault();
+    e.clipboardData.setData("text/plain", selectionToTSV());
+  };
+
+  /** 잘라내기(Cmd/Ctrl+X) — 복사 후 선택 값을 비운다. */
+  const onGridCut = (e: React.ClipboardEvent) => {
+    if (editing || !selRect) return;
+    e.preventDefault();
+    e.clipboardData.setData("text/plain", selectionToTSV());
+    clearSelValues();
+  };
+
+  /**
+   * 붙여넣기(Cmd/Ctrl+V) — 클립보드 TSV를 선택 좌상단부터 채운다(엑셀식). 표 밖으로 넘치는
+   * 만큼은 자른다(행·열 자동 추가는 하지 않는다). 편집 중엔 입력창 기본 붙여넣기에 맡긴다.
+   */
+  const onGridPaste = (e: React.ClipboardEvent) => {
+    if (editing || !selRect) return;
+    const text = e.clipboardData.getData("text/plain");
+    if (!text) return;
+    e.preventDefault();
+    const grid = text
+      .replace(/\r\n?/g, "\n")
+      .replace(/\n$/, "")
+      .split("\n")
+      .map((line) => line.split("\t"));
+    const baseR = selRect.r0;
+    const baseC = selRect.c0;
+    let lastR = baseR;
+    let lastC = baseC;
+    for (let i = 0; i < grid.length; i++) {
+      const r = baseR + i;
+      if (r >= rowCount) break; // 표 아래로 넘치면 자른다.
+      const cells = getRow(r);
+      if (!cells) continue;
+      const rowFormulas = getFormulas(r);
+      const next = Array.from({ length: colCount }, (_, c) => {
+        const pc = c - baseC;
+        if (pc >= 0 && pc < grid[i].length) {
+          lastR = Math.max(lastR, r);
+          lastC = Math.max(lastC, c);
+          return grid[i][pc];
+        }
+        // 붙여넣기 밖 셀은 값·수식을 그대로 보존한다.
+        return rowFormulas[meta.columns[c].key] ?? cells[c] ?? "";
+      });
+      setRowLocal(r, next);
+      updateMut.mutate({ index: r, cells: next });
+    }
+    // 붙여넣은 범위를 선택으로 표시한다(엑셀식). 1칸이면 활성 입력창 값도 맞춘다.
+    setEditing(null);
+    setDraft(grid[0]?.[0] ?? "");
+    setSel({ kind: "cells", a: [baseR, baseC], b: [lastR, lastC] });
+  };
+
   /**
    * 표에 포커스가 있을 때의 키 처리. 선택된 셀 위에서 글자를 누르면 그 글자로 편집을 시작하고,
    * Enter/F2는 기존 값을 이어 편집, Delete/Backspace는 선택 셀을 비운다. 처리한 키는
@@ -953,6 +1025,10 @@ export function DatasetGrid({ datasetId }: Props) {
         // tabIndex=-1이라 탭 순회엔 안 잡히고, outline은 표 테두리로 충분해 숨긴다.
         tabIndex={-1}
         onKeyDown={onGridKeyDown}
+        // 셀 범위 복사/잘라내기/붙여넣기(엑셀식). 입력창에서 올라온 이벤트도 여기서 받는다.
+        onCopy={onGridCopy}
+        onCut={onGridCut}
+        onPaste={onGridPaste}
         // overflow-hidden을 두지 않는다 — 선택 툴바가 선택 위/아래로 표 밖까지 떠야 해서다.
         // 가로 넘침은 안쪽 스크롤 div(overflow-x-auto)가 자르고, 코너는 bg-card라 티가 안 난다.
         className="border-border bg-card group/grid relative flex flex-col rounded-md border outline-none"


### PR DESCRIPTION
## 이슈
closes #866

## 작업 내용
- **복사(Cmd/Ctrl+C)**: 선택 범위를 **TSV**(탭 구분·줄바꿈)로 클립보드에 담아 엑셀·구글시트와도 주고받게 함
- **붙여넣기(Cmd/Ctrl+V)**: 클립보드 TSV를 **선택 좌상단부터** 채움. 표 밖으로 넘치는 만큼은 잘라냄(행·열 자동 추가 없음). 붙여넣은 범위를 선택으로 표시
- **잘라내기(Cmd/Ctrl+X)**: 복사 후 선택 값 비우기
- 셀 편집 중일 땐 입력창 기본 복사/붙여넣기에 맡김(그리드 핸들러는 `!editing`일 때만 개입). 입력창에서 올라온 클립보드 이벤트도 컨테이너에서 받음

## 확인
- 유닛 테스트 50개 통과(복사 TSV·붙여넣기·경계 클램프 추가), `prettier`/`eslint`/`tsc -b` 통과
- **실제 Tiptap 에디터 안에서** 브라우저 직접 확인:
  - 2×2 범위 복사 → 클립보드에 `네트워크\t92\n운영체제\t78` TSV
  - 다른 셀에 붙여넣기 → 좌상단부터 채워지고, 붙여넣기 밖 열(A+)은 보존, 표 밖 행은 무시
  - 붙여넣은 범위가 선택으로 표시됨

## 참고
- 붙여넣기는 안전을 위해 표 범위를 넘으면 **자릅니다**(행/열 자동 추가 안 함). 자동 확장이 필요하면 후속으로 넣을 수 있습니다.
- 활성 입력창 스타일/우클릭 메뉴 관련 다른 오픈 PR과 서로 다른 영역이라 독립적입니다.