### PR TITLE
fix : 블록 전체 선택 시 표만 선택 안 된 것처럼 보이던 문제

### DIFF
--- a/fe/e2e/note-table-block-selection.spec.ts
+++ b/fe/e2e/note-table-block-selection.spec.ts
@@ -1,0 +1,177 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 블록 전체 선택 시 표만 선택 안 된 것처럼 보이던 문제(#1021).
+ *
+ * 그리드는 자기 배경이 불투명해 블록 선택 하이라이트를 가린다. "다른 블록과 같은 색으로 보이는가"가
+ * 검증 대상이라 실제로 그려진 픽셀을 비교한다 — 클래스 유무로는 이 성질을 확인할 수 없다.
+ */
+
+const NOTE_ID = 1;
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+async function mockNote(page: Page) {
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/notes", (route) =>
+    route.fulfill(
+      ok({
+        notes: [
+          {
+            id: NOTE_ID,
+            title: "노트",
+            parentId: null,
+            sortOrder: 0,
+            children: [],
+          },
+        ],
+      }),
+    ),
+  );
+  await page.route(`**/api/notes/${NOTE_ID}`, (route) => {
+    if (route.request().method() === "PATCH")
+      return route.fulfill(ok({ id: NOTE_ID }));
+    return route.fulfill(
+      ok({
+        id: NOTE_ID,
+        materialId: null,
+        parentId: null,
+        title: "노트",
+        sortOrder: 0,
+        content: {
+          type: "doc",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "첫째 줄" }] },
+            { type: "datasetTable", attrs: { datasetId: 1 } },
+          ],
+        },
+        updatedAt: "2026-01-01T00:00:00Z",
+      }),
+    );
+  });
+  await page.route(/\/api\/datasets(\/|\?|$)/, (route) => {
+    const { pathname } = new URL(route.request().url());
+    if (route.request().method() !== "GET") return route.fulfill(ok({}));
+    if (pathname.endsWith("/rows"))
+      return route.fulfill(
+        ok({
+          rows: [{ id: 100, rowIndex: 0, cells: ["a1", "b1"] }],
+          offset: 0,
+          limit: 100,
+        }),
+      );
+    if (pathname.endsWith("/merges")) return route.fulfill(ok({ merges: [] }));
+    return route.fulfill(
+      ok({
+        id: 1,
+        name: null,
+        columns: [
+          { key: "c0", label: "A" },
+          { key: "c1", label: "B" },
+        ],
+        rowCount: 1,
+      }),
+    );
+  });
+}
+
+/**
+ * 문단 안쪽과 표 셀 안쪽에 실제로 그려진 색을 읽는다.
+ * 표본은 가장자리(테두리·여백)를 피해 각 영역 안쪽에서 뽑는다.
+ */
+async function sampleColors(page: Page) {
+  const points = await page.evaluate(() => {
+    const p = document
+      .querySelector(".ProseMirror > p")!
+      .getBoundingClientRect();
+    const g = document
+      .querySelector('[data-testid="dataset-grid"]')!
+      .getBoundingClientRect();
+    return {
+      paragraph: {
+        x: Math.round(p.x + p.width / 2),
+        y: Math.round(p.y + p.height / 2),
+      },
+      cell: { x: Math.round(g.x + g.width / 2), y: Math.round(g.y + 12) },
+    };
+  });
+  const shot = (await page.screenshot()).toString("base64");
+  return page.evaluate(
+    async ({ b64, points }) => {
+      const img = new Image();
+      img.src = "data:image/png;base64," + b64;
+      await img.decode();
+      const canvas = document.createElement("canvas");
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext("2d")!;
+      ctx.drawImage(img, 0, 0);
+      const at = (pt: { x: number; y: number }) =>
+        Array.from(ctx.getImageData(pt.x, pt.y, 1, 1).data)
+          .slice(0, 3)
+          .join(",");
+      return { paragraph: at(points.paragraph), cell: at(points.cell) };
+    },
+    { b64: shot, points },
+  );
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockNote(page);
+  await page.goto(`/notes?note=${NOTE_ID}`);
+  await expect(page.getByTestId("dataset-grid")).toBeVisible();
+});
+
+test.describe("블록 선택 시 표도 선택돼 보인다", () => {
+  test("표가 선택된 문단과 같은 색으로 칠해진다", async ({ page }) => {
+    const before = await sampleColors(page);
+    // 선택 전엔 문단과 표가 각자 자기 배경색이다.
+    expect(before.paragraph).not.toBe("235,225,250");
+
+    await page.getByText("첫째 줄").click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+a");
+
+    const after = await sampleColors(page);
+    // 회귀 대상: 표만 자기 배경(흰색) 그대로라 안 잡힌 것처럼 보이던 문제.
+    expect(after.cell).toBe(after.paragraph);
+    expect(after.cell).not.toBe(before.cell);
+  });
+
+  test("선택을 풀면 표 색도 돌아온다", async ({ page }) => {
+    const before = await sampleColors(page);
+
+    await page.getByText("첫째 줄").click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("Escape");
+
+    const after = await sampleColors(page);
+    expect(after.cell).toBe(before.cell);
+  });
+
+  test("표만 클릭했을 땐 전체 틴트를 씌우지 않는다", async ({ page }) => {
+    // 그땐 셀 단위 UI(활성 셀)가 뜨므로 표 전체를 덮으면 시끄럽다.
+    await page.getByText("a1").click();
+
+    await expect(page.getByTestId("dataset-block-selected")).toBeHidden();
+  });
+
+  test("틴트가 셀 클릭을 막지 않는다", async ({ page }) => {
+    await page.getByText("첫째 줄").click();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+a");
+    await expect(page.getByTestId("dataset-block-selected")).toBeVisible();
+
+    await page.getByText("a1").click();
+
+    // 덮개가 클릭을 먹으면 셀이 안 잡힌다(pointer-events 회귀 방지).
+    await expect(page.getByLabel("1행 1열 셀 (입력하면 편집)")).toBeVisible();
+  });
+});

--- a/fe/src/features/note/dataset/DatasetGrid.tsx
+++ b/fe/src/features/note/dataset/DatasetGrid.tsx
@@ -97,6 +97,11 @@ interface Props {
   /** 에디터에서 표 블록이 선택된 상태(NodeSelection)인지. 첫 셀 자동 선택 트리거. */
   blockSelected?: boolean;
   /**
+   * 문단들과 함께 잡힌 블록 선택에 이 표가 들어 있는지. 그리드 배경이 불투명해 블록 선택
+   * 하이라이트를 가리므로, 참이면 같은 색 틴트를 그리드 위에 덧씌워 선택돼 보이게 한다.
+   */
+  inBlockSelection?: boolean;
+  /**
    * 표 전체가 이미 선택된 상태에서 Cmd/Ctrl+A를 한 번 더 눌렀을 때 — 표 밖(문서 전체)으로
    * 선택을 넘긴다. 표가 키를 막고 있어 그냥 두면 사다리가 표에서 끊긴다.
    */
@@ -117,6 +122,7 @@ export function DatasetGrid({
   datasetId,
   onDeleteBlock,
   blockSelected,
+  inBlockSelection,
   onSelectAllEscape,
   siblingTables,
 }: Props) {
@@ -1904,6 +1910,17 @@ export function DatasetGrid({
         className="border-border bg-card group/grid relative flex flex-col rounded-md border outline-none"
         data-testid="dataset-grid"
       >
+        {/* 블록 선택 틴트 — 그리드 배경(bg-card)이 불투명해 블록 선택 하이라이트를 가리므로,
+          그 위에 같은 색을 덧씌워 선택된 문단과 같아 보이게 한다. 표 바깥 여백엔 하이라이트가
+          이미 비치므로 여기(박스 안)에만 씌워야 색이 두 겹으로 진해지지 않는다.
+          셀 오버레이(z-30까지)보다 위, 메뉴(z-40+)보다 아래. 클릭은 통과시킨다. */}
+        {inBlockSelection && (
+          <div
+            aria-hidden
+            data-testid="dataset-block-selected"
+            className="bg-primary/16 pointer-events-none absolute inset-0 z-[35] rounded-md"
+          />
+        )}
         {/* 값 셀만(제목 행 없음). 가로는 열이 넘치면 스크롤하고(overflow-x-auto),
           세로는 뷰포트를 두지 않아 행이 늘수록 페이지 흐름대로 자란다.
           행/열 추가 버튼은 공간을 차지하지 않게 절대 위치로 띄우고 표 호버 시에만 보인다. */}

--- a/fe/src/features/note/editor/DatasetTableView.tsx
+++ b/fe/src/features/note/editor/DatasetTableView.tsx
@@ -1,4 +1,5 @@
 import { useQueries } from "@tanstack/react-query";
+import { isNodeRangeSelection } from "@tiptap/extension-node-range";
 import { NodeSelection } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
 import { type NodeViewProps, NodeViewWrapper } from "@tiptap/react";
@@ -60,6 +61,12 @@ export function DatasetTableView({
     typeof pos === "number" &&
     selection.from === pos;
 
+  // 블록 선택(문단들과 함께 잡힌 상태)에 이 표가 들어 있는가. 블록 선택 하이라이트는 블록의
+  // 배경으로 그려지는데 그리드는 자기 배경이 불투명해(bg-card) 그 색을 가린다 — 그래서 표만
+  // 안 잡힌 것처럼 보였다. 그리드가 직접 같은 색 틴트를 덧씌워 다른 블록과 똑같이 보이게 한다.
+  // 표 단독 선택(soleSelected)은 제외한다 — 그땐 셀 단위 UI가 뜨므로 전체 틴트는 시끄럽다.
+  const inBlockSelection = selected && isNodeRangeSelection(selection);
+
   // 셀을 드래그해 범위 선택하려 할 때 표 블록이 통째로 끌려나오던 문제를 막는다.
   // 표가 NodeSelection으로 선택되면(셀 클릭 시 blockSelected) PM의 MouseDown이 spec.draggable:false를
   // 무시하고 노드의 바깥 DOM에 draggable=true를 심는다(NodeSelection 분기). 그 바깥 DOM은 TipTap이
@@ -119,6 +126,8 @@ export function DatasetTableView({
           // 곧바로 타이핑=편집이 되게 한다(블록만 선택돼 키가 먹통이던 문제 해소).
           // 여러 블록을 함께 선택한 경우엔 잡지 않는다 — 위 soleSelected 주석 참고.
           blockSelected={soleSelected}
+          // 블록 선택에 함께 잡혔음을 표 위에도 보이게 한다(위 inBlockSelection 주석 참고).
+          inBlockSelection={inBlockSelection}
           // 선택 사다리의 마지막 칸 — 표 전체 다음은 문서 전체다.
           onSelectAllEscape={escapeSelectionToDocument}
           // 표간 참조 피커·저장(tableRefs)에 쓸 같은 노트의 다른 표들.


### PR DESCRIPTION
## 이슈
closes #1021

## 작업 내용
`Cmd+A`로 전체를 잡으면 문단은 보라색으로 칠해지는데 **표만 안 잡힌 것처럼 보였다.** 실제로는 선택돼 있어 복사·삭제·이동은 정상이었고, 보이는 것만 어긋났다.

### 원인
블록 선택 하이라이트는 블록 요소의 **배경**으로 그려진다. 그런데 그리드는 자기 배경이 불투명해서(`bg-card`) 그 위에 얹혀 색을 완전히 가린다. 표 바깥 여백에만 색이 비쳐 "표는 빠진" 것처럼 읽혔다.

### 조치
표가 블록 선택에 포함되면 그리드 위에 같은 색 틴트를 덧씌운다.

- 틴트는 **그리드 박스 안쪽에만** 넣는다. 바깥 여백엔 하이라이트가 이미 비치므로, 래퍼에 씌우면 두 겹이 돼 표만 진해진다(처음에 그렇게 만들었다가 픽셀로 잡았다)
- `pointer-events-none` — 덮개가 셀 클릭을 먹으면 안 된다
- z-index는 셀 오버레이(z-30)보다 위, 메뉴(z-40+)보다 아래
- **표 단독 선택(클릭)은 제외** — 그땐 셀 단위 UI가 뜨므로 전체 틴트는 시끄럽다

## 테스트
`e2e/note-table-block-selection.spec.ts` (4건) — "다른 블록과 같은 색으로 보이는가"가 검증 대상이라 클래스 유무가 아니라 **실제로 그려진 픽셀을 비교**한다.

- 블록 선택 시 표 셀 색 == 문단 색 (`235,225,250`으로 일치)
- 선택을 풀면 원래 색으로 복귀
- 표만 클릭했을 땐 틴트 없음(과교정 방지)
- 틴트가 셀 클릭을 막지 않음(pointer-events 회귀 방지)
- 수정 전 2건 실패 → 수정 후 4/4 통과
- FE 598 tests / e2e 51종 **2회 반복 94/94** / lint · format:check · build 통과

### 측정에서 헤맨 것
표본 좌표를 그리드 상단 +30px로 잡았는데 그리드 높이가 38px이라 테두리를 찍고 있었다. 색이 다르다고 나와 원인을 한참 엉뚱한 데서 찾았다. 셀 안쪽에서 다시 재니 정확히 일치했다 — 테스트의 표본점은 가장자리를 피해 잡는다.

## 비고
`fix/table-copy-paste`(#1020)와 같은 파일을 건드리지만 영역이 달라 충돌은 작다. 먼저 머지되는 쪽에 맞춰 정리하겠다.