### PR TITLE
feat : 노트 본문 링크 삽입 (Notion 스타일)

### DIFF
--- a/fe/src/features/note/components/EditorToolbar.test.tsx
+++ b/fe/src/features/note/components/EditorToolbar.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { noteLinkOptions } from "../editor/link";
+import { EditorToolbar } from "./EditorToolbar";
+
+describe("EditorToolbar — 링크 버튼", () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    editor = new Editor({
+      element,
+      extensions: [StarterKit.configure({ link: noteLinkOptions })],
+      content: "<p>hello world</p>",
+    });
+  });
+
+  afterEach(() => {
+    editor.destroy();
+    vi.restoreAllMocks();
+  });
+
+  it("선택이 없고 링크도 아니면 비활성", () => {
+    act(() => {
+      editor.chain().setTextSelection(3).run(); // collapsed caret
+    });
+    render(<EditorToolbar editor={editor} onInsertLink={() => {}} />);
+    expect(screen.getByRole("button", { name: "링크" })).toBeDisabled();
+  });
+
+  it("텍스트가 선택되면 활성화되고, 클릭 시 onInsertLink 호출", async () => {
+    const onInsertLink = vi.fn();
+    act(() => {
+      editor.chain().setTextSelection({ from: 1, to: 6 }).run(); // "hello"
+    });
+    render(<EditorToolbar editor={editor} onInsertLink={onInsertLink} />);
+
+    const btn = screen.getByRole("button", { name: "링크" });
+    expect(btn).toBeEnabled();
+
+    await userEvent.click(btn);
+    expect(onInsertLink).toHaveBeenCalledTimes(1);
+  });
+
+  it("커서가 링크 위에 있으면 눌린 상태(aria-pressed)로 표시", () => {
+    act(() => {
+      editor
+        .chain()
+        .setTextSelection({ from: 1, to: 6 })
+        .setLink({ href: "https://example.com" })
+        .setTextSelection(3) // 링크 안으로 커서 이동(선택 없음)
+        .run();
+    });
+    render(<EditorToolbar editor={editor} onInsertLink={() => {}} />);
+
+    const btn = screen.getByRole("button", { name: "링크" });
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+    // 링크 위에서는 선택이 없어도 활성(편집 가능).
+    expect(btn).toBeEnabled();
+  });
+
+  it("onInsertLink가 없으면 링크 버튼을 렌더하지 않는다", () => {
+    render(<EditorToolbar editor={editor} />);
+    expect(
+      screen.queryByRole("button", { name: "링크" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/fe/src/features/note/components/EditorToolbar.tsx
+++ b/fe/src/features/note/components/EditorToolbar.tsx
@@ -8,6 +8,7 @@ import {
   Heading2,
   ImagePlus,
   Italic,
+  Link2,
   List,
   ListOrdered,
   Quote,
@@ -28,6 +29,8 @@ interface Props {
   editor: Editor | null;
   onInsertPage?: () => void;
   insertPagePending?: boolean;
+  /** 링크 편집 UI 열기(선택 텍스트에 링크 추가 또는 기존 링크 편집). */
+  onInsertLink?: () => void;
 }
 
 interface ToolbarButton {
@@ -41,6 +44,7 @@ export function EditorToolbar({
   editor,
   onInsertPage,
   insertPagePending,
+  onInsertLink,
 }: Props) {
   // selection 변화(마크 토글, 커서 이동 등)에 toolbar 활성 표시가 갱신되도록 구독한다.
   useEditorState({
@@ -147,6 +151,21 @@ export function EditorToolbar({
           </Button>
         );
       })}
+      {onInsertLink && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="링크"
+          aria-pressed={editor.isActive("link")}
+          className={cn(editor.isActive("link") && "bg-muted")}
+          // 선택된 텍스트가 있거나 커서가 링크 위에 있을 때만 활성.
+          disabled={editor.state.selection.empty && !editor.isActive("link")}
+          onClick={onInsertLink}
+        >
+          <Link2 className="size-4" />
+        </Button>
+      )}
       <Button
         type="button"
         variant="ghost"

--- a/fe/src/features/note/components/LinkMenu.tsx
+++ b/fe/src/features/note/components/LinkMenu.tsx
@@ -1,0 +1,174 @@
+import { type Editor, useEditorState } from "@tiptap/react";
+import { BubbleMenu } from "@tiptap/react/menus";
+import { Check, ExternalLink, Link2Off, Pencil, X } from "lucide-react";
+import { type RefObject, useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+import { normalizeUrl } from "../editor/link";
+
+interface Props {
+  editor: Editor;
+  /** 툴바 버튼·Cmd+K가 링크 편집을 열 수 있도록 open 함수를 등록할 ref. */
+  openRef: RefObject<() => void>;
+}
+
+/**
+ * 링크 버블메뉴. 커서가 링크 위에 있으면 열기·편집·해제 버튼을, 편집 중이면 URL 입력을 보여준다.
+ * 툴바 링크 버튼·Cmd+K는 openRef.current()로 편집을 연다(선택 텍스트 또는 기존 링크 대상).
+ */
+export function LinkMenu({ editor, openRef }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [url, setUrl] = useState("");
+  // shouldShow는 생성 시점 클로저라 최신 editing을 못 본다 → ref로 읽는다.
+  const editingRef = useRef(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // 링크 href를 구독해 커서가 링크 안팎을 오갈 때 버블 내용(URL·버튼)이 갱신되게 한다.
+  const href = useEditorState({
+    editor,
+    selector: ({ editor }) =>
+      (editor.getAttributes("link").href as string | undefined) ?? "",
+  });
+
+  const setEditingState = (v: boolean) => {
+    editingRef.current = v;
+    setEditing(v);
+    // 선택 변화 없이 editing만 바뀌어도 버블이 shouldShow를 다시 평가하도록 트랜잭션을 흘린다.
+    editor.view.dispatch(editor.state.tr.setMeta("linkMenu", v));
+  };
+
+  // 툴바/단축키에서 호출: 링크 위이거나 텍스트가 선택돼 있을 때만 편집을 연다.
+  useEffect(() => {
+    openRef.current = () => {
+      if (!editor.isActive("link") && editor.state.selection.empty) return;
+      setUrl((editor.getAttributes("link").href as string | undefined) ?? "");
+      setEditingState(true);
+    };
+  });
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  const apply = () => {
+    const normalized = normalizeUrl(url);
+    if (!normalized) {
+      remove();
+      return;
+    }
+    editor
+      .chain()
+      .focus()
+      .extendMarkRange("link")
+      .setLink({ href: normalized })
+      .run();
+    setEditingState(false);
+  };
+
+  const remove = () => {
+    editor.chain().focus().extendMarkRange("link").unsetLink().run();
+    setEditingState(false);
+  };
+
+  const openHref = () => {
+    if (href) window.open(href, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <BubbleMenu
+      editor={editor}
+      pluginKey="linkMenu"
+      shouldShow={({ editor }) =>
+        editor.isEditable && (editor.isActive("link") || editingRef.current)
+      }
+      options={{ placement: "bottom" }}
+      className="border-border bg-popover flex items-center gap-0.5 rounded-md border p-1 shadow-md"
+    >
+      {editing ? (
+        <>
+          <Input
+            ref={inputRef}
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                apply();
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                setEditingState(false);
+              }
+            }}
+            placeholder="https://example.com"
+            aria-label="링크 URL"
+            className="h-7 w-56 text-sm"
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="링크 적용"
+            onClick={apply}
+          >
+            <Check className="size-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="편집 취소"
+            onClick={() => setEditingState(false)}
+          >
+            <X className="size-4" />
+          </Button>
+        </>
+      ) : (
+        <>
+          <a
+            href={href || undefined}
+            onClick={(e) => {
+              e.preventDefault();
+              openHref();
+            }}
+            className="text-muted-foreground max-w-[16rem] truncate px-1 text-sm hover:underline"
+            title={href}
+          >
+            {href}
+          </a>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="링크 열기"
+            onClick={openHref}
+          >
+            <ExternalLink className="size-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="링크 편집"
+            onClick={() => {
+              setUrl(href);
+              setEditingState(true);
+            }}
+          >
+            <Pencil className="size-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="링크 해제"
+            onClick={remove}
+          >
+            <Link2Off className="size-4" />
+          </Button>
+        </>
+      )}
+    </BubbleMenu>
+  );
+}

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -20,12 +20,14 @@ import { ChildPageContext } from "../editor/childPageContext";
 import { collectDatasetIds, DatasetTable } from "../editor/datasetTable";
 import { DatasetTableContext } from "../editor/datasetTableContext";
 import { extractImageFiles, uploadAndInsertImage } from "../editor/imageUpload";
+import { LinkShortcut, noteLinkOptions } from "../editor/link";
 import { insertTableFromCells } from "../editor/pasteCellsAsTable";
 import { useAutoSaveNote } from "../hooks/useAutoSaveNote";
 import { useCreateNote, useDeleteNote } from "../hooks/useNoteMutations";
 import { useNoteTree } from "../hooks/useNoteTree";
 import { noteKeys } from "../queryKeys";
 import { EditorToolbar } from "./EditorToolbar";
+import { LinkMenu } from "./LinkMenu";
 import { SaveStatusIndicator } from "./SaveStatusIndicator";
 
 interface Props {
@@ -70,11 +72,13 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
   // editorProps 핸들러(handlePaste/handleDrop)는 생성 시점 클로저라 editor를
   // 직접 못 잡으므로 ref로 우회한다.
   const editorRef = useRef<ReturnType<typeof useEditor>>(null);
+  // 링크 편집 UI 열기 — LinkMenu가 채우고, 툴바 버튼·Cmd+K가 호출한다.
+  const openLinkEditorRef = useRef<() => void>(() => {});
 
   const editor = useEditor(
     {
       extensions: [
-        StarterKit,
+        StarterKit.configure({ link: noteLinkOptions }),
         TaskList,
         TaskItem.configure({ nested: true }),
         Image.configure({ inline: false }),
@@ -83,6 +87,9 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
         }),
         ChildPage,
         DatasetTable,
+        LinkShortcut.configure({
+          onTrigger: () => openLinkEditorRef.current(),
+        }),
       ],
       content: note.content as JSONContent,
       editorProps: {
@@ -253,7 +260,9 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
           editor={editor}
           onInsertPage={handleInsertPage}
           insertPagePending={createNote.isPending}
+          onInsertLink={() => openLinkEditorRef.current()}
         />
+        {editor && <LinkMenu editor={editor} openRef={openLinkEditorRef} />}
         {editor && (
           // nested: 리스트 항목 등 중첩 블록도 개별(한 줄) 드래그 타깃이 되게 한다.
           // edgeDetection "none": 기본값(left,top)은 항목 왼쪽 가장자리에서 부모(리스트)를

--- a/fe/src/features/note/editor/link.test.ts
+++ b/fe/src/features/note/editor/link.test.ts
@@ -1,0 +1,73 @@
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { describe, expect, it } from "vitest";
+
+import { normalizeUrl, noteLinkOptions } from "./link";
+
+describe("normalizeUrl", () => {
+  it("빈 문자열·공백은 null", () => {
+    expect(normalizeUrl("")).toBeNull();
+    expect(normalizeUrl("   ")).toBeNull();
+  });
+
+  it("스킴이 없으면 https:// 를 붙인다(Notion처럼 도메인만 입력)", () => {
+    expect(normalizeUrl("example.com")).toBe("https://example.com");
+    expect(normalizeUrl("  example.com/path?q=1 ")).toBe(
+      "https://example.com/path?q=1",
+    );
+  });
+
+  it("이미 스킴이 있으면 그대로 둔다", () => {
+    expect(normalizeUrl("http://a.com")).toBe("http://a.com");
+    expect(normalizeUrl("https://a.com")).toBe("https://a.com");
+    expect(normalizeUrl("mailto:a@b.com")).toBe("mailto:a@b.com");
+    expect(normalizeUrl("tel:+123")).toBe("tel:+123");
+  });
+
+  it("이메일처럼 보이면 mailto: 를 붙인다", () => {
+    expect(normalizeUrl("a@b.com")).toBe("mailto:a@b.com");
+  });
+
+  it("위험 스킴(javascript/data/vbscript)은 null", () => {
+    expect(normalizeUrl("javascript:alert(1)")).toBeNull();
+    expect(normalizeUrl("JavaScript:alert(1)")).toBeNull();
+    expect(normalizeUrl("data:text/html,<script>")).toBeNull();
+    expect(normalizeUrl("vbscript:msgbox")).toBeNull();
+  });
+});
+
+describe("noteLinkOptions (StarterKit Link 구성)", () => {
+  function makeEditor() {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    return new Editor({
+      element,
+      extensions: [StarterKit.configure({ link: noteLinkOptions })],
+      content: "<p>hello world</p>",
+    });
+  }
+
+  it("setLink가 note-link 클래스·target·rel을 붙인다", () => {
+    const editor = makeEditor();
+    editor
+      .chain()
+      .setTextSelection({ from: 1, to: 6 }) // "hello"
+      .setLink({ href: "https://example.com" })
+      .run();
+    const html = editor.getHTML();
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain('class="note-link"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain("noopener");
+    editor.destroy();
+  });
+
+  it("openOnClick=false — 링크 클릭이 새 창 열기를 켜지 않는다", () => {
+    const editor = makeEditor();
+    const link = editor.extensionManager.extensions.find(
+      (e) => e.name === "link",
+    );
+    expect(link?.options.openOnClick).toBe(false);
+    editor.destroy();
+  });
+});

--- a/fe/src/features/note/editor/link.ts
+++ b/fe/src/features/note/editor/link.ts
@@ -1,0 +1,53 @@
+import { Extension } from "@tiptap/core";
+import type { LinkOptions } from "@tiptap/extension-link";
+
+/**
+ * 사용자가 입력한 링크 문자열을 안전한 href로 정규화한다.
+ * - 위험 스킴(javascript:/data:/vbscript:)은 거부(null).
+ * - 스킴이 있으면 그대로(mailto:·tel: 등 포함).
+ * - 이메일처럼 보이면 mailto: 프리픽스.
+ * - 그 외에는 https:// 프리픽스(Notion처럼 "example.com"만 쳐도 링크가 되게).
+ * 반환 null = 유효하지 않음(링크 걸지 않음/해제).
+ */
+export function normalizeUrl(input: string): string | null {
+  const raw = input.trim();
+  if (!raw) return null;
+  if (/^(javascript|data|vbscript):/i.test(raw)) return null;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(raw)) return raw; // 이미 스킴 있음
+  if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(raw)) return `mailto:${raw}`;
+  return `https://${raw}`;
+}
+
+/** StarterKit에 포함된 Link 확장 옵션. 클릭으로 바로 열지 않고(버블메뉴로 열기·편집·해제) 새 탭·nofollow. */
+export const noteLinkOptions: Partial<LinkOptions> = {
+  openOnClick: false,
+  autolink: true,
+  linkOnPaste: true,
+  defaultProtocol: "https",
+  HTMLAttributes: {
+    class: "note-link",
+    rel: "noopener noreferrer nofollow",
+    target: "_blank",
+  },
+};
+
+export interface LinkShortcutOptions {
+  /** Cmd/Ctrl+K가 눌렸을 때 호출(링크 편집 UI 열기). */
+  onTrigger: () => void;
+}
+
+/** Cmd/Ctrl+K로 링크 편집 UI를 여는 단축키만 담당하는 확장. UI는 React(LinkMenu)가 처리한다. */
+export const LinkShortcut = Extension.create<LinkShortcutOptions>({
+  name: "linkShortcut",
+  addOptions() {
+    return { onTrigger: () => {} };
+  },
+  addKeyboardShortcuts() {
+    return {
+      "Mod-k": () => {
+        this.options.onTrigger();
+        return true;
+      },
+    };
+  },
+});

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -183,6 +183,15 @@
   margin-bottom: 0.1em;
 }
 
+/* 링크(note-link). primary 색 + 밑줄로 링크임을 드러낸다. openOnClick=false라 에디터 안에선
+   클릭해도 이동하지 않고(버블메뉴로 열기), 커서는 링크임을 알리도록 pointer. */
+.tiptap a.note-link {
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
 .tiptap li > p {
   margin-top: 0;
   margin-bottom: 0;


### PR DESCRIPTION
## 이슈
closes #987

## 작업 내용
노트 본문에서 선택한 텍스트에 웹 URL 하이퍼링크를 걸 수 있게 한다(Notion 스타일). StarterKit v3에 Link 확장이 이미 포함돼 있어(붙여넣기 자동 링크·마크다운 링크 동작) **UI만** 추가한다.

### 진입점 3가지
- **툴바 링크 버튼**: 텍스트가 선택돼 있거나 커서가 링크 위에 있을 때 활성. 클릭 시 편집 UI 열기.
- **Cmd/Ctrl+K 단축키**: 선택 텍스트에 링크 편집 UI 열기(`LinkShortcut` 확장).
- **링크 버블메뉴**(`LinkMenu`): 커서가 링크 위에 있으면 URL 표시 + 열기(↗)·편집(✎)·해제(✕). 편집 시 URL 입력(Enter 적용, Esc 취소).

### 세부
- Link 구성: `openOnClick:false`(에디터 안 클릭으로 이동 안 함, 버블메뉴로 열기), `autolink`, `linkOnPaste`, `defaultProtocol:https`, `target=_blank` + `rel=noopener noreferrer nofollow`, `class=note-link`.
- `normalizeUrl`: 스킴 없으면 `https://` 프리픽스("example.com"만 쳐도 링크), 이메일은 `mailto:`, `javascript:`/`data:`/`vbscript:` 차단.
- `.tiptap a.note-link` 스타일(primary 색·밑줄).

### 검증
- **실제 브라우저(Playwright)로 3가지 플로우 실측**: ① 선택→툴바 버튼→URL 입력→`<a href=https://…>` 적용 ② 링크 위 커서→버블 열기/편집/해제 ③ Cmd+K→입력→적용. URL 자동 https 정규화·target·rel·class 확인.
- 단위/통합 테스트: `link.test`(normalizeUrl·Link 구성), `EditorToolbar.test`(링크 버튼 활성/비활성/클릭/aria-pressed). *BubbleMenu는 floating-ui 기반이라 jsdom에서 렌더 안 됨 → UI 상호작용은 브라우저 검증으로 대체.*
- 노트 테스트 240개 통과 · `npm run build`(tsc -b) · format:check · eslint 클린