### PR TITLE
feat : 수식 스칼라 함수 파이프라인 + 골든 하네스 (Epic #892 스켈레톤)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaEvaluator.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaEvaluator.java
@@ -51,6 +51,26 @@ public final class FormulaEvaluator {
             case FormulaNode.Binary b -> binary(b, src);
             case FormulaNode.Ref r -> ref(r, src);
             case FormulaNode.Agg a -> agg(a, src);
+            case FormulaNode.Call c -> call(c, src);
+        };
+    }
+
+    /**
+     * 스칼라 함수. 인자를 좌→우로 평가하고 <b>에러는 그대로 번진다</b>(첫 에러 우선).
+     * arity는 파서가 이미 보장하므로 여기선 안 센다.
+     */
+    private static FormulaValue call(FormulaNode.Call c, ValueSource src) {
+        List<BigDecimal> args = new ArrayList<>();
+        for (FormulaNode arg : c.args()) {
+            FormulaValue v = evaluate(arg, src);
+            if (v instanceof FormulaValue.Err) {
+                return v;
+            }
+            args.add(((FormulaValue.Num) v).value());
+        }
+        return switch (c.func()) {
+            case "ABS" -> new FormulaValue.Num(args.get(0).abs());
+            default -> new FormulaValue.Err(FormulaValue.Err.VALUE);
         };
     }
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaNode.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaNode.java
@@ -43,4 +43,14 @@ public sealed interface FormulaNode {
      */
     record Agg(String func, List<String> colKeys) implements FormulaNode {
     }
+
+    /**
+     * 스칼라 함수 호출. 집계({@link Agg})와 달리 인자가 <b>열 참조가 아니라 식</b>이다 —
+     * {@code ABS({점수} - 10)}처럼 셀·산술을 품는다. 각 인자는 셀 단위로 평가된다.
+     *
+     * <p>IF·AND·OR·NOT이 올라탈 구조라 여기서 먼저 깐다(#893). 함수별 인자 개수(arity)는
+     * 파싱 시점에 검증한다.
+     */
+    record Call(String func, List<FormulaNode> args) implements FormulaNode {
+    }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaParser.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaParser.java
@@ -37,8 +37,15 @@ import java.util.Set;
  */
 public final class FormulaParser {
 
-    /** D8이 정한 함수 범위. IF는 비교·논리 연산자와 세트라 제외. */
+    /** 집계 함수 — 인자가 열 참조(열 전체). */
     private static final Set<String> AGGREGATES = Set.of("SUM", "AVG", "COUNT", "MIN", "MAX");
+
+    /**
+     * 스칼라 함수 — 인자가 식(셀·산술). 값은 [최소, 최대] 인자 개수(arity). {@code Integer.MAX_VALUE}는 가변.
+     * IF/AND/OR/NOT이 여기로 들어온다(#892 §13). 지금은 워킹 스켈레톤으로 {@code ABS}만.
+     */
+    private static final java.util.Map<String, int[]> SCALAR_FUNCS =
+            java.util.Map.of("ABS", new int[] {1, 1});
 
     private final String src;
     private final FormulaContext ctx;
@@ -78,6 +85,7 @@ public final class FormulaParser {
                 collect(b.right(), out);
             }
             case FormulaNode.Unary u -> collect(u.operand(), out);
+            case FormulaNode.Call c -> c.args().forEach(arg -> collect(arg, out));
             case FormulaNode.Num ignored -> {
             }
         }
@@ -147,7 +155,7 @@ public final class FormulaParser {
             return number();
         }
         if (Character.isLetter(c)) {
-            return agg();
+            return functionCall();
         }
         throw syntaxError("예상하지 못한 문자: '" + c + "'");
     }
@@ -164,15 +172,47 @@ public final class FormulaParser {
         }
     }
 
-    private FormulaNode agg() {
+    /** {@code NAME(...)} — 함수 이름을 읽고 집계/스칼라로 분기한다. */
+    private FormulaNode functionCall() {
         int start = pos;
         while (pos < src.length() && Character.isLetter(src.charAt(pos))) {
             pos++;
         }
         String name = src.substring(start, pos).toUpperCase(Locale.ROOT);
-        if (!AGGREGATES.contains(name)) {
-            throw syntaxError("지원하지 않는 함수: " + name);
+        if (AGGREGATES.contains(name)) {
+            return aggregate(name);
         }
+        if (SCALAR_FUNCS.containsKey(name)) {
+            return scalar(name);
+        }
+        throw syntaxError("지원하지 않는 함수: " + name);
+    }
+
+    /** 스칼라 함수 — 식 인자를 콤마로 나열. arity를 검증한다. */
+    private FormulaNode scalar(String name) {
+        skipSpace();
+        expect('(');
+        List<FormulaNode> args = new ArrayList<>();
+        skipSpace();
+        if (peek() != ')') {
+            args.add(expr());
+            skipSpace();
+            while (peek() == ',') {
+                pos++;
+                args.add(expr());
+                skipSpace();
+            }
+        }
+        expect(')');
+        int[] arity = SCALAR_FUNCS.get(name);
+        if (args.size() < arity[0] || args.size() > arity[1]) {
+            throw syntaxError("함수 " + name + "의 인자 개수가 맞지 않습니다: " + args.size());
+        }
+        return new FormulaNode.Call(name, List.copyOf(args));
+    }
+
+    /** 집계 함수 — 열 참조(범위·나열)를 인자로. */
+    private FormulaNode aggregate(String name) {
         skipSpace();
         expect('(');
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaWriter.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaWriter.java
@@ -61,6 +61,17 @@ public final class FormulaWriter {
                             .map(k -> "{" + name(k, ctx) + "}")
                             .collect(Collectors.joining(", ")))
                     .append(')');
+            case FormulaNode.Call c -> {
+                // 스칼라 함수는 인자가 식이라 재귀로 쓴다. 저장형·표시형이 같은 모양.
+                sb.append(c.func()).append('(');
+                for (int i = 0; i < c.args().size(); i++) {
+                    if (i > 0) {
+                        sb.append(", ");
+                    }
+                    write(c.args().get(i), sb, ctx);
+                }
+                sb.append(')');
+            }
             case FormulaNode.Ref r -> {
                 sb.append('{').append(name(r.colKey(), ctx)).append('}');
                 if (r.kind() == FormulaRefKind.ABSOLUTE) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/formula/FormulaConformanceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/formula/FormulaConformanceTest.java
@@ -1,0 +1,156 @@
+package ds.project.orino.planner.dataset.formula;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 수식 <b>평가</b>의 골든(conformance) 스위트. 파서 트리 모양이 아니라 "입력 수식 → 셀에 담길 값"을
+ * 데이터 주도로 못 박는다.
+ *
+ * <p>이 스위트가 존재하는 이유(#892 §13 ADR-2): 나중에 반응성용 FE 경량 평가기를 붙일 때
+ * <b>BE와 FE 두 구현을 교차검증할 SSOT</b>가 된다. 그래서 기능이 아니라 스켈레톤 단계(#893)부터 심는다 —
+ * 지금 기존 동작(산술·참조·집계·에러 전파)과 새 스칼라 함수({@code ABS})를 골든으로 봉인해 둔다.
+ */
+class FormulaConformanceTest {
+
+    /**
+     * 인메모리 표. {@link FormulaContext}(파싱용)와 {@link FormulaEvaluator.ValueSource}(평가용)를 겸한다.
+     * 행 번호 N(1-base) ↔ 행 id 100+N. sameRow는 0번 행(id 101)을 현재 행으로 본다.
+     */
+    private static final class Model
+            implements FormulaContext, FormulaEvaluator.ValueSource {
+
+        private final Map<String, String> labelByKey = new LinkedHashMap<>();
+        private final List<Map<String, String>> rows = new ArrayList<>();
+        private static final int CURRENT = 0;
+
+        Model column(String key, String label) {
+            labelByKey.put(key, label);
+            return this;
+        }
+
+        /** 열 순서대로 셀 값을 받아 한 행을 붙인다. */
+        Model row(String... cells) {
+            Map<String, String> row = new LinkedHashMap<>();
+            List<String> keys = List.copyOf(labelByKey.keySet());
+            for (int i = 0; i < keys.size(); i++) {
+                row.put(keys.get(i), i < cells.length ? cells[i] : "");
+            }
+            rows.add(row);
+            return this;
+        }
+
+        @Override
+        public List<String> columnKeys() {
+            return List.copyOf(labelByKey.keySet());
+        }
+
+        @Override
+        public Optional<String> keyByLabel(String label) {
+            return labelByKey.entrySet().stream()
+                    .filter(e -> e.getValue().equals(label))
+                    .map(Map.Entry::getKey)
+                    .findFirst();
+        }
+
+        @Override
+        public Optional<String> labelByKey(String key) {
+            return Optional.ofNullable(labelByKey.get(key));
+        }
+
+        @Override
+        public Optional<Long> rowIdByNumber(int rowNumber) {
+            return rowNumber >= 1 && rowNumber <= rows.size()
+                    ? Optional.of(100L + rowNumber) : Optional.empty();
+        }
+
+        @Override
+        public Optional<Integer> rowNumberById(long rowId) {
+            int n = (int) (rowId - 100L);
+            return n >= 1 && n <= rows.size() ? Optional.of(n) : Optional.empty();
+        }
+
+        @Override
+        public Optional<String> sameRow(String colKey) {
+            return labelByKey.containsKey(colKey)
+                    ? Optional.of(rows.get(CURRENT).get(colKey)) : Optional.empty();
+        }
+
+        @Override
+        public Optional<String> absolute(long rowId, String colKey) {
+            int n = (int) (rowId - 100L);
+            if (n < 1 || n > rows.size() || !labelByKey.containsKey(colKey)) {
+                return Optional.empty();
+            }
+            return Optional.of(rows.get(n - 1).get(colKey));
+        }
+
+        @Override
+        public Optional<List<String>> column(String colKey) {
+            if (!labelByKey.containsKey(colKey)) {
+                return Optional.empty();
+            }
+            return Optional.of(rows.stream().map(r -> r.get(colKey)).toList());
+        }
+    }
+
+    /** 운영에 가까운 작은 표. 현재 행(1행)은 수량=2·단가=3·메모=a·재고 비었고·상태는 에러값. */
+    private static Model model() {
+        return new Model()
+                .column("c0", "수량")
+                .column("c1", "단가")
+                .column("c2", "메모")
+                .column("c3", "재고")
+                .column("c4", "상태")
+                //       수량   단가   메모   재고   상태
+                .row("2", "3", "a", "", "#DIV/0!")
+                .row("4", "5", "", "1", "")
+                .row("", "10", "x", "2", "");
+    }
+
+    private static Stream<Arguments> cases() {
+        return Stream.of(
+                // ── 산술 ──
+                Arguments.of("사칙연산 우선순위", "=1 + 2 * 3", "7"),
+                Arguments.of("같은 행 참조 곱", "={수량} * {단가}", "6"),
+                Arguments.of("빈 셀은 0", "={재고} + {수량}", "2"),
+                Arguments.of("0으로 나누면 #DIV/0!", "=1 / 0", "#DIV/0!"),
+                // ── 참조 에러 ──
+                Arguments.of("텍스트를 산술하면 #VALUE!", "={메모} + 1", "#VALUE!"),
+                Arguments.of("에러 셀은 그대로 번진다", "={상태} + 1", "#DIV/0!"),
+                Arguments.of("절대 참조(행 번호)", "={단가}2", "5"),
+                // ── 집계 ──
+                Arguments.of("SUM은 빈 셀을 무시", "=SUM({수량})", "6"),
+                Arguments.of("COUNT는 숫자만 센다", "=COUNT({수량})", "2"),
+                Arguments.of("AVG", "=AVG({단가})", "6"),
+                Arguments.of("숫자 없는 열 AVG는 #DIV/0!", "=AVG({메모})", "#DIV/0!"),
+                Arguments.of("MIN", "=MIN({단가})", "3"),
+                Arguments.of("MAX", "=MAX({단가})", "10"),
+                Arguments.of("집계는 텍스트를 무시(합 0)", "=SUM({메모})", "0"),
+                // ── 스칼라 함수 ABS (#893 신규) ──
+                Arguments.of("ABS 리터럴", "=ABS(-5)", "5"),
+                Arguments.of("ABS 식 인자", "=ABS({수량} - {단가})", "1"),
+                Arguments.of("ABS 빈 셀 인자", "=ABS({재고} - 3)", "3"),
+                Arguments.of("ABS 인자 에러 전파", "=ABS({메모})", "#VALUE!"));
+    }
+
+    @ParameterizedTest(name = "{0}: {1} → {2}")
+    @MethodSource("cases")
+    @DisplayName("입력 수식 → 셀 값 (골든)")
+    void evaluatesTo(String name, String formula, String expected) {
+        Model m = model();
+        FormulaNode node = FormulaParser.parseInput(formula, m);
+        assertThat(FormulaEvaluator.evaluate(node, m).asCell()).isEqualTo(expected);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/formula/FormulaParserTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/formula/FormulaParserTest.java
@@ -314,4 +314,51 @@ class FormulaParserTest {
                     .isEqualTo("=0.5");
         }
     }
+
+    @Nested
+    @DisplayName("스칼라 함수 (#893) — 집계와 달리 인자가 식")
+    class Scalar {
+
+        @Test
+        @DisplayName("ABS는 Call 노드로 파싱된다")
+        void absParses() {
+            assertThat(FormulaParser.parseInput("=ABS({SFI})", ctx))
+                    .isEqualTo(new FormulaNode.Call("ABS",
+                            List.of(new FormulaNode.Ref(FormulaRefKind.SAME_ROW, "c2", null))));
+        }
+
+        @Test
+        @DisplayName("집계와 달리 산술 인자를 받는다")
+        void takesExpressionArg() {
+            // SUM({SFI} * 2)는 오류지만 ABS({SFI} * 2)는 정상이다.
+            assertThat(FormulaWriter.toStored(FormulaParser.parseInput("=ABS({SFI} * 2)", ctx)))
+                    .isEqualTo("=ABS(({c2} * 2))");
+        }
+
+        @Test
+        @DisplayName("저장형·표시형이 같은 모양이고 인자를 재귀로 쓴다")
+        void writesBothForms() {
+            FormulaNode n = FormulaParser.parseInput("=ABS({SFI Rank} * {SFI})", ctx);
+            assertThat(FormulaWriter.toStored(n)).isEqualTo("=ABS(({c1} * {c2}))");
+            assertThat(FormulaWriter.toDisplay(n, ctx)).isEqualTo("=ABS(({SFI Rank} * {SFI}))");
+        }
+
+        @Test
+        @DisplayName("인자 속 참조가 의존성으로 잡힌다")
+        void argRefsCollected() {
+            FormulaNode n = FormulaParser.parseInput("=ABS({SFI Rank} * {SFI})", ctx);
+            assertThat(FormulaParser.collectRefs(n)).containsExactlyInAnyOrder(
+                    new FormulaNode.Ref(FormulaRefKind.SAME_ROW, "c1", null),
+                    new FormulaNode.Ref(FormulaRefKind.SAME_ROW, "c2", null));
+        }
+
+        @Test
+        @DisplayName("인자 개수가 안 맞으면 오류")
+        void wrongArity() {
+            assertThatThrownBy(() -> FormulaParser.parseInput("=ABS()", ctx))
+                    .isInstanceOf(CustomException.class);
+            assertThatThrownBy(() -> FormulaParser.parseInput("=ABS({SFI}, {SFI})", ctx))
+                    .isInstanceOf(CustomException.class);
+        }
+    }
 }


### PR DESCRIPTION
## 이슈
closes #893

## 배경
Epic #892(표 수식 엔진 엑셀화)의 **워킹 스켈레톤**. 목적은 기능이 아니라 IF/AND/OR/NOT이 올라탈 **구조와 골든 하네스**를 타입 리스크 0으로 먼저 까는 것. (설계·ADR·값타입 스펙은 [Wiki §13](https://github.com/wcorn/orino/wiki/Data-Grid-Block#13-엑셀-지향-확장-epic-892))

기존 엔진엔 집계 함수(`SUM`/`AVG`/`COUNT`/`MIN`/`MAX`, **열 참조** 인자)만 있고 **식 인자를 받는 스칼라 함수 호출**이 없었다 — 이게 IF가 막히는 구조적 지점. 워밍업 함수로 `ABS`(number→number, 값 타입 확장 불필요) 하나를 끝까지 관통시킨다.

## 작업 내용
- **`FormulaNode.Call(func, args)`** — 집계(`Agg`, 열 참조)와 구분되는 스칼라 함수 호출(식 인자)
- **Parser** — `functionCall()`에서 집계/스칼라 분기, 스칼라는 식 인자를 콤마로 나열 + **arity 검증**(`ABS`=1). 집계와 달리 `ABS({SFI} * 2)` 같은 산술 인자 허용
- **Evaluator** — `Call` 평가 + 에러 좌→우 전파, `ABS`
- **Writer** — `Call` 저장형·표시형 직렬화(인자 재귀, 두 형태 동일)
- **`collectRefs`** — `Call` 인자 재귀 → `=ABS({점수})`의 참조가 의존성 그래프·재계산 전파에 잡힘
- **`FormulaConformanceTest`** — 평가 결과(값/에러)를 데이터 주도로 봉인한 골든 스위트. 기존 동작(산술·같은행/절대 참조·빈칸→0·텍스트→#VALUE!·에러 전파·SUM/COUNT/AVG/MIN/MAX·#DIV/0!) + `ABS`. **반응성 단계에서 FE 경량 평가기를 BE와 교차검증할 SSOT**(§13 ADR-2)라 스켈레톤부터 심는다

## 범위 밖 (다음 PR)
- 값 타입 확장(boolean/text), 비교연산자, `IF`/`AND`/`OR`/`NOT` → 값타입 미니스펙(§13) 적용
- `SUMIF`/`COUNTIF`

## 검증
- `FormulaParserTest`(스칼라 함수 파싱·writer·arity·의존성 추가) + `FormulaConformanceTest`(골든) 통과
- `checkstyleMain`/`checkstyleTest` 통과