### PR TITLE
feat : 데이터 그리드 편집 저장 매끄럽게(오래된 응답·전체 리셋 제거)

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
+import { delay, http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useAuthStore } from "@/features/auth/store/authStore";
@@ -692,6 +692,93 @@ describe("DatasetGrid", () => {
         "수식을 이해할 수 없습니다. - 없는 열: 무엇",
       );
     });
+  });
+
+  it("연속 편집 시 먼저 보낸 저장의 늦은 응답이 최신 편집을 덮지 않는다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let call = 0;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/rows/:i`,
+        async ({ params, request }) => {
+          const body = (await request.json()) as { cells: string[] };
+          call++;
+          // 첫 요청(먼저 보낸 편집)의 응답을 더 늦게 돌려준다.
+          if (call === 1) await delay(80);
+          return HttpResponse.json({
+            code: "OK",
+            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+          });
+        },
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    // 1) 첫째 열 편집(네트워크 → A)
+    await user.dblClick(await screen.findByText("네트워크"));
+    let input = screen.getByLabelText("셀 1행 1열");
+    fireEvent.change(input, { target: { value: "A" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // 2) 곧바로 둘째 열 편집(92 → B) — 첫 저장 응답이 아직 안 온 사이에.
+    await user.dblClick(await screen.findByText("92"));
+    input = screen.getByLabelText("셀 1행 2열");
+    fireEvent.change(input, { target: { value: "B" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(screen.getByText("B")).toBeInTheDocument());
+    // 늦은 첫 응답이 도착할 시간을 줘도, 최신 편집 B가 92로 되돌아가지 않는다.
+    await delay(140);
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.getByText("B")).toBeInTheDocument();
+    expect(screen.queryByText("92")).not.toBeInTheDocument();
+  });
+
+  it("저장 실패 시 전체 리셋(재조회) 없이 그 행만 직전 값으로 되돌린다", async () => {
+    mockDataset([
+      ["네트워크", "92"],
+      ["운영체제", "78"],
+    ]);
+    let rowsFetches = 0;
+    server.use(
+      http.get(`${API_BASE}/datasets/1/rows`, ({ request }) => {
+        rowsFetches++;
+        const url = new URL(request.url);
+        const offset = Number(url.searchParams.get("offset") ?? "0");
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              { id: 100, rowIndex: 0, cells: ["네트워크", "92"] },
+              { id: 101, rowIndex: 1, cells: ["운영체제", "78"] },
+            ],
+            offset,
+            limit: 100,
+          },
+        });
+      }),
+      http.patch(`${API_BASE}/datasets/1/rows/:i`, () =>
+        HttpResponse.json({ code: "ERR", message: "안돼요" }, { status: 400 }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("92");
+    const fetchesBefore = rowsFetches;
+
+    await user.dblClick(screen.getByText("92"));
+    const input = screen.getByLabelText("셀 1행 2열");
+    fireEvent.change(input, { target: { value: "X" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // 실패하면 그 셀만 92로 되돌아온다.
+    await waitFor(() => expect(screen.getByText("92")).toBeInTheDocument());
+    expect(screen.queryByText("X")).not.toBeInTheDocument();
+    // 다른 셀은 그대로 남는다.
+    expect(screen.getByText("78")).toBeInTheDocument();
+    // 전체 리셋(행 재조회)이 일어나지 않았다.
+    expect(rowsFetches).toBe(fetchesBefore);
   });
 
   it("[열 추가]로 POST를 호출하고 새 열이 빈 칸으로 붙는다", async () => {

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -134,22 +134,37 @@ export function DatasetGrid({ datasetId, onDeleteBlock }: Props) {
   const invalidateMerges = () =>
     queryClient.invalidateQueries({ queryKey: datasetKeys.merges(datasetId) });
 
-  const updateMut = useMutation({
-    mutationFn: (v: { index: number; cells: string[] }) =>
-      updateDatasetRow(datasetId, v.index, v.cells),
-    // 서버가 계산한 값과 수식으로 맞춘다 — '=1+2'를 치면 화면엔 3이 와야 하고,
-    // 전파가 같은 행의 다른 셀을 고쳤을 수도 있다.
-    onSuccess: (row) => {
-      setRowLocal(row.rowIndex, row.cells);
-      setFormulasLocal(row.rowIndex, row.formulas ?? {});
-    },
-    onError: (e) => {
-      // 수식 문법 오류·순환 참조는 서버가 무엇이 틀렸는지 알려준다. 그대로 보여준다.
-      const message = serverMessage(e);
-      if (message) toast(message, "error");
-      reset();
-    },
-  });
+  // 행별 저장 버전. 저장을 보낼 때마다 올리고, 응답이 오면 그 사이 같은 행을 또 고쳤는지
+  // (버전 불일치) 확인한다. 오래된 응답이 최신 편집을 덮어써 깜빡이던 문제를 없앤다.
+  const rowVersion = useRef<Map<number, number>>(new Map());
+  /**
+   * 편집 저장 — 낙관적 반영은 호출 전에 하고, 여기선 백그라운드로 PATCH만 보낸다.
+   * useMutation을 안 써 매 저장마다 그리드가 리렌더되지 않는다(연속 편집이 매끄럽게).
+   * 성공: 최신 편집일 때만 서버 계산값·수식으로 맞춘다(수식 전파 반영). 오래된 응답은 무시.
+   * 실패: 전체 리셋 대신 이 행만 직전 상태로 되돌리고 사유를 토스트한다.
+   */
+  const saveRow = (
+    index: number,
+    cells: string[],
+    prev: { cells: string[]; formulas: Record<string, string> },
+  ) => {
+    const version = (rowVersion.current.get(index) ?? 0) + 1;
+    rowVersion.current.set(index, version);
+    updateDatasetRow(datasetId, index, cells)
+      .then((row) => {
+        if (rowVersion.current.get(index) !== version) return;
+        setRowLocal(row.rowIndex, row.cells);
+        setFormulasLocal(row.rowIndex, row.formulas ?? {});
+      })
+      .catch((e) => {
+        // 수식 문법 오류·순환 참조는 서버가 무엇이 틀렸는지 알려준다. 그대로 보여준다.
+        const message = serverMessage(e);
+        if (message) toast(message, "error");
+        if (rowVersion.current.get(index) !== version) return;
+        setRowLocal(index, prev.cells);
+        setFormulasLocal(index, prev.formulas);
+      });
+  };
   const styleMut = useMutation({
     mutationFn: (v: { row: number; colKey: string; style: CellStyle }) =>
       setCellStyle(datasetId, v.row, v.colKey, v.style),
@@ -424,7 +439,7 @@ export function DatasetGrid({ datasetId, onDeleteBlock }: Props) {
     );
 
     setRowLocal(editing.row, shown);
-    updateMut.mutate({ index: editing.row, cells: sent });
+    saveRow(editing.row, sent, { cells, formulas: rowFormulas });
     setEditing(null);
   };
 
@@ -665,7 +680,7 @@ export function DatasetGrid({ datasetId, onDeleteBlock }: Props) {
       // 이미 빈 행이면 헛요청을 보내지 않는다.
       if (shown.every((v, c) => v === (cells[c] ?? ""))) continue;
       setRowLocal(r, shown);
-      updateMut.mutate({ index: r, cells: sent });
+      saveRow(r, sent, { cells, formulas: rowFormulas });
     }
   };
 
@@ -733,7 +748,7 @@ export function DatasetGrid({ datasetId, onDeleteBlock }: Props) {
         return rowFormulas[meta.columns[c].key] ?? cells[c] ?? "";
       });
       setRowLocal(r, next);
-      updateMut.mutate({ index: r, cells: next });
+      saveRow(r, next, { cells, formulas: rowFormulas });
     }
     // 붙여넣은 범위를 선택으로 표시한다(엑셀식). 1칸이면 활성 입력창 값도 맞춘다.
     setEditing(null);


### PR DESCRIPTION
## 이슈
closes #870

## 배경
셀을 a→b→c 연속 편집하면 저장이 중간중간 끊기고 느리게 느껴졌습니다. 통신 방식(REST) 문제가 아니라 **클라이언트 저장 로직** 문제였습니다:
1. 저장 응답이 **행 전체를 덮어써**, 먼저 보낸 저장의 늦은 응답이 최신 편집을 잠깐 되돌림(깜빡임)
2. `useMutation`이라 **매 저장마다 그리드 전체가 리렌더**
3. 실패 시 **전체 캐시를 비우고 재조회**(큰 깜빡임)

## 작업 내용 (즉시 저장은 그대로, 체감만 매끄럽게)
- **행별 저장 버전 가드**: 저장을 보낼 때마다 버전을 올리고, 응답이 도착하면 그 사이 같은 행을 또 고쳤는지(버전 불일치) 확인해 **최신 편집의 응답만** 반영. 오래된 응답은 무시 → 되돌림/깜빡임 제거
- 저장을 `useMutation` → **직접 호출(`saveRow`)** 로 바꿔 매 저장마다 그리드가 리렌더되지 않음
- 저장 실패 시 **전체 리셋 대신 그 행만 직전 값으로 롤백** + 사유 토스트

## 확인
- 유닛 테스트 54개 통과(신규: 오래된 응답이 최신 편집을 안 덮음 / 실패 시 재조회 없이 행 단위 롤백), `prettier`/`eslint`/`tsc -b` 통과
- **실제 에디터 안에서** 확인: PATCH 200ms 지연을 걸고 같은 행 두 열을 빠르게 연속 편집 → 첫 저장의 늦은 응답이 도착해도 둘째 편집 값이 되돌아가지 않음, 콘솔 에러 없음

## 참고
- 저장은 지금처럼 편집 즉시 보냅니다(지연 없음). 요청 수를 더 줄이고 싶으면 후속으로 '묶어 저장(디바운스)'을 얹을 수 있습니다.
- 실시간 협업(여러 명 동시 편집)이 목표가 되면 그때 WebSocket + 충돌 해결을 별도 과제로.