### PR TITLE
feat : 데이터 그리드 열 숫자 서식(통화·소수) (R2 #913)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -18,6 +18,7 @@ import ds.project.orino.planner.dataset.dto.RowsResponse;
 import ds.project.orino.planner.dataset.dto.SetCellMergeRequest;
 import ds.project.orino.planner.dataset.dto.SetCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.SetColumnAlignRequest;
+import ds.project.orino.planner.dataset.dto.SetColumnFormatRequest;
 import ds.project.orino.planner.dataset.dto.SetColumnSummaryRequest;
 import ds.project.orino.planner.dataset.dto.SetDatasetNameRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
@@ -177,6 +178,17 @@ public class DatasetController {
             @Valid @RequestBody SetColumnSummaryRequest request) {
         return ApiResponse.success(
                 datasetService.setColumnSummary(memberId, id, key, request.summary()));
+    }
+
+    /** 열 숫자 서식 설정/해제(멱등 교체, 표시 전용). null이면 해제. R2 값/표시 분리. */
+    @PatchMapping("/{id}/columns/{key}/format")
+    public ApiResponse<DatasetResponse> setColumnFormat(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable String key,
+            @Valid @RequestBody SetColumnFormatRequest request) {
+        return ApiResponse.success(
+                datasetService.setColumnFormat(memberId, id, key, request.format()));
     }
 
     /** 열 기본 정렬 초기화 — 기본 정렬(left)로 되돌린다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetColumn.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetColumn.java
@@ -33,7 +33,9 @@ public record DatasetColumn(
         @Pattern(regexp = "left|center|right", message = "허용되지 않은 정렬입니다.")
         String align,
         @Pattern(regexp = ALLOWED_SUMMARY, message = "허용되지 않은 요약 함수입니다.")
-        String summary
+        String summary,
+        @Pattern(regexp = ALLOWED_FORMAT, message = "허용되지 않은 숫자 서식입니다.")
+        String format
 ) {
     /** 열 너비 하한(px). 이보다 좁으면 값이 사실상 안 보인다. */
     public static final int MIN_WIDTH = 60;
@@ -41,29 +43,39 @@ public record DatasetColumn(
     public static final int MAX_WIDTH = 800;
     /** 허용 요약 함수. FE의 SUMMARY_FNS와 같아야 한다. */
     public static final String ALLOWED_SUMMARY = "SUM|AVERAGE|COUNT|MIN|MAX";
+    /**
+     * 허용 숫자 서식 토큰. FE의 NUMBER_FORMATS와 같아야 한다. <b>표시 전용</b> — 값·수식은 raw를
+     * 쓰고, 화면에만 이 서식으로 포맷한다(FE). BE는 토큰만 저장·검증한다.
+     */
+    public static final String ALLOWED_FORMAT = "KRW|USD|JPY|THOUSANDS|DECIMAL1|DECIMAL2";
 
-    /** 너비·정렬·요약 없이 만든다(기본 폭·기본 정렬). */
+    /** 너비·정렬·요약·서식 없이 만든다(기본 폭·기본 정렬). */
     public DatasetColumn(String key, String label) {
-        this(key, label, null, null, null);
+        this(key, label, null, null, null, null);
     }
 
-    /** key/width/align/summary는 두고 label만 바꾼 새 열 메타. */
+    /** label만 바꾼 새 열 메타(나머지 보존). */
     public DatasetColumn withLabel(String label) {
-        return new DatasetColumn(key, label, width, align, summary);
+        return new DatasetColumn(key, label, width, align, summary, format);
     }
 
-    /** key/label/align/summary는 두고 width만 바꾼 새 열 메타. */
+    /** width만 바꾼 새 열 메타(나머지 보존). */
     public DatasetColumn withWidth(Integer width) {
-        return new DatasetColumn(key, label, width, align, summary);
+        return new DatasetColumn(key, label, width, align, summary, format);
     }
 
-    /** key/label/width/summary는 두고 align만 바꾼 새 열 메타. */
+    /** align만 바꾼 새 열 메타(나머지 보존). */
     public DatasetColumn withAlign(String align) {
-        return new DatasetColumn(key, label, width, align, summary);
+        return new DatasetColumn(key, label, width, align, summary, format);
     }
 
-    /** key/label/width/align은 두고 summary만 바꾼 새 열 메타. */
+    /** summary만 바꾼 새 열 메타(나머지 보존). */
     public DatasetColumn withSummary(String summary) {
-        return new DatasetColumn(key, label, width, align, summary);
+        return new DatasetColumn(key, label, width, align, summary, format);
+    }
+
+    /** format만 바꾼 새 열 메타(나머지 보존). */
+    public DatasetColumn withFormat(String format) {
+        return new DatasetColumn(key, label, width, align, summary, format);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetColumnFormatRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetColumnFormatRequest.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.dataset.dto;
+
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * 열 숫자 서식 설정/해제 요청. {@code KRW|USD|JPY|THOUSANDS|DECIMAL1|DECIMAL2} 또는 {@code null}(해제).
+ *
+ * <p>표시 전용이라 값·수식은 건드리지 않는다 — 화면에만 이 서식으로 포맷한다(FE). 요약(summary)과
+ * 같은 규칙으로 null을 해제로 쓴다(멱등 교체).
+ */
+public record SetColumnFormatRequest(
+        @Pattern(regexp = DatasetColumn.ALLOWED_FORMAT, message = "허용되지 않은 숫자 서식입니다.")
+        String format
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -380,6 +380,25 @@ public class DatasetService {
     }
 
     /**
+     * 열 숫자 서식을 설정/해제한다(멱등 교체). null이면 지운다. <b>표시 전용</b> — 값·수식은 안
+     * 건드리고 토큰만 columns_json에 담는다. 포맷은 FE가 화면에만 적용한다.
+     */
+    @Transactional
+    public DatasetResponse setColumnFormat(Long memberId, Long datasetId, String key,
+                                           String format) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        int at = indexOfColumn(columns, key);
+        if (at < 0) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+        List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
+        updated.set(at, columns.get(at).withFormat(format));
+        dataset.updateColumns(serialize(updated));
+        return metaResponse(dataset, updated);
+    }
+
+    /**
      * 표 이름을 설정/해제한다(멱등). 빈 값(공백·null)이면 무명으로 되돌린다. 유일성은 강제하지
      * 않는다 — BE는 표가 어느 노트에 있는지 모르므로, 이름 해석은 #915에서 노트 단위(FE)로 한다.
      */

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetColumnFormatTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetColumnFormatTest.java
@@ -1,0 +1,102 @@
+package ds.project.orino.planner.dataset.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** 열 숫자 서식(R2 #913). 표시 전용 토큰만 저장·검증한다(값·수식 무관). */
+class DatasetColumnFormatTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long datasetId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"columns\":[{\"key\":\"c0\",\"label\":\"금액\"}]}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        datasetId = ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private ResultActions setFormat(String bodyJson) throws Exception {
+        return mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/format", datasetId, "c0")
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(bodyJson));
+    }
+
+    private ResultActions meta() throws Exception {
+        return mockMvc.perform(get("/api/datasets/{id}", datasetId)
+                .header(HttpHeaders.AUTHORIZATION, authHeader));
+    }
+
+    @Test
+    @DisplayName("서식을 설정하면 열에 담기고 조회에 실린다")
+    void setFormatPersists() throws Exception {
+        setFormat("{\"format\":\"KRW\"}")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].format").value("KRW"));
+        meta().andExpect(jsonPath("$.data.columns[0].format").value("KRW"));
+    }
+
+    @Test
+    @DisplayName("다시 설정하면 교체된다")
+    void replaceIsIdempotent() throws Exception {
+        setFormat("{\"format\":\"KRW\"}").andExpect(status().isOk());
+        setFormat("{\"format\":\"DECIMAL1\"}")
+                .andExpect(jsonPath("$.data.columns[0].format").value("DECIMAL1"));
+    }
+
+    @Test
+    @DisplayName("null이면 서식이 해제된다")
+    void nullClearsFormat() throws Exception {
+        setFormat("{\"format\":\"KRW\"}").andExpect(status().isOk());
+        setFormat("{\"format\":null}")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].format").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 서식은 400")
+    void invalidFormatRejected() throws Exception {
+        setFormat("{\"format\":\"EUR\"}").andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("없는 열은 404")
+    void missingColumnRejected() throws Exception {
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/format", datasetId, "c9")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"format\":\"KRW\"}"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -2502,6 +2502,62 @@ describe("DatasetGrid", () => {
     expect(screen.queryByLabelText("다른 표 참조")).not.toBeInTheDocument();
   });
 
+  // ---------- 열 숫자 서식(R2 #913) ----------
+
+  it("서식이 걸린 열은 셀 값을 포맷해 보여준다(값은 raw 유지)", async () => {
+    mockDataset([["93000"]]);
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [{ key: "c0", label: "금액", format: "KRW" }],
+            rowCount: 1,
+          },
+        }),
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    expect(await screen.findByText("₩93,000")).toBeInTheDocument();
+    expect(screen.queryByText("93000")).not.toBeInTheDocument();
+  });
+
+  it("우클릭에서 숫자 서식을 고르면 그 열에 PATCH한다", async () => {
+    mockDataset([["93000", "b"]]);
+    let patched: unknown = null;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/columns/:key/format`,
+        async ({ params, request }) => {
+          patched = { key: params.key, body: await request.json() };
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              id: 1,
+              columns: [
+                { key: "c0", label: "과목", format: "KRW" },
+                { key: "c1", label: "점수" },
+              ],
+              rowCount: 1,
+            },
+          });
+        },
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const cell = (await screen.findByText("93000"))
+      .parentElement as HTMLElement;
+    fireEvent.pointerDown(cell, { button: 0 });
+    fireEvent.contextMenu(cell);
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "서식 KRW" }));
+
+    await waitFor(() =>
+      expect(patched).toEqual({ key: "c0", body: { format: "KRW" } }),
+    );
+  });
+
   it("우클릭 메뉴에서 배경색을 고르면 선택한 셀에 일괄 PUT한다", async () => {
     mockDataset([["네트워크", "92"]]);
     let sentCells: unknown = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -39,10 +39,12 @@ import {
   type MergeSpan,
   type MergeView,
   MIN_COLUMN_WIDTH,
+  type NumberFormat,
   resetDatasetColumnWidth,
   resizeDatasetColumn,
   setCellMerge,
   setCellStylesBulk,
+  setColumnFormat,
   setColumnSummary,
   setDatasetName,
   type SummaryFn,
@@ -55,6 +57,7 @@ import { aggregate, asCell, evaluateFormula } from "./formula";
 import { useDatasetMerges } from "./hooks/useDatasetMerges";
 import { useDatasetMeta } from "./hooks/useDatasetMeta";
 import { useDatasetRows } from "./hooks/useDatasetRows";
+import { FORMAT_LABELS, formatCellValue, NUMBER_FORMATS } from "./numberFormat";
 import { datasetKeys } from "./queryKeys";
 
 /** 행 높이(px) — 고정. 좌우(열 너비)만 조절 가능하고 위아래는 조절하지 않는다. */
@@ -308,6 +311,17 @@ export function DatasetGrid({
   // 표 이름 설정/해제. 응답 메타로 캐시를 맞춰 이름이 즉시 반영된다.
   const nameMut = useMutation({
     mutationFn: (name: string) => setDatasetName(datasetId, name),
+    onSuccess: (next: DatasetMeta) =>
+      queryClient.setQueryData(datasetKeys.meta(datasetId), next),
+    onError: (e) => {
+      const message = serverMessage(e);
+      if (message) toast(message, "error");
+    },
+  });
+  // 열 숫자 서식 설정/해제(표시 전용). 응답 메타로 캐시를 맞춰 즉시 반영.
+  const formatMut = useMutation({
+    mutationFn: (v: { key: string; format: NumberFormat | null }) =>
+      setColumnFormat(datasetId, v.key, v.format),
     onSuccess: (next: DatasetMeta) =>
       queryClient.setQueryData(datasetKeys.meta(datasetId), next),
     onError: (e) => {
@@ -1335,7 +1349,9 @@ export function DatasetGrid({
           )}
           title={formula}
         >
-          {cells === undefined ? "…" : (cells[c] ?? "")}
+          {cells === undefined
+            ? "…"
+            : formatCellValue(cells[c] ?? "", meta.columns[c].format)}
         </div>
         {isActive && (
           <input
@@ -1932,6 +1948,51 @@ export function DatasetGrid({
                             summaryMut.mutate({
                               key: meta.columns[rect.c0].key,
                               fn: null,
+                            }),
+                          )}
+                          className="text-muted-foreground hover:text-foreground flex size-6 items-center justify-center rounded"
+                        >
+                          <X className="size-3" />
+                        </button>
+                      </div>
+                      {divider}
+                    </>
+                  )}
+                  {/* 숫자 서식 — 한 열만 걸쳤을 때. 표시 전용(값·수식은 raw 그대로). */}
+                  {rect.c0 === rect.c1 && (
+                    <>
+                      <div className="text-muted-foreground px-2 pt-1 text-xs">
+                        숫자 서식
+                      </div>
+                      <div className="flex items-center gap-1 px-2 py-1">
+                        {NUMBER_FORMATS.map((fmt) => (
+                          <button
+                            key={fmt}
+                            type="button"
+                            role="menuitem"
+                            aria-label={`서식 ${fmt}`}
+                            onClick={run(() =>
+                              formatMut.mutate({
+                                key: meta.columns[rect.c0].key,
+                                format: fmt,
+                              }),
+                            )}
+                            className={cn(
+                              "hover:bg-accent rounded px-1.5 py-1 text-xs",
+                              meta.columns[rect.c0].format === fmt &&
+                                "bg-accent text-foreground",
+                            )}
+                          >
+                            {FORMAT_LABELS[fmt]}
+                          </button>
+                        ))}
+                        <button
+                          type="button"
+                          aria-label="서식 지우기"
+                          onClick={run(() =>
+                            formatMut.mutate({
+                              key: meta.columns[rect.c0].key,
+                              format: null,
                             }),
                           )}
                           className="text-muted-foreground hover:text-foreground flex size-6 items-center justify-center rounded"

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -3,6 +3,15 @@ import { client } from "@/shared/api";
 /** 열 푸터 요약 함수. 서버의 DatasetColumn.ALLOWED_SUMMARY와 같아야 한다. */
 export type SummaryFn = "SUM" | "AVERAGE" | "COUNT" | "MIN" | "MAX";
 
+/** 열 숫자 서식(표시 전용). 서버의 DatasetColumn.ALLOWED_FORMAT와 같아야 한다. */
+export type NumberFormat =
+  | "KRW"
+  | "USD"
+  | "JPY"
+  | "THOUSANDS"
+  | "DECIMAL1"
+  | "DECIMAL2";
+
 export interface DatasetColumn {
   key: string;
   label: string;
@@ -12,6 +21,8 @@ export interface DatasetColumn {
   align?: CellAlign;
   /** 열 푸터 요약 함수. 없으면 이 열엔 푸터 요약이 없다. 계산된 값은 DatasetMeta.summaries로 온다. */
   summary?: SummaryFn;
+  /** 열 숫자 서식(표시 전용). 값·수식은 raw, 화면에만 이 서식으로 포맷한다. 없으면 그대로. */
+  format?: NumberFormat;
 }
 
 /** 셀·열 정렬 값. 서버의 ALLOWED_ALIGN과 같아야 한다. */
@@ -283,6 +294,21 @@ export async function updateDatasetRow(
   const { data } = await client.patch<ApiEnvelope<UpdateRowResult>>(
     `/datasets/${datasetId}/rows/${rowIndex}`,
     { cells, tableRefs },
+  );
+  return data.data;
+}
+
+/**
+ * 열 숫자 서식 설정/해제(멱등, 표시 전용). null이면 해제. 갱신된 메타를 돌려준다.
+ */
+export async function setColumnFormat(
+  datasetId: number,
+  key: string,
+  format: NumberFormat | null,
+): Promise<DatasetMeta> {
+  const { data } = await client.patch<ApiEnvelope<DatasetMeta>>(
+    `/datasets/${datasetId}/columns/${key}/format`,
+    { format },
   );
   return data.data;
 }

--- a/fe/src/features/note/dataset/numberFormat.test.ts
+++ b/fe/src/features/note/dataset/numberFormat.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCellValue } from "./numberFormat";
+
+describe("formatCellValue (표시 전용 숫자 서식)", () => {
+  it("KRW — 통화 기호 + 천단위", () => {
+    expect(formatCellValue("93000", "KRW")).toBe("₩93,000");
+  });
+
+  it("THOUSANDS — 천단위 구분", () => {
+    expect(formatCellValue("93000", "THOUSANDS")).toBe("93,000");
+  });
+
+  it("DECIMAL1 — 소수 한 자리", () => {
+    expect(formatCellValue("9.3", "DECIMAL1")).toBe("9.3");
+    expect(formatCellValue("9", "DECIMAL1")).toBe("9.0");
+  });
+
+  it("숫자가 아니면 원본 그대로 — 값을 바꾸지 않는다", () => {
+    expect(formatCellValue("진에어", "KRW")).toBe("진에어");
+    expect(formatCellValue("#VALUE!", "KRW")).toBe("#VALUE!");
+  });
+
+  it("빈칸·서식 없음은 원본 그대로", () => {
+    expect(formatCellValue("", "KRW")).toBe("");
+    expect(formatCellValue("93000")).toBe("93000");
+  });
+});

--- a/fe/src/features/note/dataset/numberFormat.ts
+++ b/fe/src/features/note/dataset/numberFormat.ts
@@ -1,0 +1,48 @@
+import type { NumberFormat } from "./api/datasets";
+
+/**
+ * 열 숫자 서식(표시 전용). 값·수식은 raw를 쓰고, 화면에만 이걸로 포맷한다(R2). 숫자가 아니면
+ * (텍스트·`#에러`·빈칸) 원본을 그대로 둔다 — 서식은 숫자 표시만 바꾸지 값을 바꾸지 않는다.
+ */
+const FORMATTERS: Record<NumberFormat, Intl.NumberFormat> = {
+  KRW: new Intl.NumberFormat("ko-KR", { style: "currency", currency: "KRW" }),
+  USD: new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }),
+  JPY: new Intl.NumberFormat("ja-JP", { style: "currency", currency: "JPY" }),
+  THOUSANDS: new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }),
+  DECIMAL1: new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }),
+  DECIMAL2: new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }),
+};
+
+/** 서식이 있고 값이 숫자면 포맷, 아니면 원본 그대로. */
+export function formatCellValue(value: string, format?: NumberFormat): string {
+  if (!format || value === "") return value;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return value; // 텍스트·에러 셀은 건드리지 않는다.
+  return FORMATTERS[format].format(n);
+}
+
+/** 서식 토큰 → 메뉴 라벨(짧게). */
+export const FORMAT_LABELS: Record<NumberFormat, string> = {
+  KRW: "₩",
+  USD: "$",
+  JPY: "¥",
+  THOUSANDS: "1,000",
+  DECIMAL1: "0.0",
+  DECIMAL2: "0.00",
+};
+
+/** 메뉴에 노출할 순서. */
+export const NUMBER_FORMATS: NumberFormat[] = [
+  "KRW",
+  "USD",
+  "JPY",
+  "THOUSANDS",
+  "DECIMAL1",
+  "DECIMAL2",
+];


### PR DESCRIPTION
## 이슈
closes #913

## 작업 내용
요구 감사 R2 — 열 단위 숫자 서식(값/표시 분리). 같은 값 93000을 `₩93,000`, 9.3을 `9.3`으로. **표시 전용** — 값·수식은 raw를 쓰고 화면에만 포맷한다.

### BE (#909 summary와 같은 패턴)
- `DatasetColumn.format`(nullable, `@Pattern` 검증) — `width·align·summary`처럼 `columns_json`에 상주, 열을 따라다님. 마이그레이션 불필요.
- `PATCH /datasets/{id}/columns/{key}/format` `{format|null}` 멱등 설정/해제.
- 허용 토큰 `KRW|USD|JPY|THOUSANDS|DECIMAL1|DECIMAL2`. **BE는 토큰만 저장·검증** — 계산·수식엔 안 쓴다(포맷은 순수 FE 표시).

### FE
- `formatCellValue(value, format)` — `Intl.NumberFormat`. **숫자가 아니면(텍스트·`#에러`·빈칸) 원본 그대로** — 서식은 숫자 표시만 바꾸지 값을 안 바꾼다.
- 셀 표시에 적용(편집 입력창은 raw 유지 — 자기 값을 다시 볼 수 있게).
- 우클릭 "숫자 서식" 메뉴(한 열 걸쳤을 때): ₩/$/¥/천단위/0.0/0.00 + 지우기.

## 테스트
- BE 5건: 설정·조회, 멱등 교체, null 해제, 잘못된 토큰 400, 없는 열 404
- FE 유닛 5건(formatCellValue: 통화·천단위·소수·텍스트 보존·빈칸/무서식) + RTL 2건(서식 열이 포맷 표시, 우클릭 설정→PATCH)
- FE 472개·BE checkstyle·전체 dataset 테스트 통과

## 확인
- 로컬 브라우저 실증 미실행(풀스택 필요). 마이그레이션 없음, 엔드포인트는 TestContainers, 포맷은 실제 Intl로 유닛 검증(₩93,000 확인).