### PR TITLE
feat : 복습 세션 카드 순서 섞기 (#934)

### DIFF
--- a/fe/src/features/review/ordering.test.ts
+++ b/fe/src/features/review/ordering.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import type { OrderingItem } from "@/features/flashcard/api/flashcards";
 
-import { fisherYates, reorder, sameOrder, shuffleForReview } from "./ordering";
+import {
+  fisherYates,
+  reorder,
+  sameOrder,
+  shuffleDeck,
+  shuffleForReview,
+} from "./ordering";
 
 const items: OrderingItem[] = [
   { id: "a", text: "1" },
@@ -58,6 +64,26 @@ describe("shuffleForReview", () => {
   it("항목이 2개 미만이면 그대로 둔다", () => {
     const one = [{ id: "x", text: "only" }];
     expect(shuffleForReview(one, () => 0)).toEqual(one);
+  });
+});
+
+describe("shuffleDeck", () => {
+  it("원소 집합을 보존한다(비파괴, 임의 타입)", () => {
+    const deck = [10, 20, 30, 40];
+    const copy = [...deck];
+    const out = shuffleDeck(deck, seq([0.1, 0.9, 0.5]));
+    expect(deck).toEqual(copy); // 원본 불변
+    expect([...out].sort((a, b) => a - b)).toEqual([10, 20, 30, 40]);
+  });
+
+  it("rng를 주면 결정적으로 섞는다", () => {
+    // rng=0이면 각 i에서 j=0 → 2장 덱이 뒤집힌다.
+    expect(shuffleDeck([1, 2], () => 0)).toEqual([2, 1]);
+  });
+
+  it("작은 덱이 원본과 같아도 강제로 바꾸지 않는다(정답 셔플과 다른 목적)", () => {
+    // rng=0.99면 항등 순열 → 그대로 둔다.
+    expect(shuffleDeck([1, 2, 3], () => 0.99)).toEqual([1, 2, 3]);
   });
 });
 

--- a/fe/src/features/review/ordering.ts
+++ b/fe/src/features/review/ordering.ts
@@ -9,16 +9,25 @@ export function sameOrder(a: OrderingItem[], b: OrderingItem[]): boolean {
 }
 
 /** Fisher–Yates 셔플(비파괴). rng는 [0,1) 난수. */
-export function fisherYates(
-  items: OrderingItem[],
-  rng: () => number,
-): OrderingItem[] {
+export function fisherYates<T>(items: T[], rng: () => number): T[] {
   const a = [...items];
   for (let i = a.length - 1; i > 0; i--) {
     const j = Math.floor(rng() * (i + 1));
     [a[i], a[j]] = [a[j], a[i]];
   }
   return a;
+}
+
+/**
+ * 복습 덱(카드 목록) 셔플. 세션 진입 시 큐를 만들 때 1회만 호출한다(렌더마다 재셔플 금지).
+ * 순서 암기를 막으려는 것이라 원본과 같은 배열이 나와도(작은 덱에서 가끔) 강제로 바꾸지 않는다 —
+ * ORDERING 카드의 정답 셔플({@link shuffleForReview})과 목적이 다르다.
+ */
+export function shuffleDeck<T>(
+  items: T[],
+  rng: () => number = Math.random,
+): T[] {
+  return fisherYates(items, rng);
 }
 
 /**

--- a/fe/src/pages/planner/ReviewSessionPage.test.tsx
+++ b/fe/src/pages/planner/ReviewSessionPage.test.tsx
@@ -117,10 +117,14 @@ describe("ReviewSessionPage", () => {
     useToastStore.setState({ toasts: [] });
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date(2026, 4, 18, 9, 0, 0));
+    // 큐 셔플(Fisher–Yates)을 결정적으로 만든다 — rng=0.99면 항상 항등 순열이라 서버 순서가
+    // 그대로 유지돼 순서 의존 검증이 안정적이다. 셔플이 실제로 적용되는지는 별도 테스트에서 확인.
+    vi.spyOn(Math, "random").mockReturnValue(0.99);
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("0건이면 빈 상태와 [홈으로] 버튼을 표시한다", async () => {
@@ -147,6 +151,19 @@ describe("ReviewSessionPage", () => {
     expect(
       screen.queryByRole("button", { name: /Again/ }),
     ).not.toBeInTheDocument();
+  });
+
+  it("세션 진입 시 카드 순서를 섞는다(서버 순서와 다르게 나올 수 있다)", async () => {
+    // rng=0이면 2장 덱 [1,2]가 [2,1]로 뒤집힌다 — 서버가 준 순서를 그대로 쓰지 않음을 확인.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    mockToday([{ id: 1 }, { id: 2 }]);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("질문 2")).toBeInTheDocument();
+    });
+    expect(screen.getByText("1 / 2")).toBeInTheDocument();
+    expect(screen.queryByText("질문 1")).not.toBeInTheDocument();
   });
 
   it("Space로 답이 공개되고 1/2/3/4 키로 평가가 전송된다", async () => {

--- a/fe/src/pages/planner/ReviewSessionPage.tsx
+++ b/fe/src/pages/planner/ReviewSessionPage.tsx
@@ -9,6 +9,7 @@ import { EmptyTodayState } from "@/features/review/components/EmptyTodayState";
 import { ReviewCard } from "@/features/review/components/ReviewCard";
 import { useCompleteReview } from "@/features/review/hooks/useCompleteReview";
 import { useTodayReviews } from "@/features/review/hooks/useTodayReviews";
+import { shuffleDeck } from "@/features/review/ordering";
 import { toast } from "@/shared/lib/toast";
 
 /**
@@ -36,7 +37,8 @@ export function ReviewSessionPage() {
         }
         return true;
       });
-      setQueue(filtered);
+      // 세션 진입마다 순서를 섞는다(순서 암기 방지). 큐는 한 번만 만들어 렌더 중 재셔플되지 않는다.
+      setQueue(shuffleDeck(filtered));
     }
   }, [data, queue, scope, materialId]);
 


### PR DESCRIPTION
## 이슈
closes #934

## 배경
복습 세션에서 카드가 **항상 같은 순서**(서버 `scheduledAt ASC, id ASC`)로 나와, 순서를 외워버려 복습 효과가 떨어졌다. 세션마다 섞어서 출제한다.

## 작업 내용
- 세션 카드-넘기기는 `GET /planner/reviews/today`를 받아 클라에서 필터해 큐를 만든다(`ReviewSessionPage`). **큐 생성 시 한 번** 섞는다(`shuffleDeck`). 큐는 `queue===null` 가드로 1회만 만들어져 렌더 중 재셔플되지 않는다.
- **BE 정렬은 건드리지 않는다** — 캘린더·다가오는 목록·요약이 시간순으로 재사용하므로. 세션 표시 순서만 무작위화.
- 순서와 무관해 안전: 짝 카드 버리기(id-set 필터)·진행 카운터(1/N)·SM-2 스케줄링(카드별 계산).

### 유틸
- `fisherYates`를 제네릭(`<T>`)으로 확장(기존 ORDERING 정답 셔플과 공유).
- `shuffleDeck<T>(items, rng=Math.random)` — 비파괴 Fisher–Yates. 순서 암기 방지가 목적이라 작은 덱이 원본과 같아도 강제로 바꾸지 않는다(정답 셔플 `shuffleForReview`와 목적 구분).

## 테스트
- `shuffleDeck` 단위: 집합 보존·비파괴, 주입 RNG 결정성(rng=0 → 뒤집힘), 항등 허용.
- 세션 페이지: 순서 의존 검증은 `Math.random=0.99`(Fisher–Yates 항등)로 고정해 안정화. **셔플 적용**은 `Math.random=0`(2장 덱 뒤집힘)으로 "질문 2가 먼저" 별도 검증.
- FE 480개·eslint·prettier 통과. BE 변경 없음.

## 확인
- 로컬 브라우저 실증 미실행(플래너+인증 풀스택 필요). RTL 통합 테스트로 셔플 적용·필터·진행을 검증.