### PR TITLE
feat : 데이터 그리드 열 푸터 요약 표면(정적) (#907)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -18,6 +18,7 @@ import ds.project.orino.planner.dataset.dto.RowsResponse;
 import ds.project.orino.planner.dataset.dto.SetCellMergeRequest;
 import ds.project.orino.planner.dataset.dto.SetCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.SetColumnAlignRequest;
+import ds.project.orino.planner.dataset.dto.SetColumnSummaryRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowResponse;
 import ds.project.orino.planner.dataset.service.DatasetService;
@@ -152,6 +153,20 @@ public class DatasetController {
             @PathVariable String key,
             @Valid @RequestBody SetColumnAlignRequest request) {
         return ApiResponse.success(datasetService.setColumnAlign(memberId, id, key, request));
+    }
+
+    /**
+     * 열 푸터 요약 함수 설정/해제(멱등 교체). {@code summary}가 null이면 해제. 값(집계)은 여기서
+     * 계산하지 않고 응답의 {@code summaries}로 따로 온다(#907 표면; 값은 #908).
+     */
+    @PatchMapping("/{id}/columns/{key}/summary")
+    public ApiResponse<DatasetResponse> setColumnSummary(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable String key,
+            @Valid @RequestBody SetColumnSummaryRequest request) {
+        return ApiResponse.success(
+                datasetService.setColumnSummary(memberId, id, key, request.summary()));
     }
 
     /** 열 기본 정렬 초기화 — 기본 정렬(left)로 되돌린다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetColumn.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetColumn.java
@@ -16,6 +16,12 @@ import jakarta.validation.constraints.Pattern;
  * <p>{@code align}은 열 <b>기본</b> 정렬(left/center/right)이며 마찬가지로 nullable이다. null이면
  * 클라이언트가 기본 정렬(left)로 그린다. 셀 단위 정렬({@link CellStyle#align})이 있으면 그쪽이
  * 이 기본을 덮는다(#828 D2). width와 같은 nullable 확장이라 마이그레이션이 필요 없다.
+ *
+ * <p>{@code summary}는 열 <b>푸터 요약</b> 함수(SUM/AVERAGE/COUNT/MIN/MAX)이며 nullable이다.
+ * null이면 이 열엔 푸터 요약이 없다. width·align과 같은 열 단위 nullable 표시 속성이라
+ * 마이그레이션이 필요 없다. <b>여기 담기는 건 함수(무엇을 계산할지)뿐이고, 계산된 값은
+ * columns_json이 아니라 응답의 {@code summaries} 맵으로 따로 내려간다</b>(값은 데이터에 따라
+ * 매번 바뀌므로 열 메타에 두지 않는다).
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record DatasetColumn(
@@ -25,30 +31,39 @@ public record DatasetColumn(
         @Max(value = MAX_WIDTH, message = "width는 " + MAX_WIDTH + " 이하여야 합니다.")
         Integer width,
         @Pattern(regexp = "left|center|right", message = "허용되지 않은 정렬입니다.")
-        String align
+        String align,
+        @Pattern(regexp = ALLOWED_SUMMARY, message = "허용되지 않은 요약 함수입니다.")
+        String summary
 ) {
     /** 열 너비 하한(px). 이보다 좁으면 값이 사실상 안 보인다. */
     public static final int MIN_WIDTH = 60;
     /** 열 너비 상한(px). 한 열이 표 전체를 밀어내는 것을 막는다. */
     public static final int MAX_WIDTH = 800;
+    /** 허용 요약 함수. FE의 SUMMARY_FNS와 같아야 한다. */
+    public static final String ALLOWED_SUMMARY = "SUM|AVERAGE|COUNT|MIN|MAX";
 
-    /** 너비·정렬 없이 만든다(기본 폭·기본 정렬). */
+    /** 너비·정렬·요약 없이 만든다(기본 폭·기본 정렬). */
     public DatasetColumn(String key, String label) {
-        this(key, label, null, null);
+        this(key, label, null, null, null);
     }
 
-    /** key/width/align은 두고 label만 바꾼 새 열 메타. */
+    /** key/width/align/summary는 두고 label만 바꾼 새 열 메타. */
     public DatasetColumn withLabel(String label) {
-        return new DatasetColumn(key, label, width, align);
+        return new DatasetColumn(key, label, width, align, summary);
     }
 
-    /** key/label/align은 두고 width만 바꾼 새 열 메타. */
+    /** key/label/align/summary는 두고 width만 바꾼 새 열 메타. */
     public DatasetColumn withWidth(Integer width) {
-        return new DatasetColumn(key, label, width, align);
+        return new DatasetColumn(key, label, width, align, summary);
     }
 
-    /** key/label/width는 두고 align만 바꾼 새 열 메타. */
+    /** key/label/width/summary는 두고 align만 바꾼 새 열 메타. */
     public DatasetColumn withAlign(String align) {
-        return new DatasetColumn(key, label, width, align);
+        return new DatasetColumn(key, label, width, align, summary);
+    }
+
+    /** key/label/width/align은 두고 summary만 바꾼 새 열 메타. */
+    public DatasetColumn withSummary(String summary) {
+        return new DatasetColumn(key, label, width, align, summary);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetResponse.java
@@ -2,14 +2,36 @@ package ds.project.orino.planner.dataset.dto;
 
 import ds.project.orino.domain.planner.dataset.entity.Dataset;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
+/**
+ * 데이터셋 메타 응답.
+ *
+ * <p>{@code summaries}는 <b>푸터 요약 값</b>이 앉는 자리다 — {@code summary} 함수가 설정된 열의
+ * key → 계산된 값(문자열). 함수(무엇을 계산할지)는 {@link DatasetColumn#summary()}에, <b>계산된
+ * 값</b>은 여기에 둔다(값은 데이터에 따라 매번 바뀌므로 열 메타와 분리).
+ *
+ * <p>이 필드의 <b>형태만</b> 먼저 고정한다(#907 푸터 표면). 지금은 요약 함수가 설정된 열마다
+ * 값이 {@code null}이다 — 집계 계산은 후속(#908)에서 채운다. FE는 값이 null이면 placeholder로
+ * 그린다.
+ */
 public record DatasetResponse(
         Long id,
         List<DatasetColumn> columns,
-        int rowCount
+        int rowCount,
+        Map<String, String> summaries
 ) {
     public static DatasetResponse of(Dataset dataset, List<DatasetColumn> columns) {
-        return new DatasetResponse(dataset.getId(), columns, dataset.getRowCount());
+        // 요약 함수가 설정된 열만 key로 담는다. 값은 아직 null(집계는 #908). null 값을 담아야 해서
+        // Collectors.toMap 대신 직접 넣는다.
+        Map<String, String> summaries = new LinkedHashMap<>();
+        for (DatasetColumn column : columns) {
+            if (column.summary() != null) {
+                summaries.put(column.key(), null);
+            }
+        }
+        return new DatasetResponse(dataset.getId(), columns, dataset.getRowCount(), summaries);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetColumnSummaryRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetColumnSummaryRequest.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * 열 푸터 요약 함수 설정/해제 요청. {@code SUM|AVERAGE|COUNT|MIN|MAX} 또는 {@code null}(해제).
+ *
+ * <p>정렬(align)과 달리 {@code null}을 <b>해제</b>로 쓴다 — 요약은 "안 보냄"과 "해제"를 구분할
+ * 필요가 없고, 열당 1개를 멱등하게 교체하는 것이라 한 PATCH로 설정·해제를 함께 다룬다.
+ */
+public record SetColumnSummaryRequest(
+        @Pattern(regexp = DatasetColumn.ALLOWED_SUMMARY, message = "허용되지 않은 요약 함수입니다.")
+        String summary
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -359,6 +359,26 @@ public class DatasetService {
         return DatasetResponse.of(dataset, updated);
     }
 
+    /**
+     * 열 푸터 요약 함수를 설정/해제한다(멱등 교체). {@code summary}가 null이면 그 열 요약을 지운다.
+     * <b>값(집계)은 여기서 계산하지 않는다</b> — 함수만 columns_json에 담고, 계산된 값은 응답의
+     * {@code summaries} 맵으로 따로 온다(#907 표면; 값 채우기는 #908).
+     */
+    @Transactional
+    public DatasetResponse setColumnSummary(Long memberId, Long datasetId, String key,
+                                            String summary) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        int at = indexOfColumn(columns, key);
+        if (at < 0) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+        List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
+        updated.set(at, columns.get(at).withSummary(summary));
+        dataset.updateColumns(serialize(updated));
+        return DatasetResponse.of(dataset, updated);
+    }
+
     private int indexOfColumn(List<DatasetColumn> columns, String key) {
         for (int i = 0; i < columns.size(); i++) {
             if (columns.get(i).key().equals(key)) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetColumnSummaryTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetColumnSummaryTest.java
@@ -1,0 +1,139 @@
+package ds.project.orino.planner.dataset.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 열 푸터 요약 <b>함수</b> 설정/해제(#907 표면). 이 페이즈는 함수만 다루고 값(집계)은 계산하지
+ * 않는다 — 응답 {@code summaries}엔 열 key만 담기고 값은 null이다(#908에서 채운다).
+ */
+class DatasetColumnSummaryTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long datasetId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"단가"},{"key":"c1","label":"수량"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        datasetId = ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private ResultActions setSummary(String key, String bodyJson) throws Exception {
+        return mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/summary", datasetId, key)
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(bodyJson));
+    }
+
+    private ResultActions meta() throws Exception {
+        return mockMvc.perform(get("/api/datasets/{id}", datasetId)
+                .header(HttpHeaders.AUTHORIZATION, authHeader));
+    }
+
+    @Test
+    @DisplayName("요약 함수를 설정하면 열에 함수가 담기고 summaries에 그 열 자리가 생긴다(값은 null)")
+    void setSummarySetsFunctionAndSlot() throws Exception {
+        setSummary("c0", "{\"summary\":\"SUM\"}")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].summary").value("SUM"))
+                // 값 자리는 열 key로 존재하되 값은 null(집계는 #908).
+                .andExpect(jsonPath("$.data.summaries", hasKey("c0")))
+                .andExpect(jsonPath("$.data.summaries.c1").doesNotExist());
+
+        // 조회에도 그대로 실린다.
+        meta().andExpect(jsonPath("$.data.columns[0].summary").value("SUM"))
+                .andExpect(jsonPath("$.data.summaries", hasKey("c0")));
+    }
+
+    @Test
+    @DisplayName("다시 설정하면 교체된다(열당 1개, 멱등)")
+    void replaceIsIdempotent() throws Exception {
+        setSummary("c0", "{\"summary\":\"SUM\"}").andExpect(status().isOk());
+        setSummary("c0", "{\"summary\":\"AVERAGE\"}")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].summary").value("AVERAGE"));
+    }
+
+    @Test
+    @DisplayName("null이면 요약이 해제된다")
+    void clearRemovesSummary() throws Exception {
+        setSummary("c0", "{\"summary\":\"SUM\"}").andExpect(status().isOk());
+        setSummary("c0", "{\"summary\":null}")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].summary").doesNotExist())
+                .andExpect(jsonPath("$.data.summaries", not(hasKey("c0"))));
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 함수는 400")
+    void invalidFunctionRejected() throws Exception {
+        setSummary("c0", "{\"summary\":\"MEDIAN\"}").andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("없는 열은 404")
+    void missingColumnRejected() throws Exception {
+        setSummary("c9", "{\"summary\":\"SUM\"}").andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("요약이 걸린 열을 지우면 요약도 함께 사라진다")
+    void deletingColumnRemovesItsSummary() throws Exception {
+        setSummary("c0", "{\"summary\":\"SUM\"}").andExpect(status().isOk());
+        mockMvc.perform(delete("/api/datasets/{id}/columns/{key}", datasetId, "c0")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+        meta().andExpect(jsonPath("$.data.summaries", not(hasKey("c0"))));
+    }
+
+    @Test
+    @DisplayName("열을 재정렬해도 요약은 key를 따라 유지된다")
+    void reorderKeepsSummary() throws Exception {
+        setSummary("c0", "{\"summary\":\"SUM\"}").andExpect(status().isOk());
+        mockMvc.perform(patch("/api/datasets/{id}/columns/order", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keys\":[\"c1\",\"c0\"]}"))
+                .andExpect(status().isOk());
+        // c0은 이제 1번 위치지만 요약은 그대로다.
+        meta().andExpect(jsonPath("$.data.columns[1].key").value("c0"))
+                .andExpect(jsonPath("$.data.columns[1].summary").value("SUM"))
+                .andExpect(jsonPath("$.data.summaries", hasKey("c0")));
+    }
+}

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -2157,6 +2157,58 @@ describe("DatasetGrid", () => {
     expect(called).toBe(false);
   });
 
+  // ---------- 열 푸터 요약 표면(#907) ----------
+
+  /** meta에 summary 함수/값을 실어 GET /datasets/1을 덮어쓴다. */
+  function mockSummaryMeta(
+    summary: string | undefined,
+    summaries: Record<string, string | null>,
+  ) {
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "점수", summary },
+            ],
+            rowCount: 1,
+            summaries,
+          },
+        }),
+      ),
+    );
+  }
+
+  it("summary가 설정된 열이 있으면 데이터 밑에 요약 푸터가 뜬다(값 없으면 —)", async () => {
+    mockDataset([["네트워크", "92"]]);
+    mockSummaryMeta("SUM", { c1: null });
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    const footer = await screen.findByLabelText("열 요약");
+    // 요약 걸린 열(c1)엔 placeholder, 안 걸린 열(c0)엔 값이 없다.
+    expect(within(footer).getByText("—")).toBeInTheDocument();
+  });
+
+  it("summary가 없으면 요약 푸터가 뜨지 않는다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+    expect(screen.queryByLabelText("열 요약")).not.toBeInTheDocument();
+  });
+
+  it("summaries에 값이 있으면 placeholder 대신 그 값을 보여준다(#908 계약)", async () => {
+    mockDataset([["네트워크", "92"]]);
+    mockSummaryMeta("SUM", { c1: "92" });
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    const footer = await screen.findByLabelText("열 요약");
+    expect(within(footer).getByText("92")).toBeInTheDocument();
+    expect(within(footer).queryByText("—")).not.toBeInTheDocument();
+  });
+
   it("우클릭 메뉴에서 배경색을 고르면 선택한 셀에 일괄 PUT한다", async () => {
     mockDataset([["네트워크", "92"]]);
     let sentCells: unknown = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -1541,6 +1541,28 @@ export function DatasetGrid({
                 })}
             </div>
           </div>
+          {/* 열 푸터 요약 — 요약 함수가 걸린 열이 하나라도 있으면 데이터 밑에 한 줄 뜬다.
+            같은 gridTemplateColumns로 열 폭에 맞추고, 가로 스크롤을 본문과 함께 탄다.
+            값(summaries[key])이 아직 없으면(null) placeholder(—) — 집계 채우기는 #908. */}
+          {meta.columns.some((col) => col.summary) && (
+            <div
+              className="border-border bg-muted/30 grid border-t text-sm"
+              style={{ gridTemplateColumns }}
+              aria-label="열 요약"
+            >
+              {meta.columns.map((col) => (
+                <div
+                  key={col.key}
+                  className={cn(
+                    "text-muted-foreground border-border truncate border-r px-2 py-1.5",
+                    ALIGN_CLASS[col.align ?? "left"],
+                  )}
+                >
+                  {col.summary ? (meta.summaries?.[col.key] ?? "—") : ""}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
 
         <ConfirmDialog

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -1,5 +1,8 @@
 import { client } from "@/shared/api";
 
+/** 열 푸터 요약 함수. 서버의 DatasetColumn.ALLOWED_SUMMARY와 같아야 한다. */
+export type SummaryFn = "SUM" | "AVERAGE" | "COUNT" | "MIN" | "MAX";
+
 export interface DatasetColumn {
   key: string;
   label: string;
@@ -7,6 +10,8 @@ export interface DatasetColumn {
   width?: number;
   /** 열 기본 정렬. 없으면 기본 정렬(left). 셀 정렬(CellStyle.align)이 있으면 그쪽이 덮는다. */
   align?: CellAlign;
+  /** 열 푸터 요약 함수. 없으면 이 열엔 푸터 요약이 없다. 계산된 값은 DatasetMeta.summaries로 온다. */
+  summary?: SummaryFn;
 }
 
 /** 셀·열 정렬 값. 서버의 ALLOWED_ALIGN과 같아야 한다. */
@@ -62,6 +67,11 @@ export interface DatasetMeta {
   id: number;
   columns: DatasetColumn[];
   rowCount: number;
+  /**
+   * 푸터 요약 값 — summary 함수가 설정된 열의 key → 계산된 값. 값이 null이면 아직 계산 전이라
+   * placeholder(`—`)로 그린다. (함수는 column.summary에, 값은 여기에. 값은 데이터마다 바뀐다.)
+   */
+  summaries?: Record<string, string | null>;
 }
 
 export interface DatasetRow {


### PR DESCRIPTION
## 이슈
closes #907

## 작업 내용
Epic #892 (a) 편집 UX — 자동합계의 **기반 프리미티브**. 열 푸터(요약 셀) 표면을 신설한다. **이 PR엔 집계 계산이 없다** — 표면이 존재하고, 열을 따라다니고, 멱등 교체되고, 열 폭에 정렬돼 렌더되는 것까지만. 값 자리는 placeholder(`—`).

리스크를 갈랐다: "신설 표면"(이 PR)과 "집계 정확성"(#908)은 서로 다른 이유로 틀어지므로 각자의 리뷰·롤백 단위를 갖는다. 이 PR 리뷰는 집계와 무관한 질문(열 삭제 시 summary 사라지나? 재정렬 따라오나? 푸터가 열 폭에 맞나?)에만 집중된다.

푸터 표면은 이번 Σ만을 위한 게 아니라 부분범위 합계(fast-follow)·열별 조건부 요약 등이 앉을 **기반**이라 독립 이슈로 둔다.

### GET 응답 계약 (여기서 고정)
- **`DatasetColumn.summary`**: nullable 함수 토큰 `SUM|AVERAGE|COUNT|MIN|MAX`. `width·align`처럼 `columns_json`에 살고 열을 따라다닌다. 열당 1개(멱등 교체).
- **`DatasetResponse.summaries`**: `{ [colKey]: string | null }` — 집계 **값**이 앉을 자리. **이 PR은 값을 null로** 내보낸다. #908이 실제 값을 채운다. 필드 형태를 지금 고정해 #908이 스키마를 다시 안 건드린다.

### BE
- `DatasetColumn`에 `summary` 추가(nullable, `@Pattern` 검증). 열 삭제 시 자연 소멸, key 기반이라 재정렬·이름변경 내성
- `PATCH /datasets/{id}/columns/{key}/summary` `{summary|null}` — 설정/해제 멱등 교체, 값(집계)은 계산 안 함
- `DatasetResponse.summaries` — summary 걸린 열 key만 담고 값은 null

### FE
- `DatasetColumn.summary`·`DatasetMeta.summaries` 타입
- 데이터 행 밑 **푸터 행** 렌더(`gridTemplateColumns` 재사용). summary 걸린 열만, 값 null이면 `—`. summary 없으면 푸터 미표시

## 테스트
- BE 7건: 설정→함수+summaries 자리, 멱등 교체, null 해제, 잘못된 함수 400, 없는 열 404, 열 삭제 시 소멸, 재정렬 후 유지
- FE 3건: summary 있으면 푸터에 `—`, 없으면 푸터 미표시, summaries 값 있으면 그 값 표시(#908 계약)
- FE 447개 통과, prettier/eslint·BE checkstyle 통과

## 후속
- #908 자동합계 배선: BE 집계 계산(COLUMN_ALL 재사용) + `summaries` 값 채우기 + 우클릭 "합계"/서브메뉴