### PR TITLE
feat : 수식 그리드 낙관적 재계산 배선 (#901)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -18,6 +18,7 @@ import ds.project.orino.planner.dataset.dto.SetCellMergeRequest;
 import ds.project.orino.planner.dataset.dto.SetCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.SetColumnAlignRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
+import ds.project.orino.planner.dataset.dto.UpdateRowResponse;
 import ds.project.orino.planner.dataset.service.DatasetService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -177,8 +178,12 @@ public class DatasetController {
         return ApiResponse.success(datasetService.getRows(memberId, id, offset, limit));
     }
 
+    /**
+     * 한 행을 수정한다. 편집한 행뿐 아니라 전파로 값이 바뀐 교차 행(집계 등)까지 함께 돌려준다 —
+     * 클라가 다른 행의 재계산도 즉시 반영하도록. 늘 편집 행을 포함한다(행 번호 오름차순).
+     */
     @PatchMapping("/{id}/rows/{rowIndex}")
-    public ApiResponse<RowView> updateRow(
+    public ApiResponse<UpdateRowResponse> updateRow(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long id,
             @PathVariable int rowIndex,

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/UpdateRowResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/UpdateRowResponse.java
@@ -1,0 +1,20 @@
+package ds.project.orino.planner.dataset.dto;
+
+import java.util.List;
+
+/**
+ * 행 수정 결과.
+ *
+ * <p>{@code edited}는 방금 수정한 그 행이다. {@code affected}는 그 수정이 <b>다른 행</b>으로
+ * 번져(집계 {@code SUM}·{@code SUMIF} 등, 다른 행을 가리키는 참조) 값이 바뀐 행들이다 —
+ * 편집 행은 제외한다. 클라이언트는 {@code edited}와 {@code affected}를 모두 캐시에 반영해,
+ * BE가 이미 다시 계산한 교차 행을 페이지 재조회 없이 즉시 보여준다(Epic #892 반응성).
+ *
+ * <p>{@code affected}는 행 번호 오름차순이며, 로드 범위 밖 행도 포함될 수 있다(클라가 로드한
+ * 범위만 골라 반영하면 된다). 번진 곳이 없으면 빈 리스트다.
+ */
+public record UpdateRowResponse(
+        RowView edited,
+        List<RowView> affected
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
@@ -50,6 +50,19 @@ public class DatasetFormulaService {
      */
     static final int MAX_PROPAGATION = 1_000;
 
+    /**
+     * 전파 중복 방지 셋({@code seen})의 셀 키 형식({@code rowId:colKey}). 이 형식은 여기서만
+     * 만들고 여기서만 되읽는다({@link #rowIdOf}) — 호출부가 값이 바뀐 행을 추려낼 때 쓴다.
+     */
+    static String seenKey(Long rowId, String colKey) {
+        return rowId + ":" + colKey;
+    }
+
+    /** {@link #seenKey}가 만든 키에서 행 id를 되읽는다. */
+    static Long rowIdOf(String seenKey) {
+        return Long.parseLong(seenKey.substring(0, seenKey.indexOf(':')));
+    }
+
     private final DatasetFormulaRepository formulaRepository;
     private final DatasetFormulaRefRepository refRepository;
     private final DatasetRowRepository rowRepository;
@@ -131,7 +144,7 @@ public class DatasetFormulaService {
             if (formula == null) {
                 continue;
             }
-            String cell = formula.getRowId() + ":" + formula.getColKey();
+            String cell = seenKey(formula.getRowId(), formula.getColKey());
             if (!seen.add(cell)) {
                 continue;
             }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -25,14 +25,17 @@ import ds.project.orino.planner.dataset.dto.SetCellMergeRequest;
 import ds.project.orino.planner.dataset.dto.SetCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.SetColumnAlignRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
+import ds.project.orino.planner.dataset.dto.UpdateRowResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.json.JsonMapper;
 
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -433,7 +436,8 @@ public class DatasetService {
      * (수식 원본은 {@code dataset_formula}에 따로). 엑셀과 같은 진입이라 별도 API가 없다.
      */
     @Transactional
-    public RowView updateRow(Long memberId, Long datasetId, int rowIndex, UpdateRowRequest request) {
+    public UpdateRowResponse updateRow(Long memberId, Long datasetId, int rowIndex,
+                                       UpdateRowRequest request) {
         Dataset dataset = getOwned(memberId, datasetId);
         List<DatasetColumn> columns = parseColumns(dataset.getColumns());
         DatasetRow row = rowRepository.findByDatasetIdAndRowIndex(datasetId, rowIndex)
@@ -468,8 +472,40 @@ public class DatasetService {
             }
         }
 
-        // 전파가 이 행의 다른 셀을 고쳤을 수 있어 다시 읽는다.
-        return buildRowView(datasetId, row, rowIndex, columns);
+        // 전파로 값이 바뀐 교차 행(집계 SUMIF 등)을 함께 돌려준다 — 클라가 다른 행의 재계산도
+        // 즉시 반영하도록. recomputed는 "rowId:colKey"들이라 행 id만 추리고, 편집 행은 뺀다.
+        Set<Long> affectedRowIds = new LinkedHashSet<>();
+        for (String cell : recomputed) {
+            affectedRowIds.add(DatasetFormulaService.rowIdOf(cell));
+        }
+        affectedRowIds.remove(row.getId());
+
+        // 편집 행: 전파가 이 행의 다른 셀도 고쳤을 수 있어 다시 읽는다.
+        RowView edited = buildRowView(datasetId, row, rowIndex, columns);
+        return new UpdateRowResponse(edited, buildRowViews(datasetId, affectedRowIds, columns));
+    }
+
+    /**
+     * 여러 행의 현재 상태를 한 번에 조립한다(수식·서식은 배치 조회). 행 번호 오름차순으로 돌려준다.
+     * 전파가 셀을 고친 뒤라 각 행 엔티티는 최신 값을 담고 있다(같은 트랜잭션의 영속 컨텍스트).
+     */
+    private List<RowView> buildRowViews(Long datasetId, Set<Long> rowIds,
+                                        List<DatasetColumn> columns) {
+        if (rowIds.isEmpty()) {
+            return List.of();
+        }
+        List<DatasetRow> rows = rowRepository.findAllById(rowIds);
+        List<Long> ids = rows.stream().map(DatasetRow::getId).toList();
+        Map<Long, Map<String, String>> formulas =
+                formulaService.displayFormulas(datasetId, ids, columns);
+        Map<Long, Map<String, CellStyle>> styles = styleService.stylesByRow(ids);
+        return rows.stream()
+                .sorted(Comparator.comparingInt(DatasetRow::getRowIndex))
+                .map(r -> new RowView(r.getId(), r.getRowIndex(),
+                        toCellList(r.getCells(), columns),
+                        formulas.getOrDefault(r.getId(), Map.of()),
+                        styles.getOrDefault(r.getId(), Map.of())))
+                .toList();
     }
 
     /**

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetCalculatedColumnTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetCalculatedColumnTest.java
@@ -83,7 +83,7 @@ class DatasetCalculatedColumnTest extends ApiTestSupport {
     @DisplayName("fill down — 한 셀의 수식이 그 열 전체에 채워지고 각 행이 자기 행을 계산한다")
     void fillDownAppliesToWholeColumn() throws Exception {
         patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("30"));
 
         fillDown("c2", 0).andExpect(status().isOk());
 
@@ -203,7 +203,7 @@ class DatasetCalculatedColumnTest extends ApiTestSupport {
     @DisplayName("행을 추가하면 열 집계가 다시 계산된다")
     void newRowRecomputesAggregate() throws Exception {
         patchRow(0, "[\"10\",\"3\",\"=SUM({단가})\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("35")); // 10+20+5
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("35")); // 10+20+5
 
         mockMvc.perform(post("/api/datasets/{id}/rows", datasetId)
                         .header(HttpHeaders.AUTHORIZATION, authHeader)

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetControllerTest.java
@@ -145,7 +145,7 @@ class DatasetControllerTest extends ApiTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"cells\":[\"네트워크\",\"100\"]}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.cells[1]").value("100"));
+                .andExpect(jsonPath("$.data.edited.cells[1]").value("100"));
 
         mockMvc.perform(get("/api/datasets/{id}/rows", id)
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
@@ -287,7 +287,7 @@ class DatasetControllerTest extends ApiTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"cells\":[\"A수정\",\"1\"]}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").value(firstId));
+                .andExpect(jsonPath("$.data.edited.id").value(firstId));
     }
 
     @Test
@@ -817,7 +817,7 @@ class DatasetControllerTest extends ApiTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"cells\":[\"네트워크\",\"92\",\"재수강\"]}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.cells[2]").value("재수강"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("재수강"));
 
         org.assertj.core.api.Assertions.assertThat(
                         datasetRowRepository.findByDatasetIdAndRowIndex(id, 0).orElseThrow().getCells())
@@ -855,8 +855,8 @@ class DatasetControllerTest extends ApiTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"cells\":[\"운영체제\"]}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.cells", hasSize(2)))
-                .andExpect(jsonPath("$.data.cells[1]").value(""));
+                .andExpect(jsonPath("$.data.edited.cells", hasSize(2)))
+                .andExpect(jsonPath("$.data.edited.cells[1]").value(""));
 
         mockMvc.perform(get("/api/datasets/{id}/rows", id)
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
@@ -876,7 +876,7 @@ class DatasetControllerTest extends ApiTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"cells\":[\"운영체제\",\"78\",\"초과분\"]}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.cells", hasSize(2)));
+                .andExpect(jsonPath("$.data.edited.cells", hasSize(2)));
 
         mockMvc.perform(get("/api/datasets/{id}/rows", id)
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
@@ -1473,7 +1473,7 @@ class DatasetControllerTest extends ApiTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"cells\":[\"3\",\"={과목}*2\"]}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.cells[1]").value("6"));
+                .andExpect(jsonPath("$.data.edited.cells[1]").value("6"));
 
         setStyle(id, 0, "c1", "{\"bg\":\"yellow\"}");
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFormulaPropagationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFormulaPropagationTest.java
@@ -17,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -77,7 +78,7 @@ class DatasetFormulaPropagationTest extends ApiTestSupport {
     @DisplayName("참조하던 셀을 고치면 수식이 따라 바뀐다 — 이 이슈의 핵심")
     void editingReferencedCellRecomputesFormula() throws Exception {
         patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\",\"\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("30"));
 
         // 단가만 고친다. 합계는 손대지 않는다.
         patchRow(0, "[\"7\",\"3\",\"={단가} * {수량}\",\"\"]").andExpect(status().isOk());
@@ -90,7 +91,7 @@ class DatasetFormulaPropagationTest extends ApiTestSupport {
     void propagatesTransitively() throws Exception {
         patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\",\"\"]").andExpect(status().isOk());
         patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\",\"={합계} + 1\"]")
-                .andExpect(jsonPath("$.data.cells[3]").value("31"));
+                .andExpect(jsonPath("$.data.edited.cells[3]").value("31"));
 
         // 단가 → 합계 → 비고 로 두 단계 번져야 한다.
         patchRow(0, "[\"5\",\"3\",\"={단가} * {수량}\",\"={합계} + 1\"]")
@@ -120,7 +121,7 @@ class DatasetFormulaPropagationTest extends ApiTestSupport {
     @DisplayName("COLUMN_ALL 전파는 그 열의 아무 행이 바뀌어도 걸린다")
     void columnAggregateRecomputesOnAnyRow() throws Exception {
         patchRow(0, "[\"10\",\"3\",\"=SUM({단가})\",\"\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("30"));
 
         // 2행의 단가를 고치면 1행의 집계가 따라 바뀐다.
         patchRow(1, "[\"5\",\"2\",\"\",\"\"]").andExpect(status().isOk());
@@ -129,11 +130,30 @@ class DatasetFormulaPropagationTest extends ApiTestSupport {
     }
 
     @Test
+    @DisplayName("응답에 편집 행과 전파된 교차 행이 함께 실린다 — 집계가 다른 행에 있어도 즉시 반영")
+    void responseCarriesEditedAndAffectedRows() throws Exception {
+        // 1행에 열 전체 집계를 둔다(단가 = 10 + 20 = 30).
+        patchRow(0, "[\"10\",\"3\",\"=SUM({단가})\",\"\"]")
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("30"))
+                // 이 편집은 다른 행으로 번지지 않는다.
+                .andExpect(jsonPath("$.data.affected", hasSize(0)));
+
+        // 2행 단가를 고치면 1행 집계가 다시 계산된다 — 편집 행(2행)과 교차 행(1행)이 함께 온다.
+        patchRow(1, "[\"5\",\"2\",\"\",\"\"]")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.edited.rowIndex").value(1))
+                .andExpect(jsonPath("$.data.edited.cells[0]").value("5"))
+                .andExpect(jsonPath("$.data.affected", hasSize(1)))
+                .andExpect(jsonPath("$.data.affected[0].rowIndex").value(0))
+                .andExpect(jsonPath("$.data.affected[0].cells[2]").value("15"));
+    }
+
+    @Test
     @DisplayName("절대 참조는 그 행이 바뀔 때 따라 바뀐다")
     void absoluteRefRecomputes() throws Exception {
         // 1행 비고가 2행 단가를 가리킨다.
         patchRow(0, "[\"10\",\"3\",\"\",\"={단가}2\"]")
-                .andExpect(jsonPath("$.data.cells[3]").value("20"));
+                .andExpect(jsonPath("$.data.edited.cells[3]").value("20"));
 
         patchRow(1, "[\"99\",\"2\",\"\",\"\"]").andExpect(status().isOk());
 
@@ -144,7 +164,7 @@ class DatasetFormulaPropagationTest extends ApiTestSupport {
     @DisplayName("에러도 전파된다 — 참조가 숫자가 아니게 되면 #VALUE!")
     void errorPropagates() throws Exception {
         patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\",\"\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("30"));
 
         patchRow(0, "[\"글자\",\"3\",\"={단가} * {수량}\",\"\"]").andExpect(status().isOk());
 
@@ -193,7 +213,7 @@ class DatasetFormulaPropagationTest extends ApiTestSupport {
         patchRow(0, "[\"10\",\"3\",\"\",\"={단가}2\"]").andExpect(status().isOk());
         // 2행 합계 = 같은 행 단가*수량. 위와 무관.
         patchRow(1, "[\"20\",\"2\",\"={단가} * {수량}\",\"\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("40"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("40"));
     }
 
     @Test
@@ -209,7 +229,7 @@ class DatasetFormulaPropagationTest extends ApiTestSupport {
 
         // 그 수식을 그대로 돌려주면 살아남는다.
         patchRow(0, "[\"2\",\"3\",\"=({단가} * {수량})\",\"\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("6"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("6"));
         rows().andExpect(jsonPath("$.data.rows[0].formulas.c2").exists());
 
         // 계산된 값을 돌려주면 사용자가 직접 입력한 것으로 보고 수식을 지운다.

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFormulaRefIntegrityTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFormulaRefIntegrityTest.java
@@ -87,7 +87,7 @@ class DatasetFormulaRefIntegrityTest extends ApiTestSupport {
     @DisplayName("참조하던 열을 지우면 수식이 #REF!가 된다 — 삭제를 막지 않는다")
     void deletingReferencedColumnMakesRef() throws Exception {
         patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("30"));
 
         deleteColumn("c1").andExpect(status().isOk());
 
@@ -117,7 +117,7 @@ class DatasetFormulaRefIntegrityTest extends ApiTestSupport {
     @DisplayName("열 집계가 참조하던 열을 지워도 #REF!")
     void deletingAggregatedColumnMakesRef() throws Exception {
         patchRow(0, "[\"10\",\"3\",\"=SUM({단가})\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("30"));
 
         deleteColumn("c0").andExpect(status().isOk());
 
@@ -130,7 +130,7 @@ class DatasetFormulaRefIntegrityTest extends ApiTestSupport {
         patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]").andExpect(status().isOk());
         // 합계를 참조하는 수식을 2행에 둔다.
         patchRow(1, "[\"20\",\"2\",\"={합계}1\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("30"));
 
         deleteColumn("c1").andExpect(status().isOk());
 
@@ -175,7 +175,7 @@ class DatasetFormulaRefIntegrityTest extends ApiTestSupport {
     void deletingReferencedRowMakesRef() throws Exception {
         // 1행 합계가 2행 단가를 콕 집어 참조.
         patchRow(0, "[\"10\",\"3\",\"={단가}2\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("20"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("20"));
 
         mockMvc.perform(delete("/api/datasets/{id}/rows/{i}", datasetId, 1)
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
@@ -188,7 +188,7 @@ class DatasetFormulaRefIntegrityTest extends ApiTestSupport {
     @DisplayName("행을 지우면 열 집계가 다시 계산된다 — 값이 하나 줄었다")
     void deletingRowRecomputesAggregate() throws Exception {
         patchRow(0, "[\"10\",\"3\",\"=SUM({단가})\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("30")); // 10 + 20
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("30")); // 10 + 20
 
         mockMvc.perform(delete("/api/datasets/{id}/rows/{i}", datasetId, 1)
                         .header(HttpHeaders.AUTHORIZATION, authHeader))

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFormulaTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFormulaTest.java
@@ -83,7 +83,7 @@ class DatasetFormulaTest extends ApiTestSupport {
     void formulaComputesAndStoresSeparately() throws Exception {
         patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]")
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("30"));
 
         // 읽기 경로는 그대로 — cells엔 계산된 값이 들어 있다.
         mockMvc.perform(get("/api/datasets/{id}/rows", datasetId)
@@ -118,14 +118,14 @@ class DatasetFormulaTest extends ApiTestSupport {
     void formulaSeesValuesFromSameRequest() throws Exception {
         // 단가를 10 → 7로 바꾸면서 합계 수식을 넣는다. 옛 값 10이 아니라 7을 써야 한다.
         patchRow(0, "[\"7\",\"3\",\"={단가} * {수량}\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("21"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("21"));
     }
 
     @Test
     @DisplayName("열 집계는 전체 행을 본다")
     void columnAggregate() throws Exception {
         patchRow(0, "[\"10\",\"3\",\"=SUM({단가})\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("30"));
 
         long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
         long formulaId = formulaRepository.findByRowIdAndColKey(rowId, "c2").orElseThrow().getId();
@@ -139,7 +139,7 @@ class DatasetFormulaTest extends ApiTestSupport {
     void absoluteRef() throws Exception {
         // 1행의 합계가 2행의 단가(20)를 가리킨다.
         patchRow(0, "[\"10\",\"3\",\"={단가}2\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("20"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("20"));
 
         long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
         long row2 = rowRepository.findByDatasetIdAndRowIndex(datasetId, 1).orElseThrow().getId();
@@ -160,33 +160,33 @@ class DatasetFormulaTest extends ApiTestSupport {
 
         // SUM은 '글자'를 무시하고 1행의 10만 더한다.
         patchRow(0, "[\"10\",\"3\",\"=SUM({단가})\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("10"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("10"));
         // COUNT도 숫자만 센다.
         patchRow(0, "[\"10\",\"3\",\"=COUNT({단가})\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("1"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("1"));
         // 산술은 무시하지 않는다.
         patchRow(1, "[\"글자\",\"2\",\"={단가} * {수량}\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("#VALUE!"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("#VALUE!"));
     }
 
     @Test
     @DisplayName("0으로 나누면 #DIV/0!, 숫자 없는 열의 AVG도 #DIV/0!")
     void divisionErrors() throws Exception {
         patchRow(0, "[\"10\",\"0\",\"={단가} / {수량}\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("#DIV/0!"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("#DIV/0!"));
 
         patchRow(0, "[\"글자\",\"0\",\"\"]").andExpect(status().isOk());
         patchRow(1, "[\"글자\",\"0\",\"=AVG({단가})\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("#DIV/0!"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("#DIV/0!"));
     }
 
     @Test
     @DisplayName("에러는 셀 단위다 — 같은 열의 다른 행은 멀쩡하다")
     void errorIsPerCell() throws Exception {
         patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("30"));
         patchRow(1, "[\"글자\",\"2\",\"={단가} * {수량}\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("#VALUE!"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("#VALUE!"));
 
         mockMvc.perform(get("/api/datasets/{id}/rows", datasetId)
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
@@ -202,7 +202,7 @@ class DatasetFormulaTest extends ApiTestSupport {
         long formulaId = formulaRepository.findByRowIdAndColKey(rowId, "c2").orElseThrow().getId();
 
         patchRow(0, "[\"10\",\"3\",\"직접입력\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("직접입력"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("직접입력"));
 
         assertThat(formulaRepository.findByRowIdAndColKey(rowId, "c2")).isEmpty();
         assertThat(refRepository.findByFormulaId(formulaId)).isEmpty();
@@ -246,7 +246,7 @@ class DatasetFormulaTest extends ApiTestSupport {
     @DisplayName("열 범위 집계는 입력 시 집합으로 굳는다")
     void rangeSnapshot() throws Exception {
         patchRow(0, "[\"10\",\"3\",\"=SUM({단가}:{수량})\"]")
-                .andExpect(jsonPath("$.data.cells[2]").value("35")); // 10+3+20+2
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("35")); // 10+3+20+2
 
         long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
         long formulaId = formulaRepository.findByRowIdAndColKey(rowId, "c2").orElseThrow().getId();
@@ -262,9 +262,9 @@ class DatasetFormulaTest extends ApiTestSupport {
     @DisplayName("여러 열에 수식을 동시에 넣을 수 있다")
     void multipleFormulasInOneRow() throws Exception {
         patchRow(0, "[\"10\",\"=2 + 1\",\"={단가} * {수량}\"]")
-                .andExpect(jsonPath("$.data.cells[1]").value("3"))
+                .andExpect(jsonPath("$.data.edited.cells[1]").value("3"))
                 // c1이 먼저 계산돼 c2가 그 값을 본다(열 순서).
-                .andExpect(jsonPath("$.data.cells[2]").value("30"));
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("30"));
 
         long rowId = rowRepository.findByDatasetIdAndRowIndex(datasetId, 0).orElseThrow().getId();
         assertThat(List.of(

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -156,7 +156,14 @@ describe("DatasetGrid", () => {
           patched = { index: Number(params.i), cells: body.cells };
           return HttpResponse.json({
             code: "OK",
-            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+            data: {
+              edited: {
+                id: 100,
+                rowIndex: Number(params.i),
+                cells: body.cells,
+              },
+              affected: [],
+            },
           });
         },
       ),
@@ -186,7 +193,14 @@ describe("DatasetGrid", () => {
           patched = { index: Number(params.i), cells: body.cells };
           return HttpResponse.json({
             code: "OK",
-            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+            data: {
+              edited: {
+                id: 100,
+                rowIndex: Number(params.i),
+                cells: body.cells,
+              },
+              affected: [],
+            },
           });
         },
       ),
@@ -218,7 +232,14 @@ describe("DatasetGrid", () => {
           patched = { index: Number(params.i), cells: body.cells };
           return HttpResponse.json({
             code: "OK",
-            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+            data: {
+              edited: {
+                id: 100,
+                rowIndex: Number(params.i),
+                cells: body.cells,
+              },
+              affected: [],
+            },
           });
         },
       ),
@@ -248,7 +269,14 @@ describe("DatasetGrid", () => {
           patched = { index: Number(params.i), cells: body.cells };
           return HttpResponse.json({
             code: "OK",
-            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+            data: {
+              edited: {
+                id: 100,
+                rowIndex: Number(params.i),
+                cells: body.cells,
+              },
+              affected: [],
+            },
           });
         },
       ),
@@ -295,7 +323,14 @@ describe("DatasetGrid", () => {
           patched = { index: Number(params.i), cells: body.cells };
           return HttpResponse.json({
             code: "OK",
-            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+            data: {
+              edited: {
+                id: 100,
+                rowIndex: Number(params.i),
+                cells: body.cells,
+              },
+              affected: [],
+            },
           });
         },
       ),
@@ -368,7 +403,14 @@ describe("DatasetGrid", () => {
           patched[Number(params.i)] = body.cells;
           return HttpResponse.json({
             code: "OK",
-            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+            data: {
+              edited: {
+                id: 100,
+                rowIndex: Number(params.i),
+                cells: body.cells,
+              },
+              affected: [],
+            },
           });
         },
       ),
@@ -402,7 +444,14 @@ describe("DatasetGrid", () => {
           patched[Number(params.i)] = body.cells;
           return HttpResponse.json({
             code: "OK",
-            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+            data: {
+              edited: {
+                id: 100,
+                rowIndex: Number(params.i),
+                cells: body.cells,
+              },
+              affected: [],
+            },
           });
         },
       ),
@@ -471,7 +520,14 @@ describe("DatasetGrid", () => {
           patched = { index: Number(params.i), cells: body.cells };
           return HttpResponse.json({
             code: "OK",
-            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+            data: {
+              edited: {
+                id: 100,
+                rowIndex: Number(params.i),
+                cells: body.cells,
+              },
+              affected: [],
+            },
           });
         },
       ),
@@ -641,10 +697,13 @@ describe("DatasetGrid", () => {
         return HttpResponse.json({
           code: "OK",
           data: {
-            id: 100,
-            rowIndex: 0,
-            cells: ["7", "21"],
-            formulas: { c1: "=({단가} * 3)" },
+            edited: {
+              id: 100,
+              rowIndex: 0,
+              cells: ["7", "21"],
+              formulas: { c1: "=({단가} * 3)" },
+            },
+            affected: [],
           },
         });
       }),
@@ -673,10 +732,13 @@ describe("DatasetGrid", () => {
         HttpResponse.json({
           code: "OK",
           data: {
-            id: 100,
-            rowIndex: 0,
-            cells: ["10", "30"],
-            formulas: { c1: "=({과목} * 3)" },
+            edited: {
+              id: 100,
+              rowIndex: 0,
+              cells: ["10", "30"],
+              formulas: { c1: "=({과목} * 3)" },
+            },
+            affected: [],
           },
         }),
       ),
@@ -692,6 +754,116 @@ describe("DatasetGrid", () => {
     // 입력한 수식이 아니라 계산 결과가 보인다.
     expect(await screen.findByText("30")).toBeInTheDocument();
     expect(screen.queryByText("={과목} * 3")).not.toBeInTheDocument();
+  });
+
+  it("수식을 입력하면 서버 응답 전에 낙관적으로 계산해 보여주고, 응답이 오면 서버 확정값으로 맞춘다", async () => {
+    mockDataset([["10", "3"]]); // 과목(c0)=10, 점수(c1)=3
+    server.use(
+      http.patch(`${API_BASE}/datasets/1/rows/:i`, async () => {
+        await delay(200);
+        // 서버 확정값(999)은 프리뷰(20)와 다르게 둬, 언제 어느 쪽이 보이는지 구분한다.
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            edited: {
+              id: 100,
+              rowIndex: 0,
+              cells: ["10", "999"],
+              formulas: { c1: "=({과목} * 2)" },
+            },
+            affected: [],
+          },
+        });
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    await user.dblClick(await screen.findByText("3"));
+    const input = await screen.findByLabelText("셀 1행 2열");
+    fireEvent.change(input, { target: { value: "={과목} * 2" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // 서버 응답(200ms) 전에 FE가 계산한 20이 곧바로 보인다(원본 수식은 안 보인다).
+    expect(await screen.findByText("20")).toBeInTheDocument();
+    expect(screen.queryByText("={과목} * 2")).not.toBeInTheDocument();
+    // 응답이 오면 서버 확정값(999)으로 바뀐다.
+    expect(await screen.findByText("999")).toBeInTheDocument();
+  });
+
+  it("수정이 다른 행의 집계로 번지면(affected) 재조회 없이 그 행도 서버 확정값으로 갱신된다", async () => {
+    // 1행 합계(c1)는 SUM(과목) 집계 — 아무 행의 과목이 바뀌면 다시 계산된다.
+    let rowsFetches = 0;
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "합계" },
+            ],
+            rowCount: 2,
+          },
+        }),
+      ),
+      http.get(`${API_BASE}/datasets/1/rows`, () => {
+        rowsFetches++;
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            rows: [
+              {
+                id: 100,
+                rowIndex: 0,
+                cells: ["10", "30"],
+                formulas: { c1: "=SUM({과목})" },
+              },
+              { id: 101, rowIndex: 1, cells: ["20", ""] },
+            ],
+            offset: 0,
+            limit: 100,
+          },
+        });
+      }),
+      http.get(`${API_BASE}/datasets/1/merges`, () =>
+        HttpResponse.json({ code: "OK", data: { merges: [] } }),
+      ),
+      // 2행 과목을 20→5로 고치면 1행 집계가 30→15로 번진다.
+      http.patch(`${API_BASE}/datasets/1/rows/:i`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            edited: { id: 101, rowIndex: 1, cells: ["5", ""] },
+            affected: [
+              {
+                id: 100,
+                rowIndex: 0,
+                cells: ["10", "15"],
+                formulas: { c1: "=SUM({과목})" },
+              },
+            ],
+          },
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    expect(await screen.findByText("30")).toBeInTheDocument();
+    const fetchesBefore = rowsFetches;
+
+    await user.dblClick(await screen.findByText("20"));
+    const input = await screen.findByLabelText("셀 2행 1열");
+    fireEvent.change(input, { target: { value: "5" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // 응답의 affected 행(1행 합계)이 재조회 없이 30→15로 갱신된다.
+    expect(await screen.findByText("15")).toBeInTheDocument();
+    expect(screen.queryByText("30")).not.toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    // 전체 행 재조회(GET /rows)가 다시 일어나지 않았다.
+    expect(rowsFetches).toBe(fetchesBefore);
   });
 
   /** c1이 수식 셀인 표 — 화면엔 30, 원본은 formulas에. */
@@ -793,7 +965,14 @@ describe("DatasetGrid", () => {
           if (call === 1) await delay(80);
           return HttpResponse.json({
             code: "OK",
-            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+            data: {
+              edited: {
+                id: 100,
+                rowIndex: Number(params.i),
+                cells: body.cells,
+              },
+              affected: [],
+            },
           });
         },
       ),
@@ -933,7 +1112,10 @@ describe("DatasetGrid", () => {
         patched = body.cells;
         return HttpResponse.json({
           code: "OK",
-          data: { id: 100, rowIndex: 0, cells: body.cells },
+          data: {
+            edited: { id: 100, rowIndex: 0, cells: body.cells },
+            affected: [],
+          },
         });
       }),
     );
@@ -1909,7 +2091,14 @@ describe("DatasetGrid", () => {
           patched[Number(params.i)] = body.cells;
           return HttpResponse.json({
             code: "OK",
-            data: { id: 100, rowIndex: Number(params.i), cells: body.cells },
+            data: {
+              edited: {
+                id: 100,
+                rowIndex: Number(params.i),
+                cells: body.cells,
+              },
+              affected: [],
+            },
           });
         },
       ),

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -45,6 +45,8 @@ import {
   updateDatasetRow,
 } from "./api/datasets";
 import { DATASET_CELLS_MIME } from "./cellClipboard";
+import type { FormulaContext, ValueSource } from "./formula";
+import { evaluateFormula } from "./formula";
 import { useDatasetMerges } from "./hooks/useDatasetMerges";
 import { useDatasetMeta } from "./hooks/useDatasetMeta";
 import { useDatasetRows } from "./hooks/useDatasetRows";
@@ -172,10 +174,14 @@ export function DatasetGrid({
     const version = (rowVersion.current.get(index) ?? 0) + 1;
     rowVersion.current.set(index, version);
     updateDatasetRow(datasetId, index, cells)
-      .then((row) => {
+      .then((res) => {
         if (rowVersion.current.get(index) !== version) return;
-        setRowLocal(row.rowIndex, row.cells);
-        setFormulasLocal(row.rowIndex, row.formulas ?? {});
+        // 편집 행 + 전파로 값이 바뀐 교차 행(집계 등)을 서버 확정값으로 맞춘다. affected 행은
+        // 로드 범위 밖일 수 있지만 setRowLocal은 인덱스 단위라 보이는 행만 실제로 갱신된다.
+        for (const row of [res.edited, ...res.affected]) {
+          setRowLocal(row.rowIndex, row.cells);
+          setFormulasLocal(row.rowIndex, row.formulas ?? {});
+        }
       })
       .catch((e) => {
         if (silent) return;
@@ -482,6 +488,80 @@ export function DatasetGrid({
   };
 
   /**
+   * 편집을 낙관적으로 미리 계산한 표시 배열을 만든다(Epic #892 반응성). 서버 확정 전까지
+   * 원본 {@code =…}가 보이지 않게, FE 경량 평가기로 편집 행의 수식을 그 자리서 계산한다.
+   *
+   * 범위는 편집 행 한 줄이다 — 편집 셀과 같은 행의 의존 수식만. 다른 행으로 번지는 집계는
+   * 서버 응답의 affected 행이 채운다. 열 전체 참조는 로드된 행만 봐서 근사이며 서버가 확정한다.
+   * 미완성·문법오류 수식은 계산을 건너뛰고 친 그대로 둔다(계속 타이핑 중일 수 있다).
+   */
+  const previewRow = (
+    row: number,
+    editedCol: number,
+    value: string,
+    cells: string[],
+    rowFormulas: Record<string, string>,
+  ): string[] => {
+    const editedKey = meta.columns[editedCol].key;
+    const editedIsFormula = value.startsWith("=");
+
+    // 이 행의 수식 맵(편집 반영). 편집 셀이 수식이면 넣고, 리터럴이면 뺀다.
+    const formulas: Record<string, string> = { ...rowFormulas };
+    if (editedIsFormula) formulas[editedKey] = value;
+    else delete formulas[editedKey];
+
+    // 작업 중 표시값. 리터럴 편집은 즉시 반영, 수식 셀은 아래서 계산해 덮는다.
+    const values = Array.from({ length: colCount }, (_, c) =>
+      c === editedCol && !editedIsFormula ? value : (cells[c] ?? ""),
+    );
+
+    const ctx: FormulaContext = {
+      columnKeys: () => meta.columns.map((c) => c.key),
+      keyByLabel: (label) => meta.columns.find((c) => c.label === label)?.key,
+      labelByKey: (key) => meta.columns.find((c) => c.key === key)?.label,
+      // 행 번호(1-base) ↔ 행 인덱스(0-base)를 그대로 가상 id로 쓴다 — 미리보기 안에서만 일관되면 된다.
+      rowIdByNumber: (n) => (n >= 1 && n <= rowCount ? n - 1 : undefined),
+      rowNumberById: (id) => (id >= 0 && id < rowCount ? id + 1 : undefined),
+    };
+    // 현재 행은 작업 중 값(values)을, 다른 행은 캐시를 본다.
+    const cellsOf = (r: number): string[] | undefined =>
+      r === row ? values : getRow(r);
+    const source: ValueSource = {
+      sameRow: (colKey) => {
+        const i = colOf(colKey);
+        return i < 0 ? undefined : values[i];
+      },
+      absolute: (rowId, colKey) => {
+        const i = colOf(colKey);
+        return i < 0 ? undefined : cellsOf(rowId)?.[i];
+      },
+      column: (colKey) => {
+        const i = colOf(colKey);
+        if (i < 0) return undefined;
+        const out: string[] = [];
+        for (let r = 0; r < rowCount; r++) {
+          const rc = cellsOf(r);
+          if (rc) out.push(rc[i] ?? "");
+        }
+        return out;
+      },
+    };
+
+    // 열 순서로 계산해 뒤 수식이 앞 결과를 보게 한다(서버의 인라인 패스와 같은 순서).
+    for (let c = 0; c < colCount; c++) {
+      const f = formulas[meta.columns[c].key];
+      if (f === undefined) continue;
+      try {
+        values[c] = evaluateFormula(f, ctx, source);
+      } catch {
+        // 미완성/문법오류: 편집 셀은 친 그대로, 나머지는 기존 값 유지.
+        if (c === editedCol) values[c] = value;
+      }
+    }
+    return values;
+  };
+
+  /**
    * 한 셀의 편집값을 저장한다(다른 셀은 값·수식을 보존). editing 상태는 건드리지 않아,
    * 자동저장(타이핑 중)과 최종 커밋이 같은 로직을 쓴다. silent면 실패해도 조용히 넘긴다.
    */
@@ -499,10 +579,8 @@ export function DatasetGrid({
     const sent = Array.from({ length: colCount }, (_, c) =>
       c === col ? value : (rowFormulas[meta.columns[c].key] ?? cells[c] ?? ""),
     );
-    // 화면엔 값을 유지한다(수식 원본이 잠깐 보이면 안 된다).
-    const shown = Array.from({ length: colCount }, (_, c) =>
-      c === col ? value : (cells[c] ?? ""),
-    );
+    // 화면엔 낙관적으로 계산한 값을 보여준다(수식 원본이 잠깐 보이면 안 된다).
+    const shown = previewRow(row, col, value, cells, rowFormulas);
     setRowLocal(row, shown);
     saveRow(row, sent, { cells, formulas: rowFormulas }, silent);
   };

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -90,6 +90,16 @@ export interface RowsPage {
   limit: number;
 }
 
+/**
+ * 행 수정 결과. `edited`는 방금 고친 행, `affected`는 그 수정이 다른 행으로 번져(집계 등)
+ * 값이 바뀐 행들(편집 행 제외, 번진 곳 없으면 빈 배열). 서버가 이미 다시 계산한 교차 행을
+ * 페이지 재조회 없이 즉시 반영하려고 함께 내려준다. 서버의 `UpdateRowResponse`와 같아야 한다.
+ */
+export interface UpdateRowResult {
+  edited: DatasetRow;
+  affected: DatasetRow[];
+}
+
 interface ApiEnvelope<T> {
   code: string;
   data: T;
@@ -234,8 +244,8 @@ export async function updateDatasetRow(
   datasetId: number,
   rowIndex: number,
   cells: string[],
-): Promise<DatasetRow> {
-  const { data } = await client.patch<ApiEnvelope<DatasetRow>>(
+): Promise<UpdateRowResult> {
+  const { data } = await client.patch<ApiEnvelope<UpdateRowResult>>(
     `/datasets/${datasetId}/rows/${rowIndex}`,
     { cells },
   );


### PR DESCRIPTION
## 이슈
closes #901

## 작업 내용
Epic #892 반응성 페이즈 2. #900에서 심은 FE 경량 평가기를 그리드에 배선했다. 계산 SSOT는 BE 유지(ADR-2), FE는 지연을 가리는 낙관적 레이어.

### 닫은 구멍
- **지연**: `=…` 수식을 치면 원본 텍스트가 보이다가 BE 응답에 계산값으로 바뀌던 것 → 즉시 프리뷰
- **교차 행 stale**: `updateRow`가 편집 행만 돌려줘, 집계(SUM 등) 같은 다른 행의 재계산이 페이지 재조회 전까지 화면에 안 뜨던 것 → 응답이 영향 행을 함께 실어 즉시 반영

### BE
- `updateRow` 응답을 `RowView` → `UpdateRowResponse { edited, affected }`로 확장. 전파(`propagateFrom`)가 이미 아는 `recomputed` 셋에서 행 id를 추려 `affected` 조립(편집 행 제외, 번진 곳 없으면 빈 배열)
- `DatasetFormulaService`에 seen 키 형식 헬퍼(`seenKey`/`rowIdOf`) 도입해 포맷을 한 곳에 봉인
- 여러 영향 행을 배치로 조립하는 `buildRowViews` 추가

### FE
- 편집 시 `evaluateFormula`로 **편집 행**을 낙관적 계산해 표시(편집 셀 + 같은 행 의존 수식). 원본 `=…`가 잠깐 보이지 않는다
- 미완성·문법오류 수식은 프리뷰 건너뛰고 친 그대로 두어 BE 확정에 맡긴다
- 저장 응답의 `edited`·`affected` 행을 캐시에 patch(재조회 없이). 로드 범위 밖 affected 행은 인덱스 단위라 보이는 행만 실제 갱신

### 한계 (명시)
- 열 전체 참조(집계) 프리뷰는 로드된 행만 봐서 근사이며 BE가 확정한다
- 프리뷰 숫자는 float64 근사(BE는 BigDecimal) — 골든 패리티가 보증하는 값만 일치
- 붙여넣기(벌크)는 낙관적 프리뷰 범위 밖(편집 타이핑 대상). BE 응답이 여전히 확정

## 테스트
- BE: `DatasetFormulaPropagationTest`에 `edited`+`affected` 반환 검증 추가, 응답 형태 변경분(`$.data.edited.*`) 반영 — dataset 컨트롤러 테스트 전부 통과(TestContainers MySQL)
- FE: 낙관적 프리뷰(서버 응답 전 계산값 표시 → 확정값 교체), 교차 행 affected 갱신(재조회 없음) 통합 테스트 추가 — 전체 435개 통과
- 린트: FE prettier/eslint, BE checkstyle 통과