### PR TITLE
fix : 셀 편집 후 blur 시 옛 값 깜빡임 제거(ref로 즉시 flush)

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -205,6 +205,38 @@ describe("DatasetGrid", () => {
     );
   });
 
+  it("선택 상태에서 타이핑 후 blur하면(엔터 없이) 그 값이 곧바로 저장된다", async () => {
+    // 클릭(선택)→타이핑→blur 시 편집전환이 아직 반영 전이어도, 미저장 값을 ref로
+    // flush해 blur 즉시 저장한다(옛 값이 잠깐 보였다가 바뀌던 깜빡임 방지).
+    mockDataset([["네트워크", "92"]]);
+    let patched: { index: number; cells: string[] } | null = null;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/rows/:i`,
+        async ({ params, request }) => {
+          const body = (await request.json()) as { cells: string[] };
+          patched = { index: Number(params.i), cells: body.cells };
+          return HttpResponse.json({
+            code: "OK",
+            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+          });
+        },
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    // 더블클릭이 아니라 한 번 클릭(선택)한 뒤 타이핑하고 blur.
+    await user.click(await screen.findByText("92"));
+    const input = screen.getByLabelText("1행 2열 셀 (입력하면 편집)");
+    fireEvent.change(input, { target: { value: "125" } });
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(patched).toEqual({ index: 0, cells: ["네트워크", "125"] }),
+    );
+  });
+
   it("셀을 한 번 클릭한 뒤 글자를 누르면 그 글자로 편집이 시작된다", async () => {
     mockDataset([["네트워크", "92"]]);
     let patched: { index: number; cells: string[] } | null = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -144,6 +144,13 @@ export function DatasetGrid({
   const rowVersion = useRef<Map<number, number>>(new Map());
   // 편집 중 자동저장 디바운스 타이머. 엔터/blur 없이도 타이핑이 멎으면 저장한다.
   const autoSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 아직 저장 안 한 최신 편집값(셀·값). onChange가 동기로 갱신하고, blur/Enter가 이걸 flush한다.
+  // (setEditing/setDraft 상태는 blur 시점에 아직 반영 전일 수 있어 stale — ref로 확실히 잡는다.)
+  const pendingEdit = useRef<{
+    row: number;
+    col: number;
+    value: string;
+  } | null>(null);
   /**
    * 편집 저장 — 낙관적 반영은 호출 전에 하고, 여기선 백그라운드로 PATCH만 보낸다.
    * useMutation을 안 써 매 저장마다 그리드가 리렌더되지 않는다(연속 편집이 매끄럽게).
@@ -502,12 +509,18 @@ export function DatasetGrid({
     autoSaveTimer.current = null;
   };
 
+  /** 아직 저장 안 한 편집값이 있으면 저장한다(ref 기반이라 stale 상태 영향 없음). */
+  const flushPendingEdit = (silent: boolean) => {
+    const p = pendingEdit.current;
+    if (!p) return;
+    persistCellEdit(p.row, p.col, p.value, silent);
+  };
+
+  /** 편집 확정(Enter·blur) — 최신 값을 즉시 저장하고 편집을 닫는다. */
   const commitEdit = () => {
-    if (!editing) return;
     cancelAutoSave();
-    if (getRow(editing.row)) {
-      persistCellEdit(editing.row, editing.col, draft, false);
-    }
+    flushPendingEdit(false);
+    pendingEdit.current = null;
     setEditing(null);
   };
 
@@ -646,8 +659,9 @@ export function DatasetGrid({
     e.stopPropagation();
     if (e.key === "Escape") {
       e.preventDefault();
-      // 이미 자동저장된 값은 남지만, 예약된 저장은 취소하고 편집을 닫는다.
+      // 이미 자동저장된 값은 남지만, 예약된 저장·미저장 편집은 버리고 편집을 닫는다.
       cancelAutoSave();
+      pendingEdit.current = null;
       setEditing(null);
       setSel(null);
       return;
@@ -965,15 +979,16 @@ export function DatasetGrid({
               setDraft(value);
               // 첫 입력이 들어오면 편집 상태로 전환(같은 input이라 IME 조합 유지).
               if (!isEditing) setEditing({ row: rowIndex, col: c });
+              // 최신 편집값을 ref에 동기로 기록 — blur/Enter/자동저장이 이걸 저장한다.
+              pendingEdit.current = { row: rowIndex, col: c, value };
               // 엔터/blur 없이도 타이핑이 잠깐 멎으면 자동저장한다(계속 저장).
               if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current);
-              autoSaveTimer.current = setTimeout(() => {
-                persistCellEdit(rowIndex, c, value, true);
-              }, 500);
+              autoSaveTimer.current = setTimeout(
+                () => flushPendingEdit(true),
+                500,
+              );
             }}
-            onBlur={() => {
-              if (isEditing) commitEdit();
-            }}
+            onBlur={() => commitEdit()}
             onKeyDown={(e) => onCellInputKeyDown(e, rowIndex, c)}
             // 편집 상태에서만 편집용 라벨을 붙인다(선택-만-한 상태는 편집이 아니므로 구분).
             aria-label={


### PR DESCRIPTION
## 이슈
closes #888

## 배경
셀을 클릭(선택)해 타이핑하고 다른 곳을 클릭(blur)하면, 순간적으로 **옛 값이 다시 보였다가** 새 값으로 바뀌었습니다. (예: `ㅇ`→다른 곳→`ㅇㅇ`→다른 곳 클릭 시 `ㅇ`이 잠깐 보였다 `ㅇㅇ`)

## 원인
클릭(선택)→타이핑 시 `select→edit` 전환이 아직 리렌더 전이라, `onBlur`의 `isEditing`·`commitEdit`의 `editing` 클로저가 **stale**이었습니다. blur가 저장을 건너뛰고 ~0.5초 뒤 **자동저장**이 저장 → 그 사이 옛 값이 보였습니다.

## 작업 내용
- 최신 편집값을 `pendingEdit` **ref**에 `onChange`가 동기로 기록하고, blur/Enter/자동저장이 그 ref를 flush → **blur 즉시 저장**(깜빡임 없음)
- `commitEdit`/`onBlur`를 ref 기반으로 단순화(stale 상태에 안 의존)

## 확인
- **MutationObserver로 타이밍 측정**: 수정 전 blur 후 옛 값 ~470ms 유지되다 바뀜 → 수정 후 blur **4ms 뒤** 새 값(깜빡임 없음)
- 유닛 테스트 통과(신규: 선택→타이핑→blur 즉시 저장), `prettier`/`eslint`/`tsc` 통과

## 참고
- 자동저장 PR(#887)에서 리뷰 중 발견된 깜빡임입니다. #887이 이미 머지되어 **최신 main 기준 별도 브랜치/PR**로 올립니다.