### PR TITLE
feat : 데이터 그리드 선택 범위 요약(표시 전용) (#911)

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -2309,6 +2309,62 @@ describe("DatasetGrid", () => {
     );
   });
 
+  // ---------- 선택 범위 요약(표시 전용, #911) ----------
+
+  it("셀 범위를 선택하면 요약 바에 합계·평균·개수가 뜬다", async () => {
+    mockDataset([
+      ["10", "20"],
+      ["30", "40"],
+    ]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const a = (await screen.findByText("10")).parentElement as HTMLElement;
+    fireEvent.pointerDown(a, { button: 0 });
+    const b = screen.getByText("40").parentElement as HTMLElement;
+    fireEvent.pointerDown(b, { button: 0, shiftKey: true }); // (0,0)~(1,1)
+
+    const bar = await screen.findByLabelText("선택 요약");
+    expect(within(bar).getByText("합계 100")).toBeInTheDocument(); // 10+20+30+40
+    expect(within(bar).getByText("평균 25")).toBeInTheDocument();
+    expect(within(bar).getByText("개수 4")).toBeInTheDocument();
+  });
+
+  it("텍스트가 섞이면 숫자만 집계한다", async () => {
+    mockDataset([
+      ["10", "x"],
+      ["30", "20"],
+    ]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const a = (await screen.findByText("10")).parentElement as HTMLElement;
+    fireEvent.pointerDown(a, { button: 0 });
+    const b = screen.getByText("20").parentElement as HTMLElement;
+    fireEvent.pointerDown(b, { button: 0, shiftKey: true });
+
+    const bar = await screen.findByLabelText("선택 요약");
+    expect(within(bar).getByText("개수 3")).toBeInTheDocument(); // 10,30,20
+    expect(within(bar).getByText("합계 60")).toBeInTheDocument();
+  });
+
+  it("단일 셀 선택이면 요약 바가 안 뜬다", async () => {
+    mockDataset([["10", "20"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const a = (await screen.findByText("10")).parentElement as HTMLElement;
+    fireEvent.pointerDown(a, { button: 0 });
+    expect(screen.queryByLabelText("선택 요약")).not.toBeInTheDocument();
+  });
+
+  it("숫자가 없는 범위면 요약 바가 안 뜬다", async () => {
+    mockDataset([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const a = (await screen.findByText("a")).parentElement as HTMLElement;
+    fireEvent.pointerDown(a, { button: 0 });
+    const b = screen.getByText("d").parentElement as HTMLElement;
+    fireEvent.pointerDown(b, { button: 0, shiftKey: true });
+    expect(screen.queryByLabelText("선택 요약")).not.toBeInTheDocument();
+  });
+
   it("우클릭 메뉴에서 배경색을 고르면 선택한 셀에 일괄 PUT한다", async () => {
     mockDataset([["네트워크", "92"]]);
     let sentCells: unknown = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -49,7 +49,7 @@ import {
 } from "./api/datasets";
 import { DATASET_CELLS_MIME } from "./cellClipboard";
 import type { FormulaContext, ValueSource } from "./formula";
-import { evaluateFormula } from "./formula";
+import { aggregate, asCell, evaluateFormula } from "./formula";
 import { useDatasetMerges } from "./hooks/useDatasetMerges";
 import { useDatasetMeta } from "./hooks/useDatasetMeta";
 import { useDatasetRows } from "./hooks/useDatasetRows";
@@ -902,6 +902,40 @@ export function DatasetGrid({
     return null;
   })();
 
+  /**
+   * 선택 범위 요약(표시 전용). 셀 범위(≥2칸)를 고르면 그 안 숫자 셀의 합계·평균·개수·최소·최대를
+   * 즉석 계산한다. <b>새 집계를 구현하지 않고</b> #900 평가기의 {@link aggregate}(=수식과 같은
+   * `agg`, conformance로 BE와 교차검증)를 그대로 태워 이중화를 만들지 않는다. 문서 값엔 절대 안
+   * 샌다 — 화면 글랜스용. 로드된 셀만 본다(가상화). 숫자가 없으면 null(바 미표시).
+   */
+  const selectionSummary = ((): {
+    count: string;
+    sum: string;
+    avg: string;
+    min: string;
+    max: string;
+  } | null => {
+    if (sel?.kind !== "cells" || !selRect) return null;
+    const area = (selRect.r1 - selRect.r0 + 1) * (selRect.c1 - selRect.c0 + 1);
+    if (area < 2) return null;
+    const values: string[] = [];
+    for (let r = selRect.r0; r <= selRect.r1; r++) {
+      const cells = getRow(r);
+      if (!cells) continue;
+      for (let c = selRect.c0; c <= selRect.c1; c++)
+        values.push(cells[c] ?? "");
+    }
+    const count = aggregate("COUNT", values);
+    if (count.kind !== "num" || count.value === 0) return null;
+    return {
+      count: asCell(count),
+      sum: asCell(aggregate("SUM", values)),
+      avg: asCell(aggregate("AVERAGE", values)),
+      min: asCell(aggregate("MIN", values)),
+      max: asCell(aggregate("MAX", values)),
+    };
+  })();
+
   /** 채우기 프리뷰(드래그로 정해진 대상)에 든 셀인지 — 소스 열 범위 안이고 대상 행 범위 안. */
   const inFillTarget = (row: number, col: number): boolean =>
     !!fillTargetRows &&
@@ -1586,6 +1620,21 @@ export function DatasetGrid({
             </div>
           )}
         </div>
+
+        {/* 선택 범위 요약 — 셀 범위를 고르는 동안에만 뜨는 얇은 바(상태바 축소판). 표시 전용:
+          문서 값엔 안 새고, 계산은 평가기 aggregate 재사용(BE와 교차검증된 그 규칙). */}
+        {selectionSummary && (
+          <div
+            aria-label="선택 요약"
+            className="border-border text-muted-foreground flex items-center justify-end gap-4 border-t px-3 py-1 text-xs"
+          >
+            <span>개수 {selectionSummary.count}</span>
+            <span>합계 {selectionSummary.sum}</span>
+            <span>평균 {selectionSummary.avg}</span>
+            <span>최소 {selectionSummary.min}</span>
+            <span>최대 {selectionSummary.max}</span>
+          </div>
+        )}
 
         <ConfirmDialog
           open={pendingColDelete !== null}

--- a/fe/src/features/note/dataset/formula/aggregate.test.ts
+++ b/fe/src/features/note/dataset/formula/aggregate.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { aggregate, asCell } from "./index";
+
+/**
+ * `aggregate`는 선택 범위 요약(표시 전용)이 쓰는 공개 API다. 새 집계가 아니라 수식 평가와 같은
+ * `agg`를 태우므로 규칙(숫자만·에러 전파·빈/텍스트 스킵)이 conformance(BE 교차검증)와 같다.
+ * 여기선 그 격리 계약을 못박는다 — 순수 함수라 값·문서를 건드리지 않고 결과만 돌려준다.
+ */
+describe("aggregate (선택 요약 표시 전용)", () => {
+  const cell = (fn: "SUM" | "AVERAGE" | "COUNT" | "MIN" | "MAX", v: string[]) =>
+    asCell(aggregate(fn, v));
+
+  it("SUM은 숫자만 더한다", () => {
+    expect(cell("SUM", ["10", "20", "30"])).toBe("60");
+  });
+
+  it("AVERAGE는 평균(엔진 AVG로 매핑)", () => {
+    expect(cell("AVERAGE", ["10", "20", "30"])).toBe("20");
+  });
+
+  it("COUNT는 숫자 셀만 센다 — 빈·텍스트 스킵", () => {
+    expect(cell("COUNT", ["10", "", "x", "20"])).toBe("2");
+  });
+
+  it("MIN·MAX", () => {
+    expect(cell("MIN", ["10", "20", "5"])).toBe("5");
+    expect(cell("MAX", ["10", "20", "5"])).toBe("20");
+  });
+
+  it("에러 셀은 그대로 번진다(수식 집계와 같은 규칙)", () => {
+    expect(cell("SUM", ["10", "#VALUE!", "20"])).toBe("#VALUE!");
+  });
+
+  it("숫자가 없으면 COUNT는 0", () => {
+    expect(cell("COUNT", ["", "x"])).toBe("0");
+  });
+});

--- a/fe/src/features/note/dataset/formula/evaluator.ts
+++ b/fe/src/features/note/dataset/formula/evaluator.ts
@@ -242,6 +242,28 @@ function ref(
 }
 
 /** 집계. 숫자가 아닌 칸·빈 칸은 무시. 열이 없으면 #REF!, 셀이 에러면 번진다. */
+/**
+ * 값 목록의 집계(SUM/AVERAGE/COUNT/MIN/MAX). 선택 범위 요약(표시 전용) 같은 데서 쓴다.
+ *
+ * <p><b>새 집계 구현이 아니라</b> 수식 평가와 같은 {@link agg}를 그대로 태운다 — 숫자만 세고,
+ * 에러는 전파하고, 빈·텍스트는 스킵하는 규칙이 `conformance.test.ts`로 BE와 교차검증된 그것과
+ * 정확히 같다. 덕분에 "SUM이 무엇인가"가 한 곳에만 산다(이중화 없음). AVERAGE는 엔진 AVG로 맞춘다.
+ */
+export function aggregate(
+  func: "SUM" | "AVERAGE" | "COUNT" | "MIN" | "MAX",
+  values: string[],
+): FormulaValue {
+  const source: ValueSource = {
+    sameRow: () => undefined,
+    absolute: () => undefined,
+    column: () => values,
+  };
+  return agg(
+    { type: "agg", func: func === "AVERAGE" ? "AVG" : func, colKeys: ["_"] },
+    source,
+  );
+}
+
 function agg(
   node: Extract<FormulaNode, { type: "agg" }>,
   src: ValueSource,

--- a/fe/src/features/note/dataset/formula/index.ts
+++ b/fe/src/features/note/dataset/formula/index.ts
@@ -4,7 +4,7 @@
  */
 export type { FormulaContext, ValueSource } from "./context";
 export { FormulaSyntaxError } from "./context";
-export { evaluate, evaluateToCell } from "./evaluator";
+export { aggregate, evaluate, evaluateToCell } from "./evaluator";
 export { collectRefs, parseInput, parseStored } from "./parser";
 export type { FormulaValue } from "./value";
 export { asCell } from "./value";


### PR DESCRIPTION
## 이슈
closes #911

## 작업 내용
Epic #892 (a) 편집 UX — 부분범위 합계의 **모델-정직한 형태**. 영속 RANGE ref는 행 id 모델과 ~8개 하위 시스템에서 부딪히고 결과 자리도 없어(푸터는 "열 전체" 1개), **일시적 선택 요약**으로 간다 — 엑셀 상태바처럼 셀 범위를 고르는 동안에만 보이고 선택이 바뀌면 사라진다.

### 이중화 함정과 해소 (핵심)
FE 로컬 계산(왕복은 드래그를 죽이니 로컬이 맞다)은 "SUM이 무엇인가" 구현을 푸터(BE)와 요약(FE) 두 곳에 만들 위험이 있다. **해소**: 선택 요약은 **새 집계를 만들지 않고 #900 평가기의 `agg`를 그대로 호출**한다(`aggregate(fn, values)`). 그 평가기는 이미 `conformance.test.ts`로 BE `FormulaConformanceTest`와 교차검증된다 → 이중화가 "관리되는" 게 아니라 **애초에 안 생긴다**. 표시도 같은 `asCell`이라 별도 포맷터(세 번째 발산점)도 없다.

### 형태
- **`sel.kind==="cells"` && ≥2칸** 선택 시 숫자 셀의 개수·합계·평균·최소·최대를 즉석 표시.
- **표시 전용** — 저장·ref·전파·무효화 0. 문서 값·수식에 절대 안 샘. 순수 FE(로드된 셀 값).
- **자리**: 선택 시에만 나타났다 사라지는 얇은 바(표 하단). orino엔 상태바가 없어 이게 사실상 미래 상태바 자리가 된다. #880 우클릭 통일과 무관(읽기 전용 정보).

### 경계
- 행/열/표 선택은 열 혼합이라 제외(부분범위 실사용=셀 드래그). 숫자 없으면 미표시. 로드된 셀만(가상화) — 셀 드래그 범위는 대개 로드돼 실용상 정확. float 근사(글랜스용, 저장값 아님).

### 범위 밖
- 영속 부분범위 합계(RANGE ref) — 모델 설계 필요, 보류. 행/열/표 선택 요약.

## 테스트
- `aggregate` 격리 유닛 6건(SUM/AVERAGE/COUNT/MIN/MAX·텍스트 스킵·에러 전파) — 수식 집계와 같은 규칙 확인
- RTL 4건: 범위 선택→바에 합계/평균/개수, 텍스트 섞임 무시, 단일 셀·숫자 없음 미표시
- FE 459개 통과, prettier/eslint 통과. BE 변경 없음

## 확인
- 로컬 브라우저 실증은 미실행(풀스택 필요). 실제 컴포넌트+평가기를 타는 RTL 통합 테스트로 검증.