### PR TITLE
feat : 수식 표간 반응성 — 전파·순환 (R9 #915 완결)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/UpdateRowResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/UpdateRowResponse.java
@@ -12,9 +12,14 @@ import java.util.List;
  *
  * <p>{@code affected}는 행 번호 오름차순이며, 로드 범위 밖 행도 포함될 수 있다(클라가 로드한
  * 범위만 골라 반영하면 된다). 번진 곳이 없으면 빈 리스트다.
+ *
+ * <p>{@code affectedDatasets}는 표간 참조로 전파가 <b>다른 표</b>에 번졌을 때 그 표 id들이다
+ * (R9 #915b). 이 응답은 이 표 스코프라 다른 표 행을 실을 수 없으니, 클라는 이 표들의 행을
+ * 다시 받아 갱신한다. 표간 전파가 없으면 빈 리스트다.
  */
 public record UpdateRowResponse(
         RowView edited,
-        List<RowView> affected
+        List<RowView> affected,
+        List<Long> affectedDatasets
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetFormulaService.java
@@ -116,7 +116,7 @@ public class DatasetFormulaService {
         }
 
         // 참조를 저장한 뒤에 본다 — 자기 참조를 그래프에서 따라갈 수 있어야 한다.
-        assertNoCycle(datasetId, row.getId(), colKey, node, columns);
+        assertNoCycle(datasetId, row.getId(), colKey, node);
 
         FormulaValue value = FormulaEvaluator.evaluate(node, new DbValues(datasetId, row, rowCells));
         if (value instanceof FormulaValue.Err e) {
@@ -155,9 +155,11 @@ public class DatasetFormulaService {
                 throw new CustomException(ErrorCode.FORMULA_PROPAGATION_TOO_WIDE,
                         "다시 계산할 수식이 " + budget + "개를 넘습니다");
             }
-            recompute(datasetId, formula);
+            // 의존 수식은 다른 표에 있을 수 있다(표간 참조). 재계산·다음 전파는 그 수식의 표 기준.
+            Long formulaDs = formula.getDatasetId();
+            recompute(formulaDs, formula);
             // 이 수식의 셀도 값이 바뀌었으니 그걸 참조하던 것들로 계속 번진다.
-            propagateFrom(datasetId, formula.getRowId(), formula.getColKey(), seen, budget);
+            propagateFrom(formulaDs, formula.getRowId(), formula.getColKey(), seen, budget);
         }
     }
 
@@ -195,33 +197,36 @@ public class DatasetFormulaService {
      * <p>참조를 따라 <b>앞으로</b> 걷는다 — 이 수식이 무엇을 참조하고, 그것들이 또 무엇을
      * 참조하는지. 도중에 자기 셀을 만나면 순환이다.
      */
-    private void assertNoCycle(Long datasetId, Long rowId, String colKey, FormulaNode node,
-                               List<DatasetColumn> columns) {
+    private void assertNoCycle(Long datasetId, Long rowId, String colKey, FormulaNode node) {
         Set<Long> visited = new HashSet<>();
         for (FormulaNode.Ref ref : FormulaParser.collectRefs(node)) {
             for (DatasetFormula target : targetsOf(datasetId, rowId, ref)) {
-                walk(datasetId, rowId, colKey, target, visited, columns);
+                walk(rowId, colKey, target, visited);
             }
         }
     }
 
-    private void walk(Long datasetId, Long selfRow, String selfCol, DatasetFormula formula,
-                      Set<Long> visited, List<DatasetColumn> columns) {
+    /**
+     * 참조 그래프를 앞으로 걸으며 자기 셀에 닿는지 본다. 표간 참조가 있어 각 수식은 <b>자기 표</b>
+     * 기준으로 파싱·추적한다(rowId는 전역 유일이라 표가 달라도 self 셀 판정이 정확하다).
+     */
+    private void walk(Long selfRow, String selfCol, DatasetFormula formula, Set<Long> visited) {
         if (formula.getRowId().equals(selfRow) && formula.getColKey().equals(selfCol)) {
             throw new CustomException(ErrorCode.FORMULA_CIRCULAR_REFERENCE);
         }
         if (!visited.add(formula.getId())) {
             return;
         }
+        Long ds = formula.getDatasetId();
         FormulaNode node;
         try {
-            node = FormulaParser.parseStored(formula.getRaw(), new DbContext(datasetId, columns));
+            node = FormulaParser.parseStored(formula.getRaw(), new DbContext(ds, columnsOf(ds)));
         } catch (CustomException e) {
             return; // 이미 깨진 수식은 순환 판정에 쓰지 않는다.
         }
         for (FormulaNode.Ref ref : FormulaParser.collectRefs(node)) {
-            for (DatasetFormula next : targetsOf(datasetId, formula.getRowId(), ref)) {
-                walk(datasetId, selfRow, selfCol, next, visited, columns);
+            for (DatasetFormula next : targetsOf(ds, formula.getRowId(), ref)) {
+                walk(selfRow, selfCol, next, visited);
             }
         }
     }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -558,17 +558,29 @@ public class DatasetService {
             }
         }
 
-        // 전파로 값이 바뀐 교차 행(집계 SUMIF 등)을 함께 돌려준다 — 클라가 다른 행의 재계산도
-        // 즉시 반영하도록. recomputed는 "rowId:colKey"들이라 행 id만 추리고, 편집 행은 뺀다.
+        // 전파로 값이 바뀐 행들. recomputed는 "rowId:colKey"라 행 id만 추리고, 편집 행은 뺀다.
         Set<Long> affectedRowIds = new LinkedHashSet<>();
         for (String cell : recomputed) {
             affectedRowIds.add(DatasetFormulaService.rowIdOf(cell));
         }
         affectedRowIds.remove(row.getId());
 
+        // 전파는 표간으로도 번진다(표간 참조). 이 표 행은 값으로 돌려주고, 다른 표는 id만 알려
+        // FE가 그 표 그리드를 다시 받게 한다 — 이 응답은 이 표 스코프라 다른 표 행을 못 싣는다.
+        Set<Long> sameDsRowIds = new LinkedHashSet<>();
+        Set<Long> otherDatasets = new LinkedHashSet<>();
+        for (DatasetRow r : rowRepository.findAllById(affectedRowIds)) {
+            if (r.getDatasetId().equals(datasetId)) {
+                sameDsRowIds.add(r.getId());
+            } else {
+                otherDatasets.add(r.getDatasetId());
+            }
+        }
+
         // 편집 행: 전파가 이 행의 다른 셀도 고쳤을 수 있어 다시 읽는다.
         RowView edited = buildRowView(datasetId, row, rowIndex, columns);
-        return new UpdateRowResponse(edited, buildRowViews(datasetId, affectedRowIds, columns));
+        return new UpdateRowResponse(edited, buildRowViews(datasetId, sameDsRowIds, columns),
+                List.copyOf(otherDatasets));
     }
 
     /**

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetCrossAggTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetCrossAggTest.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static org.hamcrest.Matchers.hasItem;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -128,17 +129,33 @@ class DatasetCrossAggTest extends ApiTestSupport {
     }
 
     @Test
-    @DisplayName("표간 자동 재계산은 밖 — 도시 값이 바뀌어도 재저장 전엔 옛 합계(#915b)")
-    void noCrossPropagationYet() throws Exception {
+    @DisplayName("도시 값이 바뀌면 요약 합계가 자동 갱신된다(표간 전파, #915b)")
+    void crossPropagation() throws Exception {
         patchSummary("=SUM({도시!금액})").andExpect(jsonPath("$.data.edited.cells[0]").value("600"));
 
-        // 도시 1행 100 → 900. 합계는 900+200+300 = 1400이 되어야 하지만 전파가 없다.
+        // 도시 1행 100 → 900. 합계 900+200+300 = 1400. 응답 affectedDatasets에 요약이 실린다.
         mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", cityId, 0)
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"cells\":[\"900\"]}"))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.affectedDatasets", hasItem((int) summaryId)));
 
-        summaryRows().andExpect(jsonPath("$.data.rows[0].cells[0]").value("600"));
+        summaryRows().andExpect(jsonPath("$.data.rows[0].cells[0]").value("1400"));
+    }
+
+    @Test
+    @DisplayName("도시에 행을 추가해도 요약 합계가 따라 커진다")
+    void crossPropagationOnRowInsert() throws Exception {
+        patchSummary("=SUM({도시!금액})").andExpect(jsonPath("$.data.edited.cells[0]").value("600"));
+
+        // 도시에 400짜리 행 추가 → 합계 1000.
+        mockMvc.perform(post("/api/datasets/{id}/rows", cityId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"400\"]}"))
+                .andExpect(status().isCreated());
+
+        summaryRows().andExpect(jsonPath("$.data.rows[0].cells[0]").value("1000"));
     }
 }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetCrossRefTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetCrossRefTest.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static org.hamcrest.Matchers.hasItem;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -128,19 +129,41 @@ class DatasetCrossRefTest extends ApiTestSupport {
     }
 
     @Test
-    @DisplayName("표간 자동 재계산은 이 슬라이스 밖 — 대상이 바뀌어도 재저장 전엔 옛 값(#915b)")
-    void noCrossPropagationYet() throws Exception {
+    @DisplayName("대상 표가 바뀌면 참조하는 표가 자동 갱신된다(표간 전파, #915b)")
+    void crossPropagation() throws Exception {
         patchCity("[\"100\",\"={요약!환율}1\"]", "{\"요약\":" + summaryId + "}")
                 .andExpect(jsonPath("$.data.edited.cells[1]").value("1300"));
 
-        // 요약 표의 환율을 1300 → 1400으로 바꾼다.
+        // 요약 표의 환율을 1300 → 1400으로 바꾼다. 응답의 affectedDatasets에 도시가 실린다.
         mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", summaryId, 0)
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"cells\":[\"1400\"]}"))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.affectedDatasets", hasItem((int) cityId)));
 
-        // 표간 전파가 없으니 도시 표는 아직 1300(재저장하면 1400). #915b에서 자동 갱신된다.
-        cityRows().andExpect(jsonPath("$.data.rows[0].cells[1]").value("1300"));
+        // 도시 표의 원화가 재저장 없이 자동으로 1400이 됐다.
+        cityRows().andExpect(jsonPath("$.data.rows[0].cells[1]").value("1400"));
+    }
+
+    @Test
+    @DisplayName("표간 순환 참조는 409 — A가 B를, B가 A의 같은 셀을 도로 가리키면")
+    void crossCycleRejected() throws Exception {
+        // 도시 원화 = 요약!환율.
+        patchCity("[\"100\",\"={요약!환율}1\"]", "{\"요약\":" + summaryId + "}")
+                .andExpect(status().isOk());
+        // 도시 표에도 이름을 붙여 요약이 도시를 가리킬 수 있게 한다.
+        mockMvc.perform(patch("/api/datasets/{id}/name", cityId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"도시\"}"))
+                .andExpect(status().isOk());
+        // 요약 환율 = 도시!원화 → 요약→도시→요약 순환.
+        mockMvc.perform(patch("/api/datasets/{id}/rows/{i}", summaryId, 0)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"cells\":[\"={도시!원화}1\"],\"tableRefs\":{\"도시\":"
+                                + cityId + "}}"))
+                .andExpect(status().isConflict());
     }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetFormulaRefRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/dataset/repository/DatasetFormulaRefRepository.java
@@ -21,7 +21,8 @@ public interface DatasetFormulaRefRepository extends JpaRepository<DatasetFormul
      * </ul>
      */
     @Query("SELECT r.formulaId FROM DatasetFormulaRef r, DatasetFormula f "
-            + "WHERE r.formulaId = f.id AND r.datasetId = :datasetId AND r.toColKey = :colKey "
+            + "WHERE r.formulaId = f.id "
+            + "AND COALESCE(r.toDatasetId, r.datasetId) = :datasetId AND r.toColKey = :colKey "
             + "AND ("
             + "  (r.toKind = ds.project.orino.domain.planner.dataset.entity.FormulaRefKind.SAME_ROW"
             + "     AND f.rowId = :rowId)"
@@ -33,15 +34,18 @@ public interface DatasetFormulaRefRepository extends JpaRepository<DatasetFormul
                                        @Param("rowId") Long rowId,
                                        @Param("colKey") String colKey);
 
-    /** 열이 통째로 바뀔 때(삭제 등) 그 열을 참조하는 수식 — 종류 불문. */
+    /**
+     * 열이 통째로 바뀔 때(삭제 등) 그 열을 참조하는 수식 — 종류 불문. 표간 참조도 잡도록 대상
+     * 표 기준(COALESCE)으로 조회한다 — 다른 표가 이 열을 참조하면 그것도 무효화 대상이다.
+     */
     @Query("SELECT DISTINCT r.formulaId FROM DatasetFormulaRef r "
-            + "WHERE r.datasetId = :datasetId AND r.toColKey = :colKey")
+            + "WHERE COALESCE(r.toDatasetId, r.datasetId) = :datasetId AND r.toColKey = :colKey")
     List<Long> findFormulaIdsReferencingColumn(@Param("datasetId") Long datasetId,
                                                @Param("colKey") String colKey);
 
-    /** 행이 지워질 때 그 행을 콕 집어 참조하던 수식 — #REF! 대상. */
+    /** 행이 지워질 때 그 행을 콕 집어 참조하던 수식 — #REF! 대상(표간 포함, 대상 표 기준). */
     @Query("SELECT DISTINCT r.formulaId FROM DatasetFormulaRef r "
-            + "WHERE r.datasetId = :datasetId AND r.toRowId = :rowId "
+            + "WHERE COALESCE(r.toDatasetId, r.datasetId) = :datasetId AND r.toRowId = :rowId "
             + "AND r.toKind = ds.project.orino.domain.planner.dataset.entity.FormulaRefKind.ABSOLUTE")
     List<Long> findFormulaIdsReferencingRow(@Param("datasetId") Long datasetId,
                                             @Param("rowId") Long rowId);

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -218,6 +218,12 @@ export function DatasetGrid({
           setRowLocal(row.rowIndex, row.cells);
           setFormulasLocal(row.rowIndex, row.formulas ?? {});
         }
+        // 표간 참조로 다른 표에 번졌으면 그 표들의 행을 무효화 — 각 표 그리드가 다시 받아 갱신한다.
+        for (const ds of res.affectedDatasets ?? []) {
+          void queryClient.invalidateQueries({
+            queryKey: ["datasets", ds, "rows"],
+          });
+        }
         // 최종 커밋(자동저장 아님)이면 열 요약 값도 갱신한다.
         if (!silent) refreshSummaries();
       })

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -110,6 +110,11 @@ export interface RowsPage {
 export interface UpdateRowResult {
   edited: DatasetRow;
   affected: DatasetRow[];
+  /**
+   * 표간 참조로 전파가 다른 표에 번졌을 때 그 표 id들(R9 #915b). 이 응답엔 다른 표 행이 없으니,
+   * 클라는 이 표들의 행 캐시를 무효화해 각 표 그리드가 다시 받게 한다. 없으면 빈 배열.
+   */
+  affectedDatasets: number[];
 }
 
 interface ApiEnvelope<T> {


### PR DESCRIPTION
## 이슈
closes #915

## 작업 내용
R9 표간 참조의 마지막 조각 — **반응성**. 대상 표가 바뀌면 참조하는 표가 자동 갱신된다(환율 셀 하나 바꾸면 그걸 참조하는 도시·요약이 전부 다시 계산). #918(절대셀)·#921(집계) 위에 전파·순환을 얹어 R9를 완결한다.

### 역방향 조회를 대상 표 기준으로
- `findDependentFormulaIds` 등 3개 쿼리의 스코프를 `r.datasetId` → **`COALESCE(r.toDatasetId, r.datasetId)`**(유효 대상 표)로 넓혔다. 표간 참조는 `to_dataset_id`에 대상이 있고, 셀이 바뀐 표를 참조하는 다른 표의 수식을 이걸로 찾는다.

### 전파·재계산·순환을 표 경계 너머로
- `propagateFrom`·`recompute`가 의존 수식의 **자기 표**(formula.datasetId) 기준으로 재계산·재귀 — 표간 의존 수식은 다른 표에 살아 있어 컨텍스트가 그 표여야 한다.
- 순환검출(`walk`)도 각 수식을 자기 표로 파싱·추적. rowId가 전역 유일이라 표가 달라도 self 셀 판정이 정확. **표간 순환(A→B→A)은 409**.

### FE 반영
- 응답은 이 표 스코프라 다른 표 행을 실을 수 없다 → `UpdateRowResponse.affectedDatasets`로 번진 표 id를 알린다. FE `saveRow`가 그 표들의 rows 쿼리를 무효화 → 각 표 그리드가 다시 받아 갱신.

## 테스트
- 이전 "표간 전파 부재(#915b)" 테스트들을 **전파 검증**으로 뒤집음: 환율 바꾸면 도시 원화 자동 1400, 도시 금액 바꾸면 요약 합계 1400, 도시 행 추가하면 합계 커짐, affectedDatasets 확인, 표간 순환 409
- 기존 intra-table 전파·순환 테스트 그대로 통과(refactor 무해), checkstyle·전체 dataset·FE 465개 통과

## 확인
- 로컬 브라우저 실증 미실행(노트+다중 표 풀스택 필요). 표간 전파는 TestContainers MySQL 통합 테스트로 end-to-end 검증. FE 무효화는 표준 react-query invalidate.