### PR TITLE
fix : 표 삭제 확인 먼저 + 되돌리기 불가로 고아 표 방지

### DIFF
--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -17,6 +17,7 @@ import { deleteDataset } from "../dataset/api/datasets";
 import { ChildPage, collectChildPageIds } from "../editor/childPage";
 import { ChildPageContext } from "../editor/childPageContext";
 import { collectDatasetIds, DatasetTable } from "../editor/datasetTable";
+import { DatasetTableContext } from "../editor/datasetTableContext";
 import { extractImageFiles, uploadAndInsertImage } from "../editor/imageUpload";
 import { useAutoSaveNote } from "../hooks/useAutoSaveNote";
 import { useCreateNote, useDeleteNote } from "../hooks/useNoteMutations";
@@ -62,6 +63,8 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
   const childIdsRef = useRef<Set<number>>(collectChildPageIds(note.content));
   // 본문의 datasetTable datasetId 집합 (블록 삭제 시 dataset 정리 diff 기준).
   const datasetIdsRef = useRef<Set<number>>(collectDatasetIds(note.content));
+  // 표 삭제 확인 시 실행할 블록 제거(되돌리기 불가). '표 삭제' 버튼 경로에서만 채워진다.
+  const pendingRemoveBlockRef = useRef<(() => void) | null>(null);
   // editorProps 핸들러(handlePaste/handleDrop)는 생성 시점 클로저라 editor를
   // 직접 못 잡으므로 ref로 우회한다.
   const editorRef = useRef<ReturnType<typeof useEditor>>(null);
@@ -189,9 +192,23 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
   };
 
   const deleteDatasetMut = useMutation({ mutationFn: deleteDataset });
+  // '표 삭제' 버튼 → 확인을 먼저 띄운다(블록은 아직 그대로). 확인 시에만 삭제한다.
+  const requestDeleteDataset = (datasetId: number, removeBlock: () => void) => {
+    pendingRemoveBlockRef.current = removeBlock;
+    setPendingDatasetDelete(datasetId);
+  };
   const confirmDatasetDelete = () => {
     if (pendingDatasetDelete == null) return;
-    deleteDatasetMut.mutate(pendingDatasetDelete, {
+    const id = pendingDatasetDelete;
+    const removeBlock = pendingRemoveBlockRef.current;
+    pendingRemoveBlockRef.current = null;
+    if (removeBlock) {
+      // diff가 이 제거를 또 감지해 중복 확인하지 않게 미리 집합에서 뺀다.
+      datasetIdsRef.current.delete(id);
+      removeBlock(); // 블록 제거(되돌리기 불가) — 확인 후에만.
+    }
+    // 실제 리소스 삭제. 이미 없는(고아) dataset이면 실패해도 블록은 이미 지웠으니 무방.
+    deleteDatasetMut.mutate(id, {
       onSuccess: () => setPendingDatasetDelete(null),
       onError: () => setPendingDatasetDelete(null),
     });
@@ -248,7 +265,9 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
         <ChildPageContext.Provider
           value={{ onOpen: onOpenNote, tree: noteTree }}
         >
-          <EditorContent editor={editor} className="relative" />
+          <DatasetTableContext.Provider value={{ requestDeleteDataset }}>
+            <EditorContent editor={editor} className="relative" />
+          </DatasetTableContext.Provider>
         </ChildPageContext.Provider>
       </div>
 
@@ -268,7 +287,11 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
       <ConfirmDialog
         open={pendingDatasetDelete !== null}
         onOpenChange={(open) => {
-          if (!open) setPendingDatasetDelete(null);
+          // 취소하면 블록 제거를 하지 않는다(확인 전엔 블록·dataset 모두 그대로).
+          if (!open) {
+            pendingRemoveBlockRef.current = null;
+            setPendingDatasetDelete(null);
+          }
         }}
         title="표(데이터셋)를 삭제할까요?"
         description="본문에서 제거한 데이터 그리드 표와 그 안의 모든 행이 삭제됩니다. 되돌릴 수 없어요."

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -924,6 +924,31 @@ describe("DatasetGrid", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("표를 못 불러오면 '다시 시도'와 '표 블록 제거'로 대응할 수 있다", async () => {
+    // 이미 삭제된 dataset을 가리키는 고아 블록 등 — 표 로드 실패 상태.
+    server.use(
+      http.get(
+        `${API_BASE}/datasets/1`,
+        () => new HttpResponse(null, { status: 404 }),
+      ),
+    );
+    const onDeleteBlock = vi.fn();
+    const user = userEvent.setup();
+    renderWithRouter(
+      <DatasetGrid datasetId={1} onDeleteBlock={onDeleteBlock} />,
+    );
+
+    expect(
+      await screen.findByText("표를 불러오지 못했어요."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "다시 시도" }),
+    ).toBeInTheDocument();
+    // 삭제된 표(고아 블록)는 '표 블록 제거'로 지운다 → 블록 제거 콜백 호출.
+    await user.click(screen.getByRole("button", { name: "표 블록 제거" }));
+    expect(onDeleteBlock).toHaveBeenCalledTimes(1);
+  });
+
   // ---------- 열 너비(resize) ----------
 
   it("헤더 경계를 드래그하면 너비를 PATCH하고 그 폭으로 그린다", async () => {

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -74,7 +74,7 @@ interface Props {
  */
 export function DatasetGrid({ datasetId, onDeleteBlock }: Props) {
   const queryClient = useQueryClient();
-  const { data: meta, isLoading, isError } = useDatasetMeta(datasetId);
+  const { data: meta, isLoading, isError, refetch } = useDatasetMeta(datasetId);
   const {
     getRow,
     getFormulas,
@@ -330,7 +330,31 @@ export function DatasetGrid({ datasetId, onDeleteBlock }: Props) {
 
   if (isLoading) return <LoadingText />;
   if (isError || !meta) {
-    return <FieldError>표를 불러오지 못했어요.</FieldError>;
+    // 표를 못 불러오는 경우: 일시적 오류면 '다시 시도', 이미 삭제된 표(고아 블록)면
+    // '표 블록 제거'로 대응한다. (되돌리기로 되살아난 삭제된 표 등)
+    return (
+      <div className="border-border bg-card my-2 flex flex-col gap-2 rounded-md border p-3">
+        <FieldError>표를 불러오지 못했어요.</FieldError>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            className="border-border hover:bg-accent rounded-md border px-2 py-1 text-sm"
+          >
+            다시 시도
+          </button>
+          {onDeleteBlock && (
+            <button
+              type="button"
+              onClick={onDeleteBlock}
+              className="text-destructive border-border hover:bg-accent rounded-md border px-2 py-1 text-sm"
+            >
+              표 블록 제거
+            </button>
+          )}
+        </div>
+      </div>
+    );
   }
 
   // 너비를 지정한 열은 고정 px, 안 한 열은 기존대로 남는 폭을 나눠 갖는다.

--- a/fe/src/features/note/editor/DatasetTableView.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.tsx
@@ -1,13 +1,33 @@
 import { type NodeViewProps, NodeViewWrapper } from "@tiptap/react";
 
 import { DatasetGrid } from "../dataset/DatasetGrid";
+import { useDatasetTableContext } from "./datasetTableContext";
 
 /**
  * 노트 본문의 데이터 그리드 블록. 노드엔 datasetId만 있고, 실제 표는 별도 dataset
  * 리소스에서 지연 로드해 편집한다. contentEditable=false로 ProseMirror 편집과 분리.
  */
-export function DatasetTableView({ node, deleteNode }: NodeViewProps) {
+export function DatasetTableView({ node, editor, getPos }: NodeViewProps) {
   const datasetId = node.attrs.datasetId as number | null;
+  const { requestDeleteDataset } = useDatasetTableContext();
+
+  // 표 삭제(우클릭 메뉴·불러오기 실패 시 블록 제거) → 확인 먼저, 확인 시 dataset 삭제 +
+  // 블록 제거를 함께. 블록 제거는 되돌리기 불가(addToHistory:false)라, Cmd+Z로 블록만
+  // 되살아나 dataset 없는 고아 표가 생기지 않는다.
+  const requestDelete = () => {
+    if (datasetId == null) return;
+    const removeBlock = () => {
+      const pos = getPos();
+      if (typeof pos !== "number") return;
+      editor.view.dispatch(
+        editor.state.tr
+          .delete(pos, pos + node.nodeSize)
+          .setMeta("addToHistory", false),
+      );
+    };
+    requestDeleteDataset(datasetId, removeBlock);
+  };
+
   return (
     <NodeViewWrapper
       as="div"
@@ -15,9 +35,7 @@ export function DatasetTableView({ node, deleteNode }: NodeViewProps) {
       contentEditable={false}
     >
       {datasetId != null && (
-        // 표 삭제는 키보드 단축키 대신 표 우클릭 메뉴에서만 한다(deleteNode로 블록 제거 →
-        // 노트가 dataset 정리 확인 다이얼로그를 띄운다).
-        <DatasetGrid datasetId={datasetId} onDeleteBlock={deleteNode} />
+        <DatasetGrid datasetId={datasetId} onDeleteBlock={requestDelete} />
       )}
     </NodeViewWrapper>
   );

--- a/fe/src/features/note/editor/datasetTableContext.ts
+++ b/fe/src/features/note/editor/datasetTableContext.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext } from "react";
+
+export interface DatasetTableContextValue {
+  /**
+   * 표 삭제 요청 — 확인 다이얼로그를 먼저 띄우고, 확인할 때만 dataset 리소스 삭제와
+   * 블록 제거(removeBlock)를 함께 처리한다. 취소하면 아무것도 바뀌지 않는다.
+   * removeBlock은 되돌리기 불가로 블록을 지운다 — Cmd+Z로 블록만 되살아나 dataset이
+   * 없는 고아 표("표를 불러오지 못했어요")가 생기던 문제를 막는다.
+   */
+  requestDeleteDataset: (datasetId: number, removeBlock: () => void) => void;
+}
+
+/**
+ * datasetTable NodeView에 삭제 요청 핸들러를 주입하는 컨텍스트.
+ * NoteEditor가 값을 채워 EditorContent를 이 Provider로 감싼다(NodeView는 상위 컨텍스트 상속).
+ */
+export const DatasetTableContext = createContext<DatasetTableContextValue>({
+  requestDeleteDataset: () => {},
+});
+
+export function useDatasetTableContext(): DatasetTableContextValue {
+  return useContext(DatasetTableContext);
+}


### PR DESCRIPTION
## 이슈
closes #872

## 배경
표를 삭제하면 dataset 리소스는 서버에서 삭제되는데, 그 뒤 **Cmd+Z(되돌리기)로 블록만 되살아나** 데이터가 없는 고아 표가 되어 `표를 불러오지 못했어요`가 떴습니다. 기존 흐름이 '블록 먼저 제거 → diff 감지 → 확인 → dataset 삭제'라, 블록 제거가 되돌리기 가능(undoable)했던 게 원인입니다.

## 작업 내용
- 표 삭제를 **확인 먼저**로 변경 — 블록은 확인 전엔 그대로. 확인할 때만 dataset 삭제 + 블록 제거를 함께 처리(취소하면 아무것도 안 바뀜)
- 블록 제거를 **되돌리기 불가**(`addToHistory:false`)로 → Cmd+Z로 고아 블록이 되살아나지 않음(확인 다이얼로그의 '되돌릴 수 없어요'와 일치)
- `DatasetTableContext`로 NoteEditor가 확인·삭제를 조율(블록 제거 diff의 중복 확인 방지)
- **이미 생긴 고아 표 대응**: 표 로드 실패 상태에 `다시 시도`(일시 오류)·`표 블록 제거`(삭제된 표) 버튼 추가

## 확인
- 유닛 테스트(FE 전체 376개) + `prettier`/`eslint`/`tsc -b` 통과
  - 신규: 표 로드 실패 시 '다시 시도'·'표 블록 제거' 노출 및 콜백 호출
- **실제 에디터에서** 확인: 우클릭 '표 삭제' → 블록 제거 + dataset 삭제 요청, 이어서 **Cmd+Z(undo) 해도 표가 되살아나지 않음**(`canUndo=false`, 히스토리에 없음)

## 참고
- 키보드로 표 삭제는 이미 막혀 있고(#869), 삭제는 우클릭 '표 삭제' 버튼으로만 됩니다. 이 PR은 그 버튼 경로를 '확인 먼저 + 되돌리기 불가'로 안전하게 만든 것입니다.
- 텍스트 범위 선택으로 블록을 함께 지우는 드문 경로는 여전히 diff 정리(확인)로 처리됩니다.