### PR TITLE
fix : 모바일 표 — 좌우 스크롤 불가 + 스크롤 구간 구분선 누락

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -3054,4 +3054,95 @@ describe("DatasetGrid", () => {
     fireEvent.keyDown(grid, { key: "z", metaKey: true, shiftKey: true });
     await waitFor(() => expect(has(["라우터", "92"])).toBe(2));
   });
+
+  // ===== 터치(모바일) — 선택이 가상 키보드를 부르지 않게 (#994) =====
+
+  const ACTIVE_INPUT = "1행 2열 셀 (입력하면 편집)";
+
+  it("터치로 셀을 탭하면 선택만 되고 활성 입력창은 뜨지 않는다(가상 키보드 방지)", async () => {
+    mockDataset([["네트워크", "92"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const cell = (await screen.findByText("92")).parentElement as HTMLElement;
+
+    fireEvent.pointerDown(cell, { button: 0, pointerType: "touch" });
+
+    // 입력창이 아예 없어야 한다 — 있으면 포커스가 가고, 모바일에선 그게 곧 키보드다.
+    expect(screen.queryByLabelText(ACTIVE_INPUT)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("셀 1행 2열")).not.toBeInTheDocument();
+    // 값은 그대로 보인다(선택 자체는 됐다).
+    expect(screen.getByText("92")).toBeInTheDocument();
+  });
+
+  it("터치로 이미 선택된 셀을 다시 탭하면 편집으로 들어간다(더블탭 아님)", async () => {
+    mockDataset([["네트워크", "92"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const cell = (await screen.findByText("92")).parentElement as HTMLElement;
+
+    fireEvent.pointerDown(cell, { button: 0, pointerType: "touch" });
+    fireEvent.pointerDown(cell, { button: 0, pointerType: "touch" });
+
+    // 이때만 입력창이 뜬다 — 편집이므로 키보드가 올라오는 게 맞다.
+    const input = await screen.findByLabelText("셀 1행 2열");
+    expect(input).toHaveValue("92");
+  });
+
+  it("터치로 다른 셀을 탭하면 편집이 아니라 그 셀 선택으로 옮겨간다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const first = (await screen.findByText("네트워크"))
+      .parentElement as HTMLElement;
+    const second = screen.getByText("92").parentElement as HTMLElement;
+
+    fireEvent.pointerDown(first, { button: 0, pointerType: "touch" });
+    fireEvent.pointerDown(second, { button: 0, pointerType: "touch" });
+
+    expect(screen.queryByLabelText("셀 1행 2열")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(ACTIVE_INPUT)).not.toBeInTheDocument();
+  });
+
+  it("터치 드래그는 범위 선택으로 잡지 않는다(스크롤에 양보)", async () => {
+    mockDataset([
+      ["네트워크", "92"],
+      ["운영체제", "78"],
+    ]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const a = (await screen.findByText("네트워크"))
+      .parentElement as HTMLElement; // (0,0)
+    const b = screen.getByText("78").parentElement as HTMLElement; // (1,1)
+
+    fireEvent.pointerDown(a, { button: 0, pointerType: "touch" });
+    fireEvent.pointerEnter(b);
+
+    const setData = vi.fn();
+    fireEvent.copy(screen.getByTestId("dataset-grid"), {
+      clipboardData: { setData, getData: () => "" },
+    });
+
+    // 범위로 번지지 않고 처음 탭한 한 칸에 머문다.
+    expect(setData).toHaveBeenCalledWith("text/plain", "네트워크");
+  });
+
+  it("마우스 클릭은 그대로 활성 입력창을 띄운다(회귀)", async () => {
+    mockDataset([["네트워크", "92"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const cell = (await screen.findByText("92")).parentElement as HTMLElement;
+
+    fireEvent.pointerDown(cell, { button: 0, pointerType: "mouse" });
+
+    expect(await screen.findByLabelText(ACTIVE_INPUT)).toHaveValue("");
+  });
+
+  it("터치 선택 뒤 물리 키보드를 쓰면 활성 입력창이 되살아난다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    const cell = (await screen.findByText("92")).parentElement as HTMLElement;
+
+    fireEvent.pointerDown(cell, { button: 0, pointerType: "touch" });
+    expect(screen.queryByLabelText(ACTIVE_INPUT)).not.toBeInTheDocument();
+
+    // 외장 키보드가 달린 태블릿 — 키를 누르는 순간 타이핑을 받을 수 있어야 한다.
+    fireEvent.keyDown(screen.getByTestId("dataset-grid"), { key: "Shift" });
+
+    expect(await screen.findByLabelText(ACTIVE_INPUT)).toBeInTheDocument();
+  });
 });

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -171,6 +171,9 @@ export function DatasetGrid({
   const [sel, setSel] = useState<Sel>(null);
   // 드래그 선택 중인 축(셀/행/열). 눌러서 끌 때만 값이 있고 window pointerup에서 해제한다.
   const selDrag = useRef<null | "cells" | "rows" | "cols">(null);
+  // 지금 선택이 터치에서 왔는지. 터치면 활성 셀 입력창을 띄우지 않는다 — <input>에 포커스가
+  // 가는 순간 가상 키보드가 떠서 표를 좌우로 스크롤할 수 없다(#994). 마우스/펜은 영향 없다.
+  const [touchSelect, setTouchSelect] = useState(false);
   // 채우기 핸들 드래그 중인 대상 행(세로). null이면 채우기 중 아님. window pointerup에서 확정한다.
   const [fillTo, setFillTo] = useState<number | null>(null);
   const fillDragging = useRef(false);
@@ -1011,18 +1014,46 @@ export function DatasetGrid({
     col >= selRect.c0 &&
     col <= selRect.c1;
 
-  // 클릭=선택, 드래그=범위, shift+클릭=확장. (더블클릭은 편집으로 따로 간다)
-  const startCellSelect = (row: number, col: number, shift: boolean) => {
+  /** (row,col)만 단일 선택된 상태인가 — 터치로 같은 셀을 다시 탭했는지 판별에 쓴다. */
+  const isSingleSelected = (row: number, col: number) =>
+    sel?.kind === "cells" &&
+    sel.a[0] === sel.b[0] &&
+    sel.a[1] === sel.b[1] &&
+    sel.a[0] === row &&
+    sel.a[1] === col;
+
+  /**
+   * 클릭=선택, 드래그=범위, shift+클릭=확장. (더블클릭은 편집으로 따로 간다)
+   *
+   * 터치는 다르게 간다(#994). 첫 탭은 선택만 하고 입력창을 띄우지 않아 가상 키보드가 뜨지
+   * 않게 하고(그래야 표를 좌우로 스크롤할 수 있다), **이미 선택된 셀을 다시 탭**하면 편집으로
+   * 들어간다 — 더블탭은 브라우저 확대 제스처와 겹쳐 모바일에서 신뢰할 수 없다.
+   * 터치 드래그도 범위 선택으로 잡지 않는다. 같은 제스처를 스크롤과 나눠 쓸 수 없고,
+   * 열이 넘치는 표에선 스크롤이 우선이다.
+   */
+  const startCellSelect = (
+    row: number,
+    col: number,
+    shift: boolean,
+    pointerType?: string,
+  ) => {
+    const viaTouch = pointerType === "touch";
     setEditing(null);
     if (shift && sel?.kind === "cells") {
       setSel({ kind: "cells", a: sel.a, b: [row, col] });
-    } else {
-      selDrag.current = "cells";
-      setSel({ kind: "cells", a: [row, col], b: [row, col] });
-      // 단일 선택 즉시 타이핑 대비: 셀 표시값으로 draft를 채워 둔다(입력창이 값을 전체
-      // 선택한 채 뜨므로, 글자를 치면 덮어써지고 한글은 그 입력창에서 조합된다).
-      setDraft(getRow(row)?.[col] ?? "");
+      return;
     }
+    if (viaTouch && isSingleSelected(row, col)) {
+      startEdit(row, col);
+      return;
+    }
+    setTouchSelect(viaTouch);
+    // 터치 드래그는 스크롤에 양보한다(범위 선택으로 잡지 않는다).
+    selDrag.current = viaTouch ? null : "cells";
+    setSel({ kind: "cells", a: [row, col], b: [row, col] });
+    // 단일 선택 즉시 타이핑 대비: 셀 표시값으로 draft를 채워 둔다(입력창이 값을 전체
+    // 선택한 채 뜨므로, 글자를 치면 덮어써지고 한글은 그 입력창에서 조합된다).
+    setDraft(getRow(row)?.[col] ?? "");
   };
 
   /**
@@ -1416,6 +1447,9 @@ export function DatasetGrid({
    */
   const onGridKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (editing) return; // 편집 중엔 입력창이 처리한다.
+    // 물리 키보드를 쓰기 시작했다는 뜻 — 터치 모드를 풀어 활성 셀 입력창을 되살린다
+    // (터치로 고른 뒤 외장 키보드로 타이핑하는 태블릿 경우).
+    if (touchSelect) setTouchSelect(false);
     // Cmd/Ctrl+Z(되돌리기) / +Shift 또는 Ctrl+Y(다시 실행). 스택이 비면 아무 일도 안 한다.
     if (isUndoRedoKey(e)) {
       e.preventDefault();
@@ -1641,13 +1675,9 @@ export function DatasetGrid({
     // 단일 셀만 선택된 상태(범위/행/열/표 아님)이고 이 셀이 그 셀이면 "활성"이다.
     // 활성 셀엔 편집 전에도 입력창을 띄워 두되 비워 둔다(값은 뒤 표시칸이 보여줌). 글자를 치면
     // 빈 칸에 들어가 그대로 덮어쓰기가 되고 편집으로 넘어간다 — 같은 <input>이라 IME도 안 끊긴다.
+    // 단, 터치로 선택한 경우엔 띄우지 않는다 — 포커스가 곧 가상 키보드라 스크롤을 막는다(#994).
     const isSelectActive =
-      !editing &&
-      sel?.kind === "cells" &&
-      sel.a[0] === sel.b[0] &&
-      sel.a[1] === sel.b[1] &&
-      sel.a[0] === rowIndex &&
-      sel.a[1] === c;
+      !editing && !touchSelect && isSingleSelected(rowIndex, c);
     const isActive = isEditing || isSelectActive;
     const cells = getRow(rowIndex);
     const formula = getFormulas(rowIndex)[colKey];
@@ -1938,7 +1968,12 @@ export function DatasetGrid({
                         // 클릭=선택, 드래그=범위, shift+클릭=확장, 더블클릭=편집.
                         onPointerDown={(e) => {
                           if (e.button === 0)
-                            startCellSelect(vi.index, c, e.shiftKey);
+                            startCellSelect(
+                              vi.index,
+                              c,
+                              e.shiftKey,
+                              e.pointerType,
+                            );
                         }}
                         onPointerEnter={() => {
                           // 채우기 드래그 중이면 이 행을 대상으로, 아니면 셀 범위 확장.
@@ -2059,7 +2094,12 @@ export function DatasetGrid({
                         }}
                         onPointerDown={(e) => {
                           if (e.button === 0)
-                            startCellSelect(m.rowIndex, ai, e.shiftKey);
+                            startCellSelect(
+                              m.rowIndex,
+                              ai,
+                              e.shiftKey,
+                              e.pointerType,
+                            );
                         }}
                         onDoubleClick={() => startEdit(m.rowIndex, ai)}
                         onContextMenu={(e) =>


### PR DESCRIPTION
## 이슈
closes #994
closes #996

> 같은 파일(`DatasetGrid.tsx`)의 표 렌더링 문제 2건이라 한 PR로 묶었다. 나눠 올리면 서로 충돌하고 리뷰가 갈린다.

## 1. 모바일에서 좌우 스크롤 불가 (#994)

모바일 PWA에서 표를 좌우로 스크롤하려고 터치하면 가상 키보드가 올라와 스크롤이 불가능했다.

### 원인

단일 셀이 선택되면(편집 아님) 그 셀 위에 **빈 `<input autoFocus>`를 미리 띄운다.** 데스크탑에선 의도된 장치다 — 선택 직후 글자를 치면 곧바로 덮어쓰기가 되고 한글 IME 조합이 끊기지 않는다.

그런데 **터치에선 이 입력창이 포커스되는 순간 가상 키보드가 뜬다.** 표를 잡으려는 첫 터치가 곧 셀 선택이라, 스크롤할 때마다 키보드가 올라왔다.

### 수정

`pointerdown`의 `e.pointerType`으로 갈랐다. **마우스·펜 동작은 그대로다.**

| | 마우스·펜 | 터치 |
|---|---|---|
| 1번째 | 선택 + 활성 입력창 | **선택만** — 입력창 없음 → 키보드 안 뜸 |
| 같은 셀 다시 | (변화 없음) | **편집 진입** — 이때만 키보드 |
| 편집 | 더블클릭 | 같은 셀 재탭 |
| 드래그 | 범위 선택 | **범위 선택 안 함** — 스크롤에 양보 |

- **더블탭을 안 쓴 이유**: 브라우저 확대 제스처와 겹쳐 모바일에서 신뢰할 수 없다. "선택된 셀 재탭"은 Excel·Sheets 모바일과 같은 관례다.
- **터치 드래그를 범위 선택으로 안 잡는 이유**: 같은 제스처를 스크롤과 나눠 쓸 수 없고, 열이 넘치는 표에선 스크롤이 우선이다.
- **물리 키보드 keydown이 오면 터치 모드를 푼다** — 외장 키보드 태블릿에서 타이핑을 받을 수 있게.
- **화면 폭이 아니라 포인터 종류로 가른 이유**: 좁은 창의 데스크탑은 마우스로 쓰고, 넓은 태블릿도 손가락으로 쓴다. 원인은 화면 크기가 아니라 입력 방식이다.

## 2. 스크롤한 구간에 행 구분선이 안 그려짐 (#996)

표가 가로로 넘칠 때 오른쪽으로 스크롤하면 **행의 가로줄이 사라졌다.** 모바일에서 발견했지만 모바일 전용이 아니다 — 창을 좁힌 데스크탑에서도 재현된다.

### 원인

행 요소가 `w-full`인데, **가로 스크롤 컨테이너 안의 블록 요소는 폭이 `auto`라 보이는 폭(clientWidth)까지만 차지한다.** 셀은 `gridTemplateColumns`대로 그 밖까지 넘쳐 그려지지만, **가로줄은 셀이 아니라 행의 `border-b`** 라서 행 폭에서 끊긴다.

실측 (390px 뷰포트 · 10열):

| | 수정 전 | 수정 후 |
|---|---|---|
| 스크롤 컨테이너 clientWidth | 262px | 262px |
| 스크롤 컨테이너 scrollWidth | 1200px | 1200px |
| 본문 컨테이너 폭 | **262px** | **1200px** |
| 행 폭 (= 가로줄 길이) | **262px** ← 여기서 끊김 | **1200px** ✅ |

같은 이유로 `w-full`을 쓰는 **세로 병합 오버레이**·**열 선택 핸들 바**·**열 요약줄**도 갇혀 있었다.

### 수정

본문 컨테이너에 **열 최소 폭 합계**를 `min-width`로 준다(지정 폭 열은 그 값, 유연폭 열은 `FLEX_COLUMN_MIN_WIDTH=120`). 그 위의 `w-full` 요소가 전부 표 전체 폭으로 늘어난다.

- 컨테이너가 그보다 넓으면 `min-width`가 안 걸려 기존 `1fr` 스트레치가 그대로 산다
- `width: max-content`로는 안 된다 — 행이 `position: absolute`(가상화)라 **절대 위치 자식은 intrinsic 폭에 기여하지 않는다.** 그래서 열 정의에서 직접 계산한다
- 유연폭 최소값을 상수화했다(드래그 리사이즈 하한 `MIN_COLUMN_WIDTH=60`과는 별개 개념)

## 테스트

`DatasetGrid.test.tsx` 9건 추가.

**#996** — jsdom엔 레이아웃이 없어 인라인 `min-width` 값으로 검증:
- 유연폭 2열 → `240px`
- 지정폭 300 + 유연폭 → `420px`
- 열 요약줄도 같은 값

**#994** — 6건 추가 (`pointerType`을 실은 pointerdown으로 두 경로를 모두 검증):

- 터치 탭 → 활성 입력창·편집 입력창 둘 다 없음 (키보드 방지)
- 터치 재탭 → 편집 진입, 기존 값 유지
- 터치로 다른 셀 탭 → 편집이 아니라 선택 이동
- 터치 드래그(pointerenter) → 범위로 안 번짐 (복사 결과로 검증)
- **마우스 클릭 → 기존대로 활성 입력창 (회귀)**
- 터치 선택 뒤 keydown → 활성 입력창 복귀

`vitest` 562건 / `npm run build`(tsc) / `format:check` / `lint` 모두 통과.

## 로컬 확인

390×844 뷰포트 + 10열 8행 표(스크롤 폭 1200px / 뷰 262px):

**#994** — 실제 `PointerEvent`로

| | 결과 |
|---|---|
| 터치 첫 탭 | 셀 입력창 **0개**, `document.activeElement` = `BODY` |
| 그 상태로 가로 스크롤 | `scrollLeft` 0 → **400** ✅ |
| 터치 재탭 | `셀 1행 1열` 입력창 생성 + 포커스 ✅ |
| 마우스 클릭 | `1행 1열 셀 (입력하면 편집)` 그대로 ✅ |

**#996** — 맨 오른쪽까지 스크롤한 상태에서

| | 결과 |
|---|---|
| 본문 컨테이너 폭 | 262 → **1200px** ✅ |
| 행 8개 모두 뷰포트 전 구간을 덮는가 | **8/8** ✅ |
| 스크린샷 | 오른쪽 끝에서도 가로줄이 이어짐 확인 |

## Wiki

- [Data-Grid-Block §5.2](https://github.com/wcorn/orino/wiki/Data-Grid-Block) — 가로 넘침 시 행 폭(min-width) 근거 + 포인터별 상호작용 표
- §10 결정 기록에 2건 추가
