### PR TITLE
feat : 플래너 좌측 탭 단일화(상위 1탭 + 본문 상단 하위탭)

### DIFF
--- a/fe/src/app/layout/Sidebar.test.tsx
+++ b/fe/src/app/layout/Sidebar.test.tsx
@@ -1,0 +1,80 @@
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { Sidebar } from "./Sidebar";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function mockSummary(now = 0) {
+  server.use(
+    http.get(`${API_BASE}/planner/reviews/summary`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          today: "2026-05-18",
+          counts: { now, overdue: 0, upcoming: now, doneToday: 0 },
+          estimatedMinutes: 0,
+          materials: [],
+        },
+      }),
+    ),
+  );
+}
+
+function renderSidebar(path = "/home") {
+  return renderWithRouter(
+    <Providers>
+      <Sidebar open={false} onClose={() => {}} />
+    </Providers>,
+    { initialEntries: [path] },
+  );
+}
+
+describe("Sidebar", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+    mockSummary(0);
+  });
+
+  it("플래너를 단일 항목으로 노출하고 캘린더/주간 계획표/루틴을 개별 항목으로 두지 않는다", async () => {
+    renderSidebar();
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: /플래너/ })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("link", { name: "주간 계획표" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "루틴" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "캘린더" })).toBeNull();
+    // 연동 설정은 별도 항목으로 유지(공용화는 #962)
+    expect(screen.getByRole("link", { name: /연동 설정/ })).toBeInTheDocument();
+  });
+
+  it("플래너 링크는 /planner/calendar를 가리킨다", async () => {
+    renderSidebar();
+    const link = await screen.findByRole("link", { name: /플래너/ });
+    expect(link).toHaveAttribute("href", "/planner/calendar");
+  });
+
+  it.each(["/planner/calendar", "/planner/plan", "/planner/routines"])(
+    "%s 에서 플래너 항목이 활성 하이라이트된다",
+    async (path) => {
+      renderSidebar(path);
+      const link = await screen.findByRole("link", { name: /플래너/ });
+      expect(link.className).toContain("text-primary");
+    },
+  );
+
+  it("/planner/settings 에서는 플래너가 아니라 연동 설정이 활성화된다", async () => {
+    renderSidebar("/planner/settings");
+    const planner = await screen.findByRole("link", { name: /플래너/ });
+    expect(planner.className).not.toContain("text-primary");
+    expect(screen.getByRole("link", { name: /연동 설정/ }).className).toContain(
+      "text-primary",
+    );
+  });
+});

--- a/fe/src/app/layout/Sidebar.tsx
+++ b/fe/src/app/layout/Sidebar.tsx
@@ -1,14 +1,12 @@
 import {
   BookOpen,
-  Calendar,
-  CalendarRange,
+  CalendarDays,
   CheckSquare,
   FileText,
   Home,
-  Repeat,
   Settings,
 } from "lucide-react";
-import { NavLink } from "react-router-dom";
+import { NavLink, useLocation } from "react-router-dom";
 
 import { useReviewSummary } from "@/features/review/hooks/useReviewSummary";
 import { cn } from "@/lib/utils";
@@ -17,6 +15,11 @@ interface NavItem {
   to: string;
   label: string;
   icon: typeof Home;
+  /**
+   * 항목을 활성으로 볼 추가 경로. 지정하면 NavLink 기본 매칭 대신 이 경로들로 판정한다.
+   * (「플래너」처럼 상위 1탭이 여러 하위 라우트를 대표하는 경우)
+   */
+  activePaths?: string[];
 }
 
 const NAV_ITEMS: NavItem[] = [
@@ -24,11 +27,19 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/planner/materials", label: "학습 자료", icon: BookOpen },
   { to: "/notes", label: "노트", icon: FileText },
   { to: "/planner/reviews", label: "복습", icon: CheckSquare },
-  { to: "/planner/calendar", label: "캘린더", icon: Calendar },
-  { to: "/planner/plan", label: "주간 계획표", icon: CalendarRange },
-  { to: "/planner/routines", label: "루틴", icon: Repeat },
+  {
+    to: "/planner/calendar",
+    label: "플래너",
+    icon: CalendarDays,
+    activePaths: ["/planner/calendar", "/planner/plan", "/planner/routines"],
+  },
   { to: "/planner/settings", label: "연동 설정", icon: Settings },
 ];
+
+/** activePaths가 지정된 항목의 활성 여부 — 해당 경로이거나 그 하위 경로면 활성. */
+function matchesActivePaths(pathname: string, paths: string[]): boolean {
+  return paths.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}
 
 interface SidebarProps {
   open: boolean;
@@ -38,6 +49,7 @@ interface SidebarProps {
 export function Sidebar({ open, onClose }: SidebarProps) {
   const { data } = useReviewSummary();
   const reviewCount = data?.counts.now ?? 0;
+  const { pathname } = useLocation();
 
   return (
     <>
@@ -67,14 +79,17 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                 <NavLink
                   to={item.to}
                   end={item.to === "/home"}
-                  className={({ isActive }) =>
-                    cn(
+                  className={({ isActive }) => {
+                    const active = item.activePaths
+                      ? matchesActivePaths(pathname, item.activePaths)
+                      : isActive;
+                    return cn(
                       "flex h-9 items-center justify-between rounded-md px-3 text-sm font-medium transition-colors",
-                      isActive
+                      active
                         ? "bg-primary/10 text-primary"
                         : "text-foreground/70 hover:bg-muted hover:text-foreground",
-                    )
-                  }
+                    );
+                  }}
                 >
                   <span className="flex items-center gap-2">
                     <Icon className="size-4" />

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -6,6 +6,7 @@ import { LoadingText } from "@/components/ui/loading-text";
 
 import { PrivateRoute } from "../features/auth/components/PrivateRoute";
 import { PublicRoute } from "../features/auth/components/PublicRoute";
+import { PlannerLayout } from "../features/planner/components/PlannerLayout";
 import { LandingPage } from "../pages/LandingPage";
 import { LoginPage } from "../pages/LoginPage";
 import { PlannerCallbackRedirect } from "../pages/planner/PlannerCallbackRedirect";
@@ -99,30 +100,33 @@ export function AppRouter() {
             path="/planner/reviews/today"
             element={<Navigate to="/planner/reviews" replace />}
           />
-          <Route
-            path="/planner/calendar"
-            element={
-              <Suspense fallback={<RouteFallback />}>
-                <PlannerCalendarPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path="/planner/routines"
-            element={
-              <Suspense fallback={<RouteFallback />}>
-                <RoutinesPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path="/planner/plan"
-            element={
-              <Suspense fallback={<RouteFallback />}>
-                <WeeklyPlanPage />
-              </Suspense>
-            }
-          />
+          {/* 플래너 통합: 캘린더·주간 계획표·루틴을 상단 하위 탭으로 묶는다 */}
+          <Route element={<PlannerLayout />}>
+            <Route
+              path="/planner/calendar"
+              element={
+                <Suspense fallback={<RouteFallback />}>
+                  <PlannerCalendarPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/planner/routines"
+              element={
+                <Suspense fallback={<RouteFallback />}>
+                  <RoutinesPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/planner/plan"
+              element={
+                <Suspense fallback={<RouteFallback />}>
+                  <WeeklyPlanPage />
+                </Suspense>
+              }
+            />
+          </Route>
           <Route
             path="/planner/settings"
             element={

--- a/fe/src/features/planner/components/PlannerLayout.test.tsx
+++ b/fe/src/features/planner/components/PlannerLayout.test.tsx
@@ -1,0 +1,52 @@
+import { screen } from "@testing-library/react";
+import { Route, Routes } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { renderWithRouter } from "@/test/render";
+
+import { PlannerLayout } from "./PlannerLayout";
+
+function renderLayout(path: string) {
+  return renderWithRouter(
+    <Routes>
+      <Route element={<PlannerLayout />}>
+        <Route path="/planner/calendar" element={<div>캘린더 본문</div>} />
+        <Route path="/planner/plan" element={<div>주간 계획표 본문</div>} />
+        <Route path="/planner/routines" element={<div>루틴 본문</div>} />
+      </Route>
+    </Routes>,
+    { initialEntries: [path] },
+  );
+}
+
+describe("PlannerLayout", () => {
+  it("하위 탭 3개(캘린더·주간 계획표·루틴)를 노출한다", () => {
+    renderLayout("/planner/calendar");
+    expect(screen.getByRole("link", { name: "캘린더" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "주간 계획표" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "루틴" })).toBeInTheDocument();
+  });
+
+  it("현재 경로의 하위 탭이 활성(aria-current=page)이고 해당 본문을 렌더한다", () => {
+    renderLayout("/planner/plan");
+    expect(screen.getByText("주간 계획표 본문")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "주간 계획표" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("link", { name: "캘린더" })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
+  it("딥링크(/planner/routines)로 진입하면 루틴 본문과 활성 탭이 보인다", () => {
+    renderLayout("/planner/routines");
+    expect(screen.getByText("루틴 본문")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "루틴" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+});

--- a/fe/src/features/planner/components/PlannerLayout.tsx
+++ b/fe/src/features/planner/components/PlannerLayout.tsx
@@ -1,0 +1,48 @@
+import { Calendar, CalendarRange, Repeat } from "lucide-react";
+import { NavLink, Outlet } from "react-router-dom";
+
+import { cn } from "@/lib/utils";
+
+const SUB_TABS = [
+  { to: "/planner/calendar", label: "캘린더", icon: Calendar },
+  { to: "/planner/plan", label: "주간 계획표", icon: CalendarRange },
+  { to: "/planner/routines", label: "루틴", icon: Repeat },
+];
+
+/**
+ * 플래너 통합 레이아웃 — 캘린더·주간 계획표·루틴을 하나의 상위 영역으로 묶고
+ * 본문 상단 하위 탭으로 전환한다. 라우트(/planner/calendar|plan|routines)는 그대로이며,
+ * 좌측 사이드바에는 「플래너」 단일 항목으로 노출된다. 세그먼트 스타일은
+ * 디자인 시스템 Tabs 토큰(bg-muted 리스트 · 활성 bg-background)을 따른다.
+ */
+export function PlannerLayout() {
+  return (
+    <div className="flex flex-col gap-6">
+      <nav aria-label="플래너 하위 메뉴" className="-mx-1 overflow-x-auto px-1">
+        <div className="bg-muted text-muted-foreground inline-flex h-9 w-fit items-center gap-1 rounded-lg p-1">
+          {SUB_TABS.map((tab) => {
+            const Icon = tab.icon;
+            return (
+              <NavLink
+                key={tab.to}
+                to={tab.to}
+                className={({ isActive }) =>
+                  cn(
+                    "inline-flex h-7 items-center gap-1.5 rounded-md px-3 text-sm font-medium whitespace-nowrap transition-colors",
+                    isActive
+                      ? "bg-background text-foreground"
+                      : "hover:text-foreground",
+                  )
+                }
+              >
+                <Icon className="size-4" />
+                {tab.label}
+              </NavLink>
+            );
+          })}
+        </div>
+      </nav>
+      <Outlet />
+    </div>
+  );
+}


### PR DESCRIPTION
## 이슈
closes #961

## 작업 내용
- 좌측 사이드바의 **캘린더·주간 계획표·루틴 3항목을 「플래너」 1항목**으로 통합 (아이콘 `CalendarDays`, `/planner/calendar`로 진입)
- 플래너 하위 3경로(`/planner/calendar|plan|routines`) 어디서든 사이드바 「플래너」가 **활성 하이라이트**되도록 `activePaths` 매칭 추가
- **`PlannerLayout` 신설** — 본문 상단 세그먼트형 하위 탭(캘린더 / 주간 계획표 / 루틴, 디자인 시스템 Tabs 토큰 재사용, 좁은 화면 가로 스크롤) + `<Outlet/>`
- `router.tsx`에서 세 라우트를 `PlannerLayout`으로 **중첩**(경로 자체는 유지)
- **연동 설정은 별도 항목으로 유지** — 연동 공용화(`/integrations` 이전)는 후속 이슈 #962
- `학습 자료`·`복습`은 Study Planner라 **손대지 않음**

## 범위 밖 (후속)
- Google 연동 공용 네임스페이스 이전 → #962 (Epic #963)

## 검증
- `tsc --noEmit` 0 · `eslint` clean · `prettier --check` clean
- 신규 `Sidebar.test.tsx`·`PlannerLayout.test.tsx` 통과, `router.test.tsx` 11/11 통과 (하위 탭 링크·중첩 라우트 포함)
- 전체 스위트 497/498 통과 (1건은 `router.test`의 `/home` lazy 렌더 레이스성 기존 flake — 단독 실행 시 재현 안 됨, 본 변경과 무관)