### PR TITLE
feat : 일상기록 데이터 모델 & Liquibase 마이그레이션

### DIFF
--- a/be/orino-app-api/src/main/resources/db/changelog/changes/046-create-lifelog-tables.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/046-create-lifelog-tables.yaml
@@ -1,0 +1,340 @@
+databaseChangeLog:
+  # 일상기록(Lifelog) 모듈 스키마 (#950, Epic #949).
+  #
+  # Moment(순간 기록) + Flow(수동 컬렉션, N:M). 노트/메모 트리를 재사용하지 않는 독립 도메인.
+  # 사진은 self-hosted MinIO에 저장하고 여기엔 object key만 담는다. 위치(lat/lng)·장소명(place_name)은
+  # 조회마다 재계산하지 않도록 denormalize 저장한다. 단일 사용자지만 기존 컨벤션(Note·Dataset)대로
+  # member_id로 스코프한다.
+
+  - changeSet:
+      id: 046-create-moment
+      author: wcorn
+      comment: 순간 기록. 사진·본문·발생시각·위치·기분을 담는 리치 카드의 본체.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: moment
+      changes:
+        - createTable:
+            tableName: moment
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              # 그 순간이 실제로 일어난 시각(정렬 키). 사진 EXIF 촬영시각 우선 → 없으면 작성시각.
+              - column:
+                  name: occurred_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: body
+                  type: TEXT
+              # 기분 키(HAPPY/CALM/EXCITED/TIRED/SAD). @Enumerated(STRING).
+              - column:
+                  name: mood
+                  type: VARCHAR(20)
+              - column:
+                  name: lat
+                  type: DECIMAL(10, 7)
+              - column:
+                  name: lng
+                  type: DECIMAL(10, 7)
+              # 역지오코딩 결과. 저장 시 1회 확정(denormalize).
+              - column:
+                  name: place_name
+                  type: VARCHAR(255)
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        # 피드 커서 페이지네이션: 역시간순(occurred_at DESC, id DESC), 멤버 스코프.
+        - createIndex:
+            tableName: moment
+            indexName: idx_moment_member_occurred
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: occurred_at
+                  descending: true
+              - column:
+                  name: id
+                  descending: true
+
+  - changeSet:
+      id: 046-create-moment-photo
+      author: wcorn
+      comment: 기록에 붙은 사진(0..N). MinIO object key와 EXIF 원본만 담는다.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: moment_photo
+      changes:
+        - createTable:
+            tableName: moment_photo
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: moment_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_moment_photo_moment
+                    references: moment(id)
+                    deleteCascade: true
+              # MinIO 원본 key (lifelog/moments/...). 공개 URL은 base(img.orino.dev)+key로 조립.
+              - column:
+                  name: object_key
+                  type: VARCHAR(512)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: thumb_key
+                  type: VARCHAR(512)
+              - column:
+                  name: width
+                  type: INT
+              - column:
+                  name: height
+                  type: INT
+              # EXIF 원본 보존(발생시각·위치 자동채움의 근거).
+              - column:
+                  name: exif_taken_at
+                  type: DATETIME(6)
+              - column:
+                  name: exif_lat
+                  type: DECIMAL(10, 7)
+              - column:
+                  name: exif_lng
+                  type: DECIMAL(10, 7)
+              - column:
+                  name: sort_order
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: moment_photo
+            indexName: idx_moment_photo_moment
+            columns:
+              - column:
+                  name: moment_id
+              - column:
+                  name: sort_order
+
+  - changeSet:
+      id: 046-create-moment-tag
+      author: wcorn
+      comment: 기록 태그(0..N). 정규화하지 않고 이름을 그대로 담는다. name 인덱스로 자동완성.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: moment_tag
+      changes:
+        - createTable:
+            tableName: moment_tag
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: moment_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_moment_tag_moment
+                    references: moment(id)
+                    deleteCascade: true
+              - column:
+                  name: name
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+        # 한 기록에 같은 태그 하나. 조회 키이자 중복 방지.
+        - createIndex:
+            tableName: moment_tag
+            indexName: uq_moment_tag
+            unique: true
+            columns:
+              - column:
+                  name: moment_id
+              - column:
+                  name: name
+        # 태그 자동완성(SELECT DISTINCT name WHERE name LIKE ?).
+        - createIndex:
+            tableName: moment_tag
+            indexName: idx_moment_tag_name
+            columns:
+              - column:
+                  name: name
+
+  - changeSet:
+      id: 046-create-flow
+      author: wcorn
+      comment: 흐름(수동 컬렉션). 담긴 기록을 시간순 서사·지도로 본다.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: flow
+      changes:
+        - createTable:
+            tableName: flow
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: title
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: TEXT
+              # 커버 이미지 key. 비우면 담긴 첫 사진으로 대체 표시(조회 시 결정).
+              - column:
+                  name: cover_object_key
+                  type: VARCHAR(512)
+              # 기간. 수동 또는 담긴 기록 min/max occurred_at으로 유도.
+              - column:
+                  name: started_at
+                  type: DATETIME(6)
+              - column:
+                  name: ended_at
+                  type: DATETIME(6)
+              # ACTIVE / ARCHIVED. @Enumerated(STRING). 불리언 회피(Hibernate validate 호환).
+              - column:
+                  name: status
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: flow
+            indexName: idx_flow_member_status_started
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: status
+              - column:
+                  name: started_at
+                  descending: true
+
+  - changeSet:
+      id: 046-create-flow-moment
+      author: wcorn
+      comment: 흐름↔기록 N:M 조인. 흐름 내 수동 정렬(sort_order). 자연키는 유니크로 보장.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: flow_moment
+      changes:
+        - createTable:
+            tableName: flow_moment
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: flow_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_flow_moment_flow
+                    references: flow(id)
+                    deleteCascade: true
+              # 기록이 지워지면 소속도 사라진다. 반대로 흐름 삭제는 소속만 지우고 기록은 남는다.
+              - column:
+                  name: moment_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_flow_moment_moment
+                    references: moment(id)
+                    deleteCascade: true
+              # 흐름 내 정렬. 기본은 occurred_at 순, 사용자가 조정하면 이 값 우선.
+              - column:
+                  name: sort_order
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: added_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        # 한 흐름에 같은 기록은 한 번만(멱등 담기). 역조회 인덱스도 겸한다.
+        - createIndex:
+            tableName: flow_moment
+            indexName: uq_flow_moment
+            unique: true
+            columns:
+              - column:
+                  name: flow_id
+              - column:
+                  name: moment_id
+        # "이 기록이 담긴 흐름" 역조회.
+        - createIndex:
+            tableName: flow_moment
+            indexName: idx_flow_moment_moment
+            columns:
+              - column:
+                  name: moment_id

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -89,3 +89,5 @@ databaseChangeLog:
       file: db/changelog/changes/044-add-dataset-name.yaml
   - include:
       file: db/changelog/changes/045-add-formula-ref-to-dataset-id.yaml
+  - include:
+      file: db/changelog/changes/046-create-lifelog-tables.yaml

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/entity/Flow.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/entity/Flow.java
@@ -1,0 +1,127 @@
+package ds.project.orino.domain.planner.lifelog.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+/**
+ * 흐름(수동 컬렉션). 사용자가 "제주 여행"처럼 만들고 기록을 담는다. 담긴 기록은 {@link FlowMoment}로
+ * N:M 연결되며, 흐름은 관점일 뿐 기록의 소유자가 아니다 — 흐름을 지워도 기록은 남는다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "flow")
+public class Flow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    /** 커버 이미지 key. 비우면 담긴 첫 사진으로 대체 표시(조회 시 결정). */
+    @Column(name = "cover_object_key", length = 512)
+    private String coverObjectKey;
+
+    @Column(name = "started_at")
+    private Instant startedAt;
+
+    @Column(name = "ended_at")
+    private Instant endedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private FlowStatus status;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected Flow() {
+    }
+
+    public Flow(Long memberId, String title, String description) {
+        this.memberId = memberId;
+        this.title = title;
+        this.description = description;
+        this.status = FlowStatus.ACTIVE;
+    }
+
+    public void update(String title, String description, String coverObjectKey,
+                       Instant startedAt, Instant endedAt, FlowStatus status) {
+        this.title = title;
+        this.description = description;
+        this.coverObjectKey = coverObjectKey;
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
+        this.status = status;
+    }
+
+    /** 담긴 기록에서 유도한 기간(min/max occurred_at)을 반영한다. */
+    public void updatePeriod(Instant startedAt, Instant endedAt) {
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getCoverObjectKey() {
+        return coverObjectKey;
+    }
+
+    public Instant getStartedAt() {
+        return startedAt;
+    }
+
+    public Instant getEndedAt() {
+        return endedAt;
+    }
+
+    public FlowStatus getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/entity/FlowMoment.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/entity/FlowMoment.java
@@ -1,0 +1,73 @@
+package ds.project.orino.domain.planner.lifelog.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+/**
+ * 흐름↔기록 N:M 조인. 한 기록이 여러 흐름에 동시에 담길 수 있다. 흐름 내 순서는 기본 occurred_at
+ * 순이되 사용자가 조정하면 {@code sortOrder}가 우선한다. (flow_id, moment_id)는 유니크라 담기는 멱등.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "flow_moment")
+public class FlowMoment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "flow_id", nullable = false)
+    private Long flowId;
+
+    @Column(name = "moment_id", nullable = false)
+    private Long momentId;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @CreatedDate
+    @Column(name = "added_at", nullable = false, updatable = false)
+    private Instant addedAt;
+
+    protected FlowMoment() {
+    }
+
+    public FlowMoment(Long flowId, Long momentId, int sortOrder) {
+        this.flowId = flowId;
+        this.momentId = momentId;
+        this.sortOrder = sortOrder;
+    }
+
+    public void updateSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getFlowId() {
+        return flowId;
+    }
+
+    public Long getMomentId() {
+        return momentId;
+    }
+
+    public Integer getSortOrder() {
+        return sortOrder;
+    }
+
+    public Instant getAddedAt() {
+        return addedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/entity/FlowStatus.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/entity/FlowStatus.java
@@ -1,0 +1,14 @@
+package ds.project.orino.domain.planner.lifelog.entity;
+
+/**
+ * 흐름 상태.
+ *
+ * <ul>
+ *     <li>{@link #ACTIVE} — 진행 중(기본). 목록 상단.</li>
+ *     <li>{@link #ARCHIVED} — 보관. 목록에서 접어둔다.</li>
+ * </ul>
+ */
+public enum FlowStatus {
+    ACTIVE,
+    ARCHIVED
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/entity/Moment.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/entity/Moment.java
@@ -1,0 +1,133 @@
+package ds.project.orino.domain.planner.lifelog.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * 순간 기록 하나. 사진·본문·발생시각·위치·기분을 담는 리치 카드의 본체.
+ *
+ * <p>사진(0..N)·태그(0..N)는 {@link MomentPhoto}·{@link MomentTag}에 별도로 담고, 흐름 소속은
+ * {@link FlowMoment}가 N:M으로 잇는다. 위치(lat/lng)와 장소명은 조회마다 재계산하지 않도록
+ * 저장 시 확정해 여기 denormalize한다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "moment")
+public class Moment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    /** 그 순간이 실제로 일어난 시각(정렬 키). 사진 EXIF 촬영시각 우선 → 없으면 작성시각. */
+    @Column(name = "occurred_at", nullable = false)
+    private Instant occurredAt;
+
+    @Column(columnDefinition = "TEXT")
+    private String body;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private Mood mood;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal lat;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal lng;
+
+    /** 역지오코딩 결과. 저장 시 1회 확정(denormalize). */
+    @Column(name = "place_name", length = 255)
+    private String placeName;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected Moment() {
+    }
+
+    public Moment(Long memberId, Instant occurredAt, String body, Mood mood,
+                  BigDecimal lat, BigDecimal lng, String placeName) {
+        this.memberId = memberId;
+        this.occurredAt = occurredAt;
+        this.body = body;
+        this.mood = mood;
+        this.lat = lat;
+        this.lng = lng;
+        this.placeName = placeName;
+    }
+
+    /**
+     * 본문·발생시각·기분·위치를 한 번에 갱신한다. 사진·태그는 별도 컬렉션이라 여기서 다루지 않는다.
+     */
+    public void update(Instant occurredAt, String body, Mood mood,
+                       BigDecimal lat, BigDecimal lng, String placeName) {
+        this.occurredAt = occurredAt;
+        this.body = body;
+        this.mood = mood;
+        this.lat = lat;
+        this.lng = lng;
+        this.placeName = placeName;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Instant getOccurredAt() {
+        return occurredAt;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public Mood getMood() {
+        return mood;
+    }
+
+    public BigDecimal getLat() {
+        return lat;
+    }
+
+    public BigDecimal getLng() {
+        return lng;
+    }
+
+    public String getPlaceName() {
+        return placeName;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/entity/MomentPhoto.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/entity/MomentPhoto.java
@@ -1,0 +1,126 @@
+package ds.project.orino.domain.planner.lifelog.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * 기록에 붙은 사진 하나. 바이트는 self-hosted MinIO에 있고 여기엔 object key만 담는다.
+ * 공개 URL은 base(img.orino.dev) + key로 조립한다(호스트 하드코딩 회피).
+ *
+ * <p>EXIF(촬영시각·GPS)는 발생시각·위치 자동채움의 근거로 원본을 보존한다 —
+ * {@link Moment}의 값은 사용자가 수정할 수 있으므로 사진 EXIF와 별개다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "moment_photo")
+public class MomentPhoto {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "moment_id", nullable = false)
+    private Long momentId;
+
+    @Column(name = "object_key", nullable = false, length = 512)
+    private String objectKey;
+
+    @Column(name = "thumb_key", length = 512)
+    private String thumbKey;
+
+    private Integer width;
+
+    private Integer height;
+
+    @Column(name = "exif_taken_at")
+    private Instant exifTakenAt;
+
+    @Column(name = "exif_lat", precision = 10, scale = 7)
+    private BigDecimal exifLat;
+
+    @Column(name = "exif_lng", precision = 10, scale = 7)
+    private BigDecimal exifLng;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    protected MomentPhoto() {
+    }
+
+    public MomentPhoto(Long momentId, String objectKey, String thumbKey,
+                       Integer width, Integer height,
+                       Instant exifTakenAt, BigDecimal exifLat, BigDecimal exifLng,
+                       int sortOrder) {
+        this.momentId = momentId;
+        this.objectKey = objectKey;
+        this.thumbKey = thumbKey;
+        this.width = width;
+        this.height = height;
+        this.exifTakenAt = exifTakenAt;
+        this.exifLat = exifLat;
+        this.exifLng = exifLng;
+        this.sortOrder = sortOrder;
+    }
+
+    public void updateSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMomentId() {
+        return momentId;
+    }
+
+    public String getObjectKey() {
+        return objectKey;
+    }
+
+    public String getThumbKey() {
+        return thumbKey;
+    }
+
+    public Integer getWidth() {
+        return width;
+    }
+
+    public Integer getHeight() {
+        return height;
+    }
+
+    public Instant getExifTakenAt() {
+        return exifTakenAt;
+    }
+
+    public BigDecimal getExifLat() {
+        return exifLat;
+    }
+
+    public BigDecimal getExifLng() {
+        return exifLng;
+    }
+
+    public Integer getSortOrder() {
+        return sortOrder;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/entity/MomentTag.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/entity/MomentTag.java
@@ -1,0 +1,47 @@
+package ds.project.orino.domain.planner.lifelog.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * 기록 태그 하나. 정규화하지 않고 이름을 그대로 담는다(단일 사용자·저볼륨). 자동완성은
+ * {@code SELECT DISTINCT name}으로 충분하다. 한 기록에 같은 이름은 유니크 제약으로 한 번만.
+ */
+@Entity
+@Table(name = "moment_tag")
+public class MomentTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "moment_id", nullable = false)
+    private Long momentId;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    protected MomentTag() {
+    }
+
+    public MomentTag(Long momentId, String name) {
+        this.momentId = momentId;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMomentId() {
+        return momentId;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/entity/Mood.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/entity/Mood.java
@@ -1,0 +1,12 @@
+package ds.project.orino.domain.planner.lifelog.entity;
+
+/**
+ * 순간의 기분. 선택 값이라 {@link Moment#getMood()}는 null일 수 있다.
+ */
+public enum Mood {
+    HAPPY,
+    CALM,
+    EXCITED,
+    TIRED,
+    SAD
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/FlowMomentRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/FlowMomentRepository.java
@@ -1,0 +1,28 @@
+package ds.project.orino.domain.planner.lifelog.repository;
+
+import ds.project.orino.domain.planner.lifelog.entity.FlowMoment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FlowMomentRepository extends JpaRepository<FlowMoment, Long> {
+
+    /** 흐름 내 순서. 기본은 sort_order, 동률이면 id(담은 순). occurred_at 정렬은 서비스에서 조합. */
+    List<FlowMoment> findAllByFlowIdOrderBySortOrderAscIdAsc(Long flowId);
+
+    /** "이 기록이 담긴 흐름" 역조회. */
+    List<FlowMoment> findAllByMomentId(Long momentId);
+
+    boolean existsByFlowIdAndMomentId(Long flowId, Long momentId);
+
+    Optional<FlowMoment> findByFlowIdAndMomentId(Long flowId, Long momentId);
+
+    void deleteByFlowIdAndMomentId(Long flowId, Long momentId);
+
+    /** 흐름 끝에 담을 때 쓸 다음 sort_order. 빈 흐름이면 -1을 반환해 첫 항목이 0이 되게 한다. */
+    @Query("SELECT COALESCE(MAX(fm.sortOrder), -1) FROM FlowMoment fm WHERE fm.flowId = :flowId")
+    int findMaxSortOrder(@Param("flowId") Long flowId);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/FlowRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/FlowRepository.java
@@ -1,0 +1,17 @@
+package ds.project.orino.domain.planner.lifelog.repository;
+
+import ds.project.orino.domain.planner.lifelog.entity.Flow;
+import ds.project.orino.domain.planner.lifelog.entity.FlowStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FlowRepository extends JpaRepository<Flow, Long> {
+
+    Optional<Flow> findByIdAndMemberId(Long id, Long memberId);
+
+    List<Flow> findAllByMemberIdOrderByStartedAtDescIdDesc(Long memberId);
+
+    List<Flow> findAllByMemberIdAndStatusOrderByStartedAtDescIdDesc(Long memberId, FlowStatus status);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/MomentPhotoRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/MomentPhotoRepository.java
@@ -1,0 +1,17 @@
+package ds.project.orino.domain.planner.lifelog.repository;
+
+import ds.project.orino.domain.planner.lifelog.entity.MomentPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface MomentPhotoRepository extends JpaRepository<MomentPhoto, Long> {
+
+    List<MomentPhoto> findAllByMomentIdOrderBySortOrderAscIdAsc(Long momentId);
+
+    /** 피드 배치 로딩: 여러 기록의 사진을 한 번에. */
+    List<MomentPhoto> findAllByMomentIdInOrderBySortOrderAscIdAsc(Collection<Long> momentIds);
+
+    void deleteByMomentId(Long momentId);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/MomentRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/MomentRepository.java
@@ -1,0 +1,15 @@
+package ds.project.orino.domain.planner.lifelog.repository;
+
+import ds.project.orino.domain.planner.lifelog.entity.Moment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MomentRepository extends JpaRepository<Moment, Long> {
+
+    Optional<Moment> findByIdAndMemberId(Long id, Long memberId);
+
+    /** 피드 기본 정렬(역시간순). 커서 페이지네이션은 #952에서 얹는다. */
+    List<Moment> findAllByMemberIdOrderByOccurredAtDescIdDesc(Long memberId);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/MomentTagRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/MomentTagRepository.java
@@ -1,0 +1,33 @@
+package ds.project.orino.domain.planner.lifelog.repository;
+
+import ds.project.orino.domain.planner.lifelog.entity.MomentTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface MomentTagRepository extends JpaRepository<MomentTag, Long> {
+
+    List<MomentTag> findAllByMomentIdOrderByIdAsc(Long momentId);
+
+    /** 피드 배치 로딩: 여러 기록의 태그를 한 번에. */
+    List<MomentTag> findAllByMomentIdIn(Collection<Long> momentIds);
+
+    void deleteByMomentId(Long momentId);
+
+    /**
+     * 태그 자동완성 — 멤버가 이미 쓴 태그 중 접두어로 시작하는 것들(중복 제거·정렬).
+     * 멤버 스코프는 태그가 붙은 기록의 소유자로 건다.
+     */
+    @Query("""
+            SELECT DISTINCT t.name
+            FROM MomentTag t
+            WHERE t.momentId IN (SELECT m.id FROM Moment m WHERE m.memberId = :memberId)
+              AND t.name LIKE :prefix
+            ORDER BY t.name ASC
+            """)
+    List<String> findDistinctNamesByMemberIdAndPrefix(@Param("memberId") Long memberId,
+                                                       @Param("prefix") String prefix);
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/lifelog/repository/FlowMomentRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/lifelog/repository/FlowMomentRepositoryTest.java
@@ -1,0 +1,108 @@
+package ds.project.orino.domain.planner.lifelog.repository;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.lifelog.entity.Flow;
+import ds.project.orino.domain.planner.lifelog.entity.FlowMoment;
+import ds.project.orino.domain.planner.lifelog.entity.Moment;
+import ds.project.orino.domain.support.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 흐름↔기록 N:M 조인의 담기·순서·빼기·역조회를 고정한다. 한 기록이 여러 흐름에 담기는 것도 확인.
+ */
+@RepositoryTest
+@Transactional
+class FlowMomentRepositoryTest {
+
+    @Autowired
+    private FlowMomentRepository flowMomentRepository;
+    @Autowired
+    private FlowRepository flowRepository;
+    @Autowired
+    private MomentRepository momentRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Long flowId;
+    private Long m1;
+    private Long m2;
+
+    @BeforeEach
+    void setUp() {
+        Long memberId = memberRepository.save(new Member("fmuser", "pw")).getId();
+        flowId = flowRepository.save(new Flow(memberId, "제주 여행", null)).getId();
+        m1 = momentRepository.save(moment(memberId, "2026-07-20T10:00:00Z")).getId();
+        m2 = momentRepository.save(moment(memberId, "2026-07-20T14:00:00Z")).getId();
+    }
+
+    @Test
+    @DisplayName("담을 때 다음 sort_order는 max+1, 빈 흐름의 첫 항목은 0")
+    void appendsWithIncrementingSortOrder() {
+        assertThat(flowMomentRepository.findMaxSortOrder(flowId)).isEqualTo(-1);
+        flowMomentRepository.save(new FlowMoment(flowId, m1, flowMomentRepository.findMaxSortOrder(flowId) + 1));
+        assertThat(flowMomentRepository.findMaxSortOrder(flowId)).isEqualTo(0);
+        flowMomentRepository.save(new FlowMoment(flowId, m2, flowMomentRepository.findMaxSortOrder(flowId) + 1));
+
+        assertThat(flowMomentRepository.findAllByFlowIdOrderBySortOrderAscIdAsc(flowId))
+                .extracting(FlowMoment::getMomentId)
+                .containsExactly(m1, m2);
+    }
+
+    @Test
+    @DisplayName("이미 담긴 기록인지 exists로 확인하고, 빼면 소속만 사라진다")
+    void existsAndRemove() {
+        flowMomentRepository.save(new FlowMoment(flowId, m1, 0));
+
+        assertThat(flowMomentRepository.existsByFlowIdAndMomentId(flowId, m1)).isTrue();
+        assertThat(flowMomentRepository.existsByFlowIdAndMomentId(flowId, m2)).isFalse();
+
+        flowMomentRepository.deleteByFlowIdAndMomentId(flowId, m1);
+        flowMomentRepository.flush();
+
+        assertThat(flowMomentRepository.existsByFlowIdAndMomentId(flowId, m1)).isFalse();
+        // 기록 자체는 남는다.
+        assertThat(momentRepository.findById(m1)).isPresent();
+    }
+
+    @Test
+    @DisplayName("순서를 조정하면 sort_order가 반영된다")
+    void reorder() {
+        FlowMoment fm1 = flowMomentRepository.save(new FlowMoment(flowId, m1, 0));
+        FlowMoment fm2 = flowMomentRepository.save(new FlowMoment(flowId, m2, 1));
+
+        fm1.updateSortOrder(1);
+        fm2.updateSortOrder(0);
+        flowMomentRepository.flush();
+
+        assertThat(flowMomentRepository.findAllByFlowIdOrderBySortOrderAscIdAsc(flowId))
+                .extracting(FlowMoment::getMomentId)
+                .containsExactly(m2, m1);
+    }
+
+    @Test
+    @DisplayName("한 기록이 여러 흐름에 담기고, 역조회로 소속 흐름을 찾는다")
+    void oneMomentInManyFlows() {
+        Long memberId = flowRepository.findById(flowId).orElseThrow().getMemberId();
+        Long flow2 = flowRepository.save(new Flow(memberId, "2026 하이라이트", null)).getId();
+        flowMomentRepository.save(new FlowMoment(flowId, m1, 0));
+        flowMomentRepository.save(new FlowMoment(flow2, m1, 0));
+
+        List<Long> flows = flowMomentRepository.findAllByMomentId(m1)
+                .stream().map(FlowMoment::getFlowId).toList();
+        assertThat(flows).containsExactlyInAnyOrder(flowId, flow2);
+    }
+
+    private Moment moment(Long memberId, String occurredAt) {
+        return new Moment(memberId, Instant.parse(occurredAt), null, null, null, null, null);
+    }
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/lifelog/repository/FlowRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/lifelog/repository/FlowRepositoryTest.java
@@ -1,0 +1,93 @@
+package ds.project.orino.domain.planner.lifelog.repository;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.lifelog.entity.Flow;
+import ds.project.orino.domain.planner.lifelog.entity.FlowStatus;
+import ds.project.orino.domain.support.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Flow 매핑·상태 기본값·멤버 스코프 조회를 고정한다.
+ */
+@RepositoryTest
+@Transactional
+class FlowRepositoryTest {
+
+    @Autowired
+    private FlowRepository flowRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        memberId = memberRepository.save(new Member("flowuser", "pw")).getId();
+    }
+
+    @Test
+    @DisplayName("새 흐름은 ACTIVE 상태로 생성된다")
+    void newFlowIsActive() {
+        Flow saved = flowRepository.save(new Flow(memberId, "제주 여행 2박3일", "2026 여름"));
+
+        Flow found = flowRepository.findById(saved.getId()).orElseThrow();
+        assertThat(found.getStatus()).isEqualTo(FlowStatus.ACTIVE);
+        assertThat(found.getTitle()).isEqualTo("제주 여행 2박3일");
+        assertThat(found.getDescription()).isEqualTo("2026 여름");
+        assertThat(found.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("update로 기간·커버·상태를 바꾼다")
+    void updatesFields() {
+        Flow flow = flowRepository.save(new Flow(memberId, "제주 여행", null));
+        flow.update("제주 여행 수정", "설명", "lifelog/cover.jpg",
+                Instant.parse("2026-07-20T00:00:00Z"), Instant.parse("2026-07-22T00:00:00Z"),
+                FlowStatus.ARCHIVED);
+        flowRepository.flush();
+
+        Flow found = flowRepository.findById(flow.getId()).orElseThrow();
+        assertThat(found.getTitle()).isEqualTo("제주 여행 수정");
+        assertThat(found.getCoverObjectKey()).isEqualTo("lifelog/cover.jpg");
+        assertThat(found.getStartedAt()).isEqualTo(Instant.parse("2026-07-20T00:00:00Z"));
+        assertThat(found.getStatus()).isEqualTo(FlowStatus.ARCHIVED);
+    }
+
+    @Test
+    @DisplayName("findByIdAndMemberId는 다른 멤버의 흐름을 넘겨주지 않는다")
+    void scopedByMember() {
+        Long other = memberRepository.save(new Member("other", "pw")).getId();
+        Long id = flowRepository.save(new Flow(memberId, "mine", null)).getId();
+
+        assertThat(flowRepository.findByIdAndMemberId(id, memberId)).isPresent();
+        assertThat(flowRepository.findByIdAndMemberId(id, other)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("상태 필터 목록은 해당 멤버의 그 상태 흐름만, 기간 역순으로")
+    void listsByStatusScopedAndOrdered() {
+        Flow a = flowRepository.save(new Flow(memberId, "A", null));
+        a.update("A", null, null, Instant.parse("2026-05-01T00:00:00Z"), null, FlowStatus.ACTIVE);
+        Flow b = flowRepository.save(new Flow(memberId, "B", null));
+        b.update("B", null, null, Instant.parse("2026-07-01T00:00:00Z"), null, FlowStatus.ACTIVE);
+        Flow c = flowRepository.save(new Flow(memberId, "C", null));
+        c.update("C", null, null, Instant.parse("2026-06-01T00:00:00Z"), null, FlowStatus.ARCHIVED);
+        flowRepository.flush();
+
+        List<String> active = flowRepository
+                .findAllByMemberIdAndStatusOrderByStartedAtDescIdDesc(memberId, FlowStatus.ACTIVE)
+                .stream().map(Flow::getTitle).toList();
+
+        assertThat(active).containsExactly("B", "A");
+    }
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/lifelog/repository/MomentRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/lifelog/repository/MomentRepositoryTest.java
@@ -1,0 +1,144 @@
+package ds.project.orino.domain.planner.lifelog.repository;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.lifelog.entity.Moment;
+import ds.project.orino.domain.planner.lifelog.entity.MomentPhoto;
+import ds.project.orino.domain.planner.lifelog.entity.MomentTag;
+import ds.project.orino.domain.planner.lifelog.entity.Mood;
+import ds.project.orino.domain.support.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Moment 및 사진·태그 매핑과 조회 규칙을 고정한다. FK cascade는 이 모듈이 {@code create-drop}으로
+ * 엔티티에서 스키마를 만들어(FK 없음) 검증할 수 없다 — Liquibase 스키마의 몫이라 app-api 통합
+ * 테스트·로컬 확인에서 본다.
+ */
+@RepositoryTest
+@Transactional
+class MomentRepositoryTest {
+
+    @Autowired
+    private MomentRepository momentRepository;
+    @Autowired
+    private MomentPhotoRepository photoRepository;
+    @Autowired
+    private MomentTagRepository tagRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        memberId = memberRepository.save(new Member("loguser", "pw")).getId();
+    }
+
+    @Test
+    @DisplayName("리치 필드(기분·위치·발생시각)가 그대로 저장·조회된다")
+    void savesAndLoadsRichFields() {
+        Moment saved = momentRepository.save(new Moment(memberId,
+                Instant.parse("2026-07-20T14:30:00Z"), "성산일출봉 정상", Mood.EXCITED,
+                new BigDecimal("33.4580000"), new BigDecimal("126.9420000"), "성산일출봉"));
+
+        Moment found = momentRepository.findById(saved.getId()).orElseThrow();
+        assertThat(found.getMemberId()).isEqualTo(memberId);
+        assertThat(found.getOccurredAt()).isEqualTo(Instant.parse("2026-07-20T14:30:00Z"));
+        assertThat(found.getBody()).isEqualTo("성산일출봉 정상");
+        assertThat(found.getMood()).isEqualTo(Mood.EXCITED);
+        assertThat(found.getLat()).isEqualByComparingTo("33.4580000");
+        assertThat(found.getLng()).isEqualByComparingTo("126.9420000");
+        assertThat(found.getPlaceName()).isEqualTo("성산일출봉");
+        assertThat(found.getCreatedAt()).isNotNull();
+        assertThat(found.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("사진 없는 텍스트 기록도 저장된다(위치·기분 null 허용)")
+    void savesTextOnlyMoment() {
+        Moment saved = momentRepository.save(new Moment(memberId,
+                Instant.parse("2026-07-19T09:12:00Z"), "오늘 커피 맛있었다", null, null, null, null));
+
+        Moment found = momentRepository.findById(saved.getId()).orElseThrow();
+        assertThat(found.getMood()).isNull();
+        assertThat(found.getLat()).isNull();
+        assertThat(found.getPlaceName()).isNull();
+    }
+
+    @Test
+    @DisplayName("findByIdAndMemberId는 다른 멤버의 기록을 넘겨주지 않는다")
+    void scopedByMember() {
+        Long other = memberRepository.save(new Member("other", "pw")).getId();
+        Long id = momentRepository.save(new Moment(memberId,
+                Instant.parse("2026-07-20T00:00:00Z"), "mine", null, null, null, null)).getId();
+
+        assertThat(momentRepository.findByIdAndMemberId(id, memberId)).isPresent();
+        assertThat(momentRepository.findByIdAndMemberId(id, other)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("피드는 발생시각 역순, 동시각이면 id 역순")
+    void feedOrdersByOccurredAtDescThenIdDesc() {
+        Long a = momentRepository.save(moment("2026-07-20T10:00:00Z")).getId();
+        Long b = momentRepository.save(moment("2026-07-21T10:00:00Z")).getId();
+        // 같은 발생시각 두 건 — 나중에 저장된 id가 앞서야.
+        Long c1 = momentRepository.save(moment("2026-07-19T10:00:00Z")).getId();
+        Long c2 = momentRepository.save(moment("2026-07-19T10:00:00Z")).getId();
+
+        List<Long> order = momentRepository
+                .findAllByMemberIdOrderByOccurredAtDescIdDesc(memberId)
+                .stream().map(Moment::getId).toList();
+
+        assertThat(order).containsExactly(b, a, c2, c1);
+    }
+
+    @Test
+    @DisplayName("사진은 sort_order 오름차순으로, 여러 기록을 배치로 읽는다")
+    void photosOrderedAndBatched() {
+        Long m1 = momentRepository.save(moment("2026-07-20T10:00:00Z")).getId();
+        Long m2 = momentRepository.save(moment("2026-07-20T11:00:00Z")).getId();
+        photoRepository.save(new MomentPhoto(m1, "k/b.jpg", "k/b_t.jpg", 100, 100,
+                Instant.parse("2026-07-20T10:00:00Z"), null, null, 1));
+        photoRepository.save(new MomentPhoto(m1, "k/a.jpg", "k/a_t.jpg", 100, 100, null, null, null, 0));
+        photoRepository.save(new MomentPhoto(m2, "k/c.jpg", null, null, null, null, null, null, 0));
+
+        assertThat(photoRepository.findAllByMomentIdOrderBySortOrderAscIdAsc(m1))
+                .extracting(MomentPhoto::getObjectKey)
+                .containsExactly("k/a.jpg", "k/b.jpg");
+        assertThat(photoRepository.findAllByMomentIdInOrderBySortOrderAscIdAsc(List.of(m1, m2)))
+                .hasSize(3);
+    }
+
+    @Test
+    @DisplayName("태그 자동완성은 멤버가 쓴 태그 중 접두어 일치를 중복 없이 정렬해 준다")
+    void tagAutocompleteDistinctPrefixScoped() {
+        Long m1 = momentRepository.save(moment("2026-07-20T10:00:00Z")).getId();
+        Long m2 = momentRepository.save(moment("2026-07-20T11:00:00Z")).getId();
+        tagRepository.save(new MomentTag(m1, "제주"));
+        tagRepository.save(new MomentTag(m2, "제주"));      // 중복 이름
+        tagRepository.save(new MomentTag(m1, "제주도"));
+        tagRepository.save(new MomentTag(m1, "여행"));
+        // 다른 멤버의 태그는 섞이면 안 된다.
+        Long other = memberRepository.save(new Member("other", "pw")).getId();
+        Long om = momentRepository.save(new Moment(other,
+                Instant.parse("2026-07-20T10:00:00Z"), null, null, null, null, null)).getId();
+        tagRepository.save(new MomentTag(om, "제주비밀"));
+
+        assertThat(tagRepository.findDistinctNamesByMemberIdAndPrefix(memberId, "제주%"))
+                .containsExactly("제주", "제주도");
+    }
+
+    private Moment moment(String occurredAt) {
+        return new Moment(memberId, Instant.parse(occurredAt), null, null, null, null, null);
+    }
+}


### PR DESCRIPTION
## 이슈
closes #950

## 작업 내용
- **Liquibase `046-create-lifelog-tables.yaml`** — `moment` · `moment_photo` · `moment_tag` · `flow` · `flow_moment` 5개 테이블 (master include)
- **엔티티** — `Moment` `MomentPhoto` `MomentTag` `Flow` `FlowMoment` + `Mood` `FlowStatus` enum (`orino-domain-rdb`, `domain.planner.lifelog`)
- **Repository 5종** — 멤버 스코프 조회 · 피드 역시간순 정렬 · 태그 자동완성(DISTINCT) · N:M 담기/순서/역조회
- **설계 결정 반영**
  - Moment ↔ Flow **N:M**(`flow_moment`, 대리키 + `(flow_id, moment_id)` 유니크로 멱등 담기)
  - 위치(`lat`/`lng` DECIMAL(10,7))·`place_name` **denormalize** 저장
  - 사진은 self-hosted **MinIO** object key만 저장, EXIF(촬영시각·GPS) 원본 보존
  - `moment` 삭제 → 사진·태그·소속 FK CASCADE / `flow` 삭제 → 소속만 제거(기록 보존)
- **기획 문서 대비 정정(코드 컨벤션 우선)** — 단일 사용자지만 `Note`·`Dataset`처럼 **`member_id` 스코프 포함**, 시각은 `Instant`/`DATETIME(6)`, 패키지는 `planner` 우산 아래. Wiki 동기화 예정

## 테스트
- `MomentRepositoryTest` · `FlowRepositoryTest` · `FlowMomentRepositoryTest` (13건) — 매핑·enum·BigDecimal·멤버 스코프·피드 정렬·태그 자동완성·N:M 담기/순서/빼기/다중 소속
- app-api 컨텍스트 부팅으로 **Liquibase 046 적용 + Hibernate `validate`** 통과(엔티티↔스키마 일치)
- checkstyle 통과

> FK CASCADE·유니크는 Liquibase 스키마의 몫이라 `create-drop` 기반 domain-rdb 단위 테스트가 아닌 app-api 통합/로컬에서 확인. 후속: #952 Moment API · #953 Flow API.

Epic: #949