### PR TITLE
feat : 데이터 그리드 우클릭 메뉴 하위 메뉴로 정리 (depth 추가)

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -641,6 +641,7 @@ describe("DatasetGrid", () => {
 
     // 헤더가 없어 열 삭제는 셀 우클릭 메뉴로 한다 — c1(점수) 값 "92" 셀을 우클릭.
     fireEvent.contextMenu(screen.getByText("92"));
+    await user.click(await screen.findByRole("menuitem", { name: "삭제" }));
     await user.click(await screen.findByRole("menuitem", { name: "열 삭제" }));
     // 확인 전엔 요청이 나가지 않는다.
     expect(deletedKey).toBeNull();
@@ -1162,6 +1163,7 @@ describe("DatasetGrid", () => {
     await screen.findByText("네트워크");
     // 인라인 삭제 버튼을 없앴으므로 행 삭제는 셀 우클릭 메뉴로 한다.
     fireEvent.contextMenu(screen.getByText("네트워크"));
+    await user.click(await screen.findByRole("menuitem", { name: "삭제" }));
     await user.click(await screen.findByRole("menuitem", { name: "행 삭제" }));
 
     await waitFor(() => expect(deleted).toBe(0));
@@ -1176,6 +1178,7 @@ describe("DatasetGrid", () => {
     );
 
     fireEvent.contextMenu(await screen.findByText("네트워크"));
+    await user.click(await screen.findByRole("menuitem", { name: "삭제" }));
     await user.click(await screen.findByRole("menuitem", { name: "표 삭제" }));
 
     // 표 삭제는 키보드 단축키 대신 이 메뉴로만 — 블록 제거 콜백(노드 삭제)을 부른다.
@@ -1184,9 +1187,10 @@ describe("DatasetGrid", () => {
 
   it("onDeleteBlock이 없으면 '표 삭제' 항목을 보이지 않는다", async () => {
     mockDataset([["네트워크", "92"]]);
+    const user = userEvent.setup();
     renderWithRouter(<DatasetGrid datasetId={1} />);
     fireEvent.contextMenu(await screen.findByText("네트워크"));
-    await screen.findByRole("menu", { name: "셀 메뉴" });
+    await user.click(await screen.findByRole("menuitem", { name: "삭제" }));
     expect(
       screen.queryByRole("menuitem", { name: "표 삭제" }),
     ).not.toBeInTheDocument();
@@ -1532,7 +1536,8 @@ describe("DatasetGrid", () => {
 
     fireEvent.contextMenu(cell);
     const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
-    await user.click(within(menu).getByLabelText("정렬 가운데"));
+    await user.click(within(menu).getByRole("menuitem", { name: "서식" }));
+    await user.click(await screen.findByLabelText("정렬 가운데"));
 
     // 배경색(green)은 보존하고 정렬만 얹어 일괄 엔드포인트로 보낸다.
     await waitFor(() =>
@@ -1586,7 +1591,8 @@ describe("DatasetGrid", () => {
 
     fireEvent.contextMenu(cell);
     const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
-    await user.click(within(menu).getByLabelText("세로 정렬 가운데"));
+    await user.click(within(menu).getByRole("menuitem", { name: "서식" }));
+    await user.click(await screen.findByLabelText("세로 정렬 가운데"));
 
     // 배경색(green)·가로 정렬(right)은 보존하고 세로 정렬만 얹어 보낸다.
     await waitFor(() =>
@@ -1839,6 +1845,7 @@ describe("DatasetGrid", () => {
     await screen.findByText("네트워크");
 
     fireEvent.contextMenu(screen.getByText("네트워크")); // 0행
+    await user.click(await screen.findByRole("menuitem", { name: "삽입" }));
     await user.click(screen.getByRole("menuitem", { name: "아래에 행 삽입" }));
 
     // 0행 아래 = atIndex 1.
@@ -1870,6 +1877,7 @@ describe("DatasetGrid", () => {
     await screen.findByText("네트워크");
 
     fireEvent.contextMenu(screen.getByText("네트워크")); // c0
+    await user.click(await screen.findByRole("menuitem", { name: "삽입" }));
     await user.click(
       screen.getByRole("menuitem", { name: "오른쪽에 열 삽입" }),
     );
@@ -1922,11 +1930,12 @@ describe("DatasetGrid", () => {
     fireEvent.contextMenu(screen.getByText("네트워크"));
     const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
     expect(within(menu).getByText("1행")).toBeInTheDocument();
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "삽입" }));
     expect(
-      within(menu).getByRole("menuitem", { name: "위에 행 삽입" }),
+      await screen.findByRole("menuitem", { name: "위에 행 삽입" }),
     ).toBeInTheDocument();
     expect(
-      within(menu).getByRole("menuitem", { name: "아래에 행 삽입" }),
+      screen.getByRole("menuitem", { name: "아래에 행 삽입" }),
     ).toBeInTheDocument();
   });
 
@@ -1939,8 +1948,9 @@ describe("DatasetGrid", () => {
     fireEvent.contextMenu(screen.getByText("네트워크"));
     const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
     expect(within(menu).getByText("1열")).toBeInTheDocument();
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "삽입" }));
     expect(
-      within(menu).getByRole("menuitem", { name: "왼쪽에 열 삽입" }),
+      await screen.findByRole("menuitem", { name: "왼쪽에 열 삽입" }),
     ).toBeInTheDocument();
   });
 
@@ -1953,6 +1963,29 @@ describe("DatasetGrid", () => {
     fireEvent.contextMenu(screen.getByText("네트워크"));
     const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
     expect(within(menu).getByText("표 전체")).toBeInTheDocument();
+  });
+
+  it("우클릭 메뉴가 하위 메뉴로 정리된다 — 펼쳐야 하위 항목이 나온다", async () => {
+    mockDataset([["a", "b"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const cell = (await screen.findByText("a")).parentElement as HTMLElement;
+    fireEvent.pointerDown(cell, { button: 0 });
+    fireEvent.contextMenu(cell);
+    const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+
+    // 최상위엔 하위 메뉴 부모(서식·삽입·삭제)가 있고, 펼치기 전엔 하위 항목이 숨어 있다.
+    expect(within(menu).getByRole("menuitem", { name: "서식" })).toBeVisible();
+    expect(within(menu).getByRole("menuitem", { name: "삽입" })).toBeVisible();
+    expect(within(menu).getByRole("menuitem", { name: "삭제" })).toBeVisible();
+    expect(
+      screen.queryByRole("menuitem", { name: "행 삭제" }),
+    ).not.toBeInTheDocument();
+
+    // 삭제를 펼치면 하위 항목이 나온다.
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "삭제" }));
+    expect(
+      await screen.findByRole("menuitem", { name: "행 삭제" }),
+    ).toBeInTheDocument();
   });
 
   it("방향키로 활성 셀을 상하좌우로 옮긴다", async () => {
@@ -2241,7 +2274,8 @@ describe("DatasetGrid", () => {
     fireEvent.pointerDown(cell, { button: 0 });
     fireEvent.contextMenu(cell);
     const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
-    fireEvent.click(within(menu).getByRole("menuitem", { name: "요약 합계" }));
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "열" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "요약 합계" }));
 
     await waitFor(() =>
       expect(patched).toEqual({ key: "c1", body: { summary: "SUM" } }),
@@ -2551,7 +2585,8 @@ describe("DatasetGrid", () => {
     fireEvent.pointerDown(cell, { button: 0 });
     fireEvent.contextMenu(cell);
     const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
-    fireEvent.click(within(menu).getByRole("menuitem", { name: "서식 KRW" }));
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "열" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "서식 KRW" }));
 
     await waitFor(() =>
       expect(patched).toEqual({ key: "c0", body: { format: "KRW" } }),
@@ -2611,8 +2646,9 @@ describe("DatasetGrid", () => {
     fireEvent.pointerDown(cell, { button: 0 });
     fireEvent.contextMenu(cell);
     const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "열" }));
     fireEvent.click(
-      within(menu).getByRole("menuitem", { name: "허용값 목록…" }),
+      await screen.findByRole("menuitem", { name: "허용값 목록…" }),
     );
 
     const dialog = await screen.findByRole("dialog", {
@@ -2655,7 +2691,8 @@ describe("DatasetGrid", () => {
 
     fireEvent.contextMenu(cell);
     const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
-    await user.click(within(menu).getByLabelText("배경색 green"));
+    await user.click(within(menu).getByRole("menuitem", { name: "서식" }));
+    await user.click(await screen.findByLabelText("배경색 green"));
 
     // 선택 셀 하나를 일괄 엔드포인트로 보낸다(정렬은 기존값 없음 → null).
     await waitFor(() =>
@@ -2689,7 +2726,8 @@ describe("DatasetGrid", () => {
 
     fireEvent.contextMenu(a);
     const menu = await screen.findByRole("menu", { name: "셀 메뉴" });
-    await user.click(within(menu).getByLabelText("배경색 blue"));
+    await user.click(within(menu).getByRole("menuitem", { name: "서식" }));
+    await user.click(await screen.findByLabelText("배경색 blue"));
 
     // 4칸(2×2)을 한 요청으로 보낸다.
     await waitFor(() => expect(requestCount).toBe(1));

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -7,7 +7,10 @@ import {
   AlignVerticalJustifyCenter,
   AlignVerticalJustifyEnd,
   AlignVerticalJustifyStart,
+  ChevronRight,
+  Columns3,
   Eraser,
+  Paintbrush,
   Plus,
   TableCellsMerge,
   TableCellsSplit,
@@ -146,6 +149,8 @@ export function DatasetGrid({
     row: number;
     col: number;
   } | null>(null);
+  // 지금 펼쳐진 우클릭 하위 메뉴(라벨). 한 번에 하나만 — 메뉴가 열릴 때 초기화한다.
+  const [openSubmenu, setOpenSubmenu] = useState<string | null>(null);
   // 선택 범위(셀/행/열/표). 클릭·드래그·핸들로 정하고, 선택 위 플로팅 툴바가 이걸 본다.
   const [sel, setSel] = useState<Sel>(null);
   // 드래그 선택 중인 축(셀/행/열). 눌러서 끌 때만 값이 있고 window pointerup에서 해제한다.
@@ -776,6 +781,7 @@ export function DatasetGrid({
       selDrag.current = null;
       setSel({ kind: "cells", a: [row, col], b: [row, col] });
     }
+    setOpenSubmenu(null);
     setCtxMenu({ x: event.clientX, y: event.clientY, row, col });
   };
 
@@ -1893,171 +1899,186 @@ export function DatasetGrid({
                   <div className="text-muted-foreground px-2 py-1 text-xs">
                     {scopeLabel}
                   </div>
-                  {/* 배경색 — 스와치 + 지우기 */}
-                  <div className="flex items-center gap-1 px-2 py-1">
-                    {CELL_BG_TOKENS.map((token) => (
+                  <SubMenu
+                    label="서식"
+                    icon={<Paintbrush className="size-3.5" />}
+                    open={openSubmenu === "서식"}
+                    onOpen={() => setOpenSubmenu("서식")}
+                  >
+                    {/* 배경색 — 스와치 + 지우기 */}
+                    <div className="flex items-center gap-1 px-2 py-1">
+                      {CELL_BG_TOKENS.map((token) => (
+                        <button
+                          key={token}
+                          type="button"
+                          aria-label={`배경색 ${token}`}
+                          onClick={run(() => applyBgSel(token))}
+                          className="border-border size-5 rounded-full border"
+                          style={{ background: `var(--cell-bg-${token})` }}
+                        />
+                      ))}
                       <button
-                        key={token}
                         type="button"
-                        aria-label={`배경색 ${token}`}
-                        onClick={run(() => applyBgSel(token))}
-                        className="border-border size-5 rounded-full border"
-                        style={{ background: `var(--cell-bg-${token})` }}
-                      />
-                    ))}
-                    <button
-                      type="button"
-                      aria-label="배경색 지우기"
-                      onClick={run(() => applyBgSel(null))}
-                      className="text-muted-foreground hover:text-foreground border-border flex size-5 items-center justify-center rounded-full border"
-                    >
-                      <X className="size-3" />
-                    </button>
-                  </div>
-                  {/* 정렬 + 서식 지우기 */}
-                  <div className="flex items-center gap-1 px-2 py-1">
-                    {ALIGN_ORDER.map((value) => {
-                      const Icon = ALIGN_ICONS[value];
-                      return (
-                        <button
-                          key={value}
-                          type="button"
-                          aria-label={`정렬 ${ALIGN_LABELS[value]}`}
-                          onClick={run(() => applyAlignSel(value))}
-                          className="text-muted-foreground hover:bg-accent hover:text-foreground flex size-6 items-center justify-center rounded"
-                        >
-                          <Icon className="size-4" />
-                        </button>
-                      );
-                    })}
-                    <span className="bg-border mx-0.5 h-4 w-px" />
-                    {VALIGN_ORDER.map((value) => {
-                      const Icon = VALIGN_ICONS[value];
-                      return (
-                        <button
-                          key={value}
-                          type="button"
-                          aria-label={`세로 정렬 ${VALIGN_LABELS[value]}`}
-                          onClick={run(() => applyValignSel(value))}
-                          className="text-muted-foreground hover:bg-accent hover:text-foreground flex size-6 items-center justify-center rounded"
-                        >
-                          <Icon className="size-4" />
-                        </button>
-                      );
-                    })}
-                    <button
-                      type="button"
-                      aria-label="서식 지우기"
-                      title="배경·정렬·세로정렬 초기화"
-                      onClick={run(clearFormatSel)}
-                      className="text-muted-foreground hover:bg-accent hover:text-foreground ml-auto flex size-6 items-center justify-center rounded"
-                    >
-                      <Eraser className="size-4" />
-                    </button>
-                  </div>
-                  {divider}
-                  {/* 열 요약 — 한 열만 걸쳤을 때. 그 열 푸터에 SUM/AVG/… 를 걸거나 지운다. */}
-                  {rect.c0 === rect.c1 && (
-                    <>
-                      <div className="text-muted-foreground px-2 pt-1 text-xs">
-                        열 요약
-                      </div>
-                      <div className="flex items-center gap-1 px-2 py-1">
-                        {SUMMARY_FNS.map((fn) => (
+                        aria-label="배경색 지우기"
+                        onClick={run(() => applyBgSel(null))}
+                        className="text-muted-foreground hover:text-foreground border-border flex size-5 items-center justify-center rounded-full border"
+                      >
+                        <X className="size-3" />
+                      </button>
+                    </div>
+                    {/* 정렬 + 서식 지우기 */}
+                    <div className="flex items-center gap-1 px-2 py-1">
+                      {ALIGN_ORDER.map((value) => {
+                        const Icon = ALIGN_ICONS[value];
+                        return (
                           <button
-                            key={fn}
+                            key={value}
                             type="button"
-                            role="menuitem"
-                            aria-label={`요약 ${SUMMARY_LABELS[fn]}`}
-                            onClick={run(() =>
-                              summaryMut.mutate({
-                                key: meta.columns[rect.c0].key,
-                                fn,
-                              }),
-                            )}
-                            className={cn(
-                              "hover:bg-accent rounded px-1.5 py-1 text-xs",
-                              meta.columns[rect.c0].summary === fn &&
-                                "bg-accent text-foreground",
-                            )}
+                            aria-label={`정렬 ${ALIGN_LABELS[value]}`}
+                            onClick={run(() => applyAlignSel(value))}
+                            className="text-muted-foreground hover:bg-accent hover:text-foreground flex size-6 items-center justify-center rounded"
                           >
-                            {SUMMARY_LABELS[fn]}
+                            <Icon className="size-4" />
                           </button>
-                        ))}
-                        <button
-                          type="button"
-                          aria-label="요약 지우기"
-                          onClick={run(() =>
-                            summaryMut.mutate({
-                              key: meta.columns[rect.c0].key,
-                              fn: null,
-                            }),
-                          )}
-                          className="text-muted-foreground hover:text-foreground flex size-6 items-center justify-center rounded"
-                        >
-                          <X className="size-3" />
-                        </button>
-                      </div>
-                      {divider}
-                    </>
-                  )}
-                  {/* 숫자 서식 — 한 열만 걸쳤을 때. 표시 전용(값·수식은 raw 그대로). */}
-                  {rect.c0 === rect.c1 && (
-                    <>
-                      <div className="text-muted-foreground px-2 pt-1 text-xs">
-                        숫자 서식
-                      </div>
-                      <div className="flex items-center gap-1 px-2 py-1">
-                        {NUMBER_FORMATS.map((fmt) => (
+                        );
+                      })}
+                      <span className="bg-border mx-0.5 h-4 w-px" />
+                      {VALIGN_ORDER.map((value) => {
+                        const Icon = VALIGN_ICONS[value];
+                        return (
                           <button
-                            key={fmt}
+                            key={value}
                             type="button"
-                            role="menuitem"
-                            aria-label={`서식 ${fmt}`}
-                            onClick={run(() =>
-                              formatMut.mutate({
-                                key: meta.columns[rect.c0].key,
-                                format: fmt,
-                              }),
-                            )}
-                            className={cn(
-                              "hover:bg-accent rounded px-1.5 py-1 text-xs",
-                              meta.columns[rect.c0].format === fmt &&
-                                "bg-accent text-foreground",
-                            )}
+                            aria-label={`세로 정렬 ${VALIGN_LABELS[value]}`}
+                            onClick={run(() => applyValignSel(value))}
+                            className="text-muted-foreground hover:bg-accent hover:text-foreground flex size-6 items-center justify-center rounded"
                           >
-                            {FORMAT_LABELS[fmt]}
+                            <Icon className="size-4" />
                           </button>
-                        ))}
-                        <button
-                          type="button"
-                          aria-label="서식 지우기"
-                          onClick={run(() =>
-                            formatMut.mutate({
-                              key: meta.columns[rect.c0].key,
-                              format: null,
-                            }),
-                          )}
-                          className="text-muted-foreground hover:text-foreground flex size-6 items-center justify-center rounded"
-                        >
-                          <X className="size-3" />
-                        </button>
-                      </div>
-                      {divider}
-                    </>
-                  )}
-                  {/* 허용값 목록(enum) — 한 열만 걸쳤을 때. 셀 편집 드롭다운 제안(느슨). */}
+                        );
+                      })}
+                      <button
+                        type="button"
+                        aria-label="서식 지우기"
+                        title="배경·정렬·세로정렬 초기화"
+                        onClick={run(clearFormatSel)}
+                        className="text-muted-foreground hover:bg-accent hover:text-foreground ml-auto flex size-6 items-center justify-center rounded"
+                      >
+                        <Eraser className="size-4" />
+                      </button>
+                    </div>
+                  </SubMenu>
                   {rect.c0 === rect.c1 && (
-                    <>
-                      {item("허용값 목록…", () =>
-                        setOptionsEditor({
-                          key: meta.columns[rect.c0].key,
-                          initial: meta.columns[rect.c0].options ?? [],
-                        }),
+                    <SubMenu
+                      label="열"
+                      icon={<Columns3 className="size-3.5" />}
+                      open={openSubmenu === "열"}
+                      onOpen={() => setOpenSubmenu("열")}
+                    >
+                      {/* 열 요약 — 한 열만 걸쳤을 때. 그 열 푸터에 SUM/AVG/… 를 걸거나 지운다. */}
+                      {rect.c0 === rect.c1 && (
+                        <>
+                          <div className="text-muted-foreground px-2 pt-1 text-xs">
+                            열 요약
+                          </div>
+                          <div className="flex items-center gap-1 px-2 py-1">
+                            {SUMMARY_FNS.map((fn) => (
+                              <button
+                                key={fn}
+                                type="button"
+                                role="menuitem"
+                                aria-label={`요약 ${SUMMARY_LABELS[fn]}`}
+                                onClick={run(() =>
+                                  summaryMut.mutate({
+                                    key: meta.columns[rect.c0].key,
+                                    fn,
+                                  }),
+                                )}
+                                className={cn(
+                                  "hover:bg-accent rounded px-1.5 py-1 text-xs",
+                                  meta.columns[rect.c0].summary === fn &&
+                                    "bg-accent text-foreground",
+                                )}
+                              >
+                                {SUMMARY_LABELS[fn]}
+                              </button>
+                            ))}
+                            <button
+                              type="button"
+                              aria-label="요약 지우기"
+                              onClick={run(() =>
+                                summaryMut.mutate({
+                                  key: meta.columns[rect.c0].key,
+                                  fn: null,
+                                }),
+                              )}
+                              className="text-muted-foreground hover:text-foreground flex size-6 items-center justify-center rounded"
+                            >
+                              <X className="size-3" />
+                            </button>
+                          </div>
+                          {divider}
+                        </>
                       )}
-                      {divider}
-                    </>
+                      {/* 숫자 서식 — 한 열만 걸쳤을 때. 표시 전용(값·수식은 raw 그대로). */}
+                      {rect.c0 === rect.c1 && (
+                        <>
+                          <div className="text-muted-foreground px-2 pt-1 text-xs">
+                            숫자 서식
+                          </div>
+                          <div className="flex items-center gap-1 px-2 py-1">
+                            {NUMBER_FORMATS.map((fmt) => (
+                              <button
+                                key={fmt}
+                                type="button"
+                                role="menuitem"
+                                aria-label={`서식 ${fmt}`}
+                                onClick={run(() =>
+                                  formatMut.mutate({
+                                    key: meta.columns[rect.c0].key,
+                                    format: fmt,
+                                  }),
+                                )}
+                                className={cn(
+                                  "hover:bg-accent rounded px-1.5 py-1 text-xs",
+                                  meta.columns[rect.c0].format === fmt &&
+                                    "bg-accent text-foreground",
+                                )}
+                              >
+                                {FORMAT_LABELS[fmt]}
+                              </button>
+                            ))}
+                            <button
+                              type="button"
+                              aria-label="서식 지우기"
+                              onClick={run(() =>
+                                formatMut.mutate({
+                                  key: meta.columns[rect.c0].key,
+                                  format: null,
+                                }),
+                              )}
+                              className="text-muted-foreground hover:text-foreground flex size-6 items-center justify-center rounded"
+                            >
+                              <X className="size-3" />
+                            </button>
+                          </div>
+                          {divider}
+                        </>
+                      )}
+                      {/* 허용값 목록(enum) — 한 열만 걸쳤을 때. 셀 편집 드롭다운 제안(느슨). */}
+                      {rect.c0 === rect.c1 && (
+                        <>
+                          {item("허용값 목록…", () =>
+                            setOptionsEditor({
+                              key: meta.columns[rect.c0].key,
+                              initial: meta.columns[rect.c0].options ?? [],
+                            }),
+                          )}
+                        </>
+                      )}
+                    </SubMenu>
                   )}
+                  {divider}
                   {/* 병합 — 셀 범위(2칸+)는 통합 병합, 단일 셀은 방향 병합·해제 */}
                   {kind === "cells" &&
                     area > 1 &&
@@ -2080,52 +2101,67 @@ export function DatasetGrid({
                       icon: <TableCellsSplit className="size-3.5" />,
                     })}
                   {showMergeSection && divider}
-                  {/* 행/열 삽입 + 너비 초기화 */}
-                  {item("위에 행 삽입", () => addRow(rect.r0), {
-                    icon: <Plus className="size-3.5" />,
-                  })}
-                  {item("아래에 행 삽입", () => addRow(rect.r1 + 1), {
-                    icon: <Plus className="size-3.5" />,
-                  })}
-                  {item("왼쪽에 열 삽입", () => addColumn(rect.c0), {
-                    icon: <Plus className="size-3.5" />,
-                  })}
-                  {item("오른쪽에 열 삽입", () => addColumn(rect.c1 + 1), {
-                    icon: <Plus className="size-3.5" />,
-                  })}
-                  {item("열 너비 초기화", () => {
-                    for (let c = rect.c0; c <= rect.c1; c++)
-                      resetColWidthMut.mutate(meta.columns[c].key);
-                  })}
+                  <SubMenu
+                    label="삽입"
+                    icon={<Plus className="size-3.5" />}
+                    open={openSubmenu === "삽입"}
+                    onOpen={() => setOpenSubmenu("삽입")}
+                  >
+                    {/* 행/열 삽입 + 너비 초기화 */}
+                    {item("위에 행 삽입", () => addRow(rect.r0), {
+                      icon: <Plus className="size-3.5" />,
+                    })}
+                    {item("아래에 행 삽입", () => addRow(rect.r1 + 1), {
+                      icon: <Plus className="size-3.5" />,
+                    })}
+                    {item("왼쪽에 열 삽입", () => addColumn(rect.c0), {
+                      icon: <Plus className="size-3.5" />,
+                    })}
+                    {item("오른쪽에 열 삽입", () => addColumn(rect.c1 + 1), {
+                      icon: <Plus className="size-3.5" />,
+                    })}
+                    {item("열 너비 초기화", () => {
+                      for (let c = rect.c0; c <= rect.c1; c++)
+                        resetColWidthMut.mutate(meta.columns[c].key);
+                    })}
+                  </SubMenu>
                   {divider}
                   {/* 내용 지우기(값만) */}
                   {item("내용 지우기", clearSelValues, {
                     icon: <Eraser className="size-3.5" />,
                   })}
                   {divider}
-                  {/* 삭제 */}
-                  {item("행 삭제", () => void deleteRowsSel(), {
-                    icon: <Trash2 className="size-3.5" />,
-                    destructive: true,
-                  })}
-                  {colCount > 1 &&
-                    item(
-                      "열 삭제",
-                      () => {
-                        // 한 열이면 데이터 손실 확인 다이얼로그, 여러 열이면 바로 지운다.
-                        if (colN === 1)
-                          setPendingColDelete(meta.columns[rect.c0].key);
-                        else void deleteColsSel();
-                      },
-                      { icon: <X className="size-3.5" />, destructive: true },
-                    )}
-                  {/* 표 전체 삭제 — 키보드 단축키를 없앤 대신 유일한 표 삭제 경로.
-                    블록을 제거하면 노트가 dataset 정리 확인 다이얼로그를 띄운다. */}
-                  {onDeleteBlock &&
-                    item("표 삭제", () => onDeleteBlock(), {
+                  <SubMenu
+                    label="삭제"
+                    icon={<Trash2 className="size-3.5" />}
+                    destructive
+                    open={openSubmenu === "삭제"}
+                    onOpen={() => setOpenSubmenu("삭제")}
+                  >
+                    {/* 삭제 */}
+                    {item("행 삭제", () => void deleteRowsSel(), {
                       icon: <Trash2 className="size-3.5" />,
                       destructive: true,
                     })}
+                    {colCount > 1 &&
+                      item(
+                        "열 삭제",
+                        () => {
+                          // 한 열이면 데이터 손실 확인 다이얼로그, 여러 열이면 바로 지운다.
+                          if (colN === 1)
+                            setPendingColDelete(meta.columns[rect.c0].key);
+                          else void deleteColsSel();
+                        },
+                        { icon: <X className="size-3.5" />, destructive: true },
+                      )}
+                    {/* 표 전체 삭제 — 키보드 단축키를 없앤 대신 유일한 표 삭제 경로.
+                    블록을 제거하면 노트가 dataset 정리 확인 다이얼로그를 띄운다. */}
+                    {onDeleteBlock &&
+                      item("표 삭제", () => onDeleteBlock(), {
+                        icon: <Trash2 className="size-3.5" />,
+                        destructive: true,
+                      })}
+                  </SubMenu>
                 </div>
               </>
             );
@@ -2154,6 +2190,57 @@ export function DatasetGrid({
       >
         <Plus className="size-3.5" />
       </button>
+    </div>
+  );
+}
+
+/**
+ * 우클릭 메뉴의 하위 메뉴(flyout). 호버하면 오른쪽으로 펼쳐진다 — 항목이 많아진 메뉴의 깊이를
+ * 늘려 최상위를 짧게 유지한다. 자식 항목을 누르면 run()이 전체 메뉴를 닫는다.
+ */
+function SubMenu({
+  label,
+  icon,
+  destructive,
+  open,
+  onOpen,
+  children,
+}: {
+  label: string;
+  icon?: React.ReactNode;
+  destructive?: boolean;
+  open: boolean;
+  onOpen: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="relative" onMouseEnter={onOpen}>
+      <button
+        type="button"
+        role="menuitem"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        // 호버·클릭으로 연다(데스크톱·터치·테스트). 한 번에 하나만 열리고(부모가 관리), 자식을
+        // 누르면 run()이 전체 메뉴를 닫는다. 떠날 때 자동으로 닫진 않는다(포인터 이동에 안 흔들림).
+        onClick={onOpen}
+        className={cn(
+          "hover:bg-accent flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm",
+          destructive && "text-destructive",
+        )}
+      >
+        {icon}
+        <span className="flex-1">{label}</span>
+        <ChevronRight className="text-muted-foreground size-3.5" />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          aria-label={label}
+          className="border-border bg-popover absolute top-0 left-full z-50 ml-1 min-w-40 rounded-md border p-1 shadow-md"
+        >
+          {children}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 이슈
closes #926

## 작업 내용
우클릭 셀 메뉴가 항목이 많아져(배경색·정렬·요약·서식·허용값·병합·삽입·내용지우기·삭제) 세로로 너무 길었다. 관련 항목을 **하위 메뉴(flyout)로 묶어** 최상위를 짧게 하고 깊이를 늘렸다.

### 재구성 (최상위 → 하위)
- **서식 ▸** 배경색 · 가로/세로 정렬 · 서식 지우기
- **열 ▸** (한 열 걸쳤을 때) 열 요약(SUM/…) · 숫자 서식(₩/…) · 허용값 목록
- **병합** 상황별 최상위(2칸+ 통합 / 단일 셀 방향·해제)
- **삽입 ▸** 위/아래 행 · 왼/오른쪽 열 · 열 너비 초기화
- **내용 지우기** 최상위(자주 씀)
- **삭제 ▸** 행/열/표 삭제

최상위가 ~11개 → **서식·[열]·[병합]·삽입·내용지우기·삭제** 로 짧아졌다.

### 상호작용
- 하위 메뉴는 호버·클릭으로 펼치고 **한 번에 하나만**(`openSubmenu` 단일 상태로 부모가 관리). 떠나도 자동으로 닫지 않아 포인터 이동에 안 흔들린다 — 터치·키보드·테스트에 robust(초기 hover-only + mouseLeave-close는 userEvent 포인터 이동에 하위 항목이 닫혀 클릭이 새는 문제가 있었다).
- 하위 항목을 누르면 `run()`이 전체 메뉴를 닫는다. 메뉴 열릴 때 `openSubmenu` 초기화.

## 테스트
- 기존 메뉴 테스트를 하위 항목 접근 전 "펼치기" 단계 추가로 갱신(삭제·삽입·열·서식)
- 구조 테스트 추가: 최상위에 서식/삽입/삭제 부모, 펼치기 전 하위 항목 숨김, 펼치면 노출
- FE 475개·prettier/eslint 통과. BE 변경 없음

## 확인
- 로컬 브라우저 실증 미실행(풀스택 필요). 실제 컴포넌트에 이벤트를 발생시키는 RTL 통합 테스트로 펼치기·하위 항목 동작 검증. 그룹핑은 리뷰에서 조정 가능.