### PR TITLE
feat : 수식 FE 경량 평가기 + 골든 교차검증 (Epic #892 반응성 1)

### DIFF
--- a/fe/src/features/note/dataset/formula/conformance.test.ts
+++ b/fe/src/features/note/dataset/formula/conformance.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import { FormulaContext, ValueSource } from "./context";
+import { evaluateFormula } from "./index";
+
+/**
+ * FE 평가기의 골든(conformance) 스위트. BE `FormulaConformanceTest.java`와 **동일한 입력/기대**를 둔다 —
+ * 두 구현이 같은 값을 내는지 교차검증하는 SSOT(Epic #892 ADR-2). 케이스를 추가·수정하면 양쪽을 같이 바꾼다.
+ *
+ * <p>새 케이스는 float64로 정확히 표현되는 값만 쓴다(BE는 BigDecimal). 미리보기의 임의 소수 오차는
+ * 골든이 아니라 BE 확정값이 다룬다.
+ */
+
+/** BE `FormulaConformanceTest.Model`과 같은 인메모리 표. 행 번호 N ↔ 행 id 100+N, 현재 행은 0번. */
+class Model implements FormulaContext, ValueSource {
+  private readonly labels = new Map<string, string>();
+  private readonly rows: Record<string, string>[] = [];
+
+  col(key: string, label: string): this {
+    this.labels.set(key, label);
+    return this;
+  }
+
+  row(...cells: string[]): this {
+    const keys = [...this.labels.keys()];
+    const row: Record<string, string> = {};
+    keys.forEach((k, i) => (row[k] = i < cells.length ? cells[i] : ""));
+    this.rows.push(row);
+    return this;
+  }
+
+  columnKeys(): string[] {
+    return [...this.labels.keys()];
+  }
+  keyByLabel(label: string): string | undefined {
+    for (const [k, v] of this.labels) {
+      if (v === label) {
+        return k;
+      }
+    }
+    return undefined;
+  }
+  labelByKey(key: string): string | undefined {
+    return this.labels.get(key);
+  }
+  rowIdByNumber(n: number): number | undefined {
+    return n >= 1 && n <= this.rows.length ? 100 + n : undefined;
+  }
+  rowNumberById(rowId: number): number | undefined {
+    const n = rowId - 100;
+    return n >= 1 && n <= this.rows.length ? n : undefined;
+  }
+  sameRow(colKey: string): string | undefined {
+    return this.labels.has(colKey) ? this.rows[0][colKey] : undefined;
+  }
+  absolute(rowId: number, colKey: string): string | undefined {
+    const n = rowId - 100;
+    if (n < 1 || n > this.rows.length || !this.labels.has(colKey)) {
+      return undefined;
+    }
+    return this.rows[n - 1][colKey];
+  }
+  column(colKey: string): string[] | undefined {
+    return this.labels.has(colKey)
+      ? this.rows.map((r) => r[colKey])
+      : undefined;
+  }
+}
+
+function model(): Model {
+  return (
+    new Model()
+      .col("c0", "수량")
+      .col("c1", "단가")
+      .col("c2", "메모")
+      .col("c3", "재고")
+      .col("c4", "상태")
+      //     수량   단가   메모  재고  상태
+      .row("2", "3", "a", "", "#DIV/0!")
+      .row("4", "5", "", "1", "")
+      .row("", "10", "x", "2", "")
+  );
+}
+
+// [이름, 수식, 기대값] — BE FormulaConformanceTest.cases()와 1:1로 맞춘다.
+const CASES: [string, string, string][] = [
+  // ── 산술 ──
+  ["사칙연산 우선순위", "=1 + 2 * 3", "7"],
+  ["같은 행 참조 곱", "={수량} * {단가}", "6"],
+  ["빈 셀은 0", "={재고} + {수량}", "2"],
+  ["0으로 나누면 #DIV/0!", "=1 / 0", "#DIV/0!"],
+  // ── 참조 에러 ──
+  ["텍스트를 산술하면 #VALUE!", "={메모} + 1", "#VALUE!"],
+  ["에러 셀은 그대로 번진다", "={상태} + 1", "#DIV/0!"],
+  ["절대 참조(행 번호)", "={단가}2", "5"],
+  // ── 집계 ──
+  ["SUM은 빈 셀을 무시", "=SUM({수량})", "6"],
+  ["COUNT는 숫자만 센다", "=COUNT({수량})", "2"],
+  ["AVG", "=AVG({단가})", "6"],
+  ["숫자 없는 열 AVG는 #DIV/0!", "=AVG({메모})", "#DIV/0!"],
+  ["MIN", "=MIN({단가})", "3"],
+  ["MAX", "=MAX({단가})", "10"],
+  ["집계는 텍스트를 무시(합 0)", "=SUM({메모})", "0"],
+  // ── 스칼라 함수 ABS ──
+  ["ABS 리터럴", "=ABS(-5)", "5"],
+  ["ABS 식 인자", "=ABS({수량} - {단가})", "1"],
+  ["ABS 빈 셀 인자", "=ABS({재고} - 3)", "3"],
+  ["ABS 인자 에러 전파", "=ABS({메모})", "#VALUE!"],
+  // ── 비교 → boolean ──
+  ["숫자 비교", "={수량} < {단가}", "TRUE"],
+  ["숫자 같음", "={수량} = 2", "TRUE"],
+  ["다름", "={수량} <> 2", "FALSE"],
+  ["텍스트 비교(대소문자 무시)", '={메모} = "A"', "TRUE"],
+  ["교차 타입: 텍스트 > 숫자", "={메모} > 999", "TRUE"],
+  ["비교 피연산자 에러 전파", "={상태} = 1", "#DIV/0!"],
+  // ── IF ──
+  ["IF 참 가지", "=IF({수량} = 2, {단가}, -1)", "3"],
+  ["IF 거짓 가지", "=IF({수량} = 9, {단가}, -1)", "-1"],
+  ["환율 자동환산 예시", '=IF({메모} = "a", {수량} * 10, {수량})', "20"],
+  ["IF 지연 평가 — 안 고른 가지 에러 무시", "=IF({수량} > 0, 7, 1 / 0)", "7"],
+  ["IF 조건 에러 전파", "=IF({상태} = 1, 1, 0)", "#DIV/0!"],
+  // ── AND/OR/NOT ──
+  ["AND", "=AND({수량} = 2, {단가} = 3)", "TRUE"],
+  ["AND 하나 거짓", "=AND({수량} = 2, {단가} = 9)", "FALSE"],
+  ["OR", "=OR({수량} = 9, {단가} = 3)", "TRUE"],
+  ["NOT", "=NOT({수량} = 2)", "FALSE"],
+  ["숫자 0은 거짓", "=NOT({재고})", "TRUE"],
+  ["문자열 인자는 #VALUE!", "=AND({메모}, 1 = 1)", "#VALUE!"],
+  // ── 산술이 boolean·문자열을 만나면 ──
+  ["boolean은 산술에서 1", "=(1 < 2) + 5", "6"],
+  ["문자열 산술은 #VALUE!", '="a" + 1', "#VALUE!"],
+  // ── 조건부 집계 SUMIF·COUNTIF ──
+  ["COUNTIF 텍스트 정확일치", '=COUNTIF({메모}, "a")', "1"],
+  ["COUNTIF 숫자 정확일치", "=COUNTIF({단가}, 3)", "1"],
+  ["COUNTIF 연산자 criteria", '=COUNTIF({단가}, ">4")', "2"],
+  ["COUNTIF 부정 — 빈 셀은 스킵", '=COUNTIF({메모}, "<>a")', "1"],
+  ["SUMIF 텍스트 조건", '=SUMIF({메모}, "a", {수량})', "2"],
+  ["SUMIF 숫자 조건 — 합 열 빈칸 무시", '=SUMIF({단가}, ">4", {수량})', "4"],
+  ["SUMIF — 조건 열 빈 행 스킵", '=SUMIF({수량}, ">0", {단가})', "8"],
+  ["criteria가 식이어도 된다", "=COUNTIF({수량}, {단가} - 1)", "1"],
+  ["조건 열 에러는 번진다", '=COUNTIF({상태}, "x")', "#DIV/0!"],
+];
+
+describe("FE 수식 평가기 골든 (BE와 교차검증)", () => {
+  it.each(CASES)("%s: %s → %s", (_name, formula, expected) => {
+    const m = model();
+    expect(evaluateFormula(formula, m, m)).toBe(expected);
+  });
+});

--- a/fe/src/features/note/dataset/formula/context.ts
+++ b/fe/src/features/note/dataset/formula/context.ts
@@ -1,0 +1,33 @@
+/**
+ * 파서·평가기가 바깥 데이터를 보는 창. BE의 `FormulaContext`/`FormulaEvaluator.ValueSource`에 대응.
+ * `undefined`는 "없음"(→ `#REF!`), 빈 문자열은 "빈 셀"로 구분한다.
+ */
+export interface FormulaContext {
+  /** 현재 열 key 목록(표시 순서). 범위 스냅샷의 기준. */
+  columnKeys(): string[];
+  /** label → key. 없으면 undefined. */
+  keyByLabel(label: string): string | undefined;
+  /** key → label. 표시용. */
+  labelByKey(key: string): string | undefined;
+  /** 화면 행 번호(1-base) → 행 id. */
+  rowIdByNumber(rowNumber: number): number | undefined;
+  /** 행 id → 현재 행 번호(1-base). */
+  rowNumberById(rowId: number): number | undefined;
+}
+
+export interface ValueSource {
+  /** 계산 중인 그 행의 열 값. 열이 없으면 undefined. */
+  sameRow(colKey: string): string | undefined;
+  /** 특정 행의 열 값. 행·열이 없으면 undefined. */
+  absolute(rowId: number, colKey: string): string | undefined;
+  /** 열 전체 값. 열이 없으면 undefined. */
+  column(colKey: string): string[] | undefined;
+}
+
+/** 문법 오류. BE의 `FORMULA_SYNTAX_ERROR`에 대응. */
+export class FormulaSyntaxError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FormulaSyntaxError";
+  }
+}

--- a/fe/src/features/note/dataset/formula/evaluator.ts
+++ b/fe/src/features/note/dataset/formula/evaluator.ts
@@ -1,0 +1,383 @@
+import { ValueSource } from "./context";
+import { FormulaNode } from "./node";
+import {
+  asCell,
+  bool,
+  ERR,
+  err,
+  FormulaValue,
+  isErr,
+  num,
+  text,
+} from "./value";
+
+/**
+ * 구문 트리 평가. BE `FormulaEvaluator`를 그대로 옮긴다 — 값 규칙(강제 변환·에러 전파·교차타입 순위)이
+ * 동일해야 골든 케이스에서 BE와 일치한다.
+ */
+export function evaluate(node: FormulaNode, src: ValueSource): FormulaValue {
+  switch (node.type) {
+    case "num":
+      return num(node.value);
+    case "str":
+      return text(node.value);
+    case "unary": {
+      const n = asNumber(evaluate(node.operand, src));
+      if (isErr(n)) {
+        return n;
+      }
+      return num(
+        node.op === "-"
+          ? -(n as { value: number }).value
+          : (n as { value: number }).value,
+      );
+    }
+    case "binary":
+      return binary(node, src);
+    case "compare":
+      return compare(node, src);
+    case "ref":
+      return ref(node, src);
+    case "agg":
+      return agg(node, src);
+    case "aggif":
+      return aggIf(node, src);
+    case "call":
+      return call(node, src);
+  }
+}
+
+function call(
+  node: Extract<FormulaNode, { type: "call" }>,
+  src: ValueSource,
+): FormulaValue {
+  const a = node.args;
+  switch (node.func) {
+    case "ABS": {
+      const n = asNumber(evaluate(a[0], src));
+      return isErr(n) ? n : num(Math.abs((n as { value: number }).value));
+    }
+    case "IF": {
+      const cond = asBool(evaluate(a[0], src));
+      if (isErr(cond)) {
+        return cond;
+      }
+      // 지연 평가: 고른 가지만 계산한다.
+      return evaluate((cond as { value: boolean }).value ? a[1] : a[2], src);
+    }
+    case "NOT": {
+      const v = asBool(evaluate(a[0], src));
+      return isErr(v) ? v : bool(!(v as { value: boolean }).value);
+    }
+    case "AND":
+    case "OR":
+      return logical(node.func, a, src);
+    default:
+      return err(ERR.VALUE);
+  }
+}
+
+/** AND/OR — 인자를 다 평가하되 에러는 전파. */
+function logical(
+  func: string,
+  args: FormulaNode[],
+  src: ValueSource,
+): FormulaValue {
+  const and = func === "AND";
+  let acc = and;
+  for (const arg of args) {
+    const v = asBool(evaluate(arg, src));
+    if (isErr(v)) {
+      return v;
+    }
+    const b = (v as { value: boolean }).value;
+    acc = and ? acc && b : acc || b;
+  }
+  return bool(acc);
+}
+
+function binary(
+  node: Extract<FormulaNode, { type: "binary" }>,
+  src: ValueSource,
+): FormulaValue {
+  const l = asNumber(evaluate(node.left, src));
+  if (isErr(l)) {
+    return l;
+  }
+  const r = asNumber(evaluate(node.right, src));
+  if (isErr(r)) {
+    return r;
+  }
+  const x = (l as { value: number }).value;
+  const y = (r as { value: number }).value;
+  switch (node.op) {
+    case "+":
+      return num(x + y);
+    case "-":
+      return num(x - y);
+    case "*":
+      return num(x * y);
+    case "/":
+      return y === 0 ? err(ERR.DIV0) : num(x / y);
+    default:
+      return err(ERR.VALUE);
+  }
+}
+
+/** 비교 → boolean. 같은 타입끼리, 다르면 number<text<bool 순위. 텍스트는 대소문자 무시. */
+function compare(
+  node: Extract<FormulaNode, { type: "compare" }>,
+  src: ValueSource,
+): FormulaValue {
+  const l = evaluate(node.left, src);
+  if (isErr(l)) {
+    return l;
+  }
+  const r = evaluate(node.right, src);
+  if (isErr(r)) {
+    return r;
+  }
+  return bool(satisfies(node.op, order(l, r)));
+}
+
+/** 비교 연산자를 order() 결과(음수/0/양수)에 적용. 비교·조건부 집계가 공유. */
+function satisfies(op: string, cmp: number): boolean {
+  switch (op) {
+    case "=":
+      return cmp === 0;
+    case "<>":
+      return cmp !== 0;
+    case "<":
+      return cmp < 0;
+    case ">":
+      return cmp > 0;
+    case "<=":
+      return cmp <= 0;
+    case ">=":
+      return cmp >= 0;
+    default:
+      return false;
+  }
+}
+
+function order(l: FormulaValue, r: FormulaValue): number {
+  if (l.kind === "num" && r.kind === "num") {
+    return sign(l.value - r.value);
+  }
+  if (l.kind === "text" && r.kind === "text") {
+    const a = l.value.toLowerCase();
+    const b = r.value.toLowerCase();
+    return a < b ? -1 : a > b ? 1 : 0;
+  }
+  if (l.kind === "bool" && r.kind === "bool") {
+    return sign(Number(l.value) - Number(r.value));
+  }
+  return sign(rank(l) - rank(r));
+}
+
+function rank(v: FormulaValue): number {
+  switch (v.kind) {
+    case "num":
+      return 0;
+    case "text":
+      return 1;
+    case "bool":
+      return 2;
+    case "err":
+      return 3;
+  }
+}
+
+/** 산술·ABS 피연산자를 숫자로 강제. Bool→1/0, Text→#VALUE!(빈 셀은 이미 0). */
+function asNumber(v: FormulaValue): FormulaValue {
+  switch (v.kind) {
+    case "num":
+      return v;
+    case "bool":
+      return num(v.value ? 1 : 0);
+    case "text":
+      return err(ERR.VALUE);
+    case "err":
+      return v;
+  }
+}
+
+/** IF 조건·AND/OR/NOT 인자를 boolean으로 강제. Num→0이면 거짓, Text는 "TRUE"/"FALSE"만. */
+function asBool(v: FormulaValue): FormulaValue {
+  switch (v.kind) {
+    case "bool":
+      return v;
+    case "num":
+      return bool(v.value !== 0);
+    case "text":
+      if (v.value.toUpperCase() === "TRUE") {
+        return bool(true);
+      }
+      return v.value.toUpperCase() === "FALSE" ? bool(false) : err(ERR.VALUE);
+    case "err":
+      return v;
+  }
+}
+
+/** 참조 → 셀 내용을 타입으로. 빈 칸은 0, 숫자는 Num, 에러 문자열은 번지고, 그 외는 Text. */
+function ref(
+  node: Extract<FormulaNode, { type: "ref" }>,
+  src: ValueSource,
+): FormulaValue {
+  const raw =
+    node.kind === "ABSOLUTE"
+      ? src.absolute(node.rowId as number, node.colKey)
+      : src.sameRow(node.colKey);
+  if (raw === undefined) {
+    return err(ERR.REF);
+  }
+  const s = raw.trim();
+  if (s === "") {
+    return num(0);
+  }
+  if (s.startsWith("#")) {
+    return err(s);
+  }
+  return cellValue(s);
+}
+
+/** 집계. 숫자가 아닌 칸·빈 칸은 무시. 열이 없으면 #REF!, 셀이 에러면 번진다. */
+function agg(
+  node: Extract<FormulaNode, { type: "agg" }>,
+  src: ValueSource,
+): FormulaValue {
+  const nums: number[] = [];
+  for (const key of node.colKeys) {
+    const col = src.column(key);
+    if (col === undefined) {
+      return err(ERR.REF);
+    }
+    for (const cell of col) {
+      const s = (cell ?? "").trim();
+      if (s.startsWith("#")) {
+        return err(s);
+      }
+      const n = parseNumber(s);
+      if (n !== null) {
+        nums.push(n);
+      }
+    }
+  }
+  const sum = nums.reduce((a, b) => a + b, 0);
+  switch (node.func) {
+    case "COUNT":
+      return num(nums.length);
+    case "SUM":
+      return num(sum);
+    case "AVG":
+      return nums.length === 0 ? err(ERR.DIV0) : num(sum / nums.length);
+    case "MIN":
+      return num(nums.length === 0 ? 0 : Math.min(...nums));
+    case "MAX":
+      return num(nums.length === 0 ? 0 : Math.max(...nums));
+    default:
+      return err(ERR.VALUE);
+  }
+}
+
+/** 조건부 집계. criteria를 한 번 풀고 조건 열을 행별로 견준다. 빈 셀 스킵, 에러 전파. */
+function aggIf(
+  node: Extract<FormulaNode, { type: "aggif" }>,
+  src: ValueSource,
+): FormulaValue {
+  const critRaw = evaluate(node.criteria, src);
+  if (isErr(critRaw)) {
+    return critRaw;
+  }
+  const crit = parseCriteria(critRaw);
+
+  const critCells = src.column(node.critCol);
+  if (critCells === undefined) {
+    return err(ERR.REF);
+  }
+  const sumif = node.sumCol !== null;
+  let sumCells: string[] = [];
+  if (sumif) {
+    const sc = src.column(node.sumCol as string);
+    if (sc === undefined) {
+      return err(ERR.REF);
+    }
+    sumCells = sc;
+  }
+
+  let sum = 0;
+  let count = 0;
+  for (let i = 0; i < critCells.length; i++) {
+    const cell = (critCells[i] ?? "").trim();
+    if (cell === "") {
+      continue; // 빈 셀은 어떤 조건에도 매치하지 않는다
+    }
+    if (cell.startsWith("#")) {
+      return err(cell);
+    }
+    if (!matches(crit.op, cellValue(cell), crit.target)) {
+      continue;
+    }
+    count++;
+    if (sumif) {
+      const sc = (sumCells[i] ?? "").trim();
+      if (sc.startsWith("#")) {
+        return err(sc);
+      }
+      const n = parseNumber(sc);
+      if (n !== null) {
+        sum += n;
+      }
+    }
+  }
+  return num(sumif ? sum : count);
+}
+
+const CRITERIA_OPS = ["<=", ">=", "<>", "<", ">", "="];
+
+function parseCriteria(v: FormulaValue): { op: string; target: FormulaValue } {
+  if (v.kind === "text") {
+    const s = v.value;
+    for (const op of CRITERIA_OPS) {
+      if (s.startsWith(op)) {
+        return { op, target: cellValue(s.slice(op.length).trim()) };
+      }
+    }
+    return { op: "=", target: cellValue(s) }; // "80"도 숫자로 봐 셀 80과 맞춘다
+  }
+  return { op: "=", target: v }; // 숫자·불린은 그대로 정확 일치
+}
+
+/** 셀·기준 문자열을 타입으로. 숫자로 읽히면 Num, 아니면 Text. */
+function cellValue(s: string): FormulaValue {
+  const n = parseNumber(s);
+  return n !== null ? num(n) : text(s);
+}
+
+/** 같은 종류면 order()로, 다르면 <>만 참(텍스트 셀은 >80에 안 걸린다). */
+function matches(
+  op: string,
+  cell: FormulaValue,
+  target: FormulaValue,
+): boolean {
+  const sameKind =
+    (cell.kind === "num" && target.kind === "num") ||
+    (cell.kind === "text" && target.kind === "text");
+  return sameKind ? satisfies(op, order(cell, target)) : op === "<>";
+}
+
+/** BE `BigDecimal` 파싱에 대응하는 엄격한 숫자 파서. 빈 문자열·비수치는 null. */
+function parseNumber(s: string): number | null {
+  if (s === "" || !/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(s)) {
+    return null;
+  }
+  const n = Number(s);
+  return Number.isFinite(n) ? n : null;
+}
+
+const sign = (n: number): number => (n < 0 ? -1 : n > 0 ? 1 : 0);
+
+/** 셀에 담길 문자열로 평가. 그리드 낙관적 재계산이 쓸 최종 형태. */
+export function evaluateToCell(node: FormulaNode, src: ValueSource): string {
+  return asCell(evaluate(node, src));
+}

--- a/fe/src/features/note/dataset/formula/index.ts
+++ b/fe/src/features/note/dataset/formula/index.ts
@@ -1,0 +1,26 @@
+/**
+ * FE 경량 수식 평가기. 계산 SSOT는 BE고, 이건 입력 즉시 미리보기용이다(Epic #892 ADR-2).
+ * BE `formula` 패키지와 동일 함수 집합을 구현하며, `conformance.test.ts`의 골든 케이스로 교차검증한다.
+ */
+export type { FormulaContext, ValueSource } from "./context";
+export { FormulaSyntaxError } from "./context";
+export { evaluate, evaluateToCell } from "./evaluator";
+export { collectRefs, parseInput, parseStored } from "./parser";
+export type { FormulaValue } from "./value";
+export { asCell } from "./value";
+
+import { FormulaContext, ValueSource } from "./context";
+import { evaluateToCell } from "./evaluator";
+import { parseInput } from "./parser";
+
+/**
+ * 사용자가 친 수식(label·행 번호)을 파싱·평가해 셀에 담길 문자열을 돌려준다.
+ * 문법 오류는 던진다(호출부가 잡아 BE 확정에 맡긴다).
+ */
+export function evaluateFormula(
+  input: string,
+  ctx: FormulaContext,
+  source: ValueSource,
+): string {
+  return evaluateToCell(parseInput(input, ctx), source);
+}

--- a/fe/src/features/note/dataset/formula/node.ts
+++ b/fe/src/features/note/dataset/formula/node.ts
@@ -1,0 +1,29 @@
+/**
+ * 수식 구문 트리. BE `FormulaNode`(sealed interface)를 discriminated union으로 옮긴다.
+ * 파싱이 끝나면 label·행 번호가 남지 않고 열 key와 행 id로만 이뤄진다.
+ */
+export type RefKind = "SAME_ROW" | "ABSOLUTE" | "COLUMN_ALL";
+
+export type RefNode = {
+  type: "ref";
+  kind: RefKind;
+  colKey: string;
+  rowId: number | null;
+};
+
+export type FormulaNode =
+  | { type: "num"; value: number }
+  | { type: "str"; value: string }
+  | { type: "unary"; op: "+" | "-"; operand: FormulaNode }
+  | { type: "binary"; op: string; left: FormulaNode; right: FormulaNode }
+  | { type: "compare"; op: string; left: FormulaNode; right: FormulaNode }
+  | RefNode
+  | { type: "agg"; func: string; colKeys: string[] }
+  | {
+      type: "aggif";
+      func: string;
+      critCol: string;
+      criteria: FormulaNode;
+      sumCol: string | null;
+    }
+  | { type: "call"; func: string; args: FormulaNode[] };

--- a/fe/src/features/note/dataset/formula/parser.ts
+++ b/fe/src/features/note/dataset/formula/parser.ts
@@ -1,0 +1,429 @@
+import { FormulaContext, FormulaSyntaxError } from "./context";
+import { FormulaNode, RefNode } from "./node";
+
+/** 집계 함수 — 인자가 열 참조(열 전체). */
+const AGGREGATES = new Set(["SUM", "AVG", "COUNT", "MIN", "MAX"]);
+/** 조건부 집계 — 열 인자 + criteria 식. */
+const COND_AGGREGATES = new Set(["SUMIF", "COUNTIF"]);
+/** 스칼라 함수 — 인자가 식. [최소, 최대] arity. */
+const SCALAR_FUNCS: Record<string, [number, number]> = {
+  ABS: [1, 1],
+  IF: [3, 3],
+  AND: [1, Infinity],
+  OR: [1, Infinity],
+  NOT: [1, 1],
+};
+
+const EOF = "\0";
+
+/**
+ * 수식 파서. BE `FormulaParser`(재귀 하강)를 그대로 옮긴다. 문법·우선순위·오류 지점이 동일해야
+ * 골든 케이스에서 BE와 일치한다.
+ */
+class Parser {
+  private pos = 0;
+
+  constructor(
+    private readonly src: string,
+    private readonly ctx: FormulaContext,
+    private readonly stored: boolean,
+  ) {}
+
+  parseAll(): FormulaNode {
+    this.skipSpace();
+    this.expect("=");
+    const node = this.expr();
+    this.skipSpace();
+    if (this.pos < this.src.length) {
+      throw this.syntaxError("수식 뒤에 남은 문자가 있습니다");
+    }
+    return node;
+  }
+
+  /** 최상위 = 비교. 산술보다 우선순위가 낮다(엑셀과 같다). 좌결합. */
+  private expr(): FormulaNode {
+    let left = this.additive();
+    for (;;) {
+      this.skipSpace();
+      const op = this.peekCompareOp();
+      if (op === null) {
+        return left;
+      }
+      this.pos += op.length;
+      left = { type: "compare", op, left, right: this.additive() };
+    }
+  }
+
+  private peekCompareOp(): string | null {
+    const c = this.peek();
+    const n = this.pos + 1 < this.src.length ? this.src[this.pos + 1] : EOF;
+    switch (c) {
+      case "=":
+        return "=";
+      case "<":
+        return n === "=" ? "<=" : n === ">" ? "<>" : "<";
+      case ">":
+        return n === "=" ? ">=" : ">";
+      default:
+        return null;
+    }
+  }
+
+  private additive(): FormulaNode {
+    let left = this.term();
+    for (;;) {
+      this.skipSpace();
+      const c = this.peek();
+      if (c !== "+" && c !== "-") {
+        return left;
+      }
+      this.pos++;
+      left = { type: "binary", op: c, left, right: this.term() };
+    }
+  }
+
+  private term(): FormulaNode {
+    let left = this.unary();
+    for (;;) {
+      this.skipSpace();
+      const c = this.peek();
+      if (c !== "*" && c !== "/") {
+        return left;
+      }
+      this.pos++;
+      left = { type: "binary", op: c, left, right: this.unary() };
+    }
+  }
+
+  private unary(): FormulaNode {
+    this.skipSpace();
+    const c = this.peek();
+    if (c === "-" || c === "+") {
+      this.pos++;
+      return { type: "unary", op: c, operand: this.unary() };
+    }
+    return this.primary();
+  }
+
+  private primary(): FormulaNode {
+    this.skipSpace();
+    const c = this.peek();
+    if (c === "(") {
+      this.pos++;
+      const inner = this.expr();
+      this.skipSpace();
+      this.expect(")");
+      return inner;
+    }
+    if (c === "{") {
+      return this.ref(false);
+    }
+    if (c === '"') {
+      return this.string();
+    }
+    if (isDigit(c) || c === ".") {
+      return this.number();
+    }
+    if (isLetter(c)) {
+      return this.functionCall();
+    }
+    throw this.syntaxError(`예상하지 못한 문자: '${c}'`);
+  }
+
+  /** `"..."` — 안의 `""`는 큰따옴표 하나로 읽는다(엑셀식 이스케이프). */
+  private string(): FormulaNode {
+    this.expect('"');
+    let out = "";
+    for (;;) {
+      if (this.pos >= this.src.length) {
+        throw this.syntaxError("문자열을 닫는 '\"'가 없습니다");
+      }
+      const c = this.src[this.pos++];
+      if (c === '"') {
+        if (this.peek() === '"') {
+          out += '"';
+          this.pos++;
+        } else {
+          return { type: "str", value: out };
+        }
+      } else {
+        out += c;
+      }
+    }
+  }
+
+  private number(): FormulaNode {
+    const start = this.pos;
+    while (
+      this.pos < this.src.length &&
+      (isDigit(this.src[this.pos]) || this.src[this.pos] === ".")
+    ) {
+      this.pos++;
+    }
+    const raw = this.src.slice(start, this.pos);
+    const value = Number(raw);
+    if (!Number.isFinite(value)) {
+      throw this.syntaxError(`숫자를 읽을 수 없습니다: ${raw}`);
+    }
+    return { type: "num", value };
+  }
+
+  private functionCall(): FormulaNode {
+    const start = this.pos;
+    while (this.pos < this.src.length && isLetter(this.src[this.pos])) {
+      this.pos++;
+    }
+    const name = this.src.slice(start, this.pos).toUpperCase();
+    if (AGGREGATES.has(name)) {
+      return this.aggregate(name);
+    }
+    if (COND_AGGREGATES.has(name)) {
+      return this.conditionalAggregate(name);
+    }
+    if (name in SCALAR_FUNCS) {
+      return this.scalar(name);
+    }
+    throw this.syntaxError(`지원하지 않는 함수: ${name}`);
+  }
+
+  private scalar(name: string): FormulaNode {
+    this.skipSpace();
+    this.expect("(");
+    const args: FormulaNode[] = [];
+    this.skipSpace();
+    if (this.peek() !== ")") {
+      args.push(this.expr());
+      this.skipSpace();
+      while (this.peek() === ",") {
+        this.pos++;
+        args.push(this.expr());
+        this.skipSpace();
+      }
+    }
+    this.expect(")");
+    const [min, max] = SCALAR_FUNCS[name];
+    if (args.length < min || args.length > max) {
+      throw this.syntaxError(
+        `함수 ${name}의 인자 개수가 맞지 않습니다: ${args.length}`,
+      );
+    }
+    return { type: "call", func: name, args };
+  }
+
+  private conditionalAggregate(name: string): FormulaNode {
+    const sumif = name === "SUMIF";
+    this.skipSpace();
+    this.expect("(");
+    const critCol = (this.ref(true) as RefNode).colKey;
+    this.skipSpace();
+    this.expect(",");
+    const criteria = this.expr();
+    let sumCol: string | null = null;
+    if (sumif) {
+      this.skipSpace();
+      this.expect(",");
+      sumCol = (this.ref(true) as RefNode).colKey;
+    }
+    this.skipSpace();
+    this.expect(")");
+    return { type: "aggif", func: name, critCol, criteria, sumCol };
+  }
+
+  private aggregate(name: string): FormulaNode {
+    this.skipSpace();
+    this.expect("(");
+    const keys: string[] = [];
+    const first = this.ref(true) as RefNode;
+    this.skipSpace();
+    if (this.peek() === ":") {
+      this.pos++;
+      const last = this.ref(true) as RefNode;
+      keys.push(...this.expandRange(first.colKey, last.colKey));
+    } else {
+      keys.push(first.colKey);
+      while (this.peek() === ",") {
+        this.pos++;
+        keys.push((this.ref(true) as RefNode).colKey);
+        this.skipSpace();
+      }
+    }
+    this.skipSpace();
+    this.expect(")");
+    return { type: "agg", func: name, colKeys: [...new Set(keys)] };
+  }
+
+  private expandRange(fromKey: string, toKey: string): string[] {
+    const all = this.ctx.columnKeys();
+    const from = all.indexOf(fromKey);
+    const to = all.indexOf(toKey);
+    if (from < 0 || to < 0) {
+      throw this.syntaxError("범위의 열을 찾을 수 없습니다");
+    }
+    return all.slice(Math.min(from, to), Math.max(from, to) + 1);
+  }
+
+  private ref(columnOnly: boolean): FormulaNode {
+    this.skipSpace();
+    this.expect("{");
+    const close = this.src.indexOf("}", this.pos);
+    if (close < 0) {
+      throw this.syntaxError("열 이름을 닫는 '}'가 없습니다");
+    }
+    const name = this.src.slice(this.pos, close);
+    this.pos = close + 1;
+    if (name.trim() === "") {
+      throw this.syntaxError("열 이름이 비었습니다");
+    }
+    const key = this.resolveKey(name);
+    const rowId = this.rowSuffix();
+    if (rowId !== null && columnOnly) {
+      throw this.syntaxError(
+        `집계 함수 안에서는 행을 지정할 수 없습니다: {${name}}`,
+      );
+    }
+    if (columnOnly) {
+      return { type: "ref", kind: "COLUMN_ALL", colKey: key, rowId: null };
+    }
+    return rowId === null
+      ? { type: "ref", kind: "SAME_ROW", colKey: key, rowId: null }
+      : { type: "ref", kind: "ABSOLUTE", colKey: key, rowId };
+  }
+
+  private resolveKey(name: string): string {
+    if (this.stored) {
+      if (!this.ctx.columnKeys().includes(name)) {
+        throw this.syntaxError(`없는 열: ${name}`);
+      }
+      return name;
+    }
+    const key = this.ctx.keyByLabel(name);
+    if (key === undefined) {
+      throw this.syntaxError(`없는 열: ${name}`);
+    }
+    return key;
+  }
+
+  private rowSuffix(): number | null {
+    if (this.stored) {
+      if (this.peek() !== "@") {
+        return null;
+      }
+      this.pos++;
+      return this.digits("행 id");
+    }
+    if (!isDigit(this.peek())) {
+      return null;
+    }
+    const number = this.digits("행 번호");
+    const rowId = this.ctx.rowIdByNumber(number);
+    if (rowId === undefined) {
+      throw this.syntaxError(`없는 행: ${number}`);
+    }
+    return rowId;
+  }
+
+  private digits(what: string): number {
+    const start = this.pos;
+    while (this.pos < this.src.length && isDigit(this.src[this.pos])) {
+      this.pos++;
+    }
+    if (start === this.pos) {
+      throw this.syntaxError(`${what}가 필요합니다`);
+    }
+    return Number(this.src.slice(start, this.pos));
+  }
+
+  private peek(): string {
+    return this.pos < this.src.length ? this.src[this.pos] : EOF;
+  }
+
+  private expect(c: string): void {
+    if (this.peek() !== c) {
+      throw this.syntaxError(`'${c}'가 필요합니다`);
+    }
+    this.pos++;
+  }
+
+  private skipSpace(): void {
+    while (this.pos < this.src.length && this.src[this.pos] === " ") {
+      this.pos++;
+    }
+  }
+
+  private syntaxError(detail: string): FormulaSyntaxError {
+    return new FormulaSyntaxError(detail);
+  }
+}
+
+const isDigit = (c: string): boolean => c >= "0" && c <= "9";
+/** BE는 `Character.isLetter` — 유니코드 글자(한글 포함). 함수명은 ASCII지만 범위는 넓게 잡는다. */
+const isLetter = (c: string): boolean => c !== EOF && /\p{L}/u.test(c);
+
+/** 사용자가 친 수식(label·행 번호) → 트리. */
+export function parseInput(text: string, ctx: FormulaContext): FormulaNode {
+  return new Parser(text, ctx, false).parseAll();
+}
+
+/** 저장된 수식(열 key·행 id) → 트리. */
+export function parseStored(text: string, ctx: FormulaContext): FormulaNode {
+  return new Parser(text, ctx, true).parseAll();
+}
+
+/** 트리가 참조하는 것들(중복 합침). 의존성 계산·재계산 범위 판단용. */
+export function collectRefs(node: FormulaNode): RefNode[] {
+  const out: RefNode[] = [];
+  collect(node, out);
+  const seen = new Set<string>();
+  return out.filter((r) => {
+    const k = `${r.kind}|${r.colKey}|${r.rowId}`;
+    if (seen.has(k)) {
+      return false;
+    }
+    seen.add(k);
+    return true;
+  });
+}
+
+function collect(node: FormulaNode, out: RefNode[]): void {
+  switch (node.type) {
+    case "ref":
+      out.push(node);
+      break;
+    case "agg":
+      node.colKeys.forEach((k) =>
+        out.push({ type: "ref", kind: "COLUMN_ALL", colKey: k, rowId: null }),
+      );
+      break;
+    case "aggif":
+      out.push({
+        type: "ref",
+        kind: "COLUMN_ALL",
+        colKey: node.critCol,
+        rowId: null,
+      });
+      if (node.sumCol !== null) {
+        out.push({
+          type: "ref",
+          kind: "COLUMN_ALL",
+          colKey: node.sumCol,
+          rowId: null,
+        });
+      }
+      collect(node.criteria, out);
+      break;
+    case "binary":
+    case "compare":
+      collect(node.left, out);
+      collect(node.right, out);
+      break;
+    case "unary":
+      collect(node.operand, out);
+      break;
+    case "call":
+      node.args.forEach((a) => collect(a, out));
+      break;
+    case "num":
+    case "str":
+      break;
+  }
+}

--- a/fe/src/features/note/dataset/formula/value.ts
+++ b/fe/src/features/note/dataset/formula/value.ts
@@ -1,0 +1,49 @@
+/**
+ * 평가 결과. BE의 `FormulaValue`(Num/Text/Bool/Err)를 그대로 옮긴다 — 셀 단위로 값 아니면 에러.
+ *
+ * <p>미리보기용이라 숫자는 float64다(BE는 BigDecimal). 골든 케이스는 정확히 표현되는 값만 골라
+ * 두 구현이 같은 문자열을 내도록 맞춘다. 임의 소수의 오차는 BE 확정값이 바로잡는다(ADR-2).
+ */
+export type FormulaValue =
+  | { kind: "num"; value: number }
+  | { kind: "text"; value: string }
+  | { kind: "bool"; value: boolean }
+  | { kind: "err"; code: string };
+
+/** BE `FormulaValue.Err`와 같은 코드. */
+export const ERR = {
+  VALUE: "#VALUE!",
+  DIV0: "#DIV/0!",
+  REF: "#REF!",
+} as const;
+
+export const num = (value: number): FormulaValue => ({ kind: "num", value });
+export const text = (value: string): FormulaValue => ({ kind: "text", value });
+export const bool = (value: boolean): FormulaValue => ({ kind: "bool", value });
+export const err = (code: string): FormulaValue => ({ kind: "err", code });
+
+export const isErr = (v: FormulaValue): v is { kind: "err"; code: string } =>
+  v.kind === "err";
+
+/** 셀에 담길 문자열. BE `asCell()`과 같은 결과여야 한다. */
+export function asCell(v: FormulaValue): string {
+  switch (v.kind) {
+    case "num":
+      return formatNumber(v.value);
+    case "text":
+      return v.value;
+    case "bool":
+      return v.value ? "TRUE" : "FALSE";
+    case "err":
+      return v.code;
+  }
+}
+
+/** BE의 `stripTrailingZeros().toPlainString()`에 대응. 지수 표기를 피한다. */
+function formatNumber(v: number): string {
+  if (!Number.isFinite(v)) {
+    return ERR.VALUE;
+  }
+  const normalized = Object.is(v, -0) ? 0 : v;
+  return String(normalized);
+}


### PR DESCRIPTION
## 이슈
closes #899

## 배경
Epic #892 **반응성 페이즈 1**. ADR-2대로 계산 SSOT는 BE로 두고, 입력 즉시 미리보기를 위해 FE에 **BE와 동일 함수 집합의 경량 평가기**를 포팅했다. 두 구현은 **같은 골든 케이스**로 교차검증한다 — 이게 이중화를 관리 가능하게 하는 SSOT.

BE-first를 FE에도 적용: 이 PR은 **엔진 + 골든 패리티만**. 그리드 낙관적 재계산 배선은 후속.

## 작업 내용
`fe/src/features/note/dataset/formula/`에 BE `formula` 패키지를 포팅:
- **`value.ts`** — 값 타입(Num/Text/Bool/Err) + `asCell`
- **`node.ts`** — AST(discriminated union)
- **`context.ts`** — `FormulaContext`/`ValueSource`(BE 인터페이스 대응)
- **`parser.ts`** — 재귀 하강. 비교(산술보다 낮은 우선순위)·산술·집계·스칼라(ABS/IF/AND/OR/NOT)·조건부집계(SUMIF/COUNTIF)·문자열 리터럴. **문법·우선순위·오류 지점이 BE와 동일**. `collectRefs`(재계산 범위 판단용)도 포함
- **`evaluator.ts`** — 강제변환(Bool→1/0·Text→#VALUE!)·에러 전파·교차타입 순위(number<text<bool)·`IF` 지연 평가·criteria 미니언어까지 BE와 동일
- **`index.ts`** — `evaluateFormula(input, ctx, source)` 공개 API

## 검증 — BE/FE 교차검증
- **`conformance.test.ts`** — `FormulaConformanceTest.java`와 **1:1 동일한 46개 입력/기대**. 전부 통과 → BE/FE가 같은 값을 낸다는 걸 증명. 케이스 추가·수정 시 양쪽을 같이 바꾼다
- `tsc`/eslint/prettier 통과

## 한계(문서화)
- 미리보기 숫자는 **float64 근사**(BE는 BigDecimal) — 골든은 정확 표현되는 값만. 임의 소수 오차는 **BE 확정값이 바로잡음**
- 집계(SUM 등)는 **전체 행 로드 시에만** 정확 — 가상화로 일부만 로드된 경우 BE에 맡긴다 → **배선 페이즈에서 다룸**

## 다음 (반응성 2)
`DatasetGrid`에 낙관적 재계산 배선 — 값 셀 편집 시 영향받는 수식 셀을 `collectRefs` 역방향으로 찾아 즉시 미리보기, BE 라운드트립이 확정