### PR TITLE
fix : 표가 든 블록을 복사·붙여넣기하면 표가 사라지던 문제

### DIFF
--- a/fe/e2e/note-table-copy-paste.spec.ts
+++ b/fe/e2e/note-table-copy-paste.spec.ts
@@ -1,0 +1,244 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 표가 든 블록을 복사·붙여넣기(#1019).
+ *
+ * 표는 노트 문서가 아니라 별도 dataset에 살아서, 클립보드로 나갈 때 "표 모양"으로 바꿔 담고
+ * 들어올 때 그 모양으로 새 표를 만든다. 클립보드 왕복은 실제 브라우저에서만 검증된다.
+ */
+
+const NOTE_ID = 1;
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+/** 붙여넣기로 만들어지는 표에 순서대로 부여할 id. */
+let nextDatasetId = 2;
+/** 생성된 dataset의 행 — 붙여넣은 내용이 실제로 담겼는지 확인한다. */
+let created: Record<number, { columns: string[]; rows: string[][] }> = {};
+
+async function mockNote(page: Page) {
+  nextDatasetId = 2;
+  created = {};
+
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/notes", (route) =>
+    route.fulfill(
+      ok({
+        notes: [
+          {
+            id: NOTE_ID,
+            title: "노트",
+            parentId: null,
+            sortOrder: 0,
+            children: [],
+          },
+        ],
+      }),
+    ),
+  );
+  await page.route(`**/api/notes/${NOTE_ID}`, (route) => {
+    if (route.request().method() === "PATCH")
+      return route.fulfill(ok({ id: NOTE_ID }));
+    return route.fulfill(
+      ok({
+        id: NOTE_ID,
+        materialId: null,
+        parentId: null,
+        title: "노트",
+        sortOrder: 0,
+        content: {
+          type: "doc",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "첫째 줄" }] },
+            { type: "datasetTable", attrs: { datasetId: 1 } },
+          ],
+        },
+        updatedAt: "2026-01-01T00:00:00Z",
+      }),
+    );
+  });
+
+  // 정규식으로 정확히 API 경로만 잡는다. `**/api/datasets**` 같은 글롭은 소스 모듈
+  // (dataset/api/datasets.ts)까지 가로채 dev 서버가 500을 낸다.
+  await page.route(/\/api\/datasets(\/|\?|$)/, async (route) => {
+    const req = route.request();
+    const { pathname } = new URL(req.url());
+    const idMatch = pathname.match(/\/datasets\/(\d+)/);
+    const id = idMatch ? Number(idMatch[1]) : null;
+
+    // 표 생성 — 새 id를 발급하고 열을 기억한다.
+    if (req.method() === "POST" && pathname.endsWith("/datasets")) {
+      const body = JSON.parse(req.postData() ?? "{}");
+      const newId = nextDatasetId++;
+      created[newId] = {
+        columns: body.columns.map((c: { label: string }) => c.label),
+        rows: [],
+      };
+      return route.fulfill(
+        ok({ id: newId, name: null, columns: body.columns, rowCount: 0 }),
+      );
+    }
+    // 행 벌크 추가
+    if (req.method() === "POST" && pathname.endsWith("/rows/bulk")) {
+      const body = JSON.parse(req.postData() ?? "{}");
+      if (id != null && created[id]) created[id].rows.push(...body.rows);
+      return route.fulfill(
+        ok({
+          id,
+          name: null,
+          columns: [],
+          rowCount: created[id!]?.rows.length ?? 0,
+        }),
+      );
+    }
+    if (req.method() !== "GET") return route.fulfill(ok({}));
+
+    if (pathname.endsWith("/rows")) {
+      if (id === 1)
+        return route.fulfill(
+          ok({
+            rows: [
+              { id: 100, rowIndex: 0, cells: ["a1", "b1"] },
+              { id: 101, rowIndex: 1, cells: ["a2", "b2"] },
+            ],
+            offset: 0,
+            limit: 100,
+          }),
+        );
+      const rows = created[id!]?.rows ?? [];
+      return route.fulfill(
+        ok({
+          rows: rows.map((cells, i) => ({ id: 900 + i, rowIndex: i, cells })),
+          offset: 0,
+          limit: 100,
+        }),
+      );
+    }
+    if (pathname.endsWith("/merges")) return route.fulfill(ok({ merges: [] }));
+
+    if (id === 1)
+      return route.fulfill(
+        ok({
+          id: 1,
+          name: "진도표",
+          columns: [
+            { key: "c0", label: "과목" },
+            { key: "c1", label: "상태" },
+          ],
+          rowCount: 2,
+        }),
+      );
+    const meta = created[id!];
+    return route.fulfill(
+      ok({
+        id,
+        name: null,
+        columns: (meta?.columns ?? []).map((label, i) => ({
+          key: `c${i}`,
+          label,
+        })),
+        rowCount: meta?.rows.length ?? 0,
+      }),
+    );
+  });
+}
+
+const clipText = (page: Page) =>
+  page.evaluate(() => navigator.clipboard.readText());
+
+test.use({ permissions: ["clipboard-read", "clipboard-write"] });
+
+test.beforeEach(async ({ page }) => {
+  await mockNote(page);
+  await page.goto(`/notes?note=${NOTE_ID}`);
+  await expect(page.getByTestId("dataset-grid")).toBeVisible();
+});
+
+test.describe("표가 든 블록 복사", () => {
+  test("텍스트로는 마크다운 표가 담긴다", async ({ page }) => {
+    await page.getByText("첫째 줄").click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+c");
+
+    const text = await clipText(page);
+    // 회귀 대상: 표 자리가 빈 줄로만 나가던 문제.
+    expect(text).toContain("진도표");
+    expect(text).toContain("| 과목 | 상태 |");
+    expect(text).toContain("| a1 | b1 |");
+    expect(text).toContain("| a2 | b2 |");
+  });
+});
+
+test.describe("표가 든 블록 붙여넣기", () => {
+  test("전체를 복사해 덮어써도 표가 살아남는다(원본과 별개인 새 표)", async ({
+    page,
+  }) => {
+    await page.getByText("첫째 줄").click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+c");
+    await page.keyboard.press("ControlOrMeta+v");
+
+    // 회귀 대상: 붙여넣기가 표를 통째로 없애 버리던 문제(전체 선택을 덮어쓰므로 1개가 맞다).
+    await expect(page.getByTestId("dataset-grid")).toHaveCount(1);
+
+    // 원본 값이 그대로 담긴 "새" 표가 만들어졌다.
+    await expect
+      .poll(() => Object.values(created).map((d) => d.rows))
+      .toContainEqual([
+        ["a1", "b1"],
+        ["a2", "b2"],
+      ]);
+    // 원본 id를 재사용하지 않는다 — 재사용하면 한쪽을 지울 때 둘 다 사라진다.
+    expect(Object.keys(created).map(Number)).not.toContain(1);
+  });
+
+  test("커서 위치에 붙여넣으면 표가 하나 더 생긴다", async ({ page }) => {
+    await page.getByText("첫째 줄").click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+c");
+
+    // 선택을 풀고 커서만 둔 뒤 붙여넣는다 → 덮어쓰지 않고 끼워 넣는다.
+    await page.getByText("첫째 줄").click();
+    await page.keyboard.press("ControlOrMeta+v");
+
+    await expect(page.getByTestId("dataset-grid")).toHaveCount(2);
+  });
+
+  test("외부(엑셀·노션)에서 복사한 표를 붙여넣으면 그리드가 된다", async ({
+    page,
+  }) => {
+    await page.getByText("첫째 줄").click();
+
+    // 외부 앱이 주는 형태 — data-dataset-id 없이 순수 <table>.
+    await page.evaluate(async () => {
+      const html =
+        "<table><tr><th>이름</th><th>점수</th></tr><tr><td>네트워크</td><td>92</td></tr></table>";
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          "text/html": new Blob([html], { type: "text/html" }),
+          "text/plain": new Blob(["이름\t점수\n네트워크\t92"], {
+            type: "text/plain",
+          }),
+        }),
+      ]);
+    });
+    await page.keyboard.press("ControlOrMeta+v");
+
+    await expect(page.getByTestId("dataset-grid")).toHaveCount(2);
+    await expect
+      .poll(() => Object.values(created).map((d) => d.columns))
+      .toContainEqual(["이름", "점수"]);
+    await expect
+      .poll(() => Object.values(created).map((d) => d.rows))
+      .toContainEqual([["네트워크", "92"]]);
+  });
+});

--- a/fe/src/features/note/components/NoteEditor.tsx
+++ b/fe/src/features/note/components/NoteEditor.tsx
@@ -25,6 +25,7 @@ import { DatasetTableContext } from "../editor/datasetTableContext";
 import { extractImageFiles, uploadAndInsertImage } from "../editor/imageUpload";
 import { LinkShortcut, noteLinkOptions } from "../editor/link";
 import { insertTableFromCells } from "../editor/pasteCellsAsTable";
+import { handleTableCopy, handleTablePaste } from "../editor/tableClipboard";
 import { useAutoSaveNote } from "../hooks/useAutoSaveNote";
 import { useCreateNote, useDeleteNote } from "../hooks/useNoteMutations";
 import { useNoteTree } from "../hooks/useNoteTree";
@@ -131,7 +132,27 @@ export function NoteEditor({ materialId, note, onOpenNote }: Props) {
             void insertTableFromCells(editorRef.current, cellsTsv);
             return true;
           }
+          // 3) 표가 든 HTML(우리 노트에서 복사한 표·엑셀·노션 등) → 표마다 새 표를 만들어 삽입.
+          //    표 데이터는 문서 밖 리소스라 같은 id를 재사용하면 두 블록이 한 표를 공유한다.
+          const html = event.clipboardData?.getData("text/html");
+          if (html && editorRef.current) {
+            if (handleTablePaste(editorRef.current, html)) {
+              event.preventDefault();
+              return true;
+            }
+          }
           return false;
+        },
+        // 표 블록은 문서엔 id만 있어 그대로 복사하면 빈 껍데기가 나간다. 표가 낀 복사에서만
+        // 실제 표 모양(<table> · 마크다운)으로 바꿔 담는다 — 다른 앱에도 표로 붙는다.
+        // (표가 없는 복사는 ProseMirror 기본 경로 그대로 — slice 정보가 보존돼야 한다.)
+        handleDOMEvents: {
+          copy: (view, event) => handleTableCopy(view, event as ClipboardEvent),
+          cut: (view, event) => {
+            if (!handleTableCopy(view, event as ClipboardEvent)) return false;
+            view.dispatch(view.state.tr.deleteSelection());
+            return true;
+          },
         },
         // 드래그앤드롭으로 이미지 업로드
         handleDrop: (_view, event) => {

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -65,6 +65,7 @@ import { useDatasetMeta } from "./hooks/useDatasetMeta";
 import { useDatasetRows } from "./hooks/useDatasetRows";
 import { FORMAT_LABELS, formatCellValue, NUMBER_FORMATS } from "./numberFormat";
 import { datasetKeys } from "./queryKeys";
+import { registerTableSnapshot } from "./tableSnapshot";
 import { useUndoStack } from "./undoStack";
 
 /** 행 높이(px) — 고정. 좌우(열 너비)만 조절 가능하고 위아래는 조절하지 않는다. */
@@ -138,7 +139,7 @@ export function DatasetGrid({
   const { push: pushUndo, undo: undoAction, redo: redoAction } = useUndoStack();
   // 스택에 쌓인 undo/redo 썽크는 나중에 실행돼 캡처 당시의 낡은 캐시 클로저를 읽으면 안 된다.
   // 매 렌더 최신 리더를 이 ref에 담아 두고, 지연 실행되는 스냅샷은 여기서 읽는다(값 갱신은 하단).
-  const liveRead = useRef({ getRow, getFormulas, getStyles });
+  const liveRead = useRef({ getRow, getFormulas, getStyles, meta });
   // 가상화 목록(본문)의 문서 최상단으로부터의 오프셋. 윈도우 스크롤 기준 가상화에 쓴다.
   const listRef = useRef<HTMLDivElement>(null);
   // 표 컨테이너 — 셀을 한 번 클릭하면 여기로 포커스를 옮겨(ProseMirror 대신) 키 입력을 직접 받는다.
@@ -197,6 +198,22 @@ export function DatasetGrid({
 
   const colCount = meta?.columns.length ?? 0;
   const rowCount = meta?.rowCount ?? 0;
+
+  // 복사할 때 이 표의 현재 내용을 동기적으로 꺼내 갈 수 있게 등록해 둔다(클립보드 직렬화는
+  // 동기라 그 자리에서 API를 못 부른다). 값은 매 렌더 갱신되는 liveRead에서 읽는다.
+  useEffect(() => {
+    return registerTableSnapshot(datasetId, () => {
+      const m = liveRead.current.meta;
+      return {
+        name: m?.name ?? null,
+        headers: m?.columns.map((c) => c.label) ?? [],
+        rows: Array.from({ length: m?.rowCount ?? 0 }, (_, r) => {
+          const cells = liveRead.current.getRow(r);
+          return (m?.columns ?? []).map((_c, i) => cells?.[i] ?? "");
+        }),
+      };
+    });
+  }, [datasetId]);
 
   const invalidateMeta = () =>
     queryClient.invalidateQueries({ queryKey: datasetKeys.meta(datasetId) });
@@ -770,7 +787,7 @@ export function DatasetGrid({
 
   // ---------- 되돌리기(undo) 헬퍼 ----------
   // liveRead ref는 최상단에 둔다(조기 return 뒤에 두면 훅 순서가 깨진다). 여기선 값만 갱신.
-  liveRead.current = { getRow, getFormulas, getStyles };
+  liveRead.current = { getRow, getFormulas, getStyles, meta };
 
   /** 한 행의 저장형(원본 수식 포함) 셀 배열 — 재저장·재삽입에 쓴다. */
   const rawRow = (cells: string[], formulas: Record<string, string>) =>

--- a/fe/src/features/note/dataset/tableSnapshot.ts
+++ b/fe/src/features/note/dataset/tableSnapshot.ts
@@ -1,0 +1,36 @@
+/**
+ * 화면에 떠 있는 표의 현재 내용을 "지금 당장(동기적으로)" 읽기 위한 등록소.
+ *
+ * 표 데이터는 노트 문서가 아니라 별도 dataset 리소스에 있어서, 복사할 때 문서만 봐서는
+ * 내용을 알 수 없다. 클립보드 직렬화는 동기 함수라 그 자리에서 API를 부를 수도 없다.
+ * 그래서 각 그리드가 마운트되는 동안 자기 스냅샷을 여기 등록해 두고, 복사 시점에 꺼내 쓴다.
+ *
+ * 아직 화면에 안 뜬(지연 로드 전) 행은 빈 칸으로 나온다 — 그래서 복사한 HTML에는
+ * datasetId도 함께 실어, 앱 안에서 붙여넣을 땐 API로 원본 전체를 다시 읽는다.
+ */
+export interface TableSnapshot {
+  name: string | null;
+  /** 열 라벨. */
+  headers: string[];
+  /** 행 값. 아직 로드되지 않은 행은 빈 문자열로 채운다. */
+  rows: string[][];
+}
+
+const registry = new Map<number, () => TableSnapshot>();
+
+/** 그리드가 마운트되는 동안 자기 스냅샷 제공자를 등록한다. 반환값을 호출하면 해제된다. */
+export function registerTableSnapshot(
+  datasetId: number,
+  get: () => TableSnapshot,
+): () => void {
+  registry.set(datasetId, get);
+  return () => {
+    // 같은 id로 다른 그리드가 이미 덮어썼다면 그쪽 것을 지우지 않는다.
+    if (registry.get(datasetId) === get) registry.delete(datasetId);
+  };
+}
+
+/** 화면에 떠 있는 표의 현재 내용. 없으면(언마운트된 표) null. */
+export function getTableSnapshot(datasetId: number): TableSnapshot | null {
+  return registry.get(datasetId)?.() ?? null;
+}

--- a/fe/src/features/note/editor/tableClipboard.ts
+++ b/fe/src/features/note/editor/tableClipboard.ts
@@ -1,0 +1,237 @@
+import type { Slice } from "@tiptap/pm/model";
+import type { DOMOutputSpec } from "@tiptap/pm/model";
+import {
+  DOMSerializer,
+  type Node as PMNode,
+  type Schema,
+} from "@tiptap/pm/model";
+import type { EditorView } from "@tiptap/pm/view";
+import type { Editor } from "@tiptap/react";
+
+import {
+  fetchDatasetMeta,
+  fetchDatasetRows,
+  setDatasetName,
+} from "../dataset/api/datasets";
+import { getTableSnapshot, type TableSnapshot } from "../dataset/tableSnapshot";
+import { createDatasetFromTable } from "../import/datasetImport";
+
+/**
+ * 표는 노트 문서가 아니라 별도 dataset에 산다. 그래서 표 블록을 그대로 복사하면 빈 껍데기가
+ * 나가고(붙여넣으면 아무것도 안 생김), 같은 datasetId를 재사용하면 두 블록이 한 표를 공유해
+ * 한쪽을 지울 때 다른 쪽 데이터까지 사라진다.
+ *
+ * 그래서 **표 모양으로 주고받는다**: 복사할 땐 진짜 `<table>`(과 마크다운 텍스트)로 내보내고,
+ * 붙여넣을 땐 그 모양으로 **새 표를 만든다**. 덤으로 엑셀·노션에서 복사한 표도 그대로 붙는다.
+ *
+ * 값만 넘어간다 — 수식은 계산된 값으로 굳고, 셀 배경색·정렬·병합·열 너비는 따라가지 않는다.
+ */
+
+/** 복사한 표에 원본 id를 실어 둔다 — 앱 안에서 붙여넣을 땐 이걸로 원본 전체를 다시 읽는다. */
+const SOURCE_ID_ATTR = "data-dataset-id";
+
+/**
+ * 표 스냅샷 → `<table>` 스펙. ProseMirror 직렬화기는 DOM 엘리먼트가 아니라 배열 스펙만 받는다
+ * (`renderSpec`이 `structure[0]`을 태그명으로 읽는다).
+ */
+function snapshotToTableSpec(
+  snapshot: TableSnapshot,
+  datasetId: number | null,
+): DOMOutputSpec {
+  const cell = (tag: "th" | "td", value: string): DOMOutputSpec =>
+    value ? [tag, {}, value] : [tag, {}];
+  const attrs: Record<string, string> = {};
+  if (datasetId != null) attrs[SOURCE_ID_ATTR] = String(datasetId);
+
+  const children: DOMOutputSpec[] = [];
+  if (snapshot.name) children.push(["caption", {}, snapshot.name]);
+  if (snapshot.headers.length > 0) {
+    children.push([
+      "thead",
+      {},
+      ["tr", {}, ...snapshot.headers.map((h) => cell("th", h))],
+    ]);
+  }
+  children.push([
+    "tbody",
+    {},
+    ...snapshot.rows.map((row) => ["tr", {}, ...row.map((v) => cell("td", v))]),
+  ]);
+  return ["table", attrs, ...children];
+}
+
+/** 표 블록만 `<table>`로 바꿔 내보내는 직렬화기. 그 외 노드는 기본 그대로. */
+function buildSerializer(schema: Schema): DOMSerializer {
+  const base = DOMSerializer.fromSchema(schema);
+  return new DOMSerializer(
+    {
+      ...base.nodes,
+      datasetTable: (node: PMNode) => {
+        const datasetId = node.attrs.datasetId as number | null;
+        const snapshot = datasetId == null ? null : getTableSnapshot(datasetId);
+        return snapshotToTableSpec(
+          snapshot ?? { name: null, headers: [], rows: [] },
+          datasetId,
+        );
+      },
+    },
+    base.marks,
+  );
+}
+
+/** 마크다운 표 한 줄. 파이프는 escape한다. */
+const mdRow = (cells: string[]) =>
+  `| ${cells.map((c) => c.replace(/\|/g, "\\|")).join(" | ")} |`;
+
+/** 표를 마크다운 표로 적는다 — 메모장·슬랙 등 텍스트만 받는 곳에서도 표 모양이 남는다. */
+function snapshotToMarkdown(snapshot: TableSnapshot): string {
+  const width = Math.max(
+    snapshot.headers.length,
+    ...snapshot.rows.map((r) => r.length),
+    0,
+  );
+  if (width === 0) return "";
+  const pad = (cells: string[]) =>
+    Array.from({ length: width }, (_, i) => cells[i] ?? "");
+  const lines: string[] = [];
+  if (snapshot.name) lines.push(snapshot.name);
+  lines.push(mdRow(pad(snapshot.headers)));
+  lines.push(`| ${Array.from({ length: width }, () => "---").join(" | ")} |`);
+  snapshot.rows.forEach((row) => lines.push(mdRow(pad(row))));
+  return lines.join("\n");
+}
+
+/** 텍스트 플레이버 직렬화 — 표만 마크다운으로 바꾸고 나머지는 기본(문단 사이 빈 줄)과 같게. */
+function tableAwareClipboardText(slice: Slice): string {
+  const parts: string[] = [];
+  slice.content.forEach((node) => {
+    if (node.type.name === "datasetTable") {
+      const datasetId = node.attrs.datasetId as number | null;
+      const snapshot = datasetId == null ? null : getTableSnapshot(datasetId);
+      parts.push(snapshot ? snapshotToMarkdown(snapshot) : "");
+      return;
+    }
+    parts.push(node.textBetween(0, node.content.size, "\n"));
+  });
+  return parts.join("\n\n");
+}
+
+/** `<table>` 엘리먼트 → 헤더/행. thead가 있거나 첫 행이 전부 th면 헤더로 본다. */
+function readTableElement(table: HTMLTableElement): {
+  name: string | null;
+  headers: string[] | null;
+  rows: string[][];
+} {
+  const name = table.querySelector("caption")?.textContent?.trim() || null;
+  const trs = [...table.querySelectorAll("tr")];
+  const cellsOf = (tr: HTMLTableRowElement) =>
+    [...tr.children].map((c) => (c.textContent ?? "").trim());
+
+  const first = trs[0];
+  const firstIsHeader =
+    !!first &&
+    first.children.length > 0 &&
+    [...first.children].every((c) => c.tagName === "TH");
+
+  const headers = firstIsHeader ? cellsOf(first) : null;
+  const bodyRows = (firstIsHeader ? trs.slice(1) : trs).map(cellsOf);
+  return { name, headers, rows: bodyRows };
+}
+
+/**
+ * 붙여넣을 표의 내용. 앱 안에서 복사한 것(원본 id가 있고 아직 살아 있음)이면 API로 원본
+ * 전체를 읽는다 — 화면에 안 뜬 행까지 온전히 따라오게. 실패하면 붙여넣은 HTML로 되돌아간다.
+ */
+async function resolveTable(table: HTMLTableElement) {
+  const fromHtml = readTableElement(table);
+  const sourceId = Number(table.getAttribute(SOURCE_ID_ATTR));
+  if (!Number.isFinite(sourceId) || sourceId <= 0) return fromHtml;
+
+  try {
+    const meta = await fetchDatasetMeta(sourceId);
+    const page = await fetchDatasetRows(sourceId, 0, meta.rowCount);
+    return {
+      name: meta.name ?? fromHtml.name,
+      headers: meta.columns.map((c) => c.label),
+      rows: page.rows.map((row) =>
+        meta.columns.map((_c, i) => row.cells[i] ?? ""),
+      ),
+    };
+  } catch {
+    // 원본이 지워졌거나 접근 불가 — 클립보드에 담겨 온 모양 그대로 만든다.
+    return fromHtml;
+  }
+}
+
+/**
+ * 붙여넣은 HTML 안의 `<table>`을 각각 **새 표**로 만들고, 그 자리에 표 블록을 끼운 HTML을 돌려준다.
+ * 표가 없으면 null(= 우리가 처리할 일이 아님).
+ */
+export async function buildPasteHtmlWithTables(
+  html: string,
+): Promise<string | null> {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const tables = [...doc.querySelectorAll("table")];
+  if (tables.length === 0) return null;
+
+  for (const table of tables) {
+    const { name, headers, rows } = await resolveTable(table);
+    // 값이 하나도 없는 표는 만들지 않는다(빈 <table> 조각이 섞여 온 경우).
+    if (rows.length === 0 && !headers) {
+      table.remove();
+      continue;
+    }
+    const datasetId = await createDatasetFromTable({ headers, rows });
+    if (name) await setDatasetName(datasetId, name);
+
+    const block = doc.createElement("div");
+    block.setAttribute("data-dataset-table", "");
+    block.setAttribute("data-dataset-id", String(datasetId));
+    table.replaceWith(block);
+  }
+  return doc.body.innerHTML;
+}
+
+/**
+ * 표가 든 복사·잘라내기를 처리한다. 처리했으면 true(호출부가 기본 동작을 막는다).
+ *
+ * `clipboardSerializer`로 갈아끼우지 않고 복사 이벤트를 직접 잡는 이유: 표가 없는 평범한
+ * 복사는 ProseMirror 기본 경로를 그대로 태워야 slice 정보(data-pm-slice)가 보존된다.
+ * 표가 낀 복사에서만 우리가 나선다.
+ */
+export function handleTableCopy(
+  view: EditorView,
+  event: ClipboardEvent,
+): boolean {
+  const slice = view.state.selection.content();
+  let hasTable = false;
+  slice.content.descendants((node) => {
+    if (node.type.name === "datasetTable") hasTable = true;
+    return !hasTable;
+  });
+  if (!hasTable || !event.clipboardData) return false;
+
+  const wrap = document.createElement("div");
+  wrap.append(
+    buildSerializer(view.state.schema).serializeFragment(slice.content),
+  );
+  event.clipboardData.setData("text/html", wrap.innerHTML);
+  event.clipboardData.setData("text/plain", tableAwareClipboardText(slice));
+  event.preventDefault();
+  return true;
+}
+
+/**
+ * 표가 든 붙여넣기를 처리한다. 처리했으면 true.
+ * 새 표를 만드는 데 네트워크가 필요해 비동기다 — 호출부는 이벤트를 막고 이 결과를 기다리지 않는다.
+ */
+export function handleTablePaste(editor: Editor, html: string): boolean {
+  if (!/<table[\s>]/i.test(html)) return false;
+  void (async () => {
+    const next = await buildPasteHtmlWithTables(html);
+    if (next == null) return;
+    // insertContent는 transformPasted(표 제거)를 타지 않으므로 표 블록이 그대로 들어간다.
+    editor.chain().focus().insertContent(next).run();
+  })();
+  return true;
+}


### PR DESCRIPTION
## 이슈
closes #1019

## 작업 내용
표 데이터는 노트 문서가 아니라 **별도 dataset 리소스**에 살고 문서엔 `datasetId`만 있다. 그래서 표를 글과 함께 복사하면 빈 껍데기가 나갔고, 붙여넣기는 `transformPasted`가 표를 제거해(같은 id를 두 블록이 공유하는 걸 막으려던 코드) 표가 통째로 사라졌다.

**id를 복제하는 대신 "표 모양"으로 주고받는 방식**으로 바꿨다.

- **복사** — 표가 낀 선택일 때만 우리가 나서서 진짜 `<table>`(HTML)과 **마크다운 표**(텍스트)로 담는다. 표가 없는 복사는 ProseMirror 기본 경로 그대로다(slice 정보 `data-pm-slice`가 보존돼야 한다)
- **붙여넣기** — `<table>`을 만나면 그 내용으로 **새 표를 만든다**. 원본과 완전히 독립이라 한쪽을 지워도 다른 쪽이 멀쩡하다
- **덤** — 엑셀·노션에서 복사한 표를 노트에 붙여넣으면 그대로 그리드가 된다

### 온전한 복사를 위한 이중 경로
복사한 `<table>`에 원본 `data-dataset-id`를 실어 둔다. 앱 안에서 붙여넣을 땐 이 id로 **API에서 원본 전체를 다시 읽어** 화면에 안 뜬(지연 로드 전) 행까지 따라오게 하고, 원본이 지워졌거나 외부에서 온 표면 클립보드의 HTML 내용으로 만든다.

### 한계 (의도된 것)
값만 넘어간다 — **수식은 계산된 값으로 굳고, 셀 배경색·정렬·병합·열 너비는 따라가지 않는다.** 표 이름은 유지된다. 서식까지 살리려면 BE에 복제 엔드포인트가 필요하다.

## 구현 메모
- 클립보드 직렬화는 동기 함수라 그 자리에서 API를 부를 수 없다 → 화면에 뜬 그리드가 자기 스냅샷을 `tableSnapshot` 등록소에 올려 두고 복사 시점에 꺼내 쓴다
- `clipboardSerializer`를 통째로 갈아끼우지 않고 `handleDOMEvents.copy`로 표가 낀 경우만 가로챈다 — 스키마는 에디터 생성 시점에 없고, 평범한 복사의 동작을 바꾸지 않기 위해서다
- ProseMirror 직렬화기는 DOM 엘리먼트가 아니라 **배열 스펙**만 받는다(`renderSpec`이 `structure[0]`을 태그명으로 읽는다). 엘리먼트를 돌려주면 `Invalid array passed to renderSpec`으로 복사가 통째로 실패하고 브라우저 기본 복사로 넘어간다

## 테스트
`e2e/note-table-copy-paste.spec.ts` (4건) — 클립보드 왕복은 실제 브라우저에서만 검증된다.

- 텍스트로 마크다운 표가 담긴다(회귀: 빈 줄만 나가던 문제)
- 전체를 복사해 덮어써도 표가 살아남고 **원본 id를 재사용하지 않는다**
- 커서 위치에 붙여넣으면 표가 하나 더 생긴다
- 외부 `<table>`(엑셀·노션 형태) 붙여넣기 → 그리드 생성 + 열·행이 그대로
- FE 598 tests / e2e 47종 **2회 반복 94/94** / lint · format:check · build 통과

### 테스트에서 잡은 함정
`page.route("**/api/datasets**")` 같은 글롭은 소스 모듈 경로(`dataset/api/datasets.ts`)까지 가로채 dev 서버가 500을 낸다. 정규식으로 API 경로만 정확히 잡아야 한다.