### PR TITLE
fix : 모바일 세로 모드에서 노트 목록이 안 보이던 문제

### DIFF
--- a/fe/src/features/note/components/NoteWorkspace.test.tsx
+++ b/fe/src/features/note/components/NoteWorkspace.test.tsx
@@ -1,8 +1,8 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { Route, Routes } from "react-router-dom";
-import { beforeEach, describe, expect, it } from "vitest";
+import { Route, Routes, useSearchParams } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { Providers } from "@/app/providers";
 import { useAuthStore } from "@/features/auth/store/authStore";
@@ -13,11 +13,26 @@ import { NoteWorkspace } from "./NoteWorkspace";
 
 const API_BASE = "https://api.orino.dev/api";
 
+// 현재 선택된 노트(URL ?note=)를 노출한다. jsdom은 CSS(md:hidden 등)를 적용하지 않아 "목록 vs
+// 에디터" 표시를 DOM 존재로 판별할 수 없으므로, 자동 선택 여부는 이 파라미터로 결정적으로 확인한다.
+function NoteParamProbe() {
+  const [sp] = useSearchParams();
+  return <div data-testid="note-param">{sp.get("note") ?? ""}</div>;
+}
+
 function renderWorkspace(initialEntries = ["/notes"]) {
   return renderWithRouter(
     <Providers>
       <Routes>
-        <Route path="/notes" element={<NoteWorkspace />} />
+        <Route
+          path="/notes"
+          element={
+            <>
+              <NoteWorkspace />
+              <NoteParamProbe />
+            </>
+          }
+        />
       </Routes>
     </Providers>,
     { initialEntries },
@@ -61,6 +76,20 @@ function mockNoteDetail(
       }),
     ),
   );
+}
+
+/** 좁은 화면(모바일, md 미만)으로 matchMedia를 목킹한다. */
+function setNarrowViewport() {
+  window.matchMedia = ((query: string) => ({
+    matches: query.includes("767"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
 }
 
 describe("NoteWorkspace (독립 노트)", () => {
@@ -292,6 +321,58 @@ describe("NoteWorkspace (독립 노트)", () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText("노트 제목")).toHaveValue("자식");
+    });
+  });
+
+  // 모바일(좁은 화면)은 노트 선택 시 트리를 숨기는 드릴다운 레이아웃. 자동 선택하면 목록을 볼 수 없다.
+  describe("모바일(좁은 화면)", () => {
+    const originalMatchMedia = window.matchMedia;
+    afterEach(() => {
+      window.matchMedia = originalMatchMedia;
+    });
+
+    it("첫 노트를 자동 선택하지 않고 목록을 보여준다", async () => {
+      setNarrowViewport();
+      mockTree([
+        { id: 1, title: "노트1", parentId: null, sortOrder: 0, children: [] },
+        { id: 2, title: "노트2", parentId: null, sortOrder: 1, children: [] },
+      ]);
+      mockNoteDetail(1, { type: "doc", content: [] }, "노트1");
+
+      renderWorkspace();
+
+      // 목록의 노트들이 보인다.
+      expect(
+        await screen.findByRole("button", { name: "노트1" }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "노트2" })).toBeInTheDocument();
+      // 자동 선택되지 않는다 → ?note= 파라미터가 비어 있다(데스크탑이면 첫 노트로 채워진다).
+      expect(screen.getByTestId("note-param").textContent).toBe("");
+      expect(screen.queryByLabelText("노트 제목")).not.toBeInTheDocument();
+    });
+
+    it("노트를 열고 '노트 목록'으로 돌아오면 목록이 다시 보인다(자동 재선택 안 함)", async () => {
+      setNarrowViewport();
+      mockTree([
+        { id: 1, title: "노트1", parentId: null, sortOrder: 0, children: [] },
+      ]);
+      mockNoteDetail(1, { type: "doc", content: [] }, "노트1");
+
+      const user = userEvent.setup();
+      renderWorkspace();
+
+      await user.click(await screen.findByRole("button", { name: "노트1" }));
+      await waitFor(() => {
+        expect(screen.getByLabelText("노트 제목")).toHaveValue("노트1");
+      });
+
+      await user.click(screen.getByRole("button", { name: /노트 목록/ }));
+
+      // 목록으로 돌아오고, effect가 즉시 다시 선택하지 않는다.
+      await waitFor(() => {
+        expect(screen.queryByLabelText("노트 제목")).not.toBeInTheDocument();
+      });
+      expect(screen.getByRole("button", { name: "노트1" })).toBeInTheDocument();
     });
   });
 });

--- a/fe/src/features/note/components/NoteWorkspace.tsx
+++ b/fe/src/features/note/components/NoteWorkspace.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { FieldError } from "@/components/ui/field-error";
 import { LoadingText } from "@/components/ui/loading-text";
+import { useIsNarrow } from "@/shared/lib/useIsNarrow";
 
 import type { NoteTreeNode } from "../api/notes";
 import { useNoteDetail } from "../hooks/useNoteDetail";
@@ -62,14 +63,17 @@ export function NoteWorkspace() {
   };
 
   const tree = treeQuery.data ?? [];
+  const isNarrow = useIsNarrow();
 
-  // 노트가 있는데 아무것도 선택 안 됐으면 첫 루트 자동 선택
+  // 노트가 있는데 아무것도 선택 안 됐으면 첫 루트 자동 선택 — 단, 데스크탑(2-pane, md+)에서만.
+  // 모바일은 노트 선택 시 트리를 숨기는 드릴다운이라, 자동 선택하면 목록을 볼 수 없고 '노트 목록'
+  // 뒤로가기를 눌러도(setActiveNote(null)) 이 effect가 즉시 다시 첫 노트를 선택해 목록으로 못 돌아간다.
   useEffect(() => {
-    if (activeNoteId == null && tree.length > 0) {
+    if (!isNarrow && activeNoteId == null && tree.length > 0) {
       setActiveNote(tree[0].id);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeNoteId, tree]);
+  }, [isNarrow, activeNoteId, tree]);
 
   const handleAddRoot = () => {
     if (createNote.isPending) return;

--- a/fe/src/features/planner/components/plan/WeeklyPlan.tsx
+++ b/fe/src/features/planner/components/plan/WeeklyPlan.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { FieldError } from "@/components/ui/field-error";
 import { LoadingText } from "@/components/ui/loading-text";
 import { cn } from "@/lib/utils";
+import { useIsNarrow } from "@/shared/lib/useIsNarrow";
 
 import { useSaveWeeklyPlan, useWeeklyPlan } from "../../hooks/useWeeklyPlan";
 import { PlanBlockCreate } from "./PlanBlockCreate";
@@ -19,24 +20,6 @@ import {
 import { WeeklyPlanGrid } from "./WeeklyPlanGrid";
 
 const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];
-
-/** 화면 폭이 좁으면(모바일) 1일 뷰로 전환. matchMedia 미지원 환경(테스트)은 데스크탑으로 간주. */
-function useIsNarrow(): boolean {
-  const [narrow, setNarrow] = useState(
-    () =>
-      typeof window !== "undefined" &&
-      typeof window.matchMedia === "function" &&
-      window.matchMedia("(max-width: 767px)").matches,
-  );
-  useEffect(() => {
-    if (typeof window.matchMedia !== "function") return;
-    const mq = window.matchMedia("(max-width: 767px)");
-    const handler = () => setNarrow(mq.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
-  return narrow;
-}
 
 /** 주간 계획표 페이지 본체. 서버 주간 템플릿을 로드해 로컬 편집 후 전량 교체로 저장한다. */
 export function WeeklyPlan() {

--- a/fe/src/shared/lib/useIsNarrow.ts
+++ b/fe/src/shared/lib/useIsNarrow.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+// Tailwind md 브레이크포인트(768px) 미만 = 모바일(좁은 화면). 레이아웃이 md에서 갈리므로 767 기준.
+const NARROW_QUERY = "(max-width: 767px)";
+
+/**
+ * 화면 폭이 좁으면(모바일, md 미만) true. 화면 회전·리사이즈에 반응한다.
+ * matchMedia 미지원 환경(테스트 jsdom)은 데스크탑으로 간주한다(false).
+ */
+export function useIsNarrow(): boolean {
+  const [narrow, setNarrow] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia(NARROW_QUERY).matches,
+  );
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const mq = window.matchMedia(NARROW_QUERY);
+    const handler = () => setNarrow(mq.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  return narrow;
+}


### PR DESCRIPTION
## 이슈
closes #985

## 증상
모바일 **세로 모드**에서 노트 목록(트리 사이드바)이 보이지 않는다. 가로 모드(2-pane)는 보이지만, 세로에선 목록에 접근할 수 없어 '가로 전환 → 노트 선택 → 다시 세로'로 우회해야 했다.

## 원인
`NoteWorkspace`의 **첫 노트 자동 선택 `useEffect`가 모든 뷰포트에서** 동작한다. 모바일은 노트가 선택되면 트리를 숨기는 드릴다운 레이아웃이라, 로드 즉시 에디터로 들어가 목록을 못 본다. '노트 목록' 뒤로가기(`setActiveNote(null)`)를 눌러도 이 effect가 **즉시 다시 첫 노트를 선택**해 목록으로 돌아갈 수 없었다. (가로는 2-pane이라 트리가 항상 보여 문제 없음.)

## 조치
- 자동 선택을 **데스크탑(2-pane, md+)에서만** 수행하도록 `useIsNarrow`로 게이트.
- `WeeklyPlan`에 있던 **동일 로직의 로컬 `useIsNarrow`를 `@/shared/lib/useIsNarrow`로 추출**해 공용화(중복 제거). matchMedia `(max-width: 767px)`, 회전·리사이즈 반응, 테스트(jsdom·matchMedia 미지원)는 데스크탑으로 간주.

## 검증
- `NoteWorkspace.test.tsx`: 좁은 화면 목킹으로 (1) 첫 노트 자동 선택 안 하고 목록 노출, (2) 노트 열고 '노트 목록'으로 돌아오면 목록 유지(자동 재선택 안 함) — 게이트 제거 시 둘 다 실패(회귀 방지 확인). CSS 미적용 jsdom 특성상 표시 여부는 URL `?note=` 파라미터로 결정적으로 판별.
- 영향 테스트 334개 통과 · `npm run build`(tsc -b) · format:check · eslint 클린