### PR TITLE
feat : 노트 Esc 하강 사다리 + 블록 복제·이동

### DIFF
--- a/fe/e2e/note-block-actions.spec.ts
+++ b/fe/e2e/note-block-actions.spec.ts
@@ -1,0 +1,210 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * Esc 하강 사다리 + 블록 복제·이동(#1013).
+ *
+ * 표는 자체 단축키를 갖고 있고 포커스가 셀 입력창에 있는데, 셀 입력창이 에디터 DOM 안이라
+ * 키가 본문까지 올라온다. 이 "가드가 실제로 먹는지"는 진짜 포커스가 있어야 검증되므로
+ * jsdom이 아닌 실제 브라우저로 본다.
+ */
+
+const NOTE_ID = 1;
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+async function mockNote(page: Page) {
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/notes", (route) =>
+    route.fulfill(
+      ok({
+        notes: [
+          {
+            id: NOTE_ID,
+            title: "노트",
+            parentId: null,
+            sortOrder: 0,
+            children: [],
+          },
+        ],
+      }),
+    ),
+  );
+  await page.route(`**/api/notes/${NOTE_ID}`, (route) => {
+    if (route.request().method() === "PATCH")
+      return route.fulfill(ok({ id: NOTE_ID }));
+    return route.fulfill(
+      ok({
+        id: NOTE_ID,
+        materialId: null,
+        parentId: null,
+        title: "노트",
+        sortOrder: 0,
+        content: {
+          type: "doc",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "첫째 줄" }] },
+            { type: "paragraph", content: [{ type: "text", text: "둘째 줄" }] },
+            { type: "datasetTable", attrs: { datasetId: 1 } },
+          ],
+        },
+        updatedAt: "2026-01-01T00:00:00Z",
+      }),
+    );
+  });
+  await page.route("**/api/datasets/**", (route) => {
+    const { pathname } = new URL(route.request().url());
+    if (pathname.endsWith("/rows"))
+      return route.fulfill(
+        ok({
+          rows: [
+            { id: 100, rowIndex: 0, cells: ["a1", "b1"] },
+            { id: 101, rowIndex: 1, cells: ["a2", "b2"] },
+          ],
+          offset: 0,
+          limit: 100,
+        }),
+      );
+    if (pathname.endsWith("/merges")) return route.fulfill(ok({ merges: [] }));
+    return route.fulfill(
+      ok({
+        id: 1,
+        name: "표",
+        columns: [
+          { key: "c0", label: "A" },
+          { key: "c1", label: "B" },
+        ],
+        rowCount: 2,
+      }),
+    );
+  });
+}
+
+/**
+ * 그 문단에 커서를 놓고, ProseMirror가 그 선택을 실제로 반영할 때까지 기다린다.
+ * click()이 돌아온 시점엔 브라우저가 캐럿만 옮겼을 뿐이라, 바로 키를 누르면 에디터가 아직
+ * 이전 선택(문서 맨 앞)을 보고 있어 엉뚱한 블록이 잡힌다.
+ */
+async function placeCursorIn(page: Page, text: string) {
+  await page.getByText(text).click();
+  await page.waitForFunction((t) => {
+    const node = window.getSelection()?.anchorNode ?? null;
+    const el = node instanceof Element ? node : node?.parentElement;
+    return el?.closest("p")?.textContent === t;
+  }, text);
+  // selectionchange 핸들러가 돌 한 프레임을 준다.
+  await page.evaluate(
+    () => new Promise((r) => requestAnimationFrame(() => r(null))),
+  );
+}
+
+const selectedBlocks = (page: Page) =>
+  page.locator(".ProseMirror-selectednoderange").count();
+
+/** 본문 문단 텍스트를 순서대로 — 복제·이동 결과를 눈으로 보듯 확인한다. */
+const paragraphs = (page: Page) =>
+  page.locator(".ProseMirror > p").allTextContents();
+
+test.beforeEach(async ({ page }) => {
+  await mockNote(page);
+  await page.goto(`/notes?note=${NOTE_ID}`);
+  await expect(page.getByLabel("노트 본문")).toBeVisible();
+  await expect(page.getByTestId("dataset-grid")).toBeVisible();
+});
+
+test.describe("Esc 하강 사다리", () => {
+  test("편집 → Esc → 현재 블록 선택 → Esc → 커서 복귀", async ({ page }) => {
+    await placeCursorIn(page, "첫째 줄");
+
+    await page.keyboard.press("Escape");
+    expect(await selectedBlocks(page)).toBe(1);
+
+    await page.keyboard.press("Escape");
+    expect(await selectedBlocks(page)).toBe(0);
+
+    // 커서가 돌아왔으니 바로 타이핑이 이어진다.
+    await page.keyboard.type("X");
+    expect(await paragraphs(page)).toContain("X첫째 줄");
+  });
+});
+
+test.describe("블록 복제·이동", () => {
+  test("Cmd+D 는 커서가 놓인 블록을 바로 아래에 복제한다", async ({ page }) => {
+    await placeCursorIn(page, "첫째 줄");
+
+    await page.keyboard.press("ControlOrMeta+d");
+
+    expect((await paragraphs(page)).slice(0, 3)).toEqual([
+      "첫째 줄",
+      "첫째 줄",
+      "둘째 줄",
+    ]);
+  });
+
+  test("Cmd+Shift+↓ 로 블록을 아래로 옮긴다", async ({ page }) => {
+    await placeCursorIn(page, "첫째 줄");
+
+    await page.keyboard.press("ControlOrMeta+Shift+ArrowDown");
+
+    expect((await paragraphs(page)).slice(0, 2)).toEqual([
+      "둘째 줄",
+      "첫째 줄",
+    ]);
+  });
+
+  test("Esc로 블록을 고른 뒤 Backspace로 그 블록만 지운다", async ({
+    page,
+  }) => {
+    await placeCursorIn(page, "둘째 줄");
+    await page.keyboard.press("Escape");
+    // 고른 게 정말 그 블록인지 먼저 못박는다 — 엉뚱한 블록이 지워지면 여기서 걸린다.
+    await expect(page.locator(".ProseMirror-selectednoderange")).toHaveText(
+      "둘째 줄",
+    );
+
+    await page.keyboard.press("Backspace");
+
+    const texts = await paragraphs(page);
+    expect(texts).toContain("첫째 줄");
+    expect(texts).not.toContain("둘째 줄");
+    // 표는 그대로다 — 고른 블록만 지워져야 한다.
+    await expect(page.getByTestId("dataset-grid")).toBeVisible();
+  });
+});
+
+test.describe("표 안에서는 본문 블록이 반응하지 않는다", () => {
+  test("셀에서 Esc를 눌러도 본문 블록이 선택되지 않는다", async ({ page }) => {
+    await page.getByText("a1").click();
+
+    await page.keyboard.press("Escape");
+
+    expect(await selectedBlocks(page)).toBe(0);
+  });
+
+  test("셀에서 Cmd+D를 눌러도 본문 블록이 복제되지 않는다", async ({
+    page,
+  }) => {
+    await page.getByText("a1").click();
+    const before = await paragraphs(page);
+
+    await page.keyboard.press("ControlOrMeta+d");
+
+    expect(await paragraphs(page)).toEqual(before);
+  });
+
+  test("셀에서 Cmd+Shift+↓를 눌러도 본문 블록이 움직이지 않는다", async ({
+    page,
+  }) => {
+    await page.getByText("a1").click();
+    const before = await paragraphs(page);
+
+    await page.keyboard.press("ControlOrMeta+Shift+ArrowDown");
+
+    expect(await paragraphs(page)).toEqual(before);
+  });
+});

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import type { NoteContent, NoteDetail } from "../api/notes";
 import { deleteDataset } from "../dataset/api/datasets";
 import { DATASET_CELLS_MIME } from "../dataset/cellClipboard";
+import { BlockActions } from "../editor/blockActions";
 import { SelectionLadder } from "../editor/blockSelection";
 import { ChildPage, collectChildPageIds } from "../editor/childPage";
 import { ChildPageContext } from "../editor/childPageContext";
@@ -95,6 +96,8 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
         NodeRange.configure({ key: null }),
         // Cmd+A 점진 선택. NodeRange의 "항상 전체 블록"을 우선순위로 덮는다.
         SelectionLadder,
+        // Esc 하강 사다리 + 블록 복제·이동.
+        BlockActions,
         LinkShortcut.configure({
           onTrigger: () => openLinkEditorRef.current(),
         }),

--- a/fe/src/features/note/editor/blockActions.test.tsx
+++ b/fe/src/features/note/editor/blockActions.test.tsx
@@ -1,0 +1,170 @@
+import { fireEvent } from "@testing-library/react";
+import { Editor } from "@tiptap/core";
+import { NodeRange } from "@tiptap/extension-node-range";
+import StarterKit from "@tiptap/starter-kit";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { BlockActions } from "./blockActions";
+import { isAllBlocksSelected, SelectionLadder } from "./blockSelection";
+
+/**
+ * Esc 하강 사다리와 블록 복제·이동. 키맵 우선순위와 브라우저 기본 동작 차단이 핵심이라
+ * 커맨드를 직접 부르지 않고 실제 키 이벤트를 에디터 DOM에 쏜다.
+ */
+
+function makeEditor(texts: string[]) {
+  const editor = new Editor({
+    extensions: [
+      StarterKit,
+      NodeRange.configure({ key: null }),
+      SelectionLadder,
+      BlockActions,
+    ],
+    content: {
+      type: "doc",
+      content: texts.map((text) => ({
+        type: "paragraph",
+        content: [{ type: "text", text }],
+      })),
+    },
+  });
+  // 핸들러가 view.hasFocus()로 가드하므로 테스트에서도 포커스를 준다(jsdom도 activeElement를 옮긴다).
+  editor.view.dom.setAttribute("tabindex", "-1");
+  document.body.append(editor.view.dom);
+  editor.view.dom.focus();
+  return editor;
+}
+
+function press(
+  editor: Editor,
+  key: string,
+  opts: Record<string, boolean> = {},
+) {
+  fireEvent.keyDown(editor.view.dom, { key, ...opts });
+}
+
+/** 문단 텍스트를 순서대로. 이동·복제 결과를 눈으로 보듯 확인한다. */
+function paragraphs(editor: Editor): string[] {
+  const out: string[] = [];
+  editor.state.doc.forEach((node) => out.push(node.textContent));
+  return out;
+}
+
+let editor: Editor | null = null;
+afterEach(() => {
+  editor?.view.dom.remove();
+  editor?.destroy();
+  editor = null;
+});
+
+describe("Esc 하강 사다리", () => {
+  it("편집 중 Esc는 커서가 놓인 블록을 선택한다", () => {
+    editor = makeEditor(["첫째", "둘째"]);
+    editor.commands.setTextSelection(2);
+
+    press(editor, "Escape");
+
+    expect(editor.state.selection.constructor.name).toContain(
+      "NodeRangeSelection",
+    );
+    // 커서가 있던 블록 하나만 — 문서 전체가 아니다.
+    expect(isAllBlocksSelected(editor.state)).toBe(false);
+    expect(
+      editor.state.doc.textBetween(
+        editor.state.selection.from,
+        editor.state.selection.to,
+      ),
+    ).toBe("첫째");
+  });
+
+  it("블록 선택 중 Esc는 선택을 풀고 커서를 돌려놓는다", () => {
+    editor = makeEditor(["첫째", "둘째"]);
+    editor.commands.setTextSelection(2);
+
+    press(editor, "Escape");
+    press(editor, "Escape");
+
+    expect(editor.state.selection.constructor.name).toContain("TextSelection");
+    expect(editor.state.selection.empty).toBe(true);
+  });
+});
+
+describe("블록 복제 (Cmd+D)", () => {
+  it("커서만 있어도 그 블록을 바로 아래에 복제한다", () => {
+    editor = makeEditor(["첫째", "둘째"]);
+    editor.commands.setTextSelection(2);
+
+    press(editor, "d", { ctrlKey: true });
+
+    expect(paragraphs(editor)).toEqual(["첫째", "첫째", "둘째"]);
+  });
+
+  it("복제본이 선택된 채로 남아 이어서 조작할 수 있다", () => {
+    editor = makeEditor(["첫째", "둘째"]);
+    editor.commands.setTextSelection(2);
+
+    press(editor, "d", { ctrlKey: true });
+
+    const { from, to } = editor.state.selection;
+    expect(editor.state.doc.textBetween(from, to)).toBe("첫째");
+    // 원본이 아니라 새로 생긴 두 번째 문단이다.
+    expect(from).toBeGreaterThan(0);
+  });
+
+  it("여러 블록을 선택했으면 그 묶음을 통째로 복제한다", () => {
+    editor = makeEditor(["첫째", "둘째", "셋째"]);
+    editor.commands.setTextSelection(2);
+    press(editor, "a", { ctrlKey: true }); // 블록 안 텍스트
+    press(editor, "a", { ctrlKey: true }); // 문서 전체 블록
+
+    press(editor, "d", { ctrlKey: true });
+
+    expect(paragraphs(editor)).toEqual([
+      "첫째",
+      "둘째",
+      "셋째",
+      "첫째",
+      "둘째",
+      "셋째",
+    ]);
+  });
+});
+
+describe("블록 이동 (Cmd+Shift+↑/↓)", () => {
+  it("위로 옮기면 앞 블록과 자리가 바뀐다", () => {
+    editor = makeEditor(["첫째", "둘째", "셋째"]);
+    editor.commands.setTextSelection(8); // "둘째" 안
+
+    press(editor, "ArrowUp", { ctrlKey: true, shiftKey: true });
+
+    expect(paragraphs(editor)).toEqual(["둘째", "첫째", "셋째"]);
+  });
+
+  it("아래로 옮기면 뒤 블록과 자리가 바뀐다", () => {
+    editor = makeEditor(["첫째", "둘째", "셋째"]);
+    editor.commands.setTextSelection(2); // "첫째" 안
+
+    press(editor, "ArrowDown", { ctrlKey: true, shiftKey: true });
+
+    expect(paragraphs(editor)).toEqual(["둘째", "첫째", "셋째"]);
+  });
+
+  it("옮긴 뒤에도 그 블록이 선택돼 있어 연속으로 옮길 수 있다", () => {
+    editor = makeEditor(["첫째", "둘째", "셋째"]);
+    editor.commands.setTextSelection(14); // "셋째" 안
+
+    press(editor, "ArrowUp", { ctrlKey: true, shiftKey: true });
+    press(editor, "ArrowUp", { ctrlKey: true, shiftKey: true });
+
+    expect(paragraphs(editor)).toEqual(["셋째", "첫째", "둘째"]);
+  });
+
+  it("맨 끝에서 더 옮기려 하면 아무 일도 일어나지 않는다", () => {
+    editor = makeEditor(["첫째", "둘째"]);
+    editor.commands.setTextSelection(2); // "첫째" 안
+
+    press(editor, "ArrowUp", { ctrlKey: true, shiftKey: true });
+
+    expect(paragraphs(editor)).toEqual(["첫째", "둘째"]);
+  });
+});

--- a/fe/src/features/note/editor/blockActions.ts
+++ b/fe/src/features/note/editor/blockActions.ts
@@ -1,0 +1,152 @@
+import { Extension } from "@tiptap/core";
+import {
+  isNodeRangeSelection,
+  NodeRangeSelection,
+} from "@tiptap/extension-node-range";
+import type { Node } from "@tiptap/pm/model";
+import { type EditorState, TextSelection } from "@tiptap/pm/state";
+import type { Editor } from "@tiptap/react";
+
+/** 문서 최상위 블록들의 위치 목록. 블록 단위 조작은 전부 이 경계를 기준으로 한다. */
+function topLevelBlocks(doc: Node): { from: number; to: number }[] {
+  const out: { from: number; to: number }[] = [];
+  let pos = 0;
+  doc.forEach((node) => {
+    out.push({ from: pos, to: pos + node.nodeSize });
+    pos += node.nodeSize;
+  });
+  return out;
+}
+
+/**
+ * 지금 조작 대상이 되는 블록 구간.
+ * 블록 선택이면 그 블록들, 커서만 있으면 커서가 놓인 블록 하나(Notion과 동일 —
+ * 블록을 고르지 않아도 "지금 있는 블록"에 복제·이동이 먹는다).
+ */
+export function targetBlockRange(
+  state: EditorState,
+): { from: number; to: number; firstIndex: number; lastIndex: number } | null {
+  const { doc, selection } = state;
+  const blocks = topLevelBlocks(doc);
+  if (blocks.length === 0) return null;
+
+  const covered: number[] = [];
+  blocks.forEach((b, i) => {
+    if (b.from < selection.to && b.to > selection.from) covered.push(i);
+  });
+  // 블록 경계에 딱 붙은 커서는 위 조건에 안 걸린다 — 그 자리를 품는 블록으로 되돌린다.
+  if (covered.length === 0) {
+    const i = blocks.findIndex(
+      (b) => b.from <= selection.from && b.to >= selection.from,
+    );
+    if (i < 0) return null;
+    covered.push(i);
+  }
+
+  const firstIndex = covered[0];
+  const lastIndex = covered[covered.length - 1];
+  return {
+    from: blocks[firstIndex].from,
+    to: blocks[lastIndex].to,
+    firstIndex,
+    lastIndex,
+  };
+}
+
+/** 커서가 놓인 블록을 블록 선택으로 승격한다(Esc 1단). */
+export function selectCurrentBlock(editor: Editor): boolean {
+  const { state, view } = editor;
+  const range = targetBlockRange(state);
+  if (!range) return false;
+  view.dispatch(
+    state.tr.setSelection(
+      NodeRangeSelection.create(state.doc, range.from, range.to),
+    ),
+  );
+  return true;
+}
+
+/** 블록 선택을 풀고 그 자리에 커서를 돌려놓는다(Esc 2단). */
+export function collapseBlockSelection(editor: Editor): boolean {
+  const { state, view } = editor;
+  if (!isNodeRangeSelection(state.selection)) return false;
+  const pos = state.selection.from;
+  view.dispatch(
+    state.tr.setSelection(TextSelection.near(state.doc.resolve(pos))),
+  );
+  return true;
+}
+
+/** 대상 블록들을 바로 아래에 복제하고, 복제본을 선택 상태로 남긴다. */
+export function duplicateBlocks(editor: Editor): boolean {
+  const { state, view } = editor;
+  const range = targetBlockRange(state);
+  if (!range) return false;
+
+  const slice = state.doc.slice(range.from, range.to);
+  const size = range.to - range.from;
+  const tr = state.tr.insert(range.to, slice.content);
+  // 복제 직후 계속 조작할 수 있게 새로 생긴 쪽을 잡아준다.
+  tr.setSelection(NodeRangeSelection.create(tr.doc, range.to, range.to + size));
+  view.dispatch(tr.scrollIntoView());
+  return true;
+}
+
+/**
+ * 대상 블록들을 위/아래 이웃과 자리바꿈한다.
+ * 지우고 다시 넣는 방식이라, 아래로 옮길 땐 삭제로 줄어든 만큼(size) 넣을 위치를 당겨야 한다.
+ */
+export function moveBlocks(editor: Editor, dir: -1 | 1): boolean {
+  const { state, view } = editor;
+  const range = targetBlockRange(state);
+  if (!range) return false;
+
+  const blocks = topLevelBlocks(state.doc);
+  const neighbor =
+    dir < 0 ? blocks[range.firstIndex - 1] : blocks[range.lastIndex + 1];
+  if (!neighbor) return false; // 이미 끝 — 조용히 아무 일도 안 한다.
+
+  const size = range.to - range.from;
+  const slice = state.doc.slice(range.from, range.to);
+  const insertAt = dir < 0 ? neighbor.from : neighbor.to - size;
+
+  const tr = state.tr.delete(range.from, range.to);
+  tr.insert(insertAt, slice.content);
+  tr.setSelection(NodeRangeSelection.create(tr.doc, insertAt, insertAt + size));
+  view.dispatch(tr.scrollIntoView());
+  return true;
+}
+
+/**
+ * 블록 단위 조작 — Esc 하강 사다리와 복제·이동.
+ *
+ * 모든 핸들러는 `view.hasFocus()`로 가드한다. 표(데이터 그리드)는 자체 단축키를 갖고 있고
+ * 포커스가 셀 입력창에 있는데, 셀 입력창은 에디터 DOM 안이라 키가 여기까지 올라온다.
+ * 가드가 없으면 셀에서 Esc·Cmd+D를 눌렀을 때 본문 블록이 함께 반응한다.
+ */
+export const BlockActions = Extension.create({
+  name: "blockActions",
+  priority: 200,
+
+  addKeyboardShortcuts() {
+    const guarded = (run: (editor: Editor) => boolean) => {
+      return ({ editor }: { editor: Editor }) => {
+        if (!editor.view.hasFocus()) return false;
+        return run(editor);
+      };
+    };
+
+    return {
+      // 편집 → 블록 선택 → 커서 복귀.
+      Escape: guarded((editor) =>
+        isNodeRangeSelection(editor.state.selection)
+          ? collapseBlockSelection(editor)
+          : selectCurrentBlock(editor),
+      ),
+      // 브라우저 기본 동작(북마크 추가)을 막고 블록을 복제한다.
+      "Mod-d": guarded(duplicateBlocks),
+      "Mod-Shift-ArrowUp": guarded((editor) => moveBlocks(editor, -1)),
+      "Mod-Shift-ArrowDown": guarded((editor) => moveBlocks(editor, 1)),
+    };
+  },
+});


### PR DESCRIPTION
## 이슈
closes #1013

## 작업 내용
#1011로 세운 블록 레이어 위에 **블록을 다루는 조작**을 올렸다.

### Esc 하강 사다리
`Cmd+A`가 올라가는 사다리였다면 `Esc`는 내려오는 사다리다.
```
텍스트 편집 → (Esc) → 현재 블록 선택 → (Esc) → 커서 복귀
```

### 블록 액션
| 키 | 동작 |
|---|---|
| `Cmd+D` | 대상 블록을 바로 아래에 복제 (복제본이 선택된 채로 남아 이어서 조작 가능) |
| `Cmd+Shift+↑/↓` | 대상 블록을 위/아래 이웃과 자리바꿈 (옮긴 뒤에도 선택 유지 → 연속 이동) |
| `Backspace` | 선택한 블록 삭제 (#1009로 이미 동작) |

블록 선택이 없고 커서만 있으면 **커서가 놓인 블록**이 대상이다(Notion과 동일 — 블록을 먼저 고르지 않아도 먹는다).

### 표와의 경계
모든 핸들러를 `editor.view.hasFocus()`로 가드했다. 표의 셀 입력창은 에디터 DOM **안**이라 키가 본문까지 올라오는데, 셀에 포커스가 있으면 `hasFocus()`가 false다. 가드가 없으면 셀에서 `Esc`·`Cmd+D`를 눌렀을 때 본문 블록이 함께 반응한다.

`Cmd+D`(북마크 추가)·`Cmd+Shift+↑`(선택 확장)는 브라우저 기본 동작이 있어 핸들러가 `true`를 반환해 막는다.

### 이동 구현 주의
지우고 다시 넣는 방식이라 **아래로 옮길 땐 삭제로 줄어든 만큼(size) 넣을 위치를 당겨야** 한다. 그러지 않으면 한 칸씩 밀린다.

## 테스트
- `blockActions.test.tsx` (9건) — 사다리 하강 2단, 복제(커서만/여러 블록), 이동(위·아래·연속·끝에서 무동작). 키맵 우선순위와 기본 동작 차단이 핵심이라 커맨드를 직접 부르지 않고 실제 키 이벤트를 쏜다
- `e2e/note-block-actions.spec.ts` (7건) — 실제 브라우저. 사다리·복제·이동·블록 삭제 + **표 가드 3종**(셀에서 Esc·Cmd+D·Cmd+Shift+↓를 눌러도 본문이 안 움직임)
- FE 598 tests / e2e 31종 **3회 반복 93/93** / lint · format:check · build 통과

### 테스트에서 잡은 함정
`click()`이 돌아온 시점엔 브라우저가 캐럿만 옮겼을 뿐이라, 곧바로 키를 누르면 에디터가 아직 **이전 선택(문서 맨 앞)**을 보고 있어 엉뚱한 블록이 잡힌다(8회 중 3회 실패). 커서가 실제로 그 문단에 반영될 때까지 기다리는 `placeCursorIn` 헬퍼로 해결했다. 실사용에선 사람이 클릭하고 키를 누르기까지 시간이 있어 드러나지 않는 테스트 타이밍 문제다.

## 남은 것 (#1010)
블록 우클릭 메뉴 — #880의 "옵션은 우클릭으로 통일" 결정과 맞물린다.