### PR TITLE
feat : 일상기록 역/정 지오코딩 (Nominatim + Redis 캐시)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/geocode/GeocodePlace.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/geocode/GeocodePlace.java
@@ -1,0 +1,17 @@
+package ds.project.orino.planner.lifelog.geocode;
+
+import java.math.BigDecimal;
+
+/**
+ * 지오코딩 결과 한 건. 역/정 지오코딩 응답과 Redis 캐시 직렬화에 공통으로 쓴다.
+ *
+ * @param placeName 장소명(Nominatim {@code display_name})
+ * @param lat       위도
+ * @param lng       경도
+ */
+public record GeocodePlace(
+        String placeName,
+        BigDecimal lat,
+        BigDecimal lng
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/geocode/client/GeocodingClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/geocode/client/GeocodingClient.java
@@ -1,0 +1,19 @@
+package ds.project.orino.planner.lifelog.geocode.client;
+
+import ds.project.orino.planner.lifelog.geocode.GeocodePlace;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 지오코딩 공급자 추상화. 인터페이스로 둬서 테스트가 외부 네트워크(Nominatim)에 의존하지 않고
+ * 스텁으로 대체할 수 있게 한다. 캐시·정책(rate limit)은 서비스/구현체의 몫이다.
+ */
+public interface GeocodingClient {
+
+    /** 좌표 → 장소명. 결과가 없으면 빈 Optional. 호출 실패는 예외를 던진다. */
+    Optional<GeocodePlace> reverse(double lat, double lng);
+
+    /** 검색어 → 후보 장소(최대 {@code limit}개). 결과 없음은 빈 리스트, 호출 실패는 예외. */
+    List<GeocodePlace> search(String query, int limit);
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/geocode/client/NominatimGeocodingClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/geocode/client/NominatimGeocodingClient.java
@@ -1,0 +1,132 @@
+package ds.project.orino.planner.lifelog.geocode.client;
+
+import ds.project.orino.planner.lifelog.geocode.GeocodePlace;
+import ds.project.orino.planner.lifelog.geocode.config.NominatimProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Nominatim(OSM) 공개 인스턴스 호출 래퍼.
+ *
+ * <p>정책 준수: 식별 User-Agent 헤더를 붙이고, 연속 호출을 {@link NominatimProperties#minInterval()}
+ * 이상으로 벌린다(초당 1회 이하). 캐시는 상위 서비스가 흡수하므로 여기선 순수 호출만 한다.
+ */
+@Component
+public class NominatimGeocodingClient implements GeocodingClient {
+
+    private final RestClient restClient;
+    private final NominatimProperties props;
+    private final ObjectMapper objectMapper;
+
+    private final ReentrantLock rateLock = new ReentrantLock(true);
+    private long lastRequestNanos;
+
+    public NominatimGeocodingClient(NominatimProperties props, ObjectMapper objectMapper) {
+        this.props = props;
+        this.objectMapper = objectMapper;
+        this.restClient = RestClient.builder()
+                .requestFactory(requestFactory(props))
+                .defaultHeader(HttpHeaders.USER_AGENT, props.userAgent())
+                .defaultHeader(HttpHeaders.ACCEPT_LANGUAGE, props.acceptLanguage())
+                .build();
+    }
+
+    private static org.springframework.http.client.ClientHttpRequestFactory requestFactory(
+            NominatimProperties props) {
+        var factory = new org.springframework.http.client.SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(props.connectTimeout());
+        factory.setReadTimeout(props.readTimeout());
+        return factory;
+    }
+
+    @Override
+    public Optional<GeocodePlace> reverse(double lat, double lng) {
+        URI uri = UriComponentsBuilder.fromUriString(props.baseUrl())
+                .path("/reverse")
+                .queryParam("format", "jsonv2")
+                .queryParam("lat", lat)
+                .queryParam("lon", lng)
+                .build()
+                .toUri();
+
+        JsonNode root = getJson(uri);
+        if (root == null || root.has("error") || !root.hasNonNull("display_name")) {
+            return Optional.empty();
+        }
+        return Optional.of(toPlace(root));
+    }
+
+    @Override
+    public List<GeocodePlace> search(String query, int limit) {
+        URI uri = UriComponentsBuilder.fromUriString(props.baseUrl())
+                .path("/search")
+                .queryParam("format", "jsonv2")
+                .queryParam("q", query)
+                .queryParam("limit", limit)
+                .build()
+                .toUri();
+
+        JsonNode root = getJson(uri);
+        List<GeocodePlace> results = new ArrayList<>();
+        if (root != null && root.isArray()) {
+            for (JsonNode node : root) {
+                if (node.hasNonNull("display_name")) {
+                    results.add(toPlace(node));
+                }
+            }
+        }
+        return results;
+    }
+
+    private GeocodePlace toPlace(JsonNode node) {
+        return new GeocodePlace(
+                node.path("display_name").asString(""),
+                new BigDecimal(node.path("lat").asString("0")),
+                new BigDecimal(node.path("lon").asString("0")));
+    }
+
+    /** rate limit을 지키며 GET 하고 JSON으로 파싱한다. 파싱 실패는 예외. */
+    private JsonNode getJson(URI uri) {
+        throttle();
+        String body = restClient.get().uri(uri).retrieve().body(String.class);
+        if (body == null || body.isBlank()) {
+            return null;
+        }
+        try {
+            return objectMapper.readTree(body);
+        } catch (JacksonException e) {
+            throw new IllegalStateException("Nominatim 응답 파싱 실패", e);
+        }
+    }
+
+    /** 직전 호출로부터 최소 간격이 지날 때까지 대기해 Nominatim rate limit을 지킨다. */
+    private void throttle() {
+        rateLock.lock();
+        try {
+            long minNanos = props.minInterval().toNanos();
+            long waitNanos = minNanos - (System.nanoTime() - lastRequestNanos);
+            if (waitNanos > 0) {
+                try {
+                    Thread.sleep(waitNanos / 1_000_000L, (int) (waitNanos % 1_000_000L));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            lastRequestNanos = System.nanoTime();
+        } finally {
+            rateLock.unlock();
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/geocode/config/NominatimProperties.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/geocode/config/NominatimProperties.java
@@ -1,0 +1,33 @@
+package ds.project.orino.planner.lifelog.geocode.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * Nominatim(OSM) 지오코딩 설정.
+ *
+ * <p>Nominatim 사용 정책 준수를 위한 값들: 식별 가능한 {@code userAgent}(필수), 초당 1회 이하로
+ * 제한하는 {@code minInterval}, 결과 캐시 TTL. 공개 인스턴스는 단일 사용자·저볼륨이라 충분하다.
+ *
+ * @param baseUrl        Nominatim base URL
+ * @param userAgent      식별용 User-Agent (Nominatim 정책상 필수)
+ * @param acceptLanguage 응답 언어 (예: ko)
+ * @param minInterval    연속 호출 최소 간격(rate limit)
+ * @param reverseTtl     역지오코딩 캐시 TTL
+ * @param searchTtl      정지오코딩(검색) 캐시 TTL
+ * @param connectTimeout 연결 타임아웃
+ * @param readTimeout    읽기 타임아웃
+ */
+@ConfigurationProperties(prefix = "geocoding.nominatim")
+public record NominatimProperties(
+        String baseUrl,
+        String userAgent,
+        String acceptLanguage,
+        Duration minInterval,
+        Duration reverseTtl,
+        Duration searchTtl,
+        Duration connectTimeout,
+        Duration readTimeout
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/geocode/controller/GeocodingController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/geocode/controller/GeocodingController.java
@@ -1,0 +1,39 @@
+package ds.project.orino.planner.lifelog.geocode.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.lifelog.geocode.GeocodePlace;
+import ds.project.orino.planner.lifelog.geocode.service.GeocodingService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 일상기록 지오코딩. 좌표↔장소명 변환을 BE가 Nominatim으로 프록시하고 Redis 캐시로 흡수한다.
+ * 장소명 표시 편의 기능이라 실패해도 기록 저장 자체는 막지 않는다(FE가 위치 없이 저장).
+ */
+@RestController
+@RequestMapping("/api/lifelog/geocode")
+public class GeocodingController {
+
+    private final GeocodingService geocodingService;
+
+    public GeocodingController(GeocodingService geocodingService) {
+        this.geocodingService = geocodingService;
+    }
+
+    /** 좌표 → 장소명. */
+    @GetMapping("/reverse")
+    public ApiResponse<GeocodePlace> reverse(@RequestParam double lat, @RequestParam double lng) {
+        return ApiResponse.success(geocodingService.reverse(lat, lng));
+    }
+
+    /** 검색어 → 후보 장소(최대 10). */
+    @GetMapping("/search")
+    public ApiResponse<List<GeocodePlace>> search(@RequestParam("q") String query,
+                                                  @RequestParam(required = false) Integer limit) {
+        return ApiResponse.success(geocodingService.search(query, limit));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/geocode/service/GeocodingService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/geocode/service/GeocodingService.java
@@ -1,0 +1,105 @@
+package ds.project.orino.planner.lifelog.geocode.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.lifelog.geocode.GeocodePlace;
+import ds.project.orino.planner.lifelog.geocode.client.GeocodingClient;
+import ds.project.orino.planner.lifelog.geocode.config.NominatimProperties;
+import ds.project.orino.redis.planner.lifelog.GeocodeCacheRepository;
+import org.springframework.stereotype.Service;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * 지오코딩 오케스트레이션: Redis 캐시 우선 조회 → 미스면 {@link GeocodingClient} 호출 → 캐시 저장.
+ *
+ * <p>외부 호출 실패는 {@link ErrorCode#LIFELOG_GEOCODING_FAILED}로 변환한다. 이 실패는 장소명 표시
+ * 편의 기능일 뿐이라, 클라이언트(FE)는 위치 없이도 기록을 저장할 수 있다(graceful degradation).
+ */
+@Service
+public class GeocodingService {
+
+    /** 좌표 캐시 키 반올림 자릿수(4 ≈ 11m). */
+    private static final int COORD_SCALE = 4;
+    private static final int MAX_SEARCH_LIMIT = 10;
+    private static final int DEFAULT_SEARCH_LIMIT = 5;
+
+    private static final TypeReference<List<GeocodePlace>> PLACE_LIST = new TypeReference<>() {
+    };
+
+    private final GeocodingClient client;
+    private final GeocodeCacheRepository cache;
+    private final NominatimProperties props;
+    private final ObjectMapper objectMapper;
+
+    public GeocodingService(GeocodingClient client, GeocodeCacheRepository cache,
+                            NominatimProperties props, ObjectMapper objectMapper) {
+        this.client = client;
+        this.cache = cache;
+        this.props = props;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 좌표 → 장소. 결과가 없으면 장소명 null로 입력 좌표를 그대로 돌려준다(FE가 좌표만 저장 가능).
+     */
+    public GeocodePlace reverse(double lat, double lng) {
+        String latKey = round(lat);
+        String lngKey = round(lng);
+
+        Optional<String> cached = cache.findReverse(latKey, lngKey);
+        if (cached.isPresent()) {
+            return objectMapper.readValue(cached.get(), GeocodePlace.class);
+        }
+
+        GeocodePlace place;
+        try {
+            place = client.reverse(lat, lng).orElse(null);
+        } catch (RuntimeException e) {
+            throw new CustomException(ErrorCode.LIFELOG_GEOCODING_FAILED, e);
+        }
+        if (place == null) {
+            // 결과 없음도 캐시해 같은 좌표 반복 조회를 흡수한다.
+            place = new GeocodePlace(null, new BigDecimal(latKey), new BigDecimal(lngKey));
+        }
+        cache.saveReverse(latKey, lngKey, objectMapper.writeValueAsString(place), props.reverseTtl());
+        return place;
+    }
+
+    /** 검색어 → 후보 장소. limit은 [1, 10]으로 보정한다. */
+    public List<GeocodePlace> search(String query, Integer limit) {
+        int size = clampLimit(limit);
+        String normalized = query.trim().toLowerCase(Locale.ROOT);
+
+        Optional<String> cached = cache.findSearch(normalized, size);
+        if (cached.isPresent()) {
+            return objectMapper.readValue(cached.get(), PLACE_LIST);
+        }
+
+        List<GeocodePlace> results;
+        try {
+            results = client.search(query.trim(), size);
+        } catch (RuntimeException e) {
+            throw new CustomException(ErrorCode.LIFELOG_GEOCODING_FAILED, e);
+        }
+        cache.saveSearch(normalized, size, objectMapper.writeValueAsString(results), props.searchTtl());
+        return results;
+    }
+
+    private String round(double coord) {
+        return BigDecimal.valueOf(coord).setScale(COORD_SCALE, RoundingMode.HALF_UP).toPlainString();
+    }
+
+    private int clampLimit(Integer limit) {
+        if (limit == null) {
+            return DEFAULT_SEARCH_LIMIT;
+        }
+        return Math.max(1, Math.min(MAX_SEARCH_LIMIT, limit));
+    }
+}

--- a/be/orino-app-api/src/main/resources/application.yml
+++ b/be/orino-app-api/src/main/resources/application.yml
@@ -66,6 +66,19 @@ holiday:
   connect-timeout: ${HOLIDAY_CONNECT_TIMEOUT:5s}
   read-timeout: ${HOLIDAY_READ_TIMEOUT:10s}
 
+geocoding:
+  nominatim:
+    base-url: ${NOMINATIM_BASE_URL:https://nominatim.openstreetmap.org}
+    # Nominatim 정책상 식별 가능한 User-Agent 필수.
+    user-agent: ${NOMINATIM_USER_AGENT:orino-lifelog/1.0 (https://orino.dev)}
+    accept-language: ${NOMINATIM_ACCEPT_LANGUAGE:ko}
+    # 초당 1회 이하(정책). 단일 사용자라 여유 있게.
+    min-interval: ${NOMINATIM_MIN_INTERVAL:1s}
+    reverse-ttl: ${NOMINATIM_REVERSE_TTL:30d}
+    search-ttl: ${NOMINATIM_SEARCH_TTL:7d}
+    connect-timeout: ${NOMINATIM_CONNECT_TIMEOUT:5s}
+    read-timeout: ${NOMINATIM_READ_TIMEOUT:10s}
+
 management:
   tracing:
     sampling:

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/lifelog/geocode/controller/GeocodingControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/lifelog/geocode/controller/GeocodingControllerTest.java
@@ -1,0 +1,75 @@
+package ds.project.orino.planner.lifelog.geocode.controller;
+
+import ds.project.orino.planner.lifelog.geocode.GeocodePlace;
+import ds.project.orino.planner.lifelog.geocode.service.GeocodingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 라우팅·파라미터 바인딩(q/lat/lng/limit)·응답 형태를 standalone MockMvc로 검증한다.
+ * (Spring 컨텍스트/DB 없이 — 새 컨텍스트로 인한 커넥션 부담 회피)
+ */
+class GeocodingControllerTest {
+
+    private GeocodingService service;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(GeocodingService.class);
+        mockMvc = MockMvcBuilders.standaloneSetup(new GeocodingController(service)).build();
+    }
+
+    @Test
+    @DisplayName("GET /reverse - lat·lng를 double로 바인딩하고 place를 반환한다")
+    void reverse() throws Exception {
+        when(service.reverse(33.458, 126.942)).thenReturn(
+                new GeocodePlace("성산일출봉", new BigDecimal("33.458"), new BigDecimal("126.942")));
+
+        mockMvc.perform(get("/api/lifelog/geocode/reverse")
+                        .param("lat", "33.458").param("lng", "126.942"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.placeName").value("성산일출봉"));
+
+        verify(service).reverse(33.458, 126.942);
+    }
+
+    @Test
+    @DisplayName("GET /search - q를 바인딩하고 limit 미지정은 null로 위임한다")
+    void searchWithoutLimit() throws Exception {
+        when(service.search(eq("성산"), isNull())).thenReturn(List.of(
+                new GeocodePlace("성산일출봉", new BigDecimal("33.458"), new BigDecimal("126.942"))));
+
+        mockMvc.perform(get("/api/lifelog/geocode/search").param("q", "성산"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].placeName").value("성산일출봉"));
+
+        verify(service).search("성산", null);
+    }
+
+    @Test
+    @DisplayName("GET /search - limit을 Integer로 바인딩한다")
+    void searchWithLimit() throws Exception {
+        when(service.search(eq("제주"), eq(3))).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/lifelog/geocode/search").param("q", "제주").param("limit", "3"))
+                .andExpect(status().isOk());
+
+        verify(service).search("제주", 3);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/lifelog/geocode/service/GeocodingServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/lifelog/geocode/service/GeocodingServiceTest.java
@@ -1,0 +1,135 @@
+package ds.project.orino.planner.lifelog.geocode.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.lifelog.geocode.GeocodePlace;
+import ds.project.orino.planner.lifelog.geocode.client.GeocodingClient;
+import ds.project.orino.planner.lifelog.geocode.config.NominatimProperties;
+import ds.project.orino.redis.planner.lifelog.GeocodeCacheRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 지오코딩 오케스트레이션(캐시 히트/미스, 클라이언트 스텁, 실패 변환, limit 보정)을 고정한다.
+ * 외부 네트워크·Redis·Spring 컨텍스트 없이 순수 로직만 검증한다.
+ */
+class GeocodingServiceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final NominatimProperties props = new NominatimProperties(
+            "https://nominatim.test", "orino-test", "ko",
+            Duration.ofSeconds(1), Duration.ofDays(30), Duration.ofDays(7),
+            Duration.ofSeconds(5), Duration.ofSeconds(10));
+
+    private GeocodingClient client;
+    private GeocodeCacheRepository cache;
+    private GeocodingService service;
+
+    @BeforeEach
+    void setUp() {
+        client = mock(GeocodingClient.class);
+        cache = mock(GeocodeCacheRepository.class);
+        service = new GeocodingService(client, cache, props, objectMapper);
+    }
+
+    @Test
+    @DisplayName("reverse 캐시 히트 - 클라이언트를 호출하지 않고 캐시값을 돌려준다")
+    void reverseCacheHit() {
+        GeocodePlace cached = new GeocodePlace("성산일출봉",
+                new BigDecimal("33.4580"), new BigDecimal("126.9420"));
+        when(cache.findReverse("33.4580", "126.9420"))
+                .thenReturn(Optional.of(objectMapper.writeValueAsString(cached)));
+
+        GeocodePlace result = service.reverse(33.4580, 126.9420);
+
+        assertThat(result.placeName()).isEqualTo("성산일출봉");
+        verify(client, never()).reverse(anyDouble(), anyDouble());
+        verify(cache, never()).saveReverse(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("reverse 캐시 미스 - 클라이언트 호출 후 결과를 캐시에 저장한다")
+    void reverseCacheMiss() {
+        when(cache.findReverse(anyString(), anyString())).thenReturn(Optional.empty());
+        when(client.reverse(33.4580, 126.9420)).thenReturn(Optional.of(
+                new GeocodePlace("성산일출봉", new BigDecimal("33.4580"), new BigDecimal("126.9420"))));
+
+        GeocodePlace result = service.reverse(33.4580, 126.9420);
+
+        assertThat(result.placeName()).isEqualTo("성산일출봉");
+        verify(cache).saveReverse(eq("33.4580"), eq("126.9420"), anyString(), eq(props.reverseTtl()));
+    }
+
+    @Test
+    @DisplayName("reverse 결과 없음 - 장소명 null로 반올림 좌표를 돌려주고 캐시한다")
+    void reverseNotFound() {
+        when(cache.findReverse(anyString(), anyString())).thenReturn(Optional.empty());
+        when(client.reverse(anyDouble(), anyDouble())).thenReturn(Optional.empty());
+
+        GeocodePlace result = service.reverse(33.456789, 126.942111);
+
+        assertThat(result.placeName()).isNull();
+        assertThat(result.lat()).isEqualByComparingTo("33.4568");
+        assertThat(result.lng()).isEqualByComparingTo("126.9421");
+        verify(cache).saveReverse(eq("33.4568"), eq("126.9421"), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("reverse 클라이언트 실패 - LIFELOG_GEOCODING_FAILED로 변환한다")
+    void reverseClientFailure() {
+        when(cache.findReverse(anyString(), anyString())).thenReturn(Optional.empty());
+        when(client.reverse(anyDouble(), anyDouble())).thenThrow(new RuntimeException("boom"));
+
+        assertThatThrownBy(() -> service.reverse(33.45, 126.94))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.LIFELOG_GEOCODING_FAILED);
+    }
+
+    @Test
+    @DisplayName("search 캐시 히트 - 캐시된 목록을 역직렬화해 돌려준다")
+    void searchCacheHit() {
+        List<GeocodePlace> cachedList = List.of(
+                new GeocodePlace("성산일출봉", new BigDecimal("33.458"), new BigDecimal("126.942")));
+        when(cache.findSearch("성산", 5))
+                .thenReturn(Optional.of(objectMapper.writeValueAsString(cachedList)));
+
+        List<GeocodePlace> result = service.search("성산", null);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).placeName()).isEqualTo("성산일출봉");
+        verify(client, never()).search(anyString(), anyInt());
+    }
+
+    @Test
+    @DisplayName("search limit은 [1,10]으로 보정되고 미지정은 5")
+    void searchClampsLimit() {
+        when(cache.findSearch(anyString(), anyInt())).thenReturn(Optional.empty());
+        when(client.search(anyString(), anyInt())).thenReturn(List.of());
+
+        service.search("제주", 50);
+        verify(client).search("제주", 10);
+
+        service.search("부산", null);
+        verify(client).search("부산", 5);
+    }
+}

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -24,7 +24,10 @@ public enum ErrorCode {
     ROUTINE_INVALID_RULE("PLN-ERR-002", "유효하지 않은 반복 규칙입니다.", 400),
     GOOGLE_NOT_CONNECTED("PLN-ERR-003", "Google 연동이 필요합니다.", 409),
     GOOGLE_API_FAILED("PLN-ERR-004", "Google API 호출에 실패했습니다.", 502),
-    GOOGLE_INVALID_GRANT("PLN-ERR-005", "Google 연동이 만료되어 재연결이 필요합니다.", 401);
+    GOOGLE_INVALID_GRANT("PLN-ERR-005", "Google 연동이 만료되어 재연결이 필요합니다.", 401),
+
+    // LIFELOG (일상기록)
+    LIFELOG_GEOCODING_FAILED("LIFELOG-ERR-001", "장소 정보를 가져오지 못했습니다.", 502);
 
     private final String code;
     private final String message;

--- a/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/lifelog/GeocodeCacheRepository.java
+++ b/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/lifelog/GeocodeCacheRepository.java
@@ -1,0 +1,50 @@
+package ds.project.orino.redis.planner.lifelog;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * 지오코딩 결과 캐시. Nominatim 정책상 캐시가 의무이며, 같은 좌표/검색어의 반복 호출을 흡수한다.
+ *
+ * <p>직렬화된 JSON 문자열을 그대로 저장한다(직렬화는 상위 서비스가 담당 — 도메인-redis 모듈이
+ * app-api 타입에 의존하지 않게). 키는 좌표를 반올림해(≈11m) 근처 좌표의 캐시 히트를 높인다.
+ */
+@Repository
+public class GeocodeCacheRepository {
+
+    private static final String REVERSE_PREFIX = "lifelog:geocode:rev:";
+    private static final String SEARCH_PREFIX = "lifelog:geocode:search:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public GeocodeCacheRepository(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public Optional<String> findReverse(String latKey, String lngKey) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(reverseKey(latKey, lngKey)));
+    }
+
+    public void saveReverse(String latKey, String lngKey, String json, Duration ttl) {
+        redisTemplate.opsForValue().set(reverseKey(latKey, lngKey), json, ttl);
+    }
+
+    public Optional<String> findSearch(String query, int limit) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(searchKey(query, limit)));
+    }
+
+    public void saveSearch(String query, int limit, String json, Duration ttl) {
+        redisTemplate.opsForValue().set(searchKey(query, limit), json, ttl);
+    }
+
+    private String reverseKey(String latKey, String lngKey) {
+        return REVERSE_PREFIX + latKey + ":" + lngKey;
+    }
+
+    private String searchKey(String query, int limit) {
+        return SEARCH_PREFIX + limit + ":" + query;
+    }
+}


### PR DESCRIPTION
## 이슈
closes #954

## 작업 내용
- **`GET /api/lifelog/geocode/reverse?lat&lng`** → 장소명(`{placeName, lat, lng}`)
- **`GET /api/lifelog/geocode/search?q&limit`** → 후보 장소 목록(limit [1,10], 기본 5)
- **`GeocodingClient` 인터페이스 + `NominatimGeocodingClient`**(공개 OSM Nominatim)
  - 인터페이스로 둬 테스트가 외부 네트워크에 의존하지 않고 스텁 가능
  - **정책 준수**: 식별 `User-Agent`(필수) · `min-interval` rate limit(초당 1회 이하) · `Accept-Language`
- **`GeocodeCacheRepository`**(Redis, `StringRedisTemplate`) — 좌표 반올림 키(≈11m)로 캐시, 히트 시 외부 호출 없음(Nominatim 캐시 의무 충족)
- 외부 실패는 `LIFELOG_GEOCODING_FAILED`(`LIFELOG-ERR-001`, 502)로 변환 — 장소명은 표시 편의라 **FE는 위치 없이도 기록 저장 가능**(graceful)
- 공개 OSM/Nominatim + 캐시 = API 키·과금 없음(orino 비용 지향과 정렬), 셀프호스트는 후속

## 테스트
- `GeocodingServiceTest` (6) — 캐시 히트(클라 미호출)·미스(호출+저장)·결과없음(장소명 null 반올림 좌표)·실패 변환·검색 캐시·limit 보정
- `GeocodingControllerTest` (3, standalone) — reverse/search 파라미터 바인딩·응답 형태
- 전체 컨텍스트 부팅으로 `NominatimProperties` 바인딩·빈 와이어링 확인 · checkstyle 통과
- ⚠️ 외부 네트워크·새 Spring 컨텍스트 없이 검증(커넥션 부담 회피)

Epic: #949 · 후속: #956(FE 위치 입력)에서 소비