### PR TITLE
feat : 복습 허브 개수를 필터 기준 총 개수로

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.6' apply false
+    id 'org.springframework.boot' version '4.0.7' apply false
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -19,11 +19,8 @@ subprojects {
         }
     }
 
-    ext['jackson-2-bom.version'] = '2.21.4'
-    ext['jackson-bom.version'] = '3.1.4'
+    // BOM보다 높은 버전이 필요한 것만 남긴다(CVE 대응). 나머지는 4.0.7 BOM이 이미 커버한다.
     ext['netty.version'] = '4.2.16.Final'
-    ext['spring-security.version'] = '7.0.5'
-    ext['tomcat.version'] = '11.0.22'
 
     repositories {
         mavenCentral()
@@ -31,7 +28,7 @@ subprojects {
 
     dependencyManagement {
         imports {
-            mavenBom "org.springframework.boot:spring-boot-dependencies:4.0.6"
+            mavenBom "org.springframework.boot:spring-boot-dependencies:4.0.7"
         }
     }
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CompletedReviewsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/CompletedReviewsResponse.java
@@ -4,10 +4,16 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.List;
 
+/**
+ * 완료된 복습 목록 페이지.
+ * {@code totalCount}는 현재 필터에 걸리는 전체 건수로, 첫 페이지(cursor 없음)에서만 채운다.
+ * 이후 페이지는 null이라 무한스크롤마다 COUNT를 돌지 않는다.
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CompletedReviewsResponse(
         List<CompletedReviewItem> items,
         String nextCursor,
-        boolean hasNext
+        boolean hasNext,
+        Long totalCount
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/UpcomingReviewsResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/dto/UpcomingReviewsResponse.java
@@ -5,11 +5,17 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDate;
 import java.util.List;
 
+/**
+ * 앞으로의 복습 목록 페이지.
+ * {@code totalCount}는 현재 필터에 걸리는 전체 건수로, 첫 페이지(cursor 없음)에서만 채운다.
+ * 이후 페이지는 null이라 무한스크롤마다 COUNT를 돌지 않는다.
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record UpcomingReviewsResponse(
         LocalDate today,
         List<UpcomingReviewItem> items,
         String nextCursor,
-        boolean hasNext
+        boolean hasNext,
+        Long totalCount
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
@@ -307,7 +307,15 @@ public class ReviewQueryService {
             ReviewSchedule last = page.get(page.size() - 1);
             nextCursor = new KeysetCursor(last.getScheduledAt(), last.getId()).encode();
         }
-        return new UpcomingReviewsResponse(today, items, nextCursor, hasNext);
+
+        // 첫 페이지에서만 COUNT — 이후 페이지는 필터가 같으므로 클라이언트가 첫 값을 유지한다.
+        Long totalCount = c == null
+                ? reviewScheduleRepository.countUpcoming(
+                        memberId, materialId, upperBound,
+                        typeFilter.cardType(), typeFilter.siblingRequired())
+                : null;
+
+        return new UpcomingReviewsResponse(today, items, nextCursor, hasNext, totalCount);
     }
 
     /** 완료된 복습 목록 — COMPLETED, completed_at DESC, 커서 keyset 페이징 + 자료/평가 필터. */
@@ -344,7 +352,13 @@ public class ReviewQueryService {
             ReviewSchedule last = page.get(page.size() - 1);
             nextCursor = new KeysetCursor(last.getCompletedAt(), last.getId()).encode();
         }
-        return new CompletedReviewsResponse(items, nextCursor, hasNext);
+
+        // 첫 페이지에서만 COUNT — 이후 페이지는 필터가 같으므로 클라이언트가 첫 값을 유지한다.
+        Long totalCount = c == null
+                ? reviewScheduleRepository.countCompleted(memberId, materialId, rating)
+                : null;
+
+        return new CompletedReviewsResponse(items, nextCursor, hasNext, totalCount);
     }
 
     private int clampSize(Integer size) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewCompletedControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewCompletedControllerTest.java
@@ -161,6 +161,44 @@ class ReviewCompletedControllerTest extends ApiTestSupport {
     }
 
     @Test
+    @DisplayName("GET completed - totalCount는 필터 기준 총 건수이며 첫 페이지에만 실린다")
+    void total_count_is_filtered_total_on_first_page() throws Exception {
+        Flashcard a = basicCard(materialA);
+        completed(a, 1, Rating.GOOD, TODAY.atTime(8, 0));
+        completed(a, 2, Rating.GOOD, TODAY.atTime(9, 0));
+        completed(a, 3, Rating.AGAIN, TODAY.atTime(10, 0));
+        completed(basicCard(materialB), 1, Rating.GOOD, TODAY.atTime(11, 0));
+
+        MvcResult first = mockMvc.perform(get("/api/planner/reviews/completed")
+                        .param("size", "2")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(2)))
+                .andExpect(jsonPath("$.data.totalCount").value(4))
+                .andReturn();
+        String cursor = JsonPath.read(first.getResponse().getContentAsString(), "$.data.nextCursor");
+
+        mockMvc.perform(get("/api/planner/reviews/completed")
+                        .param("size", "2")
+                        .param("cursor", cursor)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalCount").doesNotExist());
+
+        mockMvc.perform(get("/api/planner/reviews/completed")
+                        .param("grade", "GOOD")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalCount").value(3));
+
+        mockMvc.perform(get("/api/planner/reviews/completed")
+                        .param("materialId", String.valueOf(materialB.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalCount").value(1));
+    }
+
+    @Test
     @DisplayName("GET completed - PENDING/타인은 제외된다")
     void excludes_pending_and_others() throws Exception {
         Flashcard a = basicCard(materialA);

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewUpcomingControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewUpcomingControllerTest.java
@@ -253,6 +253,74 @@ class ReviewUpcomingControllerTest extends ApiTestSupport {
     }
 
     @Test
+    @DisplayName("GET upcoming - totalCount는 페이지 크기와 무관한 필터 기준 총 건수")
+    void total_count_is_filtered_total() throws Exception {
+        Flashcard a = basicCard(materialA);
+        pending(a, TODAY.atTime(4, 0));
+        pending(a, TODAY.atTime(5, 0));
+        pending(a, TODAY.atTime(6, 0));
+        pending(basicCard(materialB), TODAY.atTime(4, 0));
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("size", "2")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(2)))
+                .andExpect(jsonPath("$.data.totalCount").value(4));
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("materialId", String.valueOf(materialB.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalCount").value(1));
+    }
+
+    @Test
+    @DisplayName("GET upcoming - totalCount는 when/type 필터도 반영한다")
+    void total_count_reflects_when_and_type() throws Exception {
+        pending(basicCard(materialA), TODAY.atTime(4, 0));
+        pending(orderingCard(), TODAY.atTime(4, 0));
+        pending(pairCard(), TODAY.plusDays(5).atTime(4, 0));
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("when", "today")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalCount").value(2));
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("type", "pair")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalCount").value(1));
+    }
+
+    @Test
+    @DisplayName("GET upcoming - totalCount는 첫 페이지에만 실린다")
+    void total_count_only_on_first_page() throws Exception {
+        Flashcard a = basicCard(materialA);
+        pending(a, TODAY.atTime(4, 0));
+        pending(a, TODAY.atTime(5, 0));
+        pending(a, TODAY.atTime(6, 0));
+
+        MvcResult first = mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("size", "2")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalCount").value(3))
+                .andReturn();
+        String cursor = JsonPath.read(first.getResponse().getContentAsString(), "$.data.nextCursor");
+
+        mockMvc.perform(get("/api/planner/reviews/upcoming")
+                        .param("size", "2")
+                        .param("cursor", cursor)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items", hasSize(1)))
+                .andExpect(jsonPath("$.data.totalCount").doesNotExist());
+    }
+
+    @Test
     @DisplayName("GET upcoming - 잘못된 scope는 400")
     void invalid_scope_returns_400() throws Exception {
         mockMvc.perform(get("/api/planner/reviews/upcoming")

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
@@ -76,6 +76,25 @@ public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, 
                                       @Param("cursorId") Long cursorId,
                                       Pageable pageable);
 
+    /** 앞으로의 복습 총 건수 — {@link #findUpcoming}과 동일한 필터에서 커서 조건만 뺀 COUNT. */
+    @Query("""
+            SELECT COUNT(r) FROM ReviewSchedule r, Flashcard f
+            WHERE r.flashcardId = f.id
+              AND r.memberId = :memberId
+              AND r.status = ds.project.orino.domain.planner.review.entity.ReviewStatus.PENDING
+              AND (:materialId IS NULL OR f.materialId = :materialId)
+              AND (:upperBound IS NULL OR r.scheduledAt < :upperBound)
+              AND (:cardType IS NULL OR f.type = :cardType)
+              AND (:siblingRequired IS NULL
+                   OR (:siblingRequired = TRUE AND f.siblingGroupId IS NOT NULL)
+                   OR (:siblingRequired = FALSE AND f.siblingGroupId IS NULL))
+            """)
+    long countUpcoming(@Param("memberId") Long memberId,
+                       @Param("materialId") Long materialId,
+                       @Param("upperBound") Instant upperBound,
+                       @Param("cardType") FlashcardType cardType,
+                       @Param("siblingRequired") Boolean siblingRequired);
+
     /**
      * 완료된 복습 — COMPLETED를 {@code completed_at DESC, id DESC}로 keyset 페이징한다.
      * {@code materialId}/{@code grade}는 필터(null이면 무시), {@code cursorAt}/{@code cursorId}는
@@ -99,4 +118,17 @@ public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, 
                                        @Param("cursorAt") Instant cursorAt,
                                        @Param("cursorId") Long cursorId,
                                        Pageable pageable);
+
+    /** 완료된 복습 총 건수 — {@link #findCompleted}와 동일한 필터에서 커서 조건만 뺀 COUNT. */
+    @Query("""
+            SELECT COUNT(r) FROM ReviewSchedule r, Flashcard f
+            WHERE r.flashcardId = f.id
+              AND r.memberId = :memberId
+              AND r.status = ds.project.orino.domain.planner.review.entity.ReviewStatus.COMPLETED
+              AND (:materialId IS NULL OR f.materialId = :materialId)
+              AND (:grade IS NULL OR r.rating = :grade)
+            """)
+    long countCompleted(@Param("memberId") Long memberId,
+                        @Param("materialId") Long materialId,
+                        @Param("grade") Rating grade);
 }

--- a/fe/src/features/review/api/reviewHub.ts
+++ b/fe/src/features/review/api/reviewHub.ts
@@ -81,6 +81,8 @@ export interface UpcomingReviewsPage {
   /** 다음 페이지 커서. 마지막 페이지면 생략(undefined). */
   nextCursor?: string;
   hasNext: boolean;
+  /** 현재 필터에 걸리는 전체 건수. 첫 페이지에만 실린다. */
+  totalCount?: number;
 }
 
 export interface UpcomingReviewParams {
@@ -117,6 +119,8 @@ export interface CompletedReviewsPage {
   items: CompletedReviewItem[];
   nextCursor?: string;
   hasNext: boolean;
+  /** 현재 필터에 걸리는 전체 건수. 첫 페이지에만 실린다. */
+  totalCount?: number;
 }
 
 export interface CompletedReviewParams {

--- a/fe/src/pages/planner/ReviewHubPage.test.tsx
+++ b/fe/src/pages/planner/ReviewHubPage.test.tsx
@@ -282,6 +282,106 @@ describe("ReviewHubPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("필터 기준 총 개수를 표시하고, 필터가 바뀌면 갱신된다", async () => {
+    mockSummary();
+    server.use(
+      http.get(`${API_BASE}/planner/reviews/upcoming`, ({ request }) => {
+        const materialId = new URL(request.url).searchParams.get("materialId");
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            today: "2026-05-18",
+            items: [upcomingItem(1)],
+            hasNext: false,
+            totalCount: materialId ? 12 : 191,
+          },
+        });
+      }),
+    );
+    const user = userEvent.setup();
+    renderHub();
+
+    expect(await screen.findByText("총 191개")).toBeInTheDocument();
+    // 전체 총계(레일)와 달리 탭 라벨에는 숫자가 없다
+    expect(screen.getByRole("tab", { name: "앞으로" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /이펙티브 자바/ }));
+
+    expect(await screen.findByText("총 12개")).toBeInTheDocument();
+  });
+
+  it("다음 페이지를 이어붙여도 총 개수는 첫 페이지 값을 유지한다", async () => {
+    mockSummary();
+    server.use(
+      http.get(`${API_BASE}/planner/reviews/upcoming`, ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get("cursor");
+        if (!cursor) {
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              today: "2026-05-18",
+              items: [upcomingItem(1)],
+              nextCursor: "c2",
+              hasNext: true,
+              totalCount: 2,
+            },
+          });
+        }
+        // 이후 페이지엔 totalCount가 실리지 않는다
+        return HttpResponse.json({
+          code: "OK",
+          data: {
+            today: "2026-05-18",
+            items: [upcomingItem(2)],
+            hasNext: false,
+          },
+        });
+      }),
+    );
+    renderHub();
+
+    expect(await screen.findByText("총 2개")).toBeInTheDocument();
+
+    triggerIntersection();
+
+    expect(await screen.findByText("질문 2")).toBeInTheDocument();
+    expect(screen.getByText("총 2개")).toBeInTheDocument();
+  });
+
+  it("완료 탭도 필터 기준 총 개수를 표시한다", async () => {
+    mockSummary();
+    server.use(
+      http.get(`${API_BASE}/planner/reviews/upcoming`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            today: "2026-05-18",
+            items: [upcomingItem(1)],
+            hasNext: false,
+            totalCount: 191,
+          },
+        }),
+      ),
+      http.get(`${API_BASE}/planner/reviews/completed`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            items: [completedItem(5, "GOOD")],
+            hasNext: false,
+            totalCount: 42,
+          },
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderHub();
+
+    await screen.findByText("총 191개");
+    await user.click(screen.getByRole("tab", { name: "완료" }));
+
+    expect(await screen.findByText("총 42개")).toBeInTheDocument();
+  });
+
   it("[전체 복습 시작]은 scope=all 세션으로 이동한다", async () => {
     mockSummary();
     server.use(

--- a/fe/src/pages/planner/ReviewHubPage.tsx
+++ b/fe/src/pages/planner/ReviewHubPage.tsx
@@ -67,6 +67,10 @@ export function ReviewHubPage() {
   const completedItems =
     completedQuery.data?.pages.flatMap((p) => p.items) ?? [];
 
+  // totalCount는 첫 페이지에만 실린다. 필터가 바뀌면 쿼리 키가 바뀌어 첫 페이지부터 다시 받는다.
+  const upcomingTotal = upcomingQuery.data?.pages[0]?.totalCount;
+  const completedTotal = completedQuery.data?.pages[0]?.totalCount;
+
   const upcomingSentinel = useInfiniteScroll(
     () => upcomingQuery.fetchNextPage(),
     Boolean(upcomingQuery.hasNextPage) && !upcomingQuery.isFetchingNextPage,
@@ -167,12 +171,9 @@ export function ReviewHubPage() {
         <main className="min-w-0 flex-1">
           <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)}>
             <TabsList>
-              <TabsTrigger value="upcoming">
-                앞으로 {summary.counts.upcoming}
-              </TabsTrigger>
-              <TabsTrigger value="completed">
-                완료 {summary.counts.doneToday}
-              </TabsTrigger>
+              {/* 전체 총계는 좌측 레일에 있다. 여기 숫자는 필터 기준 총 개수(FilterCount). */}
+              <TabsTrigger value="upcoming">앞으로</TabsTrigger>
+              <TabsTrigger value="completed">완료</TabsTrigger>
             </TabsList>
 
             <TabsContent value="upcoming" className="flex flex-col gap-3">
@@ -209,6 +210,7 @@ export function ReviewHubPage() {
                     </button>
                   </Badge>
                 )}
+                <FilterCount total={upcomingTotal} />
               </div>
 
               <ReviewList
@@ -243,6 +245,7 @@ export function ReviewHubPage() {
                   onValueChange={setFGrade}
                   options={GRADE_OPTIONS}
                 />
+                <FilterCount total={completedTotal} />
               </div>
 
               <ReviewList
@@ -264,6 +267,18 @@ export function ReviewHubPage() {
         </main>
       </div>
     </div>
+  );
+}
+
+/** 필터 줄 오른쪽 끝의 "총 N개". 아직 못 받았으면 자리만 비워 둔다(레이아웃은 유지). */
+function FilterCount({ total }: { total?: number }) {
+  return (
+    <p
+      className="text-muted-foreground ml-auto text-sm tabular-nums"
+      aria-live="polite"
+    >
+      {total === undefined ? "" : `총 ${total.toLocaleString()}개`}
+    </p>
   );
 }
 


### PR DESCRIPTION
## 이슈
closes #997
## 작업 내용
- 복습 허브 탭 라벨에서 전체 총계 숫자 제거 (`앞으로 191` / `완료 0` → `앞으로` / `완료`)
  - 두 숫자는 필터와 무관한 서버 총계라 필터를 걸어도 변하지 않았고, 좌측 레일에 이미 동일하게 노출되고 있었음
- 필터 줄 오른쪽에 현재 필터 기준 총 개수(`총 N개`) 표시
- BE: `upcoming` / `completed` 응답에 `totalCount` 추가
  - 목록 쿼리와 동일한 WHERE에서 커서 조건만 뺀 COUNT (`countUpcoming` / `countCompleted`)
  - 첫 페이지(cursor 없음)에서만 계산 — 무한스크롤마다 COUNT를 돌지 않음
- FE: 첫 페이지의 `totalCount`를 유지 (필터가 바뀌면 쿼리 키가 바뀌어 첫 페이지부터 재요청되며 값도 갱신)

### 곁들여: Spring Boot 4.0.7 범프
기능과 무관하지만 신규 CVE로 `image-scan`(Trivy)이 HIGH 4건에 걸려 CI가 막혀 함께 처리했다.
- spring-data-commons 4.0.5 → 4.0.6 (CVE-2026-41695)
- spring-framework 7.0.7 → 7.0.8 (CVE-2026-41850 / 41842 / 41845)
- 4.0.7 BOM이 따라잡은 `ext` 핀 제거. 특히 `spring-security` 7.0.5 핀은 BOM(7.0.6)보다 낮아 두면 다운그레이드였다. `netty`만 BOM(4.2.15)보다 높아 유지
- 빌드된 jar를 CI와 같은 조건(`CRITICAL,HIGH`, `ignore-unfixed=false`)으로 로컬 Trivy 스캔 → 0건

### 테스트
- BE: 필터별 `totalCount` 검증 + 2페이지째엔 실리지 않는지 (`ReviewUpcomingControllerTest`, `ReviewCompletedControllerTest`)
- FE: 필터 변경 시 개수 갱신 / 무한스크롤 후에도 유지 / 완료 탭 개수 (`ReviewHubPage.test.tsx`)
- `./gradlew check`, `npm test`, `npm run lint`, `npm run format:check` 모두 통과
- 로컬 실행 확인: 전체 60건 → 종류=양방향 15건, 완료 15건 → 평가=양호 4건으로 표시 갱신
