### PR TITLE
feat : 일상기록 FE 흐름 지도 뷰 (react-leaflet 핀·경로)

### DIFF
--- a/fe/src/features/lifelog/flow/FlowDetailPage.test.tsx
+++ b/fe/src/features/lifelog/flow/FlowDetailPage.test.tsx
@@ -161,6 +161,9 @@ describe("FlowDetailPage", () => {
 
     await userEvent.click(screen.getByRole("tab", { name: "지도" }));
 
-    expect(screen.getByText(/지도 뷰는 곧 제공됩니다/)).toBeInTheDocument();
+    // 좌표가 없는 기록뿐이므로 지도 대신 안내를 보여준다(지도 렌더는 브라우저 전용).
+    expect(
+      screen.getByText(/위치 정보가 있는 기록이 없어요/),
+    ).toBeInTheDocument();
   });
 });

--- a/fe/src/features/lifelog/flow/FlowDetailPage.tsx
+++ b/fe/src/features/lifelog/flow/FlowDetailPage.tsx
@@ -17,6 +17,7 @@ import { useFlow } from "../hooks/useFlows";
 import { formatFlowPeriod } from "../lib/datetime";
 import { AddMomentsModal } from "./AddMomentsModal";
 import { FlowEditModal } from "./FlowEditModal";
+import { FlowMap } from "./FlowMap";
 import { FlowTimeline } from "./FlowTimeline";
 
 type View = "timeline" | "map";
@@ -120,9 +121,7 @@ export function FlowDetailPage() {
           onReorder={(momentIds) => reorderMutation.mutate(momentIds)}
         />
       ) : (
-        <p className="text-muted-foreground py-12 text-center text-sm">
-          지도 뷰는 곧 제공됩니다.
-        </p>
+        <FlowMap moments={flow.moments} />
       )}
 
       <AddMomentsModal

--- a/fe/src/features/lifelog/flow/FlowMap.test.tsx
+++ b/fe/src/features/lifelog/flow/FlowMap.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { MomentCard } from "../api/types";
+import { FlowMap } from "./FlowMap";
+
+function moment(
+  id: number,
+  lat: number | null,
+  lng: number | null,
+): MomentCard {
+  return {
+    id,
+    occurredAt: "2026-07-20T00:00:00Z",
+    body: null,
+    mood: null,
+    lat,
+    lng,
+    placeName: null,
+    tags: [],
+    photos: [],
+    flows: [],
+    createdAt: "2026-07-20T00:00:00Z",
+  };
+}
+
+describe("FlowMap", () => {
+  it("좌표 있는 기록이 없으면 안내를 보여준다(지도 미표시)", () => {
+    render(<FlowMap moments={[moment(1, null, null)]} />);
+    expect(
+      screen.getByText(/위치 정보가 있는 기록이 없어요/),
+    ).toBeInTheDocument();
+  });
+});

--- a/fe/src/features/lifelog/flow/FlowMap.tsx
+++ b/fe/src/features/lifelog/flow/FlowMap.tsx
@@ -1,0 +1,103 @@
+import "leaflet/dist/leaflet.css";
+
+import L from "leaflet";
+import { useEffect } from "react";
+import {
+  MapContainer,
+  Marker,
+  Polyline,
+  Popup,
+  TileLayer,
+  useMap,
+} from "react-leaflet";
+
+import type { MomentCard } from "../api/types";
+import { formatMomentTime } from "../lib/datetime";
+import { toGeoMoments } from "../lib/flowGeo";
+
+function numberIcon(order: number) {
+  return L.divIcon({
+    className: "lifelog-flow-pin",
+    html:
+      `<div style="display:flex;align-items:center;justify-content:center;` +
+      `width:24px;height:24px;border-radius:9999px;background:#8b00ff;color:#fff;` +
+      `font-size:12px;font-weight:600;border:2px solid #fff;box-shadow:0 1px 3px rgba(0,0,0,.4)">` +
+      `${order}</div>`,
+    iconSize: [24, 24],
+    iconAnchor: [12, 12],
+  });
+}
+
+/** 핀 좌표에 맞춰 지도 범위를 자동으로 맞춘다. */
+function FitBounds({ points }: { points: [number, number][] }) {
+  const map = useMap();
+  useEffect(() => {
+    if (points.length === 1) {
+      map.setView(points[0], 14);
+    } else if (points.length > 1) {
+      map.fitBounds(points, { padding: [40, 40] });
+    }
+  }, [points, map]);
+  return null;
+}
+
+/** 흐름 지도 뷰 — 좌표 있는 기록을 시간순 번호 핀 + 경로(polyline)로. (브라우저 전용) */
+export function FlowMap({ moments }: { moments: MomentCard[] }) {
+  const geo = toGeoMoments(moments);
+
+  if (geo.length === 0) {
+    return (
+      <p className="text-muted-foreground py-12 text-center text-sm">
+        위치 정보가 있는 기록이 없어요.
+      </p>
+    );
+  }
+
+  const positions = geo.map((g) => [g.lat, g.lng] as [number, number]);
+
+  return (
+    <MapContainer
+      center={positions[0]}
+      zoom={13}
+      scrollWheelZoom
+      style={{ height: 400, width: "100%", borderRadius: 8 }}
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      <FitBounds points={positions} />
+      {positions.length > 1 && (
+        <Polyline
+          positions={positions}
+          pathOptions={{ color: "#8b00ff", weight: 3 }}
+        />
+      )}
+      {geo.map((g) => (
+        <Marker
+          key={g.moment.id}
+          position={[g.lat, g.lng]}
+          icon={numberIcon(g.order)}
+        >
+          <Popup>
+            <div className="flex flex-col gap-1" style={{ maxWidth: 180 }}>
+              {g.moment.photos[0] && (
+                <img
+                  src={g.moment.photos[0].thumbUrl ?? g.moment.photos[0].url}
+                  alt=""
+                  style={{ width: "100%", borderRadius: 4 }}
+                />
+              )}
+              <span style={{ fontSize: 11, color: "#666" }}>
+                {formatMomentTime(g.moment.occurredAt)}
+              </span>
+              {g.moment.body && (
+                <span style={{ fontSize: 13 }}>{g.moment.body}</span>
+              )}
+            </div>
+          </Popup>
+        </Marker>
+      ))}
+    </MapContainer>
+  );
+}

--- a/fe/src/features/lifelog/lib/flowGeo.test.ts
+++ b/fe/src/features/lifelog/lib/flowGeo.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import type { MomentCard } from "../api/types";
+import { toGeoMoments } from "./flowGeo";
+
+function moment(
+  id: number,
+  lat: number | null,
+  lng: number | null,
+): MomentCard {
+  return {
+    id,
+    occurredAt: "2026-07-20T00:00:00Z",
+    body: null,
+    mood: null,
+    lat,
+    lng,
+    placeName: null,
+    tags: [],
+    photos: [],
+    flows: [],
+    createdAt: "2026-07-20T00:00:00Z",
+  };
+}
+
+describe("toGeoMoments", () => {
+  it("좌표 있는 기록만 뽑고 시간순 번호를 매긴다", () => {
+    const result = toGeoMoments([
+      moment(1, 33.45, 126.94),
+      moment(2, null, null),
+      moment(3, 35.1, 129.0),
+    ]);
+    expect(result.map((g) => g.moment.id)).toEqual([1, 3]);
+    expect(result.map((g) => g.order)).toEqual([1, 2]);
+  });
+
+  it("한쪽 좌표만 있으면 제외한다", () => {
+    expect(toGeoMoments([moment(1, 33.45, null)])).toEqual([]);
+  });
+});

--- a/fe/src/features/lifelog/lib/flowGeo.ts
+++ b/fe/src/features/lifelog/lib/flowGeo.ts
@@ -1,0 +1,25 @@
+import type { MomentCard } from "../api/types";
+
+export interface GeoMoment {
+  moment: MomentCard;
+  lat: number;
+  lng: number;
+  /** 시간순 순번(1부터). */
+  order: number;
+}
+
+/** 좌표가 있는 기록만 뽑아 시간순 번호를 매긴다(입력은 이미 흐름 순서). */
+export function toGeoMoments(moments: MomentCard[]): GeoMoment[] {
+  const result: GeoMoment[] = [];
+  for (const moment of moments) {
+    if (moment.lat != null && moment.lng != null) {
+      result.push({
+        moment,
+        lat: moment.lat,
+        lng: moment.lng,
+        order: result.length + 1,
+      });
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## 이슈
closes #958

## 작업 내용
- **`FlowMap`** — 좌표 있는 기록을 **시간순 번호 핀** + **경로(polyline)**로 지도에 표시
- **bounds 자동 fit**(핀들이 한눈에), **핀 클릭 → 팝업**(대표 사진·시각·본문)
- **좌표 없는 기록은 지도에서 생략**(타임라인엔 그대로), 좌표 있는 게 하나도 없으면 안내 문구
- `FlowDetailPage`의 **[타임라인|지도] 토글 지도 탭**에 연결(토글 상태 유지)
- `toGeoMoments` 순수 로직은 `lib/flowGeo.ts`로 분리(fast-refresh 경고 회피)

## 테스트
- `lib/flowGeo.test.ts` (2) — 좌표 있는 기록만 시간순 번호 매김·한쪽 좌표 제외
- `FlowMap.test.tsx` (1) — 좌표 없을 때 안내(지도 미표시)
- 전체 FE **524 통과**, eslint·prettier·tsc·`vite build` 그린
- ⚠️ Leaflet 지도 렌더는 브라우저 전용이라 jsdom 테스트는 순수 로직·빈 상태로 검증, 핀/경로/팝업은 로컬·E2E 확인 권장

## 🎉 일상기록 모듈 완료
Epic #949의 마지막 이슈입니다. BE 5 + FE 4 = **9개 이슈 전부 PR 완료**.