### PR TITLE
feat : 열 푸터 자동합계 배선 — 전체 열 집계(COLUMN_ALL 재사용) (#908)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetResponse.java
@@ -2,7 +2,6 @@ package ds.project.orino.planner.dataset.dto;
 
 import ds.project.orino.domain.planner.dataset.entity.Dataset;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -13,9 +12,9 @@ import java.util.Map;
  * key → 계산된 값(문자열). 함수(무엇을 계산할지)는 {@link DatasetColumn#summary()}에, <b>계산된
  * 값</b>은 여기에 둔다(값은 데이터에 따라 매번 바뀌므로 열 메타와 분리).
  *
- * <p>이 필드의 <b>형태만</b> 먼저 고정한다(#907 푸터 표면). 지금은 요약 함수가 설정된 열마다
- * 값이 {@code null}이다 — 집계 계산은 후속(#908)에서 채운다. FE는 값이 null이면 placeholder로
- * 그린다.
+ * <p>{@code summaries}엔 요약 함수가 설정된 열의 key → 계산된 값이 담긴다(#908). 계산은
+ * 서비스(엔진 접근이 있는 곳)에서 하고 여기로 넘겨받는다 — 값은 데이터에 따라 매번 바뀌므로
+ * 열 메타와 분리한다. 요약이 없으면 빈 맵이다.
  */
 public record DatasetResponse(
         Long id,
@@ -23,15 +22,8 @@ public record DatasetResponse(
         int rowCount,
         Map<String, String> summaries
 ) {
-    public static DatasetResponse of(Dataset dataset, List<DatasetColumn> columns) {
-        // 요약 함수가 설정된 열만 key로 담는다. 값은 아직 null(집계는 #908). null 값을 담아야 해서
-        // Collectors.toMap 대신 직접 넣는다.
-        Map<String, String> summaries = new LinkedHashMap<>();
-        for (DatasetColumn column : columns) {
-            if (column.summary() != null) {
-                summaries.put(column.key(), null);
-            }
-        }
+    public static DatasetResponse of(Dataset dataset, List<DatasetColumn> columns,
+                                     Map<String, String> summaries) {
         return new DatasetResponse(dataset.getId(), columns, dataset.getRowCount(), summaries);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
@@ -526,6 +526,66 @@ public class DatasetFormulaService {
         }
     }
 
+    /** 요약 함수 토큰(FE·columns_json) → 엔진 집계 함수명. AVERAGE만 엔진에선 AVG다. */
+    private static final Map<String, String> SUMMARY_ENGINE_FUNC = Map.of(
+            "SUM", "SUM", "AVERAGE", "AVG", "COUNT", "COUNT", "MIN", "MIN", "MAX", "MAX");
+
+    /**
+     * 요약 함수가 설정된 열들의 값을 계산한다(#908). 기존 엔진의 열 집계({@link FormulaNode.Agg},
+     * {@code COLUMN_ALL})를 그대로 재사용한다 — 새 계산 로직·ref kind가 없다. 전체 행을 한 번만
+     * 읽어 여러 열에 나눠 쓴다. 요약이 없으면 빈 맵.
+     *
+     * @return 열 key → 계산된 값(문자열). 열 집계는 숫자만 세고 빈/텍스트는 규칙대로 다룬다.
+     */
+    Map<String, String> computeSummaries(Long datasetId, List<DatasetColumn> columns) {
+        List<DatasetColumn> withSummary = columns.stream()
+                .filter(c -> c.summary() != null)
+                .toList();
+        Map<String, String> out = new LinkedHashMap<>();
+        if (withSummary.isEmpty()) {
+            return out;
+        }
+        FormulaEvaluator.ValueSource src = new SummaryValues(datasetId);
+        for (DatasetColumn col : withSummary) {
+            String func = SUMMARY_ENGINE_FUNC.get(col.summary());
+            FormulaValue value = FormulaEvaluator.evaluate(
+                    new FormulaNode.Agg(func, List.of(col.key())), src);
+            out.put(col.key(), value.asCell());
+        }
+        return out;
+    }
+
+    /**
+     * 열 집계 계산용 읽기 소스. 전체 행을 한 번 로드해 {@code column()}에만 답한다(요약은 열
+     * 전체 집계뿐이라 {@code sameRow}/{@code absolute}는 쓰지 않는다).
+     */
+    private final class SummaryValues implements FormulaEvaluator.ValueSource {
+        private final List<Map<String, String>> rows;
+
+        private SummaryValues(Long datasetId) {
+            this.rows = rowRepository.findByDatasetIdOrderByRowIndexAsc(datasetId).stream()
+                    .map(r -> DatasetCells.parse(r.getCells()))
+                    .toList();
+        }
+
+        @Override
+        public Optional<String> sameRow(String colKey) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> absolute(long rowId, String colKey) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<List<String>> column(String colKey) {
+            return Optional.of(rows.stream()
+                    .map(cells -> cells.getOrDefault(colKey, ""))
+                    .toList());
+        }
+    }
+
     /** 평가기가 읽을 셀 값을 DB(와 지금 만드는 행)에서 가져온다. */
     private final class DbValues implements FormulaEvaluator.ValueSource {
         private final Long datasetId;

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -106,7 +106,7 @@ public class DatasetService {
         List<DatasetColumn> columns = deduplicateLabels(request.columns());
         Dataset dataset = datasetRepository.save(new Dataset(
                 memberId, serialize(columns), nextSeqFor(columns)));
-        return DatasetResponse.of(dataset, columns);
+        return metaResponse(dataset, columns);
     }
 
     /**
@@ -198,12 +198,12 @@ public class DatasetService {
         mergeService.invalidateOnColumnInsert(datasetId, at, columns);
         updated.add(at, added);
         dataset.updateColumns(serialize(updated));
-        return DatasetResponse.of(dataset, updated);
+        return metaResponse(dataset, updated);
     }
 
     public DatasetResponse getMeta(Long memberId, Long datasetId) {
         Dataset dataset = getOwned(memberId, datasetId);
-        return DatasetResponse.of(dataset, parseColumns(dataset.getColumns()));
+        return metaResponse(dataset, parseColumns(dataset.getColumns()));
     }
 
     /**
@@ -237,7 +237,7 @@ public class DatasetService {
         styleService.invalidateColumn(datasetId, key);
         // 그 열에 걸친 병합은 영역이 온전할 수 없어 해제한다(삭제 전 열 순서로 덮는 열을 계산해야 한다).
         mergeService.invalidateColumn(datasetId, key, columns);
-        return DatasetResponse.of(dataset, updated);
+        return metaResponse(dataset, updated);
     }
 
     /**
@@ -267,7 +267,7 @@ public class DatasetService {
         dataset.updateColumns(serialize(updated));
         // 순서가 바뀌면 병합 영역이 불연속이 될 수 있어 그 dataset의 병합을 모두 해제한다(#829 O3, v1 보수적).
         mergeService.invalidateAllOnReorder(datasetId);
-        return DatasetResponse.of(dataset, updated);
+        return metaResponse(dataset, updated);
     }
 
     /**
@@ -290,7 +290,7 @@ public class DatasetService {
         // withLabel — 이름만 바꾸고 width는 보존한다. 새로 만들면 설정한 너비가 날아간다.
         updated.set(at, columns.get(at).withLabel(request.label()));
         dataset.updateColumns(serialize(updated));
-        return DatasetResponse.of(dataset, updated);
+        return metaResponse(dataset, updated);
     }
 
     /**
@@ -323,7 +323,7 @@ public class DatasetService {
         List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
         updated.set(at, columns.get(at).withWidth(width));
         dataset.updateColumns(serialize(updated));
-        return DatasetResponse.of(dataset, updated);
+        return metaResponse(dataset, updated);
     }
 
     /**
@@ -356,7 +356,7 @@ public class DatasetService {
         List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
         updated.set(at, columns.get(at).withAlign(align));
         dataset.updateColumns(serialize(updated));
-        return DatasetResponse.of(dataset, updated);
+        return metaResponse(dataset, updated);
     }
 
     /**
@@ -376,7 +376,13 @@ public class DatasetService {
         List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
         updated.set(at, columns.get(at).withSummary(summary));
         dataset.updateColumns(serialize(updated));
-        return DatasetResponse.of(dataset, updated);
+        return metaResponse(dataset, updated);
+    }
+
+    /** 메타 응답을 조립한다 — 요약 값(집계)을 계산해 함께 싣는다(#908). */
+    private DatasetResponse metaResponse(Dataset dataset, List<DatasetColumn> columns) {
+        return DatasetResponse.of(dataset, columns,
+                formulaService.computeSummaries(dataset.getId(), columns));
     }
 
     private int indexOfColumn(List<DatasetColumn> columns, String key) {
@@ -403,7 +409,7 @@ public class DatasetService {
         DatasetRow source = rowRepository.findByDatasetIdAndRowIndex(datasetId, fromRowIndex)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
         formulaService.fillDownColumn(datasetId, colKey, source, columns);
-        return DatasetResponse.of(dataset, columns);
+        return metaResponse(dataset, columns);
     }
 
     /**
@@ -473,7 +479,7 @@ public class DatasetService {
         }
         rowRepository.saveAll(entities);
         dataset.setRowCount(start + rows.size());
-        return DatasetResponse.of(dataset, columns);
+        return metaResponse(dataset, columns);
     }
 
     public RowsResponse getRows(Long memberId, Long datasetId, Integer offset, Integer limit) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetSummaryValueTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetSummaryValueTest.java
@@ -1,0 +1,137 @@
+package ds.project.orino.planner.dataset.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 열 푸터 요약 <b>값</b> 계산(#908). 기존 엔진의 열 집계(COLUMN_ALL)를 재사용해 응답
+ * {@code summaries}에 값을 채운다.
+ */
+class DatasetSummaryValueTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long datasetId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"columns":[{"key":"c0","label":"단가"},{"key":"c1","label":"수량"}]}
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        datasetId = ((Number) JsonPath.read(body, "$.data.id")).longValue();
+        mockMvc.perform(post("/api/datasets/{id}/rows/bulk", datasetId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rows\":[[\"10\",\"3\"],[\"20\",\"2\"],[\"30\",\"4\"]]}"))
+                .andExpect(status().isOk());
+    }
+
+    private void setSummary(String key, String fn) throws Exception {
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/summary", datasetId, key)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"summary\":\"" + fn + "\"}"))
+                .andExpect(status().isOk());
+    }
+
+    private ResultActions meta() throws Exception {
+        return mockMvc.perform(get("/api/datasets/{id}", datasetId)
+                .header(HttpHeaders.AUTHORIZATION, authHeader));
+    }
+
+    @Test
+    @DisplayName("SUM은 열 전체 합계를 낸다")
+    void sumValue() throws Exception {
+        setSummary("c0", "SUM");
+        meta().andExpect(jsonPath("$.data.summaries.c0").value("60")); // 10+20+30
+    }
+
+    @Test
+    @DisplayName("AVERAGE는 엔진 AVG로 매핑돼 평균을 낸다")
+    void averageValue() throws Exception {
+        setSummary("c0", "AVERAGE");
+        meta().andExpect(jsonPath("$.data.summaries.c0").value("20")); // 60/3
+    }
+
+    @Test
+    @DisplayName("COUNT는 숫자 셀만 센다")
+    void countValue() throws Exception {
+        setSummary("c0", "COUNT");
+        meta().andExpect(jsonPath("$.data.summaries.c0").value("3"));
+    }
+
+    @Test
+    @DisplayName("MIN·MAX")
+    void minMaxValue() throws Exception {
+        setSummary("c0", "MIN");
+        meta().andExpect(jsonPath("$.data.summaries.c0").value("10"));
+        setSummary("c0", "MAX");
+        meta().andExpect(jsonPath("$.data.summaries.c0").value("30"));
+    }
+
+    @Test
+    @DisplayName("셀을 고치면 요약 값이 따라 바뀐다")
+    void valueUpdatesAfterEdit() throws Exception {
+        setSummary("c0", "SUM");
+        meta().andExpect(jsonPath("$.data.summaries.c0").value("60"));
+
+        // 1행 단가 10 → 40. 합계 40+20+30 = 90.
+        mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", datasetId, 0)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"40\",\"3\"]}"))
+                .andExpect(status().isOk());
+
+        meta().andExpect(jsonPath("$.data.summaries.c0").value("90"));
+    }
+
+    @Test
+    @DisplayName("숫자가 아닌 셀이 섞여도 SUM은 숫자만 더한다")
+    void sumIgnoresNonNumeric() throws Exception {
+        mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", datasetId, 1)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"글자\",\"2\"]}"))
+                .andExpect(status().isOk());
+        setSummary("c0", "SUM");
+        // 10 + (글자 무시) + 30 = 40.
+        meta().andExpect(jsonPath("$.data.summaries.c0").value("40"));
+    }
+
+    @Test
+    @DisplayName("요약 없는 데이터셋의 summaries는 빈 맵")
+    void noSummaryEmptyMap() throws Exception {
+        meta().andExpect(jsonPath("$.data.summaries").isMap())
+                .andExpect(jsonPath("$.data.summaries.c0").doesNotExist());
+    }
+}

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -2209,6 +2209,106 @@ describe("DatasetGrid", () => {
     expect(within(footer).queryByText("—")).not.toBeInTheDocument();
   });
 
+  it("우클릭에서 요약 함수를 고르면 그 열에 PATCH하고 푸터에 값이 뜬다(#908)", async () => {
+    mockDataset([
+      ["a", "10"],
+      ["b", "20"],
+    ]);
+    let patched: unknown = null;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/columns/:key/summary`,
+        async ({ params, request }) => {
+          patched = { key: params.key, body: await request.json() };
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              id: 1,
+              columns: [
+                { key: "c0", label: "과목" },
+                { key: "c1", label: "점수", summary: "SUM" },
+              ],
+              rowCount: 2,
+              summaries: { c1: "30" },
+            },
+          });
+        },
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    // c1(점수) 열의 한 셀을 선택 → 한 열만 걸쳐 요약 메뉴가 뜬다.
+    const cell = (await screen.findByText("10")).parentElement as HTMLElement;
+    fireEvent.pointerDown(cell, { button: 0 });
+    fireEvent.contextMenu(cell);
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "요약 합계" }));
+
+    await waitFor(() =>
+      expect(patched).toEqual({ key: "c1", body: { summary: "SUM" } }),
+    );
+    const footer = await screen.findByLabelText("열 요약");
+    expect(within(footer).getByText("30")).toBeInTheDocument();
+  });
+
+  it("셀을 고쳐 커밋하면 요약 값이 갱신된다(#908)", async () => {
+    mockDataset([
+      ["a", "10"],
+      ["b", "20"],
+    ]);
+    let sum = "30";
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "점수", summary: "SUM" },
+            ],
+            rowCount: 2,
+            summaries: { c1: sum },
+          },
+        }),
+      ),
+      http.patch(
+        `${API_BASE}/datasets/1/rows/:i`,
+        async ({ params, request }) => {
+          const body = (await request.json()) as { cells: string[] };
+          sum = "999"; // 서버가 재계산했다고 가정.
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              edited: {
+                id: 100,
+                rowIndex: Number(params.i),
+                cells: body.cells,
+              },
+              affected: [],
+            },
+          });
+        },
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    const footer = await screen.findByLabelText("열 요약");
+    expect(within(footer).getByText("30")).toBeInTheDocument();
+
+    // 데이터 셀(10)을 고쳐 커밋하면 메타를 다시 받아 요약이 갱신된다.
+    await user.dblClick(screen.getByText("10"));
+    const input = await screen.findByLabelText("셀 1행 2열");
+    fireEvent.change(input, { target: { value: "15" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByLabelText("열 요약")).getByText("999"),
+      ).toBeInTheDocument(),
+    );
+  });
+
   it("우클릭 메뉴에서 배경색을 고르면 선택한 셀에 일괄 PUT한다", async () => {
     mockDataset([["네트워크", "92"]]);
     let sentCells: unknown = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -43,6 +43,8 @@ import {
   resizeDatasetColumn,
   setCellMerge,
   setCellStylesBulk,
+  setColumnSummary,
+  type SummaryFn,
   updateDatasetRow,
 } from "./api/datasets";
 import { DATASET_CELLS_MIME } from "./cellClipboard";
@@ -146,6 +148,12 @@ export function DatasetGrid({
 
   const invalidateMeta = () =>
     queryClient.invalidateQueries({ queryKey: datasetKeys.meta(datasetId) });
+  // 요약이 걸린 열이 하나라도 있으면 데이터 변경 후 메타를 다시 받아 푸터 값을 갱신한다.
+  // 요약이 없으면 헛요청을 아낀다(대부분의 표).
+  const summariesActive = meta?.columns.some((c) => c.summary) ?? false;
+  const refreshSummaries = () => {
+    if (summariesActive) void invalidateMeta();
+  };
   // 행/열 구조가 바뀌면 병합의 행 번호가 밀리거나(행 삽입·삭제) 병합이 해제될 수 있어(열 삭제·순서변경)
   // 병합을 다시 받는다.
   const invalidateMerges = () =>
@@ -188,6 +196,8 @@ export function DatasetGrid({
           setRowLocal(row.rowIndex, row.cells);
           setFormulasLocal(row.rowIndex, row.formulas ?? {});
         }
+        // 최종 커밋(자동저장 아님)이면 열 요약 값도 갱신한다.
+        if (!silent) refreshSummaries();
       })
       .catch((e) => {
         if (silent) return;
@@ -266,6 +276,17 @@ export function DatasetGrid({
     onSuccess: (next: DatasetMeta) =>
       queryClient.setQueryData(datasetKeys.meta(datasetId), next),
     onError: () => void invalidateMeta(),
+  });
+  // 열 푸터 요약 설정/해제. 응답 메타엔 계산된 summaries가 실려 있어 푸터가 즉시 맞는다.
+  const summaryMut = useMutation({
+    mutationFn: (v: { key: string; fn: SummaryFn | null }) =>
+      setColumnSummary(datasetId, v.key, v.fn),
+    onSuccess: (next: DatasetMeta) =>
+      queryClient.setQueryData(datasetKeys.meta(datasetId), next),
+    onError: (e) => {
+      const message = serverMessage(e);
+      if (message) toast(message, "error");
+    },
   });
   const addColMut = useMutation({
     mutationFn: (v: { atIndex?: number }) =>
@@ -933,6 +954,7 @@ export function DatasetGrid({
           a: [Math.min(r0, target.from), c0],
           b: [Math.max(selRect.r1, target.to), c1],
         });
+        refreshSummaries();
       })
       .catch((e) => {
         const message = serverMessage(e);
@@ -1725,6 +1747,51 @@ export function DatasetGrid({
                     </button>
                   </div>
                   {divider}
+                  {/* 열 요약 — 한 열만 걸쳤을 때. 그 열 푸터에 SUM/AVG/… 를 걸거나 지운다. */}
+                  {rect.c0 === rect.c1 && (
+                    <>
+                      <div className="text-muted-foreground px-2 pt-1 text-xs">
+                        열 요약
+                      </div>
+                      <div className="flex items-center gap-1 px-2 py-1">
+                        {SUMMARY_FNS.map((fn) => (
+                          <button
+                            key={fn}
+                            type="button"
+                            role="menuitem"
+                            aria-label={`요약 ${SUMMARY_LABELS[fn]}`}
+                            onClick={run(() =>
+                              summaryMut.mutate({
+                                key: meta.columns[rect.c0].key,
+                                fn,
+                              }),
+                            )}
+                            className={cn(
+                              "hover:bg-accent rounded px-1.5 py-1 text-xs",
+                              meta.columns[rect.c0].summary === fn &&
+                                "bg-accent text-foreground",
+                            )}
+                          >
+                            {SUMMARY_LABELS[fn]}
+                          </button>
+                        ))}
+                        <button
+                          type="button"
+                          aria-label="요약 지우기"
+                          onClick={run(() =>
+                            summaryMut.mutate({
+                              key: meta.columns[rect.c0].key,
+                              fn: null,
+                            }),
+                          )}
+                          className="text-muted-foreground hover:text-foreground flex size-6 items-center justify-center rounded"
+                        >
+                          <X className="size-3" />
+                        </button>
+                      </div>
+                      {divider}
+                    </>
+                  )}
                   {/* 병합 — 셀 범위(2칸+)는 통합 병합, 단일 셀은 방향 병합·해제 */}
                   {kind === "cells" &&
                     area > 1 &&
@@ -1824,6 +1891,16 @@ export function DatasetGrid({
     </div>
   );
 }
+
+/** 열 푸터 요약 함수 목록·라벨. 서버의 ALLOWED_SUMMARY와 같아야 한다. */
+const SUMMARY_FNS: SummaryFn[] = ["SUM", "AVERAGE", "COUNT", "MIN", "MAX"];
+const SUMMARY_LABELS: Record<SummaryFn, string> = {
+  SUM: "합계",
+  AVERAGE: "평균",
+  COUNT: "개수",
+  MIN: "최소",
+  MAX: "최대",
+};
 
 /** 정렬 값 → 아이콘. 셀 정렬 팔레트와 렌더에 공용. */
 const ALIGN_ICONS = {

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -214,6 +214,22 @@ export async function setDatasetColumnAlign(
   return data.data;
 }
 
+/**
+ * 열 푸터 요약 함수 설정/해제(멱등 교체). null이면 해제. 갱신된 메타(계산된 summaries 포함)를
+ * 돌려준다 — 캐시에 바로 반영하면 푸터 값이 즉시 맞는다.
+ */
+export async function setColumnSummary(
+  datasetId: number,
+  key: string,
+  summary: SummaryFn | null,
+): Promise<DatasetMeta> {
+  const { data } = await client.patch<ApiEnvelope<DatasetMeta>>(
+    `/datasets/${datasetId}/columns/${key}/summary`,
+    { summary },
+  );
+  return data.data;
+}
+
 /** 열 삭제. 마지막 열은 지울 수 없다(400). */
 export async function deleteDatasetColumn(
   datasetId: number,


### PR DESCRIPTION
## 이슈
closes #908

## 작업 내용
Epic #892 (a) 편집 UX — 열 푸터 **자동합계 배선**. #907(푸터 표면, #909 머지)이 깔아 둔 표면·계약(`DatasetResponse.summaries`) 위에 **올바른 숫자를 흘려넣는다**. 순수하게 집계 정확성에 집중.

### 범위
- **전체 열 집계만**(A). 기존 수식 엔진의 `COLUMN_ALL` 집계를 그대로 재사용 — 새 ref kind·계산 로직 없음. "열 전체"라 행 추가·삭제·재정렬돼도 자동으로 따라온다.
- 함수: SUM · AVERAGE · COUNT · MIN · MAX. (엔진은 `AVG`를 쓰므로 AVERAGE→AVG만 매핑.)

### BE
- `computeSummaries` — summary 걸린 열을 `FormulaNode.Agg`로 평가(전체 행 1회 로드해 여러 열에 나눠 씀). ADR-2대로 BE가 계산 SSOT.
- 모든 메타 응답을 `metaResponse` 헬퍼로 통일 → `DatasetResponse.summaries`에 계산된 값을 싣는다.

### FE
- 우클릭 "열 요약"(한 열만 걸쳤을 때) — SUM/AVG/COUNT/MIN/MAX 설정·해제(`PATCH .../summary`). 현재 함수 강조, 응답 메타로 푸터 즉시 갱신.
- 데이터 변경(셀 커밋·채우기) 후 **요약이 걸려 있을 때만** 메타 재조회로 값 갱신(요약 없는 표는 헛요청 없음).

### 범위 밖 (fast-follow)
- **부분 행 범위 합계** — `RANGE` ref kind 신설 + 행 삽입/삭제/재정렬 시맨틱 설계 필요. 별도 이슈.
- Alt+= 단축키, 실시간(타이핑 중) 갱신(현재는 커밋 시 갱신).

## 테스트
- BE 7건: SUM/AVERAGE/COUNT/MIN/MAX 정확값, 셀 편집 후 갱신, 비숫자 무시, 요약 없으면 빈 맵
- FE 2건: 우클릭으로 합계 설정→PATCH+푸터 값, 셀 커밋 후 요약 값 갱신
- FE 449개 통과, prettier/eslint·BE checkstyle 통과

## 확인
- 로컬 브라우저 실증은 미실행(풀스택 필요). 실제 컴포넌트/엔진을 타는 통합 테스트(TestContainers MySQL + RTL/MSW)로 검증.