### PR TITLE
fix : 드래그 핸들로 표 블록 이동되게 (노드 draggable 끄기)

### DIFF
--- a/fe/src/features/note/editor/datasetTable.test.ts
+++ b/fe/src/features/note/editor/datasetTable.test.ts
@@ -45,9 +45,10 @@ describe("collectDatasetIds", () => {
 });
 
 describe("DatasetTable 노드 스펙", () => {
-  it("atom block 이고 draggable=true 이다", () => {
+  it("atom block 이고 draggable=false 다(블록 이동은 외부 드래그 핸들이 담당)", () => {
     expect(DatasetTable.config.atom).toBe(true);
-    expect(DatasetTable.config.draggable).toBe(true);
+    // 표 전체가 draggable이면 셀 드래그 선택과 충돌해 이동이 꼬인다 → 노드는 끄고 핸들로만 이동.
+    expect(DatasetTable.config.draggable).toBe(false);
   });
 });
 

--- a/fe/src/features/note/editor/datasetTable.ts
+++ b/fe/src/features/note/editor/datasetTable.ts
@@ -26,7 +26,10 @@ export const DatasetTable = Node.create({
   group: "block",
   atom: true,
   selectable: true,
-  draggable: true,
+  // draggable을 노드에 켜면 표 전체(react-renderer)가 draggable="true"가 되어, 셀을 드래그해
+  // 범위 선택하려 할 때 브라우저가 블록(또는 선택된 텍스트)을 대신 끌어 이동이 꼬인다.
+  // 블록 이동은 외부 드래그 핸들(⣿)이 view.dragging을 직접 세워 처리하므로 여기선 끈다.
+  draggable: false,
 
   addAttributes() {
     return {


### PR DESCRIPTION
## 이슈
closes #874

## 배경
드래그 핸들(⣿)로 표를 옮기려 해도 이동이 안 됐습니다. datasetTable 노드가 `draggable: true`라 표 전체(react-renderer div)가 `draggable="true"` 네이티브 드래그 소스가 되는데, 표 안엔 셀 드래그 선택·편집 입력창(텍스트 선택) 등 상호작용이 많아 충돌했습니다. (실제로 셀 값이 선택된 상태로 끌면 블록 대신 그 텍스트가 끌려 다른 문단에 떨어졌습니다.)

## 작업 내용
- datasetTable 노드 `draggable: true` → `false` — 표 자체는 네이티브 드래그 소스가 아니게 함
- 블록 이동은 외부 드래그 핸들(`@tiptap/extension-drag-handle`)이 `view.dragging`을 직접 세워 처리하므로, 노드를 `draggable=false`로 둬도 **핸들 이동은 그대로 동작**. 상호작용 많은 블록 NodeView의 표준 패턴(노드는 draggable 끄고 외부 핸들로만 이동)

## 확인
- 실제 에디터(DragHandle 포함) 하네스에서:
  - `draggable=false`로 두면 표 DOM의 `draggable` 속성이 사라짐(블록이 드래그 소스 아님) → 셀/텍스트 드래그와 충돌 없음
  - 드래그 핸들 `dragstart` 시 `view.dragging`이 세워지고 블록이 이동됨(핸들 이동 유지)
- FE 전체 테스트 376개 + `prettier`/`eslint`/`tsc` 통과

## 참고
- 네이티브 HTML5 드래그(hover로 뜨는 핸들)는 자동화로 완벽 재현이 어려워, '핸들 이동이 유지되는지'와 '블록이 더는 네이티브 드래그 소스가 아닌지'를 중심으로 확인했습니다. 실제 기기에서 핸들 드래그로 표가 원하는 위치로 잘 옮겨지는지 한 번 봐 주시면 좋겠습니다.