### PR TITLE
feat : 수식 표간 절대셀 참조 BE 엔진 (R9 #918)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/UpdateRowRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/UpdateRowRequest.java
@@ -3,9 +3,19 @@ package ds.project.orino.planner.dataset.dto;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
+import java.util.Map;
 
+/**
+ * 행 수정 요청.
+ *
+ * <p>{@code tableRefs}는 표간 참조({@code ={요약!환율}1})의 <b>표 이름 → 대상 표 id</b> 맵이다.
+ * 표 이름은 노트 안에서만 유일하고 BE는 노트 스코프를 모르므로, 이 수식이 참조하는 표들을 FE가
+ * 노트 기준으로 해석해 넘긴다. 표간 참조가 없으면 null이어도 된다. 대상 표가 같은 회원 것인지는
+ * BE가 검증한다(남의 표 참조 차단).
+ */
 public record UpdateRowRequest(
         @NotNull(message = "cells는 필수입니다.")
-        List<String> cells
+        List<String> cells,
+        Map<String, Long> tableRefs
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaContext.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaContext.java
@@ -23,4 +23,26 @@ public interface FormulaContext {
 
     /** 행 id → 현재 행 번호(1-base). 표시할 때. 지워진 행이면 empty. */
     Optional<Integer> rowNumberById(long rowId);
+
+    /**
+     * 표 이름 → 대상 표 id. 표간 참조({@code {요약!환율}1})의 표 이름을 해석한다. 이름은 노트
+     * 안에서만 유일하므로 FE가 준 {@code tableRefs} 맵으로 푼다. 없거나 접근 불가면 empty.
+     * 표간 참조를 지원하지 않는 컨텍스트(테스트 등)는 기본 empty.
+     */
+    default Optional<Long> tableIdByName(String name) {
+        return Optional.empty();
+    }
+
+    /** 대상 표 id → 이름. 표간 참조 표시용. 지워졌거나 무명이면 empty. */
+    default Optional<String> tableNameById(long datasetId) {
+        return Optional.empty();
+    }
+
+    /**
+     * 대상 표의 열·행을 보는 컨텍스트. 표간 참조는 열 label·행 번호를 <b>대상 표</b> 기준으로
+     * 해석해야 한다. 기본은 자기 자신(표간 미지원 컨텍스트는 같은 표로 본다).
+     */
+    default FormulaContext forDataset(long datasetId) {
+        return this;
+    }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaEvaluator.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaEvaluator.java
@@ -32,6 +32,14 @@ public final class FormulaEvaluator {
 
         /** 열 전체 값. 열이 없으면 empty. */
         Optional<List<String>> column(String colKey);
+
+        /**
+         * 표간 절대셀({@code {요약!환율}1})의 <b>대상 표</b> 셀. 표간 참조를 지원하지 않는
+         * 소스(테스트 등)는 기본 empty → {@code #REF!}.
+         */
+        default Optional<String> crossAbsolute(long datasetId, long rowId, String colKey) {
+            return Optional.empty();
+        }
     }
 
     private FormulaEvaluator() {
@@ -207,9 +215,15 @@ public final class FormulaEvaluator {
 
     /** 참조 → 셀 내용을 타입으로. 빈 칸은 0(엑셀식), 숫자는 Num, 에러 문자열은 번지고, 그 외는 Text. */
     private static FormulaValue ref(FormulaNode.Ref r, ValueSource src) {
-        Optional<String> raw = r.kind() == FormulaRefKind.ABSOLUTE
-                ? src.absolute(r.rowId(), r.colKey())
-                : src.sameRow(r.colKey());
+        Optional<String> raw;
+        if (r.kind() == FormulaRefKind.ABSOLUTE) {
+            // 표간 참조(datasetId 있음)는 대상 표의 셀을, 아니면 이 표의 셀을 읽는다.
+            raw = r.datasetId() == null
+                    ? src.absolute(r.rowId(), r.colKey())
+                    : src.crossAbsolute(r.datasetId(), r.rowId(), r.colKey());
+        } else {
+            raw = src.sameRow(r.colKey());
+        }
         if (raw.isEmpty()) {
             return new FormulaValue.Err(FormulaValue.Err.REF);
         }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaNode.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaNode.java
@@ -43,8 +43,18 @@ public sealed interface FormulaNode {
      *   <li>{@link FormulaRefKind#SAME_ROW} — {@code rowId}는 null. 각 행이 자기 행을 가리킨다
      *   <li>{@link FormulaRefKind#ABSOLUTE} — {@code rowId}에 값
      * </ul>
+     *
+     * <p>{@code datasetId}는 <b>표간 참조</b>({@code ={요약!환율}1})의 대상 표다. null이면 같은
+     * 표(대부분). 표간은 대상 셀이 다른 표에 있어 ABSOLUTE(특정 행)만 의미가 있다 — 같은 표가
+     * 아니면 "같은 행"이 정의되지 않는다. {@code colKey}·{@code rowId}는 <b>대상 표 기준</b>이다.
      */
-    record Ref(FormulaRefKind kind, String colKey, Long rowId) implements FormulaNode {
+    record Ref(FormulaRefKind kind, String colKey, Long rowId, Long datasetId)
+            implements FormulaNode {
+
+        /** 같은 표 참조(대부분) — datasetId 없이. */
+        public Ref(FormulaRefKind kind, String colKey, Long rowId) {
+            this(kind, colKey, rowId, null);
+        }
     }
 
     /**

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaParser.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaParser.java
@@ -357,16 +357,23 @@ public final class FormulaParser {
         if (close < 0) {
             throw syntaxError("열 이름을 닫는 '}'가 없습니다");
         }
-        String name = src.substring(pos, close);
+        String content = src.substring(pos, close);
         pos = close + 1;
-        if (name.isBlank()) {
+        if (content.isBlank()) {
             throw syntaxError("열 이름이 비었습니다");
         }
 
-        String key = resolveKey(name);
-        Long rowId = rowSuffix();
+        // 표간 참조 {표!열}행 — '!' 앞은 표(입력형 이름·저장형 id), 뒤는 대상 표의 열.
+        int bang = content.indexOf('!');
+        if (bang >= 0) {
+            return crossRef(content.substring(0, bang).trim(),
+                    content.substring(bang + 1).trim(), columnOnly);
+        }
+
+        String key = resolveKey(ctx, content);
+        Long rowId = rowSuffix(ctx);
         if (rowId != null && columnOnly) {
-            throw syntaxError("집계 함수 안에서는 행을 지정할 수 없습니다: {" + name + "}");
+            throw syntaxError("집계 함수 안에서는 행을 지정할 수 없습니다: {" + content + "}");
         }
         if (columnOnly) {
             return new FormulaNode.Ref(FormulaRefKind.COLUMN_ALL, key, null);
@@ -376,19 +383,51 @@ public final class FormulaParser {
                 : new FormulaNode.Ref(FormulaRefKind.ABSOLUTE, key, rowId);
     }
 
-    private String resolveKey(String name) {
+    /**
+     * 표간 절대셀 참조 {@code {표!열}행}(#918). 대상 표를 해석하고 열·행을 <b>대상 표 기준</b>으로
+     * 푼다. 다른 표엔 "같은 행"이 없으므로 행 번호가 반드시 있어야 한다(ABSOLUTE).
+     */
+    private FormulaNode crossRef(String tablePart, String colPart, boolean columnOnly) {
+        if (columnOnly) {
+            // 표간 집계(=SUM({표!열}))는 다음 슬라이스(#915a-2)에서 다룬다.
+            throw syntaxError("표간 집계는 아직 지원하지 않습니다: {" + tablePart + "!" + colPart + "}");
+        }
+        long targetId = resolveTable(tablePart);
+        FormulaContext target = ctx.forDataset(targetId);
+        String key = resolveKey(target, colPart);
+        Long rowId = rowSuffix(target);
+        if (rowId == null) {
+            throw syntaxError("표간 셀 참조는 행 번호가 필요합니다: {" + tablePart + "!" + colPart + "}");
+        }
+        return new FormulaNode.Ref(FormulaRefKind.ABSOLUTE, key, rowId, targetId);
+    }
+
+    /** 표 부분 → 대상 표 id. 저장형은 datasetId 숫자, 입력형은 표 이름(FE tableRefs로 해석). */
+    private long resolveTable(String tablePart) {
         if (stored) {
-            if (!ctx.columnKeys().contains(name)) {
+            try {
+                return Long.parseLong(tablePart);
+            } catch (NumberFormatException e) {
+                throw syntaxError("잘못된 표 id: " + tablePart);
+            }
+        }
+        return ctx.tableIdByName(tablePart)
+                .orElseThrow(() -> syntaxError("없는 표: " + tablePart));
+    }
+
+    private String resolveKey(FormulaContext c, String name) {
+        if (stored) {
+            if (!c.columnKeys().contains(name)) {
                 throw syntaxError("없는 열: " + name);
             }
             return name;
         }
-        return ctx.keyByLabel(name)
+        return c.keyByLabel(name)
                 .orElseThrow(() -> syntaxError("없는 열: " + name));
     }
 
-    /** 행 지정을 읽는다. 없으면 null. 저장형은 {@code @id}, 입력형은 화면 행 번호. */
-    private Long rowSuffix() {
+    /** 행 지정을 읽는다. 없으면 null. 저장형은 {@code @id}, 입력형은 화면 행 번호(그 표 기준). */
+    private Long rowSuffix(FormulaContext c) {
         if (stored) {
             if (peek() != '@') {
                 return null;
@@ -401,7 +440,7 @@ public final class FormulaParser {
         }
         long number = digits("행 번호");
         // 화면 번호 → 행 id. 파싱 시점에 한 번만 해석하므로 이후 행이 밀려도 안 깨진다.
-        return ctx.rowIdByNumber((int) number)
+        return c.rowIdByNumber((int) number)
                 .orElseThrow(() -> syntaxError("없는 행: " + number));
     }
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaWriter.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaWriter.java
@@ -91,12 +91,34 @@ public final class FormulaWriter {
                 sb.append(')');
             }
             case FormulaNode.Ref r -> {
-                sb.append('{').append(name(r.colKey(), ctx)).append('}');
-                if (r.kind() == FormulaRefKind.ABSOLUTE) {
-                    sb.append(rowToken(r.rowId(), ctx));
+                if (r.datasetId() != null) {
+                    writeCrossRef(r, sb, ctx);
+                } else {
+                    sb.append('{').append(name(r.colKey(), ctx)).append('}');
+                    if (r.kind() == FormulaRefKind.ABSOLUTE) {
+                        sb.append(rowToken(r.rowId(), ctx));
+                    }
                 }
             }
         }
+    }
+
+    /**
+     * 표간 절대셀 참조. 저장형 {@code {datasetId!colKey}@rowId}, 표시형 {@code {표이름!열}행번호}.
+     * 표시형은 대상 표 기준으로 이름·label·행번호를 해석한다({@link FormulaContext#forDataset}).
+     */
+    private static void writeCrossRef(FormulaNode.Ref r, StringBuilder sb, FormulaContext ctx) {
+        long dsId = r.datasetId();
+        if (ctx == null) {
+            sb.append('{').append(dsId).append('!').append(r.colKey()).append('}')
+                    .append('@').append(r.rowId());
+            return;
+        }
+        FormulaContext target = ctx.forDataset(dsId);
+        String table = ctx.tableNameById(dsId).orElse("#REF!");
+        String col = target.labelByKey(r.colKey()).orElse("#REF!");
+        String row = target.rowNumberById(r.rowId()).map(String::valueOf).orElse("#REF!");
+        sb.append('{').append(table).append('!').append(col).append('}').append(row);
     }
 
     private static String name(String key, FormulaContext ctx) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
@@ -97,8 +97,10 @@ public class DatasetFormulaService {
      *                 같은 요청에서 바뀐 값을 즉시 반영하기 위함이다.
      */
     String saveAndEvaluate(Long datasetId, DatasetRow row, String colKey, String input,
-                           List<DatasetColumn> columns, Map<String, String> rowCells) {
-        FormulaContext ctx = new DbContext(datasetId, columns);
+                           List<DatasetColumn> columns, Map<String, String> rowCells,
+                           Map<String, Long> tableRefs, Long memberId) {
+        // 표간 참조 이름 해석·소유권 검증에 tableRefs·memberId가 필요하다(입력 파싱 한정).
+        FormulaContext ctx = new DbContext(datasetId, columns, tableRefs, memberId);
         FormulaNode node = FormulaParser.parseInput(input, ctx);
 
         DatasetFormula formula = formulaRepository.findByRowIdAndColKey(row.getId(), colKey)
@@ -474,8 +476,10 @@ public class DatasetFormulaService {
     private DatasetFormulaRef toEntity(Long formulaId, Long datasetId, FormulaNode.Ref ref) {
         return switch (ref.kind()) {
             case SAME_ROW -> DatasetFormulaRef.sameRow(formulaId, datasetId, ref.colKey());
-            case ABSOLUTE -> DatasetFormulaRef.absolute(formulaId, datasetId, ref.rowId(),
-                    ref.colKey());
+            case ABSOLUTE -> ref.datasetId() == null
+                    ? DatasetFormulaRef.absolute(formulaId, datasetId, ref.rowId(), ref.colKey())
+                    : DatasetFormulaRef.crossAbsolute(formulaId, datasetId, ref.datasetId(),
+                            ref.rowId(), ref.colKey());
             case COLUMN_ALL -> DatasetFormulaRef.columnAll(formulaId, datasetId, ref.colKey());
         };
     }
@@ -484,10 +488,21 @@ public class DatasetFormulaService {
     private final class DbContext implements FormulaContext {
         private final Long datasetId;
         private final List<DatasetColumn> columns;
+        // 표간 참조 이름 해석용(입력 파싱). 이름→대상 표 id. null이면 표간 이름 해석 불가(recompute).
+        private final Map<String, Long> tableRefs;
+        // 표간 대상 소유권 검증용. null이면 검증 없이(recompute — 저장 때 이미 검증됨).
+        private final Long memberId;
 
         private DbContext(Long datasetId, List<DatasetColumn> columns) {
+            this(datasetId, columns, null, null);
+        }
+
+        private DbContext(Long datasetId, List<DatasetColumn> columns,
+                          Map<String, Long> tableRefs, Long memberId) {
             this.datasetId = datasetId;
             this.columns = columns;
+            this.tableRefs = tableRefs;
+            this.memberId = memberId;
         }
 
         @Override
@@ -523,6 +538,37 @@ public class DatasetFormulaService {
             return rowRepository.findById(rowId)
                     .filter(r -> r.getDatasetId().equals(datasetId))
                     .map(r -> r.getRowIndex() + 1);
+        }
+
+        @Override
+        public Optional<Long> tableIdByName(String name) {
+            if (tableRefs == null) {
+                return Optional.empty();
+            }
+            Long id = tableRefs.get(name);
+            if (id == null) {
+                return Optional.empty();
+            }
+            // 남의 표 참조 차단 — 대상이 같은 회원 것일 때만 해석된다(없으면 "없는 표").
+            boolean owned = memberId != null
+                    && datasetRepository.findByIdAndMemberId(id, memberId).isPresent();
+            return owned ? Optional.of(id) : Optional.empty();
+        }
+
+        @Override
+        public Optional<String> tableNameById(long targetId) {
+            return datasetRepository.findById(targetId)
+                    .map(d -> d.getName())
+                    .filter(n -> n != null && !n.isBlank());
+        }
+
+        @Override
+        public FormulaContext forDataset(long targetId) {
+            // 대상 표의 열로 새 컨텍스트. 지워졌으면 빈 열 → 열·행 해석이 empty → #REF!.
+            List<DatasetColumn> targetColumns = datasetRepository.findById(targetId)
+                    .map(d -> DatasetColumns.parse(d.getColumns()))
+                    .orElseGet(List::of);
+            return new DbContext(targetId, targetColumns, tableRefs, memberId);
         }
     }
 
@@ -611,6 +657,15 @@ public class DatasetFormulaService {
             }
             return rowRepository.findById(rowId)
                     .filter(r -> r.getDatasetId().equals(datasetId))
+                    .map(r -> DatasetCells.parse(r.getCells()).getOrDefault(colKey, ""));
+        }
+
+        /** 표간 절대셀 — 대상 표의 그 행·열 값. 행이 없거나 대상 표가 다르면 empty → #REF!. */
+        @Override
+        public Optional<String> crossAbsolute(long targetDatasetId, long targetRowId,
+                                              String colKey) {
+            return rowRepository.findById(targetRowId)
+                    .filter(r -> r.getDatasetId().equals(targetDatasetId))
                     .map(r -> DatasetCells.parse(r.getCells()).getOrDefault(colKey, ""));
         }
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -543,7 +543,8 @@ public class DatasetService {
         // 그 재계산은 전파(#813)가 맡는다.
         for (Map.Entry<String, String> entry : formulas.entrySet()) {
             cells.put(entry.getKey(), formulaService.saveAndEvaluate(
-                    datasetId, row, entry.getKey(), entry.getValue(), columns, cells));
+                    datasetId, row, entry.getKey(), entry.getValue(), columns, cells,
+                    request.tableRefs(), memberId));
         }
 
         Map<String, String> before = DatasetCells.parse(row.getCells());

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/045-add-formula-ref-to-dataset-id.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/045-add-formula-ref-to-dataset-id.yaml
@@ -1,0 +1,31 @@
+databaseChangeLog:
+  # 표간 참조(R9 #918) — 수식 참조의 대상 표.
+  #
+  # 지금 참조는 formula가 사는 그 표 안으로만 향한다(dataset_id는 formula의 표, 역방향 조회를
+  # 좁히는 비정규화). 표간 절대셀 참조({요약!환율}1)는 대상 셀이 <b>다른 표</b>에 있다.
+  # to_dataset_id에 대상 표를 담는다 — nullable, null이면 같은 표(기존 동작 그대로, 마이그레이션
+  # 불필요). to_row_id처럼 FK를 두지 않는다: 대상 표가 지워져도 참조가 끊긴 채 남아 #REF!의
+  # 근거가 되게 한다.
+  - changeSet:
+      id: 045-add-formula-ref-to-dataset-id
+      author: wcorn
+      comment: dataset_formula_ref.to_dataset_id 추가 — 표간 참조의 대상 표(nullable).
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: dataset_formula_ref
+                columnName: to_dataset_id
+      changes:
+        - addColumn:
+            tableName: dataset_formula_ref
+            columns:
+              - column:
+                  name: to_dataset_id
+                  type: BIGINT
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: dataset_formula_ref
+            columnName: to_dataset_id

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -87,3 +87,5 @@ databaseChangeLog:
       file: db/changelog/changes/043-add-dataset-cell-style-valign.yaml
   - include:
       file: db/changelog/changes/044-add-dataset-name.yaml
+  - include:
+      file: db/changelog/changes/045-add-formula-ref-to-dataset-id.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetCrossRefTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetCrossRefTest.java
@@ -1,0 +1,146 @@
+package ds.project.orino.planner.dataset.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 표간 절대셀 참조(R9 #918). A표({@code 도시})의 수식이 B표({@code 요약})의 셀을 읽어 계산한다.
+ * 반응성(표간 전파)은 이 슬라이스 밖(#915b) — 저장 시 정확 계산까지.
+ */
+class DatasetCrossRefTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long cityId;    // A: 금액(c0)·원화(c1)
+    private long summaryId; // B: 환율(c0), 이름 "요약", 1행 = 1300
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        cityId = create("[{\"key\":\"c0\",\"label\":\"금액\"},{\"key\":\"c1\",\"label\":\"원화\"}]");
+        mockMvc.perform(post("/api/datasets/{id}/rows/bulk", cityId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rows\":[[\"100\",\"\"]]}"))
+                .andExpect(status().isOk());
+
+        summaryId = create("[{\"key\":\"c0\",\"label\":\"환율\"}]");
+        mockMvc.perform(patch("/api/datasets/{id}/name", summaryId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"요약\"}"))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/api/datasets/{id}/rows/bulk", summaryId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rows\":[[\"1300\"]]}"))
+                .andExpect(status().isOk());
+    }
+
+    private long create(String columnsJson) throws Exception {
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"columns\":" + columnsJson + "}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    /** cityId의 한 행을 tableRefs와 함께 수정. */
+    private ResultActions patchCity(String cells, String tableRefs) throws Exception {
+        return mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", cityId, 0)
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cells\":" + cells + ",\"tableRefs\":" + tableRefs + "}"));
+    }
+
+    private ResultActions cityRows() throws Exception {
+        return mockMvc.perform(get("/api/datasets/{id}/rows", cityId)
+                .header(HttpHeaders.AUTHORIZATION, authHeader));
+    }
+
+    @Test
+    @DisplayName("A표 수식이 B표 셀을 읽어 계산한다 — 핵심")
+    void crossTableCellIsRead() throws Exception {
+        // 원화 = 금액 * 요약!환율(1300) = 100 * 1300 = 130000.
+        patchCity("[\"100\",\"={금액} * {요약!환율}1\"]", "{\"요약\":" + summaryId + "}")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.edited.cells[1]").value("130000"));
+
+        // 표시형은 표 이름·열 label·행 번호로 되돌아온다.
+        cityRows().andExpect(jsonPath("$.data.rows[0].cells[1]").value("130000"))
+                .andExpect(jsonPath("$.data.rows[0].formulas.c1")
+                        .value("=({금액} * {요약!환율}1)"));
+    }
+
+    @Test
+    @DisplayName("순수 표간 셀 참조")
+    void pureCrossCell() throws Exception {
+        patchCity("[\"100\",\"={요약!환율}1\"]", "{\"요약\":" + summaryId + "}")
+                .andExpect(jsonPath("$.data.edited.cells[1]").value("1300"));
+    }
+
+    @Test
+    @DisplayName("tableRefs에 없는 표 이름은 400")
+    void unknownTableNameRejected() throws Exception {
+        patchCity("[\"100\",\"={없는표!환율}1\"]", "{\"요약\":" + summaryId + "}")
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("내 것이 아닌 표(없는 id)는 400 — 남의 표 참조 차단")
+    void notOwnedTableRejected() throws Exception {
+        patchCity("[\"100\",\"={요약!환율}1\"]", "{\"요약\":999999}")
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("대상 표에 없는 행이면 400")
+    void missingTargetRowRejected() throws Exception {
+        // 요약 표는 1행뿐인데 2행을 가리킨다.
+        patchCity("[\"100\",\"={요약!환율}2\"]", "{\"요약\":" + summaryId + "}")
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("표간 자동 재계산은 이 슬라이스 밖 — 대상이 바뀌어도 재저장 전엔 옛 값(#915b)")
+    void noCrossPropagationYet() throws Exception {
+        patchCity("[\"100\",\"={요약!환율}1\"]", "{\"요약\":" + summaryId + "}")
+                .andExpect(jsonPath("$.data.edited.cells[1]").value("1300"));
+
+        // 요약 표의 환율을 1300 → 1400으로 바꾼다.
+        mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", summaryId, 0)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"1400\"]}"))
+                .andExpect(status().isOk());
+
+        // 표간 전파가 없으니 도시 표는 아직 1300(재저장하면 1400). #915b에서 자동 갱신된다.
+        cityRows().andExpect(jsonPath("$.data.rows[0].cells[1]").value("1300"));
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetFormulaRef.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetFormulaRef.java
@@ -42,34 +42,50 @@ public class DatasetFormulaRef {
     @Column(name = "to_col_key", nullable = false, length = 64)
     private String toColKey;
 
+    /**
+     * 표간 참조({요약!환율}1)의 대상 표. null이면 같은 표(기존). FK를 두지 않아 대상 표가
+     * 지워져도 참조가 끊긴 채 남아 #REF!의 근거가 된다(to_row_id와 같은 규칙).
+     */
+    @Column(name = "to_dataset_id")
+    private Long toDatasetId;
+
     protected DatasetFormulaRef() {
     }
 
     private DatasetFormulaRef(Long formulaId, Long datasetId, FormulaRefKind toKind,
-                             Long toRowId, String toColKey) {
+                             Long toRowId, String toColKey, Long toDatasetId) {
         this.formulaId = formulaId;
         this.datasetId = datasetId;
         this.toKind = toKind;
         this.toRowId = toRowId;
         this.toColKey = toColKey;
+        this.toDatasetId = toDatasetId;
     }
 
     /** 같은 행의 열 참조({@code =c0*c1}). */
     public static DatasetFormulaRef sameRow(Long formulaId, Long datasetId, String toColKey) {
-        return new DatasetFormulaRef(formulaId, datasetId, FormulaRefKind.SAME_ROW, null, toColKey);
+        return new DatasetFormulaRef(formulaId, datasetId, FormulaRefKind.SAME_ROW, null, toColKey,
+                null);
     }
 
     /** 특정 행의 열 참조({@code =B5}). */
     public static DatasetFormulaRef absolute(Long formulaId, Long datasetId, Long toRowId,
                                              String toColKey) {
         return new DatasetFormulaRef(formulaId, datasetId, FormulaRefKind.ABSOLUTE, toRowId,
-                toColKey);
+                toColKey, null);
     }
 
     /** 열 전체 참조({@code =SUM(c2)}). */
     public static DatasetFormulaRef columnAll(Long formulaId, Long datasetId, String toColKey) {
         return new DatasetFormulaRef(formulaId, datasetId, FormulaRefKind.COLUMN_ALL, null,
-                toColKey);
+                toColKey, null);
+    }
+
+    /** 표간 절대셀 참조({@code ={요약!환율}1}). 대상 표({@code toDatasetId})의 특정 행·열. */
+    public static DatasetFormulaRef crossAbsolute(Long formulaId, Long datasetId, Long toDatasetId,
+                                                  Long toRowId, String toColKey) {
+        return new DatasetFormulaRef(formulaId, datasetId, FormulaRefKind.ABSOLUTE, toRowId,
+                toColKey, toDatasetId);
     }
 
     public Long getId() {
@@ -94,5 +110,10 @@ public class DatasetFormulaRef {
 
     public String getToColKey() {
         return toColKey;
+    }
+
+    /** 표간 참조의 대상 표. null이면 같은 표. */
+    public Long getToDatasetId() {
+        return toDatasetId;
     }
 }


### PR DESCRIPTION
## 이슈
관련 #918 (이 PR은 BE 엔진 — FE 피커는 후속 PR)

## 작업 내용
R9 표간 참조(#915)의 첫 슬라이스 **표간 절대셀 참조**의 BE 엔진. A표(도시) 수식이 B표(요약)의 셀을 읽어 계산: `={요약!환율}1`. #916(표 이름) 위에 얹는다.

### 설계 (조사에서 도출된 제약)
- **이름→id 해석은 FE 몫**: BE는 노트 스코프를 몰라 표 이름을 못 푼다. FE가 노트 안 표들로 이름을 datasetId로 해석해 **`updateRow`의 `tableRefs: {이름→datasetId}` 맵**으로 넘긴다. BE는 그 맵으로 이름을 풀고 **대상 표 기준**으로 열 label→key·행번호→rowId를 해석한다.
- **저장은 datasetId로**(`dataset_formula_ref.to_dataset_id`, 마이그레이션 045). **표시는 BE가 재해석**(datasetId→#916 이름, key→label, rowId→행번호).
- **인가**: tableRefs의 대상 datasetId가 같은 회원 것일 때만 해석(남의 표 참조 차단).

### 엔진 변경 (기존 호환)
- `FormulaNode.Ref`에 nullable `datasetId` + **3-arg 위임 생성자** → 기존 참조 코드 무변경.
- 파서: `{표!열}행` 문법. `FormulaContext`에 표이름 해석·대상 표 뷰(`forDataset`) **default 메서드**로 추가 → 기존 구현체(테스트) 무변경.
- `FormulaWriter`: 표시형 `{요약!환율}1` / 저장형 `{42!c3}@rowId`.
- `FormulaEvaluator.ValueSource.crossAbsolute` (default) → `DbValues`가 대상 표 셀 읽기.

### 범위 밖
- 표간 집계 `SUM({표!열})` → #915a-2. 표간 자동 재계산(전파·순환) → #915b(저장 시 정확 계산까지, 대상 바뀌면 재저장 — 테스트로 문서화).
- **FE 피커** — 후속 PR(노트 형제 표 배선 + 참조 삽입 UI + tableRefs 전송).

## 테스트
- BE 통합 6건: A가 B 셀 읽어 계산, 순수 표간 셀, 표시 재해석, 없는 표 이름 400, 남의/없는 표 400, 없는 행 400, 표간 전파 부재(문서화)
- 기존 conformance·파서·전파 테스트 그대로 통과, checkstyle·전체 dataset 테스트 통과

## 확인
- 로컬 브라우저 실증은 미실행(FE 피커 후속). BE 엔진은 TestContainers MySQL 통합 테스트로 end-to-end 검증(마이그레이션 포함).