### PR TITLE
feat : 노트 블록 선택 레이어 + Cmd+A 점진 선택

### DIFF
--- a/fe/e2e/note-block-selection.spec.ts
+++ b/fe/e2e/note-block-selection.spec.ts
@@ -1,0 +1,208 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 블록 선택 레이어 + Cmd+A 점진 선택(#1011).
+ *
+ * 선택은 실제 DOM 선택·포커스·데코레이션이 얽혀 있어 jsdom으로는 끝까지 못 본다
+ * (특히 표 안에서 밖으로 넘어가는 포커스 이동). 실제 브라우저로 검증한다.
+ */
+
+const NOTE_ID = 1;
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+async function mockNote(page: Page) {
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/notes", (route) =>
+    route.fulfill(
+      ok({
+        notes: [
+          {
+            id: NOTE_ID,
+            title: "노트",
+            parentId: null,
+            sortOrder: 0,
+            children: [],
+          },
+        ],
+      }),
+    ),
+  );
+  await page.route(`**/api/notes/${NOTE_ID}`, (route) => {
+    if (route.request().method() === "PATCH")
+      return route.fulfill(ok({ id: NOTE_ID }));
+    return route.fulfill(
+      ok({
+        id: NOTE_ID,
+        materialId: null,
+        parentId: null,
+        title: "노트",
+        sortOrder: 0,
+        content: {
+          type: "doc",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "첫째 줄" }] },
+            { type: "paragraph", content: [{ type: "text", text: "둘째 줄" }] },
+            { type: "datasetTable", attrs: { datasetId: 1 } },
+          ],
+        },
+        updatedAt: "2026-01-01T00:00:00Z",
+      }),
+    );
+  });
+  await page.route("**/api/datasets/**", (route) => {
+    const { pathname } = new URL(route.request().url());
+    if (pathname.endsWith("/rows"))
+      return route.fulfill(
+        ok({
+          rows: [
+            { id: 100, rowIndex: 0, cells: ["a1", "b1"] },
+            { id: 101, rowIndex: 1, cells: ["a2", "b2"] },
+          ],
+          offset: 0,
+          limit: 100,
+        }),
+      );
+    if (pathname.endsWith("/merges")) return route.fulfill(ok({ merges: [] }));
+    return route.fulfill(
+      ok({
+        id: 1,
+        name: "표",
+        columns: [
+          { key: "c0", label: "A" },
+          { key: "c1", label: "B" },
+        ],
+        rowCount: 2,
+      }),
+    );
+  });
+}
+
+/** 블록 선택으로 잡힌 블록 수. 0이면 블록 레이어가 안 잡힌 것. */
+const selectedBlocks = (page: Page) =>
+  page.locator(".ProseMirror-selectednoderange").count();
+
+/** 지금 키를 받는 곳이 에디터인지 표의 셀인지. */
+const focusOwner = (page: Page) =>
+  page.evaluate(() => {
+    const el = document.activeElement;
+    if (!el) return "none";
+    if (el.classList.contains("ProseMirror")) return "editor";
+    if (el.closest("[data-dataset-table]")) return "cell";
+    return el.tagName.toLowerCase();
+  });
+
+const selectedText = (page: Page) =>
+  page.evaluate(() => window.getSelection()?.toString() ?? "");
+
+/**
+ * 본문의 최상위 블록 수. 표 뒤에는 ProseMirror가 후행 문단을 자동으로 두므로 상수로 박지 않고
+ * 실제 개수와 비교한다("모든 블록이 잡혔다"가 검증하려는 것이다).
+ */
+const topLevelBlocks = (page: Page) => page.locator(".ProseMirror > *").count();
+
+test.beforeEach(async ({ page }) => {
+  await mockNote(page);
+  await page.goto(`/notes?note=${NOTE_ID}`);
+  await expect(page.getByLabel("노트 본문")).toBeVisible();
+  await expect(page.getByTestId("dataset-grid")).toBeVisible();
+});
+
+test.describe("본문 Cmd+A 사다리", () => {
+  test("1번째는 커서가 놓인 블록만, 2번째에 문서 전체", async ({ page }) => {
+    await page.getByText("첫째 줄").click();
+
+    await page.keyboard.press("ControlOrMeta+a");
+    // 블록 안 텍스트만 — 아직 블록 레이어로 올라가지 않는다.
+    expect(await selectedText(page)).toBe("첫째 줄");
+    expect(await selectedBlocks(page)).toBe(0);
+
+    await page.keyboard.press("ControlOrMeta+a");
+    expect(await selectedBlocks(page)).toBe(await topLevelBlocks(page));
+  });
+
+  test("전체 블록 선택 후 Backspace로 본문이 지워진다", async ({ page }) => {
+    await page.getByText("첫째 줄").click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("Backspace");
+
+    await expect(page.getByText("표(데이터셋)를 삭제할까요?")).toBeVisible();
+    await expect(page.getByText("첫째 줄")).toBeHidden();
+  });
+});
+
+test.describe("표에서의 사다리 — 셀 → 표 → 문서", () => {
+  test("표 안 첫 Cmd+A는 표에 머물고, 한 번 더 누르면 문서로 탈출한다", async ({
+    page,
+  }) => {
+    await page.getByText("a1").click();
+    expect(await focusOwner(page)).toBe("cell");
+
+    // 1번째 — 표 전체. 본문 블록으로 새지 않는다.
+    await page.keyboard.press("ControlOrMeta+a");
+    expect(await selectedBlocks(page)).toBe(0);
+
+    // 2번째 — 표 밖으로. 포커스도 에디터로 돌아와야 이후 키가 먹는다.
+    await page.keyboard.press("ControlOrMeta+a");
+    expect(await selectedBlocks(page)).toBe(await topLevelBlocks(page));
+    expect(await focusOwner(page)).toBe("editor");
+  });
+
+  test("표에서 탈출한 뒤 Backspace가 본문에 먹는다", async ({ page }) => {
+    await page.getByText("a1").click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("Backspace");
+
+    await expect(page.getByText("표(데이터셋)를 삭제할까요?")).toBeVisible();
+  });
+});
+
+test.describe("드래그 정책 (Notion식)", () => {
+  test("블록을 넘나드는 드래그는 블록 선택으로 승격된다", async ({ page }) => {
+    const first = (await page.getByText("첫째 줄").boundingBox())!;
+    const second = (await page.getByText("둘째 줄").boundingBox())!;
+
+    await page.mouse.move(first.x + 5, first.y + first.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(second.x + 40, second.y + second.height / 2, {
+      steps: 10,
+    });
+    await page.mouse.up();
+
+    expect(await selectedBlocks(page)).toBeGreaterThanOrEqual(2);
+  });
+
+  test("한 문단 안 드래그는 부분 텍스트 선택으로 남는다(서식 적용 경로)", async ({
+    page,
+  }) => {
+    // 문단 요소의 박스는 블록이라 글자보다 훨씬 넓다(오른쪽은 빈 공간). 그 비율로 끌면
+    // 글자 바깥에서 드래그가 시작·종료돼 선택이 안 잡힌다. 글자가 실제로 차지한 영역을 잰다.
+    const rect = await page.evaluate(() => {
+      const p = [...document.querySelectorAll(".ProseMirror > p")].find(
+        (el) => el.textContent === "첫째 줄",
+      )!;
+      const range = document.createRange();
+      range.selectNodeContents(p);
+      const r = range.getBoundingClientRect();
+      return { x: r.x, y: r.y, width: r.width, height: r.height };
+    });
+
+    const y = rect.y + rect.height / 2;
+    await page.mouse.move(rect.x + 1, y);
+    await page.mouse.down();
+    await page.mouse.move(rect.x + rect.width * 0.8, y, { steps: 12 });
+    await page.mouse.up();
+
+    // 선택 반영이 한 틱 늦을 수 있어 폴링으로 확인한다.
+    await expect.poll(() => selectedText(page)).not.toBe("");
+    expect(await selectedBlocks(page)).toBe(0);
+  });
+});

--- a/fe/e2e/note-table-focus.spec.ts
+++ b/fe/e2e/note-table-focus.spec.ts
@@ -112,8 +112,12 @@ test.describe("표가 있는 노트의 포커스 소유권", () => {
     await openNote(page);
   });
 
-  test("Cmd+A 후에도 포커스가 에디터에 남는다", async ({ page }) => {
+  test("전체 선택 후에도 포커스가 에디터에 남는다", async ({ page }) => {
     await page.getByText("첫째 줄").click();
+    expect(await focusOwner(page)).toBe("editor");
+
+    // Cmd+A는 점진 선택이라 두 번 눌러야 문서 전체가 잡힌다(#1011). 표를 덮는 건 두 번째다.
+    await page.keyboard.press("ControlOrMeta+a");
     expect(await focusOwner(page)).toBe("editor");
 
     await page.keyboard.press("ControlOrMeta+a");
@@ -121,9 +125,12 @@ test.describe("표가 있는 노트의 포커스 소유권", () => {
     expect(await focusOwner(page)).toBe("editor");
   });
 
-  test("Cmd+A → Backspace 로 표를 포함한 본문이 지워진다", async ({ page }) => {
+  test("전체 선택 → Backspace 로 표를 포함한 본문이 지워진다", async ({
+    page,
+  }) => {
     await page.getByText("첫째 줄").click();
-    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+a"); // 블록 안 텍스트
+    await page.keyboard.press("ControlOrMeta+a"); // 문서 전체 블록
     await page.keyboard.press("Backspace");
 
     // 표 블록이 지워지면 dataset 정리 확인 창이 뜬다(고아 dataset 방지 경로).

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -21,6 +21,7 @@
         "@tiptap/extension-drag-handle": "3.23.4",
         "@tiptap/extension-drag-handle-react": "3.23.4",
         "@tiptap/extension-image": "^3.23.4",
+        "@tiptap/extension-node-range": "3.23.4",
         "@tiptap/extension-placeholder": "^3.23.4",
         "@tiptap/extension-task-item": "^3.23.4",
         "@tiptap/extension-task-list": "^3.23.4",
@@ -2977,6 +2978,64 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
@@ -3560,7 +3619,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.23.4.tgz",
       "integrity": "sha512-wmJrIT2Ng4TP4HniA0+WCNtqL09ZBZYd9bSnyDfZiz5phEcnqfCTBGpPXiA+jTjxZp/ZrJPFTjgQPevNQIAa9g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"

--- a/fe/package.json
+++ b/fe/package.json
@@ -29,6 +29,7 @@
     "@tiptap/extension-drag-handle": "3.23.4",
     "@tiptap/extension-drag-handle-react": "3.23.4",
     "@tiptap/extension-image": "^3.23.4",
+    "@tiptap/extension-node-range": "3.23.4",
     "@tiptap/extension-placeholder": "^3.23.4",
     "@tiptap/extension-task-item": "^3.23.4",
     "@tiptap/extension-task-list": "^3.23.4",

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { DragHandle } from "@tiptap/extension-drag-handle-react";
 import Image from "@tiptap/extension-image";
+import { NodeRange } from "@tiptap/extension-node-range";
 import Placeholder from "@tiptap/extension-placeholder";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
@@ -15,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import type { NoteContent, NoteDetail } from "../api/notes";
 import { deleteDataset } from "../dataset/api/datasets";
 import { DATASET_CELLS_MIME } from "../dataset/cellClipboard";
+import { SelectionLadder } from "../editor/blockSelection";
 import { ChildPage, collectChildPageIds } from "../editor/childPage";
 import { ChildPageContext } from "../editor/childPageContext";
 import { collectDatasetIds, DatasetTable } from "../editor/datasetTable";
@@ -87,6 +89,12 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
         }),
         ChildPage,
         DatasetTable,
+        // 블록 레이어. key:null이라 블록을 넘나드는 평범한 드래그도 블록 선택으로 승격한다
+        // (Notion과 동일). 한 문단 안 드래그는 부분 텍스트 선택 그대로라 서식 적용은 안 깨진다.
+        // Shift+↑/↓ 블록 확장·드래그 핸들의 다중 블록 이동도 여기서 나온다.
+        NodeRange.configure({ key: null }),
+        // Cmd+A 점진 선택. NodeRange의 "항상 전체 블록"을 우선순위로 덮는다.
+        SelectionLadder,
         LinkShortcut.configure({
           onTrigger: () => openLinkEditorRef.current(),
         }),

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -97,6 +97,11 @@ interface Props {
   /** 에디터에서 표 블록이 선택된 상태(NodeSelection)인지. 첫 셀 자동 선택 트리거. */
   blockSelected?: boolean;
   /**
+   * 표 전체가 이미 선택된 상태에서 Cmd/Ctrl+A를 한 번 더 눌렀을 때 — 표 밖(문서 전체)으로
+   * 선택을 넘긴다. 표가 키를 막고 있어 그냥 두면 사다리가 표에서 끊긴다.
+   */
+  onSelectAllEscape?: () => void;
+  /**
    * 같은 노트의 다른 표들(자기 제외). 표간 참조 피커가 대상 표·열을 고르고, 저장 시 표 이름→id
    * 맵(tableRefs)을 만드는 데 쓴다. 이름 없는 표는 참조할 수 없다(피커에서 제외).
    */
@@ -112,6 +117,7 @@ export function DatasetGrid({
   datasetId,
   onDeleteBlock,
   blockSelected,
+  onSelectAllEscape,
   siblingTables,
 }: Props) {
   const queryClient = useQueryClient();
@@ -1219,6 +1225,13 @@ export function DatasetGrid({
   const handleNavKey = (e: React.KeyboardEvent): boolean => {
     if ((e.metaKey || e.ctrlKey) && (e.key === "a" || e.key === "A")) {
       e.preventDefault();
+      // 사다리: 셀 범위 → 표 전체 → 문서 전체. 이미 표 전체면 한 칸 더 올라가 표 밖으로
+      // 넘긴다(표가 키를 막고 있어 넘겨주지 않으면 사다리가 여기서 끊긴다).
+      if (sel?.kind === "table" && onSelectAllEscape) {
+        setSel(null);
+        onSelectAllEscape();
+        return true;
+      }
       setEditing(null);
       setSel({ kind: "table" });
       return true;

--- a/fe/src/features/note/editor/DatasetTableView.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef } from "react";
 import { type DatasetMeta, fetchDatasetMeta } from "../dataset/api/datasets";
 import { DatasetGrid } from "../dataset/DatasetGrid";
 import { datasetKeys } from "../dataset/queryKeys";
+import { selectAllBlocks } from "./blockSelection";
 import { useDatasetTableContext } from "./datasetTableContext";
 
 /**
@@ -92,6 +93,13 @@ export function DatasetTableView({
     requestDeleteDataset(datasetId, removeBlock);
   };
 
+  // 표 전체가 선택된 상태에서 Cmd+A를 한 번 더 → 문서 전체 블록으로 올라간다.
+  // 포커스가 셀 입력창에 있으므로 에디터로 되돌린 뒤 선택을 건다(안 그러면 이후 키가 또 샌다).
+  const escapeSelectionToDocument = () => {
+    editor.commands.focus();
+    selectAllBlocks(editor);
+  };
+
   return (
     <NodeViewWrapper
       ref={wrapRef}
@@ -111,6 +119,8 @@ export function DatasetTableView({
           // 곧바로 타이핑=편집이 되게 한다(블록만 선택돼 키가 먹통이던 문제 해소).
           // 여러 블록을 함께 선택한 경우엔 잡지 않는다 — 위 soleSelected 주석 참고.
           blockSelected={soleSelected}
+          // 선택 사다리의 마지막 칸 — 표 전체 다음은 문서 전체다.
+          onSelectAllEscape={escapeSelectionToDocument}
           // 표간 참조 피커·저장(tableRefs)에 쓸 같은 노트의 다른 표들.
           siblingTables={siblingTables}
         />

--- a/fe/src/features/note/editor/blockSelection.test.tsx
+++ b/fe/src/features/note/editor/blockSelection.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent } from "@testing-library/react";
+import { Editor } from "@tiptap/core";
+import { NodeRange } from "@tiptap/extension-node-range";
+import StarterKit from "@tiptap/starter-kit";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { isAllBlocksSelected, SelectionLadder } from "./blockSelection";
+
+/**
+ * Cmd+A 점진 선택 — 한 번에 다 잡지 않고 "블록 안 텍스트 → 문서 전체 블록" 순으로 넓힌다.
+ * 키맵은 우선순위 싸움이 핵심이라(코어 keymap의 selectAll, node-range의 전체-블록 Mod-a)
+ * 커맨드를 직접 부르지 않고 **실제 키 이벤트**를 에디터 DOM에 쏴서 검증한다.
+ */
+
+function makeEditor(content: unknown) {
+  return new Editor({
+    extensions: [
+      StarterKit,
+      NodeRange.configure({ key: null }),
+      SelectionLadder,
+    ],
+    content: content as never,
+  });
+}
+
+/** Cmd+A 한 번. ProseMirror는 view.dom의 keydown에서 키맵을 돌린다. */
+function pressSelectAll(editor: Editor) {
+  fireEvent.keyDown(editor.view.dom, {
+    key: "a",
+    code: "KeyA",
+    ctrlKey: true,
+  });
+}
+
+const doc = {
+  type: "doc",
+  content: [
+    { type: "paragraph", content: [{ type: "text", text: "첫째 줄" }] },
+    { type: "paragraph", content: [{ type: "text", text: "둘째 줄" }] },
+  ],
+};
+
+let editor: Editor | null = null;
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+describe("Cmd+A 점진 선택", () => {
+  it("1번째는 커서가 놓인 블록 안 텍스트만 잡는다", () => {
+    editor = makeEditor(doc);
+    // "첫째 줄" 안에 커서를 둔다.
+    editor.commands.setTextSelection(3);
+
+    pressSelectAll(editor);
+
+    const { from, to, $from } = editor.state.selection;
+    expect(from).toBe($from.start());
+    expect(to).toBe($from.end());
+    // 둘째 줄까지 넘어가지 않는다.
+    expect(editor.state.doc.textBetween(from, to)).toBe("첫째 줄");
+    expect(isAllBlocksSelected(editor.state)).toBe(false);
+  });
+
+  it("2번째에 비로소 문서 전체 블록이 잡힌다", () => {
+    editor = makeEditor(doc);
+    editor.commands.setTextSelection(3);
+
+    pressSelectAll(editor);
+    pressSelectAll(editor);
+
+    expect(isAllBlocksSelected(editor.state)).toBe(true);
+    // 텍스트 선택이 아니라 블록 선택이다 — 여기서 블록 단위 삭제·이동이 이어진다.
+    expect(editor.state.selection.constructor.name).toContain(
+      "NodeRangeSelection",
+    );
+  });
+
+  it("3번째는 꼭대기라 더 넓어지지 않는다", () => {
+    editor = makeEditor(doc);
+    editor.commands.setTextSelection(3);
+
+    pressSelectAll(editor);
+    pressSelectAll(editor);
+    const after2 = editor.state.selection.toJSON();
+    pressSelectAll(editor);
+
+    expect(editor.state.selection.toJSON()).toEqual(after2);
+  });
+
+  it("빈 블록에선 헛돌지 않고 바로 문서 전체로 간다", () => {
+    editor = makeEditor({
+      type: "doc",
+      content: [
+        { type: "paragraph" },
+        { type: "paragraph", content: [{ type: "text", text: "아래" }] },
+      ],
+    });
+    editor.commands.setTextSelection(1);
+
+    pressSelectAll(editor);
+
+    expect(isAllBlocksSelected(editor.state)).toBe(true);
+  });
+
+  it("여러 블록에 걸친 선택에서 누르면 현재 블록으로 좁아지지 않고 전체로 넓어진다", () => {
+    editor = makeEditor(doc);
+    // 첫째 줄 중간 ~ 둘째 줄 중간.
+    editor.commands.setTextSelection({ from: 3, to: 12 });
+
+    pressSelectAll(editor);
+
+    expect(isAllBlocksSelected(editor.state)).toBe(true);
+  });
+});

--- a/fe/src/features/note/editor/blockSelection.ts
+++ b/fe/src/features/note/editor/blockSelection.ts
@@ -1,0 +1,95 @@
+import { Extension } from "@tiptap/core";
+import {
+  isNodeRangeSelection,
+  NodeRangeSelection,
+} from "@tiptap/extension-node-range";
+import { type EditorState, TextSelection } from "@tiptap/pm/state";
+import type { Editor } from "@tiptap/react";
+
+/**
+ * 문서의 모든 블록을 블록 선택(NodeRangeSelection)한다.
+ * 텍스트 전체 선택(selectAll)과 달리 "블록들이 골라진" 상태라, 여기서 바로 블록 단위
+ * 삭제·이동·드래그가 이어진다.
+ */
+export function selectAllBlocks(editor: Editor): void {
+  const { state, view } = editor;
+  const { doc, tr } = state;
+  view.dispatch(
+    tr.setSelection(NodeRangeSelection.create(doc, 0, doc.content.size)),
+  );
+}
+
+/** 커서가 놓인 블록의 내용을 통째로 텍스트 선택한다(그 블록 안에서만). */
+export function selectCurrentBlockText(editor: Editor): void {
+  const { state, view } = editor;
+  const { $from } = state.selection;
+  view.dispatch(
+    state.tr.setSelection(
+      TextSelection.create(state.doc, $from.start(), $from.end()),
+    ),
+  );
+}
+
+/** 문서의 모든 블록이 블록 선택된 상태인가. */
+export function isAllBlocksSelected(state: EditorState): boolean {
+  const { selection, doc } = state;
+  if (!isNodeRangeSelection(selection)) return false;
+  return selection.from <= 1 && selection.to >= doc.content.size - 1;
+}
+
+/** 커서가 놓인 블록의 내용이 이미 통째로 선택돼 있는가. */
+export function isWholeBlockSelected(state: EditorState): boolean {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection)) return false;
+  const { $from, $to, from, to } = selection;
+  if (!$from.sameParent($to)) return false;
+  return from === $from.start() && to === $from.end();
+}
+
+/**
+ * Cmd/Ctrl+A 점진 선택 — Notion처럼 한 번에 다 잡지 않고 한 칸씩 넓힌다.
+ *
+ *   블록 안 텍스트 → 문서 전체 블록
+ *
+ * 기본 동작을 이기려면 우선순위를 올려야 한다. TipTap 코어 keymap이 `Mod-a`를
+ * `selectAll()`로, node-range가 `Mod-a`를 "항상 전체 블록"으로 쥐고 있는데, 둘 다
+ * 기본 우선순위(100)라 이 확장이 먼저 잡아야 사다리가 성립한다.
+ */
+export const SelectionLadder = Extension.create({
+  name: "selectionLadder",
+  priority: 200,
+
+  addKeyboardShortcuts() {
+    return {
+      "Mod-a": ({ editor }) => {
+        const { state } = editor;
+        const { selection } = state;
+
+        // 이미 꼭대기 — 더 넓힐 곳이 없다.
+        if (isAllBlocksSelected(state)) return true;
+
+        const isTextSel = selection instanceof TextSelection;
+        const spansBlocks =
+          isTextSel && !selection.$from.sameParent(selection.$to);
+        // 빈 블록은 "안쪽 텍스트"가 없어 한 칸이 헛돈다 — 바로 전체로 올린다.
+        const blockIsEmpty =
+          isTextSel && selection.$from.start() === selection.$from.end();
+
+        // 텍스트 선택이 아니거나(표 등 노드 선택), 이미 블록을 다 잡았거나,
+        // 여러 블록에 걸쳐 있으면 → 문서 전체 블록으로.
+        if (
+          !isTextSel ||
+          spansBlocks ||
+          blockIsEmpty ||
+          isWholeBlockSelected(state)
+        ) {
+          selectAllBlocks(editor);
+          return true;
+        }
+
+        selectCurrentBlockText(editor);
+        return true;
+      },
+    };
+  },
+});

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -262,3 +262,18 @@
 .tiptap img.ProseMirror-selectednode {
   outline: 2px solid var(--primary);
 }
+
+/* 블록 선택(NodeRangeSelection) — 글자가 아니라 블록 전체 폭이 잡혔음을 보인다.
+   라이트/다크 모두 본문 대비를 해치지 않게 primary를 옅게 깐다. */
+.tiptap .ProseMirror-selectednoderange {
+  background-color: color-mix(in srgb, var(--primary) 16%, transparent);
+  border-radius: 0.25rem;
+}
+.dark .tiptap .ProseMirror-selectednoderange {
+  background-color: color-mix(in srgb, var(--primary) 30%, transparent);
+}
+/* 블록 선택 중엔 안쪽 텍스트 하이라이트를 숨긴다 — 두 겹으로 겹쳐 보이지 않게. */
+.ProseMirror-noderangeselection ::selection,
+.ProseMirror-noderangeselection::selection {
+  background: transparent;
+}


### PR DESCRIPTION
## 이슈
closes #1011

## 작업 내용
노트 본문에 **블록 레이어**를 세우고, `Cmd+A`를 Notion처럼 점진적으로 만들었다.

### 선택 사다리
```
본문:  블록 안 텍스트 → 문서 전체 블록
표 안: 셀 범위 → 표 전체 → 문서 전체 블록
```

- `@tiptap/extension-node-range`를 **직접 의존성으로 선언**하고 `key: null`로 등록했다. 지금까지는 드래그 핸들의 전이 의존성이라 우연히 import되는 상태였다
- `SelectionLadder` 확장(`priority: 200`)으로 `Mod-a`를 잡는다. 코어 keymap의 `selectAll()`과 node-range의 "항상 전체 블록"이 둘 다 기본 우선순위(100)라 먼저 잡아야 사다리가 성립한다
- 표는 키를 막고 있어(`stopPropagation`) 사다리가 끊기므로, 표 전체가 이미 선택된 상태에서 한 번 더 누르면 `onSelectAllEscape`로 문서 전체로 넘긴다. 이때 포커스를 에디터로 되돌린다 — 안 그러면 이후 키가 셀로 샌다
- 블록 선택 하이라이트 스타일 추가(다크모드 별도 농도, 텍스트 하이라이트와 이중으로 겹치지 않게 `::selection` 투명 처리)

### 드래그 정책 (결정: Notion식)
블록을 넘나드는 평범한 드래그는 블록 선택으로 승격되고, **한 문단 안 드래그는 부분 텍스트 선택 그대로**다. 굵게·기울임 같은 서식 적용 경로가 깨지지 않는다.

### 덤으로 따라오는 것
`NodeRangeSelection`이 서면 `Shift+↑/↓` 블록 확장과 드래그 핸들의 **다중 블록 이동**이 별도 작업 없이 동작한다(드래그 핸들이 이미 이 선택 타입을 소비한다).

## 테스트
- `blockSelection.test.tsx` — 사다리 각 칸. 키맵은 우선순위 싸움이 핵심이라 커맨드를 직접 부르지 않고 **실제 키 이벤트**를 에디터 DOM에 쏜다
  - 1번째 = 그 블록 텍스트만 / 2번째 = 문서 전체 블록 / 3번째 = 꼭대기라 안 변함 / 빈 블록은 헛돌지 않고 바로 전체 / 여러 블록에 걸친 선택은 좁아지지 않고 넓어짐
  - **`SelectionLadder`를 빼면 1번째 테스트가 실패**하는 것을 확인했다(사다리 없이는 한 번에 다 잡힘)
- `e2e/note-block-selection.spec.ts` — 실제 브라우저. 사다리·표 탈출(포커스 이동 포함)·드래그 정책
  - 전체 블록 수는 상수로 박지 않고 실제 최상위 블록 수와 비교한다(표 뒤에 후행 문단이 자동으로 생긴다)
- `e2e/note-table-focus.spec.ts` 갱신 — `Cmd+A` 한 번으로는 더 이상 전체가 안 잡히므로 두 번 누르도록 수정(#1008이 잡은 포커스 회귀 자체는 그대로 지킨다)
- FE 589 tests / e2e 24종 **4회 반복 96/96** / lint · format:check · build 통과

## 남은 것 (#1010)
`Esc` 하강 사다리 · 블록 액션(삭제·복제·이동) · 블록 우클릭 메뉴