### PR TITLE
fix : 모바일 노트 좌우 여백이 과해 표가 좁던 문제

### DIFF
--- a/fe/e2e/note-mobile-width.spec.ts
+++ b/fe/e2e/note-mobile-width.spec.ts
@@ -1,0 +1,171 @@
+import { expect, type Page, test } from "@playwright/test";
+
+const NOTE_ID = 1;
+const DATASET_ID = 1;
+
+/**
+ * 노트 본문에 표 블록 하나가 박힌 화면까지 도달하는 데 필요한 API만 목킹한다.
+ * (좌우 여백은 CSS라 jsdom에서 폭을 잴 수 없어 실제 브라우저로 확인한다)
+ *
+ * dev는 VITE_API_URL=/api로 Vite 프록시를 타므로 호스트가 아닌 경로로 가로챈다.
+ */
+async function mockNoteWithTable(page: Page) {
+  const ok = (data: unknown) => ({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ code: "OK", data }),
+  });
+
+  // 액세스 토큰은 메모리에만 있어 페이지 이동 시 사라진다. 실제 앱처럼 재발급으로 세션을 세운다.
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+
+  await page.route("**/api/notes", (route) =>
+    route.fulfill(
+      ok({
+        notes: [
+          {
+            id: NOTE_ID,
+            title: "테스트 노트",
+            parentId: null,
+            sortOrder: 0,
+            children: [],
+          },
+        ],
+      }),
+    ),
+  );
+
+  await page.route(`**/api/notes/${NOTE_ID}`, (route) =>
+    route.fulfill(
+      ok({
+        id: NOTE_ID,
+        materialId: null,
+        parentId: null,
+        title: "테스트 노트",
+        sortOrder: 0,
+        content: {
+          type: "doc",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "본문" }] },
+            { type: "datasetTable", attrs: { datasetId: DATASET_ID } },
+          ],
+        },
+        updatedAt: "2026-01-01T00:00:00Z",
+      }),
+    ),
+  );
+
+  // 표 조회 3종. 등록 순서에 따른 우선순위 함정을 피하려고 한 핸들러에서 경로로 갈라준다.
+  await page.route("**/api/datasets/**", (route) => {
+    const { pathname } = new URL(route.request().url());
+    if (pathname.endsWith("/rows")) {
+      return route.fulfill(
+        ok({
+          rows: [
+            { id: 100, rowIndex: 0, cells: ["네트워크", "1주차"] },
+            { id: 101, rowIndex: 1, cells: ["OS", "2주차"] },
+          ],
+          offset: 0,
+          limit: 100,
+        }),
+      );
+    }
+    if (pathname.endsWith("/merges")) return route.fulfill(ok({ merges: [] }));
+    return route.fulfill(
+      ok({
+        id: DATASET_ID,
+        columns: [
+          { key: "c0", label: "과목" },
+          { key: "c1", label: "일정" },
+        ],
+        rowCount: 2,
+      }),
+    );
+  });
+}
+
+async function openNote(page: Page) {
+  await page.goto(`/notes?note=${NOTE_ID}`);
+  await expect(page.getByLabel("노트 본문")).toBeVisible();
+  await expect(page.getByTestId("dataset-grid")).toBeVisible();
+}
+
+/**
+ * 모바일에서 좌우 여백이 4겹(페이지 p-6 + 카드 테두리 + 본문 pl-10/pr-4 + 표 거터)으로 쌓여
+ * 390px 중 126px이 여백이던 회귀를 잡는다. 폭이 곧 읽을 수 있는 열 수라 표에 특히 치명적이었다.
+ */
+test.describe("모바일 노트 좌우 여백", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test.beforeEach(async ({ page }) => {
+    await mockNoteWithTable(page);
+    await openNote(page);
+  });
+
+  test("표가 뷰포트 폭의 80% 이상을 쓴다", async ({ page }) => {
+    const grid = await page.getByTestId("dataset-grid").boundingBox();
+    expect(grid).not.toBeNull();
+
+    // 수정 전 264/390 = 68%. 수정 후 336/390 = 86%.
+    expect(grid!.width).toBeGreaterThanOrEqual(390 * 0.8);
+  });
+
+  test("표를 넓혀도 페이지가 가로로 넘치지 않는다", async ({ page }) => {
+    // 표 full-bleed는 본문 패딩을 음수 마진으로 상쇄하는 방식이라, 짝이 어긋나면
+    // 표가 카드 밖으로 삐져나와 페이지 전체에 가로 스크롤이 생긴다.
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - window.innerWidth,
+    );
+    expect(overflow).toBeLessThanOrEqual(0);
+  });
+
+  test("블록 이동(⣿) 핸들은 모바일에서 보이지 않는다", async ({ page }) => {
+    // hover로만 뜨는 UI라 터치에선 어차피 못 쓴다. 왼쪽 거터를 없앤 만큼 뜨면 글자와 겹친다.
+    // 본문 루트가 아니라 문단 위에 올려야 핸들이 실제로 뜬다(빈 영역엔 안 뜸) — 수정 전
+    // 상태에서 이 테스트가 실패하는지로 확인했다.
+    await page.locator(".ProseMirror > p").first().hover();
+    await expect(page.getByRole("button", { name: "블록 이동" })).toBeHidden();
+  });
+});
+
+/** 데스크탑은 기존 레이아웃 그대로여야 한다(모바일 전용 변경이 넘어오지 않았는지 확인). */
+test.describe("데스크탑 노트 좌우 여백", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test.beforeEach(async ({ page }) => {
+    await mockNoteWithTable(page);
+    await openNote(page);
+  });
+
+  test("표가 본문 글과 같은 좌측선에서 시작한다(full-bleed 아님)", async ({
+    page,
+  }) => {
+    const paragraph = await page
+      .locator(".ProseMirror > p")
+      .first()
+      .boundingBox();
+    const grid = await page.getByTestId("dataset-grid").boundingBox();
+
+    expect(paragraph).not.toBeNull();
+    expect(grid).not.toBeNull();
+    expect(Math.abs(grid!.x - paragraph!.x)).toBeLessThan(2);
+  });
+
+  test("블록 이동(⣿) 핸들 자리(왼쪽 거터)가 유지된다", async ({ page }) => {
+    await page.locator(".ProseMirror > p").first().hover();
+    const handle = page.getByRole("button", { name: "블록 이동" });
+    await expect(handle).toBeVisible();
+
+    // 핸들은 본문 글 왼쪽 거터 안에 떠야 한다(글자를 가리지 않는다).
+    const handleBox = await handle.boundingBox();
+    const paragraph = await page
+      .locator(".ProseMirror > p")
+      .first()
+      .boundingBox();
+    expect(handleBox!.x + handleBox!.width).toBeLessThanOrEqual(
+      paragraph!.x + 1,
+    );
+  });
+});

--- a/fe/src/app/layout/AppLayout.tsx
+++ b/fe/src/app/layout/AppLayout.tsx
@@ -69,7 +69,9 @@ export function AppLayout() {
           open={mobileMenuOpen}
           onClose={() => setMobileMenuOpen(false)}
         />
-        <main className="min-w-0 flex-1 p-6">
+        {/* 모바일은 폭이 곧 가독성이라 페이지 여백을 줄인다(24→16). 노트처럼 안쪽에
+          카드·본문 패딩이 더 쌓이는 화면은 이 여백이 겹쳐 본문이 크게 좁아진다. */}
+        <main className="min-w-0 flex-1 p-4 md:p-6">
           <Outlet />
         </main>
       </div>

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -94,8 +94,11 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
       content: note.content as JSONContent,
       editorProps: {
         attributes: {
+          // pl-10은 블록 이동(⣿) 핸들이 본문 왼쪽에 뜰 자리다. 그 핸들은 hover로만
+          // 나타나 터치 기기엔 아예 안 뜨므로, 모바일에선 거터를 두지 않고(pl-3)
+          // 그만큼을 본문 폭으로 돌린다(핸들 자체도 md 미만에선 감춘다).
           class:
-            "prose prose-sm dark:prose-invert max-w-none min-h-[40svh] focus:outline-none py-4 pr-4 pl-10",
+            "prose prose-sm dark:prose-invert max-w-none min-h-[40svh] focus:outline-none py-4 pr-3 pl-3 md:pr-4 md:pl-10",
           "aria-label": "노트 본문",
         },
         handlePaste: (_view, event) => {
@@ -268,10 +271,13 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
           // edgeDetection "none": 기본값(left,top)은 항목 왼쪽 가장자리에서 부모(리스트)를
           // 우선해 하위 불릿 왼쪽에 호버 시 항목 핸들이 안 뜨고 글자에 대야 떴다. none이면
           // 커서 위치와 무관하게 가장 깊은 항목이 일관되게 잡혀 행 어디서나 핸들이 뜬다.
+          // hidden md:block: 핸들은 hover로만 뜨는 UI라 터치 기기에선 어차피 나타나지
+          // 않는다. 모바일에서 왼쪽 거터(pl-10)를 없앤 만큼 여기 뜨면 본문 글자와 겹치므로
+          // 아예 감춘다(데스크탑은 그대로).
           <DragHandle
             editor={editor}
             nested={{ edgeDetection: "none" }}
-            className="z-10"
+            className="z-10 hidden md:block"
           >
             <button
               type="button"

--- a/fe/src/features/note/components/NoteWorkspace.test.tsx
+++ b/fe/src/features/note/components/NoteWorkspace.test.tsx
@@ -78,6 +78,31 @@ function mockNoteDetail(
   );
 }
 
+/** 본문에 박힌 datasetTable 블록이 실제로 그려지도록 표 조회 3종을 목킹한다. */
+function mockDataset() {
+  server.use(
+    http.get(`${API_BASE}/datasets/1`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: { id: 1, columns: [{ key: "c0", label: "과목" }], rowCount: 1 },
+      }),
+    ),
+    http.get(`${API_BASE}/datasets/1/rows`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          rows: [{ id: 100, rowIndex: 0, cells: ["네트워크"] }],
+          offset: 0,
+          limit: 100,
+        },
+      }),
+    ),
+    http.get(`${API_BASE}/datasets/1/merges`, () =>
+      HttpResponse.json({ code: "OK", data: { merges: [] } }),
+    ),
+  );
+}
+
 /** 좁은 화면(모바일, md 미만)으로 matchMedia를 목킹한다. */
 function setNarrowViewport() {
   window.matchMedia = ((query: string) => ({
@@ -373,6 +398,53 @@ describe("NoteWorkspace (독립 노트)", () => {
         expect(screen.queryByLabelText("노트 제목")).not.toBeInTheDocument();
       });
       expect(screen.getByRole("button", { name: "노트1" })).toBeInTheDocument();
+    });
+
+    // 표는 본문 좌우 패딩을 음수 마진으로 상쇄해 카드 폭을 꽉 쓴다(모바일). 두 값은 짝이라
+    // 한쪽만 바꾸면 표가 카드를 넘치거나(마진이 크면) 여백이 남는다. jsdom은 CSS를 적용하지
+    // 않아 렌더된 폭으로는 검증할 수 없으므로, 짝이 맞는지를 클래스에서 숫자로 뽑아 비교한다.
+    it("표 블록의 음수 마진이 본문 좌우 패딩과 짝이 맞는다", async () => {
+      setNarrowViewport();
+      mockTree([
+        { id: 1, title: "노트1", parentId: null, sortOrder: 0, children: [] },
+      ]);
+      mockNoteDetail(
+        1,
+        {
+          type: "doc",
+          content: [{ type: "datasetTable", attrs: { datasetId: 1 } }],
+        },
+        "노트1",
+      );
+      mockDataset();
+
+      const user = userEvent.setup();
+      renderWorkspace();
+
+      await user.click(await screen.findByRole("button", { name: "노트1" }));
+
+      const body = await screen.findByLabelText("노트 본문");
+      const table = await waitFor(() => {
+        const el = document.querySelector("[data-dataset-table]");
+        if (!el) throw new Error("표 블록 미마운트");
+        return el as HTMLElement;
+      });
+
+      // md: 접두사가 없는 것 = 모바일에 적용되는 값.
+      const scale = (cls: string, prefix: string) => {
+        const found = cls
+          .split(/\s+/)
+          .find((c) => c.startsWith(prefix) && !c.includes(":"));
+        return found ? Number(found.slice(prefix.length)) : null;
+      };
+
+      const padLeft = scale(body.className, "pl-");
+      const padRight = scale(body.className, "pr-");
+      const bleed = scale(table.className, "-mx-");
+
+      expect(padLeft).not.toBeNull();
+      expect(bleed).toBe(padLeft);
+      expect(bleed).toBe(padRight);
     });
   });
 });

--- a/fe/src/features/note/editor/DatasetTableView.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.tsx
@@ -83,6 +83,10 @@ export function DatasetTableView({
       as="div"
       data-dataset-table={datasetId ?? ""}
       contentEditable={false}
+      // 표만 모바일에서 본문 좌우 패딩(pl-3 pr-3)을 음수 마진으로 상쇄해 카드 폭을 꽉 쓴다.
+      // 표는 폭이 곧 읽을 수 있는 열 수라, 글 블록과 좌측선을 맞추는 것보다 폭이 우선이다.
+      // 값이 본문 패딩과 짝이므로 한쪽만 바꾸면 표가 카드를 넘치거나 어긋난다.
+      className="-mx-3 md:mx-0"
     >
       {datasetId != null && (
         <DatasetGrid


### PR DESCRIPTION
## 이슈
closes #1006

## 작업 내용
모바일에서 좌우 여백이 4겹으로 쌓여 390px 중 126px(32%)이 여백이었다. 표는 여기에 자기 거터까지 더해져 264px만 남아 열이 잘려 보였다.

- `AppLayout` 페이지 여백을 모바일에서 축소 — `p-6` → `p-4 md:p-6`
- 노트 본문 좌우 패딩을 모바일에서 축소 — `pl-10 pr-4` → `pl-3 pr-3 md:pl-10 md:pr-4`
- 블록 이동(⣿) 핸들을 모바일에서 감춤 — hover로만 뜨는 UI라 터치 기기엔 애초에 안 나타난다. 그 자리(`pl-10` 40px)가 순수 낭비였다
- 표 블록만 `-mx-3 md:mx-0`으로 본문 패딩을 상쇄해 카드 폭을 꽉 씀 — 표는 폭이 곧 읽을 수 있는 열 수라 글 블록과의 좌측선 정렬보다 폭을 우선했다

`DatasetGrid`의 `pr-5` 거터는 유지했다. 보이지 않아도 탭하면 열이 추가되는 모바일 유일의 열 추가 경로다.

### 결과 (390px 기준)
표 폭 **264px → 336px** (뷰포트의 68% → 86%). 데스크탑은 그대로.

## 테스트
- `e2e/note-mobile-width.spec.ts` 신규 — 여백은 CSS라 jsdom에서 폭을 잴 수 없어 실제 브라우저로 검증한다
  - 모바일: 표가 뷰포트 폭의 80% 이상 / 가로 스크롤 없음(음수 마진 짝 어긋남 감지) / 핸들 안 보임
  - 데스크탑: 표가 본문 글과 같은 좌측선(full-bleed 아님) / 핸들 거터 유지
  - **수정 전 상태에서 모바일 2건이 실패하는 것을 확인**했다(264px, 핸들 노출) — 허수 테스트 아님
- `NoteWorkspace.test.tsx` — 표의 음수 마진이 본문 좌우 패딩과 짝이 맞는지 클래스에서 숫자로 뽑아 비교. 한쪽만 바꾸면 표가 카드를 넘치거나 여백이 남는 커플링을 잠근다
- FE 전체: 582 tests passed / e2e 15 passed / lint · format:check 통과