### PR TITLE
fix : 표 셀 드래그로 범위 선택 시 표가 통째로 끌려나오던 문제

### DIFF
--- a/fe/src/features/note/editor/DatasetTableView.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.tsx
@@ -69,7 +69,7 @@ export function DatasetTableView({
       // 여도 NodeSelection 분기로), 셀 드래그로 범위 선택하려 할 때 표가 통째로 끌려나온다. 드래그 소스가
       // 이 래퍼라 그리드 안쪽 onDragStart는 우회되므로, 래퍼에서 네이티브 드래그를 취소한다. 블록 이동은
       // 그리드 밖 드래그 핸들(⣿)이 자기 dragstart로 처리하므로 영향 없다. (PM 하이재킹은 stopEvent가 차단)
-      onDragStart={(e) => e.preventDefault()}
+      onDragStart={(e: React.DragEvent) => e.preventDefault()}
     >
       {datasetId != null && (
         <DatasetGrid

--- a/fe/src/features/note/editor/DatasetTableView.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.tsx
@@ -65,6 +65,11 @@ export function DatasetTableView({
       as="div"
       data-dataset-table={datasetId ?? ""}
       contentEditable={false}
+      // 표가 NodeSelection으로 선택되면 PM이 이 래퍼(nodeDOM)에 draggable=true를 심어(spec.draggable:false
+      // 여도 NodeSelection 분기로), 셀 드래그로 범위 선택하려 할 때 표가 통째로 끌려나온다. 드래그 소스가
+      // 이 래퍼라 그리드 안쪽 onDragStart는 우회되므로, 래퍼에서 네이티브 드래그를 취소한다. 블록 이동은
+      // 그리드 밖 드래그 핸들(⣿)이 자기 dragstart로 처리하므로 영향 없다. (PM 하이재킹은 stopEvent가 차단)
+      onDragStart={(e) => e.preventDefault()}
     >
       {datasetId != null && (
         <DatasetGrid

--- a/fe/src/features/note/editor/datasetTable.test.ts
+++ b/fe/src/features/note/editor/datasetTable.test.ts
@@ -68,10 +68,19 @@ describe("isGridSelfHandledEvent (셀 안 이벤트는 에디터가 무시)", ()
     }
   });
 
-  it("마우스·포커스 등은 false(PM에 맡긴다 — 포커스 이동에 필요)", () => {
+  it("dragstart면 true — 표가 선택된 상태에서 셀을 드래그해도 표가 안 끌려나오게", () => {
+    // 표 NodeSelection 상태면 PM이 노드 DOM에 draggable=true를 심어(spec.draggable:false여도)
+    // 셀 드래그가 표 이동으로 새는데, dragstart를 stopEvent로 막아 PM이 손대지 못하게 한다.
+    expect(isGridSelfHandledEvent(new Event("dragstart"))).toBe(true);
+  });
+
+  it("마우스·포커스·드롭 등은 false(PM에 맡긴다)", () => {
     expect(isGridSelfHandledEvent(new Event("mousedown"))).toBe(false);
     expect(isGridSelfHandledEvent(new Event("focus"))).toBe(false);
     expect(isGridSelfHandledEvent(new Event("click"))).toBe(false);
+    // drop/dragover는 안 막는다 — 블록 이동 핸들로 표 근처에 블록을 드롭하는 게 PM에 의존.
+    expect(isGridSelfHandledEvent(new Event("drop"))).toBe(false);
+    expect(isGridSelfHandledEvent(new Event("dragover"))).toBe(false);
   });
 });
 

--- a/fe/src/features/note/editor/datasetTable.ts
+++ b/fe/src/features/note/editor/datasetTable.ts
@@ -19,8 +19,14 @@ export interface DatasetTableAttrs {
  *   <li><b>keypress/beforeinput</b>: PM이 preventDefault → 셀에 글자가 안 들어간다(영어 입력 불가).
  *   <li><b>composition*</b>: 노드가 선택된 상태면 PM이 조합 텍스트로 노드를 대체 → 한글 치면 표 삭제.
  *   <li><b>clipboard(paste/copy/cut)</b>: PM의 handlePaste가 표 조각을 새 표로 삽입(왔다갔다).
+ *   <li><b>dragstart</b>: 표가 NodeSelection으로 선택된 상태면 PM의 MouseDown이 spec.draggable:false를
+ *       무시하고 노드 DOM(표 래퍼)에 draggable=true를 심는다(NodeSelection 분기). 그 뒤 셀을 드래그해
+ *       범위 선택하려 하면 드래그 소스가 표 래퍼가 되어(gridBox의 onDragStart는 자식이라 우회됨) PM의
+ *       dragstart가 표 노드를 통째로 끌어낸다. stopEvent로 막아 PM이 이 드래그를 손대지 않게 한다
+ *       (네이티브 드래그 취소는 NodeViewWrapper의 onDragStart preventDefault가 맡는다).
  * </ul>
- * 마우스·포커스 등은 PM에 맡긴다(그리드가 포커스 이동에 그 동작이 필요하다).
+ * 마우스·포커스 등은 PM에 맡긴다(그리드가 포커스 이동에 그 동작이 필요하다). drop/dragover는 막지 않는다
+ * — 블록 이동 핸들(⣿)로 표 근처에 다른 블록을 드롭하는 동작이 PM 드롭 처리에 의존한다.
  */
 export function isGridSelfHandledEvent(event: Event): boolean {
   switch (event.type) {
@@ -35,6 +41,7 @@ export function isGridSelfHandledEvent(event: Event): boolean {
     case "paste":
     case "copy":
     case "cut":
+    case "dragstart":
       return true;
     default:
       return false;


### PR DESCRIPTION
## 이슈
closes #981

## 작업 내용
표의 셀을 드래그해 범위를 선택하려 하면 표 블록 전체가 ProseMirror 네이티브 드래그로 끌려나오던 버그 수정.

### 원인
표 블록이 `NodeSelection`으로 선택된 상태(셀을 클릭하면 `blockSelected`)에서 셀을 mousedown하면, ProseMirror의 `MouseDown`이 노드의 `spec.draggable:false`를 무시하고 **NodeSelection 분기**로 노드 DOM(표 래퍼)에 `draggable=true`를 직접 심는다. 그 결과 드래그 소스가 표 래퍼가 되어, 그리드 안쪽 `gridBox`의 기존 `onDragStart` preventDefault(자식이라)를 우회하고 표가 통째로 끌려나온다. mouseup 시 attr을 지우므로 DOM에 흔적도 안 남아 원인 추적이 어려웠다.

### 조치 (에디터 레이어 2곳, 저위험)
- `datasetTable` NodeView의 `stopEvent`에 `dragstart` 추가 → PM의 dragstart 핸들러(`dataTransfer`/`view.dragging` 세팅)를 건너뛰게 해 표 노드 드래그 하이재킹 차단
- `DatasetTableView`의 `NodeViewWrapper`에 `onDragStart={(e) => e.preventDefault()}` → 드래그 소스가 래퍼인 네이티브 드래그 취소

### 영향 범위
- 블록 이동 핸들(⣿): 그리드 **밖** 핸들 버튼이 자기 dragstart로 처리하므로 영향 없음
- `drop`/`dragover`: 막지 않음 → 표 근처에 다른 블록을 드롭하는 동작 유지

### 검증
- `datasetTable.test.ts`: `isGridSelfHandledEvent('dragstart') === true`, `drop`/`dragover`는 `false` 유지 검증
- 노트 기능 테스트 226개 통과 · typecheck · format:check · eslint 클린
- 원인은 prosemirror-view 소스(`MouseDown` NodeSelection 분기 · `eventBelongsToView`→`stopEvent`)로 라인 단위 확정. dev 브라우저 목이 없어 인앱 실측은 로컬 스택 필요