### PR TITLE
fix : 표 셀 입력 불가/한글 표 삭제 — PM이 키·조합 이벤트 가로챔 (#946)

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -530,16 +530,18 @@ describe("DatasetGrid", () => {
     expect(await screen.findByLabelText("셀 1행 2열")).toHaveValue("d");
   });
 
-  it("셀을 한 번 클릭하면 값이 든 입력창이 떠 바로 덮어쓸 수 있다(편집 라벨은 아직 없음)", async () => {
+  it("셀을 한 번 클릭하면 값은 그대로 보이고, 활성 입력창은 비어(덮어쓰기 대기) 있다", async () => {
     mockDataset([["네트워크", "92"]]);
     const user = userEvent.setup();
     renderWithRouter(<DatasetGrid datasetId={1} />);
 
     await user.click(await screen.findByText("92"));
 
-    // 선택-만-한 활성 입력창: 값이 들어 있고 곧바로 타이핑하면 덮어써진다.
+    // 값("92")은 표시칸에 그대로 보인다.
+    expect(screen.getByText("92")).toBeInTheDocument();
+    // 선택-만-한 활성 입력창은 비어 있다 — 첫 글자를 치면 빈 칸에 들어가 그대로 덮어써진다.
     const input = screen.getByLabelText("1행 2열 셀 (입력하면 편집)");
-    expect(input).toHaveValue("92");
+    expect(input).toHaveValue("");
     // 아직 편집이 아니므로 편집용 라벨(셀 N행 M열)은 없다.
     expect(screen.queryByLabelText("셀 1행 2열")).not.toBeInTheDocument();
     // 어느 칸이 선택됐는지 보이도록 얇은 안쪽 테두리로 강조한다.
@@ -547,69 +549,39 @@ describe("DatasetGrid", () => {
     expect(input.className).toContain("ring-primary");
   });
 
-  it("셀을 클릭만 하면 값을 전체선택하지 않고(커서만 끝), 글자를 누르는 순간 전체선택해 덮어쓴다", async () => {
+  it("셀을 클릭하고 글자를 입력하면 기존 값을 덮어쓴다(전체선택 없이 빈 칸 방식)", async () => {
     mockDataset([["네트워크", "92"]]);
+    let patched: { index: number; cells: string[] } | null = null;
+    server.use(
+      http.patch(
+        `${API_BASE}/datasets/1/rows/:i`,
+        async ({ params, request }) => {
+          const body = (await request.json()) as { cells: string[] };
+          patched = { index: Number(params.i), cells: body.cells };
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              edited: {
+                id: 100,
+                rowIndex: Number(params.i),
+                cells: body.cells,
+              },
+              affected: [],
+            },
+          });
+        },
+      ),
+    );
     const user = userEvent.setup();
     renderWithRouter(<DatasetGrid datasetId={1} />);
 
     await user.click(await screen.findByText("92"));
-    const input = screen.getByLabelText(
-      "1행 2열 셀 (입력하면 편집)",
-    ) as HTMLInputElement;
-    const selectSpy = vi.spyOn(input, "select");
+    await user.keyboard("7{Enter}");
 
-    // 클릭만으론 전체선택하지 않는다(하이라이트 없음).
-    expect(selectSpy).not.toHaveBeenCalled();
-
-    // 글자를 누르면 그 순간 전체선택 → native 입력이 대체(덮어쓰기).
-    fireEvent.keyDown(input, { key: "a" });
-    expect(selectSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("편집 중에는 글자를 눌러도 전체선택하지 않는다(커서 위치에 이어서 입력)", async () => {
-    mockDataset([["네트워크", "92"]]);
-    const user = userEvent.setup();
-    renderWithRouter(<DatasetGrid datasetId={1} />);
-
-    // 더블클릭 → 편집(커서 끝). 이 상태에서 글자를 눌러도 전체선택하지 않는다.
-    await user.dblClick(await screen.findByText("92"));
-    const input = screen.getByLabelText("셀 1행 2열") as HTMLInputElement;
-    const selectSpy = vi.spyOn(input, "select");
-
-    fireEvent.keyDown(input, { key: "5" });
-    expect(selectSpy).not.toHaveBeenCalled();
-  });
-
-  it("IME 조합 키(Process)는 키다운에서 전체선택하지 않는다(조합 깨짐 방지)", async () => {
-    // 조합 도중 select()를 부르면 한글이 계속 지워진다 → Process/조합 중 키는 제외.
-    mockDataset([["네트워크", "92"]]);
-    const user = userEvent.setup();
-    renderWithRouter(<DatasetGrid datasetId={1} />);
-
-    await user.click(await screen.findByText("92"));
-    const input = screen.getByLabelText(
-      "1행 2열 셀 (입력하면 편집)",
-    ) as HTMLInputElement;
-    const selectSpy = vi.spyOn(input, "select");
-
-    fireEvent.keyDown(input, { key: "Process" });
-    expect(selectSpy).not.toHaveBeenCalled();
-  });
-
-  it("IME 덮어쓰기는 조합 시작(compositionStart) 시점에 전체선택한다(선택 상태에서만)", async () => {
-    mockDataset([["네트워크", "92"]]);
-    const user = userEvent.setup();
-    renderWithRouter(<DatasetGrid datasetId={1} />);
-
-    await user.click(await screen.findByText("92"));
-    const input = screen.getByLabelText(
-      "1행 2열 셀 (입력하면 편집)",
-    ) as HTMLInputElement;
-    const selectSpy = vi.spyOn(input, "select");
-
-    // 조합 시작 시(선택-만-한 상태) 전체선택 → 조합이 기존 값을 덮어쓴다.
-    fireEvent.compositionStart(input);
-    expect(selectSpy).toHaveBeenCalledTimes(1);
+    // "92"가 "7"로 덮어써져 저장된다(빈 입력창에 들어가 그대로 대체).
+    await waitFor(() => {
+      expect(patched).toEqual({ index: 0, cells: ["네트워크", "7"] });
+    });
   });
 
   it("셀 선택 후 한글을 조합해 입력하면 같은 입력창에서 편집돼 저장된다", async () => {
@@ -1329,9 +1301,11 @@ describe("DatasetGrid", () => {
     renderWithRouter(<DatasetGrid datasetId={1} blockSelected={true} />);
 
     // 데이터가 로드되면 첫 셀(1행 1열)이 활성 입력창으로 잡힌다 — 이어서 키를 누르면 바로 편집.
+    // 선택-만-한 상태라 입력창은 비어 있고(값은 표시칸), 첫 글자를 치면 덮어써진다.
     expect(
       await screen.findByLabelText("1행 1열 셀 (입력하면 편집)"),
-    ).toHaveValue("네트워크");
+    ).toHaveValue("");
+    expect(screen.getByText("네트워크")).toBeInTheDocument();
   });
 
   it("blockSelected여도 특정 셀을 클릭하면 그 셀이 선택된다(첫 셀로 안 튐)", async () => {
@@ -1343,9 +1317,10 @@ describe("DatasetGrid", () => {
     // 원하는 셀("92" = 1행 2열)을 정확히 클릭 → 그 셀이 활성화(첫 셀로 되돌아가지 않음).
     const cell = (await screen.findByText("92")).parentElement as HTMLElement;
     fireEvent.pointerDown(cell, { button: 0 });
+    // 그 셀의 활성 입력창이 뜬다(선택-만-한 상태라 비어 있음).
     expect(
       await screen.findByLabelText("1행 2열 셀 (입력하면 편집)"),
-    ).toHaveValue("92");
+    ).toHaveValue("");
   });
 
   // ---------- 열 너비(resize) ----------

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -80,19 +80,6 @@ const isUndoRedoKey = (e: React.KeyboardEvent): boolean =>
     (e.ctrlKey && (e.key === "y" || e.key === "Y")));
 
 /**
- * 값을 만드는 '일반' 글자 키인가(수정키 조합 제외). IME 조합키(Process·조합 중)는 제외한다 —
- * 조합 도중 입력창을 전체선택하면 조합이 깨져 글자가 사라진다. IME 덮어쓰기는 조합 시작
- * (onCompositionStart) 시점에 따로 처리한다.
- */
-const isContentKey = (e: React.KeyboardEvent): boolean =>
-  !e.ctrlKey &&
-  !e.metaKey &&
-  !e.altKey &&
-  e.key !== "Process" &&
-  !e.nativeEvent.isComposing &&
-  e.key.length === 1;
-
-/**
  * 선택 범위 — 셀 사각 범위(a=앵커, b=포커스) / 행 묶음 / 열 묶음 / 표 전체.
  * null이면 선택 없음. 선택 위 플로팅 툴바가 이 종류를 보고 옵션을 바꾼다.
  */
@@ -1041,8 +1028,8 @@ export function DatasetGrid({
   /**
    * 활성 셀 입력창의 키 처리. 선택만 한 상태에서 Enter/F2는 기존 값을 이어 편집,
    * Backspace는 편집으로 들어가 끝 글자 하나만 지우고(전체 삭제가 아니라 한 글자씩), Delete는
-   * 셀을 통째로 비운다. 글자/IME를 처음 누르면 그 순간 전체선택해 값을 덮어쓴다(클릭만으론
-   * 전체선택하지 않아 하이라이트가 없다). 어떤 키든 상위 에디터로 전파를 막는다.
+   * 셀을 통째로 비운다. 일반 글자/IME는 그대로 흘려보낸다 — 선택-만-한 입력창은 비어 있어 첫
+   * 글자가 곧 덮어쓰기가 된다. 어떤 키든 상위 에디터로 전파를 막는다.
    */
   const onCellInputKeyDown = (
     e: React.KeyboardEvent<HTMLInputElement>,
@@ -1096,7 +1083,7 @@ export function DatasetGrid({
       // 타이핑과 같은 경로로 자동저장 예약(엔터·blur로도 커밋된다).
       cancelAutoSave();
       autoSaveTimer.current = setTimeout(() => flushPendingEdit(true), 500);
-      // 전체선택을 풀고 커서를 끝으로 — 다음 Backspace가 또 전체를 지우지 않게 한다.
+      // 커서를 끝에 둬 다음 Backspace부터는 native로 한 자씩 지워지게 한다.
       requestAnimationFrame(() => {
         const el = activeInputRef.current;
         if (el) el.setSelectionRange(el.value.length, el.value.length);
@@ -1108,14 +1095,9 @@ export function DatasetGrid({
       e.preventDefault();
       clearSelValues();
       setDraft("");
-      return;
     }
-    if (!editing && isContentKey(e)) {
-      // 선택-만-한 상태에서 글자/IME를 처음 누르면 값을 덮어쓴다. 클릭 시엔 전체선택을 하지
-      // 않아(하이라이트 없음) 커서가 끝에 있지만, 이 순간에만 전체선택해 native 입력이 그 선택을
-      // 대체하게 한다 — 한 번에 덮어써지고 한글 IME 조합도 처음부터 시작된다. (편집 중이면 안 함)
-      e.currentTarget.select();
-    }
+    // 일반 글자/IME 입력은 그대로 흘려보낸다 — 선택-만-한 상태의 입력창은 비어 있어(값은 뒤
+    // 표시칸에 보인다) 첫 글자가 그대로 덮어쓰기가 된다. select()를 쓰지 않아 한글 조합이 안 깨진다.
   };
   const extendCellSelect = (row: number, col: number) => {
     if (selDrag.current !== "cells") return;
@@ -1657,8 +1639,8 @@ export function DatasetGrid({
     const colKey = meta.columns[c].key;
     const isEditing = editing?.row === rowIndex && editing.col === c;
     // 단일 셀만 선택된 상태(범위/행/열/표 아님)이고 이 셀이 그 셀이면 "활성"이다.
-    // 활성 셀엔 편집 전에도 입력창을 띄워 두고(전체선택은 안 함 — 커서만 끝에), 글자를 치면
-    // 그때 전체선택 후 덮어쓰며 편집으로 넘어간다 — 같은 <input>이라 IME 조합이 끊기지 않는다.
+    // 활성 셀엔 편집 전에도 입력창을 띄워 두되 비워 둔다(값은 뒤 표시칸이 보여줌). 글자를 치면
+    // 빈 칸에 들어가 그대로 덮어쓰기가 되고 편집으로 넘어간다 — 같은 <input>이라 IME도 안 끊긴다.
     const isSelectActive =
       !editing &&
       sel?.kind === "cells" &&
@@ -1703,19 +1685,15 @@ export function DatasetGrid({
           <input
             ref={activeInputRef}
             autoFocus
-            value={draft}
+            // 선택-만-한 상태(편집 아님)에선 입력창을 비워 둔다 — 값은 뒤 표시칸에 그대로 보이고,
+            // 첫 글자를 치면 빈 칸에 들어가 그대로 덮어쓰기가 된다(select() 없이도, 한글 IME 안전).
+            value={isEditing ? draft : ""}
             // 허용값(enum) 열이면 드롭다운 제안(datalist). 느슨 — 목록 밖도 타이핑 가능.
             list={
               meta.columns[c].options
                 ? `opts-${meta.columns[c].key}`
                 : undefined
             }
-            // 클릭 선택 땐 값을 전체선택하지 않는다(커서만 끝에) — 하이라이트 없이 선택만.
-            // 덮어쓰기: 일반 글자는 그 키다운 순간(onCellInputKeyDown), IME(한글)는 조합 시작 시점에
-            // 전체선택한다. 조합 '도중' 전체선택하면 조합이 깨져 글자가 사라지므로 시작에만 한다.
-            onCompositionStart={(e) => {
-              if (!isEditing) e.currentTarget.select();
-            }}
             onChange={(e) => {
               const value = e.target.value;
               setDraft(value);
@@ -1751,11 +1729,12 @@ export function DatasetGrid({
               // 활성(선택/편집) 셀은 얇은 안쪽 테두리로 강조해 어느 칸이 선택됐는지 보이게 한다.
               "ring-primary absolute inset-0 z-[6] h-full w-full px-2 py-1.5 ring-1 outline-none ring-inset",
               ALIGN_CLASS[align],
-              // 뒤 표시값을 가리도록 셀 배경색(없으면 카드색)으로 불투명하게 덮는다.
-              !style?.bg && "bg-card",
+              // 편집 중일 때만 뒤 표시값을 셀 배경(없으면 카드색)으로 불투명하게 덮는다. 선택-만-한
+              // 상태에선 입력창이 비어 투명이라, 뒤 표시칸의 값·배경이 그대로 보인다.
+              isEditing && !style?.bg && "bg-card",
             )}
             style={
-              style?.bg
+              isEditing && style?.bg
                 ? { background: `var(--cell-bg-${style.bg})` }
                 : undefined
             }


### PR DESCRIPTION
## 이슈
closes #946

## 증상
표 셀에 **영어가 입력되지 않고**, **한글을 치면 표가 삭제**된다.

## 근본 원인 (Playwright로 라이브 진단)
셀은 `contentEditable=false` NodeView 안의 진짜 `<input>`으로 편집한다. 그런데 셀 입력창에 포커스가 있어도 **키/입력/조합 이벤트가 ProseMirror까지 버블링돼 PM의 편집 핸들러가 가로챈다**:

- **keypress/beforeinput** → PM이 `preventDefault` → 셀에 글자가 안 들어감(**영어 입력 불가**). (라이브에서 keydown fires·not prevented인데 **beforeinput이 아예 안 뜸**을 확인. keypress를 PM 전에 stopPropagation하면 즉시 정상 입력됨을 실증.)
- **composition\*** → 노드 선택 상태에서 PM이 조합 텍스트로 노드를 대체 → **한글 치면 표 삭제**.

#945에서 추가한 `stopEvent`가 **클립보드(paste/copy/cut)만** 무시하게 해, 키보드·입력·조합 이벤트는 계속 PM으로 샜다.

## 수정 (2가지, 함께 필요)
1. **PM이 셀 이벤트를 무시하도록 `stopEvent` 확장** (`datasetTable.ts`, 핵심): keydown/keypress/keyup/beforeinput/input/composition*/clipboard 까지 `isGridSelfHandledEvent`로 true. 그리드가 자체 `<input>`으로 처리하므로 PM은 손대지 않는다. 마우스·포커스는 PM에 유지(포커스 이동에 필요).
2. **덮어쓰기에서 `select()` 완전 제거** (`DatasetGrid.tsx`): `select()`는 IME에서 조합을 깬다. 선택-만-한 상태의 입력창을 **빈 투명**으로 두고(값은 뒤 표시칸이 보여줌) 첫 글자가 빈 칸에 들어가 그대로 덮어써지게 한다. 배경은 편집 중에만 불투명.

동작: 한 번 클릭+타이핑=덮어쓰기(영어·한글), 더블클릭=끝 커서 편집, Backspace=끝 한 글자, Delete=비우기.

## 검증
- **라이브(Playwright)**: 셀 입력창에서 keypress/beforeinput를 PM 전에 막으니 즉시 정상 입력·편집 전환됨을 확인(근본 원인 실증).
- 단위: `isGridSelfHandledEvent`(키/입력/조합/클립보드=true, 마우스/포커스=false).
- 통합: 클릭 시 값 표시·입력창 빈값, 타이핑 덮어쓰기, 한글 조합 저장.
- FE 489개·eslint·prettier 통과. BE 변경 없음.