### PR TITLE
fix : 표 안 붙여넣기가 에디터로 새어 표가 하나 더 생기던 문제 (#944)

### DIFF
--- a/fe/src/features/note/editor/datasetTable.test.ts
+++ b/fe/src/features/note/editor/datasetTable.test.ts
@@ -3,7 +3,11 @@ import { NodeSelection } from "@tiptap/pm/state";
 import StarterKit from "@tiptap/starter-kit";
 import { describe, expect, it } from "vitest";
 
-import { collectDatasetIds, DatasetTable } from "./datasetTable";
+import {
+  collectDatasetIds,
+  DatasetTable,
+  isGridClipboardEvent,
+} from "./datasetTable";
 
 describe("collectDatasetIds", () => {
   it("중첩 doc에서 모든 datasetTable datasetId를 수집한다", () => {
@@ -41,6 +45,20 @@ describe("collectDatasetIds", () => {
       content: [{ type: "datasetTable", attrs: {} }],
     };
     expect(collectDatasetIds(doc).size).toBe(0);
+  });
+});
+
+describe("isGridClipboardEvent (셀 안 클립보드 이벤트는 에디터가 무시)", () => {
+  it("paste·copy·cut이면 true(에디터 handlePaste로 새지 않게 stopEvent)", () => {
+    expect(isGridClipboardEvent(new Event("paste"))).toBe(true);
+    expect(isGridClipboardEvent(new Event("copy"))).toBe(true);
+    expect(isGridClipboardEvent(new Event("cut"))).toBe(true);
+  });
+
+  it("그 외 이벤트는 false(키·마우스 등은 평소대로)", () => {
+    expect(isGridClipboardEvent(new Event("keydown"))).toBe(false);
+    expect(isGridClipboardEvent(new Event("mousedown"))).toBe(false);
+    expect(isGridClipboardEvent(new Event("input"))).toBe(false);
   });
 });
 

--- a/fe/src/features/note/editor/datasetTable.ts
+++ b/fe/src/features/note/editor/datasetTable.ts
@@ -9,6 +9,17 @@ export interface DatasetTableAttrs {
   datasetId: number;
 }
 
+/**
+ * 그리드(셀) 안에서 일어난 클립보드 이벤트인가. 이런 이벤트는 에디터(ProseMirror)가 처리하지
+ * 않게 한다({@link Node.addNodeView}의 stopEvent) — 안 그러면 셀 붙여넣기가 에디터의
+ * handlePaste까지 버블링돼 노트에 표가 하나 더 생긴다(그리드는 자체 핸들러로 붙여넣는다).
+ */
+export function isGridClipboardEvent(event: Event): boolean {
+  return (
+    event.type === "paste" || event.type === "copy" || event.type === "cut"
+  );
+}
+
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     datasetTable: {
@@ -59,7 +70,11 @@ export const DatasetTable = Node.create({
   },
 
   addNodeView() {
-    return ReactNodeViewRenderer(DatasetTableView);
+    return ReactNodeViewRenderer(DatasetTableView, {
+      // 셀 안 클립보드 이벤트는 에디터가 손대지 않는다(그리드가 직접 처리) — 셀 붙여넣기가
+      // handlePaste까지 닿아 노트에 표가 하나 더 생기던 문제를 막는다.
+      stopEvent: ({ event }) => isGridClipboardEvent(event),
+    });
   },
 
   addCommands() {


### PR DESCRIPTION
## 이슈
closes #944

## 증상
표에서 셀을 클릭하고 붙여넣기하면 값이 "왔다갔다" — 셀에 붙는 동시에 **노트 본문에 표가 하나 더 생긴다**.

## 원인
그리드는 `contentEditable=false` NodeView인데 `stopEvent`가 없어, 셀 붙여넣기 이벤트가 에디터(ProseMirror)까지 버블링된다. 에디터 `handlePaste`가 클립보드의 `DATASET_CELLS_MIME`(그리드 복사 시 부착)을 보고 **새 표를 삽입**한다 → 그리드 자체 붙여넣기 + 에디터의 새 표 삽입이 동시에 일어난다.

## 수정
`datasetTable` NodeView에 **`stopEvent`** 추가 → 그리드 안 클립보드 이벤트(paste/copy/cut)를 에디터가 무시.

- 검증(소스): prosemirror-view `eventBelongsToView`가 `target→view.dom` 경로의 NodeView `stopEvent`가 true면 PM 핸들러(paste)를 실행하지 않는다. TipTap core `NodeView.stopEvent`는 옵션 함수를 그대로 호출한다.
- 그리드의 React 클립보드 핸들러(onGridPaste 등)는 그대로 동작(루트 위임이라 무관).
- **그리드 복사 → 노트 본문 붙여넣기 → 새 표**(정상 기능)는 유지 — 그 붙여넣기는 그리드 밖이라 stopEvent 대상이 아님.
- 편집 중 셀에 텍스트 붙여넣기(입력창 native)도 유지.

## 테스트
- `isGridClipboardEvent` 예측자: paste/copy/cut=true, keydown/mousedown/input=false.
- FE 490개·eslint·prettier 통과. BE 변경 없음.

## 확인
- 로컬 브라우저 실증 미실행(노트+인증 풀스택 필요). 대신 PM/TipTap 소스로 stopEvent가 handlePaste를 차단함을 확인.