### PR TITLE
feat : 일상기록 FE 피드 + 기록 작성/편집(사진·EXIF·썸네일)

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -30,6 +30,7 @@
         "axios": "^1.14.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "exifr": "^7.1.3",
         "lucide-react": "^1.7.0",
         "pretendard": "^1.3.9",
         "react": "^19.2.0",
@@ -5883,6 +5884,12 @@
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
+    },
+    "node_modules/exifr": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
+      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",

--- a/fe/package.json
+++ b/fe/package.json
@@ -38,6 +38,7 @@
     "axios": "^1.14.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "exifr": "^7.1.3",
     "lucide-react": "^1.7.0",
     "pretendard": "^1.3.9",
     "react": "^19.2.0",

--- a/fe/src/app/layout/Sidebar.tsx
+++ b/fe/src/app/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 import {
   BookOpen,
   CalendarDays,
+  Camera,
   CheckSquare,
   FileText,
   Home,
@@ -26,6 +27,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/home", label: "홈", icon: Home },
   { to: "/planner/materials", label: "학습 자료", icon: BookOpen },
   { to: "/notes", label: "노트", icon: FileText },
+  { to: "/lifelog", label: "일상기록", icon: Camera },
   { to: "/planner/reviews", label: "복습", icon: CheckSquare },
   {
     to: "/planner/calendar",

--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -38,6 +38,8 @@ export const importWeeklyPlan = () =>
   }));
 export const importNotes = () =>
   import("../pages/NotesPage").then((m) => ({ default: m.NotesPage }));
+export const importLifelog = () =>
+  import("../pages/LifelogPage").then((m) => ({ default: m.LifelogPage }));
 
 /**
  * 로그인 후 idle 시간에 페이지 청크를 미리 받아둔다.

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -13,6 +13,7 @@ import { AppLayout } from "./layout/AppLayout";
 import {
   importHome,
   importIntegrations,
+  importLifelog,
   importMaterialDetail,
   importMaterialList,
   importNotes,
@@ -35,6 +36,7 @@ const IntegrationsPage = lazy(importIntegrations);
 const RoutinesPage = lazy(importRoutines);
 const WeeklyPlanPage = lazy(importWeeklyPlan);
 const NotesPage = lazy(importNotes);
+const LifelogPage = lazy(importLifelog);
 
 function RouteFallback() {
   return (
@@ -140,6 +142,14 @@ export function AppRouter() {
             element={
               <Suspense fallback={<RouteFallback />}>
                 <NotesPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/lifelog"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <LifelogPage />
               </Suspense>
             }
           />

--- a/fe/src/features/lifelog/api/images.ts
+++ b/fe/src/features/lifelog/api/images.ts
@@ -1,0 +1,41 @@
+import axios from "axios";
+
+import { client } from "@/shared/api";
+
+export type ImageKind = "ORIGINAL" | "THUMB";
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export interface UploadUrlResponse {
+  uploadUrl: string;
+  publicUrl: string;
+  objectKey: string;
+}
+
+/** 일상기록 사진용 presigned PUT URL을 발급받는다(원본/썸네일). */
+export async function createUploadUrl(
+  contentType: string,
+  kind: ImageKind,
+): Promise<UploadUrlResponse> {
+  const { data } = await client.post<ApiEnvelope<UploadUrlResponse>>(
+    "/lifelog/images/upload-url",
+    { contentType, kind },
+  );
+  return data.data;
+}
+
+/**
+ * presigned URL로 바이너리를 MinIO에 직접 PUT 한다(BE 미경유). 인증 헤더 없이 순수 axios로 보낸다.
+ */
+export async function putToPresigned(
+  uploadUrl: string,
+  body: Blob,
+  contentType: string,
+): Promise<void> {
+  await axios.put(uploadUrl, body, {
+    headers: { "Content-Type": contentType },
+  });
+}

--- a/fe/src/features/lifelog/api/moments.ts
+++ b/fe/src/features/lifelog/api/moments.ts
@@ -1,0 +1,59 @@
+import { client } from "@/shared/api";
+
+import type { FeedResponse, MomentCard, MomentWriteRequest } from "./types";
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export async function fetchFeed(params: {
+  cursor?: string;
+  size?: number;
+  tag?: string;
+}): Promise<FeedResponse> {
+  const { data } = await client.get<ApiEnvelope<FeedResponse>>(
+    "/lifelog/moments",
+    { params },
+  );
+  return data.data;
+}
+
+export async function fetchMoment(id: number): Promise<MomentCard> {
+  const { data } = await client.get<ApiEnvelope<MomentCard>>(
+    `/lifelog/moments/${id}`,
+  );
+  return data.data;
+}
+
+export async function createMoment(
+  request: MomentWriteRequest,
+): Promise<MomentCard> {
+  const { data } = await client.post<ApiEnvelope<MomentCard>>(
+    "/lifelog/moments",
+    request,
+  );
+  return data.data;
+}
+
+export async function updateMoment(
+  id: number,
+  request: MomentWriteRequest,
+): Promise<MomentCard> {
+  const { data } = await client.put<ApiEnvelope<MomentCard>>(
+    `/lifelog/moments/${id}`,
+    request,
+  );
+  return data.data;
+}
+
+export async function deleteMoment(id: number): Promise<void> {
+  await client.delete(`/lifelog/moments/${id}`);
+}
+
+export async function fetchTagSuggestions(query: string): Promise<string[]> {
+  const { data } = await client.get<ApiEnvelope<string[]>>("/lifelog/tags", {
+    params: { q: query },
+  });
+  return data.data;
+}

--- a/fe/src/features/lifelog/api/types.ts
+++ b/fe/src/features/lifelog/api/types.ts
@@ -1,0 +1,61 @@
+export type Mood = "HAPPY" | "CALM" | "EXCITED" | "TIRED" | "SAD";
+
+export interface MomentPhoto {
+  id: number;
+  url: string;
+  thumbUrl: string | null;
+  width: number | null;
+  height: number | null;
+  sortOrder: number;
+}
+
+export interface FlowRef {
+  id: number;
+  title: string;
+}
+
+export interface MomentCard {
+  id: number;
+  occurredAt: string;
+  body: string | null;
+  mood: Mood | null;
+  lat: number | null;
+  lng: number | null;
+  placeName: string | null;
+  tags: string[];
+  photos: MomentPhoto[];
+  flows: FlowRef[];
+  createdAt: string;
+}
+
+export interface FeedResponse {
+  items: MomentCard[];
+  nextCursor: string | null;
+}
+
+/** 생성/수정 시 사진 한 장(사전 업로드된 MinIO object key + EXIF). */
+export interface PhotoRequest {
+  objectKey: string;
+  thumbKey?: string | null;
+  width?: number | null;
+  height?: number | null;
+  exifTakenAt?: string | null;
+  exifLat?: number | null;
+  exifLng?: number | null;
+  sortOrder?: number;
+}
+
+export interface MomentWriteRequest {
+  occurredAt?: string | null;
+  body?: string | null;
+  mood?: Mood | null;
+  lat?: number | null;
+  lng?: number | null;
+  placeName?: string | null;
+  tags?: string[];
+  photos?: PhotoRequest[];
+}
+
+export interface FeedFilters {
+  tag?: string;
+}

--- a/fe/src/features/lifelog/compose/MomentEditor.tsx
+++ b/fe/src/features/lifelog/compose/MomentEditor.tsx
@@ -1,0 +1,171 @@
+import { MapPin } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { Modal } from "@/components/ui/modal";
+import { Textarea } from "@/components/ui/textarea";
+
+import type { MomentCard, Mood, PhotoRequest } from "../api/types";
+import { useCreateMoment, useUpdateMoment } from "../hooks/useMomentMutations";
+import { isoToLocalInput, localInputToIso } from "../lib/datetime";
+import { photoToRequest } from "../lib/photoKey";
+import { MoodPicker } from "./MoodPicker";
+import { InitialPhoto, PhotoUploader } from "./PhotoUploader";
+import { TagInput } from "./TagInput";
+
+interface MomentEditorProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** 있으면 수정 모드. */
+  moment?: MomentCard;
+}
+
+/** 기록 작성/수정 모달. 사진(EXIF·썸네일 업로드)·본문·발생시각·기분·태그. */
+export function MomentEditor({
+  open,
+  onOpenChange,
+  moment,
+}: MomentEditorProps) {
+  const isEdit = Boolean(moment);
+  const createMutation = useCreateMoment();
+  const updateMutation = useUpdateMoment();
+  const pending = createMutation.isPending || updateMutation.isPending;
+
+  const [photos, setPhotos] = useState<PhotoRequest[]>([]);
+  const [uploading, setUploading] = useState(0);
+  const [body, setBody] = useState("");
+  const [mood, setMood] = useState<Mood | null>(null);
+  const [tags, setTags] = useState<string[]>([]);
+  const [occurredAt, setOccurredAt] = useState("");
+  const [occurredTouched, setOccurredTouched] = useState(false);
+  const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(
+    null,
+  );
+
+  // 열릴 때 초기화(수정 모드는 기존 값).
+  useEffect(() => {
+    if (!open) return;
+    setBody(moment?.body ?? "");
+    setMood(moment?.mood ?? null);
+    setTags(moment?.tags ?? []);
+    setOccurredAt(isoToLocalInput(moment?.occurredAt));
+    setOccurredTouched(false);
+    setCoords(
+      moment?.lat != null && moment?.lng != null
+        ? { lat: moment.lat, lng: moment.lng }
+        : null,
+    );
+    setPhotos([]);
+    setUploading(0);
+  }, [open, moment]);
+
+  // 새 기록에서 첫 사진 EXIF로 발생시각·위치 자동 채움(사용자가 손대지 않았을 때만).
+  useEffect(() => {
+    if (isEdit || photos.length === 0) return;
+    const first = photos[0];
+    if (!occurredTouched && first.exifTakenAt) {
+      setOccurredAt(isoToLocalInput(first.exifTakenAt));
+    }
+    if (!coords && first.exifLat != null && first.exifLng != null) {
+      setCoords({ lat: first.exifLat, lng: first.exifLng });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [photos]);
+
+  const initialPhotos: InitialPhoto[] = (moment?.photos ?? []).map((p) => ({
+    previewUrl: p.thumbUrl ?? p.url,
+    request: photoToRequest(p),
+  }));
+
+  const canSubmit =
+    uploading === 0 &&
+    !pending &&
+    (body.trim().length > 0 || photos.length > 0);
+
+  const submit = () => {
+    const request = {
+      occurredAt: localInputToIso(occurredAt),
+      body: body.trim() || null,
+      mood,
+      lat: coords?.lat ?? null,
+      lng: coords?.lng ?? null,
+      placeName: moment?.placeName ?? null,
+      tags,
+      photos,
+    };
+    const onSuccess = () => onOpenChange(false);
+    if (moment) {
+      updateMutation.mutate({ id: moment.id, request }, { onSuccess });
+    } else {
+      createMutation.mutate(request, { onSuccess });
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title={isEdit ? "기록 수정" : "기록"}
+      size="lg"
+    >
+      <div className="mt-4 flex flex-col gap-4">
+        <PhotoUploader
+          key={moment?.id ?? "new"}
+          initial={initialPhotos}
+          onChange={setPhotos}
+          onUploadingChange={setUploading}
+        />
+
+        <Textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="지금 이 순간을 기록하세요"
+          rows={3}
+          aria-label="본문"
+        />
+
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-muted-foreground text-xs">발생 시각</span>
+          <input
+            type="datetime-local"
+            value={occurredAt}
+            onChange={(e) => {
+              setOccurredAt(e.target.value);
+              setOccurredTouched(true);
+            }}
+            className="border-border bg-background h-9 rounded-md border px-3 text-sm"
+            aria-label="발생 시각"
+          />
+        </label>
+
+        {coords && (
+          <p className="text-muted-foreground flex items-center gap-1 text-xs">
+            <MapPin className="size-3.5" />
+            위치 포함됨 ({coords.lat.toFixed(4)}, {coords.lng.toFixed(4)})
+          </p>
+        )}
+
+        <div>
+          <span className="text-muted-foreground mb-1.5 block text-xs">
+            기분
+          </span>
+          <MoodPicker value={mood} onChange={setMood} />
+        </div>
+
+        <div>
+          <span className="text-muted-foreground mb-1.5 block text-xs">
+            태그
+          </span>
+          <TagInput tags={tags} onChange={setTags} />
+        </div>
+      </div>
+
+      <Modal.Footer
+        onSubmit={submit}
+        submitLabel={isEdit ? "저장" : "기록"}
+        pending={pending}
+        pendingLabel={isEdit ? "저장 중..." : "기록 중..."}
+        submitDisabled={!canSubmit}
+      />
+    </Modal>
+  );
+}

--- a/fe/src/features/lifelog/compose/MoodPicker.tsx
+++ b/fe/src/features/lifelog/compose/MoodPicker.tsx
@@ -1,0 +1,37 @@
+import { cn } from "@/lib/utils";
+
+import type { Mood } from "../api/types";
+import { MOODS } from "../lib/moods";
+
+interface MoodPickerProps {
+  value: Mood | null;
+  onChange: (mood: Mood | null) => void;
+}
+
+/** 기분 선택. 같은 값을 다시 누르면 해제된다(선택 사항). */
+export function MoodPicker({ value, onChange }: MoodPickerProps) {
+  return (
+    <div className="flex gap-1.5" role="group" aria-label="기분">
+      {MOODS.map((mood) => {
+        const selected = value === mood.value;
+        return (
+          <button
+            key={mood.value}
+            type="button"
+            aria-label={mood.label}
+            aria-pressed={selected}
+            onClick={() => onChange(selected ? null : mood.value)}
+            className={cn(
+              "flex size-9 items-center justify-center rounded-full border text-lg transition-colors",
+              selected
+                ? "border-primary bg-primary/10"
+                : "border-border hover:bg-muted",
+            )}
+          >
+            {mood.emoji}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/fe/src/features/lifelog/compose/PhotoUploader.tsx
+++ b/fe/src/features/lifelog/compose/PhotoUploader.tsx
@@ -1,0 +1,146 @@
+import { ImagePlus, Loader2, X } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+import type { PhotoRequest } from "../api/types";
+import { uploadMomentPhoto } from "../lib/uploadPhoto";
+
+interface PhotoItem {
+  key: string;
+  previewUrl: string;
+  /** object URL이면 정리 대상. */
+  ownsPreview: boolean;
+  status: "uploading" | "done" | "error";
+  request?: PhotoRequest;
+}
+
+export interface InitialPhoto {
+  previewUrl: string;
+  request: PhotoRequest;
+}
+
+interface PhotoUploaderProps {
+  initial?: InitialPhoto[];
+  /** 업로드 완료 사진 목록이 바뀔 때마다(순서=표시 순서) 호출. */
+  onChange: (photos: PhotoRequest[]) => void;
+  /** 진행 중 업로드 수가 바뀔 때 호출(제출 버튼 비활성 판단용). */
+  onUploadingChange?: (count: number) => void;
+}
+
+/** 사진 다중 선택 → EXIF·썸네일 처리 + presigned 업로드. 완료분을 부모에 전달한다. */
+export function PhotoUploader({
+  initial,
+  onChange,
+  onUploadingChange,
+}: PhotoUploaderProps) {
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [items, setItems] = useState<PhotoItem[]>(() =>
+    (initial ?? []).map((p, i) => ({
+      key: `initial-${i}`,
+      previewUrl: p.previewUrl,
+      ownsPreview: false,
+      status: "done" as const,
+      request: p.request,
+    })),
+  );
+
+  // 완료분·진행 수를 부모에 알린다.
+  useEffect(() => {
+    onChange(
+      items
+        .filter((it) => it.status === "done" && it.request)
+        .map((it, index) => ({
+          ...(it.request as PhotoRequest),
+          sortOrder: index,
+        })),
+    );
+    onUploadingChange?.(items.filter((it) => it.status === "uploading").length);
+    // onChange/onUploadingChange는 매 렌더 새 함수일 수 있어 items에만 반응한다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items]);
+
+  const setStatus = (key: string, patch: Partial<PhotoItem>) =>
+    setItems((prev) =>
+      prev.map((it) => (it.key === key ? { ...it, ...patch } : it)),
+    );
+
+  const handleFiles = (files: FileList | null) => {
+    if (!files) return;
+    Array.from(files).forEach((file, i) => {
+      const key = `${Date.now()}-${i}-${file.name}`;
+      const previewUrl = URL.createObjectURL(file);
+      setItems((prev) => [
+        ...prev,
+        { key, previewUrl, ownsPreview: true, status: "uploading" },
+      ]);
+      uploadMomentPhoto(file)
+        .then((request) => setStatus(key, { status: "done", request }))
+        .catch(() => setStatus(key, { status: "error" }));
+    });
+    if (inputRef.current) inputRef.current.value = "";
+  };
+
+  const remove = (key: string) =>
+    setItems((prev) => {
+      const target = prev.find((it) => it.key === key);
+      if (target?.ownsPreview) URL.revokeObjectURL(target.previewUrl);
+      return prev.filter((it) => it.key !== key);
+    });
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-2">
+        {items.map((it) => (
+          <div
+            key={it.key}
+            className="border-border relative size-20 overflow-hidden rounded-md border"
+          >
+            <img
+              src={it.previewUrl}
+              alt=""
+              className="size-full object-cover"
+            />
+            {it.status === "uploading" && (
+              <div className="bg-background/60 absolute inset-0 flex items-center justify-center">
+                <Loader2 className="text-primary size-5 animate-spin" />
+              </div>
+            )}
+            {it.status === "error" && (
+              <div className="bg-destructive/70 text-destructive-foreground absolute inset-0 flex items-center justify-center text-xs">
+                실패
+              </div>
+            )}
+            <button
+              type="button"
+              aria-label="사진 제거"
+              onClick={() => remove(it.key)}
+              className="bg-foreground/60 text-background absolute top-1 right-1 flex size-5 items-center justify-center rounded-full"
+            >
+              <X className="size-3" />
+            </button>
+          </div>
+        ))}
+        <label
+          htmlFor={inputId}
+          className={cn(
+            "border-border text-muted-foreground hover:bg-muted flex size-20 cursor-pointer flex-col items-center justify-center gap-1 rounded-md border border-dashed text-xs",
+          )}
+        >
+          <ImagePlus className="size-5" />
+          사진 추가
+        </label>
+        <input
+          id={inputId}
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          className="sr-only"
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/lifelog/compose/TagInput.tsx
+++ b/fe/src/features/lifelog/compose/TagInput.tsx
@@ -1,0 +1,90 @@
+import { X } from "lucide-react";
+import { useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+import { useTagSuggestions } from "../hooks/useTagSuggestions";
+
+interface TagInputProps {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+}
+
+/** 태그 칩 + 자동완성 입력. Enter/쉼표로 추가, 중복은 무시한다. */
+export function TagInput({ tags, onChange }: TagInputProps) {
+  const [draft, setDraft] = useState("");
+  const { data: suggestions } = useTagSuggestions(draft);
+
+  const add = (raw: string) => {
+    const name = raw.trim();
+    if (name && !tags.includes(name)) {
+      onChange([...tags, name]);
+    }
+    setDraft("");
+  };
+
+  const remove = (name: string) => onChange(tags.filter((t) => t !== name));
+
+  const filteredSuggestions = (suggestions ?? []).filter(
+    (s) => !tags.includes(s),
+  );
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="bg-muted text-foreground/80 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs"
+          >
+            #{tag}
+            <button
+              type="button"
+              aria-label={`${tag} 태그 제거`}
+              onClick={() => remove(tag)}
+              className="hover:text-foreground"
+            >
+              <X className="size-3" />
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className="relative mt-1.5">
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === ",") {
+              e.preventDefault();
+              add(draft);
+            } else if (e.key === "Backspace" && !draft && tags.length > 0) {
+              remove(tags[tags.length - 1]);
+            }
+          }}
+          placeholder="태그 입력 후 Enter"
+          aria-label="태그 입력"
+        />
+        {draft.trim() && filteredSuggestions.length > 0 && (
+          <ul
+            className={cn(
+              "border-border bg-background absolute z-10 mt-1 w-full rounded-md border shadow-md",
+            )}
+          >
+            {filteredSuggestions.slice(0, 6).map((s) => (
+              <li key={s}>
+                <button
+                  type="button"
+                  onClick={() => add(s)}
+                  className="hover:bg-muted w-full px-3 py-1.5 text-left text-sm"
+                >
+                  #{s}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/lifelog/feed/FeedPage.test.tsx
+++ b/fe/src/features/lifelog/feed/FeedPage.test.tsx
@@ -1,0 +1,164 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import type { MomentCard } from "../api/types";
+import { FeedPage } from "./FeedPage";
+
+const API = "https://api.orino.dev/api";
+
+function moment(overrides: Partial<MomentCard> = {}): MomentCard {
+  return {
+    id: 1,
+    occurredAt: "2026-07-20T05:00:00Z",
+    body: "성산일출봉",
+    mood: "EXCITED",
+    lat: null,
+    lng: null,
+    placeName: "성산일출봉",
+    tags: ["제주"],
+    photos: [],
+    flows: [],
+    createdAt: "2026-07-20T05:00:00Z",
+    ...overrides,
+  };
+}
+
+function feedHandler(items: MomentCard[], nextCursor: string | null = null) {
+  return http.get(`${API}/lifelog/moments`, () =>
+    HttpResponse.json({ code: "OK", data: { items, nextCursor } }),
+  );
+}
+
+describe("FeedPage", () => {
+  it("피드의 기록 카드를 렌더한다", async () => {
+    server.use(
+      feedHandler([
+        moment({
+          id: 1,
+          body: "정상 도착",
+          placeName: "성산일출봉",
+          tags: ["제주"],
+        }),
+      ]),
+    );
+
+    renderWithRouter(<FeedPage />);
+
+    expect(await screen.findByText("정상 도착")).toBeInTheDocument();
+    expect(screen.getByText("성산일출봉")).toBeInTheDocument();
+    expect(screen.getByText("#제주")).toBeInTheDocument();
+  });
+
+  it("기록이 없으면 안내를 보여준다", async () => {
+    server.use(feedHandler([]));
+
+    renderWithRouter(<FeedPage />);
+
+    expect(
+      await screen.findByText("첫 순간을 기록해보세요."),
+    ).toBeInTheDocument();
+  });
+
+  it("더 보기로 다음 페이지를 이어 붙인다", async () => {
+    let call = 0;
+    server.use(
+      http.get(`${API}/lifelog/moments`, () => {
+        call += 1;
+        return call === 1
+          ? HttpResponse.json({
+              code: "OK",
+              data: {
+                items: [moment({ id: 1, body: "첫페이지" })],
+                nextCursor: "CURSOR",
+              },
+            })
+          : HttpResponse.json({
+              code: "OK",
+              data: {
+                items: [moment({ id: 2, body: "둘째페이지" })],
+                nextCursor: null,
+              },
+            });
+      }),
+    );
+
+    renderWithRouter(<FeedPage />);
+    expect(await screen.findByText("첫페이지")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "더 보기" }));
+
+    expect(await screen.findByText("둘째페이지")).toBeInTheDocument();
+    expect(screen.getByText("첫페이지")).toBeInTheDocument();
+  });
+
+  it("기록을 작성하면 피드에 나타난다", async () => {
+    const store: MomentCard[] = [];
+    server.use(
+      http.get(`${API}/lifelog/moments`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: { items: store, nextCursor: null },
+        }),
+      ),
+      http.post(`${API}/lifelog/moments`, async ({ request }) => {
+        const body = (await request.json()) as { body: string };
+        const created = moment({
+          id: 99,
+          body: body.body,
+          tags: [],
+          placeName: null,
+        });
+        store.unshift(created);
+        return HttpResponse.json({ code: "OK", data: created });
+      }),
+    );
+
+    renderWithRouter(<FeedPage />);
+    await screen.findByText("첫 순간을 기록해보세요.");
+
+    await userEvent.click(screen.getByRole("button", { name: "기록" }));
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.type(
+      within(dialog).getByLabelText("본문"),
+      "새 기록입니다",
+    );
+    await userEvent.click(within(dialog).getByRole("button", { name: "기록" }));
+
+    expect(await screen.findByText("새 기록입니다")).toBeInTheDocument();
+  });
+
+  it("기록을 삭제하면 피드에서 사라진다", async () => {
+    const store: MomentCard[] = [moment({ id: 7, body: "지울기록", tags: [] })];
+    server.use(
+      http.get(`${API}/lifelog/moments`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: { items: store, nextCursor: null },
+        }),
+      ),
+      http.delete(`${API}/lifelog/moments/7`, () => {
+        store.length = 0;
+        return HttpResponse.json({ code: "OK", data: null });
+      }),
+    );
+
+    renderWithRouter(<FeedPage />);
+    expect(await screen.findByText("지울기록")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "기록 메뉴" }));
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "삭제" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "삭제" }));
+
+    await waitFor(() =>
+      expect(screen.queryByText("지울기록")).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/fe/src/features/lifelog/feed/FeedPage.tsx
+++ b/fe/src/features/lifelog/feed/FeedPage.tsx
@@ -1,0 +1,102 @@
+import { Plus } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { LoadingText } from "@/components/ui/loading-text";
+import { Modal } from "@/components/ui/modal";
+
+import type { MomentCard as MomentCardType } from "../api/types";
+import { MomentEditor } from "../compose/MomentEditor";
+import { useFeed } from "../hooks/useFeed";
+import { useDeleteMoment } from "../hooks/useMomentMutations";
+import { MomentCard } from "./MomentCard";
+
+/** 일상기록 피드 — 역시간순 무한 스크롤 + 작성/수정/삭제. */
+export function FeedPage() {
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useFeed();
+  const deleteMutation = useDeleteMoment();
+
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editing, setEditing] = useState<MomentCardType | undefined>();
+  const [deleting, setDeleting] = useState<MomentCardType | undefined>();
+
+  const moments = data?.pages.flatMap((page) => page.items) ?? [];
+
+  const openCreate = () => {
+    setEditing(undefined);
+    setEditorOpen(true);
+  };
+  const openEdit = (moment: MomentCardType) => {
+    setEditing(moment);
+    setEditorOpen(true);
+  };
+
+  return (
+    <div className="mx-auto flex max-w-xl flex-col gap-4 p-4">
+      <header className="flex items-center justify-between">
+        <h1 className="text-heading font-semibold">일상기록</h1>
+        <Button onClick={openCreate}>
+          <Plus />
+          기록
+        </Button>
+      </header>
+
+      {isLoading ? (
+        <LoadingText />
+      ) : moments.length === 0 ? (
+        <p className="text-muted-foreground py-16 text-center text-sm">
+          첫 순간을 기록해보세요.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {moments.map((moment) => (
+            <MomentCard
+              key={moment.id}
+              moment={moment}
+              onEdit={openEdit}
+              onDelete={setDeleting}
+            />
+          ))}
+        </div>
+      )}
+
+      {hasNextPage && (
+        <Button
+          variant="outline"
+          onClick={() => fetchNextPage()}
+          disabled={isFetchingNextPage}
+        >
+          {isFetchingNextPage ? "불러오는 중..." : "더 보기"}
+        </Button>
+      )}
+
+      <MomentEditor
+        open={editorOpen}
+        onOpenChange={setEditorOpen}
+        moment={editing}
+      />
+
+      <Modal
+        open={Boolean(deleting)}
+        onOpenChange={(open) => !open && setDeleting(undefined)}
+        title="기록 삭제"
+        description="이 기록을 삭제하시겠어요? 되돌릴 수 없습니다."
+        size="sm"
+      >
+        <Modal.Footer
+          destructive
+          submitLabel="삭제"
+          pending={deleteMutation.isPending}
+          pendingLabel="삭제 중..."
+          onSubmit={() => {
+            if (!deleting) return;
+            deleteMutation.mutate(deleting.id, {
+              onSuccess: () => setDeleting(undefined),
+            });
+          }}
+        />
+      </Modal>
+    </div>
+  );
+}

--- a/fe/src/features/lifelog/feed/MomentCard.tsx
+++ b/fe/src/features/lifelog/feed/MomentCard.tsx
@@ -1,0 +1,67 @@
+import { MapPin, MoreHorizontal } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Menu, MenuItem } from "@/components/ui/menu";
+
+import type { MomentCard as MomentCardType } from "../api/types";
+import { formatMomentTime } from "../lib/datetime";
+import { moodEmoji } from "../lib/moods";
+import { PhotoGrid } from "./PhotoGrid";
+
+interface MomentCardProps {
+  moment: MomentCardType;
+  onEdit: (moment: MomentCardType) => void;
+  onDelete: (moment: MomentCardType) => void;
+}
+
+export function MomentCard({ moment, onEdit, onDelete }: MomentCardProps) {
+  const emoji = moodEmoji(moment.mood);
+
+  return (
+    <article className="border-border bg-background flex flex-col gap-3 rounded-xl border p-4">
+      <PhotoGrid photos={moment.photos} />
+
+      {moment.body && (
+        <p className="text-sm whitespace-pre-wrap">{moment.body}</p>
+      )}
+
+      <div className="text-muted-foreground flex items-center gap-2 text-xs">
+        {emoji && <span aria-hidden>{emoji}</span>}
+        {moment.placeName && (
+          <span className="inline-flex items-center gap-0.5">
+            <MapPin className="size-3" />
+            {moment.placeName}
+          </span>
+        )}
+        <span>{formatMomentTime(moment.occurredAt)}</span>
+        <span className="ml-auto">
+          <Menu
+            trigger={
+              <Button size="icon-sm" variant="ghost" aria-label="기록 메뉴">
+                <MoreHorizontal />
+              </Button>
+            }
+          >
+            <MenuItem onClick={() => onEdit(moment)}>편집</MenuItem>
+            <MenuItem variant="destructive" onClick={() => onDelete(moment)}>
+              삭제
+            </MenuItem>
+          </Menu>
+        </span>
+      </div>
+
+      {moment.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {moment.tags.map((tag) => (
+            <span
+              key={tag}
+              className="bg-muted text-foreground/70 rounded-full px-2 py-0.5 text-xs"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/fe/src/features/lifelog/feed/PhotoGrid.tsx
+++ b/fe/src/features/lifelog/feed/PhotoGrid.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils";
+
+import type { MomentPhoto } from "../api/types";
+
+/** 기록 카드의 사진 그리드. 1장=풀폭, 2~4장=그리드, 5장+는 마지막에 +N 오버레이. */
+export function PhotoGrid({ photos }: { photos: MomentPhoto[] }) {
+  if (photos.length === 0) return null;
+  const shown = photos.slice(0, 4);
+  const extra = photos.length - shown.length;
+
+  return (
+    <div
+      className={cn(
+        "grid gap-1 overflow-hidden rounded-lg",
+        shown.length === 1 ? "grid-cols-1" : "grid-cols-2",
+      )}
+    >
+      {shown.map((photo, i) => (
+        <a
+          key={photo.id}
+          href={photo.url}
+          target="_blank"
+          rel="noreferrer"
+          className={cn(
+            "bg-muted relative block",
+            shown.length === 1 ? "aspect-video" : "aspect-square",
+          )}
+        >
+          <img
+            src={photo.thumbUrl ?? photo.url}
+            alt=""
+            loading="lazy"
+            className="size-full object-cover"
+          />
+          {i === shown.length - 1 && extra > 0 && (
+            <span className="bg-foreground/50 text-background absolute inset-0 flex items-center justify-center text-lg font-semibold">
+              +{extra}
+            </span>
+          )}
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/fe/src/features/lifelog/hooks/useFeed.ts
+++ b/fe/src/features/lifelog/hooks/useFeed.ts
@@ -1,0 +1,18 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import { fetchFeed } from "../api/moments";
+import type { FeedFilters } from "../api/types";
+import { lifelogKeys } from "../queryKeys";
+
+const PAGE_SIZE = 20;
+
+/** 역시간순 피드(무한 스크롤). tag 필터 선택. */
+export function useFeed(filters: FeedFilters = {}) {
+  return useInfiniteQuery({
+    queryKey: lifelogKeys.feed(filters),
+    queryFn: ({ pageParam }) =>
+      fetchFeed({ cursor: pageParam, size: PAGE_SIZE, tag: filters.tag }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
+  });
+}

--- a/fe/src/features/lifelog/hooks/useMomentMutations.ts
+++ b/fe/src/features/lifelog/hooks/useMomentMutations.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { createMoment, deleteMoment, updateMoment } from "../api/moments";
+import type { MomentCard, MomentWriteRequest } from "../api/types";
+import { lifelogKeys } from "../queryKeys";
+
+/** 피드 전체를 무효화한다(필터별 캐시 포함). */
+function invalidateFeed(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: lifelogKeys.all });
+}
+
+export function useCreateMoment() {
+  const queryClient = useQueryClient();
+  return useMutation<MomentCard, Error, MomentWriteRequest>({
+    mutationFn: createMoment,
+    onSuccess: () => invalidateFeed(queryClient),
+  });
+}
+
+export function useUpdateMoment() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    MomentCard,
+    Error,
+    { id: number; request: MomentWriteRequest }
+  >({
+    mutationFn: ({ id, request }) => updateMoment(id, request),
+    onSuccess: () => invalidateFeed(queryClient),
+  });
+}
+
+export function useDeleteMoment() {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, number>({
+    mutationFn: deleteMoment,
+    onSuccess: () => invalidateFeed(queryClient),
+  });
+}

--- a/fe/src/features/lifelog/hooks/useTagSuggestions.ts
+++ b/fe/src/features/lifelog/hooks/useTagSuggestions.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchTagSuggestions } from "../api/moments";
+import { lifelogKeys } from "../queryKeys";
+
+/** 태그 자동완성. 입력이 있을 때만 조회한다. */
+export function useTagSuggestions(query: string) {
+  const trimmed = query.trim();
+  return useQuery({
+    queryKey: lifelogKeys.tags(trimmed),
+    queryFn: () => fetchTagSuggestions(trimmed),
+    enabled: trimmed.length > 0,
+    staleTime: 30_000,
+  });
+}

--- a/fe/src/features/lifelog/lib/datetime.ts
+++ b/fe/src/features/lifelog/lib/datetime.ts
@@ -1,0 +1,30 @@
+/** ISO instant → `datetime-local` 입력값(로컬 시간대, 분 단위). */
+export function isoToLocalInput(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+  );
+}
+
+/** `datetime-local` 입력값(로컬) → ISO instant. 빈 값이면 null. */
+export function localInputToIso(local: string): string | null {
+  if (!local) return null;
+  const d = new Date(local);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+/** 카드/피드 표시용 짧은 로컬 시각(예: "7월 20일 14:30"). */
+export function formatMomentTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(d);
+}

--- a/fe/src/features/lifelog/lib/exif.ts
+++ b/fe/src/features/lifelog/lib/exif.ts
@@ -1,0 +1,34 @@
+import exifr from "exifr";
+
+export interface PhotoExif {
+  /** ISO-8601 촬영시각(EXIF DateTimeOriginal). */
+  takenAt?: string;
+  lat?: number;
+  lng?: number;
+}
+
+/**
+ * 사진 EXIF에서 촬영시각·GPS를 읽는다. EXIF가 없거나 파싱 실패해도 조용히 빈 값을 돌려준다
+ * (위치·시각 자동채움은 편의 기능이라 실패가 업로드를 막지 않는다).
+ */
+export async function readExif(file: File): Promise<PhotoExif> {
+  try {
+    const parsed = await exifr.parse(file, {
+      gps: true,
+      pick: ["DateTimeOriginal", "CreateDate", "latitude", "longitude"],
+    });
+    if (!parsed) return {};
+    const takenAtDate: Date | undefined =
+      parsed.DateTimeOriginal ?? parsed.CreateDate;
+    return {
+      takenAt:
+        takenAtDate instanceof Date && !Number.isNaN(takenAtDate.getTime())
+          ? takenAtDate.toISOString()
+          : undefined,
+      lat: typeof parsed.latitude === "number" ? parsed.latitude : undefined,
+      lng: typeof parsed.longitude === "number" ? parsed.longitude : undefined,
+    };
+  } catch {
+    return {};
+  }
+}

--- a/fe/src/features/lifelog/lib/moods.ts
+++ b/fe/src/features/lifelog/lib/moods.ts
@@ -1,0 +1,13 @@
+import type { Mood } from "../api/types";
+
+export const MOODS: { value: Mood; emoji: string; label: string }[] = [
+  { value: "HAPPY", emoji: "😊", label: "기쁨" },
+  { value: "CALM", emoji: "😌", label: "평온" },
+  { value: "EXCITED", emoji: "😆", label: "신남" },
+  { value: "TIRED", emoji: "😴", label: "피곤" },
+  { value: "SAD", emoji: "😢", label: "슬픔" },
+];
+
+export function moodEmoji(mood: Mood | null): string | null {
+  return MOODS.find((m) => m.value === mood)?.emoji ?? null;
+}

--- a/fe/src/features/lifelog/lib/photoKey.ts
+++ b/fe/src/features/lifelog/lib/photoKey.ts
@@ -1,0 +1,22 @@
+import type { MomentPhoto, PhotoRequest } from "../api/types";
+
+/**
+ * 공개 URL에서 MinIO object key를 되돌린다. key는 항상 {@code lifelog/}로 시작하므로 URL에서 그
+ * 지점부터 잘라낸다. (수정 시 기존 사진을 전체치환 PUT에 다시 실어야 하는데 카드 응답엔 url만 있어
+ * key를 유도한다 — BE가 objectKey를 응답에 넣으면 이 유도는 걷어낸다.)
+ */
+export function keyFromUrl(url: string | null): string | null {
+  if (!url) return null;
+  const i = url.indexOf("lifelog/");
+  return i >= 0 ? url.slice(i) : null;
+}
+
+export function photoToRequest(photo: MomentPhoto): PhotoRequest {
+  return {
+    objectKey: keyFromUrl(photo.url) ?? "",
+    thumbKey: keyFromUrl(photo.thumbUrl),
+    width: photo.width,
+    height: photo.height,
+    sortOrder: photo.sortOrder,
+  };
+}

--- a/fe/src/features/lifelog/lib/thumbnail.test.ts
+++ b/fe/src/features/lifelog/lib/thumbnail.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { computeThumbSize } from "./thumbnail";
+
+describe("computeThumbSize", () => {
+  it("최대 변보다 작으면 원본 크기 유지(확대 안 함)", () => {
+    expect(computeThumbSize(300, 200, 480)).toEqual({
+      width: 300,
+      height: 200,
+    });
+  });
+
+  it("가로가 길면 가로를 max로 맞춰 비율 유지", () => {
+    expect(computeThumbSize(4000, 3000, 480)).toEqual({
+      width: 480,
+      height: 360,
+    });
+  });
+
+  it("세로가 길면 세로를 max로 맞춰 비율 유지", () => {
+    expect(computeThumbSize(3000, 4000, 480)).toEqual({
+      width: 360,
+      height: 480,
+    });
+  });
+
+  it("정사각형은 그대로 축소", () => {
+    expect(computeThumbSize(1000, 1000, 480)).toEqual({
+      width: 480,
+      height: 480,
+    });
+  });
+});

--- a/fe/src/features/lifelog/lib/thumbnail.ts
+++ b/fe/src/features/lifelog/lib/thumbnail.ts
@@ -1,0 +1,57 @@
+export interface ProcessedImage {
+  /** 썸네일(JPEG) 바이너리. */
+  thumbBlob: Blob;
+  /** 원본 픽셀 크기. */
+  width: number;
+  height: number;
+}
+
+/** 최대 변을 max로 맞춘 축소 크기(확대는 안 함). 순수 계산이라 단위 테스트 대상. */
+export function computeThumbSize(
+  width: number,
+  height: number,
+  max: number,
+): { width: number; height: number } {
+  const longest = Math.max(width, height);
+  if (longest <= max) {
+    return { width, height };
+  }
+  const scale = max / longest;
+  return {
+    width: Math.round(width * scale),
+    height: Math.round(height * scale),
+  };
+}
+
+/**
+ * 원본에서 썸네일(JPEG)을 만든다. 원본 크기도 함께 반환한다. 브라우저 canvas를 쓴다
+ * (테스트 환경(jsdom)에선 동작하지 않으므로 통합 테스트는 사진 없는 경로로 검증한다).
+ */
+export async function processImage(
+  file: File,
+  max = 480,
+): Promise<ProcessedImage> {
+  const bitmap = await createImageBitmap(file);
+  const { width, height } = bitmap;
+  const thumb = computeThumbSize(width, height, max);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = thumb.width;
+  canvas.height = thumb.height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    bitmap.close();
+    throw new Error("canvas 2d context를 만들 수 없습니다.");
+  }
+  ctx.drawImage(bitmap, 0, 0, thumb.width, thumb.height);
+  bitmap.close();
+
+  const thumbBlob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error("썸네일 생성 실패"))),
+      "image/jpeg",
+      0.8,
+    );
+  });
+  return { thumbBlob, width, height };
+}

--- a/fe/src/features/lifelog/lib/uploadPhoto.ts
+++ b/fe/src/features/lifelog/lib/uploadPhoto.ts
@@ -1,0 +1,31 @@
+import { createUploadUrl, putToPresigned } from "../api/images";
+import type { PhotoRequest } from "../api/types";
+import { readExif } from "./exif";
+import { processImage } from "./thumbnail";
+
+/**
+ * 사진 한 장을 처리해 moment 생성에 넣을 {@link PhotoRequest}로 만든다:
+ * EXIF 추출 → 썸네일 생성 → 원본·썸네일을 presigned URL로 MinIO에 직접 업로드.
+ */
+export async function uploadMomentPhoto(file: File): Promise<PhotoRequest> {
+  const [exif, processed] = await Promise.all([
+    readExif(file),
+    processImage(file),
+  ]);
+
+  const original = await createUploadUrl(file.type, "ORIGINAL");
+  await putToPresigned(original.uploadUrl, file, file.type);
+
+  const thumb = await createUploadUrl("image/jpeg", "THUMB");
+  await putToPresigned(thumb.uploadUrl, processed.thumbBlob, "image/jpeg");
+
+  return {
+    objectKey: original.objectKey,
+    thumbKey: thumb.objectKey,
+    width: processed.width,
+    height: processed.height,
+    exifTakenAt: exif.takenAt ?? null,
+    exifLat: exif.lat ?? null,
+    exifLng: exif.lng ?? null,
+  };
+}

--- a/fe/src/features/lifelog/queryKeys.ts
+++ b/fe/src/features/lifelog/queryKeys.ts
@@ -1,0 +1,8 @@
+import type { FeedFilters } from "./api/types";
+
+export const lifelogKeys = {
+  all: ["lifelog"] as const,
+  feed: (filters: FeedFilters) => ["lifelog", "feed", filters] as const,
+  moment: (id: number) => ["lifelog", "moment", id] as const,
+  tags: (query: string) => ["lifelog", "tags", query] as const,
+};

--- a/fe/src/pages/LifelogPage.tsx
+++ b/fe/src/pages/LifelogPage.tsx
@@ -1,0 +1,6 @@
+import { FeedPage } from "@/features/lifelog/feed/FeedPage";
+
+/** 일상기록 피드 페이지(라우트 진입점). */
+export function LifelogPage() {
+  return <FeedPage />;
+}


### PR DESCRIPTION
## 이슈
closes #955

## 작업 내용
- **`/lifelog` 라우트 + 사이드바 "일상기록" 진입**
- **피드** — 역시간순 무한 스크롤(`useInfiniteQuery`, "더 보기"), 빈 상태 안내
- **`MomentCard`** — 사진 그리드(1장 풀폭·다장 그리드·5장+ `+N`) · 본문 · 기분 이모지 · 장소칩 · 시각 · 태그 · ⋯메뉴(편집/삭제)
- **`MomentEditor` 모달(작성/수정)**
  - 사진 다중 업로드: **EXIF 추출(exifr) → 발생시각·위치 자동 채움**, **canvas 썸네일 생성**, 원본+썸네일 **presigned PUT**(#951 엔드포인트, BE 미경유)
  - 본문 · 발생시각(datetime-local) · 기분 · 태그(자동완성, #952 `/tags`)
- **api/hooks** — `fetchFeed/create/update/delete/tags`, `useFeed`·`useMomentMutations`·`useTagSuggestions`
- **lib** — `exif`·`thumbnail`(순수 `computeThumbSize` 포함)·`uploadPhoto`·`datetime`·`photoKey`
- `exifr` 의존성 추가, `LifelogPage`는 **lazy 청크(88kB)로 분리**(초기 번들 미영향)

## 테스트
- `FeedPage.test.tsx` (5, RTL+MSW) — 카드 렌더 · 페이지네이션 · 빈 상태 · **작성→피드 반영** · **삭제→피드 제거**
- `thumbnail.test.ts` (4) — 썸네일 축소 크기 계산
- 전체 FE 스위트 **512 통과**, eslint·prettier·tsc·`vite build` 그린

## 참고
- 위치는 이번 PR에서 **EXIF 좌표 자동 포함**까지. 지도 핀/검색·역지오코딩 표시는 **#956**에서.
- 수정 시 기존 사진 유지를 위해 공개 URL에서 objectKey를 유도(`photoKey`) — 추후 BE가 objectKey를 응답에 넣으면 걷어낼 수 있음.
- 사진 파이프라인(canvas/exifr)은 브라우저 전용이라 jsdom 테스트는 텍스트 경로로 검증, 실제 업로드는 로컬/E2E 확인 권장.

Epic: #949 · 다음 FE: #956(위치 입력) · #957(흐름 목록/상세) · #958(흐름 지도)