### PR TITLE
fix : 일정 메모(description)가 저장 후 사라지던 문제 (#940)

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -21,7 +21,7 @@ subprojects {
 
     ext['jackson-2-bom.version'] = '2.21.4'
     ext['jackson-bom.version'] = '3.1.4'
-    ext['netty.version'] = '4.2.15.Final'
+    ext['netty.version'] = '4.2.16.Final'
     ext['spring-security.version'] = '7.0.5'
     ext['tomcat.version'] = '11.0.22'
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/PlannerCalendarService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/PlannerCalendarService.java
@@ -133,7 +133,8 @@ public class PlannerCalendarService {
         RoutineMeta updated = new RoutineMeta(
                 event.routine().type(), event.routine().recurringEventId(), done);
         return new PlannerEvent(event.id(), event.title(), event.allDay(), event.start(),
-                event.end(), event.location(), event.recurring(), event.source(), updated);
+                event.end(), event.location(), event.description(), event.recurring(),
+                event.source(), updated);
     }
 
     private static String checkKey(String recurringEventId, String instanceDate) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/GoogleEventsResponse.java
@@ -13,6 +13,7 @@ public record GoogleEventsResponse(List<GoogleEventItem> items) {
             String id,
             String summary,
             String location,
+            String description,
             String recurringEventId,
             GoogleEventDateTime start,
             GoogleEventDateTime end,

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/PlannerEvent.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/calendar/dto/PlannerEvent.java
@@ -7,11 +7,12 @@ package ds.project.orino.planner.google.calendar.dto;
  * @param title     제목(summary, null 가능)
  * @param allDay    종일 일정 여부
  * @param start     종일이면 날짜("2026-06-10"), 시간 일정이면 사용자 TZ 로컬 datetime("2026-06-10T14:00:00")
- * @param end       종료(종일은 포함 마지막 날짜로 보정)
- * @param location  장소(null 가능)
- * @param recurring 반복 일정의 인스턴스 여부
- * @param source    항상 "google"
- * @param routine   루틴 인스턴스면 주석(type/recurringEventId/done), 아니면 null
+ * @param end         종료(종일은 포함 마지막 날짜로 보정)
+ * @param location    장소(null 가능)
+ * @param description 메모(null 가능)
+ * @param recurring   반복 일정의 인스턴스 여부
+ * @param source      항상 "google"
+ * @param routine     루틴 인스턴스면 주석(type/recurringEventId/done), 아니면 null
  */
 public record PlannerEvent(
         String id,
@@ -20,6 +21,7 @@ public record PlannerEvent(
         String start,
         String end,
         String location,
+        String description,
         boolean recurring,
         String source,
         RoutineMeta routine
@@ -27,7 +29,7 @@ public record PlannerEvent(
 
     /** 루틴 주석 없는 일반 일정. */
     public PlannerEvent(String id, String title, boolean allDay, String start, String end,
-                        String location, boolean recurring, String source) {
-        this(id, title, allDay, start, end, location, recurring, source, null);
+                        String location, String description, boolean recurring, String source) {
+        this(id, title, allDay, start, end, location, description, recurring, source, null);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/google/client/GoogleCalendarClient.java
@@ -439,6 +439,7 @@ public class GoogleCalendarClient {
                 startValue,
                 endValue,
                 item.location(),
+                item.description(),
                 item.recurringEventId() != null,
                 "google",
                 toRoutineMeta(item));

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/PlannerCalendarControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/google/calendar/PlannerCalendarControllerTest.java
@@ -85,7 +85,7 @@ class PlannerCalendarControllerTest extends ApiTestSupport {
     void setUp() throws Exception {
         responseStatus = 200;
         responseBody = """
-                {"items":[{"id":"e1","summary":"회의",
+                {"items":[{"id":"e1","summary":"회의","description":"안건: 로드맵 리뷰",
                  "start":{"dateTime":"2026-06-10T05:00:00Z"},"end":{"dateTime":"2026-06-10T06:00:00Z"}}]}""";
         tasksBody = EMPTY_ITEMS;
         dbCleaner.clean();
@@ -124,6 +124,8 @@ class PlannerCalendarControllerTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.partial").value(false))
                 .andExpect(jsonPath("$.data.events.length()").value(1))
                 .andExpect(jsonPath("$.data.events[0].title").value("회의"))
+                // 메모(description)가 읽기 피드에 실려 돌아온다(회귀 방지: #940)
+                .andExpect(jsonPath("$.data.events[0].description").value("안건: 로드맵 리뷰"))
                 .andExpect(jsonPath("$.data.reviews.length()").value(1))
                 .andExpect(jsonPath("$.data.reviews[0].readOnly").value(true))
                 .andExpect(jsonPath("$.data.reviews[0].source").value("review"))

--- a/fe/src/features/planner/api/feed.ts
+++ b/fe/src/features/planner/api/feed.ts
@@ -15,6 +15,7 @@ export interface PlannerEvent {
   start: string;
   end: string | null;
   location: string | null;
+  description?: string | null;
   recurring: boolean;
   source: "google";
   routine?: RoutineMeta | null;

--- a/fe/src/features/planner/components/calendar/EventFormDialog.test.tsx
+++ b/fe/src/features/planner/components/calendar/EventFormDialog.test.tsx
@@ -61,6 +61,7 @@ describe("EventFormDialog", () => {
       start: "2026-06-10T14:00:00",
       end: "2026-06-10T15:00:00",
       location: "강남",
+      description: "정기 검진, 보험증 챙기기",
       recurring: false,
       source: "google",
     };
@@ -76,7 +77,40 @@ describe("EventFormDialog", () => {
 
     expect(screen.getByLabelText("제목")).toHaveValue("치과 예약");
     expect(screen.getByLabelText("시작 시간")).toHaveValue("14:00");
+    // 저장돼 있던 메모(description)가 편집창에 그대로 채워져야 한다(회귀 방지: #940).
+    expect(
+      screen.getByDisplayValue("정기 검진, 보험증 챙기기"),
+    ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "삭제" })).toBeInTheDocument();
+  });
+
+  it("편집: 기존 메모를 지우지 않고 저장하면 description이 유지된다", async () => {
+    const event: PlannerEvent = {
+      id: "e1",
+      title: "치과 예약",
+      allDay: false,
+      start: "2026-06-10T14:00:00",
+      end: "2026-06-10T15:00:00",
+      location: "강남",
+      description: "정기 검진",
+      recurring: false,
+      source: "google",
+    };
+    const onSubmit = vi.fn();
+    renderWithRouter(
+      <EventFormDialog
+        {...baseProps}
+        mode="edit"
+        event={event}
+        onSubmit={onSubmit}
+        onDelete={() => {}}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "저장" }));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "정기 검진" }),
+    );
   });
 
   it("미연동이면 연결 CTA를 보여주고 폼은 없다", () => {

--- a/fe/src/features/planner/components/calendar/EventFormDialog.tsx
+++ b/fe/src/features/planner/components/calendar/EventFormDialog.tsx
@@ -59,7 +59,7 @@ function initialState(
       endDate: (event.end ?? event.start).slice(0, 10),
       endTime: allDay ? "10:00" : (event.end ?? "").slice(11, 16) || "10:00",
       location: event.location ?? "",
-      description: "",
+      description: event.description ?? "",
     };
   }
   return {


### PR DESCRIPTION
## 이슈
closes #940

## 증상
캘린더 일정 편집에서 **메모**를 입력·저장한 뒤 그 일정을 다시 클릭하면 메모가 비어 있다.

## 원인 (읽기 경로 누락)
메모는 Google Calendar에 **저장은 된다**(write: `EventRequest.description` → `GoogleEventWriteBody`). 그러나 **읽기 피드가 description을 돌려주지 않았다** — BE `PlannerEvent`·`GoogleEventItem`, FE `PlannerEvent`(feed)에 `description` 필드가 없었다. 그래서 `EventFormDialog`가 편집 시 기존 메모를 못 불러오고(`initialState`에서 `description: ""` 하드코딩), 그대로 저장하면 null로 덮였다.

## 수정 (풀스택)
### BE
- `GoogleEventsResponse.GoogleEventItem`·`PlannerEvent`에 `description` 추가.
- `GoogleCalendarClient.normalize`·`PlannerCalendarService.applyDone` 매핑 반영 → **create/update 응답도 normalize를 거치므로 함께 해결**.
- events.list 요청엔 `fields` 필터가 없어 Google이 description을 그대로 반환(추가 작업 불필요). write는 이미 `request.description()`을 전송 중이라 정상.

### FE
- `PlannerEvent`(feed)에 `description?: string | null` 추가(`tasks.notes`와 동일 패턴).
- `EventFormDialog` 편집 초기값을 `event.description ?? ""`로.

## 테스트
- BE: 읽기 피드가 `events[0].description`을 반환(`PlannerCalendarControllerTest`, mock Google 응답에 description 포함).
- FE: 편집창에 기존 메모가 채워지고(회귀), 안 건드리고 저장 시 `description` 유지(`EventFormDialog.test`).
- FE 486개·eslint·prettier, BE 컴파일·체크스타일·해당 통합 테스트 통과.

## 확인
- 로컬 브라우저 실증 미실행(플래너+Google 연동 풀스택 필요). BE 통합 테스트로 읽기 피드 라운드트립을, FE 테스트로 편집 폼 로드·저장을 검증.