### PR TITLE
feat : 리프레시 토큰 회전 유예 창 + 탭 간 재발급 조율 (#972)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/auth/service/AuthService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/auth/service/AuthService.java
@@ -79,15 +79,28 @@ public class AuthService {
         String stored = refreshTokenRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));
 
-        if (!stored.equals(refreshToken)) {
-            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        if (stored.equals(refreshToken)) {
+            // 정상 회전. 직전 토큰(stored)을 짧은 유예로 남겨, 거의 동시에 온 형제 요청(다중 탭 등)이
+            // 그 토큰으로도 통과되게 한다 — 단일 사용 회전이 서로를 무효화하며 로그아웃시키는 걸 막는다.
+            String newRefreshToken = jwtTokenProvider.createRefreshToken(memberId);
+            refreshTokenRepository.saveGrace(memberId, stored);
+            refreshTokenRepository.save(memberId, newRefreshToken);
+            return new LoginResult(
+                    new TokenResponse(jwtTokenProvider.createAccessToken(memberId)), newRefreshToken);
         }
 
-        String newAccessToken = jwtTokenProvider.createAccessToken(memberId);
-        String newRefreshToken = jwtTokenProvider.createRefreshToken(memberId);
-        refreshTokenRepository.save(memberId, newRefreshToken);
+        // 현재 토큰과 다르면, 방금 회전된 직전 토큰(유예 창 안)인지 본다.
+        boolean inGrace = refreshTokenRepository.findGraceByMemberId(memberId)
+                .map(refreshToken::equals)
+                .orElse(false);
+        if (inGrace) {
+            // 다른 요청이 이미 회전시킴 → 재회전하지 않고 현재 토큰으로 수렴시킨다(양쪽이 같은 RT를 갖게).
+            return new LoginResult(
+                    new TokenResponse(jwtTokenProvider.createAccessToken(memberId)), stored);
+        }
 
-        return new LoginResult(new TokenResponse(newAccessToken), newRefreshToken);
+        // 유효한 서명이지만 현재도 유예도 아님 → 이미 폐기됐거나 재사용(유예 창 밖). 거부.
+        throw new CustomException(ErrorCode.INVALID_TOKEN);
     }
 
     public void logout(String refreshToken) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/auth/service/AuthServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/auth/service/AuthServiceTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -106,6 +107,39 @@ class AuthServiceTest {
         assertThat(result.tokenResponse().accessToken()).isEqualTo("new-at");
         assertThat(result.refreshToken()).isEqualTo("new-rt");
         verify(refreshTokenRepository).save(1L, "new-rt");
+        // 회전 시 직전 토큰을 유예로 남긴다(동시 요청 흡수용).
+        verify(refreshTokenRepository).saveGrace(1L, "old-rt");
+    }
+
+    @Test
+    @DisplayName("현재 토큰과 다르지만 유예 창의 직전 토큰이면 재회전 없이 현재 토큰으로 수렴한다")
+    void reissue_graceWindow_convergesToCurrent() {
+        given(jwtTokenProvider.validate("old-rt")).willReturn(true);
+        given(jwtTokenProvider.getMemberId("old-rt")).willReturn(1L);
+        given(refreshTokenRepository.findByMemberId(1L)).willReturn(Optional.of("current-rt"));
+        given(refreshTokenRepository.findGraceByMemberId(1L)).willReturn(Optional.of("old-rt"));
+        given(jwtTokenProvider.createAccessToken(1L)).willReturn("fresh-at");
+
+        AuthService.LoginResult result = authService.reissue("old-rt");
+
+        assertThat(result.tokenResponse().accessToken()).isEqualTo("fresh-at");
+        // 새 토큰을 또 만들지 않고 현재 토큰으로 수렴 → 동시 탭이 같은 RT를 갖게 된다.
+        assertThat(result.refreshToken()).isEqualTo("current-rt");
+        verify(refreshTokenRepository, never()).save(eq(1L), any());
+        verify(jwtTokenProvider, never()).createRefreshToken(any());
+    }
+
+    @Test
+    @DisplayName("현재 토큰과 다르고 유예도 아니면 예외를 던진다(재사용/폐기)")
+    void reissue_notCurrentNotGrace_throws() {
+        given(jwtTokenProvider.validate("stale-rt")).willReturn(true);
+        given(jwtTokenProvider.getMemberId("stale-rt")).willReturn(1L);
+        given(refreshTokenRepository.findByMemberId(1L)).willReturn(Optional.of("current-rt"));
+        given(refreshTokenRepository.findGraceByMemberId(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.reissue("stale-rt"))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.INVALID_TOKEN));
     }
 
     @Test

--- a/be/orino-domain-redis/src/main/java/ds/project/orino/redis/auth/RefreshTokenRepository.java
+++ b/be/orino-domain-redis/src/main/java/ds/project/orino/redis/auth/RefreshTokenRepository.java
@@ -10,7 +10,11 @@ import java.util.Optional;
 public class RefreshTokenRepository {
 
     private static final String KEY_PREFIX = "auth:refresh:";
+    private static final String GRACE_PREFIX = "auth:refresh:grace:";
     private static final Duration TTL = Duration.ofDays(14);
+    // 회전 직후 짧은 유예 창. 거의 동시에 도착한 형제 요청(다중 탭 등)이 방금 회전된 직전
+    // 토큰으로도 통과되게 해, 단일 사용 회전이 서로를 무효화하며 강제 로그아웃시키는 걸 막는다.
+    private static final Duration GRACE_TTL = Duration.ofSeconds(30);
 
     private final StringRedisTemplate redisTemplate;
 
@@ -26,7 +30,17 @@ public class RefreshTokenRepository {
         return Optional.ofNullable(redisTemplate.opsForValue().get(KEY_PREFIX + memberId));
     }
 
+    /** 회전 시 직전 토큰을 짧은 유예로 남긴다(동시 회전 레이스 흡수용). */
+    public void saveGrace(Long memberId, String previousToken) {
+        redisTemplate.opsForValue().set(GRACE_PREFIX + memberId, previousToken, GRACE_TTL);
+    }
+
+    public Optional<String> findGraceByMemberId(Long memberId) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(GRACE_PREFIX + memberId));
+    }
+
     public void deleteByMemberId(Long memberId) {
         redisTemplate.delete(KEY_PREFIX + memberId);
+        redisTemplate.delete(GRACE_PREFIX + memberId);
     }
 }

--- a/fe/src/features/auth/api/auth.ts
+++ b/fe/src/features/auth/api/auth.ts
@@ -1,6 +1,5 @@
-import axios from "axios";
-
 import client from "../../../shared/api/client";
+import { broadcastLogout, refreshAccessToken } from "../refreshCoordinator";
 import { setAccessToken } from "../store/authStore";
 
 interface LoginRequest {
@@ -18,19 +17,12 @@ export async function login(request: LoginRequest): Promise<void> {
   setAccessToken(data.data.accessToken);
 }
 
-export async function reissue(): Promise<boolean> {
-  try {
-    const { data } = await axios.post<TokenResponse>(
-      `${client.defaults.baseURL}/auth/reissue`,
-      null,
-      { withCredentials: true },
-    );
-    setAccessToken(data.data.accessToken);
-    return true;
-  } catch {
-    setAccessToken(null);
-    return false;
-  }
+/**
+ * 엑세스 토큰 재발급. 코디네이터에 위임한다 — 인터셉터·앱 시작 재발급이 같은 단일 비행/Web Lock을
+ * 공유해, 동시 호출이 리프레시 토큰 회전으로 서로를 무효화하는 걸 막는다.
+ */
+export function reissue(): Promise<boolean> {
+  return refreshAccessToken();
 }
 
 export async function logout(): Promise<void> {
@@ -38,5 +30,6 @@ export async function logout(): Promise<void> {
     await client.post("/auth/logout");
   } finally {
     setAccessToken(null);
+    broadcastLogout();
   }
 }

--- a/fe/src/features/auth/refreshCoordinator.test.ts
+++ b/fe/src/features/auth/refreshCoordinator.test.ts
@@ -1,0 +1,48 @@
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { server } from "../../test/mocks/server";
+import { refreshAccessToken } from "./refreshCoordinator";
+import { useAuthStore } from "./store/authStore";
+
+const API_BASE = "https://api.orino.dev/api";
+
+describe("refreshAccessToken", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: null });
+  });
+
+  it("동시 호출을 하나의 재발급 요청으로 합친다(단일 비행)", async () => {
+    let calls = 0;
+    server.use(
+      http.post(`${API_BASE}/auth/reissue`, () => {
+        calls++;
+        return HttpResponse.json({ code: "OK", data: { accessToken: "t1" } });
+      }),
+    );
+
+    const [a, b] = await Promise.all([
+      refreshAccessToken(),
+      refreshAccessToken(),
+    ]);
+
+    expect(a).toBe(true);
+    expect(b).toBe(true);
+    expect(calls).toBe(1); // 두 호출이 합쳐져 서버는 한 번만
+    expect(useAuthStore.getState().accessToken).toBe("t1");
+  });
+
+  it("실패 시 false를 반환하고 토큰을 비운다", async () => {
+    useAuthStore.setState({ accessToken: "old" });
+    server.use(
+      http.post(`${API_BASE}/auth/reissue`, () =>
+        HttpResponse.json(null, { status: 401 }),
+      ),
+    );
+
+    const ok = await refreshAccessToken();
+
+    expect(ok).toBe(false);
+    expect(useAuthStore.getState().accessToken).toBeNull();
+  });
+});

--- a/fe/src/features/auth/refreshCoordinator.ts
+++ b/fe/src/features/auth/refreshCoordinator.ts
@@ -1,0 +1,85 @@
+import axios from "axios";
+
+import { API_BASE_URL } from "@/shared/api/config";
+
+import { setAccessToken } from "./store/authStore";
+
+/** 탭 간 재발급 직렬화용 Web Lock 이름. */
+const LOCK_NAME = "orino-auth-refresh";
+/** 탭 간 토큰/로그아웃 전파용 BroadcastChannel 이름. */
+const CHANNEL_NAME = "orino-auth";
+
+interface TokenMessage {
+  type: "token";
+  accessToken: string;
+}
+interface LogoutMessage {
+  type: "logout";
+}
+type AuthMessage = TokenMessage | LogoutMessage;
+
+const channel: BroadcastChannel | null =
+  typeof BroadcastChannel !== "undefined"
+    ? new BroadcastChannel(CHANNEL_NAME)
+    : null;
+
+// 다른 탭이 토큰을 갱신/로그아웃하면 이 탭 스토어에도 반영한다 — 그 탭들이 각자 또 재발급하거나
+// (토큰 회전 레이스로) 로그아웃당하지 않도록. BroadcastChannel은 같은 인스턴스엔 안 오므로 자기
+// 메시지를 자기가 받지 않는다.
+channel?.addEventListener("message", (e: MessageEvent<AuthMessage>) => {
+  const msg = e.data;
+  if (msg?.type === "token") {
+    setAccessToken(msg.accessToken);
+  } else if (msg?.type === "logout") {
+    setAccessToken(null);
+  }
+});
+
+let inFlight: Promise<boolean> | null = null;
+
+async function reissueOnce(): Promise<boolean> {
+  try {
+    const { data } = await axios.post<{ data: { accessToken: string } }>(
+      `${API_BASE_URL}/auth/reissue`,
+      null,
+      { withCredentials: true },
+    );
+    const token = data.data.accessToken;
+    setAccessToken(token);
+    channel?.postMessage({ type: "token", accessToken: token } as AuthMessage);
+    return true;
+  } catch {
+    setAccessToken(null);
+    return false;
+  }
+}
+
+/** Web Locks가 있으면 그 락 안에서 실행(브라우저당 동시 재발급 1개), 없으면 그냥 실행한다. */
+function withCrossTabLock(fn: () => Promise<boolean>): Promise<boolean> {
+  const locks =
+    typeof navigator !== "undefined"
+      ? (navigator as Navigator & { locks?: LockManager }).locks
+      : undefined;
+  if (locks?.request) {
+    return locks.request(LOCK_NAME, fn) as Promise<boolean>;
+  }
+  return fn();
+}
+
+/**
+ * 엑세스 토큰 재발급. 탭 안에선 진행 중 요청 하나로 합치고(단일 비행), 탭 간에는 Web Lock으로
+ * 직렬화한다. 성공하면 새 토큰을 다른 탭에도 전파한다. 인터셉터·앱 시작 재발급이 모두 이 함수를
+ * 거치게 해, 리프레시 토큰 회전(단일 사용)이 동시 호출로 서로를 무효화하며 재로그인시키는 걸 막는다.
+ */
+export function refreshAccessToken(): Promise<boolean> {
+  if (inFlight) return inFlight;
+  inFlight = withCrossTabLock(reissueOnce).finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+/** 로그아웃을 다른 탭에도 알린다(각 탭이 스토어를 비운다). */
+export function broadcastLogout(): void {
+  channel?.postMessage({ type: "logout" } as AuthMessage);
+}

--- a/fe/src/shared/api/client.test.ts
+++ b/fe/src/shared/api/client.test.ts
@@ -48,6 +48,39 @@ describe("Axios interceptor", () => {
     expect(useAuthStore.getState().accessToken).toBe("new-access-token");
   });
 
+  it("401이지만 그 사이 토큰이 이미 갱신됐으면 재발급 없이 새 토큰으로 재시도한다", async () => {
+    let reissueCalls = 0;
+    let protectedCalls = 0;
+    useAuthStore.setState({ accessToken: "stale-token" });
+
+    server.use(
+      http.get(`${API_BASE}/protected`, ({ request }) => {
+        protectedCalls++;
+        if (protectedCalls === 1) {
+          // 첫 요청이 401되기 직전, 다른 탭이 토큰을 갱신했다고 가정(브로드캐스트로 스토어 반영).
+          useAuthStore.setState({ accessToken: "fresh-token" });
+          return HttpResponse.json(null, { status: 401 });
+        }
+        return HttpResponse.json({
+          auth: request.headers.get("Authorization"),
+        });
+      }),
+      http.post(`${API_BASE}/auth/reissue`, () => {
+        reissueCalls++;
+        return HttpResponse.json({
+          code: "OK",
+          data: { accessToken: "reissued-token" },
+        });
+      }),
+    );
+
+    const { data } = await client.get("/protected");
+
+    // 재발급 없이 최신 토큰으로 재시도한다.
+    expect(data.auth).toBe("Bearer fresh-token");
+    expect(reissueCalls).toBe(0);
+  });
+
   it("reissue 실패 시 토큰을 제거한다", async () => {
     server.use(
       http.get(`${API_BASE}/protected`, () => {

--- a/fe/src/shared/api/client.ts
+++ b/fe/src/shared/api/client.ts
@@ -1,12 +1,10 @@
 import axios from "axios";
 
-import {
-  getAccessToken,
-  setAccessToken,
-} from "../../features/auth/store/authStore";
+import { refreshAccessToken } from "../../features/auth/refreshCoordinator";
+import { getAccessToken } from "../../features/auth/store/authStore";
+import { API_BASE_URL } from "./config";
 
-export const API_BASE_URL =
-  import.meta.env.VITE_API_URL ?? "https://api.orino.dev/api";
+export { API_BASE_URL };
 
 const client = axios.create({
   baseURL: API_BASE_URL,
@@ -28,42 +26,42 @@ client.interceptors.request.use((config) => {
   return config;
 });
 
-let isRefreshing = false;
-let pendingRequests: Array<() => void> = [];
+/** "Bearer xxx" → "xxx". 그 외엔 undefined. */
+function bearerToken(auth: unknown): string | undefined {
+  return typeof auth === "string" && auth.startsWith("Bearer ")
+    ? auth.slice(7)
+    : undefined;
+}
 
 client.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
 
-    if (error.response?.status !== 401 || originalRequest._retry) {
+    if (
+      error.response?.status !== 401 ||
+      !originalRequest ||
+      originalRequest._retry
+    ) {
       return Promise.reject(error);
     }
-
-    if (isRefreshing) {
-      return new Promise((resolve) => {
-        pendingRequests.push(() => resolve(client(originalRequest)));
-      });
-    }
-
     originalRequest._retry = true;
-    isRefreshing = true;
 
-    try {
-      const { data } = await axios.post(`${API_BASE_URL}/auth/reissue`, null, {
-        withCredentials: true,
-      });
-      setAccessToken(data.data.accessToken);
-      pendingRequests.forEach((cb) => cb());
+    // 다른 탭·다른 요청이 이미 토큰을 갱신했으면(스토어 토큰이 이 요청에 쓴 것과 다름) 재발급 없이
+    // 최신 토큰으로 바로 재시도한다 — 불필요한 재발급(=회전)을 아낀다.
+    const usedToken = bearerToken(originalRequest.headers?.Authorization);
+    const current = getAccessToken();
+    if (current && current !== usedToken) {
       return client(originalRequest);
-    } catch {
-      setAccessToken(null);
-      window.location.href = "/login";
-      return Promise.reject(error);
-    } finally {
-      isRefreshing = false;
-      pendingRequests = [];
     }
+
+    // 재발급은 코디네이터가 탭 내 단일 비행 + 탭 간 Web Lock으로 직렬화한다.
+    const refreshed = await refreshAccessToken();
+    if (refreshed) {
+      return client(originalRequest);
+    }
+    window.location.href = "/login";
+    return Promise.reject(error);
   },
 );
 

--- a/fe/src/shared/api/config.ts
+++ b/fe/src/shared/api/config.ts
@@ -1,0 +1,3 @@
+/** API 기본 URL. 순환 import를 피하려고 client와 분리한 leaf 모듈(다른 걸 import하지 않는다). */
+export const API_BASE_URL =
+  import.meta.env.VITE_API_URL ?? "https://api.orino.dev/api";


### PR DESCRIPTION
## 이슈
closes #972

> ⚠️ 이 수정은 앞서 작성됐으나 원격 브랜치 꼬임으로 **PR/머지가 누락**됐다(#960·#968은 정상 머지, 토큰 수정만 빠짐). 재등록.

## 배경
- 엑세스 30분(메모리 전용), 리프레시 14일(httpOnly 쿠키·Redis) — TTL은 정상.
- `reissue`가 **단일 사용 회전**이라 **동시 재발급**(다중 탭/시작-인터셉터 겹침)이 서로를 무효화 → `AUTH-ERR-002` → `/login`. **표 데이터 API도 로드 중 401로 실패해 표가 안 열림.** Playwright로 stale 세션 401 재현.

## BE (1) — 회전 유예 창
- `RefreshTokenRepository`: `grace` 키(30초) 추가, `deleteByMemberId`는 둘 다 삭제.
- `AuthService.reissue`: 현재 토큰이면 정상 회전(직전 토큰 grace 저장), 유예 창의 직전 토큰이면 재회전 없이 현재 토큰으로 수렴, 둘 다 아니면 거부.

## FE (2) — 탭 간 재발급 단일화
- `refreshCoordinator.refreshAccessToken()`: 탭 내 단일 비행 + **Web Locks** + **BroadcastChannel**(feature-detect).
- `client` 인터셉터 통합 + **토큰이 이미 바뀌었으면 재발급 없이 재시도**. `auth.reissue`는 위임, `logout`은 브로드캐스트. `API_BASE_URL`을 config로 분리.

## 테스트
- BE: 회전 시 grace 저장, 유예 수렴(재회전 안 함), 유예 밖 거부.
- FE: 동시 호출 단일 비행(서버 1회), 실패 시 토큰 비움, 토큰-변경 재시도.
- FE·BE(auth 테스트·체크스타일) 통과. cherry-pick으로 최신 main에 충돌 없이 재적용.

## 중요
- **이 PR을 배포해야 표가 정상 로드되고 재로그인이 잦지 않게 된다.** #960/#968(타이핑·커서·표이름)은 이미 main에 있으나, 표가 열리려면 이 토큰 수정이 필요.