### PR TITLE
fix : 표 한글(IME) 입력 시 글자가 계속 지워지던 문제 (#946)

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -580,6 +580,38 @@ describe("DatasetGrid", () => {
     expect(selectSpy).not.toHaveBeenCalled();
   });
 
+  it("IME 조합 키(Process)는 키다운에서 전체선택하지 않는다(조합 깨짐 방지)", async () => {
+    // 조합 도중 select()를 부르면 한글이 계속 지워진다 → Process/조합 중 키는 제외.
+    mockDataset([["네트워크", "92"]]);
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    await user.click(await screen.findByText("92"));
+    const input = screen.getByLabelText(
+      "1행 2열 셀 (입력하면 편집)",
+    ) as HTMLInputElement;
+    const selectSpy = vi.spyOn(input, "select");
+
+    fireEvent.keyDown(input, { key: "Process" });
+    expect(selectSpy).not.toHaveBeenCalled();
+  });
+
+  it("IME 덮어쓰기는 조합 시작(compositionStart) 시점에 전체선택한다(선택 상태에서만)", async () => {
+    mockDataset([["네트워크", "92"]]);
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    await user.click(await screen.findByText("92"));
+    const input = screen.getByLabelText(
+      "1행 2열 셀 (입력하면 편집)",
+    ) as HTMLInputElement;
+    const selectSpy = vi.spyOn(input, "select");
+
+    // 조합 시작 시(선택-만-한 상태) 전체선택 → 조합이 기존 값을 덮어쓴다.
+    fireEvent.compositionStart(input);
+    expect(selectSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("셀 선택 후 한글을 조합해 입력하면 같은 입력창에서 편집돼 저장된다", async () => {
     mockDataset([["네트워크", "92"]]);
     let patched: { index: number; cells: string[] } | null = null;

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -79,12 +79,18 @@ const isUndoRedoKey = (e: React.KeyboardEvent): boolean =>
   (((e.metaKey || e.ctrlKey) && (e.key === "z" || e.key === "Z")) ||
     (e.ctrlKey && (e.key === "y" || e.key === "Y")));
 
-/** 값을 만드는 키인가 — 글자 한 자 또는 한글 등 IME 조합키. 수정키 조합은 제외. */
+/**
+ * 값을 만드는 '일반' 글자 키인가(수정키 조합 제외). IME 조합키(Process·조합 중)는 제외한다 —
+ * 조합 도중 입력창을 전체선택하면 조합이 깨져 글자가 사라진다. IME 덮어쓰기는 조합 시작
+ * (onCompositionStart) 시점에 따로 처리한다.
+ */
 const isContentKey = (e: React.KeyboardEvent): boolean =>
   !e.ctrlKey &&
   !e.metaKey &&
   !e.altKey &&
-  (e.key === "Process" || e.nativeEvent.isComposing || e.key.length === 1);
+  e.key !== "Process" &&
+  !e.nativeEvent.isComposing &&
+  e.key.length === 1;
 
 /**
  * 선택 범위 — 셀 사각 범위(a=앵커, b=포커스) / 행 묶음 / 열 묶음 / 표 전체.
@@ -1704,8 +1710,12 @@ export function DatasetGrid({
                 ? `opts-${meta.columns[c].key}`
                 : undefined
             }
-            // 클릭 선택 땐 값을 전체선택하지 않는다(커서만 끝에) — 하이라이트 없이 선택만. 덮어쓰기는
-            // 첫 글자/IME를 누르는 순간 onCellInputKeyDown이 그때만 전체선택해 처리한다.
+            // 클릭 선택 땐 값을 전체선택하지 않는다(커서만 끝에) — 하이라이트 없이 선택만.
+            // 덮어쓰기: 일반 글자는 그 키다운 순간(onCellInputKeyDown), IME(한글)는 조합 시작 시점에
+            // 전체선택한다. 조합 '도중' 전체선택하면 조합이 깨져 글자가 사라지므로 시작에만 한다.
+            onCompositionStart={(e) => {
+              if (!isEditing) e.currentTarget.select();
+            }}
             onChange={(e) => {
               const value = e.target.value;
               setDraft(value);


### PR DESCRIPTION
## 이슈
closes #946

## 증상
표 셀에 입력하려 하면(특히 **한글**) 글자가 계속 삭제돼 제대로 써지지 않는다.

## 원인
#943에서 셀 덮어쓰기를 "글자 키다운 순간 입력창 전체선택(`select()`)"으로 구현했는데, `isContentKey`가 **IME 조합키(`Process`·조합 중)까지 포함**했다. **한글 조합 도중 입력창을 전체선택하면 조합이 깨져** 조합 중인 글자가 사라진다 — 매 조합 키다운마다 반복돼 "계속 삭제"처럼 보인다.

## 수정
- `isContentKey`를 **일반 글자 키(길이 1, 조합 아님)** 로 한정 — `Process`/`isComposing` 키는 키다운에서 전체선택하지 않는다.
- IME 덮어쓰기는 **조합 시작(`onCompositionStart`)** 시점에만 전체선택(조합 시작이라 안 깨짐, 선택-만-한 상태에서만).
- 일반 글자 덮어쓰기(#942)와 편집 중 이어쓰기는 그대로 유지.

## 테스트
- `Process` 키다운 시 `select()` 미호출(조합 깨짐 방지), `compositionStart` 시 선택 상태면 `select()` 호출.
- 기존 한글 조합·클릭 선택·덮어쓰기 테스트 유지. FE 492개·eslint·prettier 통과. BE 변경 없음.

## 확인
- jsdom은 실제 IME 조합을 시뮬레이트하지 못해, `select()` 호출 여부(키다운 vs compositionStart)로 메커니즘을 검증했다. 조합 도중 select 제거 + 조합 시작에만 선택이 실 브라우저 한글 입력을 정상화한다.