### PR TITLE
fix : 표 셀 드래그 시 표가 끌려나오던 문제 재수정 (onDragStartCapture)

### DIFF
--- a/fe/src/features/note/editor/DatasetTableView.test.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.test.tsx
@@ -1,0 +1,115 @@
+import { createEvent, fireEvent, waitFor } from "@testing-library/react";
+import { Editor } from "@tiptap/core";
+import { EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+import { DatasetTable } from "./datasetTable";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function mockDataset() {
+  server.use(
+    http.get(`${API_BASE}/datasets/1`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          id: 1,
+          columns: [{ key: "c0", label: "과목" }],
+          rowCount: 1,
+        },
+      }),
+    ),
+    http.get(`${API_BASE}/datasets/1/rows`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          rows: [{ id: 100, rowIndex: 0, cells: ["네트워크"] }],
+          offset: 0,
+          limit: 100,
+        },
+      }),
+    ),
+    http.get(`${API_BASE}/datasets/1/merges`, () =>
+      HttpResponse.json({ code: "OK", data: { merges: [] } }),
+    ),
+  );
+}
+
+const FAKE_RECT = {
+  x: 0,
+  y: 0,
+  width: 800,
+  height: 600,
+  top: 0,
+  right: 800,
+  bottom: 600,
+  left: 0,
+  toJSON: () => ({}),
+} as DOMRect;
+
+function makeEditor() {
+  return new Editor({
+    extensions: [StarterKit, DatasetTable],
+    content: {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "위" }] },
+        { type: "datasetTable", attrs: { datasetId: 1 } },
+      ],
+    },
+  });
+}
+
+// 표가 NodeSelection으로 선택되면 PM이 표 래퍼에 draggable=true를 심어(spec.draggable:false여도),
+// 셀을 드래그해 범위 선택하려 할 때 표가 통째로 끌려나온다. NodeViewWrapper의 onDragStartCapture로
+// 네이티브 드래그를 취소한다. 반드시 capture 변형이어야 한다 — NodeViewWrapper가 onDragStart prop을
+// 자기 것으로 덮어써 무효화하기 때문(이 회귀를 잡는 테스트).
+describe("DatasetTableView — 셀 드래그 시 표가 끌려나오지 않는다", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue(
+      FAKE_RECT,
+    );
+    mockDataset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("표 노드가 선택된 상태에서 표 래퍼의 dragstart는 preventDefault되고 PM이 표를 끌지 않는다", async () => {
+    const editor = makeEditor();
+    renderWithRouter(<EditorContent editor={editor} />);
+
+    // NodeView(표 래퍼)가 마운트될 때까지 기다린다.
+    const wrap = await waitFor(() => {
+      const el = editor.view.dom.querySelector("[data-dataset-table]");
+      if (!el) throw new Error("표 래퍼 미마운트");
+      return el as HTMLElement;
+    });
+
+    // 표를 NodeSelection으로 선택(셀 클릭 시 blockSelected 되는 상태 재현).
+    let pos = -1;
+    editor.state.doc.descendants((n, p) => {
+      if (n.type.name === "datasetTable") pos = p;
+    });
+    editor.commands.setNodeSelection(pos);
+
+    // 표 래퍼에서 시작되는 네이티브 dragstart(=PM이 draggable=true로 만든 소스) 시뮬레이션.
+    const dragEvent = createEvent.dragStart(wrap);
+    fireEvent(wrap, dragEvent);
+
+    // onDragStartCapture가 실행돼 네이티브 드래그를 취소한다 → 표가 안 끌린다.
+    expect(dragEvent.defaultPrevented).toBe(true);
+    // PM도 이 드래그를 손대지 않는다(view.dragging 미설정).
+    expect(editor.view.dragging).toBeFalsy();
+
+    editor.destroy();
+  });
+});

--- a/fe/src/features/note/editor/DatasetTableView.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.tsx
@@ -66,10 +66,12 @@ export function DatasetTableView({
       data-dataset-table={datasetId ?? ""}
       contentEditable={false}
       // 표가 NodeSelection으로 선택되면 PM이 이 래퍼(nodeDOM)에 draggable=true를 심어(spec.draggable:false
-      // 여도 NodeSelection 분기로), 셀 드래그로 범위 선택하려 할 때 표가 통째로 끌려나온다. 드래그 소스가
-      // 이 래퍼라 그리드 안쪽 onDragStart는 우회되므로, 래퍼에서 네이티브 드래그를 취소한다. 블록 이동은
-      // 그리드 밖 드래그 핸들(⣿)이 자기 dragstart로 처리하므로 영향 없다. (PM 하이재킹은 stopEvent가 차단)
-      onDragStart={(e: React.DragEvent) => e.preventDefault()}
+      // 여도 NodeSelection 분기로), 셀 드래그로 범위 선택하려 할 때 표가 통째로 끌려나온다. 여기서 네이티브
+      // 드래그를 취소한다. 반드시 onDragStart가 아닌 onDragStartCapture로 건다 — NodeViewWrapper가 자기
+      // 컨텍스트의 onDragStart(우리 표엔 no-op)로 onDragStart prop을 덮어써 무효화하지만, capture 변형은
+      // 스프레드에서 살아남아 실제로 실행된다. 블록 이동은 그리드 밖 드래그 핸들(⣿)이 자기 dragstart로
+      // 처리하므로 영향 없다(핸들은 이 래퍼 밖이라 capture 경로에 안 걸린다).
+      onDragStartCapture={(e: React.DragEvent) => e.preventDefault()}
     >
       {datasetId != null && (
         <DatasetGrid

--- a/fe/src/features/note/editor/datasetTable.ts
+++ b/fe/src/features/note/editor/datasetTable.ts
@@ -23,7 +23,7 @@ export interface DatasetTableAttrs {
  *       무시하고 노드 DOM(표 래퍼)에 draggable=true를 심는다(NodeSelection 분기). 그 뒤 셀을 드래그해
  *       범위 선택하려 하면 드래그 소스가 표 래퍼가 되어(gridBox의 onDragStart는 자식이라 우회됨) PM의
  *       dragstart가 표 노드를 통째로 끌어낸다. stopEvent로 막아 PM이 이 드래그를 손대지 않게 한다
- *       (네이티브 드래그 취소는 NodeViewWrapper의 onDragStart preventDefault가 맡는다).
+ *       (네이티브 드래그 취소는 {@link DatasetTableView}의 NodeViewWrapper onDragStartCapture가 맡는다).
  * </ul>
  * 마우스·포커스 등은 PM에 맡긴다(그리드가 포커스 이동에 그 동작이 필요하다). drop/dragover는 막지 않는다
  * — 블록 이동 핸들(⣿)로 표 근처에 다른 블록을 드롭하는 동작이 PM 드롭 처리에 의존한다.


### PR DESCRIPTION
## 이슈
closes #981

## 배경
[#982](https://github.com/wcorn/orino/pull/982)에서 같은 버그를 수정했으나 **여전히 표가 끌려나왔다.** 실제 브라우저(Playwright)로 재현·검증해 원인을 정확히 규명하고 재수정한다.

## 진짜 원인
이전 수정은 `NodeViewWrapper`에 `onDragStart={(e) => e.preventDefault()}`를 걸었는데, **이 prop이 실행되지 않았다.**

`@tiptap/react`의 `NodeViewWrapper`는 렌더 시 `{...props, onDragStart}` 순서로, 넘겨받은 `onDragStart`를 **자기 컨텍스트의 onDragStart 핸들러로 덮어쓴다.** 그 핸들러(=TipTap core `NodeView.onDragStart`)는 `[data-drag-handle]`에서 시작한 드래그가 아니면 그냥 return하는 no-op이라, 우리 표에선 preventDefault가 **호출조차 되지 않았다.** → 네이티브 HTML5 드래그가 안 막혀 표가 계속 끌려나오고, 놓은 뒤에도 드래그가 이어지는(phantom) 증상까지 발생.

## 조치
`onDragStart` → **`onDragStartCapture`**로 교체. NodeViewWrapper는 `onDragStart`만 덮어쓰고 `onDragStartCapture`는 스프레드에서 살아남아 실제로 실행된다. capture에서 preventDefault하면 (1) 네이티브 드래그가 취소되고 (2) `event.defaultPrevented`로 PM의 dragstart 하이재킹도 함께 차단된다(#982에서 넣은 stopEvent와 이중 방어).

### 실제 브라우저 검증 (Playwright)
| 신호 | 기존(onDragStart) | 수정(onDragStartCapture) |
|---|---|---|
| 핸들러 실행 | ❌ 호출 안 됨 | ✅ 실행 |
| dragstart preventDefault | ❌ false → 표 끌림 | ✅ true → 안 끌림 |
| PM `view.dragging` | ❌ SET(표 끌림) | ✅ null |

## 영향 범위
- 블록 이동 핸들(⣿): 그리드 **밖** 요소라 capture 경로에 안 걸림 → 영향 없음
- `drop`/`dragover`: 그대로 PM 처리 → 표 근처 블록 드롭 유지

## 검증
- `DatasetTableView.test.tsx` 추가: EditorContent로 실제 NodeView를 마운트해 표 래퍼의 dragstart가 preventDefault되고 `view.dragging`이 null임을 확인. `onDragStart`로 되돌리면 실패(회귀 방지 teeth 확인)
- 노트 기능 테스트 227개 통과 · `npm run build`(tsc -b) · format:check · eslint 클린