### PR TITLE
feat : 수식 SUMIF·COUNTIF (Epic #892 마일스톤 3)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaEvaluator.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaEvaluator.java
@@ -46,6 +46,7 @@ public final class FormulaEvaluator {
             case FormulaNode.Compare c -> compare(c, src);
             case FormulaNode.Ref r -> ref(r, src);
             case FormulaNode.Agg a -> agg(a, src);
+            case FormulaNode.AggIf a -> aggIf(a, src);
             case FormulaNode.Call c -> call(c, src);
         };
     }
@@ -139,8 +140,12 @@ public final class FormulaEvaluator {
         if (r instanceof FormulaValue.Err) {
             return r;
         }
-        int cmp = order(l, r);
-        boolean result = switch (c.op()) {
+        return new FormulaValue.Bool(satisfies(c.op(), order(l, r)));
+    }
+
+    /** 비교 연산자를 {@code order()} 결과(음수/0/양수)에 적용한다. 비교·조건부 집계가 공유한다. */
+    private static boolean satisfies(String op, int cmp) {
+        return switch (op) {
             case "=" -> cmp == 0;
             case "<>" -> cmp != 0;
             case "<" -> cmp < 0;
@@ -149,7 +154,6 @@ public final class FormulaEvaluator {
             case ">=" -> cmp >= 0;
             default -> false;
         };
-        return new FormulaValue.Bool(result);
     }
 
     private static int order(FormulaValue l, FormulaValue r) {
@@ -259,6 +263,97 @@ public final class FormulaEvaluator {
                     nums.stream().max(BigDecimal::compareTo).orElse(BigDecimal.ZERO));
             default -> new FormulaValue.Err(FormulaValue.Err.VALUE);
         };
+    }
+
+    /**
+     * 조건부 집계. criteria를 한 번 평가해 (연산자, 기준값)으로 풀고, 조건 열을 행별로 견준다.
+     * 빈 셀은 매치 안 하고, 에러 셀은 번진다. {@code SUMIF}는 매치된 행의 합 열 숫자만 더한다.
+     */
+    private static FormulaValue aggIf(FormulaNode.AggIf a, ValueSource src) {
+        FormulaValue critRaw = evaluate(a.criteria(), src);
+        if (critRaw instanceof FormulaValue.Err) {
+            return critRaw;
+        }
+        Criteria crit = parseCriteria(critRaw);
+
+        Optional<List<String>> critCol = src.column(a.critCol());
+        if (critCol.isEmpty()) {
+            return new FormulaValue.Err(FormulaValue.Err.REF);
+        }
+        List<String> critCells = critCol.get();
+
+        boolean sumif = a.sumCol() != null;
+        List<String> sumCells = List.of();
+        if (sumif) {
+            Optional<List<String>> sc = src.column(a.sumCol());
+            if (sc.isEmpty()) {
+                return new FormulaValue.Err(FormulaValue.Err.REF);
+            }
+            sumCells = sc.get();
+        }
+
+        BigDecimal sum = BigDecimal.ZERO;
+        int count = 0;
+        for (int i = 0; i < critCells.size(); i++) {
+            String cell = critCells.get(i) == null ? "" : critCells.get(i).trim();
+            if (cell.isEmpty()) {
+                continue; // 빈 셀은 어떤 조건에도 매치하지 않는다(엑셀식)
+            }
+            if (cell.startsWith("#")) {
+                return new FormulaValue.Err(cell);
+            }
+            if (!matches(crit.op(), cellValue(cell), crit.target())) {
+                continue;
+            }
+            count++;
+            if (sumif) {
+                String sc = i < sumCells.size() && sumCells.get(i) != null
+                        ? sumCells.get(i).trim() : "";
+                if (sc.startsWith("#")) {
+                    return new FormulaValue.Err(sc);
+                }
+                Optional<BigDecimal> n = number(sc);
+                if (n.isPresent()) {
+                    sum = sum.add(n.get());
+                }
+            }
+        }
+        return new FormulaValue.Num(sumif ? sum : BigDecimal.valueOf(count));
+    }
+
+    /** criteria(연산자 접두 + 기준값). 연산자가 없으면 정확 일치({@code =}). */
+    private record Criteria(String op, FormulaValue target) {
+    }
+
+    private static final String[] CRITERIA_OPS = {"<=", ">=", "<>", "<", ">", "="};
+
+    private static Criteria parseCriteria(FormulaValue v) {
+        if (v instanceof FormulaValue.Text t) {
+            String s = t.value();
+            for (String op : CRITERIA_OPS) {
+                if (s.startsWith(op)) {
+                    return new Criteria(op, cellValue(s.substring(op.length()).trim()));
+                }
+            }
+            return new Criteria("=", cellValue(s)); // "80"도 숫자로 봐 셀 80과 맞춘다
+        }
+        return new Criteria("=", v); // 숫자·불린은 그대로 정확 일치
+    }
+
+    /** 셀·기준 문자열을 타입으로. 숫자로 읽히면 Num, 아니면 Text. */
+    private static FormulaValue cellValue(String s) {
+        return number(s).<FormulaValue>map(FormulaValue.Num::new)
+                .orElseGet(() -> new FormulaValue.Text(s));
+    }
+
+    /**
+     * 셀이 criteria에 맞는가. 같은 종류(둘 다 숫자/둘 다 텍스트)면 {@code order()}로 견주고,
+     * 종류가 다르면 같을 수 없으니 {@code <>}만 참이다 — 텍스트 셀은 {@code >80}에 안 걸린다.
+     */
+    private static boolean matches(String op, FormulaValue cell, FormulaValue target) {
+        boolean sameKind = (cell instanceof FormulaValue.Num && target instanceof FormulaValue.Num)
+                || (cell instanceof FormulaValue.Text && target instanceof FormulaValue.Text);
+        return sameKind ? satisfies(op, order(cell, target)) : op.equals("<>");
     }
 
     private static Optional<BigDecimal> number(String s) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaNode.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaNode.java
@@ -64,4 +64,19 @@ public sealed interface FormulaNode {
      */
     record Call(String func, List<FormulaNode> args) implements FormulaNode {
     }
+
+    /**
+     * 조건부 집계({@code COUNTIF}·{@code SUMIF}). 집계와 스칼라의 하이브리드 — 열 인자(조건 열·합 열)와
+     * criteria 식(행별로 견줄 값)을 함께 든다.
+     *
+     * <ul>
+     *   <li>{@code critCol} — 조건을 검사할 열 key
+     *   <li>{@code criteria} — 한 번 평가해 얻는 조건. 문자열이면 {@code ">80"}처럼 연산자 접두를 해석하고,
+     *       아니면 정확 일치
+     *   <li>{@code sumCol} — 합할 열 key. {@code COUNTIF}는 null(개수만 센다)
+     * </ul>
+     */
+    record AggIf(String func, String critCol, FormulaNode criteria, String sumCol)
+            implements FormulaNode {
+    }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaParser.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaParser.java
@@ -40,6 +40,9 @@ public final class FormulaParser {
     /** 집계 함수 — 인자가 열 참조(열 전체). */
     private static final Set<String> AGGREGATES = Set.of("SUM", "AVG", "COUNT", "MIN", "MAX");
 
+    /** 조건부 집계 — 열 인자 + criteria 식. 행별 조건으로 견준다. */
+    private static final Set<String> COND_AGGREGATES = Set.of("SUMIF", "COUNTIF");
+
     /**
      * 스칼라 함수 — 인자가 식(셀·산술·비교). 값은 [최소, 최대] 인자 개수(arity). {@code Integer.MAX_VALUE}는 가변.
      * {@code IF}/{@code AND}/{@code OR}/{@code NOT}은 여기로 들어오되 평가는 값 타입 규칙을 따른다(#892 §13).
@@ -84,6 +87,13 @@ public final class FormulaParser {
             case FormulaNode.Ref r -> out.add(r);
             case FormulaNode.Agg a -> a.colKeys()
                     .forEach(k -> out.add(new FormulaNode.Ref(FormulaRefKind.COLUMN_ALL, k, null)));
+            case FormulaNode.AggIf a -> {
+                out.add(new FormulaNode.Ref(FormulaRefKind.COLUMN_ALL, a.critCol(), null));
+                if (a.sumCol() != null) {
+                    out.add(new FormulaNode.Ref(FormulaRefKind.COLUMN_ALL, a.sumCol(), null));
+                }
+                collect(a.criteria(), out);
+            }
             case FormulaNode.Binary b -> {
                 collect(b.left(), out);
                 collect(b.right(), out);
@@ -243,10 +253,36 @@ public final class FormulaParser {
         if (AGGREGATES.contains(name)) {
             return aggregate(name);
         }
+        if (COND_AGGREGATES.contains(name)) {
+            return conditionalAggregate(name);
+        }
         if (SCALAR_FUNCS.containsKey(name)) {
             return scalar(name);
         }
         throw syntaxError("지원하지 않는 함수: " + name);
+    }
+
+    /**
+     * 조건부 집계 — {@code COUNTIF(열, criteria)} · {@code SUMIF(열, criteria, 열)}.
+     * 열 인자는 집계처럼 열 참조({@code ref(true)})로, criteria는 스칼라 식으로 읽는다.
+     */
+    private FormulaNode conditionalAggregate(String name) {
+        boolean sumif = name.equals("SUMIF");
+        skipSpace();
+        expect('(');
+        String critCol = ((FormulaNode.Ref) ref(true)).colKey();
+        skipSpace();
+        expect(',');
+        FormulaNode criteria = expr();
+        String sumCol = null;
+        if (sumif) {
+            skipSpace();
+            expect(',');
+            sumCol = ((FormulaNode.Ref) ref(true)).colKey();
+        }
+        skipSpace();
+        expect(')');
+        return new FormulaNode.AggIf(name, critCol, criteria, sumCol);
     }
 
     /** 스칼라 함수 — 식 인자를 콤마로 나열. arity를 검증한다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaWriter.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaWriter.java
@@ -71,6 +71,14 @@ public final class FormulaWriter {
                             .map(k -> "{" + name(k, ctx) + "}")
                             .collect(Collectors.joining(", ")))
                     .append(')');
+            case FormulaNode.AggIf a -> {
+                sb.append(a.func()).append("({").append(name(a.critCol(), ctx)).append("}, ");
+                write(a.criteria(), sb, ctx);
+                if (a.sumCol() != null) {
+                    sb.append(", {").append(name(a.sumCol(), ctx)).append('}');
+                }
+                sb.append(')');
+            }
             case FormulaNode.Call c -> {
                 // 스칼라 함수는 인자가 식이라 재귀로 쓴다. 저장형·표시형이 같은 모양.
                 sb.append(c.func()).append('(');

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/formula/FormulaConformanceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/formula/FormulaConformanceTest.java
@@ -165,7 +165,17 @@ class FormulaConformanceTest {
                 Arguments.of("문자열 인자는 #VALUE!", "=AND({메모}, 1 = 1)", "#VALUE!"),
                 // ── 산술이 boolean·문자열을 만나면 ──
                 Arguments.of("boolean은 산술에서 1", "=(1 < 2) + 5", "6"),
-                Arguments.of("문자열 산술은 #VALUE!", "=\"a\" + 1", "#VALUE!"));
+                Arguments.of("문자열 산술은 #VALUE!", "=\"a\" + 1", "#VALUE!"),
+                // ── 조건부 집계 SUMIF·COUNTIF (#897) ──
+                Arguments.of("COUNTIF 텍스트 정확일치", "=COUNTIF({메모}, \"a\")", "1"),
+                Arguments.of("COUNTIF 숫자 정확일치", "=COUNTIF({단가}, 3)", "1"),
+                Arguments.of("COUNTIF 연산자 criteria", "=COUNTIF({단가}, \">4\")", "2"),
+                Arguments.of("COUNTIF 부정 — 빈 셀은 스킵", "=COUNTIF({메모}, \"<>a\")", "1"),
+                Arguments.of("SUMIF 텍스트 조건", "=SUMIF({메모}, \"a\", {수량})", "2"),
+                Arguments.of("SUMIF 숫자 조건 — 합 열 빈칸 무시", "=SUMIF({단가}, \">4\", {수량})", "4"),
+                Arguments.of("SUMIF — 조건 열 빈 행 스킵", "=SUMIF({수량}, \">0\", {단가})", "8"),
+                Arguments.of("criteria가 식이어도 된다", "=COUNTIF({수량}, {단가} - 1)", "1"),
+                Arguments.of("조건 열 에러는 번진다", "=COUNTIF({상태}, \"x\")", "#DIV/0!"));
     }
 
     @ParameterizedTest(name = "{0}: {1} → {2}")

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/formula/FormulaParserTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/formula/FormulaParserTest.java
@@ -427,4 +427,47 @@ class FormulaParserTest {
                     new FormulaNode.Ref(FormulaRefKind.SAME_ROW, "c1", null));
         }
     }
+
+    @Nested
+    @DisplayName("조건부 집계 SUMIF·COUNTIF (#897)")
+    class ConditionalAggregate {
+
+        @Test
+        @DisplayName("COUNTIF는 열·criteria 두 인자")
+        void countifParses() {
+            assertThat(FormulaParser.parseInput("=COUNTIF({SFI}, \">80\")", ctx))
+                    .isEqualTo(new FormulaNode.AggIf(
+                            "COUNTIF", "c2", new FormulaNode.Str(">80"), null));
+        }
+
+        @Test
+        @DisplayName("SUMIF는 조건 열·criteria·합 열 세 인자, 저장형·표시형 왕복")
+        void sumifWrites() {
+            FormulaNode n = FormulaParser.parseInput(
+                    "=SUMIF({SFI}, \">80\", {SFI Rank})", ctx);
+            assertThat(FormulaWriter.toStored(n)).isEqualTo("=SUMIF({c2}, \">80\", {c1})");
+            assertThat(FormulaWriter.toDisplay(n, ctx))
+                    .isEqualTo("=SUMIF({SFI}, \">80\", {SFI Rank})");
+            assertThat(FormulaParser.parseStored(FormulaWriter.toStored(n), ctx)).isEqualTo(n);
+        }
+
+        @Test
+        @DisplayName("열들은 COLUMN_ALL, criteria 속 참조는 그 문맥대로 의존성에 잡힌다")
+        void refsCollected() {
+            FormulaNode n = FormulaParser.parseInput("=SUMIF({SFI}, {SFI Rank}, {Lemma})", ctx);
+            assertThat(FormulaParser.collectRefs(n)).containsExactlyInAnyOrder(
+                    new FormulaNode.Ref(FormulaRefKind.COLUMN_ALL, "c2", null),
+                    new FormulaNode.Ref(FormulaRefKind.COLUMN_ALL, "c0", null),
+                    new FormulaNode.Ref(FormulaRefKind.SAME_ROW, "c1", null));
+        }
+
+        @Test
+        @DisplayName("인자가 모자라면 오류")
+        void malformed() {
+            assertThatThrownBy(() -> FormulaParser.parseInput("=COUNTIF({SFI})", ctx))
+                    .isInstanceOf(CustomException.class);
+            assertThatThrownBy(() -> FormulaParser.parseInput("=SUMIF({SFI}, 1)", ctx))
+                    .isInstanceOf(CustomException.class);
+        }
+    }
 }


### PR DESCRIPTION
## 이슈
closes #897

## 배경
Epic #892 마일스톤 3 — 조건부 집계. 마일스톤 2(#896)의 비교 의미(교차타입 순위·대소문자 무시)를 **행 단위 조건**으로 재사용한다. 이 시점에 "카테고리별 조건부 합계" 예시가 orino에서 통째로 돈다:

```
=SUMIF({사용처}, "교통", {금액})      · 사용처=교통인 행의 금액 합
=IF({통화} = "엔", {금액} * {환율}, {금액})   · (마일스톤 2)
```

orino는 A1 범위가 아니라 **열 key + 행 레코드** 모델이라 Excel `SUMIF(range, criteria, sum_range)`를 열 기준으로 옮겼다.

## 작업 내용
- **`FormulaNode.AggIf(func, critCol, criteria, sumCol)`** — 집계·스칼라의 하이브리드(열 인자 + criteria 식). `COUNTIF`은 `sumCol` null
- **Parser** — `COUNTIF(열, criteria)` · `SUMIF(열, criteria, 열)`. 열 인자는 집계처럼 열 참조(`ref(columnOnly)`), criteria는 스칼라 `expr()`
- **Evaluator** — criteria 문자열 미니언어(`>` `<` `>=` `<=` `<>` `=` 접두 + 값, 없으면 정확 일치. `"80"`도 숫자로 봐 셀 80과 맞춘다). 행별로 마일스톤 2의 `order()`/`satisfies()` 재사용
  - **종류가 다르면**(숫자 셀 vs 텍스트 기준 등) 같을 수 없으니 `<>`만 참 → 텍스트 셀이 `>80`에 안 걸린다(엑셀식)
  - 빈 셀은 어떤 조건에도 매치 안 함, 에러 셀은 전파. `SUMIF`는 매치된 행의 합 열 **숫자만** 더한다
- **Writer·collectRefs** — `AggIf` 반영. 두 열은 `COLUMN_ALL`, **criteria 식은 재귀**로 의존성 그래프·재계산 전파에 잡힌다

## 검증
- `FormulaParserTest`(COUNTIF/SUMIF 파싱·writer·**저장형 왕복**·의존성·형식오류) + `FormulaConformanceTest` 골든(텍스트/숫자 정확일치·연산자 criteria·부정·빈칸 스킵·식 criteria·에러 전파) 통과
- 포뮬러 **통합 테스트**(실 MySQL TestContainers) 통과
- `checkstyleMain`/`checkstyleTest` 통과
- FE 변경 없음(클라 함수 allowlist 없음)

## 범위 밖
- 와일드카드(`*` `?`) criteria · `SUMIFS`/`COUNTIFS`(다중 조건) · `AVERAGEIF`
- 빈 셀 정확일치(`COUNTIF(range, "")`) 엣지 — v1은 빈 셀을 스킵