### PR TITLE
feat : 데이터 그리드 선택 키보드 네비게이션 (#903)

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -1955,6 +1955,104 @@ describe("DatasetGrid", () => {
     expect(within(menu).getByText("표 전체")).toBeInTheDocument();
   });
 
+  it("방향키로 활성 셀을 상하좌우로 옮긴다", async () => {
+    mockDataset([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const cell = (await screen.findByText("a")).parentElement as HTMLElement;
+    fireEvent.pointerDown(cell, { button: 0 }); // (0,0) 선택
+    const input = await screen.findByLabelText("1행 1열 셀 (입력하면 편집)");
+
+    // → 오른쪽 칸으로.
+    fireEvent.keyDown(input, { key: "ArrowRight" });
+    expect(
+      await screen.findByLabelText("1행 2열 셀 (입력하면 편집)"),
+    ).toBeInTheDocument();
+
+    // ↓ 아래 칸으로.
+    fireEvent.keyDown(screen.getByLabelText("1행 2열 셀 (입력하면 편집)"), {
+      key: "ArrowDown",
+    });
+    expect(
+      await screen.findByLabelText("2행 2열 셀 (입력하면 편집)"),
+    ).toBeInTheDocument();
+  });
+
+  it("Shift+방향키로 셀 범위를 확장한다 — 우클릭 메뉴가 '셀 2개'", async () => {
+    mockDataset([["a", "b"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const a = (await screen.findByText("a")).parentElement as HTMLElement;
+    fireEvent.pointerDown(a, { button: 0 }); // (0,0)
+    const input = await screen.findByLabelText("1행 1열 셀 (입력하면 편집)");
+    fireEvent.keyDown(input, { key: "ArrowRight", shiftKey: true }); // (0,0)~(0,1)
+
+    fireEvent.contextMenu(a);
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    expect(within(menu).getByText("셀 2개")).toBeInTheDocument();
+  });
+
+  it("Ctrl/Cmd+A로 표 전체를 선택한다", async () => {
+    mockDataset([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const cell = (await screen.findByText("a")).parentElement as HTMLElement;
+    fireEvent.pointerDown(cell, { button: 0 });
+    const input = await screen.findByLabelText("1행 1열 셀 (입력하면 편집)");
+    fireEvent.keyDown(input, { key: "a", metaKey: true });
+
+    fireEvent.contextMenu(cell);
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    expect(within(menu).getByText("표 전체")).toBeInTheDocument();
+  });
+
+  it("편집 중엔 방향키가 셀을 옮기지 않는다(입력창 커서 이동에 맡긴다)", async () => {
+    mockDataset([["a", "b"]]);
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await user.dblClick(await screen.findByText("a")); // 편집 진입
+    const input = await screen.findByLabelText("셀 1행 1열");
+    fireEvent.keyDown(input, { key: "ArrowRight" });
+
+    // 여전히 같은 셀을 편집 중 — 옆 칸으로 안 넘어간다.
+    expect(screen.getByLabelText("셀 1행 1열")).toBeInTheDocument();
+    expect(screen.queryByLabelText("셀 1행 2열")).not.toBeInTheDocument();
+  });
+
+  it("행 핸들 shift+클릭으로 여러 행을 선택한다 — 우클릭 메뉴가 '2행'", async () => {
+    mockDataset([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("a");
+    fireEvent.pointerDown(screen.getByRole("button", { name: "1행 선택" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "2행 선택" }), {
+      shiftKey: true,
+    });
+
+    fireEvent.contextMenu(screen.getByText("a"));
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    expect(within(menu).getByText("2행")).toBeInTheDocument();
+  });
+
+  it("열 핸들 shift+클릭으로 여러 열을 선택한다 — 우클릭 메뉴가 '2열'", async () => {
+    mockDataset([["a", "b"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("a");
+    fireEvent.pointerDown(screen.getByRole("button", { name: "1열 선택" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "2열 선택" }), {
+      shiftKey: true,
+    });
+
+    fireEvent.contextMenu(screen.getByText("a"));
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    expect(within(menu).getByText("2열")).toBeInTheDocument();
+  });
+
   it("우클릭 메뉴에서 배경색을 고르면 선택한 셀에 일괄 PUT한다", async () => {
     mockDataset([["네트워크", "92"]]);
     let sentCells: unknown = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -739,6 +739,9 @@ export function DatasetGrid({
     c: number,
   ) => {
     e.stopPropagation();
+    // 선택-만-한 상태에선 방향키가 셀 이동, Cmd/Ctrl+A가 표 전체 선택이다(편집 중엔 입력창
+    // 기본 동작 유지 — 커서 이동·텍스트 전체선택).
+    if (!editing && handleNavKey(e)) return;
     if (e.key === "Escape") {
       e.preventDefault();
       // 이미 자동저장된 값은 남지만, 예약된 저장·미저장 편집은 버리고 편집을 닫는다.
@@ -769,8 +772,13 @@ export function DatasetGrid({
     if (selDrag.current !== "cells") return;
     setSel((s) => (s?.kind === "cells" ? { ...s, b: [row, col] } : s));
   };
-  const startRowSelect = (row: number) => {
+  const startRowSelect = (row: number, shift = false) => {
     setEditing(null);
+    // shift+클릭: 기존 행 선택의 앵커를 유지하고 여기까지 확장(셀 범위 shift 확장과 같은 결).
+    if (shift && sel?.kind === "rows") {
+      setSel({ kind: "rows", a: sel.a, b: row });
+      return;
+    }
     selDrag.current = "rows";
     setSel({ kind: "rows", a: row, b: row });
   };
@@ -778,8 +786,12 @@ export function DatasetGrid({
     if (selDrag.current !== "rows") return;
     setSel((s) => (s?.kind === "rows" ? { ...s, b: row } : s));
   };
-  const startColSelect = (col: number) => {
+  const startColSelect = (col: number, shift = false) => {
     setEditing(null);
+    if (shift && sel?.kind === "cols") {
+      setSel({ kind: "cols", a: sel.a, b: col });
+      return;
+    }
     selDrag.current = "cols";
     setSel({ kind: "cols", a: col, b: col });
   };
@@ -794,6 +806,61 @@ export function DatasetGrid({
     if (sel?.kind === "cells") return sel.b;
     return [selRect.r0, selRect.c0];
   })();
+
+  /**
+   * 활성 셀을 (dr,dc)만큼 옮긴다(경계 안으로 클램프). extend면 셀 범위를 확장한다(앵커 유지,
+   * 셀 선택이 아니었으면 현재 활성점을 앵커로 새 범위 시작). 가상화로 렌더 밖 행이면 스크롤해
+   * 들여, 옮긴 셀의 입력창이 렌더·포커스되게 한다(포커스 이동은 sel 변경 effect가 맡는다).
+   */
+  const moveActive = (dr: number, dc: number, extend: boolean) => {
+    if (!activeCell || rowCount < 1 || colCount < 1) return;
+    const [r, c] = activeCell;
+    const nr = Math.min(rowCount - 1, Math.max(0, r + dr));
+    const nc = Math.min(colCount - 1, Math.max(0, c + dc));
+    if (nr === r && nc === c && !extend) return; // 경계에서 제자리면 그대로.
+    setEditing(null);
+    if (extend) {
+      setSel((s) =>
+        s?.kind === "cells"
+          ? { kind: "cells", a: s.a, b: [nr, nc] }
+          : { kind: "cells", a: [r, c], b: [nr, nc] },
+      );
+    } else {
+      setSel({ kind: "cells", a: [nr, nc], b: [nr, nc] });
+      setDraft(getRow(nr)?.[nc] ?? "");
+    }
+    virtualizer.scrollToIndex(nr);
+  };
+
+  /**
+   * 방향키 이동·Ctrl/Cmd+A(표 전체)를 처리한다. 처리했으면 true.
+   * 편집 중이 아닐 때(선택-만-한 상태)만 호출해야 한다 — 편집 중엔 입력창 기본 동작
+   * (커서 이동·텍스트 전체선택)을 그대로 둔다.
+   */
+  const handleNavKey = (e: React.KeyboardEvent): boolean => {
+    if ((e.metaKey || e.ctrlKey) && (e.key === "a" || e.key === "A")) {
+      e.preventDefault();
+      setEditing(null);
+      setSel({ kind: "table" });
+      return true;
+    }
+    const d: [number, number] | null =
+      e.key === "ArrowUp"
+        ? [-1, 0]
+        : e.key === "ArrowDown"
+          ? [1, 0]
+          : e.key === "ArrowLeft"
+            ? [0, -1]
+            : e.key === "ArrowRight"
+              ? [0, 1]
+              : null;
+    if (d && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      e.preventDefault();
+      moveActive(d[0], d[1], e.shiftKey);
+      return true;
+    }
+    return false;
+  };
 
   /** 선택 범위의 셀 값을 모두 비운다(Delete/Backspace). 수식·값은 지우고 서식은 둔다. */
   const clearSelValues = () => {
@@ -900,6 +967,11 @@ export function DatasetGrid({
    */
   const onGridKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (editing) return; // 편집 중엔 입력창이 처리한다.
+    // 방향키 이동·Cmd/Ctrl+A(표 전체)를 먼저 처리한다.
+    if (handleNavKey(e)) {
+      e.stopPropagation();
+      return;
+    }
     if (!activeCell) return;
     const [r, c] = activeCell;
     // 한글 등 IME 조합키는 e.key가 "Process"로 오고 첫 자모를 keydown에서 얻을 수 없다.
@@ -1173,7 +1245,7 @@ export function DatasetGrid({
                   onPointerDown={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    startColSelect(c);
+                    startColSelect(c, e.shiftKey);
                   }}
                   onPointerEnter={() => extendColSelect(c)}
                   className={cn(
@@ -1300,7 +1372,7 @@ export function DatasetGrid({
                     onPointerDown={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
-                      startRowSelect(vi.index);
+                      startRowSelect(vi.index, e.shiftKey);
                     }}
                     className={cn(
                       "hover:bg-primary/60 absolute top-0 left-0 z-20 h-full w-1.5 cursor-pointer touch-none opacity-0 transition-opacity group-hover/grid:opacity-100",


### PR DESCRIPTION
## 이슈
closes #903

## 작업 내용
Epic #851 선택 시스템의 선택 모델·핸들·상호작용은 이미 구현돼 있고, 플로팅 툴바는 #880에서 "우클릭 하나로 통일"로 결정된 상태다. 남은 **키보드/선택 상호작용의 작은 격차**만 채웠다(우클릭 메뉴 그대로 유지, Epic #892 (a) "키보드 네비게이션"과도 연결).

- **방향키 네비게이션**: 활성 셀을 상하좌우로 이동(경계 클램프)
- **Shift+방향키**: 셀 범위 확장(앵커 유지, 셀 선택이 아니었으면 활성점에서 새 범위 시작)
- **Ctrl/Cmd+A**: 표 전체 선택
- **행·열 핸들 shift+클릭**: 여러 행/열 확장(기존엔 셀 범위만 shift 확장됐음)

### 설계
- 단일 셀 선택 시엔 셀 입력창이 포커스 → `onCellInputKeyDown`, 그 외 선택(행/열/범위/표)은 컨테이너 포커스 → `onGridKeyDown`. **양쪽에 배선**했다.
- **편집 중**엔 방향키·Cmd+A가 입력창 기본 동작(커서 이동·텍스트 전체선택)을 유지하도록 분기(선택-만-한 상태에서만 네비게이션).
- 가상화로 렌더 밖 셀로 이동하면 `virtualizer.scrollToIndex`로 들여, 옮긴 셀 입력창이 렌더·포커스되게 한다.
- 새 엔드포인트·BE 변경 없음(순수 FE).

## 테스트
- RTL 통합 테스트 추가: 방향키 이동, Shift+방향키 확장('셀 2개'), Cmd+A('표 전체'), 행/열 shift+클릭('2행'/'2열'), 편집 중 방향키 미개입
- FE 전체 441개 통과, prettier/eslint 통과

## 확인
- 로컬 브라우저 실증은 미실행(그리드가 노트+데이터셋+인증을 요구해 풀스택 구성 필요). 대신 실제 프로덕션 컴포넌트에 키 이벤트를 그대로 발생시키는 RTL 통합 테스트로 각 상호작용을 검증했다.