### PR TITLE
feat : 수식 표간 참조 피커 FE (R9 #918 완결)

### DIFF
--- a/fe/src/features/note/dataset/CrossRefPicker.tsx
+++ b/fe/src/features/note/dataset/CrossRefPicker.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+
+import type { DatasetMeta } from "./api/datasets";
+
+interface Props {
+  /** 참조 가능한 표들(이름 있는 형제 표만). */
+  tables: Array<DatasetMeta & { name: string }>;
+  /** 고른 참조 토큰({표!열}행)을 삽입한다. */
+  onInsert: (token: string) => void;
+  onClose: () => void;
+}
+
+/**
+ * 표간 참조 삽입 피커(R9 #918). 다른 표·열·행을 골라 {@code {표이름!열}행} 토큰을 만든다.
+ * 저장 시 BE가 표 이름을 datasetId로 풀어 대상 표 셀을 읽는다.
+ *
+ * <p>{@code data-cross-picker}로 감싸, 셀 입력창의 blur가 이 안으로 향할 땐 편집을 닫지 않는다
+ * (피커를 쓰는 동안 편집이 살아 있어야 삽입이 가능하다).
+ */
+export function CrossRefPicker({ tables, onInsert, onClose }: Props) {
+  const [tableId, setTableId] = useState(tables[0].id);
+  const table = tables.find((t) => t.id === tableId) ?? tables[0];
+  const [colKey, setColKey] = useState(table.columns[0]?.key ?? "");
+  const [row, setRow] = useState(1);
+
+  const col = table.columns.find((c) => c.key === colKey) ?? table.columns[0];
+
+  const insert = () => {
+    if (!col) return;
+    onInsert(`{${table.name}!${col.label}}${row}`);
+  };
+
+  return (
+    <div
+      data-cross-picker
+      role="dialog"
+      aria-label="표간 참조 삽입"
+      className="border-border bg-popover absolute top-0 right-0 z-50 flex flex-col gap-2 rounded-md border p-2 text-sm shadow-md"
+    >
+      <label className="flex items-center gap-2">
+        <span className="text-muted-foreground w-8 text-xs">표</span>
+        <select
+          aria-label="참조할 표"
+          value={tableId}
+          onChange={(e) => {
+            const next = tables.find((t) => t.id === Number(e.target.value));
+            if (!next) return;
+            setTableId(next.id);
+            setColKey(next.columns[0]?.key ?? "");
+          }}
+          className="border-border rounded border px-1 py-0.5"
+        >
+          {tables.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center gap-2">
+        <span className="text-muted-foreground w-8 text-xs">열</span>
+        <select
+          aria-label="참조할 열"
+          value={colKey}
+          onChange={(e) => setColKey(e.target.value)}
+          className="border-border rounded border px-1 py-0.5"
+        >
+          {table.columns.map((c) => (
+            <option key={c.key} value={c.key}>
+              {c.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center gap-2">
+        <span className="text-muted-foreground w-8 text-xs">행</span>
+        <input
+          aria-label="행 번호"
+          type="number"
+          min={1}
+          value={row}
+          onChange={(e) => setRow(Math.max(1, Number(e.target.value) || 1))}
+          className="border-border w-16 rounded border px-1 py-0.5"
+        />
+      </label>
+      <div className="flex justify-end gap-1">
+        <button
+          type="button"
+          onClick={onClose}
+          className="hover:bg-accent rounded px-2 py-1 text-xs"
+        >
+          닫기
+        </button>
+        <button
+          type="button"
+          onClick={insert}
+          className="bg-primary text-primary-foreground rounded px-2 py-1 text-xs"
+        >
+          삽입
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -2425,6 +2425,83 @@ describe("DatasetGrid", () => {
     await waitFor(() => expect(patched).toEqual({ name: "도쿄" }));
   });
 
+  // ---------- 표간 참조 피커(#918) ----------
+
+  const summarySibling = {
+    id: 2,
+    name: "요약",
+    columns: [{ key: "c0", label: "환율" }],
+    rowCount: 1,
+  };
+
+  it("피커로 다른 표 셀 참조를 삽입하고 저장 시 tableRefs를 함께 보낸다", async () => {
+    mockDataset([["a", "b"]]);
+    let body: unknown = null;
+    server.use(
+      http.patch(`${API_BASE}/datasets/1/rows/:i`, async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            edited: { id: 100, rowIndex: 0, cells: ["1300", "b"] },
+            affected: [],
+          },
+        });
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(
+      <DatasetGrid datasetId={1} siblingTables={[summarySibling]} />,
+    );
+
+    await user.dblClick(await screen.findByText("a"));
+    const input = await screen.findByLabelText("셀 1행 1열");
+    fireEvent.change(input, { target: { value: "=" } });
+
+    // 피커 열기 → 기본값(요약·환율·1행) 그대로 삽입.
+    fireEvent.click(screen.getByLabelText("다른 표 참조"));
+    const dialog = await screen.findByRole("dialog", {
+      name: "표간 참조 삽입",
+    });
+    fireEvent.click(within(dialog).getByText("삽입"));
+
+    expect(screen.getByLabelText("셀 1행 1열")).toHaveValue("={요약!환율}1");
+
+    fireEvent.keyDown(screen.getByLabelText("셀 1행 1열"), { key: "Enter" });
+    await waitFor(() =>
+      expect(body).toEqual({
+        cells: ["={요약!환율}1", "b"],
+        tableRefs: { 요약: 2 },
+      }),
+    );
+  });
+
+  it("이름 있는 형제 표가 없으면 표간 참조 버튼이 안 뜬다", async () => {
+    mockDataset([["a", "b"]]);
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await user.dblClick(await screen.findByText("a"));
+    await screen.findByLabelText("셀 1행 1열");
+    expect(screen.queryByLabelText("다른 표 참조")).not.toBeInTheDocument();
+  });
+
+  it("이름 없는 형제 표는 참조 대상에서 제외된다", async () => {
+    mockDataset([["a", "b"]]);
+    const user = userEvent.setup();
+    renderWithRouter(
+      <DatasetGrid
+        datasetId={1}
+        siblingTables={[
+          { id: 2, columns: [{ key: "c0", label: "환율" }], rowCount: 1 },
+        ]}
+      />,
+    );
+    await user.dblClick(await screen.findByText("a"));
+    await screen.findByLabelText("셀 1행 1열");
+    // 무명 표뿐이라 참조 버튼이 없다.
+    expect(screen.queryByLabelText("다른 표 참조")).not.toBeInTheDocument();
+  });
+
   it("우클릭 메뉴에서 배경색을 고르면 선택한 셀에 일괄 PUT한다", async () => {
     mockDataset([["네트워크", "92"]]);
     let sentCells: unknown = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -49,6 +49,7 @@ import {
   updateDatasetRow,
 } from "./api/datasets";
 import { DATASET_CELLS_MIME } from "./cellClipboard";
+import { CrossRefPicker } from "./CrossRefPicker";
 import type { FormulaContext, ValueSource } from "./formula";
 import { aggregate, asCell, evaluateFormula } from "./formula";
 import { useDatasetMerges } from "./hooks/useDatasetMerges";
@@ -76,6 +77,11 @@ interface Props {
   onDeleteBlock?: () => void;
   /** 에디터에서 표 블록이 선택된 상태(NodeSelection)인지. 첫 셀 자동 선택 트리거. */
   blockSelected?: boolean;
+  /**
+   * 같은 노트의 다른 표들(자기 제외). 표간 참조 피커가 대상 표·열을 고르고, 저장 시 표 이름→id
+   * 맵(tableRefs)을 만드는 데 쓴다. 이름 없는 표는 참조할 수 없다(피커에서 제외).
+   */
+  siblingTables?: DatasetMeta[];
 }
 
 /**
@@ -87,6 +93,7 @@ export function DatasetGrid({
   datasetId,
   onDeleteBlock,
   blockSelected,
+  siblingTables,
 }: Props) {
   const queryClient = useQueryClient();
   const { data: meta, isLoading, isError, refetch } = useDatasetMeta(datasetId);
@@ -141,6 +148,8 @@ export function DatasetGrid({
   // 채우기 핸들 드래그 중인 대상 행(세로). null이면 채우기 중 아님. window pointerup에서 확정한다.
   const [fillTo, setFillTo] = useState<number | null>(null);
   const fillDragging = useRef(false);
+  // 표간 참조 피커 열림 여부(활성 셀 편집 중).
+  const [crossPickerOpen, setCrossPickerOpen] = useState(false);
   // 최신 commitFill을 담아 둔다 — window pointerup(한 번만 등록)이 stale 클로저 없이 부른다.
   const commitFillRef = useRef<() => void>(() => {});
 
@@ -155,6 +164,13 @@ export function DatasetGrid({
   const refreshSummaries = () => {
     if (summariesActive) void invalidateMeta();
   };
+  // 이름 있는 형제 표만 표간 참조 대상. 저장 땐 이름→id 맵을 함께 보내 BE가 {표!열}을 푼다.
+  const namedSiblings = (siblingTables ?? []).filter(
+    (t): t is DatasetMeta & { name: string } => !!t.name,
+  );
+  const tableRefs: Record<string, number> = Object.fromEntries(
+    namedSiblings.map((t) => [t.name, t.id]),
+  );
   // 행/열 구조가 바뀌면 병합의 행 번호가 밀리거나(행 삽입·삭제) 병합이 해제될 수 있어(열 삭제·순서변경)
   // 병합을 다시 받는다.
   const invalidateMerges = () =>
@@ -188,7 +204,12 @@ export function DatasetGrid({
   ) => {
     const version = (rowVersion.current.get(index) ?? 0) + 1;
     rowVersion.current.set(index, version);
-    updateDatasetRow(datasetId, index, cells)
+    updateDatasetRow(
+      datasetId,
+      index,
+      cells,
+      Object.keys(tableRefs).length ? tableRefs : undefined,
+    )
       .then((res) => {
         if (rowVersion.current.get(index) !== version) return;
         // 편집 행 + 전파로 값이 바뀐 교차 행(집계 등)을 서버 확정값으로 맞춘다. affected 행은
@@ -644,6 +665,24 @@ export function DatasetGrid({
     flushPendingEdit(false);
     pendingEdit.current = null;
     setEditing(null);
+  };
+
+  /**
+   * 표간 참조 토큰({표!열}행)을 활성 셀 편집값 끝에 붙인다(피커에서 호출). 편집을 살려 두고
+   * (blur는 피커로 향할 때 안 닫힌다) 이어서 타이핑할 수 있게 입력창에 포커스를 돌려준다.
+   */
+  const insertCrossRef = (token: string) => {
+    // 편집 중이면 그 셀, 아니면 활성 셀. 편집이 우선(피커는 편집 중에만 뜬다).
+    const cell =
+      editing ?? (activeCell && { row: activeCell[0], col: activeCell[1] });
+    if (!cell) return;
+    const { row, col } = cell;
+    const next = draft + token;
+    setEditing({ row, col });
+    setDraft(next);
+    pendingEdit.current = { row, col, value: next };
+    setCrossPickerOpen(false);
+    requestAnimationFrame(() => activeInputRef.current?.focus());
   };
 
   /** (row,col)이 앵커인 병합. 없으면 undefined. */
@@ -1316,7 +1355,13 @@ export function DatasetGrid({
                 500,
               );
             }}
-            onBlur={() => commitEdit()}
+            onBlur={(e) => {
+              // 피커로 포커스가 넘어갈 땐 편집을 닫지 않는다 — 피커를 쓰는 동안 편집이 살아
+              // 있어야 참조 토큰을 삽입할 수 있다.
+              const rt = e.relatedTarget as HTMLElement | null;
+              if (rt?.closest("[data-cross-picker]")) return;
+              commitEdit();
+            }}
             onKeyDown={(e) => onCellInputKeyDown(e, rowIndex, c)}
             // 편집 상태에서만 편집용 라벨을 붙인다(선택-만-한 상태는 편집이 아니므로 구분).
             aria-label={
@@ -1337,6 +1382,29 @@ export function DatasetGrid({
                 : undefined
             }
           />
+        )}
+        {/* 표간 참조 — 이름 있는 형제 표가 있을 때만. mousedown preventDefault로 입력창 blur(=커밋)
+          없이 피커만 연다. */}
+        {isActive && namedSiblings.length > 0 && (
+          <>
+            <button
+              type="button"
+              aria-label="다른 표 참조"
+              title="다른 표의 셀 참조"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => setCrossPickerOpen(true)}
+              className="text-muted-foreground hover:text-foreground bg-card absolute top-0 right-0 z-[8] rounded-bl px-1 text-xs leading-5"
+            >
+              ↗
+            </button>
+            {crossPickerOpen && (
+              <CrossRefPicker
+                tables={namedSiblings}
+                onInsert={insertCrossRef}
+                onClose={() => setCrossPickerOpen(false)}
+              />
+            )}
+          </>
         )}
       </>
     );

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -272,10 +272,12 @@ export async function updateDatasetRow(
   datasetId: number,
   rowIndex: number,
   cells: string[],
+  // 표간 참조({표!열}) 이름 해석 맵: 표 이름 → 대상 datasetId. 노트 안 표는 FE만 알아서 보낸다.
+  tableRefs?: Record<string, number>,
 ): Promise<UpdateRowResult> {
   const { data } = await client.patch<ApiEnvelope<UpdateRowResult>>(
     `/datasets/${datasetId}/rows/${rowIndex}`,
-    { cells },
+    { cells, tableRefs },
   );
   return data.data;
 }

--- a/fe/src/features/note/editor/DatasetTableView.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.tsx
@@ -1,7 +1,33 @@
+import { useQueries } from "@tanstack/react-query";
+import type { Editor } from "@tiptap/react";
 import { type NodeViewProps, NodeViewWrapper } from "@tiptap/react";
 
+import { type DatasetMeta, fetchDatasetMeta } from "../dataset/api/datasets";
 import { DatasetGrid } from "../dataset/DatasetGrid";
+import { datasetKeys } from "../dataset/queryKeys";
 import { useDatasetTableContext } from "./datasetTableContext";
+
+/**
+ * 같은 노트의 다른 표들 메타(자기 제외). 표간 참조 피커·저장(tableRefs)에 쓴다. 노트 doc에서
+ * datasetTable 노드의 id를 모아 각 표 메타를 조회한다(캐시는 각 그리드가 채운 것과 공유).
+ */
+function useSiblingTables(editor: Editor, selfId: number): DatasetMeta[] {
+  const ids: number[] = [];
+  editor.state.doc.descendants((n) => {
+    if (n.type.name === "datasetTable") {
+      const id = n.attrs.datasetId as number | null;
+      if (typeof id === "number" && id !== selfId) ids.push(id);
+    }
+  });
+  const results = useQueries({
+    queries: ids.map((id) => ({
+      queryKey: datasetKeys.meta(id),
+      queryFn: () => fetchDatasetMeta(id),
+      staleTime: 60 * 1000,
+    })),
+  });
+  return results.map((r) => r.data).filter((d): d is DatasetMeta => !!d);
+}
 
 /**
  * 노트 본문의 데이터 그리드 블록. 노드엔 datasetId만 있고, 실제 표는 별도 dataset
@@ -15,6 +41,7 @@ export function DatasetTableView({
 }: NodeViewProps) {
   const datasetId = node.attrs.datasetId as number | null;
   const { requestDeleteDataset } = useDatasetTableContext();
+  const siblingTables = useSiblingTables(editor, datasetId ?? -1);
 
   // 표 삭제(우클릭 메뉴·불러오기 실패 시 블록 제거) → 확인 먼저, 확인 시 dataset 삭제 +
   // 블록 제거를 함께. 블록 제거는 되돌리기 불가(addToHistory:false)라, Cmd+Z로 블록만
@@ -46,6 +73,8 @@ export function DatasetTableView({
           // 표 블록이 선택되면(한 번 클릭·키보드 이동 등) 그리드가 첫 셀을 잡아
           // 곧바로 타이핑=편집이 되게 한다(블록만 선택돼 키가 먹통이던 문제 해소).
           blockSelected={selected}
+          // 표간 참조 피커·저장(tableRefs)에 쓸 같은 노트의 다른 표들.
+          siblingTables={siblingTables}
         />
       )}
     </NodeViewWrapper>


### PR DESCRIPTION
## 이슈
closes #918 (BE 엔진 #919에 이은 FE 슬라이스)

## 작업 내용
R9 표간 절대셀 참조의 **FE 피커**. BE 엔진(#919 머지)이 `{요약!환율}1` + `tableRefs` 맵을 이미 처리하므로, 여기선 그걸 만들어 보내는 UI를 얹어 #918을 완결한다.

### 배선 (조사에서 나온 경로)
- **`DatasetTableView`**: 노트 doc에서 형제 표(datasetTable 노드)의 id를 모아(`editor.state.doc.descendants`, 자기 제외) 각 표 메타를 `useQueries`로 조회(각 그리드가 채운 캐시 공유, 목록 엔드포인트 없음). `siblingTables`로 `DatasetGrid`에 전달.
- **`CrossRefPicker`**: 다른 표·열·행을 골라 `{표이름!열}행` 토큰을 만든다. 이름 있는 형제 표만 대상(무명 표는 참조 불가).
- **`DatasetGrid`**: 활성 셀 편집 중 "다른 표 참조" 버튼(이름 있는 형제 표가 있을 때만) → 피커 → 삽입. 저장 시 `updateDatasetRow`에 `tableRefs{이름→id}` 동봉 → BE가 이름을 datasetId로 해석.

### 포커스 처리
- 입력창은 blur에 커밋하는데, 피커를 쓰는 동안 편집이 살아 있어야 삽입된다 → blur의 `relatedTarget`이 `[data-cross-picker]` 안이면 커밋을 건너뛴다. 버튼은 `mousedown preventDefault`로 열 때 blur를 막는다.

### 한계 (문서화)
- 형제 표 목록은 노드뷰 렌더 시점 기준(방금 추가한 표는 다음 렌더에 반영).
- 표간 자동 재계산은 아직 없음(#915b) — 대상 표가 바뀌면 재저장 필요.

## 테스트
- RTL 3건: 피커로 참조 삽입 → 커밋 시 PATCH에 cells + tableRefs, 이름 있는 형제 없으면 버튼 미표시, 무명 형제만이면 제외
- FE 465개 통과, prettier/eslint 통과

## 확인
- 로컬 브라우저 실증은 미실행(노트+다중 표+인증 풀스택 필요). 실제 컴포넌트에 이벤트를 발생시키는 RTL 통합 테스트로 피커→tableRefs 경로 검증. BE 경로는 #919의 TestContainers 통합 테스트로 검증됨.