### PR TITLE
fix : Hard/Good/Easy 다음 간격이 항상 같던 문제

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/backfill/ReviewIntervalBackfillRunner.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/backfill/ReviewIntervalBackfillRunner.java
@@ -1,0 +1,41 @@
+package ds.project.orino.planner.review.backfill;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * 기동 시 {@link ReviewIntervalBackfillService}를 한 번 돌린다.
+ *
+ * <p>백필은 멱등이라(옛 규칙이 놓은 자리에 그대로 있는 행만 손댄다) 매 기동마다 실행돼도 안전하다 —
+ * 처음 한 번만 실제로 쓰고, 그 뒤로는 조회 한 번으로 끝난다. 여러 레플리카가 동시에 돌아도 같은
+ * 입력에서 같은 값을 계산하므로 결과가 갈리지 않는다.
+ *
+ * <p>테스트 프로파일에서는 돌리지 않는다 — 컨텍스트가 뜰 때마다 테스트가 심어둔 일정을 건드릴 수 있어서다.
+ * 백필 자체는 {@code ReviewIntervalBackfillServiceTest}가 직접 호출해 검증한다.
+ */
+@Component
+@Profile("!test")
+public class ReviewIntervalBackfillRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(ReviewIntervalBackfillRunner.class);
+
+    private final ReviewIntervalBackfillService backfillService;
+
+    public ReviewIntervalBackfillRunner(ReviewIntervalBackfillService backfillService) {
+        this.backfillService = backfillService;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void run() {
+        try {
+            backfillService.run();
+        } catch (RuntimeException e) {
+            // 백필 실패가 기동을 막지 않게 한다. 다음 기동에서 다시 시도한다(멱등).
+            log.error("복습 간격 규칙 백필(#1001) 실패 — 다음 기동에서 재시도한다", e);
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/backfill/ReviewIntervalBackfillService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/backfill/ReviewIntervalBackfillService.java
@@ -1,0 +1,122 @@
+package ds.project.orino.planner.review.backfill;
+
+import ds.project.orino.core.time.UserTimeZone;
+import ds.project.orino.domain.planner.review.entity.Rating;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.planner.review.service.ReviewMirrorService;
+import ds.project.orino.planner.review.sm2.Sm2Calculator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 등급별 간격 규칙 도입(#1001) 이전에 잡힌 복습 일정을 새 규칙으로 다시 계산한다.
+ *
+ * <p>앞으로 채점하는 것만 새 규칙을 타면 이미 잡힌 일정은 옛 값으로 남는다. PENDING 복습을 만들어낸
+ * <b>직전 회차</b>에 rating·간격·ease·완료시각이 그대로 남아 있으므로, 그 입력으로 새 규칙을 다시 돌려
+ * 간격·ease·due 시각을 덮어쓴다.
+ *
+ * <p><b>옛 규칙이 계산했을 값과 저장값이 일치하는 행만</b> 건드린다. 덕분에
+ * <ul>
+ *   <li>sibling burying으로 옮겨진 행을 되돌리지 않는다(저장값이 옛 계산과 다르다)</li>
+ *   <li>두 번 실행해도 no-op다 — 한 번 덮어쓰고 나면 더 이상 옛 값과 일치하지 않는다</li>
+ * </ul>
+ *
+ * <p>GOOD·AGAIN으로 만들어진 행은 새 규칙에서도 값이 같아 실제로 바뀌는 건 HARD·EASY 행뿐이다.
+ * due 날짜가 바뀐 행은 <b>옛 날짜와 새 날짜 둘 다</b> 캘린더 미러를 reconcile한다(비게 된 날짜는
+ * 이벤트가 삭제된다).
+ */
+@Service
+public class ReviewIntervalBackfillService {
+
+    private static final Logger log = LoggerFactory.getLogger(ReviewIntervalBackfillService.class);
+
+    private final ReviewScheduleRepository reviewScheduleRepository;
+    private final ReviewMirrorService reviewMirrorService;
+
+    public ReviewIntervalBackfillService(ReviewScheduleRepository reviewScheduleRepository,
+                                         ReviewMirrorService reviewMirrorService) {
+        this.reviewScheduleRepository = reviewScheduleRepository;
+        this.reviewMirrorService = reviewMirrorService;
+    }
+
+    /** 다시 계산해 저장한 복습 건수를 반환한다. */
+    @Transactional
+    public int run() {
+        ZoneId zone = UserTimeZone.get();
+        List<Object[]> pairs = reviewScheduleRepository.findPendingWithPrecedingCompleted();
+
+        // 미러 reconcile 대상 — 멤버별로 (비게 된 옛 날짜 + 새로 채워진 날짜)를 모은다.
+        Map<Long, Set<LocalDate>> affectedDates = new LinkedHashMap<>();
+        int rescheduled = 0;
+
+        for (Object[] pair : pairs) {
+            ReviewSchedule pending = (ReviewSchedule) pair[0];
+            ReviewSchedule preceding = (ReviewSchedule) pair[1];
+
+            LocalDate previousDueDate = pending.getScheduledAt().atZone(zone).toLocalDate();
+            if (!reschedule(pending, preceding, zone)) {
+                continue;
+            }
+            rescheduled++;
+
+            LocalDate newDueDate = pending.getScheduledAt().atZone(zone).toLocalDate();
+            if (!newDueDate.equals(previousDueDate)) {
+                Set<LocalDate> dates = affectedDates.computeIfAbsent(
+                        pending.getMemberId(), id -> new LinkedHashSet<>());
+                dates.add(previousDueDate);
+                dates.add(newDueDate);
+            }
+        }
+
+        if (rescheduled > 0) {
+            log.info("복습 간격 규칙 백필(#1001): {}건 재계산", rescheduled);
+            affectedDates.forEach((memberId, dates) ->
+                    reviewMirrorService.reconcileAfterCommit(memberId, dates, zone));
+        }
+        return rescheduled;
+    }
+
+    /** 새 규칙으로 덮어썼으면 true. 옛 계산과 어긋나거나 바뀔 값이 없으면 그대로 두고 false. */
+    private boolean reschedule(ReviewSchedule pending, ReviewSchedule preceding, ZoneId zone) {
+        Rating rating = preceding.getRating();
+        Instant completedAt = preceding.getCompletedAt();
+        if (rating == null || completedAt == null) {
+            return false;
+        }
+
+        int newSequence = pending.getSequence();
+        int legacyInterval = Sm2Calculator.legacyIntervalDays(
+                newSequence, preceding.getIntervalDays(), preceding.getEaseFactor(), rating);
+        Instant legacyScheduledAt = ReviewSchedule.computeScheduledAt(
+                rating, legacyInterval, completedAt, zone);
+
+        // 옛 규칙이 놓은 자리에 그대로 있는 행만 손댄다 — burying으로 옮겨졌거나 이미 백필된 행은 건너뛴다.
+        if (pending.getIntervalDays() != legacyInterval
+                || !pending.getScheduledAt().equals(legacyScheduledAt)) {
+            return false;
+        }
+
+        Sm2Calculator.Result next = Sm2Calculator.next(
+                newSequence, preceding.getIntervalDays(), preceding.getEaseFactor(), rating);
+        if (next.intervalDays() == pending.getIntervalDays()
+                && next.easeFactor().compareTo(pending.getEaseFactor()) == 0) {
+            return false;
+        }
+
+        pending.reschedule(next.intervalDays(), next.easeFactor(),
+                ReviewSchedule.computeScheduledAt(rating, next.intervalDays(), completedAt, zone));
+        return true;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/backfill/ReviewIntervalBackfillService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/backfill/ReviewIntervalBackfillService.java
@@ -96,9 +96,8 @@ public class ReviewIntervalBackfillService {
             return false;
         }
 
-        int newSequence = pending.getSequence();
         int legacyInterval = Sm2Calculator.legacyIntervalDays(
-                newSequence, preceding.getIntervalDays(), preceding.getEaseFactor(), rating);
+                pending.getSequence(), preceding.getIntervalDays(), preceding.getEaseFactor(), rating);
         Instant legacyScheduledAt = ReviewSchedule.computeScheduledAt(
                 rating, legacyInterval, completedAt, zone);
 
@@ -108,8 +107,10 @@ public class ReviewIntervalBackfillService {
             return false;
         }
 
+        // 그때 며칠 늦게 봤는지는 완료 기록에 남아 있다(elapsedDays) — 새 규칙의 days_late 보너스에 쓴다.
+        int daysLate = preceding.getElapsedDays() == null ? 0 : preceding.getElapsedDays();
         Sm2Calculator.Result next = Sm2Calculator.next(
-                newSequence, preceding.getIntervalDays(), preceding.getEaseFactor(), rating);
+                preceding.getIntervalDays(), preceding.getEaseFactor(), daysLate, rating);
         if (next.intervalDays() == pending.getIntervalDays()
                 && next.easeFactor().compareTo(pending.getEaseFactor()) == 0) {
             return false;

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCompletionService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewCompletionService.java
@@ -20,6 +20,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -53,8 +54,11 @@ public class ReviewCompletionService {
         ZoneId zone = UserTimeZone.get();
 
         int newSequence = current.getSequence() + 1;
+        // 예정일보다 늦게 봤는데도 기억했다면 그만큼 간격을 더 벌린다(Anki days_late 보너스).
+        int daysLate = (int) ChronoUnit.DAYS.between(
+                current.getScheduledAt().atZone(zone).toLocalDate(), now.atZone(zone).toLocalDate());
         Sm2Calculator.Result computed = Sm2Calculator.next(
-                newSequence, current.getIntervalDays(), current.getEaseFactor(), request.rating());
+                current.getIntervalDays(), current.getEaseFactor(), daysLate, request.rating());
 
         current.complete(request.rating(), now, zone);
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/service/ReviewQueryService.java
@@ -161,21 +161,20 @@ public class ReviewQueryService {
         StudyMaterial material = materialById.get(card.getMaterialId());
         TodayReviewFlashcard flashcardDto = TodayReviewFlashcard.of(
                 card, itemsCodec.parse(card.getItems()), TodayReviewMaterial.of(material));
-        PreviewView preview = preview(r);
         int delayDays = (int) ChronoUnit.DAYS.between(r.getScheduledAt().atZone(zone).toLocalDate(), today);
         return new TodayReviewItem(
                 r.getId(), r.getScheduledAt(), delayDays,
                 r.getSequence(), r.getIntervalDays(), r.getEaseFactor(),
-                flashcardDto, preview);
+                flashcardDto, preview(r, delayDays));
     }
 
-    private PreviewView preview(ReviewSchedule r) {
-        int newSeq = r.getSequence() + 1;
+    /** 지금 각 버튼을 누르면 다음 복습이 며칠 뒤인지. 밀린 일수가 간격에 반영되므로 함께 넘긴다. */
+    private PreviewView preview(ReviewSchedule r, int delayDays) {
         return new PreviewView(
-                Sm2Calculator.next(newSeq, r.getIntervalDays(), r.getEaseFactor(), Rating.AGAIN).intervalDays(),
-                Sm2Calculator.next(newSeq, r.getIntervalDays(), r.getEaseFactor(), Rating.HARD).intervalDays(),
-                Sm2Calculator.next(newSeq, r.getIntervalDays(), r.getEaseFactor(), Rating.GOOD).intervalDays(),
-                Sm2Calculator.next(newSeq, r.getIntervalDays(), r.getEaseFactor(), Rating.EASY).intervalDays());
+                Sm2Calculator.next(r.getIntervalDays(), r.getEaseFactor(), delayDays, Rating.AGAIN).intervalDays(),
+                Sm2Calculator.next(r.getIntervalDays(), r.getEaseFactor(), delayDays, Rating.HARD).intervalDays(),
+                Sm2Calculator.next(r.getIntervalDays(), r.getEaseFactor(), delayDays, Rating.GOOD).intervalDays(),
+                Sm2Calculator.next(r.getIntervalDays(), r.getEaseFactor(), delayDays, Rating.EASY).intervalDays());
     }
 
     // ===== v2.5 복습 허브 (조회 전용) =====

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/sm2/Sm2Calculator.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/sm2/Sm2Calculator.java
@@ -5,9 +5,42 @@ import ds.project.orino.domain.planner.review.entity.Rating;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
+/**
+ * 다음 복습 간격·ease 계산. SM-2를 뼈대로 하되 <b>Anki의 등급별 간격 배수</b>를 얹었다.
+ *
+ * <p>교과서 SM-2는 q≥3(Hard/Good/Easy)에서 간격을 {@code 직전간격 × 직전ease}로만 정해 <b>세 등급이
+ * 모두 같은 간격</b>이 나온다. rating은 ease만 바꾸고 그 ease는 다음 회차에나 쓰이므로, 효과가 한 회차
+ * 늦게 나타나고 당장은 어느 버튼을 눌러도 동일하다 — 채점이 무의미해진다(#1001). Anki가 SM-2를 그대로
+ * 쓰지 않는 이유가 이것이라, 같은 처방을 따른다.
+ *
+ * <ul>
+ *   <li>Hard는 ease와 무관하게 직전 간격의 {@value #HARD_FACTOR_TEXT}배로만 늘린다</li>
+ *   <li>Easy는 Good 간격에 {@value #EASY_BONUS_TEXT}배 보너스를 더 곱한다</li>
+ *   <li>새 ease를 <b>즉시</b> 간격에 반영한다(기존은 직전 ease를 써서 한 회차 늦었다)</li>
+ * </ul>
+ */
 public final class Sm2Calculator {
 
     public static final BigDecimal MIN_EASE = new BigDecimal("1.30");
+
+    private static final String HARD_FACTOR_TEXT = "1.2";
+    private static final String EASY_BONUS_TEXT = "1.3";
+
+    /** Hard: 직전 간격에 곱하는 배수(Anki 기본값). ease를 타지 않아 완만하게 늘어난다. */
+    private static final BigDecimal HARD_FACTOR = new BigDecimal(HARD_FACTOR_TEXT);
+    /** Easy: Good 간격에 추가로 곱하는 보너스(Anki 기본값). */
+    private static final BigDecimal EASY_BONUS = new BigDecimal(EASY_BONUS_TEXT);
+    /** 고정 단계(1·2회차)의 Hard 배수 — 곱할 직전 간격이 사실상 없어 Good 기준으로 나눈다. */
+    private static final BigDecimal EARLY_HARD_FACTOR = new BigDecimal("0.5");
+
+    private static final BigDecimal AGAIN_EASE_DELTA = new BigDecimal("-0.20");
+    private static final BigDecimal HARD_EASE_DELTA = new BigDecimal("-0.15");
+    private static final BigDecimal GOOD_EASE_DELTA = BigDecimal.ZERO;
+    private static final BigDecimal EASY_EASE_DELTA = new BigDecimal("0.15");
+
+    /** 고정 단계 간격(SM-2와 동일) — Good 기준값이고 Hard/Easy는 여기서 갈라진다. */
+    private static final int FIRST_INTERVAL_DAYS = 1;
+    private static final int SECOND_INTERVAL_DAYS = 6;
 
     private Sm2Calculator() {
     }
@@ -16,37 +49,63 @@ public final class Sm2Calculator {
     }
 
     public static Result next(int newSequence, int prevIntervalDays, BigDecimal prevEase, Rating rating) {
-        int q = qScore(rating);
-
-        if (q < 3) {
-            BigDecimal newEase = clampEase(prevEase.subtract(new BigDecimal("0.20")));
-            return new Result(1, newEase);
+        if (rating == Rating.AGAIN) {
+            // 실패는 처음부터 다시 — 간격을 되돌리고 ease를 깎는다(due 시각은 당일 10분 뒤).
+            return new Result(1, clampEase(prevEase.add(AGAIN_EASE_DELTA)));
         }
 
-        int intervalDays;
-        if (newSequence == 1) {
-            intervalDays = 1;
-        } else if (newSequence == 2) {
-            intervalDays = 6;
-        } else {
-            intervalDays = (int) Math.round(prevIntervalDays * prevEase.doubleValue());
-        }
-
-        double diff = 5 - q;
-        double delta = 0.1 - diff * (0.08 + diff * 0.02);
-        BigDecimal newEase = clampEase(
-                prevEase.add(BigDecimal.valueOf(delta).setScale(2, RoundingMode.HALF_UP)));
-
-        return new Result(intervalDays, newEase);
+        BigDecimal newEase = clampEase(prevEase.add(easeDelta(rating)));
+        return new Result(intervalDays(newSequence, prevIntervalDays, newEase, rating), newEase);
     }
 
-    private static int qScore(Rating rating) {
-        return switch (rating) {
-            case AGAIN -> 0;
-            case HARD -> 3;
-            case GOOD -> 4;
-            case EASY -> 5;
+    /**
+     * 옛 규칙(순정 SM-2)의 간격. 이미 잡힌 일정을 새 규칙으로 재계산할 때 "아직 옛 규칙이 계산한
+     * 자리에 그대로 있는 행"만 골라내는 데 쓴다(#1001 백필). 새 일정 계산에는 쓰지 않는다.
+     */
+    public static int legacyIntervalDays(int newSequence, int prevIntervalDays, BigDecimal prevEase, Rating rating) {
+        if (rating == Rating.AGAIN) {
+            return 1;
+        }
+        return switch (newSequence) {
+            case 1 -> FIRST_INTERVAL_DAYS;
+            case 2 -> SECOND_INTERVAL_DAYS;
+            default -> (int) Math.round(prevIntervalDays * prevEase.doubleValue());
         };
+    }
+
+    private static int intervalDays(int newSequence, int prevIntervalDays, BigDecimal newEase, Rating rating) {
+        int good = goodIntervalDays(newSequence, prevIntervalDays, newEase);
+        return switch (rating) {
+            // 1·2회차는 간격이 1일로 고정돼 있어 "직전 간격 × 1.2"가 의미를 못 갖는다.
+            // 그 구간만 Good 기준으로 갈라 두고, 3회차부터 Anki와 같은 직전 간격 배수를 쓴다.
+            case HARD -> newSequence >= 3
+                    ? atLeastOneDay(BigDecimal.valueOf(prevIntervalDays).multiply(HARD_FACTOR))
+                    : atLeastOneDay(BigDecimal.valueOf(good).multiply(EARLY_HARD_FACTOR));
+            case EASY -> atLeastOneDay(BigDecimal.valueOf(good).multiply(EASY_BONUS));
+            default -> good;
+        };
+    }
+
+    /** Good 기준 간격. 1·2회차는 고정(1일·6일), 그 뒤는 직전 간격 × 새 ease. */
+    private static int goodIntervalDays(int newSequence, int prevIntervalDays, BigDecimal newEase) {
+        return switch (newSequence) {
+            case 1 -> FIRST_INTERVAL_DAYS;
+            case 2 -> SECOND_INTERVAL_DAYS;
+            default -> atLeastOneDay(BigDecimal.valueOf(prevIntervalDays).multiply(newEase));
+        };
+    }
+
+    private static BigDecimal easeDelta(Rating rating) {
+        return switch (rating) {
+            case AGAIN -> AGAIN_EASE_DELTA;
+            case HARD -> HARD_EASE_DELTA;
+            case GOOD -> GOOD_EASE_DELTA;
+            case EASY -> EASY_EASE_DELTA;
+        };
+    }
+
+    private static int atLeastOneDay(BigDecimal days) {
+        return Math.max(1, days.setScale(0, RoundingMode.HALF_UP).intValue());
     }
 
     private static BigDecimal clampEase(BigDecimal value) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/review/sm2/Sm2Calculator.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/review/sm2/Sm2Calculator.java
@@ -6,41 +6,55 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 /**
- * 다음 복습 간격·ease 계산. SM-2를 뼈대로 하되 <b>Anki의 등급별 간격 배수</b>를 얹었다.
+ * 다음 복습 간격·ease 계산 — <b>Anki의 SM-2 스케줄러</b>를 그대로 옮겼다
+ * ({@code rslib/src/scheduler/states/review.rs}).
  *
- * <p>교과서 SM-2는 q≥3(Hard/Good/Easy)에서 간격을 {@code 직전간격 × 직전ease}로만 정해 <b>세 등급이
- * 모두 같은 간격</b>이 나온다. rating은 ease만 바꾸고 그 ease는 다음 회차에나 쓰이므로, 효과가 한 회차
- * 늦게 나타나고 당장은 어느 버튼을 눌러도 동일하다 — 채점이 무의미해진다(#1001). Anki가 SM-2를 그대로
- * 쓰지 않는 이유가 이것이라, 같은 처방을 따른다.
+ * <p>순정 SM-2는 q≥3(Hard/Good/Easy)에서 간격을 {@code 직전간격 × 직전ease}로만 정해 <b>세 등급이
+ * 모두 같은 간격</b>이 나온다. rating은 ease만 바꾸고 그 ease는 다음 회차에나 쓰이므로 효과가 한 회차
+ * 늦고, 당장은 어느 버튼을 눌러도 동일해 채점이 무의미해진다(#1001). Anki가 SM-2를 그대로 쓰지 않는
+ * 이유가 이것이다.
  *
+ * <pre>
+ * hard = max(round(직전간격 × 1.2),                    직전간격 + 1)
+ * good = max(round((직전간격 + 밀린일/2) × ease),        hard + 1)
+ * easy = max(round((직전간격 + 밀린일) × ease × 1.3),    good + 1)
+ * </pre>
+ *
+ * <p>세 가지가 핵심이다.
  * <ul>
- *   <li>Hard는 ease와 무관하게 직전 간격의 {@value #HARD_FACTOR_TEXT}배로만 늘린다</li>
- *   <li>Easy는 Good 간격에 {@value #EASY_BONUS_TEXT}배 보너스를 더 곱한다</li>
- *   <li>새 ease를 <b>즉시</b> 간격에 반영한다(기존은 직전 ease를 써서 한 회차 늦었다)</li>
+ *   <li><b>ease는 갱신 전 값</b>을 간격에 쓴다. 평가로 바뀐 ease는 다음 회차부터 적용된다
+ *       (Anki {@code answer_easy}는 반환 상태의 ease만 올리고 간격엔 {@code self.ease_factor}를 쓴다)</li>
+ *   <li><b>하한</b>으로 {@code hard < good < easy} 순서를 강제한다. 배수만으로는 반올림 탓에
+ *       뒤집히거나 같아질 수 있다</li>
+ *   <li><b>밀린 일수</b>(days_late)를 보너스로 얹는다 — 늦게 봤는데도 기억했다면 그만큼 더 벌린다.
+ *       Good은 절반만, Easy는 전부 반영한다</li>
  * </ul>
+ *
+ * <p>Anki의 학습 단계(learning steps)·졸업 간격은 두지 않는다. orino는 카드 생성 시 1일 뒤 첫 복습을
+ * 잡는 것이 졸업 간격 역할을 하고, 그 뒤로는 위 수식만 탄다(고정 단계 없음).
  */
 public final class Sm2Calculator {
 
+    /** Anki {@code INITIAL_EASE_FACTOR}. */
+    public static final BigDecimal INITIAL_EASE = new BigDecimal("2.50");
+    /** Anki {@code MINIMUM_EASE_FACTOR} — ease는 이 아래로 떨어지지 않는다. */
     public static final BigDecimal MIN_EASE = new BigDecimal("1.30");
 
-    private static final String HARD_FACTOR_TEXT = "1.2";
-    private static final String EASY_BONUS_TEXT = "1.3";
-
-    /** Hard: 직전 간격에 곱하는 배수(Anki 기본값). ease를 타지 않아 완만하게 늘어난다. */
-    private static final BigDecimal HARD_FACTOR = new BigDecimal(HARD_FACTOR_TEXT);
-    /** Easy: Good 간격에 추가로 곱하는 보너스(Anki 기본값). */
-    private static final BigDecimal EASY_BONUS = new BigDecimal(EASY_BONUS_TEXT);
-    /** 고정 단계(1·2회차)의 Hard 배수 — 곱할 직전 간격이 사실상 없어 Good 기준으로 나눈다. */
-    private static final BigDecimal EARLY_HARD_FACTOR = new BigDecimal("0.5");
-
+    /** Anki {@code EASE_FACTOR_AGAIN_DELTA}. */
     private static final BigDecimal AGAIN_EASE_DELTA = new BigDecimal("-0.20");
+    /** Anki {@code EASE_FACTOR_HARD_DELTA}. */
     private static final BigDecimal HARD_EASE_DELTA = new BigDecimal("-0.15");
-    private static final BigDecimal GOOD_EASE_DELTA = BigDecimal.ZERO;
+    /** Anki {@code EASE_FACTOR_EASY_DELTA}. */
     private static final BigDecimal EASY_EASE_DELTA = new BigDecimal("0.15");
 
-    /** 고정 단계 간격(SM-2와 동일) — Good 기준값이고 Hard/Easy는 여기서 갈라진다. */
-    private static final int FIRST_INTERVAL_DAYS = 1;
-    private static final int SECOND_INTERVAL_DAYS = 6;
+    /** Anki 덱 옵션 {@code hard_multiplier} 기본값. */
+    private static final BigDecimal HARD_MULTIPLIER = new BigDecimal("1.2");
+    /** Anki 덱 옵션 {@code easy_multiplier}(Easy Bonus) 기본값. */
+    private static final BigDecimal EASY_MULTIPLIER = new BigDecimal("1.3");
+    private static final BigDecimal HALF = new BigDecimal("0.5");
+
+    /** AGAIN이면 간격을 처음으로 되돌린다(due는 당일 10분 뒤 — 재학습 단계). */
+    private static final int RELEARN_INTERVAL_DAYS = 1;
 
     private Sm2Calculator() {
     }
@@ -48,14 +62,18 @@ public final class Sm2Calculator {
     public record Result(int intervalDays, BigDecimal easeFactor) {
     }
 
-    public static Result next(int newSequence, int prevIntervalDays, BigDecimal prevEase, Rating rating) {
+    /**
+     * @param prevIntervalDays 직전 복습에서 잡았던 간격(일)
+     * @param prevEase         직전 ease — <b>간격 계산에 쓰이는 값</b>이다(평가 반영 전)
+     * @param daysLate         예정일보다 며칠 늦게 봤는지(0 이상). 늦은 만큼 보너스가 붙는다
+     */
+    public static Result next(int prevIntervalDays, BigDecimal prevEase, int daysLate, Rating rating) {
         if (rating == Rating.AGAIN) {
-            // 실패는 처음부터 다시 — 간격을 되돌리고 ease를 깎는다(due 시각은 당일 10분 뒤).
-            return new Result(1, clampEase(prevEase.add(AGAIN_EASE_DELTA)));
+            return new Result(RELEARN_INTERVAL_DAYS, clampEase(prevEase.add(AGAIN_EASE_DELTA)));
         }
-
-        BigDecimal newEase = clampEase(prevEase.add(easeDelta(rating)));
-        return new Result(intervalDays(newSequence, prevIntervalDays, newEase, rating), newEase);
+        return new Result(
+                intervalDays(prevIntervalDays, prevEase, Math.max(0, daysLate), rating),
+                clampEase(prevEase.add(easeDelta(rating))));
     }
 
     /**
@@ -67,45 +85,54 @@ public final class Sm2Calculator {
             return 1;
         }
         return switch (newSequence) {
-            case 1 -> FIRST_INTERVAL_DAYS;
-            case 2 -> SECOND_INTERVAL_DAYS;
+            case 1 -> 1;
+            case 2 -> 6;
             default -> (int) Math.round(prevIntervalDays * prevEase.doubleValue());
         };
     }
 
-    private static int intervalDays(int newSequence, int prevIntervalDays, BigDecimal newEase, Rating rating) {
-        int good = goodIntervalDays(newSequence, prevIntervalDays, newEase);
-        return switch (rating) {
-            // 1·2회차는 간격이 1일로 고정돼 있어 "직전 간격 × 1.2"가 의미를 못 갖는다.
-            // 그 구간만 Good 기준으로 갈라 두고, 3회차부터 Anki와 같은 직전 간격 배수를 쓴다.
-            case HARD -> newSequence >= 3
-                    ? atLeastOneDay(BigDecimal.valueOf(prevIntervalDays).multiply(HARD_FACTOR))
-                    : atLeastOneDay(BigDecimal.valueOf(good).multiply(EARLY_HARD_FACTOR));
-            case EASY -> atLeastOneDay(BigDecimal.valueOf(good).multiply(EASY_BONUS));
-            default -> good;
+    /** 옛 규칙(순정 SM-2)의 ease 갱신폭. 백필 판별용 — {@link #legacyIntervalDays}와 같은 용도다. */
+    public static BigDecimal legacyEaseFactor(BigDecimal prevEase, Rating rating) {
+        // SM-2: ease' = ease + (0.1 - (5-q)·(0.08 + (5-q)·0.02)) — q는 AGAIN 0 / HARD 3 / GOOD 4 / EASY 5
+        BigDecimal delta = switch (rating) {
+            case AGAIN -> new BigDecimal("-0.20");
+            case HARD -> new BigDecimal("-0.14");
+            case GOOD -> BigDecimal.ZERO;
+            case EASY -> new BigDecimal("0.10");
         };
+        return clampEase(prevEase.add(delta));
     }
 
-    /** Good 기준 간격. 1·2회차는 고정(1일·6일), 그 뒤는 직전 간격 × 새 ease. */
-    private static int goodIntervalDays(int newSequence, int prevIntervalDays, BigDecimal newEase) {
-        return switch (newSequence) {
-            case 1 -> FIRST_INTERVAL_DAYS;
-            case 2 -> SECOND_INTERVAL_DAYS;
-            default -> atLeastOneDay(BigDecimal.valueOf(prevIntervalDays).multiply(newEase));
-        };
+    private static int intervalDays(int prevIntervalDays, BigDecimal prevEase, int daysLate, Rating rating) {
+        BigDecimal prev = BigDecimal.valueOf(prevIntervalDays);
+        BigDecimal late = BigDecimal.valueOf(daysLate);
+
+        // hard는 ease를 타지 않는다 — 고정 배수라 어려운 카드가 ease와 무관하게 완만히 늘어난다.
+        int hard = atLeast(prev.multiply(HARD_MULTIPLIER), prevIntervalDays + 1);
+        if (rating == Rating.HARD) {
+            return hard;
+        }
+
+        int good = atLeast(prev.add(late.multiply(HALF)).multiply(prevEase), hard + 1);
+        if (rating == Rating.GOOD) {
+            return good;
+        }
+
+        return atLeast(prev.add(late).multiply(prevEase).multiply(EASY_MULTIPLIER), good + 1);
     }
 
     private static BigDecimal easeDelta(Rating rating) {
         return switch (rating) {
             case AGAIN -> AGAIN_EASE_DELTA;
             case HARD -> HARD_EASE_DELTA;
-            case GOOD -> GOOD_EASE_DELTA;
+            case GOOD -> BigDecimal.ZERO;
             case EASY -> EASY_EASE_DELTA;
         };
     }
 
-    private static int atLeastOneDay(BigDecimal days) {
-        return Math.max(1, days.setScale(0, RoundingMode.HALF_UP).intValue());
+    /** 반올림한 일수와 하한 중 큰 값. 하한이 {@code hard < good < easy} 순서를 보장한다. */
+    private static int atLeast(BigDecimal days, int minimum) {
+        return Math.max(minimum, days.setScale(0, RoundingMode.HALF_UP).intValue());
     }
 
     private static BigDecimal clampEase(BigDecimal value) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/backfill/ReviewIntervalBackfillServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/backfill/ReviewIntervalBackfillServiceTest.java
@@ -69,7 +69,7 @@ class ReviewIntervalBackfillServiceTest extends ApiTestSupport {
     @Test
     @DisplayName("HARD로 잡힌 일정은 새 규칙(직전×1.2)으로 당겨진다")
     void hard_pending_is_pulled_in() {
-        // 3회차 완료(HARD, 직전 6일·ease 2.50) → 옛 규칙은 15일, 새 규칙은 7일
+        // 3회차 완료(HARD, 직전 6일·ease 2.50) → 옛 규칙은 15일, 새 규칙은 max(round(6×1.2), 7) = 7일
         Pair pair = givenCompletedThenPending(Rating.HARD, 3, 6, INITIAL_EASE);
 
         assertThat(backfillService.run()).isEqualTo(1);
@@ -82,26 +82,38 @@ class ReviewIntervalBackfillServiceTest extends ApiTestSupport {
     }
 
     @Test
-    @DisplayName("EASY로 잡힌 일정은 새 규칙(Good×1.3)으로 밀린다")
+    @DisplayName("EASY로 잡힌 일정은 새 규칙(직전×ease×1.3)으로 밀린다")
     void easy_pending_is_pushed_out() {
+        // 옛 규칙 15일 → 새 규칙 max(round(6×2.50×1.3), good+1) = 20일. ease도 2.60 → 2.65
         Pair pair = givenCompletedThenPending(Rating.EASY, 3, 6, INITIAL_EASE);
 
         assertThat(backfillService.run()).isEqualTo(1);
 
         ReviewSchedule pending = reload(pair.pendingId());
-        assertThat(pending.getIntervalDays()).isEqualTo(21);
+        assertThat(pending.getIntervalDays()).isEqualTo(20);
         assertThat(pending.getEaseFactor()).isEqualByComparingTo("2.65");
     }
 
     @Test
-    @DisplayName("GOOD·AGAIN으로 잡힌 일정은 새 규칙에서도 값이 같아 건드리지 않는다")
-    void good_and_again_are_untouched() {
-        Pair good = givenCompletedThenPending(Rating.GOOD, 3, 6, INITIAL_EASE);
+    @DisplayName("고정 단계가 사라져 GOOD으로 잡힌 일정도 당겨진다")
+    void good_pending_is_pulled_in() {
+        // 2회차(직전 1일)를 GOOD으로 완료 → 옛 규칙은 고정 6일, 새 규칙은 max(round(1×2.50), hard+1) = 3일
+        Pair pair = givenCompletedThenPending(Rating.GOOD, 2, 1, INITIAL_EASE);
+
+        assertThat(backfillService.run()).isEqualTo(1);
+
+        ReviewSchedule pending = reload(pair.pendingId());
+        assertThat(pending.getIntervalDays()).isEqualTo(3);
+        assertThat(pending.getEaseFactor()).isEqualByComparingTo("2.50");
+    }
+
+    @Test
+    @DisplayName("AGAIN으로 잡힌 일정은 새 규칙에서도 값이 같아 건드리지 않는다")
+    void again_is_untouched() {
         Pair again = givenCompletedThenPending(Rating.AGAIN, 3, 6, INITIAL_EASE);
 
         assertThat(backfillService.run()).isZero();
 
-        assertThat(reload(good.pendingId()).getIntervalDays()).isEqualTo(15);
         assertThat(reload(again.pendingId()).getIntervalDays()).isEqualTo(1);
     }
 
@@ -162,25 +174,12 @@ class ReviewIntervalBackfillServiceTest extends ApiTestSupport {
 
         int legacyInterval = Sm2Calculator.legacyIntervalDays(
                 pendingSequence, prevInterval, prevEase, rating);
-        BigDecimal legacyEase = legacyEase(prevEase, rating);
         ReviewSchedule pending = reviewScheduleRepository.save(new ReviewSchedule(
                 member.getId(), card.getId(), pendingSequence,
                 ReviewSchedule.computeScheduledAt(rating, legacyInterval, completedAt, TEST_ZONE),
-                legacyInterval, legacyEase));
+                legacyInterval, Sm2Calculator.legacyEaseFactor(prevEase, rating)));
 
         return new Pair(pending.getId(), completedAt);
-    }
-
-    /** 옛 규칙의 ease 갱신폭(AGAIN -0.20 / HARD -0.14 / GOOD 0 / EASY +0.10). */
-    private static BigDecimal legacyEase(BigDecimal prevEase, Rating rating) {
-        BigDecimal delta = switch (rating) {
-            case AGAIN -> new BigDecimal("-0.20");
-            case HARD -> new BigDecimal("-0.14");
-            case GOOD -> BigDecimal.ZERO;
-            case EASY -> new BigDecimal("0.10");
-        };
-        BigDecimal next = prevEase.add(delta);
-        return next.compareTo(Sm2Calculator.MIN_EASE) < 0 ? Sm2Calculator.MIN_EASE : next;
     }
 
     private ReviewSchedule reload(Long id) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/backfill/ReviewIntervalBackfillServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/backfill/ReviewIntervalBackfillServiceTest.java
@@ -1,0 +1,192 @@
+package ds.project.orino.planner.review.backfill;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.Rating;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.FixedClockConfig;
+import ds.project.orino.support.MemberFixture;
+import ds.project.orino.planner.review.sm2.Sm2Calculator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(FixedClockConfig.class)
+@DisplayName("복습 간격 규칙 백필 (#1001)")
+class ReviewIntervalBackfillServiceTest extends ApiTestSupport {
+
+    private static final BigDecimal INITIAL_EASE = new BigDecimal("2.50");
+
+    @Autowired
+    private ReviewIntervalBackfillService backfillService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+
+    @Autowired
+    private FlashcardRepository flashcardRepository;
+
+    @Autowired
+    private ReviewScheduleRepository reviewScheduleRepository;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    @Autowired
+    private Clock clock;
+
+    private Member member;
+    private StudyMaterial material;
+
+    @BeforeEach
+    void setUp() {
+        dbCleaner.clean();
+        member = memberRepository.save(MemberFixture.create());
+        material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "자료", MaterialType.BOOK));
+    }
+
+    @Test
+    @DisplayName("HARD로 잡힌 일정은 새 규칙(직전×1.2)으로 당겨진다")
+    void hard_pending_is_pulled_in() {
+        // 3회차 완료(HARD, 직전 6일·ease 2.50) → 옛 규칙은 15일, 새 규칙은 7일
+        Pair pair = givenCompletedThenPending(Rating.HARD, 3, 6, INITIAL_EASE);
+
+        assertThat(backfillService.run()).isEqualTo(1);
+
+        ReviewSchedule pending = reload(pair.pendingId());
+        assertThat(pending.getIntervalDays()).isEqualTo(7);
+        assertThat(pending.getEaseFactor()).isEqualByComparingTo("2.35");
+        assertThat(pending.getScheduledAt()).isEqualTo(
+                ReviewSchedule.computeScheduledAt(Rating.HARD, 7, pair.completedAt(), TEST_ZONE));
+    }
+
+    @Test
+    @DisplayName("EASY로 잡힌 일정은 새 규칙(Good×1.3)으로 밀린다")
+    void easy_pending_is_pushed_out() {
+        Pair pair = givenCompletedThenPending(Rating.EASY, 3, 6, INITIAL_EASE);
+
+        assertThat(backfillService.run()).isEqualTo(1);
+
+        ReviewSchedule pending = reload(pair.pendingId());
+        assertThat(pending.getIntervalDays()).isEqualTo(21);
+        assertThat(pending.getEaseFactor()).isEqualByComparingTo("2.65");
+    }
+
+    @Test
+    @DisplayName("GOOD·AGAIN으로 잡힌 일정은 새 규칙에서도 값이 같아 건드리지 않는다")
+    void good_and_again_are_untouched() {
+        Pair good = givenCompletedThenPending(Rating.GOOD, 3, 6, INITIAL_EASE);
+        Pair again = givenCompletedThenPending(Rating.AGAIN, 3, 6, INITIAL_EASE);
+
+        assertThat(backfillService.run()).isZero();
+
+        assertThat(reload(good.pendingId()).getIntervalDays()).isEqualTo(15);
+        assertThat(reload(again.pendingId()).getIntervalDays()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("두 번 돌려도 한 번만 반영된다 (멱등)")
+    void is_idempotent() {
+        Pair pair = givenCompletedThenPending(Rating.HARD, 3, 6, INITIAL_EASE);
+
+        assertThat(backfillService.run()).isEqualTo(1);
+        assertThat(backfillService.run()).isZero();
+
+        assertThat(reload(pair.pendingId()).getIntervalDays()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("burying으로 옮겨진 일정은 되돌리지 않는다")
+    void buried_pending_is_left_alone() {
+        Pair pair = givenCompletedThenPending(Rating.HARD, 3, 6, INITIAL_EASE);
+        ReviewSchedule pending = reload(pair.pendingId());
+        Instant buriedAt = pending.getScheduledAt().plusSeconds(86_400);
+        pending.reschedule(pending.getIntervalDays(), pending.getEaseFactor(), buriedAt);
+        reviewScheduleRepository.save(pending);
+
+        assertThat(backfillService.run()).isZero();
+
+        assertThat(reload(pair.pendingId()).getScheduledAt()).isEqualTo(buriedAt);
+    }
+
+    @Test
+    @DisplayName("직전 회차가 없는 1회차 일정(카드 생성분)은 건드리지 않는다")
+    void first_review_without_predecessor_is_untouched() {
+        LocalDate today = testToday(clock);
+        Flashcard card = flashcardRepository.save(
+                new Flashcard(member.getId(), material.getId(), "Q", "A"));
+        ReviewSchedule first = reviewScheduleRepository.save(
+                ReviewSchedule.firstReview(member.getId(), card.getId(), today, TEST_ZONE));
+
+        assertThat(backfillService.run()).isZero();
+
+        assertThat(reload(first.getId()).getScheduledAt()).isEqualTo(first.getScheduledAt());
+    }
+
+    /**
+     * 옛 규칙이 만들어냈을 상태를 그대로 심는다 — {@code sequence-1} 회차를 {@code rating}으로 완료하고,
+     * 거기서 옛 규칙이 계산한 간격으로 다음 회차 PENDING을 잡아둔 모양.
+     */
+    private Pair givenCompletedThenPending(Rating rating, int pendingSequence,
+                                           int prevInterval, BigDecimal prevEase) {
+        LocalDate today = testToday(clock);
+        Flashcard card = flashcardRepository.save(
+                new Flashcard(member.getId(), material.getId(), "Q", "A"));
+
+        Instant completedAt = atTestZone(today.minusDays(1).atTime(9, 0));
+        ReviewSchedule completed = new ReviewSchedule(member.getId(), card.getId(),
+                pendingSequence - 1, completedAt, prevInterval, prevEase);
+        completed.complete(rating, completedAt, TEST_ZONE);
+        reviewScheduleRepository.save(completed);
+
+        int legacyInterval = Sm2Calculator.legacyIntervalDays(
+                pendingSequence, prevInterval, prevEase, rating);
+        BigDecimal legacyEase = legacyEase(prevEase, rating);
+        ReviewSchedule pending = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), pendingSequence,
+                ReviewSchedule.computeScheduledAt(rating, legacyInterval, completedAt, TEST_ZONE),
+                legacyInterval, legacyEase));
+
+        return new Pair(pending.getId(), completedAt);
+    }
+
+    /** 옛 규칙의 ease 갱신폭(AGAIN -0.20 / HARD -0.14 / GOOD 0 / EASY +0.10). */
+    private static BigDecimal legacyEase(BigDecimal prevEase, Rating rating) {
+        BigDecimal delta = switch (rating) {
+            case AGAIN -> new BigDecimal("-0.20");
+            case HARD -> new BigDecimal("-0.14");
+            case GOOD -> BigDecimal.ZERO;
+            case EASY -> new BigDecimal("0.10");
+        };
+        BigDecimal next = prevEase.add(delta);
+        return next.compareTo(Sm2Calculator.MIN_EASE) < 0 ? Sm2Calculator.MIN_EASE : next;
+    }
+
+    private ReviewSchedule reload(Long id) {
+        return reviewScheduleRepository.findById(id).orElseThrow();
+    }
+
+    private record Pair(Long pendingId, Instant completedAt) {
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
@@ -95,9 +95,10 @@ class ReviewControllerTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.completed.completedAt").exists())
                 .andExpect(jsonPath("$.data.nextReview.flashcardId").value(card.getId()))
                 .andExpect(jsonPath("$.data.nextReview.sequence").value(2))
+                // 하루 밀려서 봤다 → good = max(round((1 + 1/2) × 2.50), hard + 1) = 4일
                 .andExpect(jsonPath("$.data.nextReview.scheduledAt",
-                        startsWith(today.plusDays(6) + "T04:00")))
-                .andExpect(jsonPath("$.data.nextReview.intervalDays").value(6))
+                        startsWith(today.plusDays(4) + "T04:00")))
+                .andExpect(jsonPath("$.data.nextReview.intervalDays").value(4))
                 .andExpect(jsonPath("$.data.nextReview.easeFactor").value(2.50))
                 .andExpect(jsonPath("$.data.nextReview.status").value("PENDING"));
 
@@ -132,14 +133,14 @@ class ReviewControllerTest extends ApiTestSupport {
     }
 
     @Test
-    @DisplayName("POST complete - EASY 평가 시 ease +0.15, 간격은 Good보다 길다")
+    @DisplayName("POST complete - EASY 평가 시 ease +0.15, 간격은 직전 × ease × 1.3")
     void complete_easy() throws Exception {
         LocalDate today = testToday(clock);
         ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
                 member.getId(), card.getId(), 2, atTestZone(today.atTime(4, 0)), 6,
                 new BigDecimal("2.50")));
 
-        // 직전 6일·ease 2.50 → ease 2.65, good = round(6×2.65)=16, easy = round(16×1.3)=21
+        // 제때 복습 → easy = max(round(6 × 2.50 × 1.3), good + 1) = 20일. ease는 다음 회차부터 2.65.
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -147,7 +148,7 @@ class ReviewControllerTest extends ApiTestSupport {
                                 {"rating":"EASY"}
                                 """))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.nextReview.intervalDays").value(21))
+                .andExpect(jsonPath("$.data.nextReview.intervalDays").value(20))
                 .andExpect(jsonPath("$.data.nextReview.easeFactor").value(2.65));
     }
 
@@ -159,7 +160,7 @@ class ReviewControllerTest extends ApiTestSupport {
                 member.getId(), card.getId(), 2, atTestZone(today.atTime(4, 0)), 6,
                 new BigDecimal("2.50")));
 
-        // 예전엔 GOOD과 똑같은 15일이 나왔다 — 이제 round(6×1.2)=7일로 갈린다.
+        // 예전엔 GOOD과 똑같은 15일이 나왔다 — 이제 round(6 × 1.2) = 7일로 갈린다.
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -262,7 +263,8 @@ class ReviewControllerTest extends ApiTestSupport {
                 new BigDecimal("2.50")));
 
         Long currentId = firstReview.getId();
-        int[] expectedIntervals = {6, 15, 38, 95};
+        // 1 → 3 → 8 → 20 → 50 (직전 × ease 2.50, hard+1 하한). 밀린 일수 없음
+        int[] expectedIntervals = {3, 8, 20, 50};
 
         for (int i = 0; i < 4; i++) {
             int expectedInterval = expectedIntervals[i];

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/ReviewControllerTest.java
@@ -132,13 +132,14 @@ class ReviewControllerTest extends ApiTestSupport {
     }
 
     @Test
-    @DisplayName("POST complete - EASY 평가 시 ease +0.10")
+    @DisplayName("POST complete - EASY 평가 시 ease +0.15, 간격은 Good보다 길다")
     void complete_easy() throws Exception {
         LocalDate today = testToday(clock);
         ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
                 member.getId(), card.getId(), 2, atTestZone(today.atTime(4, 0)), 6,
                 new BigDecimal("2.50")));
 
+        // 직전 6일·ease 2.50 → ease 2.65, good = round(6×2.65)=16, easy = round(16×1.3)=21
         mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -146,7 +147,30 @@ class ReviewControllerTest extends ApiTestSupport {
                                 {"rating":"EASY"}
                                 """))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.nextReview.easeFactor").value(2.60));
+                .andExpect(jsonPath("$.data.nextReview.intervalDays").value(21))
+                .andExpect(jsonPath("$.data.nextReview.easeFactor").value(2.65));
+    }
+
+    @Test
+    @DisplayName("POST complete - HARD 평가 시 ease -0.15, 간격은 직전 × 1.2 (#1001)")
+    void complete_hard() throws Exception {
+        LocalDate today = testToday(clock);
+        ReviewSchedule current = reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 2, atTestZone(today.atTime(4, 0)), 6,
+                new BigDecimal("2.50")));
+
+        // 예전엔 GOOD과 똑같은 15일이 나왔다 — 이제 round(6×1.2)=7일로 갈린다.
+        mockMvc.perform(post("/api/planner/reviews/{id}/complete", current.getId())
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"rating":"HARD"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nextReview.intervalDays").value(7))
+                .andExpect(jsonPath("$.data.nextReview.scheduledAt",
+                        startsWith(today.plusDays(7) + "T04:00")))
+                .andExpect(jsonPath("$.data.nextReview.easeFactor").value(2.35));
     }
 
     @Test

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsControllerTest.java
@@ -121,20 +121,21 @@ class TodayReviewsControllerTest extends ApiTestSupport {
     }
 
     @Test
-    @DisplayName("GET today - preview 4지가 SM-2와 일치 (sequence=2 기준)")
-    void preview_matches_sm2() throws Exception {
+    @DisplayName("GET today - preview 4지가 등급별로 갈린다 (sequence=2, 직전 6일·ease 2.50)")
+    void preview_differs_per_rating() throws Exception {
         LocalDate today = testToday(clock);
         reviewScheduleRepository.save(new ReviewSchedule(
                 member.getId(), card.getId(), 2, atTestZone(today.atStartOfDay()), 6,
                 new BigDecimal("2.50")));
 
+        // #1001 회귀: 예전엔 hard/good/easy가 모두 15로 같아 채점이 무의미했다.
         mockMvc.perform(get("/api/planner/reviews/today")
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.reviews[0].preview.again").value(1))
-                .andExpect(jsonPath("$.data.reviews[0].preview.hard").value(15))
+                .andExpect(jsonPath("$.data.reviews[0].preview.hard").value(7))
                 .andExpect(jsonPath("$.data.reviews[0].preview.good").value(15))
-                .andExpect(jsonPath("$.data.reviews[0].preview.easy").value(15));
+                .andExpect(jsonPath("$.data.reviews[0].preview.easy").value(21));
     }
 
     @Test

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsControllerTest.java
@@ -121,7 +121,7 @@ class TodayReviewsControllerTest extends ApiTestSupport {
     }
 
     @Test
-    @DisplayName("GET today - preview 4지가 등급별로 갈린다 (sequence=2, 직전 6일·ease 2.50)")
+    @DisplayName("GET today - preview 4지가 등급별로 갈린다 (직전 6일·ease 2.50, 제때)")
     void preview_differs_per_rating() throws Exception {
         LocalDate today = testToday(clock);
         reviewScheduleRepository.save(new ReviewSchedule(
@@ -129,13 +129,32 @@ class TodayReviewsControllerTest extends ApiTestSupport {
                 new BigDecimal("2.50")));
 
         // #1001 회귀: 예전엔 hard/good/easy가 모두 15로 같아 채점이 무의미했다.
+        // hard=max(round(6×1.2),7)=7 · good=max(round(6×2.5),8)=15 · easy=max(round(6×2.5×1.3),16)=20
         mockMvc.perform(get("/api/planner/reviews/today")
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.reviews[0].preview.again").value(1))
                 .andExpect(jsonPath("$.data.reviews[0].preview.hard").value(7))
                 .andExpect(jsonPath("$.data.reviews[0].preview.good").value(15))
-                .andExpect(jsonPath("$.data.reviews[0].preview.easy").value(21));
+                .andExpect(jsonPath("$.data.reviews[0].preview.easy").value(20));
+    }
+
+    @Test
+    @DisplayName("GET today - 밀린 복습은 preview에 밀린 일수 보너스가 반영된다")
+    void preview_includes_days_late_bonus() throws Exception {
+        LocalDate today = testToday(clock);
+        // 10일 간격으로 잡혔는데 8일 밀렸다 → good=(10+8/2)×2.5=35 · easy=(10+8)×2.5×1.3=58.5→59
+        reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 3, atTestZone(today.minusDays(8).atTime(4, 0)), 10,
+                new BigDecimal("2.50")));
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews[0].delayDays").value(8))
+                .andExpect(jsonPath("$.data.reviews[0].preview.hard").value(12))
+                .andExpect(jsonPath("$.data.reviews[0].preview.good").value(35))
+                .andExpect(jsonPath("$.data.reviews[0].preview.easy").value(59));
     }
 
     @Test

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/mirror/ReviewMirrorIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/mirror/ReviewMirrorIntegrationTest.java
@@ -177,9 +177,9 @@ class ReviewMirrorIntegrationTest extends ApiTestSupport {
 
         // 완료된 dueDate(today+1) 묶음은 N=0 → 삭제
         assertThat(mirrorRepository.findByMemberIdAndDueDate(memberId, today.plusDays(1))).isEmpty();
-        // 다음 복습(GOOD: interval 6) dueDate(today+6) 묶음은 새로 insert
+        // 다음 복습(GOOD: 직전 1일 × ease 2.50 → interval 3) dueDate(today+3) 묶음은 새로 insert
         ReviewCalendarMirror next =
-                mirrorRepository.findByMemberIdAndDueDate(memberId, today.plusDays(6)).orElseThrow();
+                mirrorRepository.findByMemberIdAndDueDate(memberId, today.plusDays(3)).orElseThrow();
         assertThat(next.getPendingCount()).isEqualTo(1);
         assertThat(next.getGoogleEventId()).isEqualTo("evt-2");
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/sm2/Sm2CalculatorTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/sm2/Sm2CalculatorTest.java
@@ -43,20 +43,27 @@ class Sm2CalculatorTest {
     class Hard {
 
         @Test
-        @DisplayName("sequence 2 → interval=6, ease는 약간 감소 (-0.14)")
+        @DisplayName("고정 단계(2회차) → Good(6일)의 절반, ease -0.15")
         void seq2() {
             Sm2Calculator.Result r = Sm2Calculator.next(2, 1, INITIAL_EASE, Rating.HARD);
 
-            assertThat(r.intervalDays()).isEqualTo(6);
-            assertThat(r.easeFactor()).isEqualByComparingTo("2.36");
+            assertThat(r.intervalDays()).isEqualTo(3);
+            assertThat(r.easeFactor()).isEqualByComparingTo("2.35");
         }
 
         @Test
-        @DisplayName("sequence 3+ → round(prevInterval * prevEase)")
+        @DisplayName("3회차부터 → 직전 간격 × 1.2 (ease를 타지 않는다)")
         void seq3_plus() {
-            Sm2Calculator.Result r = Sm2Calculator.next(3, 6, INITIAL_EASE, Rating.HARD);
+            assertThat(Sm2Calculator.next(3, 6, INITIAL_EASE, Rating.HARD).intervalDays()).isEqualTo(7);
+            assertThat(Sm2Calculator.next(4, 15, INITIAL_EASE, Rating.HARD).intervalDays()).isEqualTo(18);
+        }
 
-            assertThat(r.intervalDays()).isEqualTo(15);
+        @Test
+        @DisplayName("ease가 낮아도 간격은 직전보다 줄지 않는다")
+        void never_shrinks() {
+            Sm2Calculator.Result r = Sm2Calculator.next(4, 10, new BigDecimal("1.30"), Rating.HARD);
+
+            assertThat(r.intervalDays()).isEqualTo(12);
         }
     }
 
@@ -92,11 +99,85 @@ class Sm2CalculatorTest {
     class Easy {
 
         @Test
-        @DisplayName("ease는 +0.10")
+        @DisplayName("ease는 +0.15")
         void ease_increases() {
             Sm2Calculator.Result r = Sm2Calculator.next(3, 6, INITIAL_EASE, Rating.EASY);
 
-            assertThat(r.easeFactor()).isEqualByComparingTo("2.60");
+            assertThat(r.easeFactor()).isEqualByComparingTo("2.65");
+        }
+
+        @Test
+        @DisplayName("Good 간격 × 1.3 (새 ease를 즉시 반영)")
+        void interval_bonus() {
+            // 3회차: good = round(6 × 2.65) = 16 → 16 × 1.3 = 20.8 → 21
+            assertThat(Sm2Calculator.next(3, 6, INITIAL_EASE, Rating.EASY).intervalDays()).isEqualTo(21);
+            // 고정 단계(2회차): good = 6 → 6 × 1.3 = 7.8 → 8
+            assertThat(Sm2Calculator.next(2, 1, INITIAL_EASE, Rating.EASY).intervalDays()).isEqualTo(8);
+        }
+    }
+
+    @Nested
+    @DisplayName("등급 간 간격 (#1001 회귀)")
+    class RatingSpread {
+
+        @ParameterizedTest(name = "sequence={0}, prevInterval={1} → hard<good<easy")
+        @CsvSource({
+                "2, 1",
+                "3, 6",
+                "4, 15",
+                "5, 38"
+        })
+        @DisplayName("Hard < Good < Easy — 세 등급의 간격이 항상 갈린다")
+        void hard_good_easy_differ(int newSeq, int prevInterval) {
+            int hard = Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.HARD).intervalDays();
+            int good = Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.GOOD).intervalDays();
+            int easy = Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.EASY).intervalDays();
+
+            assertThat(hard).isLessThan(good);
+            assertThat(good).isLessThan(easy);
+        }
+
+        @Test
+        @DisplayName("ease 2.50 카드의 회차별 미리보기 (문서화)")
+        void documented_table() {
+            assertThat(previewAt(2, 1)).containsExactly(1, 3, 6, 8);
+            assertThat(previewAt(3, 6)).containsExactly(1, 7, 15, 21);
+            assertThat(previewAt(4, 15)).containsExactly(1, 18, 38, 52);
+        }
+
+        private Integer[] previewAt(int newSeq, int prevInterval) {
+            return new Integer[]{
+                    Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.AGAIN).intervalDays(),
+                    Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.HARD).intervalDays(),
+                    Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.GOOD).intervalDays(),
+                    Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.EASY).intervalDays()
+            };
+        }
+    }
+
+    @Nested
+    @DisplayName("옛 규칙 (백필 판별용)")
+    class Legacy {
+
+        @Test
+        @DisplayName("순정 SM-2 — 세 등급이 모두 같은 간격이었다")
+        void legacy_intervals_were_identical() {
+            assertThat(Sm2Calculator.legacyIntervalDays(2, 1, INITIAL_EASE, Rating.HARD)).isEqualTo(6);
+            assertThat(Sm2Calculator.legacyIntervalDays(2, 1, INITIAL_EASE, Rating.GOOD)).isEqualTo(6);
+            assertThat(Sm2Calculator.legacyIntervalDays(2, 1, INITIAL_EASE, Rating.EASY)).isEqualTo(6);
+
+            assertThat(Sm2Calculator.legacyIntervalDays(3, 6, INITIAL_EASE, Rating.HARD)).isEqualTo(15);
+            assertThat(Sm2Calculator.legacyIntervalDays(3, 6, INITIAL_EASE, Rating.EASY)).isEqualTo(15);
+        }
+
+        @Test
+        @DisplayName("GOOD은 새 규칙과 값이 같다 — 백필이 건드릴 게 없다")
+        void good_unchanged_by_new_rule() {
+            for (int seq = 2; seq <= 6; seq++) {
+                int prev = seq == 2 ? 1 : 6;
+                assertThat(Sm2Calculator.next(seq, prev, INITIAL_EASE, Rating.GOOD).intervalDays())
+                        .isEqualTo(Sm2Calculator.legacyIntervalDays(seq, prev, INITIAL_EASE, Rating.GOOD));
+            }
         }
     }
 }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/sm2/Sm2CalculatorTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/sm2/Sm2CalculatorTest.java
@@ -11,146 +11,193 @@ import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Anki({@code rslib/src/scheduler/states/review.rs})와 같은 값이 나오는지 검증한다.
+ *
+ * <pre>
+ * hard = max(round(직전 × 1.2),                   직전 + 1)
+ * good = max(round((직전 + 밀린일/2) × ease),       hard + 1)
+ * easy = max(round((직전 + 밀린일) × ease × 1.3),   good + 1)
+ * ease: AGAIN -0.20 / HARD -0.15 / GOOD 0 / EASY +0.15, 하한 1.30
+ * </pre>
+ */
 class Sm2CalculatorTest {
 
     private static final BigDecimal INITIAL_EASE = new BigDecimal("2.50");
+    private static final int ON_TIME = 0;
+
+    private static int interval(int prevInterval, Rating rating) {
+        return Sm2Calculator.next(prevInterval, INITIAL_EASE, ON_TIME, rating).intervalDays();
+    }
+
+    @Nested
+    @DisplayName("ease 갱신 (Anki 상수)")
+    class Ease {
+
+        @ParameterizedTest(name = "{0} → ease {1}")
+        @CsvSource({
+                "AGAIN, 2.30",
+                "HARD,  2.35",
+                "GOOD,  2.50",
+                "EASY,  2.65"
+        })
+        @DisplayName("AGAIN -0.20 / HARD -0.15 / GOOD 0 / EASY +0.15")
+        void deltas(Rating rating, String expected) {
+            assertThat(Sm2Calculator.next(6, INITIAL_EASE, ON_TIME, rating).easeFactor())
+                    .isEqualByComparingTo(expected);
+        }
+
+        @Test
+        @DisplayName("ease는 1.30 미만으로 떨어지지 않는다")
+        void clamps_at_minimum() {
+            BigDecimal low = new BigDecimal("1.40");
+
+            assertThat(Sm2Calculator.next(30, low, ON_TIME, Rating.AGAIN).easeFactor())
+                    .isEqualByComparingTo("1.30");
+            assertThat(Sm2Calculator.next(30, low, ON_TIME, Rating.HARD).easeFactor())
+                    .isEqualByComparingTo("1.30");
+        }
+
+        @Test
+        @DisplayName("간격에는 갱신 전 ease를 쓴다 — 평가로 바뀐 ease는 다음 회차부터다")
+        void interval_uses_ease_before_delta() {
+            // EASY: (8 + 0) × 2.50 × 1.3 = 26. 갱신 후 ease(2.65)를 썼다면 27.6 → 28이 됐을 것이다.
+            Sm2Calculator.Result r = Sm2Calculator.next(8, INITIAL_EASE, ON_TIME, Rating.EASY);
+
+            assertThat(r.intervalDays()).isEqualTo(26);
+            assertThat(r.easeFactor()).isEqualByComparingTo("2.65");
+        }
+    }
 
     @Nested
     @DisplayName("AGAIN 평가")
     class Again {
 
         @Test
-        @DisplayName("interval=1, ease는 -0.20")
-        void interval_and_ease() {
-            Sm2Calculator.Result r = Sm2Calculator.next(2, 1, INITIAL_EASE, Rating.AGAIN);
-
-            assertThat(r.intervalDays()).isEqualTo(1);
-            assertThat(r.easeFactor()).isEqualByComparingTo("2.30");
-        }
-
-        @Test
-        @DisplayName("ease는 1.30 미만으로 떨어지지 않는다 (클램프)")
-        void ease_clamps_at_min() {
-            Sm2Calculator.Result r = Sm2Calculator.next(5, 30,
-                    new BigDecimal("1.40"), Rating.AGAIN);
-
-            assertThat(r.easeFactor()).isEqualByComparingTo("1.30");
+        @DisplayName("간격을 1일로 되돌린다 (due는 당일 10분 뒤)")
+        void resets_interval() {
+            assertThat(interval(38, Rating.AGAIN)).isEqualTo(1);
+            assertThat(interval(1, Rating.AGAIN)).isEqualTo(1);
         }
     }
 
     @Nested
-    @DisplayName("HARD 평가")
-    class Hard {
+    @DisplayName("간격 계산 (Anki 수식)")
+    class Intervals {
 
         @Test
-        @DisplayName("고정 단계(2회차) → Good(6일)의 절반, ease -0.15")
-        void seq2() {
-            Sm2Calculator.Result r = Sm2Calculator.next(2, 1, INITIAL_EASE, Rating.HARD);
-
-            assertThat(r.intervalDays()).isEqualTo(3);
-            assertThat(r.easeFactor()).isEqualByComparingTo("2.35");
+        @DisplayName("HARD = 직전 × 1.2 (ease를 타지 않는다)")
+        void hard_uses_fixed_multiplier() {
+            assertThat(interval(8, Rating.HARD)).isEqualTo(10);   // round(9.6)
+            assertThat(interval(20, Rating.HARD)).isEqualTo(24);  // round(24.0)
         }
 
         @Test
-        @DisplayName("3회차부터 → 직전 간격 × 1.2 (ease를 타지 않는다)")
-        void seq3_plus() {
-            assertThat(Sm2Calculator.next(3, 6, INITIAL_EASE, Rating.HARD).intervalDays()).isEqualTo(7);
-            assertThat(Sm2Calculator.next(4, 15, INITIAL_EASE, Rating.HARD).intervalDays()).isEqualTo(18);
+        @DisplayName("GOOD = 직전 × ease")
+        void good_uses_ease() {
+            assertThat(interval(8, Rating.GOOD)).isEqualTo(20);   // round(20.0)
+            assertThat(interval(20, Rating.GOOD)).isEqualTo(50);  // round(50.0)
         }
 
         @Test
-        @DisplayName("ease가 낮아도 간격은 직전보다 줄지 않는다")
-        void never_shrinks() {
-            Sm2Calculator.Result r = Sm2Calculator.next(4, 10, new BigDecimal("1.30"), Rating.HARD);
+        @DisplayName("EASY = 직전 × ease × 1.3")
+        void easy_adds_bonus() {
+            assertThat(interval(8, Rating.EASY)).isEqualTo(26);   // round(26.0)
+            assertThat(interval(20, Rating.EASY)).isEqualTo(65);  // round(65.0)
+        }
 
-            assertThat(r.intervalDays()).isEqualTo(12);
+        @Test
+        @DisplayName("ease가 낮아도 HARD 간격은 직전보다 최소 하루는 길다")
+        void hard_never_shrinks() {
+            // round(1 × 1.2) = 1이지만 하한(직전+1)이 걸려 2일
+            assertThat(interval(1, Rating.HARD)).isEqualTo(2);
         }
     }
 
     @Nested
-    @DisplayName("GOOD 평가")
-    class Good {
+    @DisplayName("등급 간 순서 (#1001 회귀)")
+    class Ordering {
 
-        @Test
-        @DisplayName("ease 유지")
-        void ease_unchanged() {
-            Sm2Calculator.Result r = Sm2Calculator.next(3, 6, INITIAL_EASE, Rating.GOOD);
+        @ParameterizedTest(name = "직전 {0}일 → hard < good < easy")
+        @CsvSource({"1", "2", "3", "6", "8", "15", "20", "50", "95"})
+        @DisplayName("하한이 hard < good < easy 순서를 보장한다")
+        void strictly_increasing(int prevInterval) {
+            int hard = interval(prevInterval, Rating.HARD);
+            int good = interval(prevInterval, Rating.GOOD);
+            int easy = interval(prevInterval, Rating.EASY);
 
-            assertThat(r.easeFactor()).isEqualByComparingTo("2.50");
+            assertThat(hard).isGreaterThan(prevInterval);
+            assertThat(good).isGreaterThan(hard);
+            assertThat(easy).isGreaterThan(good);
         }
 
-        @ParameterizedTest(name = "sequence={0}, prevInterval={1} → interval={2}")
-        @CsvSource({
-                "1, 0, 1",
-                "2, 1, 6",
-                "3, 6, 15",
-                "4, 15, 38"
-        })
-        @DisplayName("sequence별 다음 interval")
-        void intervals(int newSeq, int prevInterval, int expected) {
-            Sm2Calculator.Result r = Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.GOOD);
+        @Test
+        @DisplayName("ease가 하한(1.30)까지 떨어져도 순서가 뒤집히지 않는다")
+        void holds_at_minimum_ease() {
+            BigDecimal minEase = Sm2Calculator.MIN_EASE;
+            // 배수만 보면 good(×1.30)이 hard(×1.20)에 붙어 반올림으로 같아질 수 있는 구간
+            int hard = Sm2Calculator.next(10, minEase, ON_TIME, Rating.HARD).intervalDays();
+            int good = Sm2Calculator.next(10, minEase, ON_TIME, Rating.GOOD).intervalDays();
+            int easy = Sm2Calculator.next(10, minEase, ON_TIME, Rating.EASY).intervalDays();
 
-            assertThat(r.intervalDays()).isEqualTo(expected);
+            assertThat(hard).isEqualTo(12);
+            assertThat(good).isEqualTo(13);
+            assertThat(easy).isEqualTo(17);
         }
     }
 
     @Nested
-    @DisplayName("EASY 평가")
-    class Easy {
+    @DisplayName("밀린 복습 보너스 (days_late)")
+    class DaysLate {
 
         @Test
-        @DisplayName("ease는 +0.15")
-        void ease_increases() {
-            Sm2Calculator.Result r = Sm2Calculator.next(3, 6, INITIAL_EASE, Rating.EASY);
-
-            assertThat(r.easeFactor()).isEqualByComparingTo("2.65");
+        @DisplayName("GOOD은 밀린 일수의 절반만 얹는다")
+        void good_adds_half() {
+            // (10 + 8/2) × 2.5 = 35
+            assertThat(Sm2Calculator.next(10, INITIAL_EASE, 8, Rating.GOOD).intervalDays()).isEqualTo(35);
         }
 
         @Test
-        @DisplayName("Good 간격 × 1.3 (새 ease를 즉시 반영)")
-        void interval_bonus() {
-            // 3회차: good = round(6 × 2.65) = 16 → 16 × 1.3 = 20.8 → 21
-            assertThat(Sm2Calculator.next(3, 6, INITIAL_EASE, Rating.EASY).intervalDays()).isEqualTo(21);
-            // 고정 단계(2회차): good = 6 → 6 × 1.3 = 7.8 → 8
-            assertThat(Sm2Calculator.next(2, 1, INITIAL_EASE, Rating.EASY).intervalDays()).isEqualTo(8);
+        @DisplayName("EASY는 밀린 일수를 전부 얹는다")
+        void easy_adds_all() {
+            // (10 + 8) × 2.5 × 1.3 = 58.5 → 59
+            assertThat(Sm2Calculator.next(10, INITIAL_EASE, 8, Rating.EASY).intervalDays()).isEqualTo(59);
+        }
+
+        @Test
+        @DisplayName("HARD는 밀린 일수를 얹지 않는다")
+        void hard_ignores_delay() {
+            assertThat(Sm2Calculator.next(10, INITIAL_EASE, 8, Rating.HARD).intervalDays())
+                    .isEqualTo(Sm2Calculator.next(10, INITIAL_EASE, ON_TIME, Rating.HARD).intervalDays());
+        }
+
+        @Test
+        @DisplayName("일찍 본 복습(음수)은 보너스가 없다")
+        void early_review_gets_no_bonus() {
+            assertThat(Sm2Calculator.next(10, INITIAL_EASE, -5, Rating.GOOD).intervalDays())
+                    .isEqualTo(Sm2Calculator.next(10, INITIAL_EASE, ON_TIME, Rating.GOOD).intervalDays());
         }
     }
 
     @Nested
-    @DisplayName("등급 간 간격 (#1001 회귀)")
-    class RatingSpread {
-
-        @ParameterizedTest(name = "sequence={0}, prevInterval={1} → hard<good<easy")
-        @CsvSource({
-                "2, 1",
-                "3, 6",
-                "4, 15",
-                "5, 38"
-        })
-        @DisplayName("Hard < Good < Easy — 세 등급의 간격이 항상 갈린다")
-        void hard_good_easy_differ(int newSeq, int prevInterval) {
-            int hard = Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.HARD).intervalDays();
-            int good = Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.GOOD).intervalDays();
-            int easy = Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.EASY).intervalDays();
-
-            assertThat(hard).isLessThan(good);
-            assertThat(good).isLessThan(easy);
-        }
+    @DisplayName("Good만 눌러온 카드의 회차별 미리보기 (문서화)")
+    class DocumentedTable {
 
         @Test
-        @DisplayName("ease 2.50 카드의 회차별 미리보기 (문서화)")
-        void documented_table() {
-            assertThat(previewAt(2, 1)).containsExactly(1, 3, 6, 8);
-            assertThat(previewAt(3, 6)).containsExactly(1, 7, 15, 21);
-            assertThat(previewAt(4, 15)).containsExactly(1, 18, 38, 52);
+        @DisplayName("ease 2.50, 제때 복습 기준")
+        void table() {
+            assertThat(previewAt(1)).containsExactly(1, 2, 3, 4);
+            assertThat(previewAt(3)).containsExactly(1, 4, 8, 10);
+            assertThat(previewAt(8)).containsExactly(1, 10, 20, 26);
+            assertThat(previewAt(20)).containsExactly(1, 24, 50, 65);
         }
 
-        private Integer[] previewAt(int newSeq, int prevInterval) {
+        private Integer[] previewAt(int prevInterval) {
             return new Integer[]{
-                    Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.AGAIN).intervalDays(),
-                    Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.HARD).intervalDays(),
-                    Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.GOOD).intervalDays(),
-                    Sm2Calculator.next(newSeq, prevInterval, INITIAL_EASE, Rating.EASY).intervalDays()
+                    interval(prevInterval, Rating.AGAIN),
+                    interval(prevInterval, Rating.HARD),
+                    interval(prevInterval, Rating.GOOD),
+                    interval(prevInterval, Rating.EASY)
             };
         }
     }
@@ -161,7 +208,7 @@ class Sm2CalculatorTest {
 
         @Test
         @DisplayName("순정 SM-2 — 세 등급이 모두 같은 간격이었다")
-        void legacy_intervals_were_identical() {
+        void intervals_were_identical() {
             assertThat(Sm2Calculator.legacyIntervalDays(2, 1, INITIAL_EASE, Rating.HARD)).isEqualTo(6);
             assertThat(Sm2Calculator.legacyIntervalDays(2, 1, INITIAL_EASE, Rating.GOOD)).isEqualTo(6);
             assertThat(Sm2Calculator.legacyIntervalDays(2, 1, INITIAL_EASE, Rating.EASY)).isEqualTo(6);
@@ -170,14 +217,16 @@ class Sm2CalculatorTest {
             assertThat(Sm2Calculator.legacyIntervalDays(3, 6, INITIAL_EASE, Rating.EASY)).isEqualTo(15);
         }
 
-        @Test
-        @DisplayName("GOOD은 새 규칙과 값이 같다 — 백필이 건드릴 게 없다")
-        void good_unchanged_by_new_rule() {
-            for (int seq = 2; seq <= 6; seq++) {
-                int prev = seq == 2 ? 1 : 6;
-                assertThat(Sm2Calculator.next(seq, prev, INITIAL_EASE, Rating.GOOD).intervalDays())
-                        .isEqualTo(Sm2Calculator.legacyIntervalDays(seq, prev, INITIAL_EASE, Rating.GOOD));
-            }
+        @ParameterizedTest(name = "{0} → 옛 ease {1}")
+        @CsvSource({
+                "AGAIN, 2.30",
+                "HARD,  2.36",
+                "GOOD,  2.50",
+                "EASY,  2.60"
+        })
+        @DisplayName("옛 ease 갱신폭은 SM-2 공식(-0.20 / -0.14 / 0 / +0.10)이었다")
+        void ease_deltas(Rating rating, String expected) {
+            assertThat(Sm2Calculator.legacyEaseFactor(INITIAL_EASE, rating)).isEqualByComparingTo(expected);
         }
     }
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewSchedule.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/entity/ReviewSchedule.java
@@ -132,6 +132,16 @@ public class ReviewSchedule {
     }
 
     /**
+     * 간격 규칙이 바뀌었을 때(#1001) 아직 오지 않은 복습을 다시 계산해 덮어쓴다.
+     * 회차·상태·평가 기록은 그대로 두고 간격·ease·due 시각만 바꾼다.
+     */
+    public void reschedule(int intervalDays, BigDecimal easeFactor, Instant scheduledAt) {
+        this.intervalDays = intervalDays;
+        this.easeFactor = easeFactor;
+        this.scheduledAt = scheduledAt;
+    }
+
+    /**
      * Sibling burying — due 시각을 익일 04:00(사용자 시간대)으로 미룬다.
      * SM-2 간격/ease/sequence/status는 건드리지 않고 due 날짜만 이동한다.
      */

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/review/repository/ReviewScheduleRepository.java
@@ -41,6 +41,23 @@ public interface ReviewScheduleRepository extends JpaRepository<ReviewSchedule, 
     /** 미러 enable 백필용 — 멤버의 모든 PENDING 복습(과거·미래 포함). */
     List<ReviewSchedule> findAllByMemberIdAndStatus(Long memberId, ReviewStatus status);
 
+    /**
+     * 간격 규칙 변경 백필용(#1001) — 아직 오지 않은 복습과 <b>그 복습을 만들어낸 직전 회차</b> 쌍.
+     * 직전 회차에 rating·간격·ease·완료시각이 남아 있어 새 규칙으로 다시 계산할 수 있다.
+     * 회차 1(카드 생성 시 자동 생성분)은 직전 회차가 없어 결과에서 자연히 빠진다.
+     * 각 원소는 {@code [PENDING, 직전 COMPLETED]} 2칸 배열이다.
+     */
+    @Query("""
+            SELECT p, c FROM ReviewSchedule p, ReviewSchedule c
+            WHERE p.status = ds.project.orino.domain.planner.review.entity.ReviewStatus.PENDING
+              AND c.status = ds.project.orino.domain.planner.review.entity.ReviewStatus.COMPLETED
+              AND c.memberId = p.memberId
+              AND c.flashcardId = p.flashcardId
+              AND c.sequence = p.sequence - 1
+            ORDER BY p.id ASC
+            """)
+    List<Object[]> findPendingWithPrecedingCompleted();
+
     /** 오늘 완료 수 — completed_at 이 [todayStart, tomorrowStart) 인 COMPLETED. */
     long countByMemberIdAndStatusAndCompletedAtGreaterThanEqualAndCompletedAtLessThan(
             Long memberId, ReviewStatus status, Instant todayStart, Instant tomorrowStart);

--- a/fe/src/pages/planner/ReviewSessionPage.test.tsx
+++ b/fe/src/pages/planner/ReviewSessionPage.test.tsx
@@ -70,8 +70,8 @@ function makeReview({
       siblingGroupId: null,
       material: { id: materialId, title: `자료 ${materialId}`, type: "BOOK" },
     },
-    // BE가 등급별로 다른 간격을 준다(#1001) — 3회차·직전 6일·ease 2.50 카드의 실제 값
-    preview: { again: 1, hard: 7, good: 15, easy: 21 },
+    // BE가 등급별로 다른 간격을 준다(#1001) — 직전 6일·ease 2.50 카드를 제때 볼 때의 실제 값
+    preview: { again: 1, hard: 7, good: 15, easy: 20 },
   };
 }
 

--- a/fe/src/pages/planner/ReviewSessionPage.test.tsx
+++ b/fe/src/pages/planner/ReviewSessionPage.test.tsx
@@ -70,7 +70,8 @@ function makeReview({
       siblingGroupId: null,
       material: { id: materialId, title: `자료 ${materialId}`, type: "BOOK" },
     },
-    preview: { again: 1, hard: 6, good: 6, easy: 15 },
+    // BE가 등급별로 다른 간격을 준다(#1001) — 3회차·직전 6일·ease 2.50 카드의 실제 값
+    preview: { again: 1, hard: 7, good: 15, easy: 21 },
   };
 }
 


### PR DESCRIPTION
## 이슈
closes #1001

## 작업 내용

Hard/Good/Easy의 다음 간격이 **항상 같은 값**이라 채점 버튼이 아무 차이도 만들지 않던 문제. 미리보기 표시 버그가 아니라 알고리즘 자체였다.

### 원인

`Sm2Calculator.next()`가 q≥3(Hard/Good/Easy)일 때 **간격 계산에 rating을 전혀 쓰지 않았다.**

```java
if (newSequence == 1)      intervalDays = 1;
else if (newSequence == 2) intervalDays = 6;                    // 세 등급 동일
else intervalDays = round(prevIntervalDays * prevEase);         // prevEase — 세 등급 동일
```

교과서 SM-2 그대로다. rating은 ease만 바꾸고 그 ease는 다음 회차에 `prevEase`로 쓰이므로 효과가 **한 회차 늦게** 나타난다. 회차와 무관하게 세 등급 간격은 언제나 동일했다.

### 조치 — Anki SM-2 스케줄러 이식

Anki 실제 구현([`rslib/src/scheduler/states/review.rs`](https://github.com/ankitects/anki/blob/main/rslib/src/scheduler/states/review.rs))을 그대로 옮겼다. 상수·수식·하한 모두 Anki 기본값이다.

```
AGAIN: interval = 1, ease = max(prev_ease − 0.20, 1.30)          # due는 당일 10분 뒤

days_late = max(0, 예정일보다 늦게 본 일수)
hard = max(round(prev_interval × 1.2),                              prev_interval + 1)
good = max(round((prev_interval + days_late/2) × prev_ease),        hard + 1)
easy = max(round((prev_interval + days_late) × prev_ease × 1.3),    good + 1)

ease delta: AGAIN −0.20 / HARD −0.15 / GOOD 0 / EASY +0.15,  하한 1.30
```

세 가지가 핵심이다.

1. **ease는 갱신 전 값**(`prev_ease`)을 간격에 쓴다. 평가로 바뀐 ease는 **다음 회차부터** 적용된다 — Anki `answer_easy`도 반환 상태의 ease만 올리고 간격엔 `self.ease_factor`를 쓴다
2. **하한**이 `hard < good < easy` 순서를 강제한다. 배수만으로는 반올림 탓에 뒤집히거나 같아질 수 있다 (예: ease가 하한 1.30까지 떨어지면 good 배수 1.30이 hard 배수 1.20에 붙는다)
3. **밀린 일수 보너스** — 늦게 봤는데도 기억했다면 그만큼 더 벌린다. Good은 절반만, Easy는 전부, Hard는 반영하지 않는다

**고정 단계 제거**: Anki에는 SM-2의 "2회차 = 6일"이 없다. 학습 단계(learning steps)를 졸업한 뒤엔 위 수식만 쓴다. orino는 카드 생성 시 1일 뒤 첫 복습을 잡는 것이 졸업 간격 역할을 하므로, 그 뒤로는 수식 하나로만 간다.

ease 2.50에서 Good만 눌러온 카드(제때 복습):

| 직전 간격 | Again | Hard | Good | Easy |
|---|---|---|---|---|
| 1d | 10분 | 2d | 3d | 4d |
| 3d | 10분 | 4d | 8d | 10d |
| 8d | 10분 | 10d | 20d | 26d |
| 20d | 10분 | 24d | 50d | 65d |

Good 진행이 `1 → 6 → 15 → 38 → 95`에서 **`1 → 3 → 8 → 20 → 50`**으로 바뀐다(기존의 절반). Anki와 같은 속도다.

### 이미 잡힌 PENDING 일정 재계산

앞으로 채점하는 것만 새 규칙을 타면 지금 잡힌 일정은 옛 값으로 남는다. `ReviewIntervalBackfillService`가 기동 시 한 번 재계산한다.

- PENDING 복습(회차 n)의 **직전 COMPLETED 복습**(회차 n−1)에 rating·간격·ease·밀린 일수(`elapsedDays`)·완료시각이 남아 있으니 그 입력으로 새 규칙을 다시 돌린다
- **옛 규칙이 계산했을 값과 저장값이 일치하는 행만** 건드린다 → sibling burying으로 옮겨진 행을 되돌리지 않고, 여러 번 돌려도 no-op(멱등)이라 마커 테이블이 필요 없다
- 회차 1(카드 생성 시 자동 생성분)은 직전 기록이 없어 건드리지 않는다
- AGAIN으로 만들어진 행은 새 규칙에서도 값이 같아 그대로 둔다
- due 날짜가 바뀐 행은 **옛 날짜·새 날짜 둘 다** 캘린더 미러를 reconcile한다(비게 된 날짜는 이벤트 삭제)
- 실패해도 기동을 막지 않는다(다음 기동에서 재시도). 테스트 프로파일에선 돌지 않고, 백필 자체는 테스트가 직접 호출해 검증한다

## 테스트

BE `./gradlew check` 전체 통과 (674개 + checkstyle), FE 568개 통과.

- `Sm2CalculatorTest` — Anki 상수별 ease 갱신, **간격에 갱신 전 ease를 쓰는지**, hard/good/easy 수식, **하한이 `hard < good < easy`를 보장하는지**(ease 하한 구간 포함, #1001 회귀), days_late 보너스(good 절반·easy 전부·hard 없음·일찍 보면 없음), 위 표 문서화
- `ReviewIntervalBackfillServiceTest` — Hard 당겨짐 / Easy 밀림 / **고정 단계 제거로 Good도 당겨짐** / AGAIN 무변경 / 멱등 / burying 행 보존 / 1회차 무변경
- `ReviewControllerTest` — Hard 7일·ease 2.35, Easy 20일·ease 2.65, 하루 밀려 본 Good 4일(보너스 반영), 연속 GOOD 진행 `3→8→20→50`
- `TodayReviewsControllerTest` — preview 4값이 갈리는지, **밀린 복습의 보너스가 preview에 반영되는지**
- `ReviewMirrorIntegrationTest` — 다음 dueDate 변경 반영

FE는 변경 없음(미리보기는 BE 값을 그대로 렌더). 옛 버그를 박제한 테스트 픽스처만 실제 값으로 교체.

## 로컬 확인

docker compose(MySQL·Redis) + `bootRun`으로 실제 API를 띄워 Anki 값과 대조했다.

| 상황 | 결과 |
|---|---|
| 직전 1일·ease 2.50·제때 | `again 1 / hard 2 / good 3 / easy 4` |
| 직전 3일 | `1 / 4 / 8 / 10` |
| 직전 8일 | `1 / 10 / 20 / 26` |
| 직전 20일 | `1 / 24 / 50 / 65` |
| 직전 10일·**8일 밀림** | `1 / 12 / 35 / 59` — good은 +4일, easy는 +8일 보너스 |
| 직전 10일·**ease 하한 1.30** | `1 / 12 / 13 / 17` — 하한이 없었으면 hard=good=13으로 겹쳤다 |

**백필**: 옛 흔적 2건(1회차 GOOD → 고정 6일 뒤 / 2회차 HARD → 15일 뒤)을 심고 재기동 → `복습 간격 규칙 백필(#1001): 2건 재계산`, DB가 `6일→3일(8/07→8/04)`, `15일/2.36→7일/2.35(8/16→8/08)`로 갱신. 한 번 더 재기동하면 로그 없음(멱등).

## Wiki

- PRD §6.5 — Anki 수식·상수·하한·days_late를 그대로 옮기고, 고정 단계를 없앤 근거와 회차별 표 갱신
- Architecture — `review/backfill/` 패키지, sm2 설명 갱신

Sources: [Anki 소스 review.rs](https://github.com/ankitects/anki/blob/main/rslib/src/scheduler/states/review.rs) · [Anki 매뉴얼 Deck Options](https://docs.ankiweb.net/deck-options.html)
