### PR TITLE
fix : 표가 가로로 넘치면 스크롤한 구간에 행 구분선이 안 그려짐

### DIFF
--- a/fe/src/features/note/dataset/DatasetGrid.test.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.test.tsx
@@ -3146,3 +3146,85 @@ describe("DatasetGrid", () => {
     expect(await screen.findByLabelText(ACTIVE_INPUT)).toBeInTheDocument();
   });
 });
+
+describe("DatasetGrid - 가로 넘침 시 행 구분선 (#996)", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+    useToastStore.setState({ toasts: [] });
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue(
+      FAKE_RECT,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** 열 정의만 바꿔 끼운다(행·병합은 mockDataset이 이미 목킹한 것을 쓴다). */
+  function mockColumnMeta(columns: unknown[]) {
+    server.use(
+      http.get(`${API_BASE}/datasets/1`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: { id: 1, columns, rowCount: 1 },
+        }),
+      ),
+    );
+  }
+
+  /** 본문 컨테이너 — 행·열 핸들 바·병합 오버레이가 모두 이 폭을 기준으로 늘어난다. */
+  function gridBody(): HTMLElement {
+    return document.querySelector<HTMLElement>(
+      '[data-testid="dataset-grid"] .overflow-x-auto > div',
+    )!;
+  }
+
+  it("유연폭 열만 있으면 최소폭 합계(120 × 열 수)가 min-width가 된다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    mockColumnMeta([
+      { key: "c0", label: "과목" },
+      { key: "c1", label: "점수" },
+    ]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+
+    expect(gridBody().style.minWidth).toBe("240px");
+  });
+
+  it("너비를 지정한 열은 그 값으로, 안 한 열은 최소폭으로 더한다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    mockColumnMeta([
+      { key: "c0", label: "과목", width: 300 },
+      { key: "c1", label: "점수" },
+    ]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("네트워크");
+
+    // 300(지정) + 120(유연) — 컨테이너가 이보다 넓으면 min-width가 안 걸려 1fr 스트레치가 산다.
+    expect(gridBody().style.minWidth).toBe("420px");
+  });
+
+  it("열이 많아 넘칠수록 min-width도 함께 커진다", async () => {
+    mockDataset([Array.from({ length: 10 }, (_, i) => `v${i}`)]);
+    mockColumnMeta(
+      Array.from({ length: 10 }, (_, i) => ({ key: `c${i}`, label: `열${i}` })),
+    );
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+    await screen.findByText("v0");
+
+    expect(gridBody().style.minWidth).toBe("1200px");
+  });
+
+  it("요약줄도 같은 min-width를 가진다 — 없으면 border-t가 보이는 폭에서 끊긴다", async () => {
+    mockDataset([["네트워크", "92"]]);
+    mockColumnMeta([
+      { key: "c0", label: "과목", width: 300 },
+      { key: "c1", label: "점수", summary: "SUM" },
+    ]);
+    renderWithRouter(<DatasetGrid datasetId={1} />);
+
+    const footer = await screen.findByLabelText("열 요약");
+    expect(footer.style.minWidth).toBe("420px");
+    expect(gridBody().style.minWidth).toBe("420px");
+  });
+});

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -535,14 +535,31 @@ export function DatasetGrid({
     );
   }
 
+  /** 유연폭(너비 미지정) 열이 줄어들 수 있는 한계. gridTemplateColumns의 minmax 최솟값과 같아야 한다. */
+  const FLEX_COL_MIN_WIDTH = 120;
+  /** 그 열이 실제로 차지할 폭. 리사이즈 드래그 중이면 아직 저장 전이라 진행 중 너비로 본다. */
+  const columnWidth = (col: (typeof meta.columns)[number]) =>
+    resizing?.key === col.key ? resizing.width : col.width;
+
   // 너비를 지정한 열은 고정 px, 안 한 열은 기존대로 남는 폭을 나눠 갖는다.
-  // 드래그 중인 열은 아직 저장 전이므로 진행 중 너비로 그린다.
   const gridTemplateColumns = meta.columns
     .map((col) => {
-      const width = resizing?.key === col.key ? resizing.width : col.width;
-      return width != null ? `${width}px` : "minmax(120px, 1fr)";
+      const width = columnWidth(col);
+      return width != null
+        ? `${width}px`
+        : `minmax(${FLEX_COL_MIN_WIDTH}px, 1fr)`;
     })
     .join(" ");
+
+  // 표가 최소한 차지하는 폭. 가로 스크롤 컨테이너 안의 블록 요소는 폭이 auto라 "보이는 폭"까지만
+  // 차지하는데, 그 위의 w-full 요소들(행의 border-b, 열 선택 핸들 바, 병합 오버레이)이 거기서 끊긴다.
+  // 셀은 gridTemplateColumns대로 그 너머까지 그려지니, 스크롤하면 줄 없이 내용만 보였다(#996).
+  // 행이 absolute라 width:max-content로는 안 된다(절대 위치 자식은 intrinsic 폭에 기여하지 않는다).
+  // 컨테이너가 이보다 넓으면 min-width가 안 걸려 기존 1fr 스트레치가 그대로 산다.
+  const minTableWidth = meta.columns.reduce(
+    (sum, col) => sum + (columnWidth(col) ?? FLEX_COL_MIN_WIDTH),
+    0,
+  );
 
   const colIndexByKey = new Map(meta.columns.map((c, i) => [c.key, i]));
   // 세로·블록 병합(rowSpan>1)은 오버레이로 그린다(가상화와 양립하려면 앵커 행 렌더에 의존하면 안 된다).
@@ -1874,7 +1891,12 @@ export function DatasetGrid({
           {/* 본문 (윈도우 가상화) */}
           <div
             ref={listRef}
-            style={{ height: virtualizer.getTotalSize(), position: "relative" }}
+            style={{
+              height: virtualizer.getTotalSize(),
+              position: "relative",
+              // 안의 w-full 요소들(행 구분선·열 핸들 바·병합 오버레이)이 표 전체 폭으로 늘어나게 한다.
+              minWidth: minTableWidth,
+            }}
           >
             {/* 열 선택 핸들 — 상단 얇은 바(열별). 표 호버 시 나타난다. 클릭=열 선택, 드래그=여러 열. */}
             <div
@@ -2122,7 +2144,8 @@ export function DatasetGrid({
           {meta.columns.some((col) => col.summary) && (
             <div
               className="border-border bg-muted/30 grid border-t text-sm"
-              style={{ gridTemplateColumns }}
+              // 본문과 같은 이유로 min-width가 필요하다 — 없으면 border-t가 보이는 폭에서 끊긴다(#996).
+              style={{ gridTemplateColumns, minWidth: minTableWidth }}
               aria-label="열 요약"
             >
               {meta.columns.map((col) => (


### PR DESCRIPTION
## 이슈
closes #996

## 작업 내용

표가 가로로 넘칠 때 오른쪽으로 스크롤하면 **행의 가로줄(구분선)이 사라지던** 문제. 모바일에서 발견했지만 창을 좁힌 데스크탑에서도 재현된다.

### 원인

가로 스크롤 컨테이너(`.overflow-x-auto`) 안의 블록 요소는 폭이 `auto`라 **보이는 폭(clientWidth)** 까지만 차지한다. 그리드 셀들은 `gridTemplateColumns`대로 그 밖까지 넘쳐 그려지지만, **가로줄은 셀이 아니라 행 요소의 `border-b`** 라서 행 폭에서 끊긴다.

같은 이유로 `w-full`을 쓰는 **세로 병합 오버레이**와 **열 선택 핸들 바**도 보이는 폭에 갇혀 오른쪽 열에서 어긋났다. 요약줄(`border-t`)도 같다.

### 조치

본문 컨테이너와 요약줄에 **열 최소 폭 합계**를 `min-width`로 준다. 그러면 그 위의 `w-full` 요소들이 모두 표 전체 폭으로 늘어난다.

```ts
const minTableWidth = meta.columns.reduce(
  (sum, col) => sum + (columnWidth(col) ?? FLEX_COL_MIN_WIDTH), 0);
```

- 지정 폭 열은 그 값, 유연폭 열은 `minmax()`의 최솟값(120px)으로 더한다. `gridTemplateColumns`와 **같은 `columnWidth()`·같은 상수**를 써서 둘이 어긋날 수 없게 했다 (리사이즈 드래그 중인 폭도 자동으로 따라간다)
- 컨테이너가 그보다 넓으면 `min-width`가 안 걸려 **기존 `1fr` 스트레치가 그대로 산다**
- 행이 `position: absolute`라 `width: max-content`로는 안 된다 — 절대 위치 자식은 intrinsic 폭에 기여하지 않는다. 그래서 열 정의에서 폭을 직접 계산한다

## 테스트

FE 581개 통과(신규 4개), eslint·tsc·prettier 클린.

`DatasetGrid.test.tsx`에 추가:

- 유연폭 열만 있으면 최소폭 합계(120 × 열 수)가 `min-width`가 된다
- 너비를 지정한 열은 그 값으로, 안 한 열은 최소폭으로 더한다 (300 + 120 = 420)
- 열이 많아 넘칠수록 `min-width`도 함께 커진다 (10열 → 1200)
- 요약줄도 같은 `min-width`를 가진다

## 로컬 확인

jsdom엔 레이아웃이 없어 위 테스트는 스타일 값만 본다. **실제 폭은 Playwright(Chromium) 390px 뷰포트·10열로 실측**했다.

| | 수정 전 | 수정 후 |
|---|---|---|
| 스크롤 컨테이너 clientWidth | 262 | 262 |
| 스크롤 컨테이너 scrollWidth | 1200 | 1200 |
| 본문 컨테이너 폭 | **262** | **1200** |
| 행 폭 (가로줄이 끊기던 지점) | **262** | **1200** |
| 셀 오른쪽 끝 / 행 오른쪽 끝 | 1266 / **328** | 1266 / **1266** |

수정 전에는 셀이 1266까지 그려지는데 행은 328에서 끝나 그 사이엔 줄이 없었다. 이슈에 적힌 실측(262 / 1200)과 정확히 일치한다.

검증 스펙을 **수정 전 코드에도 돌려 회귀를 실제로 잡는지 확인**한 뒤 삭제했다(임시 스펙, 로직은 RTL이 덮는다). 끝까지 스크롤한 마지막 열에서도 구분선이 그려지는 걸 스크린샷으로 확인했다.
