### PR TITLE
feat : 표 셀 복사 → 노트 본문에 붙여넣으면 새 표 생성

### DIFF
--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -14,11 +14,13 @@ import { Input } from "@/components/ui/input";
 
 import type { NoteContent, NoteDetail } from "../api/notes";
 import { deleteDataset } from "../dataset/api/datasets";
+import { DATASET_CELLS_MIME } from "../dataset/cellClipboard";
 import { ChildPage, collectChildPageIds } from "../editor/childPage";
 import { ChildPageContext } from "../editor/childPageContext";
 import { collectDatasetIds, DatasetTable } from "../editor/datasetTable";
 import { DatasetTableContext } from "../editor/datasetTableContext";
 import { extractImageFiles, uploadAndInsertImage } from "../editor/imageUpload";
+import { insertTableFromCells } from "../editor/pasteCellsAsTable";
 import { useAutoSaveNote } from "../hooks/useAutoSaveNote";
 import { useCreateNote, useDeleteNote } from "../hooks/useNoteMutations";
 import { useNoteTree } from "../hooks/useNoteTree";
@@ -89,16 +91,25 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
             "prose prose-sm dark:prose-invert max-w-none min-h-[40svh] focus:outline-none py-4 pr-4 pl-10",
           "aria-label": "노트 본문",
         },
-        // 클립보드 붙여넣기로 이미지 업로드
         handlePaste: (_view, event) => {
+          // 1) 클립보드 이미지 → 업로드 후 삽입
           const files = extractImageFiles(event.clipboardData);
-          if (files.length === 0) return false;
-          event.preventDefault();
-          files.forEach((file) => {
-            if (editorRef.current)
-              void uploadAndInsertImage(editorRef.current, file);
-          });
-          return true;
+          if (files.length > 0) {
+            event.preventDefault();
+            files.forEach((file) => {
+              if (editorRef.current)
+                void uploadAndInsertImage(editorRef.current, file);
+            });
+            return true;
+          }
+          // 2) 표에서 복사한 셀 → 그 조각으로 새 표를 만들어 삽입
+          const cellsTsv = event.clipboardData?.getData(DATASET_CELLS_MIME);
+          if (cellsTsv && editorRef.current) {
+            event.preventDefault();
+            void insertTableFromCells(editorRef.current, cellsTsv);
+            return true;
+          }
+          return false;
         },
         // 드래그앤드롭으로 이미지 업로드
         handleDrop: (_view, event) => {

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -280,9 +280,14 @@ describe("DatasetGrid", () => {
       clipboardData: { setData, getData: () => "" },
     });
 
-    // 2×2 범위를 엑셀 호환 TSV로 담는다.
+    // 2×2 범위를 엑셀 호환 TSV(text/plain)로 담는다.
     expect(setData).toHaveBeenCalledWith(
       "text/plain",
+      "네트워크\t92\n운영체제\t78",
+    );
+    // 본문 붙여넣기 시 새 표로 만들 수 있게, 커스텀 표식 타입으로도 담는다.
+    expect(setData).toHaveBeenCalledWith(
+      "text/x-orino-dataset-cells",
       "네트워크\t92\n운영체제\t78",
     );
   });

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -40,6 +40,7 @@ import {
   setCellStylesBulk,
   updateDatasetRow,
 } from "./api/datasets";
+import { DATASET_CELLS_MIME } from "./cellClipboard";
 import { useDatasetMerges } from "./hooks/useDatasetMerges";
 import { useDatasetMeta } from "./hooks/useDatasetMeta";
 import { useDatasetRows } from "./hooks/useDatasetRows";
@@ -706,14 +707,19 @@ export function DatasetGrid({
   const onGridCopy = (e: React.ClipboardEvent) => {
     if (editing || !selRect) return;
     e.preventDefault();
-    e.clipboardData.setData("text/plain", selectionToTSV());
+    const tsv = selectionToTSV();
+    e.clipboardData.setData("text/plain", tsv);
+    // 표식도 함께 담는다 — 노트 본문에 붙여넣으면 이 조각으로 새 표를 만든다.
+    e.clipboardData.setData(DATASET_CELLS_MIME, tsv);
   };
 
   /** 잘라내기(Cmd/Ctrl+X) — 복사 후 선택 값을 비운다. */
   const onGridCut = (e: React.ClipboardEvent) => {
     if (editing || !selRect) return;
     e.preventDefault();
-    e.clipboardData.setData("text/plain", selectionToTSV());
+    const tsv = selectionToTSV();
+    e.clipboardData.setData("text/plain", tsv);
+    e.clipboardData.setData(DATASET_CELLS_MIME, tsv);
     clearSelValues();
   };
 

--- a/fe/src/features/note/dataset/cellClipboard.test.ts
+++ b/fe/src/features/note/dataset/cellClipboard.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { DATASET_CELLS_MIME, parseCellTsv } from "./cellClipboard";
+
+describe("parseCellTsv", () => {
+  it("탭·줄바꿈 TSV를 2차원 배열로 파싱한다", () => {
+    expect(parseCellTsv("a\tb\nc\td")).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+  });
+
+  it("끝 개행 1개는 무시하고 CRLF도 처리한다", () => {
+    expect(parseCellTsv("a\tb\r\nc\td\n")).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+  });
+
+  it("한 칸(탭·줄바꿈 없음)도 1x1로 파싱한다", () => {
+    expect(parseCellTsv("x")).toEqual([["x"]]);
+  });
+});
+
+describe("DATASET_CELLS_MIME", () => {
+  it("일반 텍스트와 구분되는 커스텀 타입이다", () => {
+    expect(DATASET_CELLS_MIME).toBe("text/x-orino-dataset-cells");
+  });
+});

--- a/fe/src/features/note/dataset/cellClipboard.ts
+++ b/fe/src/features/note/dataset/cellClipboard.ts
@@ -1,0 +1,15 @@
+/**
+ * 표 셀 복사 표식(MIME). 그리드에서 셀 범위를 복사할 때 text/plain(TSV)과 함께 이 타입으로도
+ * 담아, 노트 본문에 붙여넣으면 "우리 표에서 복사한 셀"임을 구분해 그 조각으로 새 표를 만든다.
+ * (외부/일반 텍스트 붙여넣기와 헷갈리지 않게 표식을 쓴다.)
+ */
+export const DATASET_CELLS_MIME = "text/x-orino-dataset-cells";
+
+/** TSV(탭·줄바꿈) → 2차원 셀 배열. 끝 개행 1개는 무시한다. */
+export function parseCellTsv(text: string): string[][] {
+  return text
+    .replace(/\r\n?/g, "\n")
+    .replace(/\n$/, "")
+    .split("\n")
+    .map((line) => line.split("\t"));
+}

--- a/fe/src/features/note/editor/pasteCellsAsTable.test.ts
+++ b/fe/src/features/note/editor/pasteCellsAsTable.test.ts
@@ -1,0 +1,79 @@
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+
+import { DatasetTable } from "./datasetTable";
+import { insertTableFromCells } from "./pasteCellsAsTable";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function makeEditor() {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  return new Editor({
+    element: el,
+    extensions: [StarterKit, DatasetTable],
+    content: { type: "doc", content: [{ type: "paragraph" }] },
+  });
+}
+
+function datasetTableIds(editor: Editor): number[] {
+  const ids: number[] = [];
+  editor.state.doc.descendants((n) => {
+    if (n.type.name === "datasetTable") ids.push(n.attrs.datasetId as number);
+  });
+  return ids;
+}
+
+describe("insertTableFromCells", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+  });
+
+  it("복사한 셀 TSV로 새 표(dataset)를 만들어 삽입한다", async () => {
+    let createdColumns: unknown[] = [];
+    let bulkRows: unknown = null;
+    server.use(
+      http.post(`${API_BASE}/datasets`, async ({ request }) => {
+        createdColumns = ((await request.json()) as { columns: unknown[] })
+          .columns;
+        return HttpResponse.json({
+          code: "OK",
+          data: { id: 42, columns: createdColumns, rowCount: 0 },
+        });
+      }),
+      http.post(`${API_BASE}/datasets/42/rows/bulk`, async ({ request }) => {
+        bulkRows = ((await request.json()) as { rows: unknown }).rows;
+        return HttpResponse.json({
+          code: "OK",
+          data: { id: 42, columns: createdColumns, rowCount: 2 },
+        });
+      }),
+    );
+
+    const editor = makeEditor();
+    await insertTableFromCells(editor, "네트워크\t92\n운영체제\t78");
+
+    // 새 datasetTable 노드가 datasetId=42로 삽입된다.
+    expect(datasetTableIds(editor)).toEqual([42]);
+    // 값만(헤더 없음) 2행 2열로 벌크 업로드된다.
+    expect(bulkRows).toEqual([
+      ["네트워크", "92"],
+      ["운영체제", "78"],
+    ]);
+    // 헤더가 없으니 열은 기본 2개(값 폭 기준).
+    expect(createdColumns.length).toBe(2);
+    editor.destroy();
+  });
+
+  it("빈 TSV는 표를 만들지 않는다", async () => {
+    const editor = makeEditor();
+    await insertTableFromCells(editor, "");
+    expect(datasetTableIds(editor)).toEqual([]);
+    editor.destroy();
+  });
+});

--- a/fe/src/features/note/editor/pasteCellsAsTable.ts
+++ b/fe/src/features/note/editor/pasteCellsAsTable.ts
@@ -1,0 +1,21 @@
+import type { Editor } from "@tiptap/react";
+
+import { parseCellTsv } from "../dataset/cellClipboard";
+import { createDatasetFromTable } from "../import/datasetImport";
+
+/**
+ * 표에서 복사한 셀(TSV)을 노트 본문에 붙여넣을 때 → 그 조각으로 새 표(dataset)를 만들어
+ * 커서 위치에 삽입한다. 헤더 없이 값만 있으므로 열 라벨은 기본값(열 N)으로 채워진다.
+ * 빈 붙여넣기는 무시한다.
+ */
+export async function insertTableFromCells(
+  editor: Editor,
+  tsv: string,
+): Promise<void> {
+  const rows = parseCellTsv(tsv);
+  if (rows.length === 0 || (rows.length === 1 && rows[0].join("") === "")) {
+    return;
+  }
+  const datasetId = await createDatasetFromTable({ headers: null, rows });
+  editor.chain().focus().insertDatasetTable({ datasetId }).run();
+}


### PR DESCRIPTION
## 이슈
closes #884

## 배경
표에서 셀 범위를 드래그로 복사한 뒤 **노트 본문(표 밖)에 붙여넣으면 그 조각만으로 새 표가 생성**되면 좋겠다는 요청입니다.

## 작업 내용
- 그리드 복사(Cmd/Ctrl+C·X) 시 `text/plain`(TSV)과 함께 **커스텀 표식 타입**(`text/x-orino-dataset-cells`)으로도 담습니다
- 노트 에디터 `handlePaste`가 그 표식을 감지하면 → TSV를 파싱해 **새 dataset 생성**(`createDatasetFromTable`, 헤더 없이 값만) → 커서 위치에 `datasetTable` 블록 삽입
- 표식이 없으면(외부·일반 텍스트 붙여넣기) 기존대로 동작 — 우리 표 복사본만 표로 만들어 오작동 방지
- 로직 분리: `dataset/cellClipboard`(MIME·`parseCellTsv`), `editor/pasteCellsAsTable`(`insertTableFromCells`)

## 확인
- 유닛 테스트 383개 통과(신규: `parseCellTsv`, `insertTableFromCells` 생성·삽입, 복사 표식), `prettier`/`eslint`/`tsc` 통과
- **실제 에디터에서**:
  - 2×2 범위 복사 → 본문 문단에 붙여넣기 → **복사한 값으로 새 표가 생성**되어 커서 위치에 삽입됨(원본 표는 그대로)
  - **실제 Cmd+C → Cmd+V**(시스템 클립보드 왕복)에서도 커스텀 표식이 살아남아 새 표 생성 확인