### PR TITLE
fix : 글자 있는 셀에서 드래그 시작 시 텍스트 끌림 방지

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import {
+  createEvent,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { delay, http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -242,6 +248,19 @@ describe("DatasetGrid", () => {
     await waitFor(() => {
       expect(patched).toEqual({ index: 0, cells: ["네트워크", ""] });
     });
+  });
+
+  it("셀에서 드래그를 시작해도 글자가 끌려나가지 않는다(네이티브 드래그 차단)", async () => {
+    mockDataset([["네트워크", "92"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("92");
+
+    // 글자 있는 셀에서 드래그 시작(dragstart)은 preventDefault돼야 한다 — 안 그러면 활성
+    // 입력창의 선택 텍스트가 네이티브로 끌려 셀 범위 선택 대신 글자가 복사된다.
+    const grid = screen.getByTestId("dataset-grid");
+    const dragStart = createEvent.dragStart(grid);
+    fireEvent(grid, dragStart);
+    expect(dragStart.defaultPrevented).toBe(true);
   });
 
   it("셀 범위를 복사하면 TSV(탭·줄바꿈)로 클립보드에 담는다", async () => {

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -1091,6 +1091,10 @@ export function DatasetGrid({
         onCopy={onGridCopy}
         onCut={onGridCut}
         onPaste={onGridPaste}
+        // 글자가 있는 셀에서 드래그를 시작하면 브라우저가 그 텍스트(활성 입력창의 선택 영역)를
+        // 네이티브로 끌어 셀 범위 선택 대신 텍스트가 복사됐다. 그리드 안에서 시작되는 네이티브
+        // 드래그를 막아 드래그=범위 선택만 되게 한다. 블록 이동 핸들은 그리드 밖이라 영향 없다.
+        onDragStart={(e) => e.preventDefault()}
         // overflow-hidden을 두지 않는다 — 선택 툴바가 선택 위/아래로 표 밖까지 떠야 해서다.
         // 가로 넘침은 안쪽 스크롤 div(overflow-x-auto)가 자르고, 코너는 bg-card라 티가 안 난다.
         className="border-border bg-card group/grid relative flex flex-col rounded-md border outline-none"


### PR DESCRIPTION
## 이슈
closes #878

## 배경
셀 여러 개를 드래그로 선택할 때, **글자가 있는 셀에서 드래그를 시작하면** 그 글자(활성 입력창의 선택 텍스트)가 브라우저 네이티브 드래그로 끌려나가, 셀 범위 선택이 안 되고 텍스트가 복사됐습니다.

## 작업 내용
- 그리드 컨테이너에 `onDragStart={(e) => e.preventDefault()}` 추가 → 그리드 **안에서 시작되는 네이티브 드래그를 차단**. 드래그는 오직 셀 범위 선택(포인터 기반)만 동작
- 블록 이동 드래그 핸들(⣿)은 그리드 **밖**(에디터 gutter)이라 영향 없음. 복사/붙여넣기(클립보드 이벤트)도 무관

## 확인
- 유닛 테스트 58개 통과(신규: 셀 dragstart가 preventDefault됨), `prettier`/`eslint`/`tsc` 통과
- **브라우저에서**: 글자 있는 셀(`92`) 클릭 후 그 입력창에서 `dragstart` → `defaultPrevented=true`(텍스트 네이티브 드래그 차단), 포인터 드래그 범위 선택은 그대로 동작