### PR TITLE
feat : 일상기록 Moment CRUD API + 피드 커서 + 태그 자동완성

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/image/service/LifelogImageStorageService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/image/service/LifelogImageStorageService.java
@@ -71,10 +71,19 @@ public class LifelogImageStorageService {
                 .build();
 
         String uploadUrl = presigner.presignPutObject(presignRequest).url().toString();
-        String publicUrl = "%s/%s/%s".formatted(
-                stripTrailingSlash(props.endpoint()), props.bucket(), key);
 
-        return new LifelogImageUploadUrlResponse(uploadUrl, publicUrl, key);
+        return new LifelogImageUploadUrlResponse(uploadUrl, toPublicUrl(key), key);
+    }
+
+    /**
+     * object key를 공개 URL로 조립한다(base + bucket + key). 호스트를 하드코딩하지 않고 설정에서 받아
+     * 환경별로 갈린다. null/blank 키는 그대로 반환한다.
+     */
+    public String toPublicUrl(String objectKey) {
+        if (objectKey == null || objectKey.isBlank()) {
+            return objectKey;
+        }
+        return "%s/%s/%s".formatted(stripTrailingSlash(props.endpoint()), props.bucket(), objectKey);
     }
 
     /**

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/controller/MomentController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/controller/MomentController.java
@@ -1,0 +1,70 @@
+package ds.project.orino.planner.lifelog.moment.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.lifelog.moment.dto.FeedResponse;
+import ds.project.orino.planner.lifelog.moment.dto.MomentCard;
+import ds.project.orino.planner.lifelog.moment.dto.MomentWriteRequest;
+import ds.project.orino.planner.lifelog.moment.service.MomentService;
+import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+
+@RestController
+@RequestMapping("/api/lifelog/moments")
+public class MomentController {
+
+    private final MomentService momentService;
+
+    public MomentController(MomentService momentService) {
+        this.momentService = momentService;
+    }
+
+    @PostMapping
+    public ApiResponse<MomentCard> create(@AuthenticationPrincipal Long memberId,
+                                          @Valid @RequestBody MomentWriteRequest request) {
+        return ApiResponse.success(momentService.create(memberId, request));
+    }
+
+    /** 역시간순 피드(커서 페이지네이션). 선택 필터: tag·기간(from/to, ISO-8601). */
+    @GetMapping
+    public ApiResponse<FeedResponse> feed(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) Integer size,
+            @RequestParam(required = false) String tag,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to) {
+        return ApiResponse.success(momentService.feed(memberId, cursor, size, tag, from, to));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<MomentCard> findOne(@AuthenticationPrincipal Long memberId,
+                                           @PathVariable Long id) {
+        return ApiResponse.success(momentService.findOne(memberId, id));
+    }
+
+    @PutMapping("/{id}")
+    public ApiResponse<MomentCard> update(@AuthenticationPrincipal Long memberId,
+                                          @PathVariable Long id,
+                                          @Valid @RequestBody MomentWriteRequest request) {
+        return ApiResponse.success(momentService.update(memberId, id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> delete(@AuthenticationPrincipal Long memberId,
+                                    @PathVariable Long id) {
+        momentService.delete(memberId, id);
+        return ApiResponse.success();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/controller/MomentTagController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/controller/MomentTagController.java
@@ -1,0 +1,31 @@
+package ds.project.orino.planner.lifelog.moment.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.lifelog.moment.service.MomentService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 태그 자동완성. 멤버가 이미 쓴 태그 중 접두어로 시작하는 것들을 돌려준다.
+ */
+@RestController
+@RequestMapping("/api/lifelog/tags")
+public class MomentTagController {
+
+    private final MomentService momentService;
+
+    public MomentTagController(MomentService momentService) {
+        this.momentService = momentService;
+    }
+
+    @GetMapping
+    public ApiResponse<List<String>> autocomplete(@AuthenticationPrincipal Long memberId,
+                                                  @RequestParam(value = "q", required = false) String query) {
+        return ApiResponse.success(momentService.autocompleteTags(memberId, query));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/dto/FeedResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/dto/FeedResponse.java
@@ -1,0 +1,12 @@
+package ds.project.orino.planner.lifelog.moment.dto;
+
+import java.util.List;
+
+/**
+ * 피드 한 페이지. {@code nextCursor}가 null이면 마지막 페이지다.
+ */
+public record FeedResponse(
+        List<MomentCard> items,
+        String nextCursor
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/dto/FlowRef.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/dto/FlowRef.java
@@ -1,0 +1,10 @@
+package ds.project.orino.planner.lifelog.moment.dto;
+
+/**
+ * 기록이 담긴 흐름 요약(카드에서 "이 기록이 어느 흐름에" 표시용).
+ */
+public record FlowRef(
+        Long id,
+        String title
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/dto/MomentCard.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/dto/MomentCard.java
@@ -1,0 +1,25 @@
+package ds.project.orino.planner.lifelog.moment.dto;
+
+import ds.project.orino.domain.planner.lifelog.entity.Mood;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 피드·상세 공통 응답 카드. 사진·태그·소속 흐름을 함께 담는다.
+ */
+public record MomentCard(
+        Long id,
+        Instant occurredAt,
+        String body,
+        Mood mood,
+        BigDecimal lat,
+        BigDecimal lng,
+        String placeName,
+        List<String> tags,
+        List<MomentPhotoResponse> photos,
+        List<FlowRef> flows,
+        Instant createdAt
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/dto/MomentPhotoRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/dto/MomentPhotoRequest.java
@@ -1,0 +1,32 @@
+package ds.project.orino.planner.lifelog.moment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * 기록에 붙일 사진 하나. objectKey/thumbKey는 사전 발급된 presigned 업로드로 이미 MinIO에 올라간
+ * 오브젝트를 가리킨다(#951). EXIF는 FE가 읽어 함께 보낸다.
+ *
+ * @param objectKey    MinIO 원본 key (필수)
+ * @param thumbKey     썸네일 key
+ * @param width        원본 너비(px)
+ * @param height       원본 높이(px)
+ * @param exifTakenAt  EXIF 촬영시각
+ * @param exifLat      EXIF GPS 위도
+ * @param exifLng      EXIF GPS 경도
+ * @param sortOrder    기록 내 사진 순서(없으면 0)
+ */
+public record MomentPhotoRequest(
+        @NotBlank
+        String objectKey,
+        String thumbKey,
+        Integer width,
+        Integer height,
+        Instant exifTakenAt,
+        BigDecimal exifLat,
+        BigDecimal exifLng,
+        Integer sortOrder
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/dto/MomentPhotoResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/dto/MomentPhotoResponse.java
@@ -1,0 +1,14 @@
+package ds.project.orino.planner.lifelog.moment.dto;
+
+/**
+ * 응답용 사진. key 대신 조립된 공개 URL을 준다.
+ */
+public record MomentPhotoResponse(
+        Long id,
+        String url,
+        String thumbUrl,
+        Integer width,
+        Integer height,
+        Integer sortOrder
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/dto/MomentWriteRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/dto/MomentWriteRequest.java
@@ -1,0 +1,33 @@
+package ds.project.orino.planner.lifelog.moment.dto;
+
+import ds.project.orino.domain.planner.lifelog.entity.Mood;
+import jakarta.validation.Valid;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 기록 생성·수정 공통 요청. 수정(PUT)은 사진·태그를 이 배열로 <b>전체 치환</b>한다.
+ *
+ * @param occurredAt 발생시각(없으면 서버 현재시각)
+ * @param body       본문
+ * @param mood       기분
+ * @param lat        위도 (lng와 함께 오거나 함께 없음)
+ * @param lng        경도
+ * @param placeName  장소명(FE가 역지오코딩 결과를 전달)
+ * @param tags       태그 목록(중복·공백은 서버가 정리)
+ * @param photos     사진 목록(순서 포함)
+ */
+public record MomentWriteRequest(
+        Instant occurredAt,
+        String body,
+        Mood mood,
+        BigDecimal lat,
+        BigDecimal lng,
+        String placeName,
+        List<String> tags,
+        @Valid
+        List<MomentPhotoRequest> photos
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/service/FeedCursor.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/service/FeedCursor.java
@@ -1,0 +1,41 @@
+package ds.project.orino.planner.lifelog.moment.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+
+/**
+ * 피드 커서. 마지막 항목의 {@code (occurredAt, id)}를 불투명 문자열로 인코딩한다.
+ * occurred_at은 DATETIME(6) micros 그대로 담아 정렬 tie-break가 정확히 이어지게 한다.
+ */
+public record FeedCursor(Instant occurredAt, long id) {
+
+    /** {@code {isoInstant}|{id}}를 base64url로. */
+    public String encode() {
+        String raw = occurredAt.toString() + "|" + id;
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** null/blank면 첫 페이지(null). 형식이 깨졌으면 400. */
+    public static FeedCursor decode(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+        try {
+            String raw = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
+            int sep = raw.lastIndexOf('|');
+            if (sep < 0) {
+                throw new IllegalArgumentException("커서 구분자 없음");
+            }
+            Instant at = Instant.parse(raw.substring(0, sep));
+            long id = Long.parseLong(raw.substring(sep + 1));
+            return new FeedCursor(at, id);
+        } catch (RuntimeException e) {
+            throw new CustomException(ErrorCode.BAD_REQUEST, e);
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/service/MomentCardAssembler.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/service/MomentCardAssembler.java
@@ -1,0 +1,118 @@
+package ds.project.orino.planner.lifelog.moment.service;
+
+import ds.project.orino.domain.planner.lifelog.entity.Flow;
+import ds.project.orino.domain.planner.lifelog.entity.FlowMoment;
+import ds.project.orino.domain.planner.lifelog.entity.Moment;
+import ds.project.orino.domain.planner.lifelog.entity.MomentPhoto;
+import ds.project.orino.domain.planner.lifelog.entity.MomentTag;
+import ds.project.orino.domain.planner.lifelog.repository.FlowMomentRepository;
+import ds.project.orino.domain.planner.lifelog.repository.FlowRepository;
+import ds.project.orino.domain.planner.lifelog.repository.MomentPhotoRepository;
+import ds.project.orino.domain.planner.lifelog.repository.MomentTagRepository;
+import ds.project.orino.planner.lifelog.image.service.LifelogImageStorageService;
+import ds.project.orino.planner.lifelog.moment.dto.FlowRef;
+import ds.project.orino.planner.lifelog.moment.dto.MomentCard;
+import ds.project.orino.planner.lifelog.moment.dto.MomentPhotoResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Moment 엔티티 목록을 {@link MomentCard}로 조립한다. 사진·태그·소속 흐름을 <b>배치로</b> 한 번에
+ * 읽어 N+1을 피한다(피드가 주 사용처).
+ */
+@Component
+public class MomentCardAssembler {
+
+    private final MomentPhotoRepository photoRepository;
+    private final MomentTagRepository tagRepository;
+    private final FlowMomentRepository flowMomentRepository;
+    private final FlowRepository flowRepository;
+    private final LifelogImageStorageService imageStorageService;
+
+    public MomentCardAssembler(MomentPhotoRepository photoRepository,
+                               MomentTagRepository tagRepository,
+                               FlowMomentRepository flowMomentRepository,
+                               FlowRepository flowRepository,
+                               LifelogImageStorageService imageStorageService) {
+        this.photoRepository = photoRepository;
+        this.tagRepository = tagRepository;
+        this.flowMomentRepository = flowMomentRepository;
+        this.flowRepository = flowRepository;
+        this.imageStorageService = imageStorageService;
+    }
+
+    public MomentCard toCard(Moment moment) {
+        return toCards(List.of(moment)).get(0);
+    }
+
+    /** 입력 순서를 유지하며 카드로 변환한다. */
+    public List<MomentCard> toCards(List<Moment> moments) {
+        if (moments.isEmpty()) {
+            return List.of();
+        }
+        List<Long> momentIds = moments.stream().map(Moment::getId).toList();
+
+        Map<Long, List<MomentPhoto>> photosByMoment =
+                photoRepository.findAllByMomentIdInOrderBySortOrderAscIdAsc(momentIds).stream()
+                        .collect(Collectors.groupingBy(MomentPhoto::getMomentId));
+
+        Map<Long, List<MomentTag>> tagsByMoment =
+                tagRepository.findAllByMomentIdIn(momentIds).stream()
+                        .collect(Collectors.groupingBy(MomentTag::getMomentId));
+
+        List<FlowMoment> memberships = flowMomentRepository.findAllByMomentIdIn(momentIds);
+        Map<Long, String> flowTitles = flowRepository.findAllById(
+                        memberships.stream().map(FlowMoment::getFlowId).distinct().toList()).stream()
+                .collect(Collectors.toMap(Flow::getId, Flow::getTitle));
+        Map<Long, List<FlowMoment>> flowsByMoment =
+                memberships.stream().collect(Collectors.groupingBy(FlowMoment::getMomentId));
+
+        return moments.stream()
+                .map(m -> new MomentCard(
+                        m.getId(),
+                        m.getOccurredAt(),
+                        m.getBody(),
+                        m.getMood(),
+                        m.getLat(),
+                        m.getLng(),
+                        m.getPlaceName(),
+                        tagNames(tagsByMoment.get(m.getId())),
+                        photoResponses(photosByMoment.get(m.getId())),
+                        flowRefs(flowsByMoment.get(m.getId()), flowTitles),
+                        m.getCreatedAt()))
+                .toList();
+    }
+
+    private List<String> tagNames(List<MomentTag> tags) {
+        return tags == null ? List.of() : tags.stream().map(MomentTag::getName).toList();
+    }
+
+    private List<MomentPhotoResponse> photoResponses(List<MomentPhoto> photos) {
+        if (photos == null) {
+            return List.of();
+        }
+        return photos.stream()
+                .map(p -> new MomentPhotoResponse(
+                        p.getId(),
+                        imageStorageService.toPublicUrl(p.getObjectKey()),
+                        imageStorageService.toPublicUrl(p.getThumbKey()),
+                        p.getWidth(),
+                        p.getHeight(),
+                        p.getSortOrder()))
+                .toList();
+    }
+
+    private List<FlowRef> flowRefs(List<FlowMoment> memberships, Map<Long, String> flowTitles) {
+        if (memberships == null) {
+            return List.of();
+        }
+        return memberships.stream()
+                .map(FlowMoment::getFlowId)
+                .map(id -> new FlowRef(id, flowTitles.get(id)))
+                .filter(ref -> ref.title() != null)
+                .toList();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/service/MomentService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/moment/service/MomentService.java
@@ -1,0 +1,206 @@
+package ds.project.orino.planner.lifelog.moment.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.lifelog.entity.Moment;
+import ds.project.orino.domain.planner.lifelog.entity.MomentPhoto;
+import ds.project.orino.domain.planner.lifelog.entity.MomentTag;
+import ds.project.orino.domain.planner.lifelog.repository.MomentPhotoRepository;
+import ds.project.orino.domain.planner.lifelog.repository.MomentRepository;
+import ds.project.orino.domain.planner.lifelog.repository.MomentTagRepository;
+import ds.project.orino.planner.lifelog.image.service.LifelogImageStorageService;
+import ds.project.orino.planner.lifelog.moment.dto.FeedResponse;
+import ds.project.orino.planner.lifelog.moment.dto.MomentCard;
+import ds.project.orino.planner.lifelog.moment.dto.MomentPhotoRequest;
+import ds.project.orino.planner.lifelog.moment.dto.MomentWriteRequest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 기록(Moment) CRUD·피드. 사진·태그는 별도 테이블에 저장하고 카드 조립은 {@link MomentCardAssembler}가
+ * 배치로 한다. 사진 삭제는 DB CASCADE로 행이 지워진 뒤 MinIO 오브젝트를 best-effort로 정리한다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class MomentService {
+
+    private static final int DEFAULT_FEED_SIZE = 20;
+    private static final int MAX_FEED_SIZE = 50;
+
+    private final MomentRepository momentRepository;
+    private final MomentPhotoRepository photoRepository;
+    private final MomentTagRepository tagRepository;
+    private final MomentCardAssembler assembler;
+    private final LifelogImageStorageService imageStorageService;
+    private final Clock clock;
+
+    public MomentService(MomentRepository momentRepository,
+                         MomentPhotoRepository photoRepository,
+                         MomentTagRepository tagRepository,
+                         MomentCardAssembler assembler,
+                         LifelogImageStorageService imageStorageService,
+                         Clock clock) {
+        this.momentRepository = momentRepository;
+        this.photoRepository = photoRepository;
+        this.tagRepository = tagRepository;
+        this.assembler = assembler;
+        this.imageStorageService = imageStorageService;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public MomentCard create(Long memberId, MomentWriteRequest request) {
+        validate(request);
+        Instant occurredAt = request.occurredAt() != null ? request.occurredAt() : clock.instant();
+
+        Moment moment = momentRepository.save(new Moment(
+                memberId, occurredAt, blankToNull(request.body()), request.mood(),
+                request.lat(), request.lng(), blankToNull(request.placeName())));
+
+        savePhotos(moment.getId(), request.photos());
+        saveTags(moment.getId(), request.tags());
+        return assembler.toCard(moment);
+    }
+
+    public MomentCard findOne(Long memberId, Long momentId) {
+        return assembler.toCard(getOwned(memberId, momentId));
+    }
+
+    public FeedResponse feed(Long memberId, String cursor, Integer size,
+                             String tag, Instant from, Instant to) {
+        int limit = clampSize(size);
+        FeedCursor decoded = FeedCursor.decode(cursor);
+
+        List<Moment> rows = momentRepository.findFeed(
+                memberId, from, to, blankToNull(tag),
+                decoded == null ? null : decoded.occurredAt(),
+                decoded == null ? null : decoded.id(),
+                PageRequest.of(0, limit + 1));
+
+        String nextCursor = null;
+        if (rows.size() > limit) {
+            Moment last = rows.get(limit - 1);
+            nextCursor = new FeedCursor(last.getOccurredAt(), last.getId()).encode();
+            rows = rows.subList(0, limit);
+        }
+        return new FeedResponse(assembler.toCards(rows), nextCursor);
+    }
+
+    @Transactional
+    public MomentCard update(Long memberId, Long momentId, MomentWriteRequest request) {
+        validate(request);
+        Moment moment = getOwned(memberId, momentId);
+        Instant occurredAt = request.occurredAt() != null ? request.occurredAt() : moment.getOccurredAt();
+        moment.update(occurredAt, blankToNull(request.body()), request.mood(),
+                request.lat(), request.lng(), blankToNull(request.placeName()));
+
+        // 사진·태그 전체 치환. 제거된 오브젝트 key는 MinIO에서 best-effort로 지운다.
+        Set<String> oldKeys = collectKeys(photoRepository.findAllByMomentIdOrderBySortOrderAscIdAsc(momentId));
+        photoRepository.deleteByMomentId(momentId);
+        tagRepository.deleteByMomentId(momentId);
+        savePhotos(momentId, request.photos());
+        saveTags(momentId, request.tags());
+
+        Set<String> newKeys = collectKeys(photoRepository.findAllByMomentIdOrderBySortOrderAscIdAsc(momentId));
+        oldKeys.removeAll(newKeys);
+        imageStorageService.deleteObjects(oldKeys);
+
+        return assembler.toCard(moment);
+    }
+
+    @Transactional
+    public void delete(Long memberId, Long momentId) {
+        Moment moment = getOwned(memberId, momentId);
+        Set<String> keys = collectKeys(photoRepository.findAllByMomentIdOrderBySortOrderAscIdAsc(momentId));
+        // DB FK CASCADE로 사진·태그·흐름소속 행이 함께 지워진다.
+        momentRepository.delete(moment);
+        imageStorageService.deleteObjects(keys);
+    }
+
+    /** 태그 자동완성 — 멤버가 쓴 태그 중 접두어 일치(중복 제거·정렬). */
+    public List<String> autocompleteTags(Long memberId, String query) {
+        String prefix = query == null ? "" : query.trim();
+        return tagRepository.findDistinctNamesByMemberIdAndPrefix(memberId, prefix + "%");
+    }
+
+    private Moment getOwned(Long memberId, Long momentId) {
+        return momentRepository.findByIdAndMemberId(momentId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.LIFELOG_MOMENT_NOT_FOUND));
+    }
+
+    private void validate(MomentWriteRequest request) {
+        boolean hasLat = request.lat() != null;
+        boolean hasLng = request.lng() != null;
+        if (hasLat != hasLng) {
+            throw new CustomException(ErrorCode.LIFELOG_INVALID_COORDINATE);
+        }
+        boolean noBody = blankToNull(request.body()) == null;
+        boolean noPhotos = request.photos() == null || request.photos().isEmpty();
+        if (noBody && noPhotos) {
+            throw new CustomException(ErrorCode.LIFELOG_EMPTY_MOMENT);
+        }
+    }
+
+    private void savePhotos(Long momentId, List<MomentPhotoRequest> photos) {
+        if (photos == null || photos.isEmpty()) {
+            return;
+        }
+        List<MomentPhoto> entities = new ArrayList<>();
+        for (int i = 0; i < photos.size(); i++) {
+            MomentPhotoRequest p = photos.get(i);
+            int sortOrder = p.sortOrder() != null ? p.sortOrder() : i;
+            entities.add(new MomentPhoto(momentId, p.objectKey(), p.thumbKey(),
+                    p.width(), p.height(), p.exifTakenAt(), p.exifLat(), p.exifLng(), sortOrder));
+        }
+        photoRepository.saveAll(entities);
+    }
+
+    private void saveTags(Long momentId, List<String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return;
+        }
+        Set<String> seen = new LinkedHashSet<>();
+        for (String tag : tags) {
+            if (tag == null) {
+                continue;
+            }
+            String trimmed = tag.trim();
+            if (!trimmed.isEmpty()) {
+                seen.add(trimmed);
+            }
+        }
+        List<MomentTag> entities = seen.stream().map(name -> new MomentTag(momentId, name)).toList();
+        tagRepository.saveAll(entities);
+    }
+
+    private Set<String> collectKeys(List<MomentPhoto> photos) {
+        Set<String> keys = new HashSet<>();
+        for (MomentPhoto p : photos) {
+            keys.add(p.getObjectKey());
+            if (p.getThumbKey() != null) {
+                keys.add(p.getThumbKey());
+            }
+        }
+        return keys;
+    }
+
+    private int clampSize(Integer size) {
+        if (size == null) {
+            return DEFAULT_FEED_SIZE;
+        }
+        return Math.max(1, Math.min(MAX_FEED_SIZE, size));
+    }
+
+    private String blankToNull(String s) {
+        return (s == null || s.isBlank()) ? null : s;
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/lifelog/moment/controller/MomentControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/lifelog/moment/controller/MomentControllerTest.java
@@ -1,0 +1,275 @@
+package ds.project.orino.planner.lifelog.moment.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 기록 CRUD·피드·태그 자동완성 통합 테스트. 사진 삭제(MinIO)는 별도 유닛 테스트(#951)가 다루므로
+ * 여기서는 삭제/수정 시 <b>제거되는 사진 key가 없도록</b> 시나리오를 짜 외부 호출 없이 검증한다.
+ */
+class MomentControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private Member otherMember;
+    private String authHeader;
+    private String otherAuthHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        otherMember = memberRepository.save(MemberFixture.create("other", "password"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        otherAuthHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+    }
+
+    // ---------------- create ----------------
+
+    @Test
+    @DisplayName("POST /moments - 사진·태그·위치·기분을 담은 리치 카드를 만든다")
+    void createRichMoment() throws Exception {
+        postMoment(authHeader, """
+                {
+                  "occurredAt": "2026-07-20T05:30:00Z",
+                  "body": "성산일출봉 정상",
+                  "mood": "EXCITED",
+                  "lat": 33.4580000, "lng": 126.9420000,
+                  "placeName": "성산일출봉",
+                  "tags": ["제주", "여행", "제주"],
+                  "photos": [
+                    {"objectKey": "lifelog/moments/1/a.jpg", "thumbKey": "lifelog/thumbs/1/a.jpg", "sortOrder": 0}
+                  ]
+                }
+                """)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.body").value("성산일출봉 정상"))
+                .andExpect(jsonPath("$.data.mood").value("EXCITED"))
+                .andExpect(jsonPath("$.data.placeName").value("성산일출봉"))
+                .andExpect(jsonPath("$.data.tags", hasSize(2)))
+                .andExpect(jsonPath("$.data.photos", hasSize(1)))
+                .andExpect(jsonPath("$.data.photos[0].url",
+                        startsWith("https://img.orino.dev/note-images/lifelog/moments/")))
+                .andExpect(jsonPath("$.data.photos[0].thumbUrl", containsString("lifelog/thumbs/")))
+                .andExpect(jsonPath("$.data.flows", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("POST /moments - 사진 없는 텍스트 기록도 만든다")
+    void createTextOnly() throws Exception {
+        postMoment(authHeader, """
+                {"body": "오늘 커피 맛있었다"}
+                """)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.body").value("오늘 커피 맛있었다"))
+                .andExpect(jsonPath("$.data.occurredAt").exists());
+    }
+
+    @Test
+    @DisplayName("POST /moments - 본문·사진 모두 없으면 400")
+    void rejectEmpty() throws Exception {
+        postMoment(authHeader, """
+                {"tags": ["빈것"]}
+                """)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("LIFELOG-ERR-003"));
+    }
+
+    @Test
+    @DisplayName("POST /moments - 위도만 있으면 400")
+    void rejectCoordMismatch() throws Exception {
+        postMoment(authHeader, """
+                {"body": "x", "lat": 33.45}
+                """)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("LIFELOG-ERR-004"));
+    }
+
+    // ---------------- feed ----------------
+
+    @Test
+    @DisplayName("GET /moments - 역시간순 + 커서 페이지네이션")
+    void feedOrderAndCursor() throws Exception {
+        create("""
+                {"body": "A", "occurredAt": "2026-07-20T01:00:00Z"}""");
+        create("""
+                {"body": "B", "occurredAt": "2026-07-20T02:00:00Z"}""");
+        create("""
+                {"body": "C", "occurredAt": "2026-07-20T03:00:00Z"}""");
+
+        String body = mockMvc.perform(get("/api/lifelog/moments").param("size", "2")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(2)))
+                .andExpect(jsonPath("$.data.items[0].body").value("C"))
+                .andExpect(jsonPath("$.data.items[1].body").value("B"))
+                .andExpect(jsonPath("$.data.nextCursor").exists())
+                .andReturn().getResponse().getContentAsString();
+
+        String cursor = JsonPath.read(body, "$.data.nextCursor");
+        mockMvc.perform(get("/api/lifelog/moments").param("size", "2").param("cursor", cursor)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.items[0].body").value("A"))
+                .andExpect(jsonPath("$.data.nextCursor").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET /moments?tag= - 태그로 필터한다")
+    void feedTagFilter() throws Exception {
+        create("""
+                {"body": "제주기록", "tags": ["제주"]}""");
+        create("""
+                {"body": "그냥기록", "tags": ["일상"]}""");
+
+        mockMvc.perform(get("/api/lifelog/moments").param("tag", "제주")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.items[0].body").value("제주기록"));
+    }
+
+    // ---------------- findOne / scope ----------------
+
+    @Test
+    @DisplayName("GET /moments/{id} - 조회, 다른 멤버는 404")
+    void findOneScoped() throws Exception {
+        long id = create("""
+                {"body": "내 기록"}""");
+
+        mockMvc.perform(get("/api/lifelog/moments/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.body").value("내 기록"));
+
+        mockMvc.perform(get("/api/lifelog/moments/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("LIFELOG-ERR-002"));
+    }
+
+    // ---------------- update ----------------
+
+    @Test
+    @DisplayName("PUT /moments/{id} - 본문·태그·사진을 치환한다(제거 사진 없음)")
+    void updateReplaces() throws Exception {
+        long id = create("""
+                {"body": "원본", "tags": ["old"]}""");
+
+        mockMvc.perform(put("/api/lifelog/moments/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "body": "수정본",
+                                  "tags": ["new1", "new2"],
+                                  "photos": [{"objectKey": "lifelog/moments/1/z.jpg", "sortOrder": 0}]
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.body").value("수정본"))
+                .andExpect(jsonPath("$.data.tags", hasSize(2)))
+                .andExpect(jsonPath("$.data.photos", hasSize(1)));
+    }
+
+    // ---------------- delete ----------------
+
+    @Test
+    @DisplayName("DELETE /moments/{id} - 삭제 후 404 (사진 없는 기록)")
+    void deleteMoment() throws Exception {
+        long id = create("""
+                {"body": "지울것", "tags": ["t"]}""");
+
+        mockMvc.perform(delete("/api/lifelog/moments/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/lifelog/moments/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("DELETE /moments/{id} - 다른 멤버는 404, 기록은 남는다")
+    void deleteScoped() throws Exception {
+        long id = create("""
+                {"body": "내것"}""");
+
+        mockMvc.perform(delete("/api/lifelog/moments/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/api/lifelog/moments/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+    }
+
+    // ---------------- tags autocomplete ----------------
+
+    @Test
+    @DisplayName("GET /tags?q= - 멤버가 쓴 태그 접두어 자동완성(중복 제거)")
+    void tagAutocomplete() throws Exception {
+        create("""
+                {"body": "a", "tags": ["제주", "여행"]}""");
+        create("""
+                {"body": "b", "tags": ["제주", "제주도"]}""");
+
+        mockMvc.perform(get("/api/lifelog/tags").param("q", "제주")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0]").value("제주"))
+                .andExpect(jsonPath("$.data[1]").value("제주도"));
+    }
+
+    // ---------------- auth ----------------
+
+    @Test
+    @DisplayName("GET /moments - 인증 없으면 401")
+    void requiresAuth() throws Exception {
+        mockMvc.perform(get("/api/lifelog/moments"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ---------------- helpers ----------------
+
+    private ResultActions postMoment(String auth, String json) throws Exception {
+        return mockMvc.perform(post("/api/lifelog/moments")
+                .header(HttpHeaders.AUTHORIZATION, auth)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json));
+    }
+
+    private long create(String json) throws Exception {
+        String body = postMoment(authHeader, json)
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/lifelog/moment/service/FeedCursorTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/lifelog/moment/service/FeedCursorTest.java
@@ -1,0 +1,41 @@
+package ds.project.orino.planner.lifelog.moment.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FeedCursorTest {
+
+    @Test
+    @DisplayName("encode/decode 왕복 - micros 정밀도까지 보존한다")
+    void roundTripPreservesMicros() {
+        FeedCursor original = new FeedCursor(Instant.parse("2026-07-20T05:30:00.123456Z"), 4242L);
+
+        FeedCursor decoded = FeedCursor.decode(original.encode());
+
+        assertThat(decoded.occurredAt()).isEqualTo(Instant.parse("2026-07-20T05:30:00.123456Z"));
+        assertThat(decoded.id()).isEqualTo(4242L);
+    }
+
+    @Test
+    @DisplayName("null/blank는 첫 페이지(null)")
+    void nullMeansFirstPage() {
+        assertThat(FeedCursor.decode(null)).isNull();
+        assertThat(FeedCursor.decode("  ")).isNull();
+    }
+
+    @Test
+    @DisplayName("깨진 커서는 400")
+    void invalidCursorIsBadRequest() {
+        assertThatThrownBy(() -> FeedCursor.decode("!!!not-base64!!!"))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAD_REQUEST);
+    }
+}

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -27,7 +27,10 @@ public enum ErrorCode {
     GOOGLE_INVALID_GRANT("PLN-ERR-005", "Google 연동이 만료되어 재연결이 필요합니다.", 401),
 
     // LIFELOG (일상기록)
-    LIFELOG_GEOCODING_FAILED("LIFELOG-ERR-001", "장소 정보를 가져오지 못했습니다.", 502);
+    LIFELOG_GEOCODING_FAILED("LIFELOG-ERR-001", "장소 정보를 가져오지 못했습니다.", 502),
+    LIFELOG_MOMENT_NOT_FOUND("LIFELOG-ERR-002", "존재하지 않는 기록입니다.", 404),
+    LIFELOG_EMPTY_MOMENT("LIFELOG-ERR-003", "본문이나 사진 중 하나는 있어야 합니다.", 400),
+    LIFELOG_INVALID_COORDINATE("LIFELOG-ERR-004", "위도와 경도는 함께 지정해야 합니다.", 400);
 
     private final String code;
     private final String message;

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/FlowMomentRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/FlowMomentRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,6 +16,9 @@ public interface FlowMomentRepository extends JpaRepository<FlowMoment, Long> {
 
     /** "이 기록이 담긴 흐름" 역조회. */
     List<FlowMoment> findAllByMomentId(Long momentId);
+
+    /** 피드 배치 로딩: 여러 기록의 소속 흐름을 한 번에. */
+    List<FlowMoment> findAllByMomentIdIn(Collection<Long> momentIds);
 
     boolean existsByFlowIdAndMomentId(Long flowId, Long momentId);
 

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/MomentRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/MomentRepository.java
@@ -1,8 +1,12 @@
 package ds.project.orino.domain.planner.lifelog.repository;
 
 import ds.project.orino.domain.planner.lifelog.entity.Moment;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,6 +14,30 @@ public interface MomentRepository extends JpaRepository<Moment, Long> {
 
     Optional<Moment> findByIdAndMemberId(Long id, Long memberId);
 
-    /** 피드 기본 정렬(역시간순). 커서 페이지네이션은 #952에서 얹는다. */
+    /** 피드 기본 정렬(역시간순). 커서 페이지네이션은 {@link #findFeed}를 쓴다. */
     List<Moment> findAllByMemberIdOrderByOccurredAtDescIdDesc(Long memberId);
+
+    /**
+     * 피드 커서 페이지네이션. 역시간순(occurred_at DESC, id DESC), 선택 필터(tag·기간).
+     * 커서는 {@code (cursorAt, cursorId)} — null이면 첫 페이지. limit은 {@code pageable}로 준다.
+     */
+    @Query("""
+            SELECT m FROM Moment m
+            WHERE m.memberId = :memberId
+              AND (:from IS NULL OR m.occurredAt >= :from)
+              AND (:to IS NULL OR m.occurredAt <= :to)
+              AND (:tag IS NULL OR EXISTS (
+                    SELECT 1 FROM MomentTag t WHERE t.momentId = m.id AND t.name = :tag))
+              AND (:cursorAt IS NULL
+                    OR m.occurredAt < :cursorAt
+                    OR (m.occurredAt = :cursorAt AND m.id < :cursorId))
+            ORDER BY m.occurredAt DESC, m.id DESC
+            """)
+    List<Moment> findFeed(@Param("memberId") Long memberId,
+                          @Param("from") Instant from,
+                          @Param("to") Instant to,
+                          @Param("tag") String tag,
+                          @Param("cursorAt") Instant cursorAt,
+                          @Param("cursorId") Long cursorId,
+                          Pageable pageable);
 }


### PR DESCRIPTION
## 이슈
closes #952

## 작업 내용
- **`POST /api/lifelog/moments`** — 사진(다중)·본문·발생시각·위치·기분·태그. 빈 기록·좌표 짝 검증
- **`GET /api/lifelog/moments`** — 역시간순 **커서 페이지네이션**(`occurred_at, id`) + 선택 필터 `tag`·기간(`from`/`to`)
- **`GET/PUT/DELETE /api/lifelog/moments/{id}`** — PUT은 사진·태그 **전체 치환**, DELETE는 DB FK CASCADE로 사진·태그·흐름소속 제거
- **`GET /api/lifelog/tags?q=`** — 멤버가 쓴 태그 접두어 자동완성(DISTINCT)
- **`MomentCardAssembler`** — 사진·태그·소속 흐름을 배치 로딩해 N+1 회피
- **사진 정리** — 삭제/수정 시 제거된 object key를 #951 `deleteObjects`로 best-effort 삭제(공개 URL은 `toPublicUrl`로 조립)
- 커서는 `(occurredAt, id)`를 base64url로 인코딩, DATETIME(6) micros 정밀도 보존
- 신규 에러코드 `LIFELOG-ERR-002/003/004`

## 테스트
- `MomentControllerTest` (13, 통합/TestContainers) — 리치 생성·텍스트 생성·빈/좌표 검증·피드 순서·커서 2페이지·태그 필터·조회 스코프·수정 치환·삭제(404)·삭제 스코프·태그 자동완성·인증
- `FeedCursorTest` (3) — 왕복 micros 정밀도·null 첫페이지·깨진 커서 400
- ⚠️ 삭제/수정 통합 테스트는 **제거 사진 key가 없도록** 설계해 MinIO 외부 호출 없이 검증(사진 삭제 로직은 #951 유닛 커버). checkstyle 통과

Epic: #949 · 다음: #953(Flow API), #955(FE 피드)