### PR TITLE
chore : 노드 팬 소음 저감 2차 — 최대 주파수 캡(2.2GHz)

### DIFF
--- a/infra/ansible/roles/node_os/defaults/main.yml
+++ b/infra/ansible/roles/node_os/defaults/main.yml
@@ -14,3 +14,10 @@ node_os_sysctls:
 node_os_power_tuning_enabled: true
 node_os_platform_profile: quiet          # quiet | balanced | performance
 node_os_energy_perf_preference: power    # power | balance_power | balance_performance | performance | default
+
+# 최대 주파수 캡(#989 후속). EPP=power 만으론 idle 클럭이 여전히 ~3.3GHz까지 올라
+# 발열이 안 떨어졌음(팬 3200→2600rpm 에서 정체). Ryzen 7 5800H base 3.2GHz / boost 4.46GHz →
+# base 아래(2.2GHz)로 캡해 부스트를 사실상 차단하고 발열을 낮춘다.
+# 16스레드라 2.2GHz 캡도 대부분 idle 인 이 클러스터엔 성능 여유가 충분하다.
+# 0 이면 캡하지 않음(원복). cpuinfo_max 로 클램프되므로 값이 커도 안전.
+node_os_scaling_max_freq_khz: 2200000    # 2.2GHz. 0=캡 해제

--- a/infra/ansible/roles/node_os/templates/orino-power-tuning.sh.j2
+++ b/infra/ansible/roles/node_os/templates/orino-power-tuning.sh.j2
@@ -6,6 +6,7 @@ set -u
 
 PROFILE="{{ node_os_platform_profile }}"
 EPP="{{ node_os_energy_perf_preference }}"
+MAXFREQ="{{ node_os_scaling_max_freq_khz }}"   # kHz, 0=캡 해제
 
 # 1) ACPI platform_profile (팬 커브 완화)
 pp=/sys/firmware/acpi/platform_profile
@@ -28,6 +29,31 @@ if [ "$applied" -gt 0 ]; then
   echo "energy_performance_preference -> $EPP (${applied} cpus)"
 else
   echo "EPP: 쓰기 가능한 인터페이스 없음(active pstate 아님?) → 스킵"
+fi
+
+# 3) 전 코어 최대 주파수 캡 (부스트 차단 → 발열↓) — 0 이면 원복(cpuinfo_max 로 해제)
+capped=0
+for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_max_freq; do
+  [ -w "$f" ] || continue
+  d="$(dirname "$f")"
+  hw_max="$(cat "$d/cpuinfo_max_freq" 2>/dev/null)" || continue
+  if [ "$MAXFREQ" -gt 0 ] 2>/dev/null; then
+    # cpuinfo_max 초과 요청은 하드웨어 상한으로 클램프
+    target="$MAXFREQ"; [ "$target" -gt "$hw_max" ] && target="$hw_max"
+  else
+    target="$hw_max"   # 캡 해제 = 하드웨어 상한으로 복원
+  fi
+  # scaling_min 이 target 보다 크면 먼저 낮춰야 쓰기가 거부되지 않음
+  cur_min="$(cat "$d/scaling_min_freq" 2>/dev/null)"
+  if [ -n "$cur_min" ] && [ "$cur_min" -gt "$target" ]; then
+    echo "$(cat "$d/cpuinfo_min_freq")" > "$d/scaling_min_freq" 2>/dev/null
+  fi
+  echo "$target" > "$f" && capped=$((capped+1))
+done
+if [ "$capped" -gt 0 ]; then
+  echo "scaling_max_freq -> ${MAXFREQ} kHz 요청 (${capped} cpus, 하드웨어 상한으로 클램프)"
+else
+  echo "scaling_max_freq: 쓰기 가능한 인터페이스 없음 → 스킵"
 fi
 
 exit 0


### PR DESCRIPTION
## 이슈
closes #989

## 배경
1차 튜닝(PR #990: platform_profile=quiet + EPP=power) 적용 후 실측 결과, 팬은 3200→2600rpm 로 내려갔지만 **온도가 거의 안 떨어져(note1 61℃, note2 68℃) '조용'까진 아니었음.** 원인은 EPP=power 가 부스트 성향만 낮출 뿐 **최대 주파수는 여전히 ~3.3GHz까지 올라가서** 발열이 유지된 것.

## 작업 내용
전 코어 `scaling_max_freq` 캡 추가:
- Ryzen 7 5800H (base 3.2GHz / boost 4.46GHz) → **2.2GHz 로 캡해 부스트 사실상 차단**
- 16스레드라 대부분 idle 인 이 클러스터엔 성능 여유 충분
- `node_os_scaling_max_freq_khz` 변수로 조정(**0=캡 해제**), `cpuinfo_max`로 안전 클램프
- `scaling_min`이 target 보다 크면 먼저 낮춰 쓰기 거부 방지
- 기존 orino-power-tuning 스크립트에 3번 단계로 추가 → systemd oneshot 으로 재부팅에도 유지

## 검증
- ansible-lint production 프로파일 통과
- 렌더링 스크립트 `bash -n` 통과
- 적용(CICD) 후 before/after 온도·팬 재실측 → Engineering Log 기록 예정