### PR TITLE
feat : 복습할 때 답을 직접 적는 칸

### DIFF
--- a/fe/src/features/review/components/ReviewCard.tsx
+++ b/fe/src/features/review/components/ReviewCard.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
 import { MATERIAL_TYPE_ICONS } from "@/features/material/utils";
 import { cn } from "@/lib/utils";
 
@@ -56,21 +57,51 @@ const RATING_BUTTONS: RatingButton[] = [
 
 export function ReviewCard({ review, pending, onRate }: Props) {
   const [revealed, setRevealed] = useState(false);
+  // 머릿속으로만 떠올리면 답을 본 순간 "아 이거였지"가 돼 채점이 후해진다.
+  // 적게 해서 리트리벌을 강제하고, 공개 후엔 정답과 나란히 놓고 채점하게 한다.
+  // 저장하지 않는다 — 채점과 함께 사라지는 화면 전용 상태다.
+  const [note, setNote] = useState("");
+  const noteRef = useRef<HTMLTextAreaElement>(null);
   const isOrdering = review.flashcard.type === "ORDERING";
 
   useEffect(() => {
     setRevealed(false);
+    setNote("");
   }, [review.id]);
+
+  // 카드가 뜨면(그리고 다음 카드로 넘어가 입력칸이 다시 붙으면) 바로 타이핑할 수 있게 포커스.
+  // 터치 기기는 제외한다 — 질문을 읽기도 전에 가상 키보드가 화면을 덮는다(#994와 같은 이유).
+  useEffect(() => {
+    if (revealed) return;
+    if (window.matchMedia?.("(pointer: coarse)").matches) return;
+    noteRef.current?.focus();
+  }, [review.id, revealed]);
+
+  const reveal = () => {
+    // 입력칸에서 포커스를 뺀다 — 안 그러면 뒤이은 1~4 채점 키가 입력칸으로 흘러든다.
+    noteRef.current?.blur();
+    setRevealed(true);
+  };
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
+      // 입력칸 안에서 답을 여는 유일한 키. Enter는 줄바꿈이라 쓸 수 없다.
+      if (
+        !revealed &&
+        (event.metaKey || event.ctrlKey) &&
+        event.key === "Enter"
+      ) {
+        event.preventDefault();
+        reveal();
+        return;
+      }
       if (isTypingTarget(event.target)) return;
       if (!revealed) {
         if (event.code === "Space" || event.key === "Enter") {
           // 순서 카드 드래그 핸들의 Space/Enter(항목 집기)에는 양보한다
           if (isInDragArea(event.target)) return;
           event.preventDefault();
-          setRevealed(true);
+          reveal();
         }
         return;
       }
@@ -122,20 +153,61 @@ export function ReviewCard({ review, pending, onRate }: Props) {
           </div>
         )}
 
+        {/* 내 답 — 공개 전엔 적는 칸, 공개 후엔 정답 바로 위에 읽기 전용으로 남아 비교 대상이 된다.
+          빈칸이어도 답을 볼 수 있다(막지 않는다). 안 적었으면 공개 후엔 아무것도 남기지 않는다. */}
+        {!revealed ? (
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="review-answer-note"
+              className="text-muted-foreground text-xs font-medium"
+            >
+              내 답
+            </label>
+            <Textarea
+              id="review-answer-note"
+              ref={noteRef}
+              rows={3}
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="떠오르는 대로 적어보세요 (⌘/Ctrl+Enter로 답 보기)"
+            />
+          </div>
+        ) : (
+          note.trim() !== "" && (
+            <section className="flex flex-col gap-1.5">
+              <h3 className="text-muted-foreground text-xs font-medium">
+                내 답
+              </h3>
+              <div className="bg-muted/30 rounded-lg px-4 py-3">
+                <p className="text-foreground text-sm whitespace-pre-wrap">
+                  {note}
+                </p>
+              </div>
+            </section>
+          )
+        )}
+
         {!revealed ? (
           <div className="flex justify-center">
-            <Button size="lg" onClick={() => setRevealed(true)}>
-              {isOrdering ? "정답 확인 (Space)" : "답 보기 (Space)"}
+            <Button size="lg" onClick={reveal}>
+              {isOrdering ? "정답 확인" : "답 보기"}
             </Button>
           </div>
         ) : (
           <>
             {!isOrdering && (
-              <div className="bg-card border-border rounded-lg border px-4 py-6 text-center">
-                <p className="text-foreground text-lg whitespace-pre-wrap">
-                  {review.flashcard.back}
-                </p>
-              </div>
+              // 위의 "내 답"과 나란히 놓고 비교하는 자리라 제목을 붙인다(순서 카드는
+              // OrderingReviewCard가 "내 배열/정답 순서"로 이미 구분해준다).
+              <section className="flex flex-col gap-1.5">
+                <h3 className="text-muted-foreground text-xs font-medium">
+                  정답
+                </h3>
+                <div className="bg-card border-border rounded-lg border px-4 py-6 text-center">
+                  <p className="text-foreground text-lg whitespace-pre-wrap">
+                    {review.flashcard.back}
+                  </p>
+                </div>
+              </section>
             )}
 
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">

--- a/fe/src/pages/planner/ReviewSessionPage.test.tsx
+++ b/fe/src/pages/planner/ReviewSessionPage.test.tsx
@@ -40,9 +40,15 @@ interface ReviewSpec {
   id: number;
   delayDays?: number;
   materialId?: number;
+  ordering?: boolean;
 }
 
-function makeReview({ id, delayDays = 0, materialId = 1 }: ReviewSpec) {
+function makeReview({
+  id,
+  delayDays = 0,
+  materialId = 1,
+  ordering = false,
+}: ReviewSpec) {
   return {
     id,
     scheduledAt: "2026-05-18T04:00:00",
@@ -52,15 +58,30 @@ function makeReview({ id, delayDays = 0, materialId = 1 }: ReviewSpec) {
     easeFactor: 2.5,
     flashcard: {
       id: id * 10,
-      type: "BASIC",
+      type: ordering ? "ORDERING" : "BASIC",
       front: `질문 ${id}`,
-      back: `답 ${id}`,
-      items: null,
+      back: ordering ? null : `답 ${id}`,
+      items: ordering
+        ? [
+            { id: `${id}-a`, text: `항목 A${id}` },
+            { id: `${id}-b`, text: `항목 B${id}` },
+          ]
+        : null,
       siblingGroupId: null,
       material: { id: materialId, title: `자료 ${materialId}`, type: "BOOK" },
     },
     preview: { again: 1, hard: 6, good: 6, easy: 15 },
   };
+}
+
+type User = ReturnType<typeof userEvent.setup>;
+
+/**
+ * 답을 여는 단축키. 기본 흐름에선 답 입력칸에 포커스가 있어 Space가 그리로 들어가므로,
+ * 입력칸 안에서도 통하는 ⌘/Ctrl+Enter를 쓴다(Enter는 줄바꿈이라 못 쓴다).
+ */
+async function revealAnswer(user: User) {
+  await user.keyboard("{Control>}{Enter}{/Control}");
 }
 
 function mockToday(specs: ReviewSpec[]) {
@@ -166,7 +187,7 @@ describe("ReviewSessionPage", () => {
     expect(screen.queryByText("질문 1")).not.toBeInTheDocument();
   });
 
-  it("Space로 답이 공개되고 1/2/3/4 키로 평가가 전송된다", async () => {
+  it("⌘/Ctrl+Enter로 답이 공개되고 1/2/3/4 키로 평가가 전송된다", async () => {
     mockToday([{ id: 1 }]);
     const ratings: Array<{ id: number; rating: string }> = [];
     mockComplete(ratings);
@@ -177,9 +198,10 @@ describe("ReviewSessionPage", () => {
       expect(screen.getByText("질문 1")).toBeInTheDocument();
     });
 
-    await user.keyboard(" ");
+    await revealAnswer(user);
     expect(await screen.findByText("답 1")).toBeInTheDocument();
 
+    // 공개 시 입력칸에서 포커스가 빠져야 숫자 키가 입력이 아닌 채점으로 간다
     await user.keyboard("3");
     await waitFor(() => {
       expect(ratings).toEqual([{ id: 1, rating: "GOOD" }]);
@@ -196,14 +218,14 @@ describe("ReviewSessionPage", () => {
       expect(screen.getByText("질문 1")).toBeInTheDocument();
     });
 
-    await user.keyboard(" ");
+    await revealAnswer(user);
     await user.click(await screen.findByRole("button", { name: /Good/ }));
 
     await waitFor(() => {
       expect(screen.getByText("질문 2")).toBeInTheDocument();
     });
 
-    await user.keyboard(" ");
+    await revealAnswer(user);
     await user.click(await screen.findByRole("button", { name: /Good/ }));
 
     await waitFor(() => {
@@ -261,7 +283,7 @@ describe("ReviewSessionPage", () => {
     });
     expect(screen.getByText("1 / 3")).toBeInTheDocument();
 
-    await user.keyboard(" ");
+    await revealAnswer(user);
     await user.click(await screen.findByRole("button", { name: /Good/ }));
 
     await waitFor(() => {
@@ -272,5 +294,109 @@ describe("ReviewSessionPage", () => {
     expect(
       await screen.findByText(/짝 카드는 다른 날 복습해요/),
     ).toBeInTheDocument();
+  });
+
+  describe("답 적기", () => {
+    it("적은 답이 공개 후에도 정답과 함께 남는다", async () => {
+      mockToday([{ id: 1 }]);
+      const user = userEvent.setup();
+      renderPage();
+
+      const note = await screen.findByLabelText("내 답");
+      await user.type(note, "내가 떠올린 답");
+      await revealAnswer(user);
+
+      // 입력칸은 사라지고 적은 내용이 읽기 전용으로 남아 정답과 나란히 보인다
+      expect(screen.queryByLabelText("내 답")).not.toBeInTheDocument();
+      expect(screen.getByText("내가 떠올린 답")).toBeInTheDocument();
+      expect(screen.getByText("답 1")).toBeInTheDocument();
+    });
+
+    it("채점하면 다음 카드의 입력칸이 비워진다", async () => {
+      mockToday([{ id: 1 }, { id: 2 }]);
+      mockComplete([]);
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.type(
+        await screen.findByLabelText("내 답"),
+        "1번 카드에 쓴 답",
+      );
+      await revealAnswer(user);
+      await user.click(await screen.findByRole("button", { name: /Good/ }));
+
+      await waitFor(() => {
+        expect(screen.getByText("질문 2")).toBeInTheDocument();
+      });
+      expect(await screen.findByLabelText("내 답")).toHaveValue("");
+      expect(screen.queryByText("1번 카드에 쓴 답")).not.toBeInTheDocument();
+    });
+
+    it("빈칸이어도 답을 볼 수 있고, 이때 '내 답'은 남지 않는다", async () => {
+      mockToday([{ id: 1 }]);
+      const user = userEvent.setup();
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText("질문 1")).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /답 보기/ }));
+
+      expect(await screen.findByText("답 1")).toBeInTheDocument();
+      expect(screen.queryByText("내 답")).not.toBeInTheDocument();
+    });
+
+    it("순서 카드에도 입력칸이 있다", async () => {
+      mockToday([{ id: 1, ordering: true }]);
+      const user = userEvent.setup();
+      renderPage();
+
+      const note = await screen.findByLabelText("내 답");
+      await user.type(note, "A가 먼저다");
+      await user.click(screen.getByRole("button", { name: /정답 확인/ }));
+
+      expect(await screen.findByText("정답 순서")).toBeInTheDocument();
+      expect(screen.getByText("A가 먼저다")).toBeInTheDocument();
+    });
+
+    it("입력칸 밖에 포커스가 있으면 Space로도 답이 열린다", async () => {
+      mockToday([{ id: 1 }]);
+      const user = userEvent.setup();
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText("질문 1")).toBeInTheDocument();
+      });
+      // 자동 포커스된 입력칸에서 포커스를 뺀다(기존 Space 단축키가 그대로 사는지)
+      (document.activeElement as HTMLElement | null)?.blur();
+
+      await user.keyboard(" ");
+      expect(await screen.findByText("답 1")).toBeInTheDocument();
+    });
+
+    it("터치 기기에서는 입력칸에 자동 포커스하지 않는다", async () => {
+      const originalMatchMedia = window.matchMedia;
+      window.matchMedia = ((query: string) => ({
+        matches: query.includes("pointer: coarse"),
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        onchange: null,
+        dispatchEvent: () => false,
+      })) as unknown as typeof window.matchMedia;
+
+      try {
+        mockToday([{ id: 1 }]);
+        renderPage();
+
+        const note = await screen.findByLabelText("내 답");
+        // 가상 키보드가 질문을 덮지 않도록 포커스를 주지 않는다
+        expect(note).not.toHaveFocus();
+      } finally {
+        window.matchMedia = originalMatchMedia;
+      }
+    });
   });
 });


### PR DESCRIPTION
## 이슈
closes #999

## 작업 내용

- 복습 카드 앞면 아래에 답을 적는 입력칸을 추가했다. 머릿속으로만 떠올리면 답을 본 순간 "아 이거였지"가 되어 Good/Easy를 후하게 주게 되는데, 적게 해서 리트리벌을 강제한다
- 답을 공개하면 적은 내용이 **정답 바로 위에** 읽기 전용으로 남아 나란히 비교하며 채점할 수 있다. 정답 박스에도 제목("정답")을 붙여 두 블록이 짝으로 읽히게 했다
- Again/Hard/Good/Easy 중 하나를 고르면 다음 카드에서 입력칸이 비워진다
- 순서 맞추기(ORDERING) 카드에도 동일하게 들어간다

### 저장하지 않는다

적은 내용은 화면 전용 상태로, 채점과 함께 사라진다. **BE 변경 없음(FE only).** 나중에 오답노트로 남기고 싶어지면 별도 이슈로 승격한다.

### 강제하지 않는다

빈칸이어도 `답 보기`를 누를 수 있다. 칸이 눈앞에 있는 것 자체가 넛지고, 정말 모르는 카드에서 막히지 않는다. 안 적었으면 공개 후 "내 답" 블록은 아예 뜨지 않는다.

### 키보드 (변경점)

입력칸에 자동 포커스가 잡히면서 **기본 흐름의 답 보기 단축키가 `Space` → `⌘/Ctrl+Enter`로 바뀐다.** (Enter는 줄바꿈이라 쓸 수 없다)

| 상황 | 키 |
|---|---|
| 입력칸에 포커스 (기본) | `⌘/Ctrl + Enter` = 답 보기 |
| 입력칸 밖에 포커스 | `Space`/`Enter` = 답 보기 (기존 그대로) |
| 답 공개 후 | `1`/`2`/`3`/`4` = 채점 (기존 그대로) |

공개 시 입력칸에서 포커스를 빼기 때문에, 숫자 키가 입력으로 흘러들지 않고 채점으로 간다.

데스크탑에선 카드가 뜨면 입력칸에 자동 포커스해 바로 타이핑할 수 있다. **터치 기기(`pointer: coarse`)에선 자동 포커스하지 않는다** — 질문을 읽기도 전에 가상 키보드가 화면을 덮기 때문(#994와 같은 이유).

## 테스트

`ReviewSessionPage.test.tsx`에 6개 추가 (전체 565개 통과):

- 적은 답이 공개 후에도 정답과 함께 남는다
- 채점하면 다음 카드의 입력칸이 비워진다
- 빈칸이어도 답을 볼 수 있고, 이때 "내 답"은 남지 않는다
- 순서 카드에도 입력칸이 있다
- 입력칸 밖에 포커스가 있으면 `Space`로도 답이 열린다
- 터치 기기에서는 자동 포커스하지 않는다

기존 `Space` 공개 테스트들은 바뀐 단축키(`⌘/Ctrl+Enter`)를 쓰도록 헬퍼로 정리했다.

포커스·키보드는 jsdom이 실제와 다르게 흉내낼 수 있어 **Playwright(Chromium)로 직접 확인**했다 — 자동 포커스 → 클릭 없이 타이핑 → `Ctrl+Enter` 공개 → `3` 채점 → 다음 카드에서 비워지고 다시 포커스, 그리고 모바일 뷰포트(390px)에서 자동 포커스가 안 잡히는 것까지. (검증용 스펙은 임시로 돌리고 삭제 — 로직은 RTL이 덮는다)
