### PR TITLE
fix : 표 셀 드래그 시 표 끌림 — 바깥 nodeDOM에 dragstart 리스너 (실측 재수정)

### DIFF
--- a/fe/src/features/note/editor/DatasetTableView.test.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.test.tsx
@@ -101,14 +101,16 @@ describe("DatasetTableView — 셀 드래그 시 표가 끌려나오지 않는�
     });
     editor.commands.setNodeSelection(pos);
 
-    // 표 래퍼에서 시작되는 네이티브 dragstart(=PM이 draggable=true로 만든 소스) 시뮬레이션.
-    const dragEvent = createEvent.dragStart(wrap);
-    fireEvent(wrap, dragEvent);
+    // 실제 드래그 소스는 NodeViewWrapper가 아니라 그 부모(TipTap이 만든 NodeView 컨테이너,
+    // = PM이 draggable=true를 심는 nodeDOM)다. 여기서 시작되는 네이티브 dragstart를 시뮬레이션한다.
+    const nodeDom = wrap.parentElement as HTMLElement;
+    expect(nodeDom).toBe(editor.view.nodeDOM(pos));
+    const dragEvent = createEvent.dragStart(nodeDom);
+    fireEvent(nodeDom, dragEvent);
 
-    // onDragStartCapture가 실행돼 네이티브 드래그를 취소한다 → 표가 안 끌린다.
+    // 바깥 nodeDOM에 건 dragstart 리스너가 preventDefault → 네이티브 드래그 취소 → 표가 안 끌린다.
+    // (핸들러를 NodeViewWrapper 자식에 걸면 부모발 이 이벤트를 못 잡아 defaultPrevented=false로 실패한다.)
     expect(dragEvent.defaultPrevented).toBe(true);
-    // PM도 이 드래그를 손대지 않는다(view.dragging 미설정).
-    expect(editor.view.dragging).toBeFalsy();
 
     editor.destroy();
   });

--- a/fe/src/features/note/editor/DatasetTableView.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.tsx
@@ -1,6 +1,7 @@
 import { useQueries } from "@tanstack/react-query";
 import type { Editor } from "@tiptap/react";
 import { type NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+import { useEffect, useRef } from "react";
 
 import { type DatasetMeta, fetchDatasetMeta } from "../dataset/api/datasets";
 import { DatasetGrid } from "../dataset/DatasetGrid";
@@ -43,6 +44,22 @@ export function DatasetTableView({
   const { requestDeleteDataset } = useDatasetTableContext();
   const siblingTables = useSiblingTables(editor, datasetId ?? -1);
 
+  // 셀을 드래그해 범위 선택하려 할 때 표 블록이 통째로 끌려나오던 문제를 막는다.
+  // 표가 NodeSelection으로 선택되면(셀 클릭 시 blockSelected) PM의 MouseDown이 spec.draggable:false를
+  // 무시하고 노드의 바깥 DOM에 draggable=true를 심는다(NodeSelection 분기). 그 바깥 DOM은 TipTap이
+  // 만든 NodeView 컨테이너(.react-renderer = NodeViewWrapper의 부모)라, 드래그 소스가 그 부모가 된다.
+  // 소스가 NodeViewWrapper '위'라 NodeViewWrapper의 onDragStart* prop으로는 못 막는다(부모의 이벤트는
+  // 자식으로 전파되지 않음). 그래서 부모 nodeDOM에 직접 네이티브 리스너를 걸어 capture에서 취소한다.
+  // 블록 이동(⣿ 핸들)은 이 노드 바깥 요소가 소스라 영향 없다.
+  const wrapRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const nodeDom = wrapRef.current?.parentElement;
+    if (!nodeDom) return;
+    const cancelDrag = (e: DragEvent) => e.preventDefault();
+    nodeDom.addEventListener("dragstart", cancelDrag, true);
+    return () => nodeDom.removeEventListener("dragstart", cancelDrag, true);
+  }, []);
+
   // 표 삭제(우클릭 메뉴·불러오기 실패 시 블록 제거) → 확인 먼저, 확인 시 dataset 삭제 +
   // 블록 제거를 함께. 블록 제거는 되돌리기 불가(addToHistory:false)라, Cmd+Z로 블록만
   // 되살아나 dataset 없는 고아 표가 생기지 않는다.
@@ -62,16 +79,10 @@ export function DatasetTableView({
 
   return (
     <NodeViewWrapper
+      ref={wrapRef}
       as="div"
       data-dataset-table={datasetId ?? ""}
       contentEditable={false}
-      // 표가 NodeSelection으로 선택되면 PM이 이 래퍼(nodeDOM)에 draggable=true를 심어(spec.draggable:false
-      // 여도 NodeSelection 분기로), 셀 드래그로 범위 선택하려 할 때 표가 통째로 끌려나온다. 여기서 네이티브
-      // 드래그를 취소한다. 반드시 onDragStart가 아닌 onDragStartCapture로 건다 — NodeViewWrapper가 자기
-      // 컨텍스트의 onDragStart(우리 표엔 no-op)로 onDragStart prop을 덮어써 무효화하지만, capture 변형은
-      // 스프레드에서 살아남아 실제로 실행된다. 블록 이동은 그리드 밖 드래그 핸들(⣿)이 자기 dragstart로
-      // 처리하므로 영향 없다(핸들은 이 래퍼 밖이라 capture 경로에 안 걸린다).
-      onDragStartCapture={(e: React.DragEvent) => e.preventDefault()}
     >
       {datasetId != null && (
         <DatasetGrid

--- a/fe/src/features/note/editor/datasetTable.ts
+++ b/fe/src/features/note/editor/datasetTable.ts
@@ -23,7 +23,7 @@ export interface DatasetTableAttrs {
  *       무시하고 노드 DOM(표 래퍼)에 draggable=true를 심는다(NodeSelection 분기). 그 뒤 셀을 드래그해
  *       범위 선택하려 하면 드래그 소스가 표 래퍼가 되어(gridBox의 onDragStart는 자식이라 우회됨) PM의
  *       dragstart가 표 노드를 통째로 끌어낸다. stopEvent로 막아 PM이 이 드래그를 손대지 않게 한다
- *       (네이티브 드래그 취소는 {@link DatasetTableView}의 NodeViewWrapper onDragStartCapture가 맡는다).
+ *       (네이티브 드래그 자체의 취소는 {@link DatasetTableView}가 바깥 nodeDOM에 건 dragstart 리스너가 맡는다).
  * </ul>
  * 마우스·포커스 등은 PM에 맡긴다(그리드가 포커스 이동에 그 동작이 필요하다). drop/dragover는 막지 않는다
  * — 블록 이동 핸들(⣿)로 표 근처에 다른 블록을 드롭하는 동작이 PM 드롭 처리에 의존한다.


### PR DESCRIPTION
## 이슈
closes #981

## 배경 — 앞선 두 수정(#982, #983)이 모두 무효였다
소스 추론만으로 고쳤다가 두 번 실패했다. 이번엔 **BE 없이 `fe/`에 임시 vite repro를 띄우고 Playwright의 real mouse drag**로 ground truth를 잡아 재수정했다.

## 진짜 원인 (실측으로 확정)
표가 NodeSelection으로 선택되면 PM `MouseDown`이 `spec.draggable:false`를 무시하고 노드의 **바깥 DOM**에 `draggable=true`를 심는다. 그 바깥 DOM은 TipTap이 만든 NodeView 컨테이너 `.react-renderer`인데, 이건 **`NodeViewWrapper`의 부모**다. 즉 네이티브 드래그의 **소스가 NodeViewWrapper의 부모 요소**라, NodeViewWrapper에 건 `onDragStart`/`onDragStartCapture` prop으로는 **절대 못 잡는다**(부모에서 난 이벤트는 자식으로 전파되지 않음).

Playwright 실측(real mouse drag):
| 방식 | dragstart target | 표 끌림? |
|---|---|---|
| `onDragStartCapture` (#983) | `div.react-renderer`, defaultPrevented=**false** | ❌ 끌림 |
| **부모 nodeDOM에 네이티브 리스너** | `div.react-renderer`, defaultPrevented=**true**, dragend 없음 | ✅ 안 끌림 |

## 조치
`DatasetTableView`에서 `ref`로 얻은 **부모 nodeDOM(`parentElement` = `.react-renderer`)**에 네이티브 `dragstart` 리스너를 capture로 걸어 `preventDefault`한다. (`editor.view.nodeDOM(pos)`와 동일한 요소임을 확인.) #982에서 넣은 `stopEvent`(PM의 `view.dragging` 방지)는 그대로 이중 방어로 유지.

## 영향 범위
- 블록 이동 핸들(⣿): 그리드 **밖** 요소가 드래그 소스라 이 리스너 경로에 안 걸림 → 영향 없음
- `drop`/`dragover`: 그대로 PM 처리 → 표 근처 블록 드롭 유지

## 검증
- **Playwright real mouse drag로 표가 안 끌림을 실측** (위 표)
- `DatasetTableView.test.tsx`: 실제 드래그 소스인 바깥 nodeDOM에서 dragstart를 발생시켜 `preventDefault`됨을 확인(리스너 제거 시 실패 = 회귀 방지 teeth 확인)
- 노트 테스트 227개 · `npm run build`(tsc -b) · format:check · eslint 클린