### PR TITLE
fix : 표 블록 선택 시 키보드로 표가 삭제되던 문제 제거

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -812,6 +812,31 @@ describe("DatasetGrid", () => {
     await waitFor(() => expect(deleted).toBe(0));
   });
 
+  it("우클릭 메뉴 '표 삭제'는 블록 삭제 콜백을 호출한다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    const onDeleteBlock = vi.fn();
+    const user = userEvent.setup();
+    renderWithRouter(
+      <DatasetGrid datasetId={1} onDeleteBlock={onDeleteBlock} />,
+    );
+
+    fireEvent.contextMenu(await screen.findByText("네트워크"));
+    await user.click(await screen.findByRole("menuitem", { name: "표 삭제" }));
+
+    // 표 삭제는 키보드 단축키 대신 이 메뉴로만 — 블록 제거 콜백(노드 삭제)을 부른다.
+    expect(onDeleteBlock).toHaveBeenCalledTimes(1);
+  });
+
+  it("onDeleteBlock이 없으면 '표 삭제' 항목을 보이지 않는다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    fireEvent.contextMenu(await screen.findByText("네트워크"));
+    await screen.findByRole("menu", { name: "셀 메뉴" });
+    expect(
+      screen.queryByRole("menuitem", { name: "표 삭제" }),
+    ).not.toBeInTheDocument();
+  });
+
   // ---------- 열 너비(resize) ----------
 
   it("헤더 경계를 드래그하면 너비를 PATCH하고 그 폭으로 그린다", async () => {

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -63,6 +63,8 @@ type Sel =
 
 interface Props {
   datasetId: number;
+  /** 표 블록(노드) 자체를 문서에서 제거한다. 우클릭 메뉴의 '표 삭제'에서 쓴다. */
+  onDeleteBlock?: () => void;
 }
 
 /**
@@ -70,7 +72,7 @@ interface Props {
  * 지연 로드 + 셀 편집. 세로는 노트 페이지 흐름을 따라 무한히 자라고(자체 스크롤 뷰포트 없음),
  * 가로는 열이 화면을 넘으면 스크롤한다. 열 너비는 셀 오른쪽 경계 드래그로 조절한다.
  */
-export function DatasetGrid({ datasetId }: Props) {
+export function DatasetGrid({ datasetId, onDeleteBlock }: Props) {
   const queryClient = useQueryClient();
   const { data: meta, isLoading, isError } = useDatasetMeta(datasetId);
   const {
@@ -1460,6 +1462,13 @@ export function DatasetGrid({ datasetId }: Props) {
                       },
                       { icon: <X className="size-3.5" />, destructive: true },
                     )}
+                  {/* 표 전체 삭제 — 키보드 단축키를 없앤 대신 유일한 표 삭제 경로.
+                    블록을 제거하면 노트가 dataset 정리 확인 다이얼로그를 띄운다. */}
+                  {onDeleteBlock &&
+                    item("표 삭제", () => onDeleteBlock(), {
+                      icon: <Trash2 className="size-3.5" />,
+                      destructive: true,
+                    })}
                 </div>
               </>
             );

--- a/fe/src/features/note/editor/DatasetTableView.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.tsx
@@ -6,7 +6,7 @@ import { DatasetGrid } from "../dataset/DatasetGrid";
  * 노트 본문의 데이터 그리드 블록. 노드엔 datasetId만 있고, 실제 표는 별도 dataset
  * 리소스에서 지연 로드해 편집한다. contentEditable=false로 ProseMirror 편집과 분리.
  */
-export function DatasetTableView({ node }: NodeViewProps) {
+export function DatasetTableView({ node, deleteNode }: NodeViewProps) {
   const datasetId = node.attrs.datasetId as number | null;
   return (
     <NodeViewWrapper
@@ -14,7 +14,11 @@ export function DatasetTableView({ node }: NodeViewProps) {
       data-dataset-table={datasetId ?? ""}
       contentEditable={false}
     >
-      {datasetId != null && <DatasetGrid datasetId={datasetId} />}
+      {datasetId != null && (
+        // 표 삭제는 키보드 단축키 대신 표 우클릭 메뉴에서만 한다(deleteNode로 블록 제거 →
+        // 노트가 dataset 정리 확인 다이얼로그를 띄운다).
+        <DatasetGrid datasetId={datasetId} onDeleteBlock={deleteNode} />
+      )}
     </NodeViewWrapper>
   );
 }

--- a/fe/src/features/note/editor/datasetTable.test.ts
+++ b/fe/src/features/note/editor/datasetTable.test.ts
@@ -1,3 +1,6 @@
+import { Editor } from "@tiptap/core";
+import { NodeSelection } from "@tiptap/pm/state";
+import StarterKit from "@tiptap/starter-kit";
 import { describe, expect, it } from "vitest";
 
 import { collectDatasetIds, DatasetTable } from "./datasetTable";
@@ -45,5 +48,88 @@ describe("DatasetTable 노드 스펙", () => {
   it("atom block 이고 draggable=true 이다", () => {
     expect(DatasetTable.config.atom).toBe(true);
     expect(DatasetTable.config.draggable).toBe(true);
+  });
+});
+
+describe("DatasetTable 노드 선택 시 키 차단(표 단축키 제거)", () => {
+  function editorWithTable() {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    return new Editor({
+      element,
+      extensions: [StarterKit, DatasetTable],
+      content: {
+        type: "doc",
+        content: [
+          { type: "paragraph", content: [{ type: "text", text: "위" }] },
+          { type: "datasetTable", attrs: { datasetId: 1 } },
+        ],
+      },
+    });
+  }
+  // 표 블록 키 차단은 우리 플러그인에만 있는 handleTextInput으로 골라낸다.
+  // (ProseMirror prop 타입이 this 바인딩을 요구해, 호출용으로 느슨하게 캐스팅한다.)
+  type GuardProps = {
+    handleKeyDown: (view: unknown, event: KeyboardEvent) => boolean;
+    handleTextInput: (
+      view: unknown,
+      from: number,
+      to: number,
+      text: string,
+    ) => boolean;
+  };
+  function guardPlugin(editor: Editor): GuardProps {
+    const plugin = editor.view.state.plugins.find(
+      (p) => p.props.handleTextInput,
+    );
+    return plugin!.props as unknown as GuardProps;
+  }
+  function selectTableNode(editor: Editor) {
+    let pos = -1;
+    editor.state.doc.descendants((node, p) => {
+      if (node.type.name === "datasetTable") pos = p;
+    });
+    editor.commands.setNodeSelection(pos);
+    return pos;
+  }
+  const keydown = (k: string, init: KeyboardEventInit = {}) =>
+    new KeyboardEvent("keydown", { key: k, ...init });
+
+  it("표 노드가 선택되면 문자·Backspace·Delete가 막혀 표가 유지된다", () => {
+    const editor = editorWithTable();
+    const pos = selectTableNode(editor);
+    expect(editor.state.selection instanceof NodeSelection).toBe(true);
+    const props = guardPlugin(editor);
+    const onKey = (k: string, init?: KeyboardEventInit) =>
+      props.handleKeyDown(editor.view, keydown(k, init));
+
+    expect(onKey("d")).toBe(true); // 글자 → 노드 교체(=표 삭제) 차단
+    expect(onKey("Backspace")).toBe(true);
+    expect(onKey("Delete")).toBe(true);
+    // 문자 삽입(beforeinput) 경로도 막는다.
+    expect(props.handleTextInput(editor.view, pos, pos + 1, "d")).toBe(true);
+    editor.destroy();
+  });
+
+  it("방향키·Cmd 조합은 통과한다(표에서 빠져나가기·복사 등)", () => {
+    const editor = editorWithTable();
+    selectTableNode(editor);
+    const props = guardPlugin(editor);
+    const onKey = (k: string, init?: KeyboardEventInit) =>
+      props.handleKeyDown(editor.view, keydown(k, init));
+
+    expect(onKey("ArrowDown")).toBe(false);
+    expect(onKey("Escape")).toBe(false);
+    expect(onKey("c", { metaKey: true })).toBe(false);
+    editor.destroy();
+  });
+
+  it("일반 문단에선 문자 입력을 막지 않는다", () => {
+    const editor = editorWithTable();
+    editor.commands.setTextSelection(1); // 문단 안(텍스트 선택)
+    const props = guardPlugin(editor);
+    expect(props.handleKeyDown(editor.view, keydown("d"))).toBe(false);
+    expect(props.handleTextInput(editor.view, 1, 1, "d")).toBe(false);
+    editor.destroy();
   });
 });

--- a/fe/src/features/note/editor/datasetTable.ts
+++ b/fe/src/features/note/editor/datasetTable.ts
@@ -1,6 +1,6 @@
 import { mergeAttributes, Node } from "@tiptap/core";
 import { Fragment, type Node as PMNode, Slice } from "@tiptap/pm/model";
-import { Plugin } from "@tiptap/pm/state";
+import { NodeSelection, Plugin } from "@tiptap/pm/state";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 
 import { DatasetTableView } from "./DatasetTableView";
@@ -83,6 +83,36 @@ export const DatasetTable = Node.create({
               Fragment.fromArray(kept),
               slice.openStart,
               slice.openEnd,
+            );
+          },
+          // 표 블록(노드)이 선택된 상태에서 문서를 바꾸는 키를 전부 막는다.
+          // ProseMirror는 노드가 선택됐을 때 글자를 치면 노드를 그 글자로 교체(=표 삭제)하고,
+          // Backspace/Delete로도 지운다. 셀 선택 없이 블록만 잡혔을 때 'd' 등으로 표가
+          // 사라지던 문제를 없앤다. 표 삭제는 표 우클릭 메뉴의 '표 삭제'로만 한다.
+          handleKeyDown(view, event) {
+            const { selection } = view.state;
+            const nodeSelected =
+              selection instanceof NodeSelection &&
+              selection.node.type.name === nodeType;
+            if (!nodeSelected) return false;
+            if (event.key === "Backspace" || event.key === "Delete") {
+              return true;
+            }
+            // 순수 문자/숫자/기호 한 글자(수정키 없음)로 노드가 교체되는 것을 막는다.
+            // 방향키·Esc·Tab, Cmd/Ctrl 조합(복사·실행취소 등)은 그대로 통과시킨다.
+            return (
+              event.key.length === 1 &&
+              !event.ctrlKey &&
+              !event.metaKey &&
+              !event.altKey
+            );
+          },
+          // 문자 삽입 경로(beforeinput)도 막는다 — keydown만으로 잡히지 않는 브라우저 대비.
+          handleTextInput(view) {
+            const { selection } = view.state;
+            return (
+              selection instanceof NodeSelection &&
+              selection.node.type.name === nodeType
             );
           },
         },


### PR DESCRIPTION
## 이슈
closes #868

## 배경
셀이 아니라 **표 블록(노드) 자체가 선택된 상태**(드래그 핸들·표 여백 클릭, 키보드 이동 등)에서 글자('d' 등)를 누르면 ProseMirror가 노드를 그 글자로 교체 → **표가 삭제**됐습니다. Backspace/Delete도 마찬가지. 이전 수정(#859/#861)은 '셀 선택 시 포커스 캡처'라서 이 경로(셀 미선택·블록만 선택)를 못 막았습니다.

## 작업 내용
- `datasetTable` 확장에 ProseMirror 플러그인 추가 — 노드가 선택된 상태에서:
  - `handleKeyDown`: 문자 한 글자·`Backspace`·`Delete` 차단
  - `handleTextInput`: 문자 삽입(beforeinput) 차단
  - 방향키·`Esc`·`Cmd/Ctrl` 조합은 통과(표에서 빠져나가기·복사·실행취소 유지)
- 키보드 삭제를 없앤 대신 **표 우클릭 메뉴에 '표 삭제'** 추가 → `deleteNode`로 블록 제거(노트의 '표를 삭제할까요?' 확인 다이얼로그로 이어짐)

## 확인
- 유닛 테스트 통과(FE 전체 373개), `prettier`/`eslint`/`tsc -b` 통과
  - 신규: 노드 선택 시 문자·Backspace·Delete·textInput 차단, 방향키·Cmd 통과, 문단은 미차단, 우클릭 '표 삭제' 콜백
- **실제 Tiptap 에디터 안에서** 브라우저 직접 확인:
  - 표 노드 NodeSelection 상태에서 `d`/`Delete`/`Backspace` → 표 유지(doc 변화 없음, 글자 삽입 안 됨)
  - 우클릭 '표 삭제' → 블록 제거됨

## 참고
- 실제 노트 편집기에선 블록 제거 시 기존 '표(데이터셋)를 삭제할까요?' 확인 다이얼로그가 뜹니다.
- 표 관련 다른 오픈 PR들과 파일 영역이 일부 겹칠 수 있으나(우클릭 메뉴), 순차 머지 시 충돌은 경미하며 조정 가능합니다.