### PR TITLE
fix : 표 값 셀 Backspace가 한 글자만 지우게 (#936)

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -347,6 +347,44 @@ describe("DatasetGrid", () => {
     });
   });
 
+  it("값이 있는 셀을 선택하고 Backspace를 누르면 전체가 아니라 끝 글자 하나만 지운다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    let patched: { index: number; cells: string[] } | null = null;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/rows/:i`,
+        async ({ params, request }) => {
+          const body = (await request.json()) as { cells: string[] };
+          patched = { index: Number(params.i), cells: body.cells };
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              edited: {
+                id: 100,
+                rowIndex: Number(params.i),
+                cells: body.cells,
+              },
+              affected: [],
+            },
+          });
+        },
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    await user.click(await screen.findByText("네트워크"));
+    await user.keyboard("{Backspace}");
+
+    // 통째로 비우지 않고 편집으로 들어가 끝 글자 하나만 지운다.
+    const input = await screen.findByLabelText("셀 1행 1열");
+    expect((input as HTMLInputElement).value).toBe("네트워");
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => {
+      expect(patched).toEqual({ index: 0, cells: ["네트워", "92"] });
+    });
+  });
+
   it("셀에서 드래그를 시작해도 글자가 끌려나가지 않는다(네이티브 드래그 차단)", async () => {
     mockDataset([["네트워크", "92"]]);
     renderWithRouter(<DatasetGrid datasetId={1} />);

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -1027,8 +1027,9 @@ export function DatasetGrid({
 
   /**
    * 활성 셀 입력창의 키 처리. 선택만 한 상태에서 Enter/F2는 기존 값을 이어 편집,
-   * Delete/Backspace는 셀을 즉시 비운다. 글자/IME는 input 기본 동작(전체선택 덮어쓰기·조합)에
-   * 맡긴다. 어떤 키든 상위 에디터로 전파를 막아 단축키(표 삭제 등)가 튀지 않게 한다.
+   * Backspace는 편집으로 들어가 끝 글자 하나만 지우고(전체 삭제가 아니라 한 글자씩), Delete는
+   * 셀을 통째로 비운다. 글자/IME는 input 기본 동작(전체선택 덮어쓰기·조합)에 맡긴다.
+   * 어떤 키든 상위 에디터로 전파를 막아 단축키(표 삭제 등)가 튀지 않게 한다.
    */
   const onCellInputKeyDown = (
     e: React.KeyboardEvent<HTMLInputElement>,
@@ -1069,7 +1070,28 @@ export function DatasetGrid({
       setDraft(getFormulas(r)[meta.columns[c].key] ?? getRow(r)?.[c] ?? "");
       return;
     }
-    if (!editing && (e.key === "Delete" || e.key === "Backspace")) {
+    if (!editing && e.key === "Backspace") {
+      // 선택-만-한 상태에선 값이 전체 선택돼 있어 그대로 두면 한 번에 다 지워진다.
+      // 편집으로 전환해 끝 글자 하나만 지우고, 커서를 끝에 둬 다음 Backspace부턴 native로 한 자씩.
+      e.preventDefault();
+      const raw = getFormulas(r)[meta.columns[c].key] ?? getRow(r)?.[c] ?? "";
+      const next = raw.slice(0, -1);
+      beginEditCapture(r, c); // 되돌리기용: 편집 전 행 내용 캡처
+      setEditing({ row: r, col: c });
+      setDraft(next);
+      pendingEdit.current = { row: r, col: c, value: next };
+      // 타이핑과 같은 경로로 자동저장 예약(엔터·blur로도 커밋된다).
+      cancelAutoSave();
+      autoSaveTimer.current = setTimeout(() => flushPendingEdit(true), 500);
+      // 전체선택을 풀고 커서를 끝으로 — 다음 Backspace가 또 전체를 지우지 않게 한다.
+      requestAnimationFrame(() => {
+        const el = activeInputRef.current;
+        if (el) el.setSelectionRange(el.value.length, el.value.length);
+      });
+      return;
+    }
+    if (!editing && e.key === "Delete") {
+      // Delete는 셀을 통째로 비운다(스프레드시트식 '내용 지우기').
       e.preventDefault();
       clearSelValues();
       setDraft("");


### PR DESCRIPTION
## 이슈
closes #936

## 증상
표에서 이미 글자가 있는 셀을 클릭한 뒤 Backspace를 누르면 **셀 전체가 지워졌다**. 한 글자만 지우려던 동작과 어긋남.

## 원인
셀을 한 번 클릭하면 '선택'(편집 아님) 상태가 되고, 활성 입력창에 값이 **전체 선택**된 채로 뜬다. 이 상태의 Backspace를 `clearSelValues()`로 처리해 셀을 통째로 비웠다(`DatasetGrid.tsx` onCellInputKeyDown).

## 수정
- **단일 활성 셀 Backspace** → 편집 모드로 전환해 **끝 글자 하나만** 지우고 커서를 끝에 둔다. 이후 Backspace부턴 입력창 native로 한 자씩. 되돌리기 캡처(beginEditCapture)·자동저장 예약 포함.
- **Delete**는 기존대로 셀을 통째로 비운다(스프레드시트식 '내용 지우기').
- **여러 셀/행/열 선택** 시 Backspace는 기존대로 범위 비우기(gridBox 경로, 변경 없음).

## 테스트
- "네트워크" 셀 선택 → Backspace → 입력값 "네트워"(편집 상태) → 커밋 시 PATCH `["네트워","92"]`.
- 기존 Delete(셀 비우기) 테스트 유지. FE 487개·eslint·prettier 통과. BE 변경 없음.

## 확인
- 로컬 브라우저 실증 미실행(노트+인증 풀스택 필요). RTL 통합 테스트로 검증.