### PR TITLE
feat : 일상기록 FE 흐름 목록 + 상세(타임라인)

### DIFF
--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -40,6 +40,14 @@ export const importNotes = () =>
   import("../pages/NotesPage").then((m) => ({ default: m.NotesPage }));
 export const importLifelog = () =>
   import("../pages/LifelogPage").then((m) => ({ default: m.LifelogPage }));
+export const importLifelogFlows = () =>
+  import("../pages/LifelogFlowsPage").then((m) => ({
+    default: m.LifelogFlowsPage,
+  }));
+export const importLifelogFlowDetail = () =>
+  import("../pages/LifelogFlowDetailPage").then((m) => ({
+    default: m.LifelogFlowDetailPage,
+  }));
 
 /**
  * 로그인 후 idle 시간에 페이지 청크를 미리 받아둔다.

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -14,6 +14,8 @@ import {
   importHome,
   importIntegrations,
   importLifelog,
+  importLifelogFlowDetail,
+  importLifelogFlows,
   importMaterialDetail,
   importMaterialList,
   importNotes,
@@ -37,6 +39,8 @@ const RoutinesPage = lazy(importRoutines);
 const WeeklyPlanPage = lazy(importWeeklyPlan);
 const NotesPage = lazy(importNotes);
 const LifelogPage = lazy(importLifelog);
+const LifelogFlowsPage = lazy(importLifelogFlows);
+const LifelogFlowDetailPage = lazy(importLifelogFlowDetail);
 
 function RouteFallback() {
   return (
@@ -150,6 +154,22 @@ export function AppRouter() {
             element={
               <Suspense fallback={<RouteFallback />}>
                 <LifelogPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/lifelog/flows"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <LifelogFlowsPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/lifelog/flows/:id"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <LifelogFlowDetailPage />
               </Suspense>
             }
           />

--- a/fe/src/features/lifelog/api/flows.ts
+++ b/fe/src/features/lifelog/api/flows.ts
@@ -1,0 +1,113 @@
+import { client } from "@/shared/api";
+
+import type { MomentCard } from "./types";
+
+export type FlowStatus = "ACTIVE" | "ARCHIVED";
+
+export interface FlowSummary {
+  id: number;
+  title: string;
+  description: string | null;
+  coverUrl: string | null;
+  startedAt: string | null;
+  endedAt: string | null;
+  momentCount: number;
+  status: FlowStatus;
+}
+
+export interface FlowDetail {
+  id: number;
+  title: string;
+  description: string | null;
+  coverUrl: string | null;
+  startedAt: string | null;
+  endedAt: string | null;
+  status: FlowStatus;
+  moments: MomentCard[];
+}
+
+export interface FlowCreateRequest {
+  title: string;
+  description?: string | null;
+}
+
+export interface FlowUpdateRequest {
+  title: string;
+  description?: string | null;
+  coverObjectKey?: string | null;
+  status: FlowStatus;
+}
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export async function fetchFlows(status?: FlowStatus): Promise<FlowSummary[]> {
+  const { data } = await client.get<ApiEnvelope<FlowSummary[]>>(
+    "/lifelog/flows",
+    { params: status ? { status } : undefined },
+  );
+  return data.data;
+}
+
+export async function fetchFlow(id: number): Promise<FlowDetail> {
+  const { data } = await client.get<ApiEnvelope<FlowDetail>>(
+    `/lifelog/flows/${id}`,
+  );
+  return data.data;
+}
+
+export async function createFlow(
+  request: FlowCreateRequest,
+): Promise<FlowSummary> {
+  const { data } = await client.post<ApiEnvelope<FlowSummary>>(
+    "/lifelog/flows",
+    request,
+  );
+  return data.data;
+}
+
+export async function updateFlow(
+  id: number,
+  request: FlowUpdateRequest,
+): Promise<FlowSummary> {
+  const { data } = await client.put<ApiEnvelope<FlowSummary>>(
+    `/lifelog/flows/${id}`,
+    request,
+  );
+  return data.data;
+}
+
+export async function deleteFlow(id: number): Promise<void> {
+  await client.delete(`/lifelog/flows/${id}`);
+}
+
+export async function addMomentsToFlow(
+  id: number,
+  momentIds: number[],
+): Promise<FlowDetail> {
+  const { data } = await client.post<ApiEnvelope<FlowDetail>>(
+    `/lifelog/flows/${id}/moments`,
+    { momentIds },
+  );
+  return data.data;
+}
+
+export async function removeMomentFromFlow(
+  id: number,
+  momentId: number,
+): Promise<void> {
+  await client.delete(`/lifelog/flows/${id}/moments/${momentId}`);
+}
+
+export async function reorderFlowMoments(
+  id: number,
+  momentIds: number[],
+): Promise<FlowDetail> {
+  const { data } = await client.put<ApiEnvelope<FlowDetail>>(
+    `/lifelog/flows/${id}/moments/order`,
+    { momentIds },
+  );
+  return data.data;
+}

--- a/fe/src/features/lifelog/feed/FeedPage.tsx
+++ b/fe/src/features/lifelog/feed/FeedPage.tsx
@@ -1,7 +1,8 @@
-import { Plus } from "lucide-react";
+import { Layers, Plus } from "lucide-react";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { LoadingText } from "@/components/ui/loading-text";
 import { Modal } from "@/components/ui/modal";
 
@@ -36,10 +37,19 @@ export function FeedPage() {
     <div className="mx-auto flex max-w-xl flex-col gap-4 p-4">
       <header className="flex items-center justify-between">
         <h1 className="text-heading font-semibold">일상기록</h1>
-        <Button onClick={openCreate}>
-          <Plus />
-          기록
-        </Button>
+        <div className="flex items-center gap-2">
+          <Link
+            to="/lifelog/flows"
+            className={buttonVariants({ variant: "outline", size: "default" })}
+          >
+            <Layers />
+            흐름
+          </Link>
+          <Button onClick={openCreate}>
+            <Plus />
+            기록
+          </Button>
+        </div>
       </header>
 
       {isLoading ? (

--- a/fe/src/features/lifelog/flow/AddMomentsModal.tsx
+++ b/fe/src/features/lifelog/flow/AddMomentsModal.tsx
@@ -1,0 +1,104 @@
+import { ImageIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { Modal } from "@/components/ui/modal";
+
+import { useFeed } from "../hooks/useFeed";
+import { useAddMoments } from "../hooks/useFlowMutations";
+import { formatMomentTime } from "../lib/datetime";
+
+interface AddMomentsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  flowId: number;
+  /** 이미 담긴 기록 id — 목록에서 제외한다. */
+  existingIds: number[];
+}
+
+/** 기록을 흐름에 담기 — 최근 기록에서 체크박스로 선택해 추가한다. */
+export function AddMomentsModal({
+  open,
+  onOpenChange,
+  flowId,
+  existingIds,
+}: AddMomentsModalProps) {
+  const { data } = useFeed();
+  const addMutation = useAddMoments(flowId);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    if (open) setSelected(new Set());
+  }, [open]);
+
+  const candidates = (data?.pages.flatMap((page) => page.items) ?? []).filter(
+    (m) => !existingIds.includes(m.id),
+  );
+
+  const toggle = (id: number) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const submit = () => {
+    if (selected.size === 0) return;
+    addMutation.mutate([...selected], {
+      onSuccess: () => onOpenChange(false),
+    });
+  };
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange} title="기록 담기">
+      <div className="mt-4 max-h-96 overflow-y-auto">
+        {candidates.length === 0 ? (
+          <p className="text-muted-foreground py-8 text-center text-sm">
+            담을 수 있는 기록이 없어요.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-1">
+            {candidates.map((moment) => (
+              <li key={moment.id}>
+                <label className="hover:bg-muted flex cursor-pointer items-center gap-3 rounded-lg p-2">
+                  <Checkbox
+                    checked={selected.has(moment.id)}
+                    onChange={() => toggle(moment.id)}
+                    aria-label={`기록 ${moment.id} 선택`}
+                  />
+                  <div className="bg-muted text-muted-foreground flex size-10 shrink-0 items-center justify-center overflow-hidden rounded">
+                    {moment.photos[0] ? (
+                      <img
+                        src={moment.photos[0].thumbUrl ?? moment.photos[0].url}
+                        alt=""
+                        className="size-full object-cover"
+                      />
+                    ) : (
+                      <ImageIcon className="size-4" />
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-muted-foreground text-xs">
+                      {formatMomentTime(moment.occurredAt)}
+                    </p>
+                    <p className="truncate text-sm">
+                      {moment.body ?? "(사진)"}
+                    </p>
+                  </div>
+                </label>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <Modal.Footer
+        onSubmit={submit}
+        submitLabel={selected.size > 0 ? `${selected.size}개 담기` : "담기"}
+        pending={addMutation.isPending}
+        pendingLabel="담는 중..."
+        submitDisabled={selected.size === 0 || addMutation.isPending}
+      />
+    </Modal>
+  );
+}

--- a/fe/src/features/lifelog/flow/FlowCard.tsx
+++ b/fe/src/features/lifelog/flow/FlowCard.tsx
@@ -1,0 +1,36 @@
+import { ImageIcon } from "lucide-react";
+import { Link } from "react-router-dom";
+
+import type { FlowSummary } from "../api/flows";
+import { formatFlowPeriod } from "../lib/datetime";
+
+/** 흐름 목록의 카드. 커버·제목·기간·기록 수. */
+export function FlowCard({ flow }: { flow: FlowSummary }) {
+  const period = formatFlowPeriod(flow.startedAt, flow.endedAt);
+
+  return (
+    <Link
+      to={`/lifelog/flows/${flow.id}`}
+      className="border-border bg-background hover:border-primary/40 flex flex-col overflow-hidden rounded-xl border transition-colors"
+    >
+      <div className="bg-muted text-muted-foreground flex aspect-video items-center justify-center">
+        {flow.coverUrl ? (
+          <img
+            src={flow.coverUrl}
+            alt=""
+            loading="lazy"
+            className="size-full object-cover"
+          />
+        ) : (
+          <ImageIcon className="size-8" />
+        )}
+      </div>
+      <div className="flex flex-col gap-0.5 p-3">
+        <span className="truncate text-sm font-medium">{flow.title}</span>
+        <span className="text-muted-foreground text-xs">
+          {period && <span>{period} · </span>}기록 {flow.momentCount}
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/fe/src/features/lifelog/flow/FlowCreateModal.tsx
+++ b/fe/src/features/lifelog/flow/FlowCreateModal.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { Textarea } from "@/components/ui/textarea";
+
+import { useCreateFlow } from "../hooks/useFlowMutations";
+
+interface FlowCreateModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/** 새 흐름 생성 모달. 생성 후 상세로 이동한다. */
+export function FlowCreateModal({ open, onOpenChange }: FlowCreateModalProps) {
+  const navigate = useNavigate();
+  const createMutation = useCreateFlow();
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setTitle("");
+      setDescription("");
+    }
+  }, [open]);
+
+  const submit = () => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    createMutation.mutate(
+      { title: trimmed, description: description.trim() || null },
+      {
+        onSuccess: (flow) => {
+          onOpenChange(false);
+          navigate(`/lifelog/flows/${flow.id}`);
+        },
+      },
+    );
+  };
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange} title="새 흐름">
+      <div className="mt-4 flex flex-col gap-3">
+        <Input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="흐름 제목 (예: 제주 여행 2박3일)"
+          aria-label="흐름 제목"
+        />
+        <Textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="설명 (선택)"
+          rows={2}
+          aria-label="흐름 설명"
+        />
+      </div>
+      <Modal.Footer
+        onSubmit={submit}
+        submitLabel="만들기"
+        pending={createMutation.isPending}
+        pendingLabel="만드는 중..."
+        submitDisabled={!title.trim() || createMutation.isPending}
+      />
+    </Modal>
+  );
+}

--- a/fe/src/features/lifelog/flow/FlowDetailPage.test.tsx
+++ b/fe/src/features/lifelog/flow/FlowDetailPage.test.tsx
@@ -1,0 +1,166 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { Route, Routes } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import type { FlowDetail } from "../api/flows";
+import type { MomentCard } from "../api/types";
+import { FlowDetailPage } from "./FlowDetailPage";
+
+const API = "https://api.orino.dev/api";
+
+function moment(id: number, body: string, occurredAt: string): MomentCard {
+  return {
+    id,
+    occurredAt,
+    body,
+    mood: null,
+    lat: null,
+    lng: null,
+    placeName: null,
+    tags: [],
+    photos: [],
+    flows: [],
+    createdAt: occurredAt,
+  };
+}
+
+function renderDetail() {
+  return renderWithRouter(
+    <Routes>
+      <Route path="/lifelog/flows/:id" element={<FlowDetailPage />} />
+    </Routes>,
+    { initialEntries: ["/lifelog/flows/1"] },
+  );
+}
+
+function detailHandlers(moments: MomentCard[]) {
+  const state = { moments };
+  const detail = (): FlowDetail => ({
+    id: 1,
+    title: "제주 여행",
+    description: null,
+    coverUrl: null,
+    startedAt: null,
+    endedAt: null,
+    status: "ACTIVE",
+    moments: state.moments,
+  });
+  return [
+    http.get(`${API}/lifelog/flows/1`, () =>
+      HttpResponse.json({ code: "OK", data: detail() }),
+    ),
+    http.delete(`${API}/lifelog/flows/1/moments/:mid`, ({ params }) => {
+      state.moments = state.moments.filter((m) => m.id !== Number(params.mid));
+      return HttpResponse.json({ code: "OK", data: null });
+    }),
+    http.put(`${API}/lifelog/flows/1/moments/order`, async ({ request }) => {
+      const body = (await request.json()) as { momentIds: number[] };
+      state.moments = body.momentIds
+        .map((id) => state.moments.find((m) => m.id === id))
+        .filter((m): m is MomentCard => Boolean(m));
+      return HttpResponse.json({ code: "OK", data: detail() });
+    }),
+    http.post(`${API}/lifelog/flows/1/moments`, async ({ request }) => {
+      const body = (await request.json()) as { momentIds: number[] };
+      body.momentIds.forEach((id) =>
+        state.moments.push(moment(id, `추가된${id}`, "2026-07-21T00:00:00Z")),
+      );
+      return HttpResponse.json({ code: "OK", data: detail() });
+    }),
+    http.get(`${API}/lifelog/moments`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          items: [moment(50, "담을기록", "2026-07-19T00:00:00Z")],
+          nextCursor: null,
+        },
+      }),
+    ),
+  ];
+}
+
+describe("FlowDetailPage", () => {
+  it("타임라인에 담긴 기록을 시간순으로 보여준다", async () => {
+    server.use(
+      ...detailHandlers([
+        moment(5, "아침", "2026-07-20T00:00:00Z"),
+        moment(6, "저녁", "2026-07-20T10:00:00Z"),
+      ]),
+    );
+    renderDetail();
+
+    expect(await screen.findByText("아침")).toBeInTheDocument();
+    expect(screen.getByText("저녁")).toBeInTheDocument();
+  });
+
+  it("기록을 빼면 타임라인에서 사라진다", async () => {
+    server.use(
+      ...detailHandlers([
+        moment(5, "지울기록", "2026-07-20T00:00:00Z"),
+        moment(6, "남을기록", "2026-07-20T10:00:00Z"),
+      ]),
+    );
+    renderDetail();
+    await screen.findByText("지울기록");
+
+    const item = screen.getByText("지울기록").closest("li")!;
+    await userEvent.click(
+      within(item).getByRole("button", { name: "흐름에서 빼기" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText("지울기록")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("남을기록")).toBeInTheDocument();
+  });
+
+  it("순서를 내리면 반영된다", async () => {
+    server.use(
+      ...detailHandlers([
+        moment(5, "첫번째", "2026-07-20T00:00:00Z"),
+        moment(6, "두번째", "2026-07-20T10:00:00Z"),
+      ]),
+    );
+    renderDetail();
+    await screen.findByText("첫번째");
+
+    const first = screen.getByText("첫번째").closest("li")!;
+    await userEvent.click(
+      within(first).getByRole("button", { name: "아래로" }),
+    );
+
+    await waitFor(() => {
+      const items = screen.getAllByRole("listitem");
+      expect(within(items[0]).getByText("두번째")).toBeInTheDocument();
+      expect(within(items[1]).getByText("첫번째")).toBeInTheDocument();
+    });
+  });
+
+  it("기록을 담으면 타임라인에 추가된다", async () => {
+    server.use(...detailHandlers([]));
+    renderDetail();
+    await screen.findByText(/아직 담긴 기록이 없어요/);
+
+    await userEvent.click(screen.getByRole("button", { name: "담기" }));
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(within(dialog).getByLabelText("기록 50 선택"));
+    await userEvent.click(within(dialog).getByRole("button", { name: /담기/ }));
+
+    expect(await screen.findByText("추가된50")).toBeInTheDocument();
+  });
+
+  it("지도 탭으로 전환할 수 있다", async () => {
+    server.use(...detailHandlers([moment(5, "기록", "2026-07-20T00:00:00Z")]));
+    renderDetail();
+    await screen.findByText("기록");
+
+    await userEvent.click(screen.getByRole("tab", { name: "지도" }));
+
+    expect(screen.getByText(/지도 뷰는 곧 제공됩니다/)).toBeInTheDocument();
+  });
+});

--- a/fe/src/features/lifelog/flow/FlowDetailPage.tsx
+++ b/fe/src/features/lifelog/flow/FlowDetailPage.tsx
@@ -1,0 +1,156 @@
+import { ArrowLeft, MoreHorizontal, Plus } from "lucide-react";
+import { useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+
+import { Button, buttonVariants } from "@/components/ui/button";
+import { LoadingText } from "@/components/ui/loading-text";
+import { Menu, MenuItem } from "@/components/ui/menu";
+import { Modal } from "@/components/ui/modal";
+import { cn } from "@/lib/utils";
+
+import {
+  useDeleteFlow,
+  useRemoveMoment,
+  useReorderMoments,
+} from "../hooks/useFlowMutations";
+import { useFlow } from "../hooks/useFlows";
+import { formatFlowPeriod } from "../lib/datetime";
+import { AddMomentsModal } from "./AddMomentsModal";
+import { FlowEditModal } from "./FlowEditModal";
+import { FlowTimeline } from "./FlowTimeline";
+
+type View = "timeline" | "map";
+
+/** 흐름 상세 — 헤더 + [타임라인|지도] 토글 + 담기. (지도 뷰는 #958에서 채운다) */
+export function FlowDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const flowId = Number(id);
+  const navigate = useNavigate();
+
+  const { data: flow, isLoading } = useFlow(flowId);
+  const removeMutation = useRemoveMoment(flowId);
+  const reorderMutation = useReorderMoments(flowId);
+  const deleteMutation = useDeleteFlow();
+
+  const [view, setView] = useState<View>("timeline");
+  const [addOpen, setAddOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  if (isLoading) {
+    return (
+      <div className="p-8">
+        <LoadingText />
+      </div>
+    );
+  }
+  if (!flow) {
+    return (
+      <p className="text-muted-foreground p-8 text-center text-sm">
+        흐름을 찾을 수 없습니다.
+      </p>
+    );
+  }
+
+  const period = formatFlowPeriod(flow.startedAt, flow.endedAt);
+
+  return (
+    <div className="mx-auto flex max-w-xl flex-col gap-4 p-4">
+      <header className="flex items-start gap-2">
+        <Link
+          to="/lifelog/flows"
+          aria-label="흐름 목록"
+          className={buttonVariants({ variant: "ghost", size: "icon-sm" })}
+        >
+          <ArrowLeft />
+        </Link>
+        <div className="min-w-0 flex-1">
+          <h1 className="text-heading truncate font-semibold">{flow.title}</h1>
+          <p className="text-muted-foreground text-xs">
+            {flow.description && <span>{flow.description} · </span>}
+            {period && <span>{period} · </span>}기록 {flow.moments.length}
+          </p>
+        </div>
+        <Button onClick={() => setAddOpen(true)} size="sm">
+          <Plus />
+          담기
+        </Button>
+        <Menu
+          trigger={
+            <Button size="icon-sm" variant="ghost" aria-label="흐름 메뉴">
+              <MoreHorizontal />
+            </Button>
+          }
+        >
+          <MenuItem onClick={() => setEditOpen(true)}>편집</MenuItem>
+          <MenuItem variant="destructive" onClick={() => setDeleteOpen(true)}>
+            삭제
+          </MenuItem>
+        </Menu>
+      </header>
+
+      <div
+        className="bg-muted flex w-fit gap-0.5 rounded-lg p-0.5"
+        role="tablist"
+        aria-label="뷰 전환"
+      >
+        {(["timeline", "map"] as View[]).map((v) => (
+          <button
+            key={v}
+            type="button"
+            role="tab"
+            aria-selected={view === v}
+            onClick={() => setView(v)}
+            className={cn(
+              "rounded-md px-3 py-1 text-sm transition-colors",
+              view === v
+                ? "bg-background shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {v === "timeline" ? "타임라인" : "지도"}
+          </button>
+        ))}
+      </div>
+
+      {view === "timeline" ? (
+        <FlowTimeline
+          moments={flow.moments}
+          onRemove={(momentId) => removeMutation.mutate(momentId)}
+          onReorder={(momentIds) => reorderMutation.mutate(momentIds)}
+        />
+      ) : (
+        <p className="text-muted-foreground py-12 text-center text-sm">
+          지도 뷰는 곧 제공됩니다.
+        </p>
+      )}
+
+      <AddMomentsModal
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        flowId={flowId}
+        existingIds={flow.moments.map((m) => m.id)}
+      />
+      <FlowEditModal open={editOpen} onOpenChange={setEditOpen} flow={flow} />
+      <Modal
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        title="흐름 삭제"
+        description="흐름을 삭제합니다. 담겼던 기록 자체는 남습니다."
+        size="sm"
+      >
+        <Modal.Footer
+          destructive
+          submitLabel="삭제"
+          pending={deleteMutation.isPending}
+          pendingLabel="삭제 중..."
+          onSubmit={() =>
+            deleteMutation.mutate(flowId, {
+              onSuccess: () => navigate("/lifelog/flows"),
+            })
+          }
+        />
+      </Modal>
+    </div>
+  );
+}

--- a/fe/src/features/lifelog/flow/FlowEditModal.tsx
+++ b/fe/src/features/lifelog/flow/FlowEditModal.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { Textarea } from "@/components/ui/textarea";
+
+import type { FlowDetail, FlowStatus } from "../api/flows";
+import { useUpdateFlow } from "../hooks/useFlowMutations";
+import { keyFromUrl } from "../lib/photoKey";
+
+interface FlowEditModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  flow: FlowDetail;
+}
+
+/** 흐름 제목·설명·상태 수정. 커버는 현재 보이는 이미지를 유지한다. */
+export function FlowEditModal({
+  open,
+  onOpenChange,
+  flow,
+}: FlowEditModalProps) {
+  const updateMutation = useUpdateFlow();
+  const [title, setTitle] = useState(flow.title);
+  const [description, setDescription] = useState(flow.description ?? "");
+  const [status, setStatus] = useState<FlowStatus>(flow.status);
+
+  useEffect(() => {
+    if (open) {
+      setTitle(flow.title);
+      setDescription(flow.description ?? "");
+      setStatus(flow.status);
+    }
+  }, [open, flow]);
+
+  const submit = () => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    updateMutation.mutate(
+      {
+        id: flow.id,
+        request: {
+          title: trimmed,
+          description: description.trim() || null,
+          // 응답엔 objectKey가 없어 현재 커버 URL에서 유도해 보이는 이미지를 유지한다.
+          coverObjectKey: keyFromUrl(flow.coverUrl),
+          status,
+        },
+      },
+      { onSuccess: () => onOpenChange(false) },
+    );
+  };
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange} title="흐름 수정">
+      <div className="mt-4 flex flex-col gap-3">
+        <Input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          aria-label="흐름 제목"
+        />
+        <Textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="설명 (선택)"
+          rows={2}
+          aria-label="흐름 설명"
+        />
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={status === "ARCHIVED"}
+            onChange={(e) =>
+              setStatus(e.target.checked ? "ARCHIVED" : "ACTIVE")
+            }
+          />
+          보관됨
+        </label>
+      </div>
+      <Modal.Footer
+        onSubmit={submit}
+        submitLabel="저장"
+        pending={updateMutation.isPending}
+        pendingLabel="저장 중..."
+        submitDisabled={!title.trim() || updateMutation.isPending}
+      />
+    </Modal>
+  );
+}

--- a/fe/src/features/lifelog/flow/FlowListPage.test.tsx
+++ b/fe/src/features/lifelog/flow/FlowListPage.test.tsx
@@ -1,0 +1,62 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import type { FlowSummary } from "../api/flows";
+import { FlowListPage } from "./FlowListPage";
+
+const API = "https://api.orino.dev/api";
+
+function flow(overrides: Partial<FlowSummary> = {}): FlowSummary {
+  return {
+    id: 1,
+    title: "제주 여행",
+    description: null,
+    coverUrl: null,
+    startedAt: "2026-07-20T00:00:00Z",
+    endedAt: "2026-07-22T00:00:00Z",
+    momentCount: 5,
+    status: "ACTIVE",
+    ...overrides,
+  };
+}
+
+describe("FlowListPage", () => {
+  it("상태별로 흐름을 보여주고 필터를 바꾸면 다시 조회한다", async () => {
+    server.use(
+      http.get(`${API}/lifelog/flows`, ({ request }) => {
+        const status = new URL(request.url).searchParams.get("status");
+        const data =
+          status === "ARCHIVED"
+            ? [flow({ id: 2, title: "보관된흐름", status: "ARCHIVED" })]
+            : [flow({ id: 1, title: "진행흐름" })];
+        return HttpResponse.json({ code: "OK", data });
+      }),
+    );
+
+    renderWithRouter(<FlowListPage />, { initialEntries: ["/lifelog/flows"] });
+
+    expect(await screen.findByText("진행흐름")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "보관" }));
+
+    expect(await screen.findByText("보관된흐름")).toBeInTheDocument();
+    expect(screen.queryByText("진행흐름")).not.toBeInTheDocument();
+  });
+
+  it("흐름이 없으면 안내를 보여준다", async () => {
+    server.use(
+      http.get(`${API}/lifelog/flows`, () =>
+        HttpResponse.json({ code: "OK", data: [] }),
+      ),
+    );
+
+    renderWithRouter(<FlowListPage />, { initialEntries: ["/lifelog/flows"] });
+
+    expect(await screen.findByText(/아직 흐름이 없어요/)).toBeInTheDocument();
+  });
+});

--- a/fe/src/features/lifelog/flow/FlowListPage.tsx
+++ b/fe/src/features/lifelog/flow/FlowListPage.tsx
@@ -1,0 +1,79 @@
+import { ArrowLeft, Plus } from "lucide-react";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+import { Button, buttonVariants } from "@/components/ui/button";
+import { LoadingText } from "@/components/ui/loading-text";
+import { cn } from "@/lib/utils";
+
+import type { FlowStatus } from "../api/flows";
+import { useFlows } from "../hooks/useFlows";
+import { FlowCard } from "./FlowCard";
+import { FlowCreateModal } from "./FlowCreateModal";
+
+const FILTERS: { label: string; value: FlowStatus | undefined }[] = [
+  { label: "진행중", value: "ACTIVE" },
+  { label: "보관", value: "ARCHIVED" },
+  { label: "전체", value: undefined },
+];
+
+/** 흐름 목록 — 상태 필터 + 새 흐름 생성. */
+export function FlowListPage() {
+  const [status, setStatus] = useState<FlowStatus | undefined>("ACTIVE");
+  const [createOpen, setCreateOpen] = useState(false);
+  const { data: flows, isLoading } = useFlows(status);
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-4 p-4">
+      <header className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Link
+            to="/lifelog"
+            aria-label="피드로"
+            className={buttonVariants({ variant: "ghost", size: "icon-sm" })}
+          >
+            <ArrowLeft />
+          </Link>
+          <h1 className="text-heading font-semibold">흐름</h1>
+        </div>
+        <Button onClick={() => setCreateOpen(true)}>
+          <Plus />새 흐름
+        </Button>
+      </header>
+
+      <div className="flex gap-1.5">
+        {FILTERS.map((f) => (
+          <button
+            key={f.label}
+            type="button"
+            onClick={() => setStatus(f.value)}
+            className={cn(
+              "rounded-full px-3 py-1 text-sm transition-colors",
+              status === f.value
+                ? "bg-primary/10 text-primary"
+                : "text-foreground/70 hover:bg-muted",
+            )}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {isLoading ? (
+        <LoadingText />
+      ) : (flows ?? []).length === 0 ? (
+        <p className="text-muted-foreground py-16 text-center text-sm">
+          아직 흐름이 없어요. 여행이나 하루를 하나로 엮어보세요.
+        </p>
+      ) : (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          {(flows ?? []).map((flow) => (
+            <FlowCard key={flow.id} flow={flow} />
+          ))}
+        </div>
+      )}
+
+      <FlowCreateModal open={createOpen} onOpenChange={setCreateOpen} />
+    </div>
+  );
+}

--- a/fe/src/features/lifelog/flow/FlowTimeline.tsx
+++ b/fe/src/features/lifelog/flow/FlowTimeline.tsx
@@ -1,0 +1,103 @@
+import { ChevronDown, ChevronUp, ImageIcon, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+import type { MomentCard } from "../api/types";
+import { formatDay, formatMomentTime, localDateKey } from "../lib/datetime";
+
+interface FlowTimelineProps {
+  moments: MomentCard[];
+  onRemove: (momentId: number) => void;
+  onReorder: (momentIds: number[]) => void;
+}
+
+/** 흐름 상세의 타임라인 뷰 — 날짜 구분 + 시간순 서사. 항목 빼기·순서 조정. */
+export function FlowTimeline({
+  moments,
+  onRemove,
+  onReorder,
+}: FlowTimelineProps) {
+  if (moments.length === 0) {
+    return (
+      <p className="text-muted-foreground py-12 text-center text-sm">
+        아직 담긴 기록이 없어요. [기록 담기]로 추가하세요.
+      </p>
+    );
+  }
+
+  const move = (index: number, delta: number) => {
+    const next = [...moments];
+    const target = index + delta;
+    if (target < 0 || target >= next.length) return;
+    [next[index], next[target]] = [next[target], next[index]];
+    onReorder(next.map((m) => m.id));
+  };
+
+  let lastDay = "";
+
+  return (
+    <ol className="flex flex-col gap-2">
+      {moments.map((moment, index) => {
+        const dayKey = localDateKey(moment.occurredAt);
+        const showDay = dayKey !== lastDay;
+        lastDay = dayKey;
+        return (
+          <li key={moment.id}>
+            {showDay && (
+              <p className="text-muted-foreground mt-3 mb-1 text-xs font-medium">
+                {formatDay(moment.occurredAt)}
+              </p>
+            )}
+            <div className="border-border flex items-center gap-3 rounded-lg border p-2">
+              <div className="bg-muted text-muted-foreground flex size-12 shrink-0 items-center justify-center overflow-hidden rounded">
+                {moment.photos[0] ? (
+                  <img
+                    src={moment.photos[0].thumbUrl ?? moment.photos[0].url}
+                    alt=""
+                    className="size-full object-cover"
+                  />
+                ) : (
+                  <ImageIcon className="size-4" />
+                )}
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-muted-foreground text-xs">
+                  {formatMomentTime(moment.occurredAt)}
+                </p>
+                <p className="truncate text-sm">{moment.body ?? "(사진)"}</p>
+              </div>
+              <div className="flex items-center">
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  aria-label="위로"
+                  disabled={index === 0}
+                  onClick={() => move(index, -1)}
+                >
+                  <ChevronUp />
+                </Button>
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  aria-label="아래로"
+                  disabled={index === moments.length - 1}
+                  onClick={() => move(index, 1)}
+                >
+                  <ChevronDown />
+                </Button>
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  aria-label="흐름에서 빼기"
+                  onClick={() => onRemove(moment.id)}
+                >
+                  <X />
+                </Button>
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/fe/src/features/lifelog/hooks/useFlowMutations.ts
+++ b/fe/src/features/lifelog/hooks/useFlowMutations.ts
@@ -1,0 +1,72 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  addMomentsToFlow,
+  createFlow,
+  deleteFlow,
+  type FlowCreateRequest,
+  type FlowSummary,
+  type FlowUpdateRequest,
+  removeMomentFromFlow,
+  reorderFlowMoments,
+  updateFlow,
+} from "../api/flows";
+import { lifelogKeys } from "../queryKeys";
+
+type QueryClient = ReturnType<typeof useQueryClient>;
+
+function invalidateFlows(queryClient: QueryClient) {
+  queryClient.invalidateQueries({ queryKey: lifelogKeys.all });
+}
+
+export function useCreateFlow() {
+  const queryClient = useQueryClient();
+  return useMutation<FlowSummary, Error, FlowCreateRequest>({
+    mutationFn: createFlow,
+    onSuccess: () => invalidateFlows(queryClient),
+  });
+}
+
+export function useUpdateFlow() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    FlowSummary,
+    Error,
+    { id: number; request: FlowUpdateRequest }
+  >({
+    mutationFn: ({ id, request }) => updateFlow(id, request),
+    onSuccess: () => invalidateFlows(queryClient),
+  });
+}
+
+export function useDeleteFlow() {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, number>({
+    mutationFn: deleteFlow,
+    onSuccess: () => invalidateFlows(queryClient),
+  });
+}
+
+export function useAddMoments(flowId: number) {
+  const queryClient = useQueryClient();
+  return useMutation<unknown, Error, number[]>({
+    mutationFn: (momentIds) => addMomentsToFlow(flowId, momentIds),
+    onSuccess: () => invalidateFlows(queryClient),
+  });
+}
+
+export function useRemoveMoment(flowId: number) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, number>({
+    mutationFn: (momentId) => removeMomentFromFlow(flowId, momentId),
+    onSuccess: () => invalidateFlows(queryClient),
+  });
+}
+
+export function useReorderMoments(flowId: number) {
+  const queryClient = useQueryClient();
+  return useMutation<unknown, Error, number[]>({
+    mutationFn: (momentIds) => reorderFlowMoments(flowId, momentIds),
+    onSuccess: () => invalidateFlows(queryClient),
+  });
+}

--- a/fe/src/features/lifelog/hooks/useFlows.ts
+++ b/fe/src/features/lifelog/hooks/useFlows.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchFlow, fetchFlows, type FlowStatus } from "../api/flows";
+import { lifelogKeys } from "../queryKeys";
+
+export function useFlows(status?: FlowStatus) {
+  return useQuery({
+    queryKey: lifelogKeys.flows(status),
+    queryFn: () => fetchFlows(status),
+  });
+}
+
+export function useFlow(id: number) {
+  return useQuery({
+    queryKey: lifelogKeys.flow(id),
+    queryFn: () => fetchFlow(id),
+  });
+}

--- a/fe/src/features/lifelog/lib/datetime.ts
+++ b/fe/src/features/lifelog/lib/datetime.ts
@@ -28,3 +28,31 @@ export function formatMomentTime(iso: string): string {
     minute: "2-digit",
   }).format(d);
 }
+
+/** 날짜만(예: "7월 20일"). */
+export function formatDay(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "long",
+    day: "numeric",
+  }).format(d);
+}
+
+/** 흐름 기간(예: "7월 20일 – 7월 22일"). 한쪽만 있으면 그것만, 없으면 빈 문자열. */
+export function formatFlowPeriod(
+  start: string | null,
+  end: string | null,
+): string {
+  const s = start ? formatDay(start) : "";
+  const e = end ? formatDay(end) : "";
+  if (s && e) return s === e ? s : `${s} – ${e}`;
+  return s || e;
+}
+
+/** 같은 로컬 날짜인지(타임라인 날짜 구분용). */
+export function localDateKey(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+}

--- a/fe/src/features/lifelog/queryKeys.ts
+++ b/fe/src/features/lifelog/queryKeys.ts
@@ -9,4 +9,6 @@ export const lifelogKeys = {
     ["lifelog", "geocode", "reverse", lat, lng] as const,
   geocodeSearch: (query: string) =>
     ["lifelog", "geocode", "search", query] as const,
+  flows: (status?: string) => ["lifelog", "flows", status ?? "all"] as const,
+  flow: (id: number) => ["lifelog", "flow", id] as const,
 };

--- a/fe/src/pages/LifelogFlowDetailPage.tsx
+++ b/fe/src/pages/LifelogFlowDetailPage.tsx
@@ -1,0 +1,5 @@
+import { FlowDetailPage } from "@/features/lifelog/flow/FlowDetailPage";
+
+export function LifelogFlowDetailPage() {
+  return <FlowDetailPage />;
+}

--- a/fe/src/pages/LifelogFlowsPage.tsx
+++ b/fe/src/pages/LifelogFlowsPage.tsx
@@ -1,0 +1,5 @@
+import { FlowListPage } from "@/features/lifelog/flow/FlowListPage";
+
+export function LifelogFlowsPage() {
+  return <FlowListPage />;
+}


### PR DESCRIPTION
## 이슈
closes #957

## 작업 내용
- **`/lifelog/flows` 목록** — `FlowCard`(커버·제목·기간·기록 수) · status 필터(진행중/보관/전체) · **새 흐름 생성**(→ 상세로 이동)
- **`/lifelog/flows/:id` 상세** — 헤더(제목·기간·기록수·⋯편집/삭제) + **[타임라인 | 지도] 토글**
  - **타임라인** — 날짜 구분 + 시간순 서사, 항목 **빼기**(기록 보존) · **순서 조정**(위/아래)
  - **기록 담기 모달** — 최근 기록 체크박스 선택(이미 담긴 것 제외)
  - **흐름 수정** — 제목·설명·상태(보관), 삭제(기록 보존)
- 피드 헤더에 **"흐름" 링크** 추가, `api/flows` · `useFlows`/`useFlow` · `useFlowMutations`
- **지도 탭은 자리만** 잡아두고 실제 지도 뷰는 **#958**에서 채운다

## 테스트
- `FlowListPage.test.tsx` (2) — 상태 필터 재조회 · 빈 상태
- `FlowDetailPage.test.tsx` (5) — 타임라인 시간순 · **빼기** · **순서 내리기** · **담기→반영** · 지도 탭 전환
- 전체 FE **521 통과**, eslint·prettier·tsc·`vite build` 그린

## 참고
- 흐름 수정 시 커버는 현재 보이는 URL에서 objectKey를 유도해 유지(#955와 같은 한계 — BE가 objectKey 응답 시 제거 가능)
- 순서 조정은 위/아래 버튼(드래그는 후속)

Epic: #949 · 마지막 FE: #958(흐름 지도 뷰)