### PR TITLE
chore : 노드 팬 소음 저감 — idle 부스트 억제 IaC화

### DIFF
--- a/infra/ansible/roles/node_os/defaults/main.yml
+++ b/infra/ansible/roles/node_os/defaults/main.yml
@@ -5,3 +5,12 @@
 node_os_sysctls:
   fs.inotify.max_user_instances: "1024"   # 기본 128 → 1024
   fs.inotify.max_user_watches: "524288"   # 기본 ~119k → 524288
+
+# 노드 팬 소음 저감(#989).
+# ASUS+AMD 노트북 노드가 idle(CPU 98~99%)인데도 EPP=performance 로 상시 풀부스트 →
+# 발열(Tctl 61~70℃) → 펌웨어가 팬을 3200rpm 상시 가동해 소음이 큼.
+# platform_profile=quiet + 전 코어 EPP=power 로 idle 부스트를 억제한다.
+# amd_pstate(active) + acpi platform_profile 을 쓰는 노드 기준. 인터페이스가 없으면 스킵.
+node_os_power_tuning_enabled: true
+node_os_platform_profile: quiet          # quiet | balanced | performance
+node_os_energy_perf_preference: power    # power | balance_power | balance_performance | performance | default

--- a/infra/ansible/roles/node_os/handlers/main.yml
+++ b/infra/ansible/roles/node_os/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# 스크립트/유닛이 바뀌면 즉시 재적용(oneshot 재실행)한다.
+- name: Reexec power tuning
+  ansible.builtin.systemd:
+    name: orino-power-tuning.service
+    state: restarted
+    daemon_reload: true

--- a/infra/ansible/roles/node_os/tasks/main.yml
+++ b/infra/ansible/roles/node_os/tasks/main.yml
@@ -10,3 +10,32 @@
   loop: "{{ node_os_sysctls | dict2items }}"
   loop_control:
     label: "{{ item.key }} = {{ item.value }}"
+
+# --- 팬 소음 저감(#989): idle 부스트 억제 ---
+- name: 전력/발열 튜닝 스크립트 배포
+  ansible.builtin.template:
+    src: orino-power-tuning.sh.j2
+    dest: /usr/local/sbin/orino-power-tuning.sh
+    owner: root
+    group: root
+    mode: "0755"
+  when: node_os_power_tuning_enabled | bool
+  notify: Reexec power tuning
+
+- name: 전력/발열 튜닝 systemd 유닛 배포
+  ansible.builtin.template:
+    src: orino-power-tuning.service.j2
+    dest: /etc/systemd/system/orino-power-tuning.service
+    owner: root
+    group: root
+    mode: "0644"
+  when: node_os_power_tuning_enabled | bool
+  notify: Reexec power tuning
+
+- name: 전력/발열 튜닝 유닛 활성화 (부팅 시 자동 재적용)
+  ansible.builtin.systemd:
+    name: orino-power-tuning.service
+    enabled: true
+    state: started
+    daemon_reload: true
+  when: node_os_power_tuning_enabled | bool

--- a/infra/ansible/roles/node_os/templates/orino-power-tuning.service.j2
+++ b/infra/ansible/roles/node_os/templates/orino-power-tuning.service.j2
@@ -1,0 +1,14 @@
+# {{ ansible_managed }}
+# 노드 팬 소음 저감(#989): 부팅 시 idle 부스트 억제 설정을 재적용한다.
+[Unit]
+Description=Orino node power/thermal tuning (fan noise reduction, #989)
+After=multi-user.target
+# CPU/ACPI 인터페이스는 부팅 직후 준비되므로 별도 의존성 없이 실행
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/orino-power-tuning.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/ansible/roles/node_os/templates/orino-power-tuning.sh.j2
+++ b/infra/ansible/roles/node_os/templates/orino-power-tuning.sh.j2
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# {{ ansible_managed }}
+# 노드 팬 소음 저감(#989): idle 부스트 억제로 발열·팬속도를 낮춘다.
+# sysfs 쓰기는 재부팅 시 사라지므로 이 스크립트를 systemd oneshot 으로 부팅마다 재적용한다.
+set -u
+
+PROFILE="{{ node_os_platform_profile }}"
+EPP="{{ node_os_energy_perf_preference }}"
+
+# 1) ACPI platform_profile (팬 커브 완화)
+pp=/sys/firmware/acpi/platform_profile
+if [ -w "$pp" ] && grep -qw "$PROFILE" /sys/firmware/acpi/platform_profile_choices 2>/dev/null; then
+  echo "$PROFILE" > "$pp" && echo "platform_profile -> $PROFILE"
+else
+  echo "platform_profile: 인터페이스 없음 또는 미지원 값($PROFILE) → 스킵"
+fi
+
+# 2) 전 코어 EPP (idle 부스트 억제) — amd_pstate/intel_pstate active 모드 필요
+applied=0
+for f in /sys/devices/system/cpu/cpu*/cpufreq/energy_performance_preference; do
+  [ -w "$f" ] || continue
+  avail_file="$(dirname "$f")/energy_performance_available_preferences"
+  if grep -qw "$EPP" "$avail_file" 2>/dev/null; then
+    echo "$EPP" > "$f" && applied=$((applied+1))
+  fi
+done
+if [ "$applied" -gt 0 ]; then
+  echo "energy_performance_preference -> $EPP (${applied} cpus)"
+else
+  echo "EPP: 쓰기 가능한 인터페이스 없음(active pstate 아님?) → 스킵"
+fi
+
+exit 0


### PR DESCRIPTION
## 이슈
closes #989

## 작업 내용
note1/note2(ASUS+AMD 노트북 노드)가 **idle(CPU 98~99%)인데도 팬이 상시 3200 RPM**으로 돌아 소음이 컸음. 원인은 전력 정책이 성능 편향(`EPP=performance`, `platform_profile=balanced`)으로 고정되어, 노드가 놀아도 CPU가 최대 부스트(최대 4.2GHz) → 발열(Tctl 61~70℃) → 펌웨어가 팬을 상시 최대 가동.

Ansible `node_os` 역할에 전력/발열 튜닝을 코드화:
- `platform_profile` → **quiet** (팬 커브 완화)
- 전 코어 **EPP → power** (idle 부스트 억제 → 발열↓ → 팬↓)
- **systemd oneshot 유닛**으로 재부팅 시 자동 재적용 (sysfs 직접 쓰기는 휘발되므로)
- CPU/ACPI 인터페이스가 없거나 미지원 값이면 스크립트에서 안전하게 스킵 (`node_os_power_tuning_enabled`로 on/off)

### 변경 파일
- `defaults/main.yml` — 튜닝 변수 추가
- `tasks/main.yml` — 스크립트·유닛 배포 + 활성화 태스크
- `handlers/main.yml` — 변경 시 oneshot 재실행
- `templates/orino-power-tuning.sh.j2`, `orino-power-tuning.service.j2`

### 적용/검증 (머지 후 또는 사전 승인 시)
- `ansible-playbook site.yml` 재실행으로 노드 반영
- before/after 온도·팬 실측 → Engineering Log 기록 예정

ansible-lint production 프로파일 통과, syntax-check 통과.