### PR TITLE
feat : 데이터 그리드 수식 도움말 패널 (#928)

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -2502,6 +2502,27 @@ describe("DatasetGrid", () => {
     expect(screen.queryByLabelText("다른 표 참조")).not.toBeInTheDocument();
   });
 
+  // ---------- 수식 도움말(#928) ----------
+
+  it("수식(=)을 편집하면 '?' 도움말 버튼이 뜨고, 누르면 도움말이 열린다", async () => {
+    mockDataset([["a", "b"]]);
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await user.dblClick(await screen.findByText("a"));
+    const input = await screen.findByLabelText("셀 1행 1열");
+
+    // 일반 값이면 도움말 버튼이 없다.
+    expect(screen.queryByLabelText("수식 도움말")).not.toBeInTheDocument();
+
+    // = 를 치면 도움말 버튼이 뜬다.
+    fireEvent.change(input, { target: { value: "=" } });
+    fireEvent.click(await screen.findByLabelText("수식 도움말"));
+
+    const dialog = await screen.findByRole("dialog", { name: "수식 도움말" });
+    expect(within(dialog).getByText("셀 참조")).toBeInTheDocument();
+    expect(within(dialog).getByText("= SUM({금액})")).toBeInTheDocument();
+  });
+
   // ---------- 열 숫자 서식(R2 #913) ----------
 
   it("서식이 걸린 열은 셀 값을 포맷해 보여준다(값은 raw 유지)", async () => {

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -56,6 +56,7 @@ import { ColumnOptionsEditor } from "./ColumnOptionsEditor";
 import { CrossRefPicker } from "./CrossRefPicker";
 import type { FormulaContext, ValueSource } from "./formula";
 import { aggregate, asCell, evaluateFormula } from "./formula";
+import { FormulaHelp } from "./FormulaHelp";
 import { useDatasetMerges } from "./hooks/useDatasetMerges";
 import { useDatasetMeta } from "./hooks/useDatasetMeta";
 import { useDatasetRows } from "./hooks/useDatasetRows";
@@ -155,6 +156,8 @@ export function DatasetGrid({
   const fillDragging = useRef(false);
   // 표간 참조 피커 열림 여부(활성 셀 편집 중).
   const [crossPickerOpen, setCrossPickerOpen] = useState(false);
+  // 수식 도움말 패널 열림 여부.
+  const [showFormulaHelp, setShowFormulaHelp] = useState(false);
   // 허용값 목록 편집기(우클릭 "허용값 목록…"에서 연다). 대상 열 key + 현재 값.
   const [optionsEditor, setOptionsEditor] = useState<{
     key: string;
@@ -1459,6 +1462,20 @@ export function DatasetGrid({
             )}
           </>
         )}
+        {/* 수식 도움말 — 수식(=로 시작)을 편집하는 중에만 뜬다. mousedown preventDefault로
+          입력창 blur(=커밋) 없이 도움말만 연다. */}
+        {isEditing && draft.trimStart().startsWith("=") && (
+          <button
+            type="button"
+            aria-label="수식 도움말"
+            title="수식 사용법"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => setShowFormulaHelp(true)}
+            className="text-muted-foreground hover:text-foreground bg-card absolute bottom-0 left-0 z-[8] rounded-tr px-1 text-xs leading-5"
+          >
+            ?
+          </button>
+        )}
       </>
     );
   };
@@ -1814,6 +1831,11 @@ export function DatasetGrid({
             }}
             onClose={() => setOptionsEditor(null)}
           />
+        )}
+
+        {/* 수식 도움말 패널 — 편집 중 "?" 버튼에서 연다. */}
+        {showFormulaHelp && (
+          <FormulaHelp onClose={() => setShowFormulaHelp(false)} />
         )}
 
         {/* 우클릭 컨텍스트 메뉴 — 선택 범위에 맞춰 서식·병합·행/열 옵션을 한 곳에 모은다.

--- a/fe/src/features/note/dataset/FormulaHelp.tsx
+++ b/fe/src/features/note/dataset/FormulaHelp.tsx
@@ -1,0 +1,147 @@
+interface Row {
+  /** 문법·예시(모노). */
+  code: string;
+  /** 설명. */
+  desc: string;
+}
+
+interface Section {
+  title: string;
+  rows: Row[];
+}
+
+/**
+ * 수식 도움말 내용. 엔진(FormulaParser)이 실제로 받는 문법만 싣는다 — 여기와 엔진이 어긋나면
+ * 사용자가 안 되는 걸 쓰게 된다. 함수명은 엔진 그대로(AVG 등).
+ */
+const SECTIONS: Section[] = [
+  {
+    title: "기본",
+    rows: [
+      {
+        code: "= {단가} * {수량}",
+        desc: "= 로 시작하고, 열은 이름을 {} 로 감싼다",
+      },
+    ],
+  },
+  {
+    title: "셀 참조",
+    rows: [
+      { code: "{과목}", desc: "같은 행의 그 열" },
+      { code: "{점수}2", desc: "2행의 그 열(행 번호로 콕 집기)" },
+      {
+        code: "{요약!환율}1",
+        desc: "다른 표(요약)의 1행 환율 — 표에 이름이 있어야 함",
+      },
+    ],
+  },
+  {
+    title: "산술",
+    rows: [
+      { code: "+  -  *  /", desc: "사칙연산, 괄호로 우선순위" },
+      { code: "= ({단가} + {배송}) * {수량}", desc: "" },
+    ],
+  },
+  {
+    title: "비교 (참/거짓)",
+    rows: [
+      { code: "=  <>  <  >  <=  >=", desc: "" },
+      { code: "= {점수} >= 80", desc: "" },
+    ],
+  },
+  {
+    title: "조건",
+    rows: [
+      {
+        code: '= IF({통화}="엔", {금액}*{환율}, {금액})',
+        desc: "조건이 참이면 둘째, 거짓이면 셋째",
+      },
+      { code: "AND(...)  OR(...)  NOT(...)", desc: "여러 조건을 묶는다" },
+    ],
+  },
+  {
+    title: "집계 (열 전체)",
+    rows: [
+      { code: "= SUM({금액})", desc: "합계 — 숫자만 더한다" },
+      { code: "AVG  COUNT  MIN  MAX", desc: "평균·개수·최소·최대" },
+    ],
+  },
+  {
+    title: "조건부 집계",
+    rows: [
+      {
+        code: '= SUMIF({분류}, "교통", {금액})',
+        desc: "분류가 '교통'인 행의 금액 합",
+      },
+      { code: '= COUNTIF({분류}, "식사")', desc: "분류가 '식사'인 행 수" },
+    ],
+  },
+  {
+    title: "표간 참조",
+    rows: [
+      { code: "= SUM({도쿄!금액})", desc: "다른 표(도쿄)의 열 합계" },
+      { code: "= {요약!환율}1", desc: "다른 표의 특정 셀" },
+    ],
+  },
+  {
+    title: "함수",
+    rows: [{ code: "= ABS({차이})", desc: "절댓값" }],
+  },
+  {
+    title: "에러값",
+    rows: [
+      { code: "#REF!", desc: "참조가 끊김(열·행·표가 사라짐)" },
+      { code: "#DIV/0!", desc: "0으로 나눔" },
+      { code: "#VALUE!", desc: "숫자가 아닌 걸 계산" },
+    ],
+  },
+];
+
+/** 수식 도움말 패널(표시 전용). 문법·예시를 카테고리별로 보여준다. 바깥 클릭·닫기로 닫는다. */
+export function FormulaHelp({ onClose }: { onClose: () => void }) {
+  return (
+    <>
+      <div className="fixed inset-0 z-40" onClick={onClose} />
+      <div
+        role="dialog"
+        aria-label="수식 도움말"
+        className="border-border bg-popover fixed top-1/2 left-1/2 z-50 max-h-[80vh] w-80 -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-md border p-3 shadow-md"
+      >
+        <div className="mb-2 flex items-center justify-between">
+          <h2 className="text-sm font-medium">수식 도움말</h2>
+          <button
+            type="button"
+            aria-label="도움말 닫기"
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground text-xs"
+          >
+            닫기
+          </button>
+        </div>
+        <div className="flex flex-col gap-3">
+          {SECTIONS.map((section) => (
+            <section key={section.title}>
+              <h3 className="text-muted-foreground mb-1 text-xs font-medium">
+                {section.title}
+              </h3>
+              <div className="flex flex-col gap-1">
+                {section.rows.map((row) => (
+                  <div key={row.code}>
+                    <code className="bg-muted rounded px-1 py-0.5 text-xs">
+                      {row.code}
+                    </code>
+                    {row.desc && (
+                      <span className="text-muted-foreground ml-2 text-xs">
+                        {row.desc}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## 이슈
closes #928

## 작업 내용
수식 능력이 많이 늘어(셀 참조·산술·비교·IF/AND/OR/NOT·집계·SUMIF·표간 참조·ABS·에러값) 처음 쓰는 사람이 문법을 알기 어려웠다. **수식 도움말 패널**을 붙였다.

### 형태
- 셀을 **수식으로 편집하는 중**(=로 시작)에만 셀에 작은 **"?" 버튼**이 뜬다 → 도움말 패널을 연다. `mousedown preventDefault`로 입력창 blur(=커밋) 없이 연다.
- 패널은 카테고리별 문법 + 예시(모노): 셀 참조(`{열}`·`{열}2`·`{표!열}1`) / 산술 / 비교 / 조건(IF·AND·OR·NOT) / 집계(SUM·AVG·COUNT·MIN·MAX) / 조건부 집계(SUMIF·COUNTIF) / 표간 참조·집계 / 함수(ABS) / 에러값(#REF!·#DIV/0!·#VALUE!).
- 표시 전용(읽기). 바깥 클릭·닫기로 닫는다.

### 원칙
- 내용은 **엔진(FormulaParser 허용 함수)과 일치** — 실제 되는 것만 싣는다(함수명도 엔진 그대로 `AVG` 등). 어긋나면 안 되는 걸 알려주게 되므로.
- 우클릭 메뉴와 **독립**(#927 재구성과 무충돌).

## 테스트
- RTL: 일반 값 편집 땐 "?" 없음, `=` 치면 버튼 노출→클릭하면 도움말 다이얼로그에 "셀 참조"·`= SUM({금액})` 등 내용
- FE 475개·prettier/eslint 통과. BE 변경 없음

## 확인
- 로컬 브라우저 실증 미실행(노트+인증 풀스택 필요). RTL 통합 테스트로 트리거·내용 검증.