### PR TITLE
fix : 표 이름을 클릭해도 포커스가 첫 셀로 튀던 문제

### DIFF
--- a/fe/e2e/note-table-name-focus.spec.ts
+++ b/fe/e2e/note-table-name-focus.spec.ts
@@ -1,0 +1,149 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 표 이름을 클릭해도 포커스가 첫 셀로 튀던 문제(#1017).
+ *
+ * 어느 요소가 실제로 포커스를 갖는지가 전부라 jsdom으로는 검증되지 않는다.
+ */
+
+const NOTE_ID = 1;
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+async function mockNote(page: Page) {
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/notes", (route) =>
+    route.fulfill(
+      ok({
+        notes: [
+          {
+            id: NOTE_ID,
+            title: "노트",
+            parentId: null,
+            sortOrder: 0,
+            children: [],
+          },
+        ],
+      }),
+    ),
+  );
+  await page.route(`**/api/notes/${NOTE_ID}`, (route) => {
+    if (route.request().method() === "PATCH")
+      return route.fulfill(ok({ id: NOTE_ID }));
+    return route.fulfill(
+      ok({
+        id: NOTE_ID,
+        materialId: null,
+        parentId: null,
+        title: "노트",
+        sortOrder: 0,
+        content: {
+          type: "doc",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "첫째 줄" }] },
+            { type: "datasetTable", attrs: { datasetId: 1 } },
+          ],
+        },
+        updatedAt: "2026-01-01T00:00:00Z",
+      }),
+    );
+  });
+  await page.route("**/api/datasets/**", (route) => {
+    const { pathname } = new URL(route.request().url());
+    if (route.request().method() !== "GET") return route.fulfill(ok({}));
+    if (pathname.endsWith("/rows"))
+      return route.fulfill(
+        ok({
+          rows: [
+            { id: 100, rowIndex: 0, cells: ["a1", "b1"] },
+            { id: 101, rowIndex: 1, cells: ["a2", "b2"] },
+          ],
+          offset: 0,
+          limit: 100,
+        }),
+      );
+    if (pathname.endsWith("/merges")) return route.fulfill(ok({ merges: [] }));
+    return route.fulfill(
+      ok({
+        id: 1,
+        name: "진도표",
+        columns: [
+          { key: "c0", label: "A" },
+          { key: "c1", label: "B" },
+        ],
+        rowCount: 2,
+      }),
+    );
+  });
+}
+
+/** 지금 포커스를 가진 요소의 aria-label(없으면 태그명). */
+const focusedLabel = (page: Page) =>
+  page.evaluate(() => {
+    const el = document.activeElement;
+    return el?.getAttribute("aria-label") ?? el?.tagName ?? "none";
+  });
+
+test.beforeEach(async ({ page }) => {
+  await mockNote(page);
+  await page.goto(`/notes?note=${NOTE_ID}`);
+  await expect(page.getByTestId("dataset-grid")).toBeVisible();
+});
+
+test.describe("표 이름 포커스", () => {
+  test("전체 블록 선택 뒤에도 표 이름을 클릭하면 이름에 포커스가 남는다", async ({
+    page,
+  }) => {
+    await page.getByText("첫째 줄").click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+a");
+
+    await page.getByLabel("표 이름").click();
+
+    // 회귀 대상: 그리드가 첫 셀을 잡아 이름 입력창에서 포커스를 빼앗던 문제.
+    expect(await focusedLabel(page)).toBe("표 이름");
+  });
+
+  test("표 이름에서 Cmd+A → Cmd+C 로 이름이 복사된다", async ({ page }) => {
+    await page.getByText("첫째 줄").click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+a");
+
+    await page.getByLabel("표 이름").click();
+    await page.keyboard.press("ControlOrMeta+a");
+
+    const sel = await page.evaluate(() => {
+      const el = document.activeElement as HTMLInputElement | null;
+      return { start: el?.selectionStart, end: el?.selectionEnd, v: el?.value };
+    });
+    expect(sel).toEqual({ start: 0, end: 3, v: "진도표" });
+  });
+
+  test("표 이름을 고칠 수 있다", async ({ page }) => {
+    await page.getByText("첫째 줄").click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+a");
+
+    await page.getByLabel("표 이름").click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.type("새 이름");
+
+    await expect(page.getByLabel("표 이름")).toHaveValue("새 이름");
+  });
+
+  test("표 바깥에서 표 블록을 고르면 기존대로 첫 셀이 잡힌다", async ({
+    page,
+  }) => {
+    // 과교정 방지 — 자동 첫 셀 선택은 표 바깥에서 선택했을 때를 위한 기능이다.
+    await page.getByText("첫째 줄").click();
+    await page.keyboard.press("ArrowDown");
+
+    await expect(page.getByLabel("1행 1열 셀 (입력하면 편집)")).toBeVisible();
+  });
+});

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -1865,6 +1865,13 @@ export function DatasetGrid({
         // 표 이름 입력창도 표(노드뷰) 안이라, 클릭하면 ProseMirror가 포커스를 도로 가져가 입력이
         // 안 됐다. 셀과 같은 방식으로 클릭 뒤(mouseup 이후) 포커스를 다시 잡아 이긴다.
         onClick={(e) => e.currentTarget.focus({ preventScroll: true })}
+        // 이름에 들어오면 셀 선택을 푼다. 활성 셀 입력창은 autoFocus로 뜨는데, 남겨 두면
+        // 다시 마운트될 때마다 방금 클릭한 이름에서 포커스를 되가져가 이름을 못 고쳤다(#1017).
+        // 선택을 없애 입력창 자체를 내리는 게 확실하다("이름을 만지는 중 = 셀 편집 아님").
+        onFocus={() => {
+          setSel(null);
+          setEditing(null);
+        }}
         onKeyDown={(e) => {
           if (e.key === "Enter") e.currentTarget.blur();
         }}


### PR DESCRIPTION
## 이슈
closes #1017

## 작업 내용
표 이름을 클릭해도 포커스가 표의 첫 셀로 옮겨가 이름을 고치거나 선택·복사할 수 없었다.

### 원인
표 이름 입력창과 **활성 셀 입력창(`autoFocus`)이 포커스를 두고 경합**한다. 셀 선택이 남아 있으면 활성 셀 입력창이 마운트돼 있고, 다시 마운트될 때마다 `autoFocus`가 방금 클릭한 이름 입력창에서 포커스를 되가져간다.

추적해 보니 순서가 이랬다:
```
mousedown:표 이름 → mouseup:표 이름 → click:표 이름
→ focusin:표 이름          (이름 입력창의 onClick이 잡음)
→ focusin:1행 1열 셀        (셀 입력창이 되가져감)
```

### 조치
이름 입력창에 포커스가 들어오면 셀 선택을 해제한다 — 입력창 자체를 내려 경합을 없앤다. "이름을 만지는 중 = 셀 편집 아님"이라 의미도 맞다.

처음엔 "표 안에 포커스가 있으면 첫 셀을 가로채지 않는다"는 가드를 자동 선택 effect에 넣었는데, 실제로 추적해 보니 **그 effect는 이름 클릭 때 아예 돌지 않았다**(이미 이전 단계에서 셀이 잡혀 있었다). 테스트로 뒷받침되지 않는 방어 코드라 걷어냈다.

## 테스트
`e2e/note-table-name-focus.spec.ts` (4건) — 어느 요소가 실제로 포커스를 갖는지가 전부라 jsdom으로는 검증되지 않는다.

- 전체 블록 선택 뒤에도 이름 클릭 시 포커스 유지 · 이름 `Cmd+A` 선택 · 이름 수정
- 과교정 방지: 표 바깥에서 표 블록을 고르면 **기존대로 첫 셀이 잡힌다**
- 수정 전 3건 실패 → 수정 후 4/4 통과
- FE 598 tests / e2e 43종 / lint · format:check · build 통과

## 남은 것
같이 보고된 **표 블록 복사·붙여넣기**(`Cmd+C`/`Cmd+V`로 표가 사라지는 문제)는 원인이 달라 별도로 진행한다 — `datasetTable`의 `transformPasted`가 `datasetId` 중복을 막으려 붙여넣기 slice에서 표를 제거하고 있다.