### PR TITLE
feat : 데이터 그리드 셀 세로 정렬(top/middle/bottom)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/BulkCellStyleRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/BulkCellStyleRequest.java
@@ -27,7 +27,9 @@ public record BulkCellStyleRequest(
             @Pattern(regexp = "red|orange|yellow|green|blue|purple", message = "허용되지 않은 배경색입니다.")
             String bg,
             @Pattern(regexp = "left|center|right", message = "허용되지 않은 정렬입니다.")
-            String align
+            String align,
+            @Pattern(regexp = "top|middle|bottom", message = "허용되지 않은 세로 정렬입니다.")
+            String valign
     ) {
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/CellStyle.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/CellStyle.java
@@ -12,12 +12,16 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CellStyle(
         String bg,
-        String align
+        String align,
+        String valign
 ) {
     /** 허용 배경색 토큰. 디자인 시스템의 셀 하이라이트 팔레트와 맞춘다. */
     public static final java.util.Set<String> ALLOWED_BG =
             java.util.Set.of("red", "orange", "yellow", "green", "blue", "purple");
-    /** 허용 정렬 값. */
+    /** 허용 가로 정렬 값. */
     public static final java.util.Set<String> ALLOWED_ALIGN =
             java.util.Set.of("left", "center", "right");
+    /** 허용 세로 정렬 값. */
+    public static final java.util.Set<String> ALLOWED_VALIGN =
+            java.util.Set.of("top", "middle", "bottom");
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetCellStyleRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetCellStyleRequest.java
@@ -12,6 +12,8 @@ public record SetCellStyleRequest(
         @Pattern(regexp = "red|orange|yellow|green|blue|purple", message = "허용되지 않은 배경색입니다.")
         String bg,
         @Pattern(regexp = "left|center|right", message = "허용되지 않은 정렬입니다.")
-        String align
+        String align,
+        @Pattern(regexp = "top|middle|bottom", message = "허용되지 않은 세로 정렬입니다.")
+        String valign
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetCellStyleService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetCellStyleService.java
@@ -27,18 +27,19 @@ public class DatasetCellStyleService {
      * 셀 서식을 통째로 교체한다(부분 갱신 아님). 둘 다 null이면 서식이 없어진 것이므로 행을 지운다 —
      * 빈 행을 남기면 sparse가 깨진다.
      */
-    public void setStyle(Long datasetId, Long rowId, String colKey, String bg, String align) {
+    public void setStyle(
+            Long datasetId, Long rowId, String colKey, String bg, String align, String valign) {
         DatasetCellStyle existing = styleRepository.findByRowIdAndColKey(rowId, colKey).orElse(null);
-        if (bg == null && align == null) {
+        if (bg == null && align == null && valign == null) {
             if (existing != null) {
                 styleRepository.delete(existing);
             }
             return;
         }
         if (existing == null) {
-            styleRepository.save(new DatasetCellStyle(datasetId, rowId, colKey, bg, align));
+            styleRepository.save(new DatasetCellStyle(datasetId, rowId, colKey, bg, align, valign));
         } else {
-            existing.update(bg, align);
+            existing.update(bg, align, valign);
         }
     }
 
@@ -50,7 +51,9 @@ public class DatasetCellStyleService {
         Map<Long, Map<String, CellStyle>> result = new HashMap<>();
         for (DatasetCellStyle style : styleRepository.findByRowIdIn(rowIds)) {
             result.computeIfAbsent(style.getRowId(), k -> new HashMap<>())
-                    .put(style.getColKey(), new CellStyle(style.getBg(), style.getAlign()));
+                    .put(
+                            style.getColKey(),
+                            new CellStyle(style.getBg(), style.getAlign(), style.getValign()));
         }
         return result;
     }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -487,7 +487,8 @@ public class DatasetService {
         DatasetRow row = rowRepository.findByDatasetIdAndRowIndex(datasetId, rowIndex)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
 
-        styleService.setStyle(datasetId, row.getId(), colKey, request.bg(), request.align());
+        styleService.setStyle(
+                datasetId, row.getId(), colKey, request.bg(), request.align(), request.valign());
         return buildRowView(datasetId, row, rowIndex, columns);
     }
 
@@ -509,7 +510,8 @@ public class DatasetService {
             DatasetRow row = rowByIndex.computeIfAbsent(t.rowIndex(), idx ->
                     rowRepository.findByDatasetIdAndRowIndex(datasetId, idx)
                             .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND)));
-            styleService.setStyle(datasetId, row.getId(), t.colKey(), t.bg(), t.align());
+            styleService.setStyle(
+                    datasetId, row.getId(), t.colKey(), t.bg(), t.align(), t.valign());
         }
         return rowByIndex.entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/043-add-dataset-cell-style-valign.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/043-add-dataset-cell-style-valign.yaml
@@ -1,0 +1,24 @@
+databaseChangeLog:
+  # 셀 세로 정렬(top/middle/bottom). 없으면 null(기본=위). 세로 병합 셀 등에서 쓴다.
+  # 가로 정렬(align)과 같은 방식으로 문자열로 저장한다.
+  - changeSet:
+      id: 043-add-dataset-cell-style-valign
+      author: wcorn
+      comment: dataset_cell_style.valign 추가 — 셀 세로 정렬(top/middle/bottom).
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: dataset_cell_style
+                columnName: valign
+      changes:
+        - addColumn:
+            tableName: dataset_cell_style
+            columns:
+              - column:
+                  name: valign
+                  type: VARCHAR(16)
+      rollback:
+        - dropColumn:
+            tableName: dataset_cell_style
+            columnName: valign

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -83,3 +83,5 @@ databaseChangeLog:
       file: db/changelog/changes/041-create-dataset-cell-style.yaml
   - include:
       file: db/changelog/changes/042-create-dataset-merge.yaml
+  - include:
+      file: db/changelog/changes/043-add-dataset-cell-style-valign.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -1422,6 +1422,31 @@ class DatasetControllerTest extends ApiTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"align\":\"justify\"}"))
                 .andExpect(status().isBadRequest());
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c1/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"valign\":\"baseline\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PUT cells/{col}/style - 세로 정렬(valign)을 저장하고 행 조회 시 온다")
+    void set_cell_valign() throws Exception {
+        long id = createDataset();
+        bulk(id, "[[\"네트워크\",\"92\"]]");
+
+        mockMvc.perform(put("/api/datasets/{id}/rows/0/cells/c1/style", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"align\":\"center\",\"valign\":\"middle\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.styles.c1.align").value("center"))
+                .andExpect(jsonPath("$.data.styles.c1.valign").value("middle"));
+
+        mockMvc.perform(get("/api/datasets/{id}/rows", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rows[0].styles.c1.valign").value("middle"));
     }
 
     @Test

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetCellStyle.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetCellStyle.java
@@ -50,6 +50,10 @@ public class DatasetCellStyle {
     @Column(length = 16)
     private String align;
 
+    /** 세로 정렬 top/middle/bottom. 없으면 null(기본=위). 세로 병합 셀 등에서 쓴다. */
+    @Column(length = 16)
+    private String valign;
+
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private Instant createdAt;
@@ -61,23 +65,26 @@ public class DatasetCellStyle {
     protected DatasetCellStyle() {
     }
 
-    public DatasetCellStyle(Long datasetId, Long rowId, String colKey, String bg, String align) {
+    public DatasetCellStyle(
+            Long datasetId, Long rowId, String colKey, String bg, String align, String valign) {
         this.datasetId = datasetId;
         this.rowId = rowId;
         this.colKey = colKey;
         this.bg = bg;
         this.align = align;
+        this.valign = valign;
     }
 
-    /** 서식을 덮어쓴다. 둘 다 null이면 서식 없는 셀 — 호출부가 이 행을 지운다. */
-    public void update(String bg, String align) {
+    /** 서식을 덮어쓴다. 전부 null이면 서식 없는 셀 — 호출부가 이 행을 지운다. */
+    public void update(String bg, String align, String valign) {
         this.bg = bg;
         this.align = align;
+        this.valign = valign;
     }
 
     /** 지정된 서식이 하나도 없으면 true. 이 상태면 행을 남길 이유가 없다. */
     public boolean isEmpty() {
-        return bg == null && align == null;
+        return bg == null && align == null && valign == null;
     }
 
     public Long getId() {
@@ -102,5 +109,9 @@ public class DatasetCellStyle {
 
     public String getAlign() {
         return align;
+    }
+
+    public String getValign() {
+        return valign;
     }
 }

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -1355,9 +1355,98 @@ describe("DatasetGrid", () => {
     // 배경색(green)은 보존하고 정렬만 얹어 일괄 엔드포인트로 보낸다.
     await waitFor(() =>
       expect(sentCells).toEqual([
-        { rowIndex: 0, colKey: "c0", bg: "green", align: "center" },
+        {
+          rowIndex: 0,
+          colKey: "c0",
+          bg: "green",
+          align: "center",
+          valign: null,
+        },
       ]),
     );
+  });
+
+  it("우클릭 메뉴에서 세로 정렬을 고르면 배경색·가로 정렬을 보존해 일괄 PUT한다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    // c0에 이미 배경색(green)·가로 정렬(right)이 있는 상태로 시작한다.
+    server.use(
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              {
+                id: 100,
+                rowIndex: 0,
+                cells: ["네트워크", "92"],
+                formulas: {},
+                styles: { c0: { bg: "green", align: "right" } },
+              },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+    let sentCells: unknown = null;
+    server.use(
+      http.put(`${API_BASE}/datasets/1/cells/style`, async ({ request }) => {
+        sentCells = ((await request.json()) as { cells: unknown }).cells;
+        return HttpResponse.json({ code: "OK", data: [] });
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const cell = (await screen.findByText("네트워크"))
+      .parentElement as HTMLElement; // (0,0)=c0
+    fireEvent.pointerDown(cell, { button: 0 });
+
+    fireEvent.contextMenu(cell);
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    await user.click(within(menu).getByLabelText("세로 정렬 가운데"));
+
+    // 배경색(green)·가로 정렬(right)은 보존하고 세로 정렬만 얹어 보낸다.
+    await waitFor(() =>
+      expect(sentCells).toEqual([
+        {
+          rowIndex: 0,
+          colKey: "c0",
+          bg: "green",
+          align: "right",
+          valign: "middle",
+        },
+      ]),
+    );
+  });
+
+  it("서버가 준 valign으로 셀 세로 정렬 클래스를 그린다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    server.use(
+      http.get(`${API_BASE}/datasets/1/rows`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              {
+                id: 100,
+                rowIndex: 0,
+                cells: ["네트워크", "92"],
+                formulas: {},
+                styles: { c1: { valign: "bottom" } },
+              },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        }),
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    // valign=bottom 셀은 세로 flex로 내려 justify-end로 정렬한다.
+    expect((await screen.findByText("92")).className).toContain("justify-end");
+    // valign 없는 셀은 기본(truncate) 그대로.
+    expect(screen.getByText("네트워크").className).toContain("truncate");
   });
 
   it("가로 병합 앵커는 colSpan으로 넓게, 덮인 셀은 렌더하지 않는다", async () => {
@@ -1716,7 +1805,7 @@ describe("DatasetGrid", () => {
     // 선택 셀 하나를 일괄 엔드포인트로 보낸다(정렬은 기존값 없음 → null).
     await waitFor(() =>
       expect(sentCells).toEqual([
-        { rowIndex: 0, colKey: "c1", bg: "green", align: null },
+        { rowIndex: 0, colKey: "c1", bg: "green", align: null, valign: null },
       ]),
     );
   });

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -4,6 +4,9 @@ import {
   AlignCenter,
   AlignLeft,
   AlignRight,
+  AlignVerticalJustifyCenter,
+  AlignVerticalJustifyEnd,
+  AlignVerticalJustifyStart,
   Eraser,
   Plus,
   TableCellsMerge,
@@ -25,6 +28,7 @@ import {
   type CellAlign,
   type CellBgToken,
   type CellStyle,
+  type CellValign,
   type DatasetMeta,
   deleteCellMerge,
   deleteDatasetColumn,
@@ -862,19 +866,36 @@ export function DatasetGrid({
   // 서식 적용은 선택 전체를 한 요청으로 보낸다(표 전체도 1회). 각 셀은 통째 교체라
   // 바꾸지 않는 속성(정렬/배경)은 그 셀의 현재값을 채워 보존한다.
   const applyBgSel = (bg: CellBgToken | null) => {
-    const cells = selCellRefs().map(({ row, colKey }) => ({
-      rowIndex: row,
-      colKey,
-      style: { bg: bg ?? undefined, align: getStyles(row)[colKey]?.align },
-    }));
+    const cells = selCellRefs().map(({ row, colKey }) => {
+      const cur = getStyles(row)[colKey];
+      return {
+        rowIndex: row,
+        colKey,
+        style: { bg: bg ?? undefined, align: cur?.align, valign: cur?.valign },
+      };
+    });
     if (cells.length) bulkStyleMut.mutate(cells);
   };
   const applyAlignSel = (align: CellAlign | null) => {
-    const cells = selCellRefs().map(({ row, colKey }) => ({
-      rowIndex: row,
-      colKey,
-      style: { bg: getStyles(row)[colKey]?.bg, align: align ?? undefined },
-    }));
+    const cells = selCellRefs().map(({ row, colKey }) => {
+      const cur = getStyles(row)[colKey];
+      return {
+        rowIndex: row,
+        colKey,
+        style: { bg: cur?.bg, align: align ?? undefined, valign: cur?.valign },
+      };
+    });
+    if (cells.length) bulkStyleMut.mutate(cells);
+  };
+  const applyValignSel = (valign: CellValign | null) => {
+    const cells = selCellRefs().map(({ row, colKey }) => {
+      const cur = getStyles(row)[colKey];
+      return {
+        rowIndex: row,
+        colKey,
+        style: { bg: cur?.bg, align: cur?.align, valign: valign ?? undefined },
+      };
+    });
     if (cells.length) bulkStyleMut.mutate(cells);
   };
   const clearFormatSel = () => {
@@ -949,13 +970,23 @@ export function DatasetGrid({
     const style = getStyles(rowIndex)[colKey];
     // 셀 정렬(override) > 열 기본 정렬 > 기본(left) (#828 D2).
     const align = style?.align ?? meta.columns[c].align ?? "left";
+    // 세로 정렬은 셀 서식에만 있다. 없으면 위(top).
+    const valign = style?.valign ?? "top";
     return (
       <>
         {/* 표시값은 항상 렌더한다(레이아웃·테스트 기준). 활성 셀이면 그 위에 입력창이 겹친다.
-          셀 서식(배경색·정렬)은 우클릭 메뉴로 통일했다(셀별 팔레트 버튼 제거). */}
+          셀 서식(배경색·정렬)은 우클릭 메뉴로 통일했다(셀별 팔레트 버튼 제거).
+          기본(top)은 truncate 블록 그대로(말줄임 유지). 가운데/아래일 때만 세로 flex로 내려
+          justify-*로 위치를 잡는다 — 세로 병합된 큰 셀에서 유용하다. */}
         <div
           className={cn(
-            "h-full cursor-text truncate px-2 py-1.5",
+            "h-full cursor-text px-2 py-1.5",
+            valign === "top"
+              ? "truncate"
+              : cn(
+                  "flex flex-col overflow-hidden whitespace-nowrap",
+                  VALIGN_CLASS[valign],
+                ),
             ALIGN_CLASS[align],
             cells === undefined && "text-muted-foreground/40",
             isCellError(cells?.[c]) && "text-destructive",
@@ -1394,10 +1425,25 @@ export function DatasetGrid({
                         </button>
                       );
                     })}
+                    <span className="bg-border mx-0.5 h-4 w-px" />
+                    {VALIGN_ORDER.map((value) => {
+                      const Icon = VALIGN_ICONS[value];
+                      return (
+                        <button
+                          key={value}
+                          type="button"
+                          aria-label={`세로 정렬 ${VALIGN_LABELS[value]}`}
+                          onClick={run(() => applyValignSel(value))}
+                          className="text-muted-foreground hover:bg-accent hover:text-foreground flex size-6 items-center justify-center rounded"
+                        >
+                          <Icon className="size-4" />
+                        </button>
+                      );
+                    })}
                     <button
                       type="button"
                       aria-label="서식 지우기"
-                      title="배경·정렬 초기화"
+                      title="배경·정렬·세로정렬 초기화"
                       onClick={run(clearFormatSel)}
                       className="text-muted-foreground hover:bg-accent hover:text-foreground ml-auto flex size-6 items-center justify-center rounded"
                     >
@@ -1524,6 +1570,26 @@ const ALIGN_CLASS: Record<CellAlign, string> = {
 };
 /** 정렬 버튼 순서. */
 const ALIGN_ORDER: CellAlign[] = ["left", "center", "right"];
+
+/** 세로 정렬 값 → 아이콘. 셀 정렬 팔레트와 렌더에 공용. */
+const VALIGN_ICONS = {
+  top: AlignVerticalJustifyStart,
+  middle: AlignVerticalJustifyCenter,
+  bottom: AlignVerticalJustifyEnd,
+} as const;
+const VALIGN_LABELS: Record<CellValign, string> = {
+  top: "위",
+  middle: "가운데",
+  bottom: "아래",
+};
+/** 세로 정렬 값 → Tailwind flex 정렬 클래스. 셀은 세로 flex라 justify-*로 위/아래를 잡는다. */
+const VALIGN_CLASS: Record<CellValign, string> = {
+  top: "justify-start",
+  middle: "justify-center",
+  bottom: "justify-end",
+};
+/** 세로 정렬 버튼 순서. */
+const VALIGN_ORDER: CellValign[] = ["top", "middle", "bottom"];
 
 /** 서버가 알려주는 실패 사유(수식 문법 오류·순환 참조 등). 없으면 조용히 넘어간다. */
 function serverMessage(e: unknown): string | null {

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -12,6 +12,9 @@ export interface DatasetColumn {
 /** 셀·열 정렬 값. 서버의 ALLOWED_ALIGN과 같아야 한다. */
 export type CellAlign = "left" | "center" | "right";
 
+/** 셀 세로 정렬 값. 서버의 ALLOWED_VALIGN과 같아야 한다. 세로 병합 셀 등에서 쓴다. */
+export type CellValign = "top" | "middle" | "bottom";
+
 /** 열 너비 하한(px). 서버의 DatasetColumn.MIN_WIDTH와 같아야 한다. */
 export const MIN_COLUMN_WIDTH = 60;
 /** 열 너비 상한(px). 서버의 DatasetColumn.MAX_WIDTH와 같아야 한다. */
@@ -32,6 +35,7 @@ export type CellBgToken = (typeof CELL_BG_TOKENS)[number];
 export interface CellStyle {
   bg?: CellBgToken;
   align?: CellAlign;
+  valign?: CellValign;
 }
 
 /** 병합 요청의 span(앵커 기준 rowSpan×colSpan). (1,1)은 병합이 아니다. */
@@ -250,7 +254,11 @@ export async function setCellStyle(
 ): Promise<DatasetRow> {
   const { data } = await client.put<ApiEnvelope<DatasetRow>>(
     `/datasets/${datasetId}/rows/${rowIndex}/cells/${colKey}/style`,
-    { bg: style.bg ?? null, align: style.align ?? null },
+    {
+      bg: style.bg ?? null,
+      align: style.align ?? null,
+      valign: style.valign ?? null,
+    },
   );
   return data.data;
 }
@@ -271,6 +279,7 @@ export async function setCellStylesBulk(
         colKey: c.colKey,
         bg: c.style.bg ?? null,
         align: c.style.align ?? null,
+        valign: c.style.valign ?? null,
       })),
     },
   );


### PR DESCRIPTION
## 이슈
closes #890

## 작업 내용
- 셀 서식에 **세로 정렬(valign)** 추가 — 가로 정렬(left/center/right)을 그대로 미러링. 세로로 병합된 큰 셀에서 값을 위/가운데/아래로 맞출 수 있다.
- **BE**
  - `dataset_cell_style.valign` 컬럼 추가(Liquibase `043`, `VARCHAR(16)`, rollback 포함)
  - 엔티티/DTO(`CellStyle`, `SetCellStyleRequest`, `BulkCellStyleRequest.Target`)·서비스에 valign 반영
  - 검증 `@Pattern(top|middle|bottom)`, 셋 다 null이면 서식 행 삭제(sparse 유지)
- **FE**
  - `CellStyle.valign` 타입 + 단건·일괄 서식 요청에 valign 전송
  - 우클릭 메뉴에 세로 정렬 버튼 3개 추가(가로 정렬·배경색은 보존해 통째 교체)
  - 셀 렌더: 기본(top)은 기존 `truncate`(말줄임) 그대로 두고, 가운데/아래일 때만 세로 flex(`justify-*`)로 내려 위치를 잡는다 — DOM 구조·말줄임 회귀 없음
- **테스트**
  - BE 통합: valign 저장·행 조회 반영, 잘못된 값 거부
  - FE 통합: 서버 valign → 렌더 클래스, 우클릭 세로 정렬 시 배경색·가로 정렬 보존 일괄 PUT

## 검증
- BE `DatasetControllerTest` 통과(실 MySQL TestContainers)
- FE `DatasetGrid.test.tsx` 60개 통과, `tsc`/eslint/prettier·프로덕션 빌드 정상