### PR TITLE
feat : 데이터 그리드 표 이름(표면) — 표간 참조 기반 (#916)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -19,6 +19,7 @@ import ds.project.orino.planner.dataset.dto.SetCellMergeRequest;
 import ds.project.orino.planner.dataset.dto.SetCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.SetColumnAlignRequest;
 import ds.project.orino.planner.dataset.dto.SetColumnSummaryRequest;
+import ds.project.orino.planner.dataset.dto.SetDatasetNameRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowResponse;
 import ds.project.orino.planner.dataset.service.DatasetService;
@@ -101,6 +102,15 @@ public class DatasetController {
             @PathVariable Long id,
             @Valid @RequestBody ReorderColumnsRequest request) {
         return ApiResponse.success(datasetService.reorderColumns(memberId, id, request));
+    }
+
+    /** 표 이름 설정/해제(멱등). 빈 값이면 무명으로. R9 표간 참조가 이름으로 표를 지목한다. */
+    @PatchMapping("/{id}/name")
+    public ApiResponse<DatasetResponse> setName(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @Valid @RequestBody SetDatasetNameRequest request) {
+        return ApiResponse.success(datasetService.setName(memberId, id, request.name()));
     }
 
     /** 한 셀의 수식을 그 열 전체에 채운다(계산 열 만들기). */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetResponse.java
@@ -18,12 +18,14 @@ import java.util.Map;
  */
 public record DatasetResponse(
         Long id,
+        String name,
         List<DatasetColumn> columns,
         int rowCount,
         Map<String, String> summaries
 ) {
     public static DatasetResponse of(Dataset dataset, List<DatasetColumn> columns,
                                      Map<String, String> summaries) {
-        return new DatasetResponse(dataset.getId(), columns, dataset.getRowCount(), summaries);
+        return new DatasetResponse(dataset.getId(), dataset.getName(), columns,
+                dataset.getRowCount(), summaries);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetDatasetNameRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetDatasetNameRequest.java
@@ -1,0 +1,13 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.Size;
+
+/**
+ * 표 이름 설정/해제 요청. 빈 값(null·공백)이면 무명으로 되돌린다. 유일성은 강제하지 않는다 —
+ * 표간 참조(#915)의 이름 해석은 현재 노트 안 표들 사이에서 FE가 다룬다.
+ */
+public record SetDatasetNameRequest(
+        @Size(max = 255, message = "표 이름은 255자 이하여야 합니다.")
+        String name
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -379,6 +379,18 @@ public class DatasetService {
         return metaResponse(dataset, updated);
     }
 
+    /**
+     * 표 이름을 설정/해제한다(멱등). 빈 값(공백·null)이면 무명으로 되돌린다. 유일성은 강제하지
+     * 않는다 — BE는 표가 어느 노트에 있는지 모르므로, 이름 해석은 #915에서 노트 단위(FE)로 한다.
+     */
+    @Transactional
+    public DatasetResponse setName(Long memberId, Long datasetId, String name) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        String trimmed = name == null || name.isBlank() ? null : name.trim();
+        dataset.updateName(trimmed);
+        return metaResponse(dataset, parseColumns(dataset.getColumns()));
+    }
+
     /** 메타 응답을 조립한다 — 요약 값(집계)을 계산해 함께 싣는다(#908). */
     private DatasetResponse metaResponse(Dataset dataset, List<DatasetColumn> columns) {
         return DatasetResponse.of(dataset, columns,

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/044-add-dataset-name.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/044-add-dataset-name.yaml
@@ -1,0 +1,29 @@
+databaseChangeLog:
+  # 표 이름 (R9 표간 참조 기반, #916).
+  #
+  # 지금 표(dataset)는 사용자용 이름이 없어 노트 안 여러 표를 구별할 수 없다. name을 두면
+  # 한 노트의 표들을 이름으로 가리킬 수 있고, 후속(#915) 표간 참조 수식이 {표!열}처럼 이름으로
+  # 대상 표를 지목한다. nullable — 무명 표(기존)는 그대로 두어 마이그레이션이 필요 없다.
+  - changeSet:
+      id: 044-add-dataset-name
+      author: wcorn
+      comment: dataset.name 추가 — 표 사용자용 이름(nullable).
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: dataset
+                columnName: name
+      changes:
+        - addColumn:
+            tableName: dataset
+            columns:
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: dataset
+            columnName: name

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -85,3 +85,5 @@ databaseChangeLog:
       file: db/changelog/changes/042-create-dataset-merge.yaml
   - include:
       file: db/changelog/changes/043-add-dataset-cell-style-valign.yaml
+  - include:
+      file: db/changelog/changes/044-add-dataset-name.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetNameTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetNameTest.java
@@ -1,0 +1,99 @@
+package ds.project.orino.planner.dataset.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** 표 이름 설정/해제(#916). 표간 참조(#915)의 기반 — 이 페이즈는 이름 저장·조회만. */
+class DatasetNameTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long datasetId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"columns\":[{\"key\":\"c0\",\"label\":\"금액\"}]}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        datasetId = ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private ResultActions setName(String bodyJson) throws Exception {
+        return mockMvc.perform(patch("/api/datasets/{id}/name", datasetId)
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(bodyJson));
+    }
+
+    private ResultActions meta() throws Exception {
+        return mockMvc.perform(get("/api/datasets/{id}", datasetId)
+                .header(HttpHeaders.AUTHORIZATION, authHeader));
+    }
+
+    @Test
+    @DisplayName("표는 기본적으로 무명이다")
+    void unnamedByDefault() throws Exception {
+        meta().andExpect(jsonPath("$.data.name").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("이름을 설정하면 저장되고 조회에 실린다")
+    void setNamePersists() throws Exception {
+        setName("{\"name\":\"도쿄\"}")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("도쿄"));
+        meta().andExpect(jsonPath("$.data.name").value("도쿄"));
+    }
+
+    @Test
+    @DisplayName("다시 설정하면 교체된다")
+    void renameReplaces() throws Exception {
+        setName("{\"name\":\"도쿄\"}").andExpect(status().isOk());
+        setName("{\"name\":\"오사카\"}")
+                .andExpect(jsonPath("$.data.name").value("오사카"));
+    }
+
+    @Test
+    @DisplayName("빈 값이면 무명으로 되돌린다")
+    void blankClearsName() throws Exception {
+        setName("{\"name\":\"도쿄\"}").andExpect(status().isOk());
+        setName("{\"name\":\"  \"}")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("255자를 넘으면 400")
+    void tooLongRejected() throws Exception {
+        String longName = "가".repeat(256);
+        setName("{\"name\":\"" + longName + "\"}").andExpect(status().isBadRequest());
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/Dataset.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/Dataset.java
@@ -29,6 +29,10 @@ public class Dataset {
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
+    /** 표 사용자용 이름(nullable). 노트 안 표 구별·표간 참조(#915)가 이름으로 지목한다. */
+    @Column(name = "name")
+    private String name;
+
     /** 열 메타 JSON 문자열: {@code [{"key","label"}, ...]}. */
     @Column(name = "columns_json", columnDefinition = "JSON", nullable = false)
     private String columns;
@@ -66,6 +70,11 @@ public class Dataset {
         this.columns = columns;
     }
 
+    /** 표 이름을 바꾼다. 빈 값(null)이면 무명으로 돌린다. */
+    public void updateName(String name) {
+        this.name = name;
+    }
+
     /** 열 key 하나를 발급하고 카운터를 올린다. */
     public int issueColumnSeq() {
         return nextColumnSeq++;
@@ -81,6 +90,10 @@ public class Dataset {
 
     public Long getMemberId() {
         return memberId;
+    }
+
+    public String getName() {
+        return name;
     }
 
     public String getColumns() {

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -2365,6 +2365,66 @@ describe("DatasetGrid", () => {
     expect(screen.queryByLabelText("선택 요약")).not.toBeInTheDocument();
   });
 
+  // ---------- 표 이름(#916) ----------
+
+  it("무명 표는 이름 자리에 placeholder를 보여준다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const input = await screen.findByLabelText("표 이름");
+    expect(input).toHaveValue("");
+    expect(input).toHaveAttribute("placeholder", "표 이름");
+  });
+
+  it("meta.name이 있으면 이름 칸에 그 값이 뜬다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            name: "요약",
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "점수" },
+            ],
+            rowCount: 1,
+          },
+        }),
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    expect(await screen.findByLabelText("표 이름")).toHaveValue("요약");
+  });
+
+  it("이름을 입력하고 벗어나면 PATCH로 저장한다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let patched: unknown = null;
+    server.use(
+      http.patch(`${API_BASE}/datasets/1/name`, async ({ request }) => {
+        patched = await request.json();
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            name: "도쿄",
+            columns: [
+              { key: "c0", label: "과목" },
+              { key: "c1", label: "점수" },
+            ],
+            rowCount: 1,
+            summaries: {},
+          },
+        });
+      }),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const input = await screen.findByLabelText("표 이름");
+    fireEvent.change(input, { target: { value: "도쿄" } });
+    fireEvent.blur(input);
+    await waitFor(() => expect(patched).toEqual({ name: "도쿄" }));
+  });
+
   it("우클릭 메뉴에서 배경색을 고르면 선택한 셀에 일괄 PUT한다", async () => {
     mockDataset([["네트워크", "92"]]);
     let sentCells: unknown = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -44,6 +44,7 @@ import {
   setCellMerge,
   setCellStylesBulk,
   setColumnSummary,
+  setDatasetName,
   type SummaryFn,
   updateDatasetRow,
 } from "./api/datasets";
@@ -276,6 +277,16 @@ export function DatasetGrid({
     onSuccess: (next: DatasetMeta) =>
       queryClient.setQueryData(datasetKeys.meta(datasetId), next),
     onError: () => void invalidateMeta(),
+  });
+  // 표 이름 설정/해제. 응답 메타로 캐시를 맞춰 이름이 즉시 반영된다.
+  const nameMut = useMutation({
+    mutationFn: (name: string) => setDatasetName(datasetId, name),
+    onSuccess: (next: DatasetMeta) =>
+      queryClient.setQueryData(datasetKeys.meta(datasetId), next),
+    onError: (e) => {
+      const message = serverMessage(e);
+      if (message) toast(message, "error");
+    },
   });
   // 열 푸터 요약 설정/해제. 응답 메타엔 계산된 summaries가 실려 있어 푸터가 즉시 맞는다.
   const summaryMut = useMutation({
@@ -1335,6 +1346,22 @@ export function DatasetGrid({
     // 바깥 래퍼: 표 아래·오른쪽에 얇은 여백(gutter)을 확보해 행/열 추가 바를 표 "밖"에 둔다.
     // → 추가 바가 가장자리 셀을 가리지 않고, 그 자리(아래/오른쪽)에 호버할 때만 각각 나타난다.
     <div className="relative my-2 pr-5 pb-5">
+      {/* 표 이름 — 노트 안 표를 구별하고, 표간 참조(#915)가 이름으로 지목한다. 무명이면
+        placeholder. 편집을 닫으면(Enter·blur) 바뀐 값만 저장한다. meta.name 변경 시 key로 리셋. */}
+      <input
+        key={meta.name ?? ""}
+        aria-label="표 이름"
+        defaultValue={meta.name ?? ""}
+        placeholder="표 이름"
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur();
+        }}
+        onBlur={(e) => {
+          const value = e.currentTarget.value.trim();
+          if (value !== (meta.name ?? "")) nameMut.mutate(value);
+        }}
+        className="text-foreground placeholder:text-muted-foreground/50 mb-1 w-full border-0 bg-transparent px-0.5 text-sm font-medium outline-none"
+      />
       <div
         ref={gridBoxRef}
         // 셀 선택 시 이 컨테이너로 포커스가 와 키 입력을 직접 받는다(에디터로 새지 않게).

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -65,6 +65,8 @@ export interface MergeView {
 
 export interface DatasetMeta {
   id: number;
+  /** 표 사용자용 이름. 없으면 무명. 노트 안 표 구별·표간 참조(#915)가 이름으로 지목한다. */
+  name?: string;
   columns: DatasetColumn[];
   rowCount: number;
   /**
@@ -274,6 +276,20 @@ export async function updateDatasetRow(
   const { data } = await client.patch<ApiEnvelope<UpdateRowResult>>(
     `/datasets/${datasetId}/rows/${rowIndex}`,
     { cells },
+  );
+  return data.data;
+}
+
+/**
+ * 표 이름 설정/해제(멱등). 빈 값이면 무명으로. 갱신된 메타를 돌려준다 — 캐시에 바로 반영.
+ */
+export async function setDatasetName(
+  datasetId: number,
+  name: string,
+): Promise<DatasetMeta> {
+  const { data } = await client.patch<ApiEnvelope<DatasetMeta>>(
+    `/datasets/${datasetId}/name`,
+    { name },
   );
   return data.data;
 }


### PR DESCRIPTION
## 이슈
closes #916

## 작업 내용
R9(표간 참조 #915)의 **기반 프리미티브** — 표에 사용자용 이름을 부여한다. **이 PR엔 수식/참조가 없다**: 표가 이름을 갖고, 저장되고, UI에 보이고, 응답에 실리는 것까지만. 표간 참조 문법·ref 확장은 후속(#915).

리스크 분리(#907/#908 패턴): "표 이름이라는 신설 개념"(이 PR)과 "표간 참조 엔진"(#915)은 서로 다른 이유로 틀어지므로 각자의 리뷰·롤백 단위를 갖는다. 표 이름은 그 자체로도 유용(한 노트에 여러 표 구별).

### BE
- `Dataset.name`(nullable VARCHAR) + Liquibase `044-add-dataset-name`. null이면 무명(기존 그대로, 마이그레이션 무해).
- `PATCH /datasets/{id}/name` `{name|null}` — 멱등 설정/해제, 빈 값(공백)이면 무명으로.
- `DatasetResponse.name`에 실어 내림.
- **유일성은 BE에서 강제하지 않는다** — BE는 표가 어느 노트에 있는지 모른다(noteId 없음). 표간 참조의 이름 해석은 #915에서 **현재 노트 안 표들 사이**(FE 스코프)에서 다룬다.

### FE
- `DatasetMeta.name` 타입 + 표 위 편집 가능한 이름(무명이면 placeholder "표 이름"). Enter·blur로 저장, 응답 메타로 즉시 반영.
- `setDatasetName` API.

### 후속 (#915 표간 참조 배선)
- 수식 문법 `{표!열}`, ref 모델 표간 확장(대상 datasetId), 표간 전파·순환, 평가. v1은 같은 노트 안 표끼리.

## 테스트
- BE 5건: 기본 무명, 설정·조회, 재설정 교체, 빈 값 해제, 255자 초과 400
- FE 3건: 무명 placeholder, meta.name 표시, 입력→blur→PATCH
- FE 462개·BE checkstyle·전체 dataset 테스트 통과(마이그레이션 TestContainers 적용)

## 확인
- 로컬 브라우저 실증은 미실행(풀스택 필요). 마이그레이션+엔드포인트는 TestContainers MySQL, UI는 RTL로 검증.