### PR TITLE
feat : 노트 블록 우클릭 메뉴

### DIFF
--- a/fe/e2e/note-block-context-menu.spec.ts
+++ b/fe/e2e/note-block-context-menu.spec.ts
@@ -1,0 +1,216 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 블록 우클릭 메뉴(#1015).
+ *
+ * 우클릭은 좌표 → 문서 위치 변환(posAtCoords)과 실제 마우스 이벤트가 얽혀 있어 jsdom으로는
+ * 검증되지 않는다. 표 안 우클릭이 표 메뉴로 가는지(경계)도 실제 브라우저로 본다.
+ */
+
+const NOTE_ID = 1;
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+async function mockNote(page: Page) {
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/notes", (route) =>
+    route.fulfill(
+      ok({
+        notes: [
+          {
+            id: NOTE_ID,
+            title: "노트",
+            parentId: null,
+            sortOrder: 0,
+            children: [],
+          },
+        ],
+      }),
+    ),
+  );
+  await page.route(`**/api/notes/${NOTE_ID}`, (route) => {
+    if (route.request().method() === "PATCH")
+      return route.fulfill(ok({ id: NOTE_ID }));
+    return route.fulfill(
+      ok({
+        id: NOTE_ID,
+        materialId: null,
+        parentId: null,
+        title: "노트",
+        sortOrder: 0,
+        content: {
+          type: "doc",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "첫째 줄" }] },
+            { type: "paragraph", content: [{ type: "text", text: "둘째 줄" }] },
+            { type: "datasetTable", attrs: { datasetId: 1 } },
+          ],
+        },
+        updatedAt: "2026-01-01T00:00:00Z",
+      }),
+    );
+  });
+  await page.route("**/api/datasets/**", (route) => {
+    const { pathname } = new URL(route.request().url());
+    if (pathname.endsWith("/rows"))
+      return route.fulfill(
+        ok({
+          rows: [
+            { id: 100, rowIndex: 0, cells: ["a1", "b1"] },
+            { id: 101, rowIndex: 1, cells: ["a2", "b2"] },
+          ],
+          offset: 0,
+          limit: 100,
+        }),
+      );
+    if (pathname.endsWith("/merges")) return route.fulfill(ok({ merges: [] }));
+    return route.fulfill(
+      ok({
+        id: 1,
+        name: "표",
+        columns: [
+          { key: "c0", label: "A" },
+          { key: "c1", label: "B" },
+        ],
+        rowCount: 2,
+      }),
+    );
+  });
+}
+
+/**
+ * 그 문단에 커서를 놓고, ProseMirror가 그 선택을 실제로 반영할 때까지 기다린다.
+ * click()이 돌아온 시점엔 브라우저가 캐럿만 옮겼을 뿐이라, 바로 키를 누르면 에디터가 아직
+ * 이전 선택(문서 맨 앞)을 보고 있어 엉뚱한 블록이 잡힌다.
+ */
+async function placeCursorIn(page: Page, text: string) {
+  await page.getByText(text).click();
+  await page.waitForFunction((t) => {
+    const node = window.getSelection()?.anchorNode ?? null;
+    const el = node instanceof Element ? node : node?.parentElement;
+    return el?.closest("p")?.textContent === t;
+  }, text);
+  // selectionchange 핸들러가 돌 한 프레임을 준다.
+  await page.evaluate(
+    () => new Promise((r) => requestAnimationFrame(() => r(null))),
+  );
+}
+
+const selectedBlocks = (page: Page) =>
+  page.locator(".ProseMirror-selectednoderange").count();
+
+/** 본문 문단 텍스트를 순서대로 — 복제·이동 결과를 눈으로 보듯 확인한다. */
+const paragraphs = (page: Page) =>
+  page.locator(".ProseMirror > p").allTextContents();
+
+test.beforeEach(async ({ page }) => {
+  await mockNote(page);
+  await page.goto(`/notes?note=${NOTE_ID}`);
+  await expect(page.getByLabel("노트 본문")).toBeVisible();
+  await expect(page.getByTestId("dataset-grid")).toBeVisible();
+});
+
+const blockMenu = (page: Page) => page.getByRole("menu", { name: "블록 메뉴" });
+const cellMenu = (page: Page) => page.getByRole("menu", { name: "셀 메뉴" });
+
+/** 그 문단을 우클릭한다. */
+async function rightClick(page: Page, text: string) {
+  await page.getByText(text).click({ button: "right" });
+}
+
+test.describe("블록 우클릭 메뉴", () => {
+  test("문단을 우클릭하면 그 블록이 선택되고 메뉴가 뜬다", async ({ page }) => {
+    await rightClick(page, "둘째 줄");
+
+    await expect(blockMenu(page)).toBeVisible();
+    // 우클릭한 블록이 잡힌다 — 엉뚱한 블록에 조작이 먹으면 안 된다.
+    await expect(page.locator(".ProseMirror-selectednoderange")).toHaveText(
+      "둘째 줄",
+    );
+    await expect(blockMenu(page)).toContainText("블록 1개");
+  });
+
+  test("여러 블록을 고른 뒤 그 위에서 우클릭하면 선택이 유지된다", async ({
+    page,
+  }) => {
+    await placeCursorIn(page, "첫째 줄");
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+a");
+    const count = await selectedBlocks(page);
+
+    await rightClick(page, "둘째 줄");
+
+    // 선택을 깨고 한 블록으로 좁히면 여러 블록 조작이 불가능해진다.
+    expect(await selectedBlocks(page)).toBe(count);
+    await expect(blockMenu(page)).toContainText(`블록 ${count}개`);
+  });
+
+  test("[복제]가 그 블록을 바로 아래에 복제한다", async ({ page }) => {
+    await rightClick(page, "첫째 줄");
+    await blockMenu(page).getByRole("menuitem", { name: /복제/ }).click();
+
+    expect((await paragraphs(page)).slice(0, 3)).toEqual([
+      "첫째 줄",
+      "첫째 줄",
+      "둘째 줄",
+    ]);
+    await expect(blockMenu(page)).toBeHidden();
+  });
+
+  test("[아래로 이동]이 뒤 블록과 자리를 바꾼다", async ({ page }) => {
+    await rightClick(page, "첫째 줄");
+    await blockMenu(page)
+      .getByRole("menuitem", { name: /아래로 이동/ })
+      .click();
+
+    expect((await paragraphs(page)).slice(0, 2)).toEqual([
+      "둘째 줄",
+      "첫째 줄",
+    ]);
+  });
+
+  test("[삭제]가 그 블록만 지운다", async ({ page }) => {
+    await rightClick(page, "둘째 줄");
+    await blockMenu(page).getByRole("menuitem", { name: "삭제" }).click();
+
+    const texts = await paragraphs(page);
+    expect(texts).toContain("첫째 줄");
+    expect(texts).not.toContain("둘째 줄");
+    await expect(page.getByTestId("dataset-grid")).toBeVisible();
+  });
+
+  test("바깥을 클릭하면 닫힌다", async ({ page }) => {
+    await rightClick(page, "첫째 줄");
+    await expect(blockMenu(page)).toBeVisible();
+
+    await page.mouse.click(5, 5);
+
+    await expect(blockMenu(page)).toBeHidden();
+  });
+
+  test("Esc로 닫으면 메뉴만 닫히고 블록 선택은 남는다", async ({ page }) => {
+    await rightClick(page, "첫째 줄");
+    await page.keyboard.press("Escape");
+
+    await expect(blockMenu(page)).toBeHidden();
+    // Esc 하강 사다리가 같이 돌아 선택까지 풀리면 안 된다.
+    expect(await selectedBlocks(page)).toBe(1);
+  });
+});
+
+test.describe("표와의 경계", () => {
+  test("표 안 우클릭은 표 메뉴가 뜨고 블록 메뉴는 안 뜬다", async ({
+    page,
+  }) => {
+    await page.getByText("a1").click({ button: "right" });
+
+    await expect(cellMenu(page)).toBeVisible();
+    await expect(blockMenu(page)).toBeHidden();
+  });
+});

--- a/fe/src/features/note/components/BlockContextMenu.tsx
+++ b/fe/src/features/note/components/BlockContextMenu.tsx
@@ -1,0 +1,146 @@
+import type { Editor } from "@tiptap/react";
+import { ArrowDown, ArrowUp, Copy, Trash2 } from "lucide-react";
+import { type ReactNode, useEffect, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+import {
+  duplicateBlocks,
+  moveBlocks,
+  selectBlockAt,
+  selectionCovers,
+  targetBlockRange,
+} from "../editor/blockActions";
+
+interface Props {
+  editor: Editor | null;
+}
+
+/** 메뉴가 뷰포트 밖으로 나가지 않게 잡아둘 대략의 크기. */
+const MENU_WIDTH = 192;
+const MENU_HEIGHT = 180;
+
+/**
+ * 블록 우클릭 메뉴. 키보드 단축키로만 가능하던 블록 조작(복제·이동·삭제)을 마우스에도 연다.
+ *
+ * 옵션은 우클릭 하나로 통일한다(#880에서 표가 내린 결정과 같은 방향 — 발견성보다 단순성·비중복).
+ * 표 안에서의 우클릭은 표가 자기 메뉴를 띄우므로 여기서 가로채지 않는다.
+ */
+export function BlockContextMenu({ editor }: Props) {
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    if (!editor) return;
+    const dom = editor.view.dom;
+
+    const onContextMenu = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      // 표는 자기 우클릭 메뉴를 갖고 있다 — 건드리지 않는다.
+      if (target?.closest("[data-dataset-table]")) return;
+
+      const at = editor.view.posAtCoords({ left: e.clientX, top: e.clientY });
+      if (!at) return;
+
+      e.preventDefault();
+      // 이미 고른 블록들 위에서 누른 거면 그 선택을 유지한다(여러 블록 조작을 이어가게).
+      // 바깥을 눌렀으면 그 블록으로 선택을 옮긴다.
+      if (!selectionCovers(editor.state, at.pos)) {
+        selectBlockAt(editor, at.pos);
+      }
+      setMenu({ x: e.clientX, y: e.clientY });
+    };
+
+    dom.addEventListener("contextmenu", onContextMenu);
+    return () => dom.removeEventListener("contextmenu", onContextMenu);
+  }, [editor]);
+
+  // 메뉴가 열려 있는 동안의 Esc는 메뉴만 닫는다(선택 사다리를 건드리지 않게 capture에서 잡는다).
+  useEffect(() => {
+    if (!menu) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      e.stopPropagation();
+      setMenu(null);
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [menu]);
+
+  if (!editor || !menu) return null;
+
+  const range = targetBlockRange(editor.state);
+  const blockCount = range ? range.lastIndex - range.firstIndex + 1 : 0;
+
+  const run = (action: () => void) => () => {
+    action();
+    setMenu(null);
+    editor.commands.focus();
+  };
+
+  const item = (
+    label: string,
+    shortcut: string,
+    icon: ReactNode,
+    action: () => void,
+    destructive = false,
+  ) => (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={run(action)}
+      className={cn(
+        "hover:bg-accent flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm",
+        destructive && "text-destructive",
+      )}
+    >
+      {icon}
+      <span className="flex-1">{label}</span>
+      <span className="text-muted-foreground text-xs">{shortcut}</span>
+    </button>
+  );
+
+  return (
+    <>
+      {/* 바깥 클릭·우클릭으로 닫는다. */}
+      <div
+        className="fixed inset-0 z-40"
+        onClick={() => setMenu(null)}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setMenu(null);
+        }}
+      />
+      <div
+        role="menu"
+        aria-label="블록 메뉴"
+        className="border-border bg-popover fixed z-50 min-w-44 rounded-md border p-1 shadow-md"
+        style={{
+          left: Math.min(menu.x, window.innerWidth - MENU_WIDTH),
+          top: Math.min(menu.y, window.innerHeight - MENU_HEIGHT),
+        }}
+      >
+        <div className="text-muted-foreground px-2 py-1 text-xs">
+          블록 {blockCount}개
+        </div>
+        {item("복제", "⌘D", <Copy className="size-3.5" />, () =>
+          duplicateBlocks(editor),
+        )}
+        {item("위로 이동", "⌘⇧↑", <ArrowUp className="size-3.5" />, () =>
+          moveBlocks(editor, -1),
+        )}
+        {item("아래로 이동", "⌘⇧↓", <ArrowDown className="size-3.5" />, () =>
+          moveBlocks(editor, 1),
+        )}
+        <div className="bg-border my-1 h-px" />
+        {item(
+          "삭제",
+          "⌫",
+          <Trash2 className="size-3.5" />,
+          () => editor.commands.deleteSelection(),
+          true,
+        )}
+      </div>
+    </>
+  );
+}

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -29,6 +29,7 @@ import { useAutoSaveNote } from "../hooks/useAutoSaveNote";
 import { useCreateNote, useDeleteNote } from "../hooks/useNoteMutations";
 import { useNoteTree } from "../hooks/useNoteTree";
 import { noteKeys } from "../queryKeys";
+import { BlockContextMenu } from "./BlockContextMenu";
 import { EditorToolbar } from "./EditorToolbar";
 import { LinkMenu } from "./LinkMenu";
 import { SaveStatusIndicator } from "./SaveStatusIndicator";
@@ -306,6 +307,7 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
             <EditorContent editor={editor} className="relative" />
           </DatasetTableContext.Provider>
         </ChildPageContext.Provider>
+        <BlockContextMenu editor={editor} />
       </div>
 
       <ConfirmDialog

--- a/fe/src/features/note/editor/blockActions.ts
+++ b/fe/src/features/note/editor/blockActions.ts
@@ -53,6 +53,35 @@ export function targetBlockRange(
   };
 }
 
+/** 그 위치를 품는 최상위 블록의 구간. 우클릭 지점의 블록을 집을 때 쓴다. */
+export function blockRangeAt(
+  doc: Node,
+  pos: number,
+): { from: number; to: number } | null {
+  return topLevelBlocks(doc).find((b) => b.from <= pos && b.to >= pos) ?? null;
+}
+
+/** 지금 선택이 그 위치를 이미 품고 있는가. 우클릭이 기존 선택을 깨야 할지 판단한다. */
+export function selectionCovers(state: EditorState, pos: number): boolean {
+  const range = isNodeRangeSelection(state.selection)
+    ? { from: state.selection.from, to: state.selection.to }
+    : null;
+  return !!range && range.from <= pos && range.to >= pos;
+}
+
+/** 그 위치의 블록을 블록 선택한다. */
+export function selectBlockAt(editor: Editor, pos: number): boolean {
+  const { state, view } = editor;
+  const range = blockRangeAt(state.doc, pos);
+  if (!range) return false;
+  view.dispatch(
+    state.tr.setSelection(
+      NodeRangeSelection.create(state.doc, range.from, range.to),
+    ),
+  );
+  return true;
+}
+
 /** 커서가 놓인 블록을 블록 선택으로 승격한다(Esc 1단). */
 export function selectCurrentBlock(editor: Editor): boolean {
   const { state, view } = editor;

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -272,8 +272,9 @@
 .dark .tiptap .ProseMirror-selectednoderange {
   background-color: color-mix(in srgb, var(--primary) 30%, transparent);
 }
-/* 블록 선택 중엔 안쪽 텍스트 하이라이트를 숨긴다 — 두 겹으로 겹쳐 보이지 않게. */
+/* 블록 선택 중엔 안쪽 텍스트 하이라이트를 숨긴다 — 두 겹으로 겹쳐 보이지 않게.
+   ::selection에 적용되는 건 background-color다(단축 background 대신 이쪽을 쓴다). */
 .ProseMirror-noderangeselection ::selection,
 .ProseMirror-noderangeselection::selection {
-  background: transparent;
+  background-color: transparent;
 }


### PR DESCRIPTION
## 이슈
closes #1015

## 작업 내용
#1013에서 키보드 단축키로만 가능하던 블록 조작을 **우클릭 메뉴**로도 열었다. 에픽 #1010의 마지막 단계다.

옵션은 우클릭 하나로 통일한다 — #880에서 표가 셀별 팔레트 버튼을 걷어내고 우클릭으로 모은 것과 같은 방향(발견성보다 단순성·비중복).

- 문단 우클릭 → 그 블록이 선택되고 메뉴가 뜬다
- **이미 여러 블록을 골라둔 상태에서 그 위를 우클릭하면 선택을 유지한다** — 선택을 깨고 한 블록으로 좁히면 여러 블록 조작이 불가능해진다
- 항목: 복제(⌘D) · 위로 이동(⌘⇧↑) · 아래로 이동(⌘⇧↓) · 삭제(⌫). 단축키를 함께 노출해 키보드 경로를 알린다
- 바깥 클릭·우클릭·Esc로 닫는다. **Esc는 메뉴만 닫고 블록 선택은 남긴다**(capture에서 잡아 Esc 하강 사다리가 같이 돌지 않게)

### 표와의 경계
표 안 우클릭은 표가 자기 메뉴(셀 메뉴)를 띄우므로 가로채지 않는다. `[data-dataset-table]` 안에서 발생한 이벤트면 그대로 흘려보낸다.

### 구현 메모
커서 위치 메뉴라 공용 `Menu`(트리거 기반 드롭다운)는 맞지 않아, 표가 쓰는 것과 같은 패턴(고정 위치 + 전면 오버레이로 닫기 + 뷰포트 클램프)을 따랐다.

## 테스트
`e2e/note-block-context-menu.spec.ts` (8건) — 우클릭은 좌표→문서 위치 변환(`posAtCoords`)과 실제 마우스 이벤트가 얽혀 jsdom으로는 검증되지 않아 실제 브라우저로 본다.

- 우클릭 시 그 블록이 선택되는지(엉뚱한 블록에 조작이 먹으면 안 된다) · 여러 블록 선택 유지 · 복제 · 아래로 이동 · 삭제 · 바깥 클릭 닫기 · Esc는 메뉴만 닫기 · **표 안 우클릭은 표 메뉴**
- FE 598 tests / e2e 39종 **3회 반복 117/117** / lint · format:check · build 통과

## 에픽 #1010 완료
선행 포커스 정리(#1008) → 블록 레이어 + Cmd+A 사다리(#1011) → Esc 사다리 + 블록 액션(#1013) → 우클릭 메뉴(#1015).