### PR TITLE
feat : 데이터 그리드 열 허용값 목록(enum/드롭다운) (R3 #914)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/controller/DatasetController.java
@@ -19,6 +19,7 @@ import ds.project.orino.planner.dataset.dto.SetCellMergeRequest;
 import ds.project.orino.planner.dataset.dto.SetCellStyleRequest;
 import ds.project.orino.planner.dataset.dto.SetColumnAlignRequest;
 import ds.project.orino.planner.dataset.dto.SetColumnFormatRequest;
+import ds.project.orino.planner.dataset.dto.SetColumnOptionsRequest;
 import ds.project.orino.planner.dataset.dto.SetColumnSummaryRequest;
 import ds.project.orino.planner.dataset.dto.SetDatasetNameRequest;
 import ds.project.orino.planner.dataset.dto.UpdateRowRequest;
@@ -189,6 +190,17 @@ public class DatasetController {
             @Valid @RequestBody SetColumnFormatRequest request) {
         return ApiResponse.success(
                 datasetService.setColumnFormat(memberId, id, key, request.format()));
+    }
+
+    /** 열 허용값 목록(enum) 설정/해제(멱등, 느슨). 빈 목록이면 해제. R3 드롭다운 편의. */
+    @PatchMapping("/{id}/columns/{key}/options")
+    public ApiResponse<DatasetResponse> setColumnOptions(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @PathVariable String key,
+            @Valid @RequestBody SetColumnOptionsRequest request) {
+        return ApiResponse.success(
+                datasetService.setColumnOptions(memberId, id, key, request.options()));
     }
 
     /** 열 기본 정렬 초기화 — 기본 정렬(left)로 되돌린다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetColumn.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/DatasetColumn.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 
+import java.util.List;
+
 /**
  * 데이터셋 열 메타. key는 안정 식별자, label은 표시명.
  *
@@ -35,7 +37,9 @@ public record DatasetColumn(
         @Pattern(regexp = ALLOWED_SUMMARY, message = "허용되지 않은 요약 함수입니다.")
         String summary,
         @Pattern(regexp = ALLOWED_FORMAT, message = "허용되지 않은 숫자 서식입니다.")
-        String format
+        String format,
+        // 허용값 목록(enum). null이면 자유 입력. FE 드롭다운 편의용 — 서버는 값을 강제하지 않는다(느슨).
+        List<String> options
 ) {
     /** 열 너비 하한(px). 이보다 좁으면 값이 사실상 안 보인다. */
     public static final int MIN_WIDTH = 60;
@@ -51,31 +55,36 @@ public record DatasetColumn(
 
     /** 너비·정렬·요약·서식 없이 만든다(기본 폭·기본 정렬). */
     public DatasetColumn(String key, String label) {
-        this(key, label, null, null, null, null);
+        this(key, label, null, null, null, null, null);
     }
 
     /** label만 바꾼 새 열 메타(나머지 보존). */
     public DatasetColumn withLabel(String label) {
-        return new DatasetColumn(key, label, width, align, summary, format);
+        return new DatasetColumn(key, label, width, align, summary, format, options);
     }
 
     /** width만 바꾼 새 열 메타(나머지 보존). */
     public DatasetColumn withWidth(Integer width) {
-        return new DatasetColumn(key, label, width, align, summary, format);
+        return new DatasetColumn(key, label, width, align, summary, format, options);
     }
 
     /** align만 바꾼 새 열 메타(나머지 보존). */
     public DatasetColumn withAlign(String align) {
-        return new DatasetColumn(key, label, width, align, summary, format);
+        return new DatasetColumn(key, label, width, align, summary, format, options);
     }
 
     /** summary만 바꾼 새 열 메타(나머지 보존). */
     public DatasetColumn withSummary(String summary) {
-        return new DatasetColumn(key, label, width, align, summary, format);
+        return new DatasetColumn(key, label, width, align, summary, format, options);
     }
 
     /** format만 바꾼 새 열 메타(나머지 보존). */
     public DatasetColumn withFormat(String format) {
-        return new DatasetColumn(key, label, width, align, summary, format);
+        return new DatasetColumn(key, label, width, align, summary, format, options);
+    }
+
+    /** options만 바꾼 새 열 메타(나머지 보존). */
+    public DatasetColumn withOptions(List<String> options) {
+        return new DatasetColumn(key, label, width, align, summary, format, options);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetColumnOptionsRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/dto/SetColumnOptionsRequest.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.dataset.dto;
+
+import java.util.List;
+
+/**
+ * 열 허용값 목록(enum) 설정/해제 요청. 값 목록을 주거나 {@code null}·빈 목록(해제).
+ *
+ * <p>느슨한 제약이다 — 서버는 이 목록으로 셀 값을 <b>강제하지 않는다</b>. FE 드롭다운(datalist)
+ * 편의를 위한 목록일 뿐이라, 붙여넣기·임포트·수식 결과가 목록 밖이어도 그대로 받는다. 서버는
+ * 목록을 정규화(공백 제거·중복 제거)해 저장만 한다.
+ */
+public record SetColumnOptionsRequest(
+        List<String> options
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/dataset/service/DatasetService.java
@@ -398,6 +398,53 @@ public class DatasetService {
         return metaResponse(dataset, updated);
     }
 
+    /** 허용값 목록 상한. 드롭다운 편의용이라 과도한 목록은 막는다. */
+    static final int MAX_OPTIONS = 200;
+
+    /**
+     * 열 허용값 목록(enum)을 설정/해제한다(멱등 교체). 빈 목록·null이면 해제(자유 입력). 값은
+     * <b>강제하지 않고</b>(느슨) 목록만 정규화해 저장한다 — 공백 정리·중복 제거·순서 보존.
+     */
+    @Transactional
+    public DatasetResponse setColumnOptions(Long memberId, Long datasetId, String key,
+                                            List<String> options) {
+        Dataset dataset = getOwned(memberId, datasetId);
+        List<DatasetColumn> columns = parseColumns(dataset.getColumns());
+        int at = indexOfColumn(columns, key);
+        if (at < 0) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+        List<DatasetColumn> updated = new java.util.ArrayList<>(columns);
+        updated.set(at, columns.get(at).withOptions(normalizeOptions(options)));
+        dataset.updateColumns(serialize(updated));
+        return metaResponse(dataset, updated);
+    }
+
+    /** 공백 정리·빈값/중복 제거(순서 보존). 비면 null(해제). 상한을 넘으면 거부. */
+    private List<String> normalizeOptions(List<String> options) {
+        if (options == null) {
+            return null;
+        }
+        java.util.LinkedHashSet<String> set = new java.util.LinkedHashSet<>();
+        for (String o : options) {
+            if (o == null) {
+                continue;
+            }
+            String trimmed = o.trim();
+            if (!trimmed.isEmpty()) {
+                set.add(trimmed);
+            }
+        }
+        if (set.isEmpty()) {
+            return null;
+        }
+        if (set.size() > MAX_OPTIONS) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST,
+                    "허용값은 " + MAX_OPTIONS + "개를 넘을 수 없습니다");
+        }
+        return List.copyOf(set);
+    }
+
     /**
      * 표 이름을 설정/해제한다(멱등). 빈 값(공백·null)이면 무명으로 되돌린다. 유일성은 강제하지
      * 않는다 — BE는 표가 어느 노트에 있는지 모르므로, 이름 해석은 #915에서 노트 단위(FE)로 한다.

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetColumnOptionsTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/dataset/controller/DatasetColumnOptionsTest.java
@@ -1,0 +1,104 @@
+package ds.project.orino.planner.dataset.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.hamcrest.Matchers.contains;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** 열 허용값 목록(enum, R3 #914). 느슨 — 목록만 정규화해 저장하고 값은 강제하지 않는다. */
+class DatasetColumnOptionsTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long datasetId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        String body = mockMvc.perform(post("/api/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"columns\":[{\"key\":\"c0\",\"label\":\"통화\"}]}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        datasetId = ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private ResultActions setOptions(String bodyJson) throws Exception {
+        return mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/options", datasetId, "c0")
+                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(bodyJson));
+    }
+
+    private ResultActions meta() throws Exception {
+        return mockMvc.perform(get("/api/datasets/{id}", datasetId)
+                .header(HttpHeaders.AUTHORIZATION, authHeader));
+    }
+
+    @Test
+    @DisplayName("허용값 목록을 설정하면 열에 담기고 조회에 실린다")
+    void setOptionsPersists() throws Exception {
+        setOptions("{\"options\":[\"원\",\"엔\"]}")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].options", contains("원", "엔")));
+        meta().andExpect(jsonPath("$.data.columns[0].options", contains("원", "엔")));
+    }
+
+    @Test
+    @DisplayName("공백 정리·중복 제거·순서 보존")
+    void normalizes() throws Exception {
+        setOptions("{\"options\":[\"원\",\"  원  \",\"엔\",\"\",\"엔\"]}")
+                .andExpect(jsonPath("$.data.columns[0].options", contains("원", "엔")));
+    }
+
+    @Test
+    @DisplayName("빈 목록이면 해제된다")
+    void emptyClears() throws Exception {
+        setOptions("{\"options\":[\"원\"]}").andExpect(status().isOk());
+        setOptions("{\"options\":[]}")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.columns[0].options").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("null이면 해제된다")
+    void nullClears() throws Exception {
+        setOptions("{\"options\":[\"원\"]}").andExpect(status().isOk());
+        setOptions("{\"options\":null}")
+                .andExpect(jsonPath("$.data.columns[0].options").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("없는 열은 404")
+    void missingColumn() throws Exception {
+        mockMvc.perform(patch("/api/datasets/{id}/columns/{key}/options", datasetId, "c9")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"options\":[\"원\"]}"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/fe/src/features/note/dataset/ColumnOptionsEditor.tsx
+++ b/fe/src/features/note/dataset/ColumnOptionsEditor.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+
+interface Props {
+  /** 현재 허용값(한 줄에 하나로 편집). */
+  initial: string[];
+  /** 정규화 전 원본 줄 목록을 넘긴다(서버가 공백·중복을 정리한다). */
+  onSave: (options: string[]) => void;
+  onClose: () => void;
+}
+
+/**
+ * 열 허용값 목록(enum) 편집기(R3 #914). 한 줄에 하나씩. 느슨한 제약이라 이 목록은 셀 편집의
+ * 드롭다운 제안으로만 쓰이고 값을 강제하지 않는다. 비워 저장하면 해제(자유 입력).
+ */
+export function ColumnOptionsEditor({ initial, onSave, onClose }: Props) {
+  const [text, setText] = useState(initial.join("\n"));
+
+  const save = () => {
+    onSave(text.split("\n").map((s) => s.trim()));
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40" onClick={onClose} />
+      <div
+        role="dialog"
+        aria-label="허용값 목록 편집"
+        className="border-border bg-popover fixed top-1/2 left-1/2 z-50 flex w-64 -translate-x-1/2 -translate-y-1/2 flex-col gap-2 rounded-md border p-3 text-sm shadow-md"
+      >
+        <div className="text-muted-foreground text-xs">
+          허용값을 한 줄에 하나씩. 비우면 해제됩니다.
+        </div>
+        <textarea
+          aria-label="허용값"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={5}
+          className="border-border rounded border px-2 py-1"
+        />
+        <div className="flex justify-end gap-1">
+          <button
+            type="button"
+            onClick={onClose}
+            className="hover:bg-accent rounded px-2 py-1 text-xs"
+          >
+            닫기
+          </button>
+          <button
+            type="button"
+            onClick={save}
+            className="bg-primary text-primary-foreground rounded px-2 py-1 text-xs"
+          >
+            저장
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -2558,6 +2558,76 @@ describe("DatasetGrid", () => {
     );
   });
 
+  // ---------- 열 허용값 목록(enum, R3 #914) ----------
+
+  it("허용값 열은 셀 편집에 드롭다운 제안(datalist)을 붙인다", async () => {
+    mockDataset([["원"]]);
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            id: 1,
+            columns: [{ key: "c0", label: "통화", options: ["원", "엔"] }],
+            rowCount: 1,
+          },
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await user.dblClick(await screen.findByText("원"));
+    const input = await screen.findByLabelText("셀 1행 1열");
+    expect(input).toHaveAttribute("list", "opts-c0");
+    expect(
+      document.getElementById("opts-c0")?.querySelectorAll("option"),
+    ).toHaveLength(2);
+  });
+
+  it("우클릭 허용값 목록 편집기에서 저장하면 그 열에 PATCH한다", async () => {
+    mockDataset([["a", "b"]]);
+    let patched: unknown = null;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/columns/:key/options`,
+        async ({ params, request }) => {
+          patched = { key: params.key, body: await request.json() };
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              id: 1,
+              columns: [
+                { key: "c0", label: "과목", options: ["원", "엔"] },
+                { key: "c1", label: "점수" },
+              ],
+              rowCount: 1,
+            },
+          });
+        },
+      ),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const cell = (await screen.findByText("a")).parentElement as HTMLElement;
+    fireEvent.pointerDown(cell, { button: 0 });
+    fireEvent.contextMenu(cell);
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    fireEvent.click(
+      within(menu).getByRole("menuitem", { name: "허용값 목록…" }),
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "허용값 목록 편집",
+    });
+    fireEvent.change(within(dialog).getByLabelText("허용값"), {
+      target: { value: "원\n엔" },
+    });
+    fireEvent.click(within(dialog).getByText("저장"));
+
+    await waitFor(() =>
+      expect(patched).toEqual({ key: "c0", body: { options: ["원", "엔"] } }),
+    );
+  });
+
   it("우클릭 메뉴에서 배경색을 고르면 선택한 셀에 일괄 PUT한다", async () => {
     mockDataset([["네트워크", "92"]]);
     let sentCells: unknown = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -45,12 +45,14 @@ import {
   setCellMerge,
   setCellStylesBulk,
   setColumnFormat,
+  setColumnOptions,
   setColumnSummary,
   setDatasetName,
   type SummaryFn,
   updateDatasetRow,
 } from "./api/datasets";
 import { DATASET_CELLS_MIME } from "./cellClipboard";
+import { ColumnOptionsEditor } from "./ColumnOptionsEditor";
 import { CrossRefPicker } from "./CrossRefPicker";
 import type { FormulaContext, ValueSource } from "./formula";
 import { aggregate, asCell, evaluateFormula } from "./formula";
@@ -153,6 +155,11 @@ export function DatasetGrid({
   const fillDragging = useRef(false);
   // 표간 참조 피커 열림 여부(활성 셀 편집 중).
   const [crossPickerOpen, setCrossPickerOpen] = useState(false);
+  // 허용값 목록 편집기(우클릭 "허용값 목록…"에서 연다). 대상 열 key + 현재 값.
+  const [optionsEditor, setOptionsEditor] = useState<{
+    key: string;
+    initial: string[];
+  } | null>(null);
   // 최신 commitFill을 담아 둔다 — window pointerup(한 번만 등록)이 stale 클로저 없이 부른다.
   const commitFillRef = useRef<() => void>(() => {});
 
@@ -311,6 +318,17 @@ export function DatasetGrid({
   // 표 이름 설정/해제. 응답 메타로 캐시를 맞춰 이름이 즉시 반영된다.
   const nameMut = useMutation({
     mutationFn: (name: string) => setDatasetName(datasetId, name),
+    onSuccess: (next: DatasetMeta) =>
+      queryClient.setQueryData(datasetKeys.meta(datasetId), next),
+    onError: (e) => {
+      const message = serverMessage(e);
+      if (message) toast(message, "error");
+    },
+  });
+  // 열 허용값 목록 설정/해제. 응답 메타로 캐시를 맞춘다.
+  const optionsMut = useMutation({
+    mutationFn: (v: { key: string; options: string[] }) =>
+      setColumnOptions(datasetId, v.key, v.options),
     onSuccess: (next: DatasetMeta) =>
       queryClient.setQueryData(datasetKeys.meta(datasetId), next),
     onError: (e) => {
@@ -1358,6 +1376,12 @@ export function DatasetGrid({
             ref={activeInputRef}
             autoFocus
             value={draft}
+            // 허용값(enum) 열이면 드롭다운 제안(datalist). 느슨 — 목록 밖도 타이핑 가능.
+            list={
+              meta.columns[c].options
+                ? `opts-${meta.columns[c].key}`
+                : undefined
+            }
             // 선택만 한 상태(편집 전)에선 값을 통째로 선택해 둔다 — 글자를 치면 덮어써지고,
             // 한글도 첫 자모부터 이 입력창에서 조합된다(엘리먼트 교체가 없어 조합이 안 끊긴다).
             onFocus={(e) => {
@@ -1404,6 +1428,13 @@ export function DatasetGrid({
                 : undefined
             }
           />
+        )}
+        {isActive && meta.columns[c].options && (
+          <datalist id={`opts-${meta.columns[c].key}`}>
+            {meta.columns[c].options!.map((o) => (
+              <option key={o} value={o} />
+            ))}
+          </datalist>
         )}
         {/* 표간 참조 — 이름 있는 형제 표가 있을 때만. mousedown preventDefault로 입력창 blur(=커밋)
           없이 피커만 연다. */}
@@ -1773,6 +1804,18 @@ export function DatasetGrid({
           pending={deleteColMut.isPending}
         />
 
+        {/* 허용값 목록 편집기 — 우클릭 "허용값 목록…"에서 연다. 저장 시 그 열 options 교체. */}
+        {optionsEditor && (
+          <ColumnOptionsEditor
+            initial={optionsEditor.initial}
+            onSave={(options) => {
+              optionsMut.mutate({ key: optionsEditor.key, options });
+              setOptionsEditor(null);
+            }}
+            onClose={() => setOptionsEditor(null)}
+          />
+        )}
+
         {/* 우클릭 컨텍스트 메뉴 — 선택 범위에 맞춰 서식·병합·행/열 옵션을 한 곳에 모은다.
           (별도 플로팅 툴바 없이 우클릭 하나로 통일한다.) */}
         {ctxMenu &&
@@ -2000,6 +2043,18 @@ export function DatasetGrid({
                           <X className="size-3" />
                         </button>
                       </div>
+                      {divider}
+                    </>
+                  )}
+                  {/* 허용값 목록(enum) — 한 열만 걸쳤을 때. 셀 편집 드롭다운 제안(느슨). */}
+                  {rect.c0 === rect.c1 && (
+                    <>
+                      {item("허용값 목록…", () =>
+                        setOptionsEditor({
+                          key: meta.columns[rect.c0].key,
+                          initial: meta.columns[rect.c0].options ?? [],
+                        }),
+                      )}
                       {divider}
                     </>
                   )}

--- a/fe/src/features/note/dataset/api/datasets.ts
+++ b/fe/src/features/note/dataset/api/datasets.ts
@@ -23,6 +23,8 @@ export interface DatasetColumn {
   summary?: SummaryFn;
   /** 열 숫자 서식(표시 전용). 값·수식은 raw, 화면에만 이 서식으로 포맷한다. 없으면 그대로. */
   format?: NumberFormat;
+  /** 허용값 목록(enum). 있으면 셀 편집에 드롭다운 제안(느슨 — 강제 아님). 없으면 자유 입력. */
+  options?: string[];
 }
 
 /** 셀·열 정렬 값. 서버의 ALLOWED_ALIGN과 같아야 한다. */
@@ -294,6 +296,21 @@ export async function updateDatasetRow(
   const { data } = await client.patch<ApiEnvelope<UpdateRowResult>>(
     `/datasets/${datasetId}/rows/${rowIndex}`,
     { cells, tableRefs },
+  );
+  return data.data;
+}
+
+/**
+ * 열 허용값 목록(enum) 설정/해제(멱등, 느슨). 빈 배열이면 해제. 서버가 정규화한 메타를 돌려준다.
+ */
+export async function setColumnOptions(
+  datasetId: number,
+  key: string,
+  options: string[],
+): Promise<DatasetMeta> {
+  const { data } = await client.patch<ApiEnvelope<DatasetMeta>>(
+    `/datasets/${datasetId}/columns/${key}/options`,
+    { options },
   );
   return data.data;
 }


### PR DESCRIPTION
## 이슈
closes #914

## 작업 내용
요구 감사 R3(마지막 항목) — 열에 허용값 목록(enum). 통화=원/엔, 사용처=교통/식사 처럼 열에 정해진 선택지. **느슨한 제약**(검증 정책 결정): 서버는 값을 강제하지 않고 목록은 FE 드롭다운 편의로만 쓴다.

### 왜 느슨인가
엄격(서버 거부)은 붙여넣기·임포트·수식 결과·기존 데이터와 충돌해 모델과 싸운다. R2 "표시 전용"과 같은 결로, options는 입력 UX(datalist 제안)만 만들고 저장은 자유롭게 받는다. 오타 없는 SUMIF 카테고리라는 실사용 가치는 드롭다운으로 충분히 얻는다.

### BE (#909 패턴)
- `DatasetColumn.options`(nullable List) — `width·align·summary·format`처럼 `columns_json`에 상주.
- `PATCH /datasets/{id}/columns/{key}/options` — 정규화(공백·빈값·중복 제거, 순서 보존, 상한 200), 빈 목록·null이면 해제.
- 셀 값 검증은 하지 않는다(느슨).

### FE
- options 열이면 셀 입력창에 `<datalist>`를 붙여 드롭다운 제안 — **목록 밖도 타이핑 가능**(느슨).
- 우클릭 "허용값 목록…" → 편집기(한 줄에 하나) → 저장. 비우면 해제.

## 테스트
- BE 5건: 설정·조회, 정규화(공백·중복·순서), 빈 목록/null 해제, 없는 열 404
- FE 2건: 허용값 열이 datalist 제안 붙임, 우클릭 편집기 저장→PATCH
- FE 474개·BE checkstyle·전체 dataset 테스트 통과

## 확인
- 로컬 브라우저 실증 미실행(풀스택 필요). 마이그레이션 없음, 엔드포인트·정규화는 TestContainers, datalist는 RTL로 검증.