### PR TITLE
feat : 일상기록 Flow CRUD + 담기/빼기/정렬 API

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/controller/FlowController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/controller/FlowController.java
@@ -1,0 +1,92 @@
+package ds.project.orino.planner.lifelog.flow.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.domain.planner.lifelog.entity.FlowStatus;
+import ds.project.orino.planner.lifelog.flow.dto.AddMomentsRequest;
+import ds.project.orino.planner.lifelog.flow.dto.FlowCreateRequest;
+import ds.project.orino.planner.lifelog.flow.dto.FlowDetail;
+import ds.project.orino.planner.lifelog.flow.dto.FlowSummary;
+import ds.project.orino.planner.lifelog.flow.dto.FlowUpdateRequest;
+import ds.project.orino.planner.lifelog.flow.dto.ReorderMomentsRequest;
+import ds.project.orino.planner.lifelog.flow.service.FlowService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/lifelog/flows")
+public class FlowController {
+
+    private final FlowService flowService;
+
+    public FlowController(FlowService flowService) {
+        this.flowService = flowService;
+    }
+
+    @PostMapping
+    public ApiResponse<FlowSummary> create(@AuthenticationPrincipal Long memberId,
+                                           @Valid @RequestBody FlowCreateRequest request) {
+        return ApiResponse.success(flowService.create(memberId, request));
+    }
+
+    @GetMapping
+    public ApiResponse<List<FlowSummary>> list(@AuthenticationPrincipal Long memberId,
+                                               @RequestParam(required = false) FlowStatus status) {
+        return ApiResponse.success(flowService.list(memberId, status));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<FlowDetail> detail(@AuthenticationPrincipal Long memberId,
+                                          @PathVariable Long id) {
+        return ApiResponse.success(flowService.detail(memberId, id));
+    }
+
+    @PutMapping("/{id}")
+    public ApiResponse<FlowSummary> update(@AuthenticationPrincipal Long memberId,
+                                           @PathVariable Long id,
+                                           @Valid @RequestBody FlowUpdateRequest request) {
+        return ApiResponse.success(flowService.update(memberId, id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> delete(@AuthenticationPrincipal Long memberId,
+                                    @PathVariable Long id) {
+        flowService.delete(memberId, id);
+        return ApiResponse.success();
+    }
+
+    /** 기록 담기(단건/다건, 멱등). */
+    @PostMapping("/{id}/moments")
+    public ApiResponse<FlowDetail> addMoments(@AuthenticationPrincipal Long memberId,
+                                              @PathVariable Long id,
+                                              @RequestBody AddMomentsRequest request) {
+        return ApiResponse.success(flowService.addMoments(memberId, id, request.allMomentIds()));
+    }
+
+    /** 기록 빼기 — 소속만 제거, 기록은 보존. */
+    @DeleteMapping("/{id}/moments/{momentId}")
+    public ApiResponse<Void> removeMoment(@AuthenticationPrincipal Long memberId,
+                                          @PathVariable Long id,
+                                          @PathVariable Long momentId) {
+        flowService.removeMoment(memberId, id, momentId);
+        return ApiResponse.success();
+    }
+
+    /** 흐름 내 순서 조정. */
+    @PutMapping("/{id}/moments/order")
+    public ApiResponse<FlowDetail> reorder(@AuthenticationPrincipal Long memberId,
+                                           @PathVariable Long id,
+                                           @Valid @RequestBody ReorderMomentsRequest request) {
+        return ApiResponse.success(flowService.reorder(memberId, id, request.momentIds()));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/dto/AddMomentsRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/dto/AddMomentsRequest.java
@@ -1,0 +1,26 @@
+package ds.project.orino.planner.lifelog.flow.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 흐름에 기록 담기. 단건({@code momentId}) 또는 다건({@code momentIds}) 어느 쪽으로도 보낼 수 있다.
+ * 서버가 둘을 합쳐 처리하며, 이미 담긴 기록·소유가 아닌 기록은 무시한다(멱등).
+ */
+public record AddMomentsRequest(
+        Long momentId,
+        List<Long> momentIds
+) {
+
+    /** 단건·다건을 하나로 합친다. */
+    public List<Long> allMomentIds() {
+        List<Long> ids = new ArrayList<>();
+        if (momentId != null) {
+            ids.add(momentId);
+        }
+        if (momentIds != null) {
+            ids.addAll(momentIds);
+        }
+        return ids;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/dto/FlowCreateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/dto/FlowCreateRequest.java
@@ -1,0 +1,16 @@
+package ds.project.orino.planner.lifelog.flow.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 흐름 생성 요청.
+ *
+ * @param title       흐름 제목(필수)
+ * @param description 설명
+ */
+public record FlowCreateRequest(
+        @NotBlank
+        String title,
+        String description
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/dto/FlowDetail.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/dto/FlowDetail.java
@@ -1,0 +1,22 @@
+package ds.project.orino.planner.lifelog.flow.dto;
+
+import ds.project.orino.domain.planner.lifelog.entity.FlowStatus;
+import ds.project.orino.planner.lifelog.moment.dto.MomentCard;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 흐름 상세. 담긴 기록을 순서(sort_order 우선, 동률이면 occurred_at)대로 카드로 담는다.
+ */
+public record FlowDetail(
+        Long id,
+        String title,
+        String description,
+        String coverUrl,
+        Instant startedAt,
+        Instant endedAt,
+        FlowStatus status,
+        List<MomentCard> moments
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/dto/FlowSummary.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/dto/FlowSummary.java
@@ -1,0 +1,20 @@
+package ds.project.orino.planner.lifelog.flow.dto;
+
+import ds.project.orino.domain.planner.lifelog.entity.FlowStatus;
+
+import java.time.Instant;
+
+/**
+ * 흐름 목록 카드. 기간은 담긴 기록에서 유도해 저장된 값, 커버는 없으면 담긴 첫 사진.
+ */
+public record FlowSummary(
+        Long id,
+        String title,
+        String description,
+        String coverUrl,
+        Instant startedAt,
+        Instant endedAt,
+        long momentCount,
+        FlowStatus status
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/dto/FlowUpdateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/dto/FlowUpdateRequest.java
@@ -1,0 +1,23 @@
+package ds.project.orino.planner.lifelog.flow.dto;
+
+import ds.project.orino.domain.planner.lifelog.entity.FlowStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 흐름 수정 요청. 기간(started/ended)은 담긴 기록에서 유도하므로 여기서 받지 않는다.
+ *
+ * @param title           제목(필수)
+ * @param description     설명
+ * @param coverObjectKey  커버 이미지 key(비우면 담긴 첫 사진으로 대체 표시)
+ * @param status          ACTIVE/ARCHIVED
+ */
+public record FlowUpdateRequest(
+        @NotBlank
+        String title,
+        String description,
+        String coverObjectKey,
+        @NotNull
+        FlowStatus status
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/dto/ReorderMomentsRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/dto/ReorderMomentsRequest.java
@@ -1,0 +1,14 @@
+package ds.project.orino.planner.lifelog.flow.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+/**
+ * 흐름 내 순서 조정. 이 목록 순서대로 sort_order를 재기록한다(목록에 없는 소속은 뒤로 밀린다).
+ */
+public record ReorderMomentsRequest(
+        @NotNull
+        List<Long> momentIds
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/service/FlowService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/lifelog/flow/service/FlowService.java
@@ -1,0 +1,275 @@
+package ds.project.orino.planner.lifelog.flow.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.lifelog.entity.Flow;
+import ds.project.orino.domain.planner.lifelog.entity.FlowMoment;
+import ds.project.orino.domain.planner.lifelog.entity.FlowStatus;
+import ds.project.orino.domain.planner.lifelog.entity.Moment;
+import ds.project.orino.domain.planner.lifelog.entity.MomentPhoto;
+import ds.project.orino.domain.planner.lifelog.repository.FlowMomentRepository;
+import ds.project.orino.domain.planner.lifelog.repository.FlowRepository;
+import ds.project.orino.domain.planner.lifelog.repository.MomentPhotoRepository;
+import ds.project.orino.domain.planner.lifelog.repository.MomentRepository;
+import ds.project.orino.planner.lifelog.flow.dto.FlowCreateRequest;
+import ds.project.orino.planner.lifelog.flow.dto.FlowDetail;
+import ds.project.orino.planner.lifelog.flow.dto.FlowSummary;
+import ds.project.orino.planner.lifelog.flow.dto.FlowUpdateRequest;
+import ds.project.orino.planner.lifelog.image.service.LifelogImageStorageService;
+import ds.project.orino.planner.lifelog.moment.dto.MomentCard;
+import ds.project.orino.planner.lifelog.moment.dto.MomentPhotoResponse;
+import ds.project.orino.planner.lifelog.moment.service.MomentCardAssembler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 흐름(Flow) CRUD와 N:M 담기/빼기/순서 조정.
+ *
+ * <p>순서 규칙: {@code sort_order} 오름차순, 동률이면 {@code occurred_at} — 즉 <b>기본은 시간순 서사</b>,
+ * 사용자가 순서를 바꾸면(reorder) sort_order가 우선한다. 기간(started/ended)은 담긴 기록에서 유도해
+ * 저장하고, 커버는 없으면 담긴 첫(시간순) 사진으로 대체한다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class FlowService {
+
+    private final FlowRepository flowRepository;
+    private final FlowMomentRepository flowMomentRepository;
+    private final MomentRepository momentRepository;
+    private final MomentPhotoRepository photoRepository;
+    private final MomentCardAssembler assembler;
+    private final LifelogImageStorageService imageStorageService;
+
+    public FlowService(FlowRepository flowRepository,
+                       FlowMomentRepository flowMomentRepository,
+                       MomentRepository momentRepository,
+                       MomentPhotoRepository photoRepository,
+                       MomentCardAssembler assembler,
+                       LifelogImageStorageService imageStorageService) {
+        this.flowRepository = flowRepository;
+        this.flowMomentRepository = flowMomentRepository;
+        this.momentRepository = momentRepository;
+        this.photoRepository = photoRepository;
+        this.assembler = assembler;
+        this.imageStorageService = imageStorageService;
+    }
+
+    @Transactional
+    public FlowSummary create(Long memberId, FlowCreateRequest request) {
+        Flow flow = flowRepository.save(new Flow(memberId, request.title(), request.description()));
+        return new FlowSummary(flow.getId(), flow.getTitle(), flow.getDescription(),
+                null, null, null, 0, flow.getStatus());
+    }
+
+    public List<FlowSummary> list(Long memberId, FlowStatus status) {
+        List<Flow> flows = status == null
+                ? flowRepository.findAllByMemberIdOrderByStartedAtDescIdDesc(memberId)
+                : flowRepository.findAllByMemberIdAndStatusOrderByStartedAtDescIdDesc(memberId, status);
+        return buildSummaries(flows);
+    }
+
+    public FlowDetail detail(Long memberId, Long flowId) {
+        Flow flow = getOwned(memberId, flowId);
+        List<Moment> ordered = orderedMoments(flowId);
+        List<MomentCard> cards = assembler.toCards(ordered);
+        return new FlowDetail(flow.getId(), flow.getTitle(), flow.getDescription(),
+                resolveCoverUrl(flow, cards), flow.getStartedAt(), flow.getEndedAt(),
+                flow.getStatus(), cards);
+    }
+
+    @Transactional
+    public FlowSummary update(Long memberId, Long flowId, FlowUpdateRequest request) {
+        Flow flow = getOwned(memberId, flowId);
+        // 기간은 담긴 기록에서 유도된 값 유지(사용자가 직접 바꾸지 않는다).
+        flow.update(request.title(), request.description(), request.coverObjectKey(),
+                flow.getStartedAt(), flow.getEndedAt(), request.status());
+        return summaryOf(flow, flowMomentRepository.findAllByFlowIdOrderBySortOrderAscIdAsc(flowId).size());
+    }
+
+    /** 흐름 삭제 — flow_moment만 CASCADE로 제거되고 담겼던 기록은 보존된다. */
+    @Transactional
+    public void delete(Long memberId, Long flowId) {
+        flowRepository.delete(getOwned(memberId, flowId));
+    }
+
+    @Transactional
+    public FlowDetail addMoments(Long memberId, Long flowId, Collection<Long> requestedMomentIds) {
+        getOwned(memberId, flowId);
+        for (Long momentId : dedupe(requestedMomentIds)) {
+            // 소유한 기록만, 이미 담긴 건 건너뛴다(멱등).
+            boolean owned = momentRepository.findByIdAndMemberId(momentId, memberId).isPresent();
+            if (owned && !flowMomentRepository.existsByFlowIdAndMomentId(flowId, momentId)) {
+                flowMomentRepository.save(new FlowMoment(flowId, momentId, 0));
+            }
+        }
+        recomputePeriod(flowId);
+        return detail(memberId, flowId);
+    }
+
+    @Transactional
+    public void removeMoment(Long memberId, Long flowId, Long momentId) {
+        getOwned(memberId, flowId);
+        flowMomentRepository.deleteByFlowIdAndMomentId(flowId, momentId);
+        recomputePeriod(flowId);
+    }
+
+    @Transactional
+    public FlowDetail reorder(Long memberId, Long flowId, List<Long> momentIds) {
+        getOwned(memberId, flowId);
+        Map<Long, FlowMoment> byMoment = flowMomentRepository.findAllByFlowIdOrderBySortOrderAscIdAsc(flowId)
+                .stream().collect(Collectors.toMap(FlowMoment::getMomentId, fm -> fm));
+        int order = 0;
+        for (Long momentId : momentIds) {
+            FlowMoment fm = byMoment.get(momentId);
+            if (fm != null) {
+                fm.updateSortOrder(order++);
+            }
+        }
+        return detail(memberId, flowId);
+    }
+
+    // ---------------- helpers ----------------
+
+    private Flow getOwned(Long memberId, Long flowId) {
+        return flowRepository.findByIdAndMemberId(flowId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.LIFELOG_FLOW_NOT_FOUND));
+    }
+
+    /** 흐름의 기록을 (sort_order, occurred_at, id) 순으로 정렬해 반환. */
+    private List<Moment> orderedMoments(Long flowId) {
+        List<FlowMoment> memberships = flowMomentRepository.findAllByFlowIdOrderBySortOrderAscIdAsc(flowId);
+        if (memberships.isEmpty()) {
+            return List.of();
+        }
+        Map<Long, Moment> moments = momentRepository.findAllById(
+                        memberships.stream().map(FlowMoment::getMomentId).toList()).stream()
+                .collect(Collectors.toMap(Moment::getId, m -> m));
+
+        return memberships.stream()
+                .filter(fm -> moments.containsKey(fm.getMomentId()))
+                .sorted(Comparator
+                        .comparingInt(FlowMoment::getSortOrder)
+                        .thenComparing(fm -> moments.get(fm.getMomentId()).getOccurredAt())
+                        .thenComparing(FlowMoment::getMomentId))
+                .map(fm -> moments.get(fm.getMomentId()))
+                .toList();
+    }
+
+    /** 담긴 기록의 min/max occurred_at을 흐름 기간으로 저장한다(비면 null). */
+    private void recomputePeriod(Long flowId) {
+        Flow flow = flowRepository.findById(flowId).orElseThrow();
+        List<Long> momentIds = flowMomentRepository.findAllByFlowIdOrderBySortOrderAscIdAsc(flowId)
+                .stream().map(FlowMoment::getMomentId).toList();
+        if (momentIds.isEmpty()) {
+            flow.updatePeriod(null, null);
+            return;
+        }
+        List<Instant> times = momentRepository.findAllById(momentIds).stream()
+                .map(Moment::getOccurredAt).sorted().toList();
+        flow.updatePeriod(times.get(0), times.get(times.size() - 1));
+    }
+
+    private String resolveCoverUrl(Flow flow, List<MomentCard> orderedCards) {
+        if (flow.getCoverObjectKey() != null) {
+            return imageStorageService.toPublicUrl(flow.getCoverObjectKey());
+        }
+        // 커버 미지정 → 시간순 첫 기록의 첫 사진.
+        for (MomentCard card : orderedCards) {
+            if (!card.photos().isEmpty()) {
+                MomentPhotoResponse p = card.photos().get(0);
+                return p.thumbUrl() != null ? p.thumbUrl() : p.url();
+            }
+        }
+        return null;
+    }
+
+    private FlowSummary summaryOf(Flow flow, long momentCount) {
+        return new FlowSummary(flow.getId(), flow.getTitle(), flow.getDescription(),
+                flow.getCoverObjectKey() != null ? imageStorageService.toPublicUrl(flow.getCoverObjectKey()) : null,
+                flow.getStartedAt(), flow.getEndedAt(), momentCount, flow.getStatus());
+    }
+
+    /** 목록 요약을 배치로 만든다(커버 fallback·카운트를 몇 번의 쿼리로). */
+    private List<FlowSummary> buildSummaries(List<Flow> flows) {
+        if (flows.isEmpty()) {
+            return List.of();
+        }
+        List<Long> flowIds = flows.stream().map(Flow::getId).toList();
+        Map<Long, List<FlowMoment>> membershipsByFlow =
+                flowMomentRepository.findAllByFlowIdIn(flowIds).stream()
+                        .collect(Collectors.groupingBy(FlowMoment::getFlowId));
+
+        // 커버 fallback 대상(커버 미지정 흐름)의 시간순 첫 기록.
+        List<Long> allMomentIds = membershipsByFlow.values().stream()
+                .flatMap(List::stream).map(FlowMoment::getMomentId).distinct().toList();
+        Map<Long, Moment> moments = allMomentIds.isEmpty() ? Map.of()
+                : momentRepository.findAllById(allMomentIds).stream()
+                        .collect(Collectors.toMap(Moment::getId, m -> m));
+
+        Map<Long, Long> firstMomentByFlow = new HashMap<>();
+        for (Flow flow : flows) {
+            if (flow.getCoverObjectKey() != null) {
+                continue;
+            }
+            membershipsByFlow.getOrDefault(flow.getId(), List.of()).stream()
+                    .map(fm -> moments.get(fm.getMomentId()))
+                    .filter(Objects::nonNull)
+                    .min(Comparator.comparing(Moment::getOccurredAt).thenComparing(Moment::getId))
+                    .ifPresent(m -> firstMomentByFlow.put(flow.getId(), m.getId()));
+        }
+        Map<Long, MomentPhoto> firstPhotoByMoment = firstMomentByFlow.isEmpty() ? Map.of()
+                : photoRepository.findAllByMomentIdInOrderBySortOrderAscIdAsc(
+                                new ArrayList<>(new LinkedHashSet<>(firstMomentByFlow.values()))).stream()
+                        .collect(Collectors.toMap(MomentPhoto::getMomentId, p -> p, (a, b) -> a));
+
+        List<FlowSummary> summaries = new ArrayList<>();
+        for (Flow flow : flows) {
+            long count = membershipsByFlow.getOrDefault(flow.getId(), List.of()).size();
+            summaries.add(new FlowSummary(flow.getId(), flow.getTitle(), flow.getDescription(),
+                    coverUrlForList(flow, firstMomentByFlow, firstPhotoByMoment),
+                    flow.getStartedAt(), flow.getEndedAt(), count, flow.getStatus()));
+        }
+        return summaries;
+    }
+
+    private String coverUrlForList(Flow flow, Map<Long, Long> firstMomentByFlow,
+                                   Map<Long, MomentPhoto> firstPhotoByMoment) {
+        if (flow.getCoverObjectKey() != null) {
+            return imageStorageService.toPublicUrl(flow.getCoverObjectKey());
+        }
+        Long firstMomentId = firstMomentByFlow.get(flow.getId());
+        if (firstMomentId == null) {
+            return null;
+        }
+        MomentPhoto photo = firstPhotoByMoment.get(firstMomentId);
+        if (photo == null) {
+            return null;
+        }
+        String key = photo.getThumbKey() != null ? photo.getThumbKey() : photo.getObjectKey();
+        return imageStorageService.toPublicUrl(key);
+    }
+
+    private Set<Long> dedupe(Collection<Long> ids) {
+        Set<Long> result = new LinkedHashSet<>();
+        if (ids != null) {
+            for (Long id : ids) {
+                if (id != null) {
+                    result.add(id);
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/lifelog/flow/controller/FlowControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/lifelog/flow/controller/FlowControllerTest.java
@@ -1,0 +1,267 @@
+package ds.project.orino.planner.lifelog.flow.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 흐름 CRUD·N:M 담기/빼기/정렬 통합 테스트. 흐름 조작은 기록을 지우지 않으므로(MinIO 미접촉)
+ * 사진 포함 기록으로 커버 fallback까지 검증한다.
+ */
+class FlowControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private String otherAuthHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        memberRepository.save(MemberFixture.create("other", "password"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        otherAuthHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+    }
+
+    @Test
+    @DisplayName("POST /flows - ACTIVE 상태로 흐름을 만든다")
+    void createFlow() throws Exception {
+        mockMvc.perform(post("/api/lifelog/flows")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "제주 여행 2박3일", "description": "2026 여름"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("제주 여행 2박3일"))
+                .andExpect(jsonPath("$.data.momentCount").value(0))
+                .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    @DisplayName("GET /flows?status= - 상태로 필터한다")
+    void listByStatus() throws Exception {
+        long active = createFlow("진행중");
+        long archived = createFlow("보관대상");
+        updateFlow(archived, "보관대상", "ARCHIVED");
+
+        mockMvc.perform(get("/api/lifelog/flows").param("status", "ACTIVE")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(1)))
+                .andExpect(jsonPath("$.data[0].id").value((int) active));
+    }
+
+    @Test
+    @DisplayName("담기 후 상세는 시간순, 기간이 유도된다")
+    void addAndDetailChronological() throws Exception {
+        long flow = createFlow("제주 여행");
+        long m2 = createMoment("""
+                {"body": "낮", "occurredAt": "2026-07-20T05:00:00Z"}""");
+        long m1 = createMoment("""
+                {"body": "아침", "occurredAt": "2026-07-20T00:00:00Z"}""");
+        long m3 = createMoment("""
+                {"body": "저녁", "occurredAt": "2026-07-20T11:00:00Z"}""");
+
+        // 단건 + 다건 혼합으로 담기.
+        addMoments(flow, "{\"momentId\": %d}".formatted(m2));
+        addMoments(flow, "{\"momentIds\": [%d, %d]}".formatted(m1, m3));
+
+        mockMvc.perform(get("/api/lifelog/flows/{id}", flow)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.moments", hasSize(3)))
+                .andExpect(jsonPath("$.data.moments[0].body").value("아침"))
+                .andExpect(jsonPath("$.data.moments[1].body").value("낮"))
+                .andExpect(jsonPath("$.data.moments[2].body").value("저녁"))
+                // 발생시각은 요청 시간대(Asia/Seoul, +09:00)로 렌더된다: 00:00Z→09:00, 11:00Z→20:00.
+                .andExpect(jsonPath("$.data.startedAt").value(containsString("2026-07-20T09:00:00")))
+                .andExpect(jsonPath("$.data.endedAt").value(containsString("2026-07-20T20:00:00")));
+    }
+
+    @Test
+    @DisplayName("담기는 멱등하고, 소유가 아닌 기록은 무시된다")
+    void addIsIdempotentAndScoped() throws Exception {
+        long flow = createFlow("F");
+        long mine = createMoment("""
+                {"body": "내것"}""");
+        long theirs = createMomentAs(otherAuthHeader, """
+                {"body": "남의것"}""");
+
+        addMoments(flow, "{\"momentIds\": [%d, %d, %d]}".formatted(mine, mine, theirs));
+
+        mockMvc.perform(get("/api/lifelog/flows/{id}", flow)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.moments", hasSize(1)))
+                .andExpect(jsonPath("$.data.moments[0].body").value("내것"));
+    }
+
+    @Test
+    @DisplayName("커버 미지정이면 시간순 첫 기록의 첫 사진을 커버로")
+    void coverFallbackToFirstPhoto() throws Exception {
+        long flow = createFlow("여행");
+        long m = createMoment("""
+                {"body": "사진기록", "photos": [
+                  {"objectKey": "lifelog/moments/1/p.jpg", "thumbKey": "lifelog/thumbs/1/p.jpg"}
+                ]}""");
+        addMoments(flow, "{\"momentId\": %d}".formatted(m));
+
+        // 상세
+        mockMvc.perform(get("/api/lifelog/flows/{id}", flow)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.coverUrl", containsString("lifelog/thumbs/")));
+        // 목록
+        mockMvc.perform(get("/api/lifelog/flows")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data[0].coverUrl", containsString("lifelog/thumbs/")))
+                .andExpect(jsonPath("$.data[0].momentCount").value(1));
+    }
+
+    @Test
+    @DisplayName("PUT order - 흐름 내 순서를 재기록한다")
+    void reorder() throws Exception {
+        long flow = createFlow("F");
+        long m1 = createMoment("""
+                {"body": "1", "occurredAt": "2026-07-20T00:00:00Z"}""");
+        long m2 = createMoment("""
+                {"body": "2", "occurredAt": "2026-07-20T01:00:00Z"}""");
+        long m3 = createMoment("""
+                {"body": "3", "occurredAt": "2026-07-20T02:00:00Z"}""");
+        addMoments(flow, "{\"momentIds\": [%d, %d, %d]}".formatted(m1, m2, m3));
+
+        mockMvc.perform(put("/api/lifelog/flows/{id}/moments/order", flow)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"momentIds\": [%d, %d, %d]}".formatted(m3, m1, m2)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.moments[0].body").value("3"))
+                .andExpect(jsonPath("$.data.moments[1].body").value("1"))
+                .andExpect(jsonPath("$.data.moments[2].body").value("2"));
+    }
+
+    @Test
+    @DisplayName("빼기는 소속만 제거하고 기록은 남긴다")
+    void removeKeepsMoment() throws Exception {
+        long flow = createFlow("F");
+        long m1 = createMoment("""
+                {"body": "a"}""");
+        long m2 = createMoment("""
+                {"body": "b"}""");
+        addMoments(flow, "{\"momentIds\": [%d, %d]}".formatted(m1, m2));
+
+        mockMvc.perform(delete("/api/lifelog/flows/{fid}/moments/{mid}", flow, m1)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/lifelog/flows/{id}", flow)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.moments", hasSize(1)))
+                .andExpect(jsonPath("$.data.moments[0].body").value("b"));
+        // 뺀 기록 자체는 보존.
+        mockMvc.perform(get("/api/lifelog/moments/{id}", m1)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("흐름 삭제는 소속만 지우고 담겼던 기록은 보존한다")
+    void deleteFlowPreservesMoments() throws Exception {
+        long flow = createFlow("버릴흐름");
+        long m = createMoment("""
+                {"body": "살아남을것"}""");
+        addMoments(flow, "{\"momentId\": %d}".formatted(m));
+
+        mockMvc.perform(delete("/api/lifelog/flows/{id}", flow)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/lifelog/flows/{id}", flow)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(get("/api/lifelog/moments/{id}", m)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("다른 멤버의 흐름은 404")
+    void flowScoped() throws Exception {
+        long flow = createFlow("내흐름");
+
+        mockMvc.perform(get("/api/lifelog/flows/{id}", flow)
+                        .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("LIFELOG-ERR-005"));
+    }
+
+    @Test
+    @DisplayName("GET /flows - 인증 없으면 401")
+    void requiresAuth() throws Exception {
+        mockMvc.perform(get("/api/lifelog/flows"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ---------------- helpers ----------------
+
+    private long createFlow(String title) throws Exception {
+        String body = mockMvc.perform(post("/api/lifelog/flows")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\": \"%s\"}".formatted(title)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private void updateFlow(long id, String title, String status) throws Exception {
+        mockMvc.perform(put("/api/lifelog/flows/{id}", id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\": \"%s\", \"status\": \"%s\"}".formatted(title, status)))
+                .andExpect(status().isOk());
+    }
+
+    private void addMoments(long flowId, String json) throws Exception {
+        mockMvc.perform(post("/api/lifelog/flows/{id}/moments", flowId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk());
+    }
+
+    private long createMoment(String json) throws Exception {
+        return createMomentAs(authHeader, json);
+    }
+
+    private long createMomentAs(String auth, String json) throws Exception {
+        String body = mockMvc.perform(post("/api/lifelog/moments")
+                        .header(HttpHeaders.AUTHORIZATION, auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+}

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -30,7 +30,8 @@ public enum ErrorCode {
     LIFELOG_GEOCODING_FAILED("LIFELOG-ERR-001", "장소 정보를 가져오지 못했습니다.", 502),
     LIFELOG_MOMENT_NOT_FOUND("LIFELOG-ERR-002", "존재하지 않는 기록입니다.", 404),
     LIFELOG_EMPTY_MOMENT("LIFELOG-ERR-003", "본문이나 사진 중 하나는 있어야 합니다.", 400),
-    LIFELOG_INVALID_COORDINATE("LIFELOG-ERR-004", "위도와 경도는 함께 지정해야 합니다.", 400);
+    LIFELOG_INVALID_COORDINATE("LIFELOG-ERR-004", "위도와 경도는 함께 지정해야 합니다.", 400),
+    LIFELOG_FLOW_NOT_FOUND("LIFELOG-ERR-005", "존재하지 않는 흐름입니다.", 404);
 
     private final String code;
     private final String message;

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/FlowMomentRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/lifelog/repository/FlowMomentRepository.java
@@ -20,6 +20,9 @@ public interface FlowMomentRepository extends JpaRepository<FlowMoment, Long> {
     /** 피드 배치 로딩: 여러 기록의 소속 흐름을 한 번에. */
     List<FlowMoment> findAllByMomentIdIn(Collection<Long> momentIds);
 
+    /** 흐름 목록 배치 로딩: 여러 흐름의 소속 기록을 한 번에(카운트·커버·기간 계산용). */
+    List<FlowMoment> findAllByFlowIdIn(Collection<Long> flowIds);
+
     boolean existsByFlowIdAndMomentId(Long flowId, Long momentId);
 
     Optional<FlowMoment> findByFlowIdAndMomentId(Long flowId, Long momentId);


### PR DESCRIPTION
## 이슈
closes #953

## 작업 내용
- **`POST/GET/PUT/DELETE /api/lifelog/flows`** — 생성·목록(`status` 필터)·상세·수정·삭제
- **`POST /flows/{id}/moments`** — 담기(단건 `momentId` / 다건 `momentIds`, **멱등**, 소유 아닌 기록 무시)
- **`DELETE /flows/{id}/moments/{momentId}`** — 빼기(소속만 제거, 기록 보존)
- **`PUT /flows/{id}/moments/order`** — 흐름 내 순서 재기록
- **상세 정렬** — `sort_order` 우선, 동률이면 `occurred_at` → **기본은 시간순 서사**, reorder 시 수동 순서 우선
- **흐름 삭제** — DB FK CASCADE로 `flow_moment`만 제거, **담겼던 기록은 보존**(흐름은 관점일 뿐 소유자 아님)
- **기간 유도** — 담긴 기록의 min/max `occurred_at`을 흐름에 저장(add/remove 시 재계산 → 목록에서 N+1 없이 읽음)
- **커버 fallback** — 커버 미지정 시 시간순 첫 기록의 첫 사진(목록은 배치 조회 3쿼리)
- `MomentCardAssembler`(#952) 재사용, 신규 에러코드 `LIFELOG-ERR-005`

## 테스트
- `FlowControllerTest` (11, 통합/TestContainers) — 생성·상태필터·담기(시간순·기간유도)·멱등/소유스코프·커버 fallback(상세+목록)·정렬·빼기(기록보존)·흐름삭제(기록보존)·멤버스코프·인증
- ⚠️ 흐름 조작은 기록/사진을 지우지 않아 MinIO 미접촉 → 사진 포함 시나리오도 hermetic. checkstyle 통과

Epic: #949 · **BE 완료** → 다음은 FE(#955~#958)