### PR TITLE
fix : 표가 있는 노트에서 Cmd+A 후 Backspace가 먹지 않던 문제

### DIFF
--- a/fe/e2e/note-table-focus.spec.ts
+++ b/fe/e2e/note-table-focus.spec.ts
@@ -1,0 +1,145 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 표가 있는 노트에서 Cmd+A → Backspace가 먹지 않던 회귀(#1008).
+ *
+ * 원인은 포커스 소유권이었다 — 문서 전체 선택이 표를 "덮으면" 그리드가 자기가 선택된 줄 알고
+ * 첫 셀을 잡아, 셀 <input>이 DOM 포커스를 가져가 키 입력이 에디터 대신 셀로 샜다.
+ * 포커스는 CSS/jsdom으로 재현되지 않아(활성 요소가 실제로 바뀌어야 한다) 실제 브라우저로 검증한다.
+ * 행 데이터 로드 타이밍에 좌우돼 불규칙했으므로 반복 실행으로 안정성까지 본다.
+ */
+
+const NOTE_ID = 1;
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+async function mockNoteWithTable(page: Page) {
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+
+  await page.route("**/api/notes", (route) =>
+    route.fulfill(
+      ok({
+        notes: [
+          {
+            id: NOTE_ID,
+            title: "테스트 노트",
+            parentId: null,
+            sortOrder: 0,
+            children: [],
+          },
+        ],
+      }),
+    ),
+  );
+
+  await page.route(`**/api/notes/${NOTE_ID}`, (route) => {
+    if (route.request().method() === "PATCH")
+      return route.fulfill(ok({ id: NOTE_ID }));
+    return route.fulfill(
+      ok({
+        id: NOTE_ID,
+        materialId: null,
+        parentId: null,
+        title: "테스트 노트",
+        sortOrder: 0,
+        content: {
+          type: "doc",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "첫째 줄" }] },
+            { type: "datasetTable", attrs: { datasetId: 1 } },
+            { type: "paragraph", content: [{ type: "text", text: "셋째 줄" }] },
+          ],
+        },
+        updatedAt: "2026-01-01T00:00:00Z",
+      }),
+    );
+  });
+
+  await page.route("**/api/datasets/**", (route) => {
+    const { pathname } = new URL(route.request().url());
+    if (pathname.endsWith("/rows"))
+      return route.fulfill(
+        ok({
+          rows: [
+            { id: 100, rowIndex: 0, cells: ["a1", "b1"] },
+            { id: 101, rowIndex: 1, cells: ["a2", "b2"] },
+          ],
+          offset: 0,
+          limit: 100,
+        }),
+      );
+    if (pathname.endsWith("/merges")) return route.fulfill(ok({ merges: [] }));
+    return route.fulfill(
+      ok({
+        id: 1,
+        name: "표",
+        columns: [
+          { key: "c0", label: "A" },
+          { key: "c1", label: "B" },
+        ],
+        rowCount: 2,
+      }),
+    );
+  });
+}
+
+async function openNote(page: Page) {
+  await page.goto(`/notes?note=${NOTE_ID}`);
+  await expect(page.getByLabel("노트 본문")).toBeVisible();
+  await expect(page.getByTestId("dataset-grid")).toBeVisible();
+}
+
+/** 지금 키 입력을 받는 요소가 에디터인지 표의 셀 입력창인지. */
+function focusOwner(page: Page) {
+  return page.evaluate(() => {
+    const el = document.activeElement;
+    if (!el) return "none";
+    if (el.classList.contains("ProseMirror")) return "editor";
+    if (el.closest("[data-dataset-table]")) return "cell";
+    return el.tagName.toLowerCase();
+  });
+}
+
+test.describe("표가 있는 노트의 포커스 소유권", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockNoteWithTable(page);
+    await openNote(page);
+  });
+
+  test("Cmd+A 후에도 포커스가 에디터에 남는다", async ({ page }) => {
+    await page.getByText("첫째 줄").click();
+    expect(await focusOwner(page)).toBe("editor");
+
+    await page.keyboard.press("ControlOrMeta+a");
+    // 회귀 대상: 전체 선택이 표를 덮자 그리드가 첫 셀을 잡아 포커스를 가져가던 문제.
+    expect(await focusOwner(page)).toBe("editor");
+  });
+
+  test("Cmd+A → Backspace 로 표를 포함한 본문이 지워진다", async ({ page }) => {
+    await page.getByText("첫째 줄").click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("Backspace");
+
+    // 표 블록이 지워지면 dataset 정리 확인 창이 뜬다(고아 dataset 방지 경로).
+    await expect(page.getByText("표(데이터셋)를 삭제할까요?")).toBeVisible();
+    await expect(page.getByText("첫째 줄")).toBeHidden();
+    await expect(page.getByText("셋째 줄")).toBeHidden();
+  });
+
+  test("표를 클릭하면 여전히 셀이 잡혀 바로 타이핑할 수 있다", async ({
+    page,
+  }) => {
+    // 좁힌 조건이 과해서 표 단독 선택까지 막지 않았는지 확인한다.
+    await page.getByText("a1").click();
+    expect(await focusOwner(page)).toBe("cell");
+
+    await page.keyboard.type("X");
+    await expect(page.getByTestId("dataset-grid")).toContainText("X");
+  });
+});

--- a/fe/src/features/note/editor/DatasetTableView.test.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.test.tsx
@@ -1,4 +1,9 @@
-import { createEvent, fireEvent, waitFor } from "@testing-library/react";
+import {
+  createEvent,
+  fireEvent,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { Editor } from "@tiptap/core";
 import { EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
@@ -112,6 +117,68 @@ describe("DatasetTableView — 셀 드래그 시 표가 끌려나오지 않는�
     // (핸들러를 NodeViewWrapper 자식에 걸면 부모발 이 이벤트를 못 잡아 defaultPrevented=false로 실패한다.)
     expect(dragEvent.defaultPrevented).toBe(true);
 
+    editor.destroy();
+  });
+});
+
+// TipTap의 `selected`는 "이 표가 단독 선택됨"이 아니라 "선택이 이 표를 덮음"이라(isNodeViewSelected),
+// Cmd+A(문서 전체 선택)에서도 참이 된다. 그대로 그리드에 넘기면 표를 건드리지도 않았는데 그리드가
+// 첫 셀을 잡고 셀 입력창이 DOM 포커스를 가져가, 그 뒤 키 입력이 에디터 대신 셀로 새어 Backspace가
+// 먹통이 됐다(#1008). 표'만' 선택됐을 때로 좁힌 것을 검증한다.
+describe("DatasetTableView — 표를 덮는 선택이 셀 포커스를 뺏지 않는다", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "mock-token" });
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue(
+      FAKE_RECT,
+    );
+    mockDataset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** 표 노드의 문서 내 위치. */
+  function datasetTablePos(editor: Editor): number {
+    let pos = -1;
+    editor.state.doc.descendants((n, p) => {
+      if (n.type.name === "datasetTable") pos = p;
+    });
+    return pos;
+  }
+
+  const activeCellInput = () =>
+    screen.queryByLabelText("1행 1열 셀 (입력하면 편집)");
+
+  it("문서 전체 선택(Cmd+A)은 표의 첫 셀을 잡지 않는다", async () => {
+    const editor = makeEditor();
+    renderWithRouter(<EditorContent editor={editor} />);
+    await screen.findByTestId("dataset-grid");
+
+    editor.commands.selectAll();
+
+    // NodeView의 선택 반영은 rAF로 미뤄지므로 붙잡을 시간을 준다.
+    await waitFor(() => {
+      expect(editor.state.selection.from).toBeLessThanOrEqual(
+        datasetTablePos(editor),
+      );
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(activeCellInput()).not.toBeInTheDocument();
+    editor.destroy();
+  });
+
+  it("표만 선택하면(NodeSelection) 첫 셀을 잡아 바로 타이핑할 수 있다", async () => {
+    const editor = makeEditor();
+    renderWithRouter(<EditorContent editor={editor} />);
+    await screen.findByTestId("dataset-grid");
+
+    editor.commands.setNodeSelection(datasetTablePos(editor));
+
+    await waitFor(() => {
+      expect(activeCellInput()).toBeInTheDocument();
+    });
     editor.destroy();
   });
 });

--- a/fe/src/features/note/editor/DatasetTableView.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.tsx
@@ -1,4 +1,5 @@
 import { useQueries } from "@tanstack/react-query";
+import { NodeSelection } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
 import { type NodeViewProps, NodeViewWrapper } from "@tiptap/react";
 import { useEffect, useRef } from "react";
@@ -43,6 +44,20 @@ export function DatasetTableView({
   const datasetId = node.attrs.datasetId as number | null;
   const { requestDeleteDataset } = useDatasetTableContext();
   const siblingTables = useSiblingTables(editor, datasetId ?? -1);
+
+  // TipTap의 `selected`는 "이 표가 단독 선택됨"이 아니라 "선택이 이 표를 덮음"이다
+  // (isNodeViewSelected: from <= pos && to >= pos + nodeSize). 그래서 Cmd+A(문서 전체)나
+  // 표를 가로지르는 드래그에서도 참이 된다. 그대로 그리드에 넘기면 표를 건드리지도 않았는데
+  // 그리드가 첫 셀을 잡고(DatasetGrid의 blockSelected effect) 셀 입력창이 DOM 포커스를
+  // 가져가, 그 뒤 키 입력이 에디터 대신 셀로 새어 Backspace 같은 게 먹통이 됐다.
+  // 표'만' 선택된 NodeSelection일 때로 좁힌다 — 원래 의도(표만 골랐을 때 바로 타이핑=편집).
+  const selection = editor.state.selection;
+  const pos = getPos();
+  const soleSelected =
+    selected &&
+    selection instanceof NodeSelection &&
+    typeof pos === "number" &&
+    selection.from === pos;
 
   // 셀을 드래그해 범위 선택하려 할 때 표 블록이 통째로 끌려나오던 문제를 막는다.
   // 표가 NodeSelection으로 선택되면(셀 클릭 시 blockSelected) PM의 MouseDown이 spec.draggable:false를
@@ -92,9 +107,10 @@ export function DatasetTableView({
         <DatasetGrid
           datasetId={datasetId}
           onDeleteBlock={requestDelete}
-          // 표 블록이 선택되면(한 번 클릭·키보드 이동 등) 그리드가 첫 셀을 잡아
+          // 표 블록'만' 선택되면(한 번 클릭·키보드 이동 등) 그리드가 첫 셀을 잡아
           // 곧바로 타이핑=편집이 되게 한다(블록만 선택돼 키가 먹통이던 문제 해소).
-          blockSelected={selected}
+          // 여러 블록을 함께 선택한 경우엔 잡지 않는다 — 위 soleSelected 주석 참고.
+          blockSelected={soleSelected}
           // 표간 참조 피커·저장(tableRefs)에 쓸 같은 노트의 다른 표들.
           siblingTables={siblingTables}
         />


### PR DESCRIPTION
## 이슈
closes #1008

## 작업 내용
`Cmd+A` 후 `Backspace`가 표가 있는 노트에서 6번 중 4~5번 먹지 않았다. 원인은 **포커스 소유권**이었다.

TipTap의 NodeView `selected`는 "이 노드가 단독 선택됨"이 아니라 **"선택이 이 노드를 덮음"**이다:

```js
// @tiptap/core isNodeViewSelected
if (from <= pos && to >= pos + nodeSize) return true;
```

그래서 `Cmd+A`(문서 전체)나 표를 가로지르는 드래그에서도 참이 됐고, 표를 건드리지도 않았는데 그리드가 첫 셀을 잡아(`DatasetGrid.tsx:498`) 셀 `<input>`이 DOM 포커스를 가져갔다. 이후 키 입력은 ProseMirror가 아니라 셀로 들어가 아무 일도 일어나지 않았다.

- `DatasetTableView`에서 `blockSelected`를 **표만 선택된 `NodeSelection`**일 때로 좁혔다
- 원래 의도(표만 골랐을 때 바로 타이핑=편집)는 그대로 유지된다

행 데이터 로드 타이밍(`getRow(0)`)에 따라 effect가 도는 시점이 갈려 성공/실패가 불규칙했던 것도 함께 사라진다.

## 테스트
- `e2e/note-table-focus.spec.ts` 신규 — 포커스는 실제 활성 요소가 바뀌어야 재현되므로 jsdom이 아닌 실제 브라우저로 검증
  - `Cmd+A` 후 포커스가 에디터에 남는지 / `Cmd+A` → `Backspace`로 실제로 지워지는지 / 표 클릭 시엔 여전히 셀이 잡히는지(과교정 방지)
  - **6회 반복: 수정 전 18건 중 5건 실패 → 수정 후 18/18 통과.** 불규칙성이 사라진 것까지 확인
- `DatasetTableView.test.tsx` — 전체 선택은 첫 셀을 잡지 않고, 표 단독 선택은 잡는다 (수정 전 실패 확인)
- FE 전체: 584 tests / e2e 18 / lint · format:check · build 통과

## 비고
Notion식 블록 단위 조작을 도입하면 "여러 블록 선택 → 삭제·복제·이동"이 전부 이 길목을 지나므로 선행 과제였다. 별도 프로토타입으로 `@tiptap/extension-node-range`(블록 레이어)와 표 선택 레이어 사이엔 충돌이 없음을 확인했고, 유일한 걸림돌이 이 포커스 문제였다.