### PR TITLE
feat : 수식 IF·비교연산자·AND/OR/NOT (Epic #892 마일스톤 2)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaEvaluator.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaEvaluator.java
@@ -40,46 +40,76 @@ public final class FormulaEvaluator {
     public static FormulaValue evaluate(FormulaNode node, ValueSource src) {
         return switch (node) {
             case FormulaNode.Num n -> new FormulaValue.Num(n.value());
-            case FormulaNode.Unary u -> {
-                FormulaValue v = evaluate(u.operand(), src);
-                yield switch (v) {
-                    case FormulaValue.Err e -> e;
-                    case FormulaValue.Num n ->
-                            new FormulaValue.Num(u.op() == '-' ? n.value().negate() : n.value());
-                };
-            }
+            case FormulaNode.Str s -> new FormulaValue.Text(s.value());
+            case FormulaNode.Unary u -> unary(u, src);
             case FormulaNode.Binary b -> binary(b, src);
+            case FormulaNode.Compare c -> compare(c, src);
             case FormulaNode.Ref r -> ref(r, src);
             case FormulaNode.Agg a -> agg(a, src);
             case FormulaNode.Call c -> call(c, src);
         };
     }
 
+    private static FormulaValue unary(FormulaNode.Unary u, ValueSource src) {
+        FormulaValue n = asNumber(evaluate(u.operand(), src));
+        if (n instanceof FormulaValue.Err) {
+            return n;
+        }
+        BigDecimal v = ((FormulaValue.Num) n).value();
+        return new FormulaValue.Num(u.op() == '-' ? v.negate() : v);
+    }
+
     /**
-     * 스칼라 함수. 인자를 좌→우로 평가하고 <b>에러는 그대로 번진다</b>(첫 에러 우선).
-     * arity는 파서가 이미 보장하므로 여기선 안 센다.
+     * 스칼라 함수. {@code IF}는 <b>고른 가지만</b> 평가(지연)하고, 나머지는 인자를 평가해 값 규칙을 적용한다.
+     * 어디서든 에러는 좌→우 첫 에러가 번진다. arity는 파서가 보장한다.
      */
     private static FormulaValue call(FormulaNode.Call c, ValueSource src) {
-        List<BigDecimal> args = new ArrayList<>();
-        for (FormulaNode arg : c.args()) {
-            FormulaValue v = evaluate(arg, src);
-            if (v instanceof FormulaValue.Err) {
-                return v;
-            }
-            args.add(((FormulaValue.Num) v).value());
-        }
+        List<FormulaNode> a = c.args();
         return switch (c.func()) {
-            case "ABS" -> new FormulaValue.Num(args.get(0).abs());
+            case "ABS" -> {
+                FormulaValue n = asNumber(evaluate(a.get(0), src));
+                yield n instanceof FormulaValue.Err ? n
+                        : new FormulaValue.Num(((FormulaValue.Num) n).value().abs());
+            }
+            case "IF" -> {
+                FormulaValue cond = asBool(evaluate(a.get(0), src));
+                if (cond instanceof FormulaValue.Err) {
+                    yield cond;
+                }
+                // 지연 평가: 고른 가지만 계산한다(안 고른 가지의 에러·비용 억제).
+                yield evaluate(((FormulaValue.Bool) cond).value() ? a.get(1) : a.get(2), src);
+            }
+            case "NOT" -> {
+                FormulaValue v = asBool(evaluate(a.get(0), src));
+                yield v instanceof FormulaValue.Err ? v
+                        : new FormulaValue.Bool(!((FormulaValue.Bool) v).value());
+            }
+            case "AND", "OR" -> logical(c.func(), a, src);
             default -> new FormulaValue.Err(FormulaValue.Err.VALUE);
         };
     }
 
+    /** {@code AND}/{@code OR} — 인자를 다 평가하되(엑셀식) 에러는 전파한다. */
+    private static FormulaValue logical(String func, List<FormulaNode> args, ValueSource src) {
+        boolean and = func.equals("AND");
+        boolean acc = and;
+        for (FormulaNode arg : args) {
+            FormulaValue v = asBool(evaluate(arg, src));
+            if (v instanceof FormulaValue.Err) {
+                return v;
+            }
+            boolean b = ((FormulaValue.Bool) v).value();
+            acc = and ? acc && b : acc || b;
+        }
+        return new FormulaValue.Bool(acc);
+    }
+
     private static FormulaValue binary(FormulaNode.Binary b, ValueSource src) {
-        FormulaValue l = evaluate(b.left(), src);
+        FormulaValue l = asNumber(evaluate(b.left(), src));
         if (l instanceof FormulaValue.Err) {
             return l;
         }
-        FormulaValue r = evaluate(b.right(), src);
+        FormulaValue r = asNumber(evaluate(b.right(), src));
         if (r instanceof FormulaValue.Err) {
             return r;
         }
@@ -96,7 +126,82 @@ public final class FormulaEvaluator {
         };
     }
 
-    /** 산술 속 참조. 빈 칸은 0으로 보고(엑셀과 같다), 숫자가 아니면 {@code #VALUE!}. */
+    /**
+     * 비교 → boolean. 같은 타입끼리는 그 타입으로, 다르면 <b>number &lt; text &lt; boolean</b> 순위로 견준다
+     * (엑셀 타입 순서 — 임의 텍스트가 임의 숫자보다 크다). 텍스트는 대소문자를 무시한다.
+     */
+    private static FormulaValue compare(FormulaNode.Compare c, ValueSource src) {
+        FormulaValue l = evaluate(c.left(), src);
+        if (l instanceof FormulaValue.Err) {
+            return l;
+        }
+        FormulaValue r = evaluate(c.right(), src);
+        if (r instanceof FormulaValue.Err) {
+            return r;
+        }
+        int cmp = order(l, r);
+        boolean result = switch (c.op()) {
+            case "=" -> cmp == 0;
+            case "<>" -> cmp != 0;
+            case "<" -> cmp < 0;
+            case ">" -> cmp > 0;
+            case "<=" -> cmp <= 0;
+            case ">=" -> cmp >= 0;
+            default -> false;
+        };
+        return new FormulaValue.Bool(result);
+    }
+
+    private static int order(FormulaValue l, FormulaValue r) {
+        if (l instanceof FormulaValue.Num a && r instanceof FormulaValue.Num b) {
+            return a.value().compareTo(b.value());
+        }
+        if (l instanceof FormulaValue.Text a && r instanceof FormulaValue.Text b) {
+            return a.value().compareToIgnoreCase(b.value());
+        }
+        if (l instanceof FormulaValue.Bool a && r instanceof FormulaValue.Bool b) {
+            return Boolean.compare(a.value(), b.value());
+        }
+        return Integer.compare(rank(l), rank(r));
+    }
+
+    private static int rank(FormulaValue v) {
+        return switch (v) {
+            case FormulaValue.Num ignored -> 0;
+            case FormulaValue.Text ignored -> 1;
+            case FormulaValue.Bool ignored -> 2;
+            case FormulaValue.Err ignored -> 3;
+        };
+    }
+
+    /** 산술·ABS·비교 피연산자를 숫자로 강제한다. Bool→1/0, Text→{@code #VALUE!}(빈 셀은 이미 0). */
+    private static FormulaValue asNumber(FormulaValue v) {
+        return switch (v) {
+            case FormulaValue.Num n -> n;
+            case FormulaValue.Bool b -> new FormulaValue.Num(b.value() ? BigDecimal.ONE : BigDecimal.ZERO);
+            case FormulaValue.Text ignored -> new FormulaValue.Err(FormulaValue.Err.VALUE);
+            case FormulaValue.Err e -> e;
+        };
+    }
+
+    /** IF 조건·AND/OR/NOT 인자를 boolean으로 강제한다. Num→0이면 거짓, Text는 "TRUE"/"FALSE"만 허용. */
+    private static FormulaValue asBool(FormulaValue v) {
+        return switch (v) {
+            case FormulaValue.Bool b -> b;
+            case FormulaValue.Num n -> new FormulaValue.Bool(n.value().signum() != 0);
+            case FormulaValue.Text t -> {
+                if (t.value().equalsIgnoreCase("TRUE")) {
+                    yield new FormulaValue.Bool(true);
+                }
+                yield t.value().equalsIgnoreCase("FALSE")
+                        ? new FormulaValue.Bool(false)
+                        : new FormulaValue.Err(FormulaValue.Err.VALUE);
+            }
+            case FormulaValue.Err e -> e;
+        };
+    }
+
+    /** 참조 → 셀 내용을 타입으로. 빈 칸은 0(엑셀식), 숫자는 Num, 에러 문자열은 번지고, 그 외는 Text. */
     private static FormulaValue ref(FormulaNode.Ref r, ValueSource src) {
         Optional<String> raw = r.kind() == FormulaRefKind.ABSOLUTE
                 ? src.absolute(r.rowId(), r.colKey())
@@ -114,7 +219,7 @@ public final class FormulaEvaluator {
         }
         return number(s)
                 .<FormulaValue>map(FormulaValue.Num::new)
-                .orElseGet(() -> new FormulaValue.Err(FormulaValue.Err.VALUE));
+                .orElseGet(() -> new FormulaValue.Text(s));
     }
 
     /**

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaNode.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaNode.java
@@ -17,12 +17,23 @@ public sealed interface FormulaNode {
     record Num(BigDecimal value) implements FormulaNode {
     }
 
+    /** 리터럴 문자열. {@code "엔"}처럼 큰따옴표로 감싼다. */
+    record Str(String value) implements FormulaNode {
+    }
+
     /** 단항 부호. {@code op}는 '+' 또는 '-'. */
     record Unary(char op, FormulaNode operand) implements FormulaNode {
     }
 
     /** 이항 산술. {@code op}는 '+' '-' '*' '/'. */
     record Binary(char op, FormulaNode left, FormulaNode right) implements FormulaNode {
+    }
+
+    /**
+     * 비교. {@code op}는 {@code = <> < > <= >=}. 산술({@link Binary})보다 우선순위가 낮고
+     * 결과는 boolean이다. 두 글자 연산자가 있어 op를 String으로 둔다.
+     */
+    record Compare(String op, FormulaNode left, FormulaNode right) implements FormulaNode {
     }
 
     /**

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaParser.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaParser.java
@@ -41,11 +41,15 @@ public final class FormulaParser {
     private static final Set<String> AGGREGATES = Set.of("SUM", "AVG", "COUNT", "MIN", "MAX");
 
     /**
-     * 스칼라 함수 — 인자가 식(셀·산술). 값은 [최소, 최대] 인자 개수(arity). {@code Integer.MAX_VALUE}는 가변.
-     * IF/AND/OR/NOT이 여기로 들어온다(#892 §13). 지금은 워킹 스켈레톤으로 {@code ABS}만.
+     * 스칼라 함수 — 인자가 식(셀·산술·비교). 값은 [최소, 최대] 인자 개수(arity). {@code Integer.MAX_VALUE}는 가변.
+     * {@code IF}/{@code AND}/{@code OR}/{@code NOT}은 여기로 들어오되 평가는 값 타입 규칙을 따른다(#892 §13).
      */
-    private static final java.util.Map<String, int[]> SCALAR_FUNCS =
-            java.util.Map.of("ABS", new int[] {1, 1});
+    private static final java.util.Map<String, int[]> SCALAR_FUNCS = java.util.Map.of(
+            "ABS", new int[] {1, 1},
+            "IF", new int[] {3, 3},
+            "AND", new int[] {1, Integer.MAX_VALUE},
+            "OR", new int[] {1, Integer.MAX_VALUE},
+            "NOT", new int[] {1, 1});
 
     private final String src;
     private final FormulaContext ctx;
@@ -85,8 +89,14 @@ public final class FormulaParser {
                 collect(b.right(), out);
             }
             case FormulaNode.Unary u -> collect(u.operand(), out);
+            case FormulaNode.Compare cmp -> {
+                collect(cmp.left(), out);
+                collect(cmp.right(), out);
+            }
             case FormulaNode.Call c -> c.args().forEach(arg -> collect(arg, out));
             case FormulaNode.Num ignored -> {
+            }
+            case FormulaNode.Str ignored -> {
             }
         }
     }
@@ -102,7 +112,33 @@ public final class FormulaParser {
         return node;
     }
 
+    /** 최상위 = 비교. 산술보다 우선순위가 낮다(엑셀과 같다). 좌결합. */
     private FormulaNode expr() {
+        FormulaNode left = additive();
+        while (true) {
+            skipSpace();
+            String op = peekCompareOp();
+            if (op == null) {
+                return left;
+            }
+            pos += op.length();
+            left = new FormulaNode.Compare(op, left, additive());
+        }
+    }
+
+    /** 현재 위치의 비교 연산자를 본다. {@code = <> <= >= < >} 중 하나거나 null. */
+    private String peekCompareOp() {
+        char c = peek();
+        char n = pos + 1 < src.length() ? src.charAt(pos + 1) : '\0';
+        return switch (c) {
+            case '=' -> "=";
+            case '<' -> n == '=' ? "<=" : n == '>' ? "<>" : "<";
+            case '>' -> n == '=' ? ">=" : ">";
+            default -> null;
+        };
+    }
+
+    private FormulaNode additive() {
         FormulaNode left = term();
         while (true) {
             skipSpace();
@@ -151,6 +187,9 @@ public final class FormulaParser {
         if (c == '{') {
             return ref(false);
         }
+        if (c == '"') {
+            return string();
+        }
         if (Character.isDigit(c) || c == '.') {
             return number();
         }
@@ -158,6 +197,28 @@ public final class FormulaParser {
             return functionCall();
         }
         throw syntaxError("예상하지 못한 문자: '" + c + "'");
+    }
+
+    /** {@code "..."} — 안의 {@code ""}는 큰따옴표 하나로 읽는다(엑셀식 이스케이프). */
+    private FormulaNode string() {
+        expect('"');
+        StringBuilder sb = new StringBuilder();
+        while (true) {
+            if (pos >= src.length()) {
+                throw syntaxError("문자열을 닫는 '\"'가 없습니다");
+            }
+            char c = src.charAt(pos++);
+            if (c == '"') {
+                if (peek() == '"') {
+                    sb.append('"');
+                    pos++;
+                } else {
+                    return new FormulaNode.Str(sb.toString());
+                }
+            } else {
+                sb.append(c);
+            }
+        }
     }
 
     private FormulaNode number() {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaValue.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaValue.java
@@ -12,6 +12,14 @@ public sealed interface FormulaValue {
     record Num(BigDecimal value) implements FormulaValue {
     }
 
+    /** 문자열. 텍스트 셀·문자열 리터럴·문자열 비교의 결과가 여기로 온다. */
+    record Text(String value) implements FormulaValue {
+    }
+
+    /** 참/거짓. 비교연산자·논리 함수(IF 조건·AND/OR/NOT)의 결과. 엑셀처럼 셀엔 TRUE/FALSE로 담긴다. */
+    record Bool(boolean value) implements FormulaValue {
+    }
+
     /** {@code #VALUE!} {@code #DIV/0!} {@code #REF!} 같은 셀 에러. */
     record Err(String code) implements FormulaValue {
 
@@ -24,6 +32,8 @@ public sealed interface FormulaValue {
     default String asCell() {
         return switch (this) {
             case Num n -> n.value().stripTrailingZeros().toPlainString();
+            case Text t -> t.value();
+            case Bool b -> b.value() ? "TRUE" : "FALSE";
             case Err e -> e.code();
         };
     }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaWriter.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaWriter.java
@@ -44,6 +44,9 @@ public final class FormulaWriter {
     private static void write(FormulaNode node, StringBuilder sb, FormulaContext ctx) {
         switch (node) {
             case FormulaNode.Num n -> sb.append(plain(n.value()));
+            case FormulaNode.Str s -> sb.append('"')
+                    .append(s.value().replace("\"", "\"\""))
+                    .append('"');
             case FormulaNode.Unary u -> {
                 sb.append(u.op());
                 write(u.operand(), sb, ctx);
@@ -54,6 +57,13 @@ public final class FormulaWriter {
                 write(b.left(), sb, ctx);
                 sb.append(' ').append(b.op()).append(' ');
                 write(b.right(), sb, ctx);
+                sb.append(')');
+            }
+            case FormulaNode.Compare c -> {
+                sb.append('(');
+                write(c.left(), sb, ctx);
+                sb.append(' ').append(c.op()).append(' ');
+                write(c.right(), sb, ctx);
                 sb.append(')');
             }
             case FormulaNode.Agg a -> sb.append(a.func()).append('(')

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/formula/FormulaConformanceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/formula/FormulaConformanceTest.java
@@ -138,11 +138,34 @@ class FormulaConformanceTest {
                 Arguments.of("MIN", "=MIN({단가})", "3"),
                 Arguments.of("MAX", "=MAX({단가})", "10"),
                 Arguments.of("집계는 텍스트를 무시(합 0)", "=SUM({메모})", "0"),
-                // ── 스칼라 함수 ABS (#893 신규) ──
+                // ── 스칼라 함수 ABS (#893) ──
                 Arguments.of("ABS 리터럴", "=ABS(-5)", "5"),
                 Arguments.of("ABS 식 인자", "=ABS({수량} - {단가})", "1"),
                 Arguments.of("ABS 빈 셀 인자", "=ABS({재고} - 3)", "3"),
-                Arguments.of("ABS 인자 에러 전파", "=ABS({메모})", "#VALUE!"));
+                Arguments.of("ABS 인자 에러 전파", "=ABS({메모})", "#VALUE!"),
+                // ── 비교 → boolean (#895) ──
+                Arguments.of("숫자 비교", "={수량} < {단가}", "TRUE"),
+                Arguments.of("숫자 같음", "={수량} = 2", "TRUE"),
+                Arguments.of("다름", "={수량} <> 2", "FALSE"),
+                Arguments.of("텍스트 비교(대소문자 무시)", "={메모} = \"A\"", "TRUE"),
+                Arguments.of("교차 타입: 텍스트 > 숫자", "={메모} > 999", "TRUE"),
+                Arguments.of("비교 피연산자 에러 전파", "={상태} = 1", "#DIV/0!"),
+                // ── IF (#895) ──
+                Arguments.of("IF 참 가지", "=IF({수량} = 2, {단가}, -1)", "3"),
+                Arguments.of("IF 거짓 가지", "=IF({수량} = 9, {단가}, -1)", "-1"),
+                Arguments.of("환율 자동환산 예시", "=IF({메모} = \"a\", {수량} * 10, {수량})", "20"),
+                Arguments.of("IF 지연 평가 — 안 고른 가지 에러 무시", "=IF({수량} > 0, 7, 1 / 0)", "7"),
+                Arguments.of("IF 조건 에러 전파", "=IF({상태} = 1, 1, 0)", "#DIV/0!"),
+                // ── AND/OR/NOT (#895) ──
+                Arguments.of("AND", "=AND({수량} = 2, {단가} = 3)", "TRUE"),
+                Arguments.of("AND 하나 거짓", "=AND({수량} = 2, {단가} = 9)", "FALSE"),
+                Arguments.of("OR", "=OR({수량} = 9, {단가} = 3)", "TRUE"),
+                Arguments.of("NOT", "=NOT({수량} = 2)", "FALSE"),
+                Arguments.of("숫자 0은 거짓", "=NOT({재고})", "TRUE"),
+                Arguments.of("문자열 인자는 #VALUE!", "=AND({메모}, 1 = 1)", "#VALUE!"),
+                // ── 산술이 boolean·문자열을 만나면 ──
+                Arguments.of("boolean은 산술에서 1", "=(1 < 2) + 5", "6"),
+                Arguments.of("문자열 산술은 #VALUE!", "=\"a\" + 1", "#VALUE!"));
     }
 
     @ParameterizedTest(name = "{0}: {1} → {2}")

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/formula/FormulaParserTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/formula/FormulaParserTest.java
@@ -257,10 +257,10 @@ class FormulaParserTest {
         }
 
         @Test
-        @DisplayName("D8 범위 밖 함수면 오류 — IF는 아직 없다")
+        @DisplayName("지원하지 않는 함수면 오류 — IF는 이제 되지만 COUNTA는 아직")
         void unsupportedFunction() {
-            expectSyntaxError("=IF({SFI} > 1, 1, 0)");
             expectSyntaxError("=COUNTA({SFI})");
+            expectSyntaxError("=VLOOKUP({SFI}, {Lemma}, 1)");
         }
 
         @Test
@@ -359,6 +359,72 @@ class FormulaParserTest {
                     .isInstanceOf(CustomException.class);
             assertThatThrownBy(() -> FormulaParser.parseInput("=ABS({SFI}, {SFI})", ctx))
                     .isInstanceOf(CustomException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("조건·비교·논리 (#895)")
+    class Conditional {
+
+        @Test
+        @DisplayName("비교는 산술보다 우선순위가 낮다")
+        void comparisonBelowArithmetic() {
+            // 1 + 2 < 4  →  (1+2) < 4
+            assertThat(FormulaWriter.toStored(FormulaParser.parseInput("=1 + 2 < 4", ctx)))
+                    .isEqualTo("=((1 + 2) < 4)");
+        }
+
+        @Test
+        @DisplayName("두 글자 비교 연산자를 읽는다")
+        void twoCharOperators() {
+            assertThat(FormulaWriter.toStored(FormulaParser.parseInput("={SFI} <> {SFI Rank}", ctx)))
+                    .isEqualTo("=({c2} <> {c1})");
+            assertThat(FormulaWriter.toStored(FormulaParser.parseInput("={SFI} >= 1", ctx)))
+                    .isEqualTo("=({c2} >= 1)");
+        }
+
+        @Test
+        @DisplayName("문자열 리터럴 — 안의 \"\"는 따옴표 하나")
+        void stringLiteral() {
+            assertThat(FormulaParser.parseInput("=\"엔\"", ctx))
+                    .isEqualTo(new FormulaNode.Str("엔"));
+            assertThat(FormulaParser.parseInput("=\"a\"\"b\"", ctx))
+                    .isEqualTo(new FormulaNode.Str("a\"b"));
+        }
+
+        @Test
+        @DisplayName("IF는 조건·가지 세 인자를 받고 비교·문자열을 품는다")
+        void ifParses() {
+            FormulaNode n = FormulaParser.parseInput(
+                    "=IF({SFI} = \"엔\", {SFI Rank} * 2, {SFI Rank})", ctx);
+            assertThat(FormulaWriter.toStored(n))
+                    .isEqualTo("=IF(({c2} = \"엔\"), ({c1} * 2), {c1})");
+        }
+
+        @Test
+        @DisplayName("IF 인자 개수가 3이 아니면 오류")
+        void ifArity() {
+            assertThatThrownBy(() -> FormulaParser.parseInput("=IF({SFI} > 1, 1)", ctx))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("IF·문자열·비교의 저장형을 다시 파싱하면 같은 트리 — 서비스 왕복 안전")
+        void storedReparsesIdentically() {
+            FormulaNode a = FormulaParser.parseInput(
+                    "=IF({SFI} = \"엔\", {SFI Rank} * 2, {SFI Rank})", ctx);
+            FormulaNode b = FormulaParser.parseStored(FormulaWriter.toStored(a), ctx);
+            assertThat(b).isEqualTo(a);
+        }
+
+        @Test
+        @DisplayName("AND/OR/NOT + 조건 속 참조가 의존성으로 잡힌다")
+        void logicalRefs() {
+            FormulaNode n = FormulaParser.parseInput(
+                    "=AND({SFI} > 1, NOT({SFI Rank} = 0))", ctx);
+            assertThat(FormulaParser.collectRefs(n)).containsExactlyInAnyOrder(
+                    new FormulaNode.Ref(FormulaRefKind.SAME_ROW, "c2", null),
+                    new FormulaNode.Ref(FormulaRefKind.SAME_ROW, "c1", null));
         }
     }
 }


### PR DESCRIPTION
## 이슈
closes #895

## 배경
Epic #892 마일스톤 2 — **진짜 언락 지점**. 스켈레톤(#894/#893)이 깐 `FormulaNode.Call` 구조 위에 값 타입(boolean/text)을 얹어 조건 계산을 연다. [값 타입 미니 스펙(Wiki §13)](https://github.com/wcorn/orino/wiki/Data-Grid-Block#13-엑셀-지향-확장-epic-892)이 여기서 처음 적용됐다.

목표 예시가 이제 돈다: `=IF({통화} = "엔", {금액} * {환율}, {금액})`

## 작업 내용
- **값 타입** — `FormulaValue`에 `Text`·`Bool` 추가. `asCell()`은 `TRUE`/`FALSE`·문자열로 담는다(셀엔 타입 없음, O11 유지)
- **노드** — `Str`(문자열 리터럴), `Compare`(비교; `<=`·`<>`가 있어 op가 String)
- **Parser** — 최상위에 **비교 레벨**(산술보다 낮은 우선순위, 좌결합) + 문자열 리터럴 `"..."`(`""`→`"` 이스케이프) + `IF`(arity 3)·`AND`/`OR`(1+)·`NOT`(1) 등록
- **Evaluator** (값 타입 스펙대로)
  - 비교 → boolean. 같은 타입끼리, 다르면 **number<text<bool** 순위(임의 텍스트 > 임의 숫자), 텍스트는 대소문자 무시
  - `IF` **지연 평가** — 고른 가지만 계산(안 고른 가지 에러·비용 억제)
  - `AND`/`OR`/`NOT` — 숫자 `0=false`·`"TRUE"/"FALSE"` 강제, 인자 다 평가하되 에러 전파
  - 산술 피연산자 강제: `Bool`→1/0, `Text`→`#VALUE!`. 참조는 비수치 셀을 `Text`로(빈 셀은 여전히 0)
- **Writer·collectRefs** — `Str`·`Compare` 반영, 인자 재귀 → **조건 속 참조도 의존성 그래프·재계산 전파에 잡힘**

## 검증
- `FormulaParserTest`(비교 우선순위·2글자 연산자·문자열·IF·arity·의존성·**저장형 왕복**) + `FormulaConformanceTest` 골든(비교·IF 참/거짓·지연평가·AND/OR/NOT·환율 예시·에러 전파) 통과
- 포뮬러 **통합 테스트**(`DatasetFormula*`, 실 MySQL TestContainers) 통과 — 서비스 저장/재파싱/재계산 경로 이상 없음
- `checkstyleMain`/`checkstyleTest` 통과
- FE 변경 없음 — 클라 함수 allowlist가 없어 수식 문자열을 그대로 BE에 보낸다(반응성은 후속 마일스톤)

## 범위 밖 (마일스톤 3)
- `SUMIF`/`COUNTIF`
- 빈 셀 텍스트비교 `""`는 v1에서 `0`으로 근사(엣지, §13 문서화)