### PR TITLE
feat : 데이터 그리드 채우기 핸들 — 세로 드래그 범위 채우기 (#905)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -6,6 +6,7 @@ import ds.project.orino.planner.dataset.dto.BulkCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.BulkRowsRequest;
 import ds.project.orino.planner.dataset.dto.CreateDatasetRequest;
 import ds.project.orino.planner.dataset.dto.DatasetResponse;
+import ds.project.orino.planner.dataset.dto.FillCellsRequest;
 import ds.project.orino.planner.dataset.dto.InsertRowRequest;
 import ds.project.orino.planner.dataset.dto.InsertRowResponse;
 import ds.project.orino.planner.dataset.dto.RenameColumnRequest;
@@ -110,6 +111,18 @@ public class DatasetController {
             @RequestParam int fromRowIndex) {
         return ApiResponse.success(
                 datasetService.fillDownColumn(memberId, id, key, fromRowIndex));
+    }
+
+    /**
+     * 채우기 핸들(세로 드래그) — 소스 블록을 대상 행들에 타일링해 채운다. 값이 바뀐(대상 +
+     * 전파) 행들을 돌려준다(행 번호 오름차순).
+     */
+    @PostMapping("/{id}/cells/fill")
+    public ApiResponse<List<RowView>> fillCells(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @Valid @RequestBody FillCellsRequest request) {
+        return ApiResponse.success(datasetService.fillCells(memberId, id, request));
     }
 
     /** 열 너비 변경(px). 열 단위 표시 속성이라 행은 건드리지 않는다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/FillCellsRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/FillCellsRequest.java
@@ -1,0 +1,21 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.List;
+
+/**
+ * 채우기 핸들(세로 드래그) 요청. 소스 블록을 대상 행들에 타일링해 채운다.
+ *
+ * <p>{@code cols}는 채울 열들(소스·대상이 공유). {@code srcR0..srcR1}은 소스 행 범위(선택 블록),
+ * {@code dstR0..dstR1}은 대상 행 범위다(모두 rowIndex, 포함). 대상은 소스와 겹치지 않고 바로
+ * 위(dstR1 = srcR0-1) 또는 바로 아래(dstR0 = srcR1+1)로 인접해야 한다 — 세부 검증은 서비스에서.
+ */
+public record FillCellsRequest(
+        @NotEmpty List<String> cols,
+        @PositiveOrZero int srcR0,
+        @PositiveOrZero int srcR1,
+        @PositiveOrZero int dstR0,
+        @PositiveOrZero int dstR1
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -357,6 +358,59 @@ public class DatasetFormulaService {
             propagateFrom(datasetId, row.getId(), colKey, seen, budget);
         }
         return filled;
+    }
+
+    /**
+     * 소스 블록을 대상 행들에 <b>세로로 타일링</b>해 채운다(엑셀 채우기 핸들). 소스 셀이 수식이면
+     * 저장형을 글자 그대로 옮긴다(D9: 같은 행 참조는 행마다 상대, 절대 참조는 핀 고정). 리터럴이면
+     * 값을 옮기고 대상의 기존 수식은 지운다.
+     *
+     * <p><b>전부 쓴 뒤 한 번만 전파한다</b>({@link #fillDownColumn}과 같은 이유) — 채우는 도중
+     * 열 집계가 반쯤 채워진 상태로 재계산돼 틀린 값이 나오지 않게.
+     *
+     * @param srcR0   소스 첫 행의 rowIndex(타일링 기준점)
+     * @param srcRows rowIndex 오름차순 소스 행들(선택 블록의 행)
+     * @param dstRows 채울 대상 행들(소스 위/아래로 인접, 소스와 겹치지 않음)
+     * @return 값이 바뀐(대상 + 전파) 행 id들
+     */
+    Set<Long> fillRange(Long datasetId, List<String> cols, int srcR0, List<DatasetRow> srcRows,
+                        List<DatasetRow> dstRows, List<DatasetColumn> columns) {
+        int h = srcRows.size();
+        // 1단계 — 전부 쓴다(아직 전파하지 않는다).
+        for (DatasetRow dst : dstRows) {
+            int offset = Math.floorMod(dst.getRowIndex() - srcR0, h);
+            DatasetRow src = srcRows.get(offset);
+            Map<String, String> srcCells = DatasetCells.parse(src.getCells());
+            for (String col : cols) {
+                DatasetFormula srcFormula =
+                        formulaRepository.findByRowIdAndColKey(src.getId(), col).orElse(null);
+                if (srcFormula != null) {
+                    writeFormula(datasetId, dst, col, srcFormula.getRaw(), columns);
+                } else {
+                    Map<String, String> cells = DatasetCells.parse(dst.getCells());
+                    cells.put(col, srcCells.getOrDefault(col, ""));
+                    dst.updateCells(DatasetCells.serialize(cells));
+                    removeIfAny(dst.getId(), col);
+                }
+            }
+        }
+        // 2단계 — 값이 다 확정된 뒤 한 번 전파한다. seen을 공유해 열 집계는 최종 값으로 한 번만.
+        Set<String> seen = new HashSet<>();
+        int budget = dstRows.size() * cols.size() + MAX_PROPAGATION;
+        for (DatasetRow dst : dstRows) {
+            for (String col : cols) {
+                propagateFrom(datasetId, dst.getId(), col, seen, budget);
+            }
+        }
+        // 영향 행 = 대상 + 전파로 바뀐 행.
+        Set<Long> affected = new LinkedHashSet<>();
+        for (DatasetRow dst : dstRows) {
+            affected.add(dst.getId());
+        }
+        for (String cell : seen) {
+            affected.add(rowIdOf(cell));
+        }
+        return affected;
     }
 
     /**

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -12,6 +12,7 @@ import ds.project.orino.planner.dataset.dto.CellStyle;
 import ds.project.orino.planner.dataset.dto.CreateDatasetRequest;
 import ds.project.orino.planner.dataset.dto.DatasetColumn;
 import ds.project.orino.planner.dataset.dto.DatasetResponse;
+import ds.project.orino.planner.dataset.dto.FillCellsRequest;
 import ds.project.orino.planner.dataset.dto.InsertRowRequest;
 import ds.project.orino.planner.dataset.dto.InsertRowResponse;
 import ds.project.orino.planner.dataset.dto.MergesResponse;
@@ -383,6 +384,52 @@ public class DatasetService {
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
         formulaService.fillDownColumn(datasetId, colKey, source, columns);
         return DatasetResponse.of(dataset, columns);
+    }
+
+    /**
+     * 채우기 핸들(세로 드래그) — 소스 블록을 대상 행들에 타일링해 채운다. 대상은 소스와 겹치지
+     * 않고 바로 위/아래로 인접해야 한다. 값이 바뀐(대상 + 전파) 행들을 돌려준다 — FE가 재조회
+     * 없이 반영한다.
+     */
+    @Transactional
+    public List<RowView> fillCells(Long memberId, Long datasetId, FillCellsRequest request) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        for (String col : request.cols()) {
+            if (indexOfColumn(columns, col) < 0) {
+                throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+            }
+        }
+        int rowCount = dataset.getRowCount();
+        int srcR0 = request.srcR0();
+        int srcR1 = request.srcR1();
+        int dstR0 = request.dstR0();
+        int dstR1 = request.dstR1();
+        // 범위가 표 안에 있고, 소스·대상 각각 정상 순서인지.
+        if (srcR0 > srcR1 || dstR0 > dstR1 || srcR1 >= rowCount || dstR1 >= rowCount) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        // 대상은 소스와 겹치지 않고 바로 아래(dstR0 = srcR1+1) 또는 바로 위(dstR1 = srcR0-1)여야 한다.
+        boolean below = dstR0 == srcR1 + 1;
+        boolean above = dstR1 == srcR0 - 1;
+        if (!below && !above) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST,
+                    "채우기 대상은 소스 바로 위/아래로 인접해야 합니다");
+        }
+
+        List<DatasetRow> srcRows = rowRepository
+                .findByDatasetIdAndRowIndexGreaterThanEqualAndRowIndexLessThanOrderByRowIndexAsc(
+                        datasetId, srcR0, srcR1 + 1);
+        List<DatasetRow> dstRows = rowRepository
+                .findByDatasetIdAndRowIndexGreaterThanEqualAndRowIndexLessThanOrderByRowIndexAsc(
+                        datasetId, dstR0, dstR1 + 1);
+        if (srcRows.isEmpty() || dstRows.isEmpty()) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+
+        Set<Long> affected = formulaService.fillRange(
+                datasetId, request.cols(), srcR0, srcRows, dstRows, columns);
+        return buildRowViews(datasetId, affected, columns);
     }
 
     /** 행 벌크 추가(끝에 append). Import 청크에 사용. */

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFillTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetFillTest.java
@@ -1,0 +1,173 @@
+package ds.project.orino.planner.dataset.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** 채우기 핸들(세로 드래그 범위 채우기). 소스 블록을 대상 행들에 타일링해 채운다. */
+class DatasetFillTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long datasetId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"단가"},{"key":"c1","label":"수량"},
+                                            {"key":"c2","label":"합계"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        datasetId = ((Number) JsonPath.read(body, "$.data.id")).longValue();
+        mockMvc.perform(post("/api/datasets/{id}/rows/bulk", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rows\":[[\"10\",\"3\",\"\"],[\"20\",\"2\",\"\"],[\"5\",\"4\",\"\"]]}"))
+                .andExpect(status().isOk());
+    }
+
+    private ResultActions patchRow(int rowIndex, String cells) throws Exception {
+        return mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", datasetId, rowIndex)
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cells\":" + cells + "}"));
+    }
+
+    private ResultActions fill(String body) throws Exception {
+        return mockMvc.perform(post("/api/datasets/{id}/cells/fill", datasetId)
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body));
+    }
+
+    private ResultActions rows() throws Exception {
+        return mockMvc.perform(get("/api/datasets/{id}/rows", datasetId)
+                .header(HttpHeaders.AUTHORIZATION, authHeader));
+    }
+
+    @Test
+    @DisplayName("수식을 아래로 채우면 행마다 자기 행 기준으로 상대 평가된다 — 핵심")
+    void fillFormulaDownIsRelativePerRow() throws Exception {
+        patchRow(0, "[\"10\",\"3\",\"={단가} * {수량}\"]")
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("30"));
+
+        // c2 수식을 1~2행에 채운다.
+        fill("{\"cols\":[\"c2\"],\"srcR0\":0,\"srcR1\":0,\"dstR0\":1,\"dstR1\":2}")
+                .andExpect(status().isOk())
+                // 응답은 영향 행(대상 1·2행)을 행 번호 순으로 싣는다.
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].rowIndex").value(1))
+                .andExpect(jsonPath("$.data[0].cells[2]").value("40")) // 20*2
+                .andExpect(jsonPath("$.data[1].rowIndex").value(2))
+                .andExpect(jsonPath("$.data[1].cells[2]").value("20")); // 5*4
+
+        // 원본 수식도 각 행에 심겼다(표시형은 열 이름 그대로).
+        rows().andExpect(jsonPath("$.data.rows[1].cells[2]").value("40"))
+                .andExpect(jsonPath("$.data.rows[1].formulas.c2").value("=({단가} * {수량})"))
+                .andExpect(jsonPath("$.data.rows[2].cells[2]").value("20"));
+    }
+
+    @Test
+    @DisplayName("리터럴을 아래로 채우면 값이 복사된다")
+    void fillLiteralDown() throws Exception {
+        fill("{\"cols\":[\"c0\"],\"srcR0\":0,\"srcR1\":0,\"dstR0\":1,\"dstR1\":2}")
+                .andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[1].cells[0]").value("10"))
+                .andExpect(jsonPath("$.data.rows[2].cells[0]").value("10"));
+    }
+
+    @Test
+    @DisplayName("리터럴로 채우면 대상의 기존 수식은 지워진다")
+    void fillLiteralClearsExistingFormula() throws Exception {
+        // 2행 c2를 수식으로 만든 뒤, 리터럴을 그 위로 채우면 수식이 사라진다.
+        patchRow(2, "[\"5\",\"4\",\"={단가} * {수량}\"]")
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("20"));
+
+        // 0행 c2(리터럴 "")를 1~2행에 채운다 → 2행 수식이 리터럴로 덮인다.
+        fill("{\"cols\":[\"c2\"],\"srcR0\":0,\"srcR1\":0,\"dstR0\":1,\"dstR1\":2}")
+                .andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[2].cells[2]").value(""))
+                .andExpect(jsonPath("$.data.rows[2].formulas.c2").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("위로도 채울 수 있다")
+    void fillUp() throws Exception {
+        patchRow(2, "[\"5\",\"4\",\"={단가} * {수량}\"]").andExpect(status().isOk());
+
+        // 2행 수식을 0~1행에 위로 채운다.
+        fill("{\"cols\":[\"c2\"],\"srcR0\":2,\"srcR1\":2,\"dstR0\":0,\"dstR1\":1}")
+                .andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[0].cells[2]").value("30")) // 10*3
+                .andExpect(jsonPath("$.data.rows[1].cells[2]").value("40")); // 20*2
+    }
+
+    @Test
+    @DisplayName("집계는 채운 뒤 최종 값으로 다시 계산된다(교차 행 반영)")
+    void fillPropagatesToAggregateOnce() throws Exception {
+        // 2행 c2에 c0 열 합계를 둔다(=SUM(단가) = 10+20+5 = 35).
+        patchRow(2, "[\"5\",\"4\",\"=SUM({단가})\"]")
+                .andExpect(jsonPath("$.data.edited.cells[2]").value("35"));
+
+        // 0행 단가(10)를 1행에 채운다 → 1행 단가가 20→10. 집계는 10+10+5 = 25.
+        fill("{\"cols\":[\"c0\"],\"srcR0\":0,\"srcR1\":0,\"dstR0\":1,\"dstR1\":1}")
+                .andExpect(status().isOk());
+
+        rows().andExpect(jsonPath("$.data.rows[1].cells[0]").value("10"))
+                .andExpect(jsonPath("$.data.rows[2].cells[2]").value("25"));
+    }
+
+    @Test
+    @DisplayName("대상이 소스와 인접하지 않으면 400")
+    void nonAdjacentTargetRejected() throws Exception {
+        // 소스 0행, 대상 2행(1행을 건너뜀) → 400.
+        fill("{\"cols\":[\"c0\"],\"srcR0\":0,\"srcR1\":0,\"dstR0\":2,\"dstR1\":2}")
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("cols가 비면 400")
+    void emptyColsRejected() throws Exception {
+        fill("{\"cols\":[],\"srcR0\":0,\"srcR1\":0,\"dstR0\":1,\"dstR1\":1}")
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("표 밖 행이면 400")
+    void outOfRangeRejected() throws Exception {
+        fill("{\"cols\":[\"c0\"],\"srcR0\":2,\"srcR1\":2,\"dstR0\":3,\"dstR1\":3}")
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -2053,6 +2053,110 @@ describe("DatasetGrid", () => {
     expect(within(menu).getByText("2열")).toBeInTheDocument();
   });
 
+  // ---------- 채우기 핸들(fill) ----------
+
+  it("채우기 핸들을 아래로 끌면 소스 셀을 대상 행에 채우고 응답으로 화면을 맞춘다", async () => {
+    mockDataset([
+      ["a", "1"],
+      ["b", "2"],
+      ["c", "3"],
+    ]);
+    let filled: unknown = null;
+    server.use(
+      http.post(`${API_BASE}/datasets/1/cells/fill`, async ({ request }) => {
+        filled = await request.json();
+        return HttpResponse.json({
+          code: "OK",
+          data: [
+            { id: 101, rowIndex: 1, cells: ["a", "2"] },
+            { id: 102, rowIndex: 2, cells: ["a", "3"] },
+          ],
+        });
+      }),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const src = (await screen.findByText("a")).parentElement as HTMLElement; // (0,0)
+    fireEvent.pointerDown(src, { button: 0 }); // 선택
+
+    const handle = await screen.findByLabelText("채우기 핸들");
+    fireEvent.pointerDown(handle);
+    // 3행(rowIndex 2)까지 끈다.
+    fireEvent.pointerEnter(screen.getByText("c").parentElement as HTMLElement);
+    fireEvent.pointerUp(window);
+
+    await waitFor(() =>
+      expect(filled).toEqual({
+        cols: ["c0"],
+        srcR0: 0,
+        srcR1: 0,
+        dstR0: 1,
+        dstR1: 2,
+      }),
+    );
+    // 응답 행들이 반영돼 c0가 세 행 모두 "a"가 된다("b"·"c"는 사라진다).
+    await waitFor(() =>
+      expect(screen.getAllByText("a").length).toBeGreaterThanOrEqual(3),
+    );
+    expect(screen.queryByText("b")).not.toBeInTheDocument();
+    expect(screen.queryByText("c")).not.toBeInTheDocument();
+  });
+
+  it("채우기 핸들을 위로도 끌 수 있다", async () => {
+    mockDataset([
+      ["a", "1"],
+      ["b", "2"],
+      ["c", "3"],
+    ]);
+    let filled: unknown = null;
+    server.use(
+      http.post(`${API_BASE}/datasets/1/cells/fill`, async ({ request }) => {
+        filled = await request.json();
+        return HttpResponse.json({ code: "OK", data: [] });
+      }),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const src = (await screen.findByText("c")).parentElement as HTMLElement; // (2,0)
+    fireEvent.pointerDown(src, { button: 0 });
+
+    const handle = await screen.findByLabelText("채우기 핸들");
+    fireEvent.pointerDown(handle);
+    fireEvent.pointerEnter(screen.getByText("a").parentElement as HTMLElement); // 위로 1행
+    fireEvent.pointerUp(window);
+
+    await waitFor(() =>
+      expect(filled).toEqual({
+        cols: ["c0"],
+        srcR0: 2,
+        srcR1: 2,
+        dstR0: 0,
+        dstR1: 1,
+      }),
+    );
+  });
+
+  it("채우기 핸들을 소스 안에서 놓으면(대상 없음) 채우지 않는다", async () => {
+    mockDataset([
+      ["a", "1"],
+      ["b", "2"],
+    ]);
+    let called = false;
+    server.use(
+      http.post(`${API_BASE}/datasets/1/cells/fill`, () => {
+        called = true;
+        return HttpResponse.json({ code: "OK", data: [] });
+      }),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const src = (await screen.findByText("a")).parentElement as HTMLElement;
+    fireEvent.pointerDown(src, { button: 0 });
+    const handle = await screen.findByLabelText("채우기 핸들");
+    fireEvent.pointerDown(handle);
+    fireEvent.pointerUp(window); // 대상 행으로 안 끌고 바로 놓음
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(called).toBe(false);
+  });
+
   it("우클릭 메뉴에서 배경색을 고르면 선택한 셀에 일괄 PUT한다", async () => {
     mockDataset([["네트워크", "92"]]);
     let sentCells: unknown = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -33,6 +33,7 @@ import {
   deleteCellMerge,
   deleteDatasetColumn,
   deleteDatasetRow,
+  fillCells,
   insertDatasetRow,
   MAX_COLUMN_WIDTH,
   type MergeSpan,
@@ -134,6 +135,11 @@ export function DatasetGrid({
   const [sel, setSel] = useState<Sel>(null);
   // 드래그 선택 중인 축(셀/행/열). 눌러서 끌 때만 값이 있고 window pointerup에서 해제한다.
   const selDrag = useRef<null | "cells" | "rows" | "cols">(null);
+  // 채우기 핸들 드래그 중인 대상 행(세로). null이면 채우기 중 아님. window pointerup에서 확정한다.
+  const [fillTo, setFillTo] = useState<number | null>(null);
+  const fillDragging = useRef(false);
+  // 최신 commitFill을 담아 둔다 — window pointerup(한 번만 등록)이 stale 클로저 없이 부른다.
+  const commitFillRef = useRef<() => void>(() => {});
 
   const colCount = meta?.columns.length ?? 0;
   const rowCount = meta?.rowCount ?? 0;
@@ -314,6 +320,8 @@ export function DatasetGrid({
   useEffect(() => {
     const up = () => {
       selDrag.current = null;
+      // 채우기 핸들 드래그였다면 확정한다(대상 없으면 조용히 끝냄).
+      if (fillDragging.current) commitFillRef.current();
     };
     const key = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
@@ -862,6 +870,78 @@ export function DatasetGrid({
     return false;
   };
 
+  /**
+   * 채우기 대상 행 범위(세로). 핸들을 소스 아래로 끌면 소스 다음 행부터, 위로 끌면 소스 앞
+   * 행까지. 소스 안이면 null(채울 게 없음).
+   */
+  const fillTargetRows = ((): { from: number; to: number } | null => {
+    if (fillTo === null || !selRect) return null;
+    if (fillTo > selRect.r1) return { from: selRect.r1 + 1, to: fillTo };
+    if (fillTo < selRect.r0) return { from: fillTo, to: selRect.r0 - 1 };
+    return null;
+  })();
+
+  /** 채우기 프리뷰(드래그로 정해진 대상)에 든 셀인지 — 소스 열 범위 안이고 대상 행 범위 안. */
+  const inFillTarget = (row: number, col: number): boolean =>
+    !!fillTargetRows &&
+    !!selRect &&
+    row >= fillTargetRows.from &&
+    row <= fillTargetRows.to &&
+    col >= selRect.c0 &&
+    col <= selRect.c1;
+
+  /** 채우기 핸들을 눌렀다 — 셀 위로 포인터가 지나가면 {@link updateFill}이 대상 행을 정한다. */
+  const startFill = (e: React.PointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    fillDragging.current = true;
+    setFillTo(null);
+  };
+
+  /** 채우기 드래그 중 포인터가 지나간 행을 대상으로 잡는다. */
+  const updateFill = (row: number) => {
+    if (fillDragging.current) setFillTo(row);
+  };
+
+  /**
+   * 채우기 확정(핸들 놓음) — 소스 블록을 대상 행들에 채우고, 응답 행들로 캐시를 맞춘다.
+   * 채운 뒤 소스+대상을 감싸는 범위를 선택으로 남긴다(엑셀식). 대상이 없으면 조용히 끝낸다.
+   */
+  const commitFill = () => {
+    const target = fillTargetRows;
+    fillDragging.current = false;
+    setFillTo(null);
+    if (!selRect || !target) return;
+    const cols: string[] = [];
+    for (let c = selRect.c0; c <= selRect.c1; c++)
+      cols.push(meta.columns[c].key);
+    const { r0, c0, c1 } = selRect;
+    fillCells(datasetId, {
+      cols,
+      srcR0: r0,
+      srcR1: selRect.r1,
+      dstR0: target.from,
+      dstR1: target.to,
+    })
+      .then((rows) => {
+        for (const row of rows) {
+          setRowLocal(row.rowIndex, row.cells);
+          setFormulasLocal(row.rowIndex, row.formulas ?? {});
+        }
+        setSel({
+          kind: "cells",
+          a: [Math.min(r0, target.from), c0],
+          b: [Math.max(selRect.r1, target.to), c1],
+        });
+      })
+      .catch((e) => {
+        const message = serverMessage(e);
+        if (message) toast(message, "error");
+      });
+  };
+  // window pointerup이 최신 commitFill을 부르도록 매 렌더 동기화한다.
+  commitFillRef.current = commitFill;
+
   /** 선택 범위의 셀 값을 모두 비운다(Delete/Backspace). 수식·값은 지우고 서식은 둔다. */
   const clearSelValues = () => {
     if (!selRect) return;
@@ -1325,7 +1405,11 @@ export function DatasetGrid({
                           if (e.button === 0)
                             startCellSelect(vi.index, c, e.shiftKey);
                         }}
-                        onPointerEnter={() => extendCellSelect(vi.index, c)}
+                        onPointerEnter={() => {
+                          // 채우기 드래그 중이면 이 행을 대상으로, 아니면 셀 범위 확장.
+                          if (fillDragging.current) updateFill(vi.index);
+                          else extendCellSelect(vi.index, c);
+                        }}
                         onDoubleClick={() => startEdit(vi.index, c)}
                         onContextMenu={(e) => openContextMenu(e, vi.index, c)}
                       >
@@ -1334,6 +1418,24 @@ export function DatasetGrid({
                         {inSel(vi.index, c) && (
                           <div className="bg-primary/15 pointer-events-none absolute inset-0 z-[5]" />
                         )}
+                        {/* 채우기 프리뷰 — 드래그로 정해진 대상 셀에 점선 테두리. */}
+                        {inFillTarget(vi.index, c) && (
+                          <div className="border-primary pointer-events-none absolute inset-0 z-[5] border border-dashed" />
+                        )}
+                        {/* 채우기 핸들 — 셀 선택의 우하단 모서리에 작은 사각. 세로로 끌어 채운다. */}
+                        {sel?.kind === "cells" &&
+                          !editing &&
+                          selRect &&
+                          vi.index === selRect.r1 &&
+                          c === selRect.c1 && (
+                            <div
+                              role="button"
+                              aria-label="채우기 핸들"
+                              title="드래그해 값·수식을 아래로 채우기"
+                              onPointerDown={startFill}
+                              className="border-card bg-primary absolute -right-[3px] -bottom-[3px] z-[7] size-1.5 cursor-crosshair touch-none border"
+                            />
+                          )}
                         {/* 열 너비 조절 — 셀 오른쪽 경계 드래그(제목 행이 없어 셀로 옮겼다).
                           셀 호버 시 나타난다. 가로 병합 앵커엔 경계가 모호해 달지 않는다. */}
                         {!anchor && (

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -252,6 +252,33 @@ export async function updateDatasetRow(
   return data.data;
 }
 
+/** 채우기 핸들(세로 드래그) 요청. 서버의 `FillCellsRequest`와 같아야 한다. */
+export interface FillCellsRequest {
+  /** 채울 열들(소스·대상 공유). */
+  cols: string[];
+  /** 소스 행 범위(rowIndex, 포함). */
+  srcR0: number;
+  srcR1: number;
+  /** 대상 행 범위(rowIndex, 포함). 소스와 겹치지 않고 바로 위/아래로 인접. */
+  dstR0: number;
+  dstR1: number;
+}
+
+/**
+ * 채우기 핸들 — 소스 블록을 대상 행들에 세로로 타일링해 채운다. 값이 바뀐(대상 + 전파)
+ * 행들을 돌려준다(행 번호 오름차순). 재조회 없이 캐시에 반영하면 된다.
+ */
+export async function fillCells(
+  datasetId: number,
+  req: FillCellsRequest,
+): Promise<DatasetRow[]> {
+  const { data } = await client.post<ApiEnvelope<DatasetRow[]>>(
+    `/datasets/${datasetId}/cells/fill`,
+    req,
+  );
+  return data.data;
+}
+
 /**
  * 셀 서식(배경색·정렬)을 통째로 교체한다. 빈 style이면 그 셀 서식을 지운다.
  * 값·수식과 무관한 표시 속성이라 cells는 안 바뀐다.


### PR DESCRIPTION
## 이슈
closes #905

## 작업 내용
Epic #892 (a) 편집 UX — 엑셀식 **채우기 핸들**(세로 드래그 범위 채우기). BE엔 이미 열 전체 채우기(`fillDownColumn`)가 있었지만 FE UI가 없고 열 전체만 됐다. 여기선 **드래그한 만큼(임의 행 수) 세로로** 채우는 범위 채우기를 새로 만들었다.

수식 주소 모델이 채우기에 유리하다(D9): 같은 행 참조 `{c0}`는 복사만 해도 행마다 자기 행을 가리켜 **엑셀식 상대 참조처럼** 동작하고, 절대 참조 `{c0}@142`는 핀 고정(`$A$1`). 즉 소스 셀의 원본(수식 저장형/리터럴)을 글자 그대로 대상에 옮기면 된다.

### BE
- `POST /datasets/{id}/cells/fill` — 소스 블록(cols, srcR0..srcR1)을 대상 행(dstR0..dstR1)에 **세로 타일링**해 채운다
- **전부 쓴 뒤 한 번만 전파**(`fillDownColumn`과 같은 이유) — 채우는 도중 열 집계가 반쯤 채워진 상태로 재계산되지 않게
- 수식은 `writeFormula`로 저장형 복사, 리터럴은 값 복사 + `removeIfAny`로 기존 수식 제거
- 응답: 영향받은(대상 + 전파) 행 리스트(`buildRowViews` 재사용) → FE가 재조회 없이 patch
- 검증: cols 비어있음/범위 밖/소스·대상 비인접 → 400

### FE
- 셀 선택 우하단에 채우기 핸들, 세로 드래그로 대상 행 지정 + 점선 프리뷰
- 놓으면 `fillCells` 호출, 응답 행들을 값·수식 캐시에 patch, 소스+대상을 감싸는 범위를 선택으로 남김(엑셀식)
- window pointerup은 최신 `commitFill`을 ref로 참조(stale 클로저 회피)

### 범위 밖 (후속)
- 숫자 시리즈 자동증가(1·2·3…) — v1은 복사/타일만
- 가로(좌·우) 채우기, 더블클릭 자동 채우기, 행/열/표 선택에서의 채우기

## 테스트
- BE 통합 8건: 수식 아래로 채우면 행마다 상대 평가, 리터럴 채우기, 리터럴이 기존 수식 제거, 위로 채우기, 집계 전파(교차 행), 비인접·빈 cols·범위 밖 400
- FE RTL 3건: 아래로 채우기(요청 파라미터 + 응답 patch), 위로 채우기, 소스 안에서 놓으면 미호출
- FE 전체 444개 통과, prettier/eslint·BE checkstyle 통과

## 확인
- 로컬 브라우저 실증은 미실행(그리드가 노트+데이터셋+인증 풀스택 필요). 실제 프로덕션 컴포넌트에 포인터 이벤트를 발생시키는 RTL 통합 테스트 + TestContainers MySQL BE 테스트로 검증했다.