### PR TITLE
feat : 표 블록 선택 시 첫 셀 자동 선택(키 입력=편집)

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -949,6 +949,30 @@ describe("DatasetGrid", () => {
     expect(onDeleteBlock).toHaveBeenCalledTimes(1);
   });
 
+  it("표 블록이 선택되면(blockSelected) 첫 셀을 자동으로 잡아 바로 편집되게 한다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} blockSelected={true} />);
+
+    // 데이터가 로드되면 첫 셀(1행 1열)이 활성 입력창으로 잡힌다 — 이어서 키를 누르면 바로 편집.
+    expect(
+      await screen.findByLabelText("1행 1열 셀 (입력하면 편집)"),
+    ).toHaveValue("네트워크");
+  });
+
+  it("blockSelected여도 특정 셀을 클릭하면 그 셀이 선택된다(첫 셀로 안 튐)", async () => {
+    mockDataset([["네트워크", "92"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} blockSelected={true} />);
+    // 처음엔 블록 선택으로 첫 셀이 잡힌다.
+    await screen.findByLabelText("1행 1열 셀 (입력하면 편집)");
+
+    // 원하는 셀("92" = 1행 2열)을 정확히 클릭 → 그 셀이 활성화(첫 셀로 되돌아가지 않음).
+    const cell = (await screen.findByText("92")).parentElement as HTMLElement;
+    fireEvent.pointerDown(cell, { button: 0 });
+    expect(
+      await screen.findByLabelText("1행 2열 셀 (입력하면 편집)"),
+    ).toHaveValue("92");
+  });
+
   // ---------- 열 너비(resize) ----------
 
   it("헤더 경계를 드래그하면 너비를 PATCH하고 그 폭으로 그린다", async () => {

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -65,6 +65,8 @@ interface Props {
   datasetId: number;
   /** 표 블록(노드) 자체를 문서에서 제거한다. 우클릭 메뉴의 '표 삭제'에서 쓴다. */
   onDeleteBlock?: () => void;
+  /** 에디터에서 표 블록이 선택된 상태(NodeSelection)인지. 첫 셀 자동 선택 트리거. */
+  blockSelected?: boolean;
 }
 
 /**
@@ -72,7 +74,11 @@ interface Props {
  * 지연 로드 + 셀 편집. 세로는 노트 페이지 흐름을 따라 무한히 자라고(자체 스크롤 뷰포트 없음),
  * 가로는 열이 화면을 넘으면 스크롤한다. 열 너비는 셀 오른쪽 경계 드래그로 조절한다.
  */
-export function DatasetGrid({ datasetId, onDeleteBlock }: Props) {
+export function DatasetGrid({
+  datasetId,
+  onDeleteBlock,
+  blockSelected,
+}: Props) {
   const queryClient = useQueryClient();
   const { data: meta, isLoading, isError, refetch } = useDatasetMeta(datasetId);
   const {
@@ -327,6 +333,21 @@ export function DatasetGrid({ datasetId, onDeleteBlock }: Props) {
     if (editing || singleActive) return;
     if (sel) gridBoxRef.current?.focus({ preventScroll: true });
   }, [sel, editing]);
+
+  // 표 블록이 선택되면(한 번 클릭·키보드 이동 등) 첫 셀을 자동으로 잡는다 → 이어서 키를 누르면
+  // 그 글자로 곧바로 편집이 시작된다(블록만 선택돼 타이핑이 먹통이던 문제 해소). 이미 셀을 고른
+  // 상태(범위·특정 셀)나 편집 중이면 건드리지 않는다.
+  useEffect(() => {
+    if (!blockSelected || sel || editing) return;
+    if (rowCount < 1 || colCount < 1) return; // 메타 로드 전.
+    const first = getRow(0);
+    if (!first) return; // 첫 행 데이터 로드 전이면, 로드되며(getRow 갱신) 다시 시도한다.
+    setSel({ kind: "cells", a: [0, 0], b: [0, 0] });
+    setDraft(first[0] ?? "");
+    // 의존성은 blockSelected(선택 진입)·로드 상태(rowCount/colCount/getRow)만 둔다. sel/editing을
+    // 넣으면 Esc로 해제(sel→null)할 때 다시 첫 셀을 잡아 버리므로 뺀다(가드로만 읽는다).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [blockSelected, rowCount, colCount, getRow]);
 
   if (isLoading) return <LoadingText />;
   if (isError || !meta) {

--- a/fe/src/features/note/editor/DatasetTableView.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.tsx
@@ -7,7 +7,12 @@ import { useDatasetTableContext } from "./datasetTableContext";
  * 노트 본문의 데이터 그리드 블록. 노드엔 datasetId만 있고, 실제 표는 별도 dataset
  * 리소스에서 지연 로드해 편집한다. contentEditable=false로 ProseMirror 편집과 분리.
  */
-export function DatasetTableView({ node, editor, getPos }: NodeViewProps) {
+export function DatasetTableView({
+  node,
+  editor,
+  getPos,
+  selected,
+}: NodeViewProps) {
   const datasetId = node.attrs.datasetId as number | null;
   const { requestDeleteDataset } = useDatasetTableContext();
 
@@ -35,7 +40,13 @@ export function DatasetTableView({ node, editor, getPos }: NodeViewProps) {
       contentEditable={false}
     >
       {datasetId != null && (
-        <DatasetGrid datasetId={datasetId} onDeleteBlock={requestDelete} />
+        <DatasetGrid
+          datasetId={datasetId}
+          onDeleteBlock={requestDelete}
+          // 표 블록이 선택되면(한 번 클릭·키보드 이동 등) 그리드가 첫 셀을 잡아
+          // 곧바로 타이핑=편집이 되게 한다(블록만 선택돼 키가 먹통이던 문제 해소).
+          blockSelected={selected}
+        />
       )}
     </NodeViewWrapper>
   );


### PR DESCRIPTION
## 이슈
closes #876

## 배경
표를 정확히 셀이 아니라 대충 클릭하면(또는 키보드 이동 등) 표 블록(NodeSelection)만 선택되는데, 이 상태에서 키를 눌러도 아무 일도 안 일어났습니다(#869에서 블록 선택 시 파괴적 키를 막아둠). '표 클릭 후 키 = 클릭 두 번(편집)'처럼 되게 합니다.

## 작업 내용
- `DatasetTableView`가 `NodeViewProps.selected`를 `blockSelected`로 그리드에 전달
- 표 블록이 선택되면 그리드가 **첫 셀(1행 1열)을 자동 선택** → 이어서 키를 누르면 그 글자로 곧바로 편집 시작(기존 셀 타이핑-편집 로직 재사용)
- **특정 셀을 정확히 클릭**하면 그 셀이 선택되며 첫 셀로 튀지 않음(`sel` 가드)
- 첫 행 데이터 로드 전엔 대기했다가 로드되면(getRow 갱신) 값과 함께 잡음. Esc 해제는 다시 안 잡히게 의존성 조정

## 확인
- 유닛 테스트 378개 통과(신규: 블록 선택 시 첫 셀 자동 / 특정 셀 클릭 유지), `prettier`/`eslint`/`tsc` 통과
- **실제 에디터에서**:
  - 표 블록 NodeSelection → 첫 셀(1행 1열) 자동 활성 → `X` 입력 시 그 셀이 'X'로 편집됨(표 삭제 안 됨)
  - '92'(2행 2열) 셀을 정확히 클릭 → 그 셀이 활성(첫 셀로 안 튐)

## 참고
- #869(블록 선택 시 파괴적 키 차단)와 함께 동작합니다: 이제 블록만 선택돼도 키가 '표 삭제'가 아니라 '첫 셀 편집'으로 이어집니다.