### PR TITLE
fix : 표 제목 입력 포커스 + 선택 셀 커서 맨앞 깜빡임 (#967)

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -547,6 +547,18 @@ describe("DatasetGrid", () => {
     // 어느 칸이 선택됐는지 보이도록 얇은 안쪽 테두리로 강조한다.
     expect(input.className).toContain("ring-1");
     expect(input.className).toContain("ring-primary");
+    // 빈 입력창의 커서가 맨 앞에서 깜빡이지 않도록 선택-만-한 상태에선 커서를 숨긴다.
+    expect(input.className).toContain("caret-transparent");
+  });
+
+  it("편집에 들어가면 커서를 다시 보이게 한다(caret-transparent 해제)", async () => {
+    mockDataset([["네트워크", "92"]]);
+    const user = userEvent.setup();
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    await user.dblClick(await screen.findByText("92"));
+    const input = screen.getByLabelText("셀 1행 2열");
+    expect(input.className).not.toContain("caret-transparent");
   });
 
   it("셀을 클릭하고 글자를 입력하면 기존 값을 덮어쓴다(전체선택 없이 빈 칸 방식)", async () => {

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -1732,6 +1732,9 @@ export function DatasetGrid({
               // 편집 중일 때만 뒤 표시값을 셀 배경(없으면 카드색)으로 불투명하게 덮는다. 선택-만-한
               // 상태에선 입력창이 비어 투명이라, 뒤 표시칸의 값·배경이 그대로 보인다.
               isEditing && !style?.bg && "bg-card",
+              // 선택-만-한 상태의 입력창은 비어 있어 커서가 맨 앞에서 깜빡인다 — 값은 뒤 표시칸이
+              // 보여주므로 여기선 커서를 숨긴다(엑셀식 선택 셀엔 텍스트 커서 없음). 편집 시 보인다.
+              !isEditing && "caret-transparent",
             )}
             style={
               isEditing && style?.bg
@@ -1799,6 +1802,9 @@ export function DatasetGrid({
         aria-label="표 이름"
         defaultValue={meta.name ?? ""}
         placeholder="표 이름"
+        // 표 이름 입력창도 표(노드뷰) 안이라, 클릭하면 ProseMirror가 포커스를 도로 가져가 입력이
+        // 안 됐다. 셀과 같은 방식으로 클릭 뒤(mouseup 이후) 포커스를 다시 잡아 이긴다.
+        onClick={(e) => e.currentTarget.focus({ preventScroll: true })}
         onKeyDown={(e) => {
           if (e.key === "Enter") e.currentTarget.blur();
         }}


### PR DESCRIPTION
## 이슈
closes #967

## 증상
1. **표 제목("표 이름") 입력이 안 됨** — 이름 입력창이 표(NodeView) 안이라 클릭하면 ProseMirror가 포커스를 도로 가져가 입력이 안 됨(셀과 같은 원인).
2. **선택-만-한 셀의 커서가 맨 앞에서 깜빡임** — 선택 상태 입력창을 빈 투명으로 두는 방식(값은 뒤 표시칸이 보여줌)이라, 빈 입력창의 커서가 맨 앞(위치0)에서 깜빡여 어색.

## 수정 (DatasetGrid.tsx)
- **표 이름 입력창**: 클릭 시 `focus({ preventScroll:true })` 재획득 → PM의 포커스 탈취를 이긴다(셀 클릭 재포커스와 동일 패턴).
- **셀 입력창**: 편집이 아닐 땐 `caret-transparent`로 커서를 숨긴다(엑셀식 선택 셀엔 텍스트 커서 없음). 편집 들어가면 다시 보인다.

## 의존
- 표 제목의 **키 입력 자체**가 먹으려면 노드뷰 keypress를 PM이 안 가로채게 하는 **stopEvent 확장(#960)** 이 함께 배포돼야 한다(이 PR은 포커스 되잡기 담당). 두 PR이 같이 들어가면 표 제목 입력이 완결된다.

## 테스트
- 선택-만-한 셀 입력창은 `caret-transparent`, 편집 진입 시 해제.
- 표 이름 포커스는 PM 상호작용이라 jsdom 재현 불가 → 코드 패턴은 셀의 검증된 재포커스와 동일.
- FE 490개·eslint·prettier 통과. BE 변경 없음. 별도 워크트리에서 작업.

## 확인
- 운영 사이트는 배포된 토큰 재발급 버그(#965 대기)로 표 로드가 막혀 라이브 재현이 불가했다. 커서 문제는 원인이 코드상 명확(빈 입력창)해 테스트로, 표 이름은 셀과 동일 구조로 수정.