### PR TITLE
feat : 수식 표간 집계 SUM({표!열}) (R9 #921)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaEvaluator.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaEvaluator.java
@@ -40,6 +40,14 @@ public final class FormulaEvaluator {
         default Optional<String> crossAbsolute(long datasetId, long rowId, String colKey) {
             return Optional.empty();
         }
+
+        /**
+         * 표간 집계({@code =SUM({도쿄!금액})})의 <b>대상 표</b> 열 전체. 표간을 지원하지 않는
+         * 소스는 기본 empty → {@code #REF!}.
+         */
+        default Optional<List<String>> crossColumn(long datasetId, String colKey) {
+            return Optional.empty();
+        }
     }
 
     private FormulaEvaluator() {
@@ -54,6 +62,7 @@ public final class FormulaEvaluator {
             case FormulaNode.Compare c -> compare(c, src);
             case FormulaNode.Ref r -> ref(r, src);
             case FormulaNode.Agg a -> agg(a, src);
+            case FormulaNode.CrossAgg a -> crossAgg(a, src);
             case FormulaNode.AggIf a -> aggIf(a, src);
             case FormulaNode.Call c -> call(c, src);
         };
@@ -247,20 +256,45 @@ public final class FormulaEvaluator {
     private static FormulaValue agg(FormulaNode.Agg a, ValueSource src) {
         List<BigDecimal> nums = new ArrayList<>();
         for (String key : a.colKeys()) {
-            Optional<List<String>> col = src.column(key);
-            if (col.isEmpty()) {
-                return new FormulaValue.Err(FormulaValue.Err.REF);
-            }
-            for (String cell : col.get()) {
-                String s = cell == null ? "" : cell.trim();
-                if (s.startsWith("#")) {
-                    return new FormulaValue.Err(s);
-                }
-                number(s).ifPresent(nums::add);
+            FormulaValue err = collectNums(src.column(key), nums);
+            if (err != null) {
+                return err;
             }
         }
+        return reduceNums(a.func(), nums);
+    }
 
-        return switch (a.func()) {
+    /** 표간 집계 — 대상 표의 한 열을 같은 규칙으로 집계한다(#915a-2). */
+    private static FormulaValue crossAgg(FormulaNode.CrossAgg a, ValueSource src) {
+        List<BigDecimal> nums = new ArrayList<>();
+        FormulaValue err = collectNums(src.crossColumn(a.datasetId(), a.colKey()), nums);
+        if (err != null) {
+            return err;
+        }
+        return reduceNums(a.func(), nums);
+    }
+
+    /**
+     * 열 값들에서 숫자만 골라 {@code nums}에 담는다. 열이 없으면 {@code #REF!}, 셀이 에러면 그
+     * 에러를 <b>반환</b>한다(그 경우 호출부가 즉시 그 에러를 낸다). 정상이면 null.
+     */
+    private static FormulaValue collectNums(Optional<List<String>> col, List<BigDecimal> nums) {
+        if (col.isEmpty()) {
+            return new FormulaValue.Err(FormulaValue.Err.REF);
+        }
+        for (String cell : col.get()) {
+            String s = cell == null ? "" : cell.trim();
+            if (s.startsWith("#")) {
+                return new FormulaValue.Err(s);
+            }
+            number(s).ifPresent(nums::add);
+        }
+        return null;
+    }
+
+    /** 모은 숫자에 집계 함수를 적용한다. agg·crossAgg 공용(규칙 한 곳). */
+    private static FormulaValue reduceNums(String func, List<BigDecimal> nums) {
+        return switch (func) {
             // 숫자만 센다. 비어있지 않은 걸 세는 COUNTA는 D8 범위 밖.
             case "COUNT" -> new FormulaValue.Num(BigDecimal.valueOf(nums.size()));
             case "SUM" -> new FormulaValue.Num(

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaNode.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaNode.java
@@ -66,6 +66,14 @@ public sealed interface FormulaNode {
     }
 
     /**
+     * 표간 집계({@code =SUM({도쿄!금액})}) — <b>다른 표</b>의 한 열 전체를 집계한다(#915a-2).
+     * 같은 표 집계({@link Agg})와 달리 대상 표({@code datasetId})가 다르고, 표간엔 열 하나만
+     * 지원한다(범위·나열은 후속). {@code colKey}는 대상 표 기준.
+     */
+    record CrossAgg(String func, Long datasetId, String colKey) implements FormulaNode {
+    }
+
+    /**
      * 스칼라 함수 호출. 집계({@link Agg})와 달리 인자가 <b>열 참조가 아니라 식</b>이다 —
      * {@code ABS({점수} - 10)}처럼 셀·산술을 품는다. 각 인자는 셀 단위로 평가된다.
      *

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaParser.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaParser.java
@@ -87,6 +87,8 @@ public final class FormulaParser {
             case FormulaNode.Ref r -> out.add(r);
             case FormulaNode.Agg a -> a.colKeys()
                     .forEach(k -> out.add(new FormulaNode.Ref(FormulaRefKind.COLUMN_ALL, k, null)));
+            case FormulaNode.CrossAgg a -> out.add(
+                    new FormulaNode.Ref(FormulaRefKind.COLUMN_ALL, a.colKey(), null, a.datasetId()));
             case FormulaNode.AggIf a -> {
                 out.add(new FormulaNode.Ref(FormulaRefKind.COLUMN_ALL, a.critCol(), null));
                 if (a.sumCol() != null) {
@@ -316,6 +318,15 @@ public final class FormulaParser {
         List<String> keys = new ArrayList<>();
         FormulaNode.Ref first = (FormulaNode.Ref) ref(true);
         skipSpace();
+        // 표간 집계 — 다른 표의 열 하나만(v1). 범위·나열은 후속(#915a-2 범위 밖).
+        if (first.datasetId() != null) {
+            if (peek() == ':' || peek() == ',') {
+                throw syntaxError("표간 집계는 열 하나만 지원합니다");
+            }
+            skipSpace();
+            expect(')');
+            return new FormulaNode.CrossAgg(name, first.datasetId(), first.colKey());
+        }
         if (peek() == ':') {
             // 범위 — 지금 그 사이에 있는 열들로 펼쳐 집합으로 굳힌다(D7).
             pos++;
@@ -388,13 +399,13 @@ public final class FormulaParser {
      * 푼다. 다른 표엔 "같은 행"이 없으므로 행 번호가 반드시 있어야 한다(ABSOLUTE).
      */
     private FormulaNode crossRef(String tablePart, String colPart, boolean columnOnly) {
-        if (columnOnly) {
-            // 표간 집계(=SUM({표!열}))는 다음 슬라이스(#915a-2)에서 다룬다.
-            throw syntaxError("표간 집계는 아직 지원하지 않습니다: {" + tablePart + "!" + colPart + "}");
-        }
         long targetId = resolveTable(tablePart);
         FormulaContext target = ctx.forDataset(targetId);
         String key = resolveKey(target, colPart);
+        if (columnOnly) {
+            // 표간 집계 인자 — 대상 표의 열 전체(행 없음). CrossAgg 조립은 aggregate()가 한다.
+            return new FormulaNode.Ref(FormulaRefKind.COLUMN_ALL, key, null, targetId);
+        }
         Long rowId = rowSuffix(target);
         if (rowId == null) {
             throw syntaxError("표간 셀 참조는 행 번호가 필요합니다: {" + tablePart + "!" + colPart + "}");

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaWriter.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/formula/FormulaWriter.java
@@ -71,6 +71,19 @@ public final class FormulaWriter {
                             .map(k -> "{" + name(k, ctx) + "}")
                             .collect(Collectors.joining(", ")))
                     .append(')');
+            case FormulaNode.CrossAgg a -> {
+                // 표시 SUM({도쿄!금액}) / 저장 SUM({42!c0}).
+                sb.append(a.func()).append("({");
+                if (ctx == null) {
+                    sb.append(a.datasetId()).append('!').append(a.colKey());
+                } else {
+                    String table = ctx.tableNameById(a.datasetId()).orElse("#REF!");
+                    String col = ctx.forDataset(a.datasetId()).labelByKey(a.colKey())
+                            .orElse("#REF!");
+                    sb.append(table).append('!').append(col);
+                }
+                sb.append("})");
+            }
             case FormulaNode.AggIf a -> {
                 sb.append(a.func()).append("({").append(name(a.critCol(), ctx)).append("}, ");
                 write(a.criteria(), sb, ctx);

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
@@ -233,8 +233,10 @@ public class DatasetFormulaService {
                     .map(List::of).orElseGet(List::of);
             case ABSOLUTE -> formulaRepository.findByRowIdAndColKey(ref.rowId(), ref.colKey())
                     .map(List::of).orElseGet(List::of);
-            // 집계는 그 열의 모든 수식에 닿는다.
-            case COLUMN_ALL -> formulaRepository.findByDatasetIdAndColKey(datasetId, ref.colKey());
+            // 집계는 그 열의 모든 수식에 닿는다. 표간 집계면 대상 표의 열이다(같은 colKey가
+            // 이 표에도 있어 자기 자신으로 오인하지 않게 — #915a-2).
+            case COLUMN_ALL -> formulaRepository.findByDatasetIdAndColKey(
+                    ref.datasetId() == null ? datasetId : ref.datasetId(), ref.colKey());
         };
     }
 
@@ -480,7 +482,10 @@ public class DatasetFormulaService {
                     ? DatasetFormulaRef.absolute(formulaId, datasetId, ref.rowId(), ref.colKey())
                     : DatasetFormulaRef.crossAbsolute(formulaId, datasetId, ref.datasetId(),
                             ref.rowId(), ref.colKey());
-            case COLUMN_ALL -> DatasetFormulaRef.columnAll(formulaId, datasetId, ref.colKey());
+            case COLUMN_ALL -> ref.datasetId() == null
+                    ? DatasetFormulaRef.columnAll(formulaId, datasetId, ref.colKey())
+                    : DatasetFormulaRef.crossColumnAll(formulaId, datasetId, ref.datasetId(),
+                            ref.colKey());
         };
     }
 
@@ -667,6 +672,16 @@ public class DatasetFormulaService {
             return rowRepository.findById(targetRowId)
                     .filter(r -> r.getDatasetId().equals(targetDatasetId))
                     .map(r -> DatasetCells.parse(r.getCells()).getOrDefault(colKey, ""));
+        }
+
+        /** 표간 열 집계 — 대상 표의 그 열 전체 값(행 순서). */
+        @Override
+        public Optional<List<String>> crossColumn(long targetDatasetId, String colKey) {
+            List<String> values = rowRepository
+                    .findByDatasetIdOrderByRowIndexAsc(targetDatasetId).stream()
+                    .map(r -> DatasetCells.parse(r.getCells()).getOrDefault(colKey, ""))
+                    .toList();
+            return Optional.of(values);
         }
 
         /** 열이 실재하는지는 파서가 저장 시점에 이미 검증했다. 지워진 열은 #814가 다룬다. */

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetCrossAggTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetCrossAggTest.java
@@ -1,0 +1,144 @@
+package ds.project.orino.planner.dataset.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 표간 집계(R9 #915a-2). 요약 표가 {@code =SUM({도시!금액})}로 도시 표의 열을 집계한다.
+ * 반응성(표간 전파)은 #915b — 저장 시 정확 계산까지.
+ */
+class DatasetCrossAggTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long cityId;    // 대상: 이름 "도시", 금액(c0) = 100,200,300
+    private long summaryId; // 참조: 합계(c0)
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        cityId = create("[{\"key\":\"c0\",\"label\":\"금액\"}]");
+        mockMvc.perform(patch("/api/datasets/{id}/name", cityId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"도시\"}"))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/api/datasets/{id}/rows/bulk", cityId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rows\":[[\"100\"],[\"200\"],[\"300\"]]}"))
+                .andExpect(status().isOk());
+
+        summaryId = create("[{\"key\":\"c0\",\"label\":\"합계\"}]");
+        mockMvc.perform(post("/api/datasets/{id}/rows/bulk", summaryId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"rows\":[[\"\"]]}"))
+                .andExpect(status().isOk());
+    }
+
+    private long create(String columnsJson) throws Exception {
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"columns\":" + columnsJson + "}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    /** 요약 표 0행을 도시 참조와 함께 수정. */
+    private ResultActions patchSummary(String formula) throws Exception {
+        return mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", summaryId, 0)
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cells\":[\"" + formula + "\"],\"tableRefs\":{\"도시\":" + cityId + "}}"));
+    }
+
+    private ResultActions summaryRows() throws Exception {
+        return mockMvc.perform(get("/api/datasets/{id}/rows", summaryId)
+                .header(HttpHeaders.AUTHORIZATION, authHeader));
+    }
+
+    @Test
+    @DisplayName("요약이 도시 열의 SUM을 끌어온다 — 핵심")
+    void crossSum() throws Exception {
+        patchSummary("=SUM({도시!금액})")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.edited.cells[0]").value("600")); // 100+200+300
+
+        summaryRows().andExpect(jsonPath("$.data.rows[0].cells[0]").value("600"))
+                .andExpect(jsonPath("$.data.rows[0].formulas.c0").value("=SUM({도시!금액})"));
+    }
+
+    @Test
+    @DisplayName("AVG·COUNT·MIN·MAX")
+    void otherFuncs() throws Exception {
+        patchSummary("=AVG({도시!금액})").andExpect(jsonPath("$.data.edited.cells[0]").value("200"));
+        patchSummary("=COUNT({도시!금액})").andExpect(jsonPath("$.data.edited.cells[0]").value("3"));
+        patchSummary("=MIN({도시!금액})").andExpect(jsonPath("$.data.edited.cells[0]").value("100"));
+        patchSummary("=MAX({도시!금액})").andExpect(jsonPath("$.data.edited.cells[0]").value("300"));
+    }
+
+    @Test
+    @DisplayName("표간 집계와 산술을 섞을 수 있다")
+    void crossAggInArithmetic() throws Exception {
+        patchSummary("=SUM({도시!금액}) * 2")
+                .andExpect(jsonPath("$.data.edited.cells[0]").value("1200"));
+    }
+
+    @Test
+    @DisplayName("표간 집계는 열 하나만 — 나열은 400")
+    void crossAggMultiColumnRejected() throws Exception {
+        patchSummary("=SUM({도시!금액}, {도시!금액})").andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("tableRefs에 없는 표는 400")
+    void unknownTableRejected() throws Exception {
+        mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", summaryId, 0)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"=SUM({없는표!금액})\"],\"tableRefs\":{}}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("표간 자동 재계산은 밖 — 도시 값이 바뀌어도 재저장 전엔 옛 합계(#915b)")
+    void noCrossPropagationYet() throws Exception {
+        patchSummary("=SUM({도시!금액})").andExpect(jsonPath("$.data.edited.cells[0]").value("600"));
+
+        // 도시 1행 100 → 900. 합계는 900+200+300 = 1400이 되어야 하지만 전파가 없다.
+        mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", cityId, 0)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"900\"]}"))
+                .andExpect(status().isOk());
+
+        summaryRows().andExpect(jsonPath("$.data.rows[0].cells[0]").value("600"));
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetFormulaRef.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/entity/DatasetFormulaRef.java
@@ -88,6 +88,13 @@ public class DatasetFormulaRef {
                 toColKey, toDatasetId);
     }
 
+    /** 표간 열 집계 참조({@code =SUM({도쿄!금액})}). 대상 표({@code toDatasetId})의 열 전체. */
+    public static DatasetFormulaRef crossColumnAll(Long formulaId, Long datasetId, Long toDatasetId,
+                                                   String toColKey) {
+        return new DatasetFormulaRef(formulaId, datasetId, FormulaRefKind.COLUMN_ALL, null,
+                toColKey, toDatasetId);
+    }
+
     public Long getId() {
         return id;
     }


### PR DESCRIPTION
## 이슈
closes #921

## 작업 내용
R9 표간 참조의 둘째 슬라이스 — **표간 집계** `=SUM({도시!금액})`. 요약 표가 각 도시 표의 열 합계를 끌어온다. #918(표간 절대셀) 엔진 위에 얹는다.

### 최소 침습 (a-1과 같은 전략)
- **`Agg` 노드는 안 건드림** — 새 `CrossAgg(func, datasetId, colKey)` 노드를 additive 추가. 같은 표 집계는 기존 `Agg` 그대로.
- 파서: `SUM({표!열})` — 인자가 표간이면 `CrossAgg`, 같은 표면 `Agg`. **v1은 단일 열만**(표간 범위·나열 거부).
- 평가기: `crossColumn(datasetId, colKey)`로 대상 표 열 읽어 **기존 집계 규칙 공유**(`agg`·`crossAgg`가 `collectNums`·`reduceNums` 공용 → 규칙 한 곳).
- writer(표시 `SUM({도시!금액})`/저장 `SUM({42!c0})`), `collectRefs`, `DatasetFormulaRef.crossColumnAll`.

### 버그 수정 (이 작업이 드러낸 것)
순환검출(`targetsOf`)이 표간 COLUMN_ALL을 **자기 표**의 같은 colKey로 봐 자기참조로 오인 → 409. 요약 `합계`가 c0이고 도시 `금액`도 c0이라 정확히 충돌. `toDatasetId`로 대상 표를 보게 수정.

### 재사용/범위 밖
- 이름 해석·인가·표시 재해석·`tableRefs`는 #918 것 그대로. **마이그레이션·API·FE 변경 없음** — FE는 이미 named siblings의 tableRefs를 보내므로 `=SUM({도쿄!금액})`을 타이핑하면 동작(프리뷰는 폴백, BE 확정).
- 표간 자동 재계산(전파·순환) → #915b. 표간 범위/다중 열, 표간 SUMIF → 후속.

## 테스트
- BE 통합 6건: SUM=600·AVG/COUNT/MIN/MAX, 산술 혼합, 표간 다중열 400, 없는 표 400, 표간 전파 부재(문서화)
- 기존 conformance·파서·전파 테스트 그대로 통과, checkstyle·전체 dataset 테스트 통과

## 확인
- 로컬 브라우저 실증 미실행(BE-only). TestContainers MySQL 통합 테스트로 end-to-end 검증.