### PR TITLE
feat : 일상기록 사진 presigned 업로드 확장 (원본+썸네일)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/image/config/LifelogImageConfig.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/image/config/LifelogImageConfig.java
@@ -1,0 +1,36 @@
+package ds.project.orino.planner.lifelog.image.config;
+
+import ds.project.orino.planner.image.config.ImageStorageProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+import java.net.URI;
+
+/**
+ * 일상기록 사진 삭제용 {@link S3Client} 빈.
+ * <p>
+ * 노트 이미지 파이프라인은 presigned URL만 발급해 바이트를 BE가 거치지 않지만, 일상기록은
+ * moment/사진 삭제 시 MinIO 오브젝트를 best-effort로 지워야 해서 서버측 클라이언트가 필요하다.
+ * 발급 설정({@link ImageStorageProperties})은 노트 이미지와 공유한다(같은 MinIO·버킷).
+ */
+@Configuration
+public class LifelogImageConfig {
+
+    @Bean
+    public S3Client lifelogImageS3Client(ImageStorageProperties props) {
+        return S3Client.builder()
+                .region(Region.of(props.region()))
+                .endpointOverride(URI.create(props.endpoint()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(props.accessKey(), props.secretKey())))
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build())
+                .build();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/image/controller/LifelogImageController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/image/controller/LifelogImageController.java
@@ -1,0 +1,35 @@
+package ds.project.orino.planner.lifelog.image.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.lifelog.image.dto.LifelogImageUploadUrlRequest;
+import ds.project.orino.planner.lifelog.image.dto.LifelogImageUploadUrlResponse;
+import ds.project.orino.planner.lifelog.image.service.LifelogImageStorageService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/lifelog/images")
+public class LifelogImageController {
+
+    private final LifelogImageStorageService imageStorageService;
+
+    public LifelogImageController(LifelogImageStorageService imageStorageService) {
+        this.imageStorageService = imageStorageService;
+    }
+
+    /**
+     * 일상기록 사진(원본/썸네일) 업로드용 presigned PUT URL을 발급한다.
+     * 브라우저는 uploadUrl로 이미지를 직접 PUT 한 뒤 objectKey를 moment 생성 요청에 실어 보낸다.
+     */
+    @PostMapping("/upload-url")
+    public ApiResponse<LifelogImageUploadUrlResponse> createUploadUrl(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody LifelogImageUploadUrlRequest request) {
+        return ApiResponse.success(
+                imageStorageService.createUploadUrl(memberId, request.contentType(), request.kind()));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/image/dto/ImageKind.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/image/dto/ImageKind.java
@@ -1,0 +1,14 @@
+package ds.project.orino.planner.lifelog.image.dto;
+
+/**
+ * 업로드할 이미지 종류. 원본과 썸네일을 각각 다른 key prefix로 저장한다.
+ *
+ * <ul>
+ *     <li>{@link #ORIGINAL} — 원본. {@code lifelog/moments/...}</li>
+ *     <li>{@link #THUMB} — 썸네일(FE canvas 생성). {@code lifelog/thumbs/...}</li>
+ * </ul>
+ */
+public enum ImageKind {
+    ORIGINAL,
+    THUMB
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/image/dto/LifelogImageUploadUrlRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/image/dto/LifelogImageUploadUrlRequest.java
@@ -1,0 +1,22 @@
+package ds.project.orino.planner.lifelog.image.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * 일상기록 사진 presigned 업로드 URL 발급 요청.
+ *
+ * @param contentType 업로드할 이미지 MIME 타입 (image/* 만 허용)
+ * @param kind        원본/썸네일 구분 — key prefix가 갈린다
+ */
+public record LifelogImageUploadUrlRequest(
+        @NotBlank
+        @Pattern(regexp = "image/(png|jpeg|jpg|gif|webp)",
+                message = "지원하지 않는 이미지 형식입니다.")
+        String contentType,
+
+        @NotNull
+        ImageKind kind
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/image/dto/LifelogImageUploadUrlResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/image/dto/LifelogImageUploadUrlResponse.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.lifelog.image.dto;
+
+/**
+ * 일상기록 사진 presigned 업로드 URL 발급 응답.
+ *
+ * @param uploadUrl 브라우저가 이미지 바이너리를 직접 PUT 할 presigned URL (만료 있음)
+ * @param publicUrl 업로드 후 표시할 공개 URL (img.orino.dev)
+ * @param objectKey MinIO object key — moment 생성 시 {@code objectKey}/{@code thumbKey}로 저장한다
+ */
+public record LifelogImageUploadUrlResponse(
+        String uploadUrl,
+        String publicUrl,
+        String objectKey
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/image/service/LifelogImageStorageService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/image/service/LifelogImageStorageService.java
@@ -1,0 +1,106 @@
+package ds.project.orino.planner.lifelog.image.service;
+
+import ds.project.orino.planner.image.config.ImageStorageProperties;
+import ds.project.orino.planner.lifelog.image.dto.ImageKind;
+import ds.project.orino.planner.lifelog.image.dto.LifelogImageUploadUrlResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 일상기록 사진의 presigned 업로드 URL 발급과 오브젝트 삭제를 담당한다.
+ * <p>
+ * 업로드 바이트는 노트 이미지와 마찬가지로 BE를 거치지 않고 브라우저가 presigned URL로 MinIO에
+ * 직접 PUT 한다(zero-copy). 원본/썸네일은 서로 다른 key prefix로 저장하고, 발급 응답에
+ * {@code objectKey}를 함께 돌려줘 moment 저장 시 그대로 쓰게 한다.
+ */
+@Service
+public class LifelogImageStorageService {
+
+    private static final Logger log = LoggerFactory.getLogger(LifelogImageStorageService.class);
+
+    private static final Map<String, String> EXTENSIONS = Map.of(
+            "image/png", "png",
+            "image/jpeg", "jpg",
+            "image/jpg", "jpg",
+            "image/gif", "gif",
+            "image/webp", "webp");
+
+    private static final String ORIGINAL_PREFIX = "lifelog/moments";
+    private static final String THUMB_PREFIX = "lifelog/thumbs";
+
+    private final S3Presigner presigner;
+    private final S3Client s3Client;
+    private final ImageStorageProperties props;
+
+    public LifelogImageStorageService(S3Presigner imageS3Presigner,
+                                      S3Client lifelogImageS3Client,
+                                      ImageStorageProperties props) {
+        this.presigner = imageS3Presigner;
+        this.s3Client = lifelogImageS3Client;
+        this.props = props;
+    }
+
+    /**
+     * memberId·kind별 경로에 랜덤 키를 만들고 presigned PUT URL·공개 URL·objectKey를 반환한다.
+     */
+    public LifelogImageUploadUrlResponse createUploadUrl(Long memberId, String contentType, ImageKind kind) {
+        String ext = EXTENSIONS.getOrDefault(contentType, "bin");
+        String prefix = kind == ImageKind.THUMB ? THUMB_PREFIX : ORIGINAL_PREFIX;
+        String key = "%s/%d/%s.%s".formatted(prefix, memberId, UUID.randomUUID(), ext);
+
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(props.bucket())
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofSeconds(props.presignExpirySeconds()))
+                .putObjectRequest(objectRequest)
+                .build();
+
+        String uploadUrl = presigner.presignPutObject(presignRequest).url().toString();
+        String publicUrl = "%s/%s/%s".formatted(
+                stripTrailingSlash(props.endpoint()), props.bucket(), key);
+
+        return new LifelogImageUploadUrlResponse(uploadUrl, publicUrl, key);
+    }
+
+    /**
+     * 오브젝트를 best-effort로 삭제한다. DB 정합성이 우선이라 삭제 실패는 로그만 남기고 넘어간다
+     * (고아 오브젝트는 용량만 차지 — 주기적 스윕으로 회수). null/blank 키는 건너뛴다.
+     */
+    public void deleteObjects(Collection<String> objectKeys) {
+        if (objectKeys == null) {
+            return;
+        }
+        for (String key : objectKeys) {
+            if (key == null || key.isBlank()) {
+                continue;
+            }
+            try {
+                s3Client.deleteObject(DeleteObjectRequest.builder()
+                        .bucket(props.bucket())
+                        .key(key)
+                        .build());
+            } catch (RuntimeException e) {
+                log.warn("일상기록 사진 삭제 실패(best-effort, 무시): key={}", key, e);
+            }
+        }
+    }
+
+    private String stripTrailingSlash(String s) {
+        return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/lifelog/image/controller/LifelogImageControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/lifelog/image/controller/LifelogImageControllerTest.java
@@ -1,0 +1,105 @@
+package ds.project.orino.planner.lifelog.image.controller;
+
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class LifelogImageControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    @Test
+    @DisplayName("POST upload-url ORIGINAL - lifelog/moments 경로로 presigned URL·objectKey를 발급한다")
+    void createOriginalUploadUrl() throws Exception {
+        mockMvc.perform(post("/api/lifelog/images/upload-url")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"contentType": "image/jpeg", "kind": "ORIGINAL"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.uploadUrl", containsString("note-images/lifelog/moments/")))
+                .andExpect(jsonPath("$.data.uploadUrl", containsString("X-Amz-Signature")))
+                .andExpect(jsonPath("$.data.publicUrl",
+                        startsWith("https://img.orino.dev/note-images/lifelog/moments/")))
+                .andExpect(jsonPath("$.data.publicUrl", containsString(".jpg")))
+                .andExpect(jsonPath("$.data.objectKey", startsWith("lifelog/moments/")))
+                .andExpect(jsonPath("$.data.objectKey", containsString(".jpg")));
+    }
+
+    @Test
+    @DisplayName("POST upload-url THUMB - lifelog/thumbs 경로로 발급한다")
+    void createThumbUploadUrl() throws Exception {
+        mockMvc.perform(post("/api/lifelog/images/upload-url")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"contentType": "image/webp", "kind": "THUMB"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.objectKey", startsWith("lifelog/thumbs/")))
+                .andExpect(jsonPath("$.data.objectKey", containsString(".webp")));
+    }
+
+    @Test
+    @DisplayName("POST upload-url - 이미지가 아닌 contentType은 400")
+    void rejectNonImage() throws Exception {
+        mockMvc.perform(post("/api/lifelog/images/upload-url")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"contentType": "application/pdf", "kind": "ORIGINAL"}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST upload-url - kind 누락은 400")
+    void rejectMissingKind() throws Exception {
+        mockMvc.perform(post("/api/lifelog/images/upload-url")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"contentType": "image/jpeg"}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST upload-url - 인증 없으면 401")
+    void requiresAuth() throws Exception {
+        mockMvc.perform(post("/api/lifelog/images/upload-url")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"contentType": "image/jpeg", "kind": "ORIGINAL"}
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/lifelog/image/service/LifelogImageStorageServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/lifelog/image/service/LifelogImageStorageServiceTest.java
@@ -1,0 +1,68 @@
+package ds.project.orino.planner.lifelog.image.service;
+
+import ds.project.orino.planner.image.config.ImageStorageProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 삭제 유틸의 best-effort 계약을 고정한다: null/blank 키는 건너뛰고, 개별 삭제 실패는 삼켜
+ * DB 정합성 흐름을 막지 않는다. presigned URL 발급 경로는 컨트롤러 통합 테스트에서 검증한다.
+ */
+class LifelogImageStorageServiceTest {
+
+    private final ImageStorageProperties props = new ImageStorageProperties(
+            "https://img.orino.dev", "note-images", "us-east-1", "k", "s", 300);
+
+    @Test
+    @DisplayName("deleteObjects - 유효한 키만 삭제하고 null/blank는 건너뛴다")
+    void deletesOnlyValidKeys() {
+        S3Client s3 = mock(S3Client.class);
+        when(s3.deleteObject(any(DeleteObjectRequest.class)))
+                .thenReturn(DeleteObjectResponse.builder().build());
+        LifelogImageStorageService service = new LifelogImageStorageService(null, s3, props);
+
+        service.deleteObjects(Arrays.asList("lifelog/moments/1/a.jpg", null, "  ", "lifelog/thumbs/1/a.jpg"));
+
+        verify(s3, times(2)).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    @Test
+    @DisplayName("deleteObjects - 개별 삭제 실패는 삼키고 나머지를 계속 지운다")
+    void swallowsFailuresBestEffort() {
+        S3Client s3 = mock(S3Client.class);
+        doThrow(AwsServiceException.builder().message("boom").build())
+                .when(s3).deleteObject(any(DeleteObjectRequest.class));
+        LifelogImageStorageService service = new LifelogImageStorageService(null, s3, props);
+
+        assertThatCode(() -> service.deleteObjects(List.of("k1.jpg", "k2.jpg")))
+                .doesNotThrowAnyException();
+        verify(s3, times(2)).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    @Test
+    @DisplayName("deleteObjects - null 컬렉션은 아무것도 안 한다")
+    void nullCollectionIsNoop() {
+        S3Client s3 = mock(S3Client.class);
+        LifelogImageStorageService service = new LifelogImageStorageService(null, s3, props);
+
+        service.deleteObjects(null);
+
+        verify(s3, never()).deleteObject(any(DeleteObjectRequest.class));
+    }
+}


### PR DESCRIPTION
## 이슈
closes #951

## 작업 내용
- **`POST /api/lifelog/images/upload-url {contentType, kind}`** → `{uploadUrl, publicUrl, objectKey}`
  - 기존 노트 이미지 파이프라인(`S3Presigner`·`ImageStorageProperties`, MinIO/`note-images`)을 그대로 재사용
  - 바이트는 BE 미경유(zero-copy) — 브라우저가 presigned URL로 MinIO에 직접 PUT
- **key prefix 분기**: `ORIGINAL` → `lifelog/moments/{memberId}/{uuid}.ext`, `THUMB` → `lifelog/thumbs/{memberId}/{uuid}.ext`
- **`objectKey` 반환** — moment 생성 시 `objectKey`/`thumbKey`로 저장(공개 URL은 base+key 조립, 호스트 하드코딩 회피)
- **삭제 유틸** — moment 삭제/수정 시 제거된 key를 지울 `S3Client` 빈 + `deleteObjects()` **best-effort**(실패는 로그만, DB 정합성 우선). #952/#953에서 호출
- 사진은 self-hosted MinIO라 요청 과금 없음(ELOG-008은 AWS S3 이야기)

## 테스트
- `LifelogImageControllerTest` (5) — ORIGINAL/THUMB 경로·presigned 서명·publicUrl·objectKey · 비이미지 400 · kind 누락 400 · 인증 401
- `LifelogImageStorageServiceTest` (3) — 삭제 best-effort: 유효 키만 삭제 · null/blank 스킵 · 개별 실패 삼킴
- checkstyle 통과

Epic: #949 · 후속: #955(FE 업로드)에서 이 엔드포인트 소비