### PR TITLE
feat : 여행 도메인 테이블 + 엔티티 (Liquibase 047)

### DIFF
--- a/be/orino-app-api/src/main/resources/db/changelog/changes/047-create-travel-tables.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/047-create-travel-tables.yaml
@@ -1,0 +1,341 @@
+databaseChangeLog:
+  # 여행(Travel) 모듈 스키마 (#1030, Epic #1029). 1단계 토대.
+  #
+  # 절대 틀리면 안 되는 것 두 가지.
+  #   1) 일정 시각은 여행 타임존의 "벽시계 값"이다 — activity_date=DATE, start_time=TIME.
+  #      DATETIME/Instant로 저장하면 여행 타임존을 바꾸는 순간 전 일정이 통째로 밀린다.
+  #   2) 여행 상태(예정/진행 중/완료)·D-day·일차는 컬럼을 두지 않고 매 조회 시 파생한다.
+  #      저장하면 날짜가 넘어갈 때 갱신할 주체가 없어 반드시 어긋난다.
+  #
+  # travel_place는 1단계에 쓰지 않지만 지금 만든다 — trip.destination_place_id·
+  # trip_activity.place_id FK를 2단계에 붙이면 ALTER가 필요하다. 테이블은 처음부터 두고
+  # 2단계에 "쓰기 시작"한다.
+  #
+  # 컨벤션 — 불리언은 BIT(1)(BOOLEAN=tinyint는 Hibernate validate 실패), 절대시각은 DATETIME(6),
+  # 단일 사용자지만 최상위 엔티티(trip·travel_place)에 member_id 스코프를 둔다.
+
+  - changeSet:
+      id: 047-create-travel-place
+      author: wcorn
+      comment: 장소 캐시. 여행에 종속되지 않고 멤버 단위로 재사용한다(⭐ 좋았던 곳 판정).
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: travel_place
+      changes:
+        - createTable:
+            tableName: travel_place
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              # 구글 장소 식별자. 직접 입력한 장소면 NULL(중복 허용).
+              - column:
+                  name: google_place_id
+                  type: VARCHAR(255)
+              - column:
+                  name: name
+                  type: VARCHAR(200)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: address
+                  type: VARCHAR(500)
+              - column:
+                  name: lat
+                  type: DECIMAL(10, 7)
+              - column:
+                  name: lng
+                  type: DECIMAL(10, 7)
+              - column:
+                  name: category
+                  type: VARCHAR(100)
+              - column:
+                  name: phone
+                  type: VARCHAR(50)
+              # 구글 평점(0.0~5.0).
+              - column:
+                  name: rating
+                  type: DECIMAL(2, 1)
+              # 영업시간 캐시. details_refreshed_at + 30일이 지나면 재조회한다.
+              - column:
+                  name: opening_hours
+                  type: JSON
+              # MinIO에 캐시한 대표 사진 key. 공개 URL은 base(img.orino.dev)+key로 조립.
+              - column:
+                  name: photo_object_key
+                  type: VARCHAR(512)
+              # Google 사진 저작자 표기(사용 조건상 필수).
+              - column:
+                  name: photo_attribution
+                  type: VARCHAR(500)
+              - column:
+                  name: details_refreshed_at
+                  type: DATETIME(6)
+              # 직접 입력 여부. manual은 MySQL 8.4 예약어라 컬럼명으로 쓸 수 없다.
+              - column:
+                  name: manual_entry
+                  type: BIT(1)
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        # 같은 구글 장소를 두 번 저장하지 않는다. NULL은 중복 허용 = 직접 입력 다건 OK.
+        - createIndex:
+            tableName: travel_place
+            indexName: uk_place_member_google
+            unique: true
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: google_place_id
+        # 최근/이름 조회.
+        - createIndex:
+            tableName: travel_place
+            indexName: idx_place_member_name
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: name
+
+  - changeSet:
+      id: 047-create-trip
+      author: wcorn
+      comment: 여행 1건. 상태·D-day는 컬럼 없이 timezone 기준으로 파생한다.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: trip
+      changes:
+        - createTable:
+            tableName: trip
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              # 미입력 시 목적지명으로 채워 저장한다(빈 제목을 만들지 않는다).
+              - column:
+                  name: title
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              # 목적지 표시명. 목록 카드 메타에 쓰려고 denormalize한다.
+              - column:
+                  name: destination_name
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              # 검색으로 고른 목적지 도시. 1단계는 항상 NULL(수동 입력), 2단계부터 채운다.
+              - column:
+                  name: destination_place_id
+                  type: BIGINT
+                  constraints:
+                    foreignKeyName: fk_trip_destination_place
+                    references: travel_place(id)
+              - column:
+                  name: start_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              # >= start_date 는 애플리케이션 검증(DB CHECK를 두지 않는다).
+              - column:
+                  name: end_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              # IANA ID(Asia/Tokyo). 상태·D-day·알림 시각 환산의 유일한 기준.
+              - column:
+                  name: timezone
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+              # ISO 4217(JPY).
+              - column:
+                  name: currency
+                  type: CHAR(3)
+                  constraints:
+                    nullable: false
+              # 목적지 좌표 — 날씨 조회 기준점.
+              - column:
+                  name: lat
+                  type: DECIMAL(10, 7)
+              - column:
+                  name: lng
+                  type: DECIMAL(10, 7)
+              - column:
+                  name: default_notify_minutes
+                  type: INT
+                  defaultValueNumeric: 15
+                  constraints:
+                    nullable: false
+              - column:
+                  name: morning_summary_enabled
+                  type: BIT(1)
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        # 예정·진행 중 정렬(시작일 오름차순).
+        - createIndex:
+            tableName: trip
+            indexName: idx_trip_member_start
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: start_date
+        # 완료 정렬(종료일 내림차순).
+        - createIndex:
+            tableName: trip
+            indexName: idx_trip_member_end
+            columns:
+              - column:
+                  name: member_id
+              - column:
+                  name: end_date
+                  descending: true
+
+  - changeSet:
+      id: 047-create-trip-activity
+      author: wcorn
+      comment: 일정 1건. activity_date IS NULL 이 미배정 보관함이다.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: trip_activity
+      changes:
+        - createTable:
+            tableName: trip_activity
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: trip_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_trip_activity_trip
+                    references: trip(id)
+                    deleteCascade: true
+              - column:
+                  name: title
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              # NULL = 미배정 보관함. 값이 있으면 여행 기간 내 날짜만 허용(애플리케이션 검증).
+              - column:
+                  name: activity_date
+                  type: DATE
+              # 같은 날짜(또는 보관함) 내 정렬. 시각이 아니라 이 값이 유일한 정렬 기준이다 —
+              # 시각 없는 일정이 허용되고, 드래그로 정한 순서가 시각보다 우선한다.
+              - column:
+                  name: sort_order
+                  type: INT
+                  constraints:
+                    nullable: false
+              # 여행 타임존의 벽시계 시각. UTC로 변환하지 않는다.
+              - column:
+                  name: start_time
+                  type: TIME
+              # FK는 아래에서 별도로 건다 — ON DELETE SET NULL은 인라인 제약으로 표현할 수 없다.
+              - column:
+                  name: place_id
+                  type: BIGINT
+              - column:
+                  name: memo
+                  type: VARCHAR(1000)
+              # 예약 페이지 링크 1개.
+              - column:
+                  name: url
+                  type: VARCHAR(500)
+              - column:
+                  name: notify_enabled
+                  type: BIT(1)
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              # NULL이면 trip.default_notify_minutes를 쓴다.
+              - column:
+                  name: notify_minutes
+                  type: INT
+              - column:
+                  name: departure_notify_enabled
+                  type: BIT(1)
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        # 장소가 지워져도 일정은 남는다(참조만 끊는다).
+        - addForeignKeyConstraint:
+            baseTableName: trip_activity
+            baseColumnNames: place_id
+            constraintName: fk_trip_activity_place
+            referencedTableName: travel_place
+            referencedColumnNames: id
+            onDelete: SET NULL
+        # 보드 조회의 유일한 접근 경로.
+        - createIndex:
+            tableName: trip_activity
+            indexName: idx_activity_trip_date_order
+            columns:
+              - column:
+                  name: trip_id
+              - column:
+                  name: activity_date
+              - column:
+                  name: sort_order

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -91,3 +91,5 @@ databaseChangeLog:
       file: db/changelog/changes/045-add-formula-ref-to-dataset-id.yaml
   - include:
       file: db/changelog/changes/046-create-lifelog-tables.yaml
+  - include:
+      file: db/changelog/changes/047-create-travel-tables.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/schema/TravelSchemaTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/schema/TravelSchemaTest.java
@@ -1,0 +1,184 @@
+package ds.project.orino.schema;
+
+import ds.project.orino.support.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 여행 스키마(047)에서 Hibernate {@code validate}가 봐주지 않는 것들을 고정한다 —
+ * <b>FK 삭제 규칙 · 인덱스 · 컬럼 타입</b>. validate는 컬럼의 존재와 타입 호환만 보므로
+ * cascade가 빠져도, 인덱스가 없어도 통과한다.
+ *
+ * <p>도메인 모듈의 Repository 테스트는 {@code create-drop}으로 엔티티에서 스키마를 만들어
+ * FK 자체가 없다. 그래서 cascade·SET NULL은 Liquibase 스키마가 적용된 여기서만 볼 수 있다.
+ */
+@IntegrationTest
+class TravelSchemaTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("여행을 지우면 일정도 함께 지워진다(ON DELETE CASCADE)")
+    @Transactional
+    void deletingTripCascadesToActivities() {
+        long memberId = insertMember("cascade-member");
+        long tripId = insertTrip(memberId, "도쿄");
+        jdbcTemplate.update("""
+                INSERT INTO trip_activity (trip_id, title, activity_date, sort_order, start_time,
+                                           notify_enabled, departure_notify_enabled,
+                                           created_at, updated_at)
+                VALUES (?, '센소지', '2026-10-24', 0, '10:30:00', b'0', b'0', NOW(6), NOW(6))
+                """, tripId);
+
+        jdbcTemplate.update("DELETE FROM trip WHERE id = ?", tripId);
+
+        assertThat(countActivities(tripId)).isZero();
+    }
+
+    @Test
+    @DisplayName("장소를 지우면 일정은 남고 참조만 끊긴다(ON DELETE SET NULL)")
+    @Transactional
+    void deletingPlaceNullsActivityReference() {
+        long memberId = insertMember("setnull-member");
+        long tripId = insertTrip(memberId, "도쿄");
+        long placeId = insertPlace(memberId, "ChIJ_senso_ji", "센소지");
+        jdbcTemplate.update("""
+                INSERT INTO trip_activity (trip_id, title, activity_date, sort_order, place_id,
+                                           notify_enabled, departure_notify_enabled,
+                                           created_at, updated_at)
+                VALUES (?, '센소지', '2026-10-24', 0, ?, b'0', b'0', NOW(6), NOW(6))
+                """, tripId, placeId);
+
+        jdbcTemplate.update("DELETE FROM travel_place WHERE id = ?", placeId);
+
+        assertThat(countActivities(tripId)).isEqualTo(1);
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT place_id FROM trip_activity WHERE trip_id = ?", Long.class, tripId))
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("FK 삭제 규칙이 스키마에 실제로 걸려 있다")
+    void foreignKeyDeleteRules() {
+        assertThat(deleteRuleOf("fk_trip_activity_trip")).isEqualTo("CASCADE");
+        assertThat(deleteRuleOf("fk_trip_activity_place")).isEqualTo("SET NULL");
+        // 목적지 장소는 여행이 참조 중이면 지워지면 안 된다. 삭제 규칙을 안 주면 InnoDB가
+        // RESTRICT로 동작하지만 information_schema에는 NO ACTION으로 적힌다(같은 뜻).
+        assertThat(deleteRuleOf("fk_trip_destination_place")).isEqualTo("NO ACTION");
+    }
+
+    @Test
+    @DisplayName("조회 경로가 되는 인덱스가 전부 있다")
+    void indexesExist() {
+        assertThat(indexColumnsOf("trip", "idx_trip_member_start"))
+                .containsExactly("member_id", "start_date");
+        assertThat(indexColumnsOf("trip", "idx_trip_member_end"))
+                .containsExactly("member_id", "end_date");
+        // 보드 조회의 유일한 접근 경로.
+        assertThat(indexColumnsOf("trip_activity", "idx_activity_trip_date_order"))
+                .containsExactly("trip_id", "activity_date", "sort_order");
+        assertThat(indexColumnsOf("travel_place", "uk_place_member_google"))
+                .containsExactly("member_id", "google_place_id");
+        assertThat(indexColumnsOf("travel_place", "idx_place_member_name"))
+                .containsExactly("member_id", "name");
+    }
+
+    @Test
+    @DisplayName("같은 구글 장소는 멤버당 하나지만, 직접 입력(NULL)은 여러 건 허용된다")
+    @Transactional
+    void uniqueIndexAllowsMultipleManualPlaces() {
+        long memberId = insertMember("place-member");
+        insertPlace(memberId, null, "골목 카페 A");
+        insertPlace(memberId, null, "골목 카페 B");
+
+        Integer manualCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM travel_place WHERE member_id = ? AND google_place_id IS NULL",
+                Integer.class, memberId);
+
+        assertThat(manualCount).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("일정 시각은 DATE·TIME이다 — DATETIME으로 바뀌면 타임존 변경 시 전 일정이 밀린다")
+    void wallClockColumnTypes() {
+        assertThat(columnTypeOf("trip_activity", "activity_date")).isEqualTo("date");
+        assertThat(columnTypeOf("trip_activity", "start_time")).isEqualTo("time");
+        assertThat(columnTypeOf("trip", "start_date")).isEqualTo("date");
+        assertThat(columnTypeOf("trip", "end_date")).isEqualTo("date");
+        // 여행 타임존은 IANA ID 문자열. 여기서 파생 계산의 기준이 나온다.
+        assertThat(columnTypeOf("trip", "timezone")).isEqualTo("varchar");
+    }
+
+    @Test
+    @DisplayName("불리언 컬럼은 BIT(1)이다(BOOLEAN=tinyint면 Hibernate validate가 깨진다)")
+    void booleanColumnsAreBit() {
+        assertThat(columnTypeOf("trip", "morning_summary_enabled")).isEqualTo("bit");
+        assertThat(columnTypeOf("trip_activity", "notify_enabled")).isEqualTo("bit");
+        assertThat(columnTypeOf("trip_activity", "departure_notify_enabled")).isEqualTo("bit");
+        assertThat(columnTypeOf("travel_place", "manual_entry")).isEqualTo("bit");
+    }
+
+    private long insertMember(String username) {
+        jdbcTemplate.update(
+                "INSERT INTO member (login_id, password, created_at, updated_at)"
+                        + " VALUES (?, 'pw', NOW(6), NOW(6))", username);
+        return jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+    }
+
+    private long insertTrip(long memberId, String destination) {
+        jdbcTemplate.update("""
+                INSERT INTO trip (member_id, title, destination_name, start_date, end_date,
+                                  timezone, currency, default_notify_minutes,
+                                  morning_summary_enabled, created_at, updated_at)
+                VALUES (?, ?, ?, '2026-10-24', '2026-10-27', 'Asia/Tokyo', 'JPY', 15, b'0',
+                        NOW(6), NOW(6))
+                """, memberId, destination, destination);
+        return jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+    }
+
+    private long insertPlace(long memberId, String googlePlaceId, String name) {
+        jdbcTemplate.update("""
+                INSERT INTO travel_place (member_id, google_place_id, name, manual_entry,
+                                          created_at, updated_at)
+                VALUES (?, ?, ?, b'0', NOW(6), NOW(6))
+                """, memberId, googlePlaceId, name);
+        return jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+    }
+
+    private Integer countActivities(long tripId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM trip_activity WHERE trip_id = ?", Integer.class, tripId);
+    }
+
+    private String deleteRuleOf(String constraintName) {
+        return jdbcTemplate.queryForObject("""
+                SELECT delete_rule FROM information_schema.referential_constraints
+                WHERE constraint_schema = DATABASE() AND constraint_name = ?
+                """, String.class, constraintName);
+    }
+
+    private List<String> indexColumnsOf(String table, String indexName) {
+        return jdbcTemplate.queryForList("""
+                SELECT column_name FROM information_schema.statistics
+                WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?
+                ORDER BY seq_in_index
+                """, String.class, table, indexName);
+    }
+
+    private String columnTypeOf(String table, String column) {
+        Map<String, Object> row = jdbcTemplate.queryForMap("""
+                SELECT data_type FROM information_schema.columns
+                WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ?
+                """, table, column);
+        return String.valueOf(row.get("data_type"));
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TravelPlace.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TravelPlace.java
@@ -1,0 +1,212 @@
+package ds.project.orino.domain.planner.travel.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * 장소 캐시 하나. 구글에서 가져온 장소 또는 직접 입력한 장소를 담는다.
+ *
+ * <p><b>여행에 종속되지 않는다.</b> 이전 여행에서 평점 4 이상을 준 장소에 {@code ⭐ 좋았던 곳}
+ * 배지를 다는 요구가 있어, 장소는 여행을 가로질러 멤버 단위로 재사용돼야 한다.
+ *
+ * <p>1단계에서는 아무것도 쓰지 않는다. {@link Trip#getDestinationPlaceId()}·
+ * {@link TripActivity#getPlaceId()} FK를 나중에 붙이면 ALTER가 필요해 테이블만 미리 두고,
+ * 2단계(장소 검색)부터 채우기 시작한다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "travel_place")
+public class TravelPlace {
+
+    /** 영업시간·사진 캐시 유효기간. 이 기간이 지나면 구글에서 다시 받아온다. */
+    public static final Duration DETAILS_TTL = Duration.ofDays(30);
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    /** 구글 장소 식별자. 직접 입력한 장소면 null(멤버당 여러 건 허용). */
+    @Column(name = "google_place_id", length = 255)
+    private String googlePlaceId;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(length = 500)
+    private String address;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal lat;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal lng;
+
+    @Column(length = 100)
+    private String category;
+
+    @Column(length = 50)
+    private String phone;
+
+    /** 구글 평점(0.0~5.0). */
+    @Column(precision = 2, scale = 1)
+    private BigDecimal rating;
+
+    /** 영업시간 원본 JSON. 구조를 해석하지 않고 그대로 캐시했다가 FE에 넘긴다. */
+    @Column(name = "opening_hours", columnDefinition = "JSON")
+    private String openingHours;
+
+    /** MinIO에 캐시한 대표 사진 key. 공개 URL은 base + key로 조립한다. */
+    @Column(name = "photo_object_key", length = 512)
+    private String photoObjectKey;
+
+    /** Google 사진 저작자 표기. 사진을 쓰면 함께 노출해야 한다. */
+    @Column(name = "photo_attribution", length = 500)
+    private String photoAttribution;
+
+    /** 영업시간·사진을 마지막으로 갱신한 시각. null이면 아직 상세를 받은 적 없다. */
+    @Column(name = "details_refreshed_at")
+    private Instant detailsRefreshedAt;
+
+    /**
+     * 구글 검색이 아니라 사용자가 직접 입력한 장소인지.
+     * 컬럼명이 {@code manual}이 아닌 이유 — MySQL 8.4의 예약어라 그대로 쓰면 DDL이 깨진다.
+     */
+    @Column(name = "manual_entry", nullable = false)
+    private boolean manualEntry = false;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected TravelPlace() {
+    }
+
+    private TravelPlace(Long memberId, String googlePlaceId, String name, boolean manualEntry) {
+        this.memberId = memberId;
+        this.googlePlaceId = googlePlaceId;
+        this.name = name;
+        this.manualEntry = manualEntry;
+    }
+
+    /** 구글 검색 결과로 담은 장소. */
+    public static TravelPlace fromGoogle(Long memberId, String googlePlaceId, String name) {
+        return new TravelPlace(memberId, googlePlaceId, name, false);
+    }
+
+    /** 검색에 안 나오는 곳을 직접 입력한 장소. {@code google_place_id}가 없다. */
+    public static TravelPlace manual(Long memberId, String name) {
+        return new TravelPlace(memberId, null, name, true);
+    }
+
+    /** 위치·주소·분류 등 검색 응답으로 채워지는 기본 정보. */
+    public void updateBasics(String address, BigDecimal lat, BigDecimal lng,
+                             String category, BigDecimal rating) {
+        this.address = address;
+        this.lat = lat;
+        this.lng = lng;
+        this.category = category;
+        this.rating = rating;
+    }
+
+    /** 상세 조회(영업시간·전화·사진) 결과를 채우고 갱신 시각을 찍는다. */
+    public void updateDetails(String phone, String openingHours, String photoObjectKey,
+                              String photoAttribution, Instant refreshedAt) {
+        this.phone = phone;
+        this.openingHours = openingHours;
+        this.photoObjectKey = photoObjectKey;
+        this.photoAttribution = photoAttribution;
+        this.detailsRefreshedAt = refreshedAt;
+    }
+
+    /** 캐시된 상세가 없거나 {@link #DETAILS_TTL}이 지났으면 재조회 대상이다. */
+    public boolean needsDetailsRefresh(Instant now) {
+        return detailsRefreshedAt == null || detailsRefreshedAt.plus(DETAILS_TTL).isBefore(now);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public String getGooglePlaceId() {
+        return googlePlaceId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public BigDecimal getLat() {
+        return lat;
+    }
+
+    public BigDecimal getLng() {
+        return lng;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public BigDecimal getRating() {
+        return rating;
+    }
+
+    public String getOpeningHours() {
+        return openingHours;
+    }
+
+    public String getPhotoObjectKey() {
+        return photoObjectKey;
+    }
+
+    public String getPhotoAttribution() {
+        return photoAttribution;
+    }
+
+    public Instant getDetailsRefreshedAt() {
+        return detailsRefreshedAt;
+    }
+
+    public boolean isManualEntry() {
+        return manualEntry;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/Trip.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/Trip.java
@@ -1,0 +1,223 @@
+package ds.project.orino.domain.planner.travel.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * 여행 1건. 일정({@link TripActivity})의 소유자이자 타임존·통화의 기준점이다.
+ *
+ * <p><b>상태·D-day·일차 번호를 저장하지 않는다.</b> 셋 다 "오늘"에 의존하는 값이라 컬럼으로 두면
+ * 날짜가 넘어가는 순간 어긋난다. 대신 {@link #status(Clock)}·{@link #daysUntilStart(Clock)}으로
+ * 조회 시마다 파생하며, 기준은 기기 시간대가 아니라 {@link #timezone}의 오늘이다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "trip")
+public class Trip {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    /** 최대 50자. 미입력 시 목적지명으로 채워 저장한다(빈 제목을 만들지 않는다). */
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    /** 목적지 표시명. 목록 카드 메타에 쓰려고 denormalize한다. */
+    @Column(name = "destination_name", nullable = false, length = 100)
+    private String destinationName;
+
+    /** 검색으로 고른 목적지 도시({@link TravelPlace}). 1단계는 항상 null(수동 입력). */
+    @Column(name = "destination_place_id")
+    private Long destinationPlaceId;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    /** 종료일(당일 포함). 항상 {@code >= startDate} — 애플리케이션에서 검증한다. */
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    /** IANA 타임존 ID(예: {@code Asia/Tokyo}). 상태·D-day·알림 시각 환산의 유일한 기준. */
+    @Column(nullable = false, length = 64)
+    private String timezone;
+
+    /** ISO 4217 통화 코드(예: {@code JPY}). */
+    @Column(nullable = false, length = 3)
+    private String currency;
+
+    /** 목적지 좌표 — 날씨 조회 기준점. */
+    @Column(precision = 10, scale = 7)
+    private BigDecimal lat;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal lng;
+
+    /** 여행 단위 기본 알림 시점(분 전). 일정이 값을 따로 정하지 않으면 이걸 쓴다. */
+    @Column(name = "default_notify_minutes", nullable = false)
+    private int defaultNotifyMinutes = 15;
+
+    @Column(name = "morning_summary_enabled", nullable = false)
+    private boolean morningSummaryEnabled = false;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected Trip() {
+    }
+
+    public Trip(Long memberId, String title, String destinationName, LocalDate startDate,
+                LocalDate endDate, String timezone, String currency) {
+        this.memberId = memberId;
+        this.title = title;
+        this.destinationName = destinationName;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.timezone = timezone;
+        this.currency = currency;
+    }
+
+    /** 제목·목적지·기간·타임존·통화 등 기본 정보를 갱신한다. */
+    public void update(String title, String destinationName, LocalDate startDate,
+                       LocalDate endDate, String timezone, String currency) {
+        this.title = title;
+        this.destinationName = destinationName;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.timezone = timezone;
+        this.currency = currency;
+    }
+
+    /** 목적지 좌표(날씨 기준점)와 검색으로 고른 목적지 장소를 잇는다. 2단계부터 쓴다. */
+    public void updateDestinationPlace(Long destinationPlaceId, BigDecimal lat, BigDecimal lng) {
+        this.destinationPlaceId = destinationPlaceId;
+        this.lat = lat;
+        this.lng = lng;
+    }
+
+    public void updateNotificationSettings(int defaultNotifyMinutes, boolean morningSummaryEnabled) {
+        this.defaultNotifyMinutes = defaultNotifyMinutes;
+        this.morningSummaryEnabled = morningSummaryEnabled;
+    }
+
+    /** 여행 타임존 기준 오늘 날짜. 상태·D-day·일차 계산은 전부 이 값을 기준으로 한다. */
+    public LocalDate todayAtDestination(Clock clock) {
+        return LocalDate.now(clock.withZone(ZoneId.of(timezone)));
+    }
+
+    /** 여행 타임존의 오늘로 판정한 상태. */
+    public TripStatus status(Clock clock) {
+        return statusOn(todayAtDestination(clock));
+    }
+
+    /** 주어진 날짜를 오늘로 보고 판정한 상태. 목록을 한 번에 훑을 때 오늘을 재사용한다. */
+    public TripStatus statusOn(LocalDate today) {
+        return TripStatus.of(today, startDate, endDate);
+    }
+
+    /**
+     * 시작일까지 남은 일수(D-day). 시작 당일이면 0, 이미 시작했으면 음수다.
+     * 표시 여부(예정 여행에만 노출)는 호출부가 {@link #status(Clock)}로 판단한다.
+     */
+    public long daysUntilStart(Clock clock) {
+        return ChronoUnit.DAYS.between(todayAtDestination(clock), startDate);
+    }
+
+    /** 여행 총 일수(당일 포함). 하루짜리 여행이면 1. */
+    public int totalDays() {
+        return (int) ChronoUnit.DAYS.between(startDate, endDate) + 1;
+    }
+
+    /** 해당 날짜의 일차 번호(시작일이 1일차). 여행 기간 밖이면 범위를 벗어난 값이 나온다. */
+    public int dayNumberOf(LocalDate date) {
+        return (int) ChronoUnit.DAYS.between(startDate, date) + 1;
+    }
+
+    /** 여행 기간에 속한 날짜인지. 일정의 {@code activityDate} 검증에 쓴다. */
+    public boolean covers(LocalDate date) {
+        return !date.isBefore(startDate) && !date.isAfter(endDate);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDestinationName() {
+        return destinationName;
+    }
+
+    public Long getDestinationPlaceId() {
+        return destinationPlaceId;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public BigDecimal getLat() {
+        return lat;
+    }
+
+    public BigDecimal getLng() {
+        return lng;
+    }
+
+    public int getDefaultNotifyMinutes() {
+        return defaultNotifyMinutes;
+    }
+
+    public boolean isMorningSummaryEnabled() {
+        return morningSummaryEnabled;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TripActivity.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TripActivity.java
@@ -1,0 +1,207 @@
+package ds.project.orino.domain.planner.travel.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * 일정 1건. {@code activityDate}가 null이면 <b>미배정 보관함</b>이다(날짜를 아직 못 정한 후보).
+ *
+ * <p><b>시각은 여행 타임존의 벽시계 값이다.</b> {@code activityDate}는 {@code DATE},
+ * {@code startTime}은 {@code TIME}으로 담고 UTC로 환산하지 않는다. {@code Instant}로 저장하면
+ * 여행 타임존을 바꾸는 순간 전 일정이 통째로 밀린다. 절대시각이 필요한 곳은 알림 예약뿐이고,
+ * 거기서만 {@code trip.timezone}으로 환산한다.
+ *
+ * <p><b>정렬은 {@code sortOrder}만 본다.</b> 시각으로 정렬하지 않는다 — 시각 없는 일정이
+ * 허용되고, 사용자가 드래그로 정한 순서가 시각보다 우선한다. 순서 변경은 해당 날짜의 행 전체를
+ * 0..n-1로 재부여한다(하루 10건 남짓이라 gap index는 과설계다).
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "trip_activity")
+public class TripActivity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "trip_id", nullable = false)
+    private Long tripId;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    /** null = 미배정 보관함. 값이 있으면 여행 기간 내 날짜여야 한다({@link Trip#covers}). */
+    @Column(name = "activity_date")
+    private LocalDate activityDate;
+
+    /** 같은 날짜(또는 보관함) 안에서의 순서. 0부터 빈틈없이 부여한다. */
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    /** 여행 타임존의 벽시계 시각. null이면 시각 미정 일정이다. */
+    @Column(name = "start_time")
+    private LocalTime startTime;
+
+    /** 연결된 {@link TravelPlace}. 2단계(장소 검색)부터 채운다. */
+    @Column(name = "place_id")
+    private Long placeId;
+
+    @Column(length = 1000)
+    private String memo;
+
+    /** 예약 페이지 링크 1개. */
+    @Column(length = 500)
+    private String url;
+
+    @Column(name = "notify_enabled", nullable = false)
+    private boolean notifyEnabled = false;
+
+    /** 알림 시점(분 전). null이면 {@link Trip#getDefaultNotifyMinutes()}를 쓴다. */
+    @Column(name = "notify_minutes")
+    private Integer notifyMinutes;
+
+    @Column(name = "departure_notify_enabled", nullable = false)
+    private boolean departureNotifyEnabled = false;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected TripActivity() {
+    }
+
+    public TripActivity(Long tripId, String title, LocalDate activityDate, int sortOrder,
+                        LocalTime startTime) {
+        this.tripId = tripId;
+        this.title = title;
+        this.activityDate = activityDate;
+        this.sortOrder = sortOrder;
+        this.startTime = startTime;
+    }
+
+    /** 제목·시각·메모·링크 갱신. 날짜와 순서는 이동 전용 메서드로만 바꾼다. */
+    public void update(String title, LocalTime startTime, String memo, String url) {
+        this.title = title;
+        this.startTime = startTime;
+        this.memo = memo;
+        this.url = url;
+    }
+
+    /**
+     * 날짜와 순서를 함께 옮긴다. 날짜 이동이면 양쪽 날짜를 재인덱싱해야 하므로
+     * 호출부가 한 트랜잭션 안에서 처리한다.
+     *
+     * @param activityDate null이면 보관함으로 내린다
+     */
+    public void moveTo(LocalDate activityDate, int sortOrder) {
+        this.activityDate = activityDate;
+        this.sortOrder = sortOrder;
+    }
+
+    /** 같은 날짜 안에서 순서만 재부여한다(0..n-1 재인덱싱). */
+    public void reorderTo(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public void updatePlace(Long placeId) {
+        this.placeId = placeId;
+    }
+
+    public void updateNotification(boolean notifyEnabled, Integer notifyMinutes,
+                                   boolean departureNotifyEnabled) {
+        this.notifyEnabled = notifyEnabled;
+        this.notifyMinutes = notifyMinutes;
+        this.departureNotifyEnabled = departureNotifyEnabled;
+    }
+
+    /** 날짜가 없는 미배정 일정(보관함)인지. */
+    public boolean isUnscheduled() {
+        return activityDate == null;
+    }
+
+    /**
+     * 알림을 실제로 예약할 수 있는 일정인지. <b>DB 제약이 아니라 여기서 판정한다</b> —
+     * 시각이 없으면 알림 스위치가 켜져 있어도 언제 보낼지 정할 수 없고, 보관함 일정은
+     * 날짜조차 없다.
+     */
+    public boolean isNotifiable() {
+        return notifyEnabled && activityDate != null && startTime != null;
+    }
+
+    /** 이 일정에 적용할 알림 시점(분 전). 자체 값이 없으면 여행 기본값으로 떨어진다. */
+    public int resolveNotifyMinutes(int tripDefaultMinutes) {
+        return notifyMinutes != null ? notifyMinutes : tripDefaultMinutes;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getTripId() {
+        return tripId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public LocalDate getActivityDate() {
+        return activityDate;
+    }
+
+    public int getSortOrder() {
+        return sortOrder;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public Long getPlaceId() {
+        return placeId;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public boolean isNotifyEnabled() {
+        return notifyEnabled;
+    }
+
+    public Integer getNotifyMinutes() {
+        return notifyMinutes;
+    }
+
+    public boolean isDepartureNotifyEnabled() {
+        return departureNotifyEnabled;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TripStatus.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TripStatus.java
@@ -1,0 +1,39 @@
+package ds.project.orino.domain.planner.travel.entity;
+
+import java.time.LocalDate;
+
+/**
+ * 여행 상태. <b>컬럼으로 저장하지 않고 매 조회 시 파생한다.</b>
+ *
+ * <p>저장하면 날짜가 넘어갈 때 상태를 갱신할 주체가 없어 반드시 어긋난다(예정인 채로 멈춘
+ * 진행 중 여행). 기준 날짜는 기기 시간대가 아니라 <b>여행 타임존의 오늘</b>이다 —
+ * {@link Trip#statusOn(LocalDate)}를 쓰면 이 기준이 강제된다.
+ */
+public enum TripStatus {
+
+    /** 오늘 &lt; 시작일. */
+    UPCOMING,
+
+    /** 시작일 ≤ 오늘 ≤ 종료일. */
+    ONGOING,
+
+    /** 오늘 &gt; 종료일. */
+    COMPLETED;
+
+    /**
+     * 기간과 기준 날짜를 비교해 상태를 판정한다.
+     *
+     * @param today     여행 타임존 기준 오늘 날짜
+     * @param startDate 여행 시작일
+     * @param endDate   여행 종료일(당일 포함)
+     */
+    public static TripStatus of(LocalDate today, LocalDate startDate, LocalDate endDate) {
+        if (today.isBefore(startDate)) {
+            return UPCOMING;
+        }
+        if (today.isAfter(endDate)) {
+            return COMPLETED;
+        }
+        return ONGOING;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TravelPlaceRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TravelPlaceRepository.java
@@ -1,0 +1,27 @@
+package ds.project.orino.domain.planner.travel.repository;
+
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 장소 캐시 조회. 여행이 아니라 <b>멤버</b>로 스코프한다 — 같은 장소를 여행마다 새로 만들면
+ * "이전 여행에서 좋았던 곳" 판정이 불가능하다.
+ *
+ * <p>1단계에서는 쓰지 않는다. 2단계(장소 검색)부터 채우기 시작한다.
+ */
+public interface TravelPlaceRepository extends JpaRepository<TravelPlace, Long> {
+
+    Optional<TravelPlace> findByIdAndMemberId(Long id, Long memberId);
+
+    /** 이미 담아둔 구글 장소인지 확인해 중복 저장을 막는다({@code uk_place_member_google}). */
+    Optional<TravelPlace> findByMemberIdAndGooglePlaceId(Long memberId, String googlePlaceId);
+
+    /** 여러 일정의 장소를 한 번에 붙일 때 쓰는 배치 조회(N+1 회피). */
+    List<TravelPlace> findAllByIdIn(List<Long> ids);
+
+    /** 이름 부분일치 — 직접 입력한 장소를 다시 고를 때. */
+    List<TravelPlace> findAllByMemberIdAndNameContainingOrderByNameAsc(Long memberId, String name);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripActivityRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripActivityRepository.java
@@ -1,0 +1,66 @@
+package ds.project.orino.domain.planner.travel.repository;
+
+import ds.project.orino.domain.planner.travel.entity.TripActivity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 일정 조회. 모든 접근이 {@code idx_activity_trip_date_order (trip_id, activity_date, sort_order)}를
+ * 탄다.
+ *
+ * <p>정렬은 {@code sortOrder}만 본다 — 시각으로 정렬하지 않는다(시각 없는 일정이 허용되고
+ * 드래그 순서가 시각보다 우선한다). 동점은 {@code id}로 갈라 순서를 결정적으로 만든다.
+ */
+public interface TripActivityRepository extends JpaRepository<TripActivity, Long> {
+
+    Optional<TripActivity> findByIdAndTripId(Long id, Long tripId);
+
+    /**
+     * 보드 조회 — 한 여행의 전 일정을 한 번에 읽는다. 날짜별 그룹핑은 애플리케이션에서 한다.
+     * 보관함({@code activity_date IS NULL})이 MySQL NULLS-FIRST 규칙에 따라 앞에 온다.
+     */
+    List<TripActivity> findAllByTripIdOrderByActivityDateAscSortOrderAscIdAsc(Long tripId);
+
+    /** 특정 날짜의 일정. 재인덱싱·삽입 위치 계산에 쓴다. */
+    List<TripActivity> findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(
+            Long tripId, LocalDate activityDate);
+
+    /** 미배정 보관함. {@code activityDate IS NULL}은 파생 쿼리로 표현할 수 없어 직접 쓴다. */
+    @Query("""
+            SELECT a FROM TripActivity a
+            WHERE a.tripId = :tripId AND a.activityDate IS NULL
+            ORDER BY a.sortOrder ASC, a.id ASC
+            """)
+    List<TripActivity> findUnscheduled(@Param("tripId") Long tripId);
+
+    /** 새 일정을 맨 뒤에 붙일 때 쓸 다음 순서값. 빈 날짜면 0. */
+    @Query("""
+            SELECT COALESCE(MAX(a.sortOrder) + 1, 0) FROM TripActivity a
+            WHERE a.tripId = :tripId
+              AND (:activityDate IS NULL AND a.activityDate IS NULL
+                   OR a.activityDate = :activityDate)
+            """)
+    int nextSortOrder(@Param("tripId") Long tripId, @Param("activityDate") LocalDate activityDate);
+
+    /**
+     * 여행 기간이 줄어 기간 밖으로 밀려난 일정. 보관함으로 내릴 대상을 고른다.
+     * 보관함 일정({@code activityDate IS NULL})은 애초에 대상이 아니다.
+     */
+    @Query("""
+            SELECT a FROM TripActivity a
+            WHERE a.tripId = :tripId
+              AND a.activityDate IS NOT NULL
+              AND (a.activityDate < :startDate OR a.activityDate > :endDate)
+            ORDER BY a.activityDate ASC, a.sortOrder ASC, a.id ASC
+            """)
+    List<TripActivity> findOutsidePeriod(@Param("tripId") Long tripId,
+                                         @Param("startDate") LocalDate startDate,
+                                         @Param("endDate") LocalDate endDate);
+
+    long countByTripId(Long tripId);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripRepository.java
@@ -1,0 +1,29 @@
+package ds.project.orino.domain.planner.travel.repository;
+
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 여행 조회. <b>상태로 필터하는 쿼리 메서드를 두지 않는다</b> — 상태는 컬럼이 아니라
+ * 여행 타임존의 오늘로 파생하는 값이라 SQL에서 판정할 수 없다. 대신 기간 비교로 뽑고
+ * 표시 순서만 인덱스에 맞춘다.
+ */
+public interface TripRepository extends JpaRepository<Trip, Long> {
+
+    Optional<Trip> findByIdAndMemberId(Long id, Long memberId);
+
+    /** 예정·진행 중 목록: 아직 끝나지 않은 여행을 시작일 오름차순으로. {@code idx_trip_member_start}. */
+    List<Trip> findAllByMemberIdAndEndDateGreaterThanEqualOrderByStartDateAscIdAsc(
+            Long memberId, LocalDate today);
+
+    /** 완료 목록: 이미 끝난 여행을 종료일 내림차순으로. {@code idx_trip_member_end}. */
+    List<Trip> findAllByMemberIdAndEndDateLessThanOrderByEndDateDescIdDesc(
+            Long memberId, LocalDate today);
+
+    /** 여행 목록 화면 전체. 최근 여행이 위로. */
+    List<Trip> findAllByMemberIdOrderByStartDateDescIdDesc(Long memberId);
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/entity/TripActivityTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/entity/TripActivityTest.java
@@ -1,0 +1,78 @@
+package ds.project.orino.domain.planner.travel.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 알림 유효성은 DB 제약이 아니라 엔티티가 판정한다. 스위치만 보고 알림을 만들면 시각 없는
+ * 일정·보관함 일정에 대해 "언제 보낼지 없는" 알림이 예약된다.
+ */
+class TripActivityTest {
+
+    private static final LocalDate DAY = LocalDate.of(2026, 10, 24);
+
+    @Test
+    @DisplayName("날짜와 시각이 모두 있고 스위치가 켜져야 알림 대상이다")
+    void notifiableOnlyWithDateAndTime() {
+        TripActivity scheduled = new TripActivity(1L, "센소지", DAY, 0, LocalTime.of(10, 0));
+        scheduled.updateNotification(true, null, false);
+        assertThat(scheduled.isNotifiable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("시각이 없으면 스위치가 켜져 있어도 알림을 만들지 않는다")
+    void notNotifiableWithoutTime() {
+        TripActivity noTime = new TripActivity(1L, "쇼핑", DAY, 0, null);
+        noTime.updateNotification(true, 30, false);
+
+        assertThat(noTime.isNotifiable()).isFalse();
+    }
+
+    @Test
+    @DisplayName("보관함 일정(날짜 없음)은 알림 대상이 아니다")
+    void notNotifiableWhenUnscheduled() {
+        TripActivity archived = new TripActivity(1L, "후보", null, 0, LocalTime.of(10, 0));
+        archived.updateNotification(true, null, false);
+
+        assertThat(archived.isUnscheduled()).isTrue();
+        assertThat(archived.isNotifiable()).isFalse();
+    }
+
+    @Test
+    @DisplayName("스위치가 꺼져 있으면 날짜·시각이 있어도 대상이 아니다")
+    void notNotifiableWhenDisabled() {
+        TripActivity off = new TripActivity(1L, "센소지", DAY, 0, LocalTime.of(10, 0));
+
+        assertThat(off.isNotifiable()).isFalse();
+    }
+
+    @Test
+    @DisplayName("알림 시점은 자체 값 우선, 없으면 여행 기본값으로 떨어진다")
+    void resolvesNotifyMinutes() {
+        TripActivity own = new TripActivity(1L, "센소지", DAY, 0, LocalTime.of(10, 0));
+        own.updateNotification(true, 30, false);
+        assertThat(own.resolveNotifyMinutes(15)).isEqualTo(30);
+
+        TripActivity inherited = new TripActivity(1L, "우에노", DAY, 1, LocalTime.of(13, 0));
+        inherited.updateNotification(true, null, false);
+        assertThat(inherited.resolveNotifyMinutes(15)).isEqualTo(15);
+    }
+
+    @Test
+    @DisplayName("moveTo(null, …)은 일정을 보관함으로 내린다")
+    void moveToArchive() {
+        TripActivity activity = new TripActivity(1L, "센소지", DAY, 3, LocalTime.of(10, 0));
+
+        activity.moveTo(null, 0);
+
+        assertThat(activity.isUnscheduled()).isTrue();
+        assertThat(activity.getSortOrder()).isZero();
+        // 시각은 남는다 — 날짜만 정하면 그대로 되살아난다.
+        assertThat(activity.getStartTime()).isEqualTo(LocalTime.of(10, 0));
+    }
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/entity/TripTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/entity/TripTest.java
@@ -1,0 +1,155 @@
+package ds.project.orino.domain.planner.travel.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 저장하지 않고 파생하는 값들(상태·D-day·일차)을 고정한다. 이 계산이 틀리면 컬럼이 없으니
+ * DB를 봐도 알 수 없다 — 여기가 유일한 안전망이다.
+ */
+class TripTest {
+
+    private static final ZoneId TOKYO = ZoneId.of("Asia/Tokyo");
+
+    /** 도쿄 여행 10/24~10/27. 에픽의 실사용 일정 그대로다. */
+    private static Trip tokyoTrip() {
+        return new Trip(1L, "도쿄", "도쿄", LocalDate.of(2026, 10, 24),
+                LocalDate.of(2026, 10, 27), "Asia/Tokyo", "JPY");
+    }
+
+    /** 기기 시간대와 무관하게 판정돼야 하므로, 시스템 존을 일부러 여행지와 다르게 준다. */
+    private static Clock utcClockAt(String instant) {
+        return Clock.fixed(Instant.parse(instant), ZoneId.of("UTC"));
+    }
+
+    @Nested
+    @DisplayName("상태 판정")
+    class Status {
+
+        @Test
+        @DisplayName("오늘이 시작일 전이면 예정")
+        void upcomingBeforeStart() {
+            assertThat(tokyoTrip().status(utcClockAt("2026-10-20T03:00:00Z")))
+                    .isEqualTo(TripStatus.UPCOMING);
+        }
+
+        @Test
+        @DisplayName("시작일·종료일 당일도 진행 중이다(경계 포함)")
+        void ongoingIncludesBothEnds() {
+            assertThat(tokyoTrip().status(utcClockAt("2026-10-24T03:00:00Z")))
+                    .isEqualTo(TripStatus.ONGOING);
+            assertThat(tokyoTrip().status(utcClockAt("2026-10-27T03:00:00Z")))
+                    .isEqualTo(TripStatus.ONGOING);
+        }
+
+        @Test
+        @DisplayName("종료일 다음날부터 완료")
+        void completedAfterEnd() {
+            assertThat(tokyoTrip().status(utcClockAt("2026-10-28T03:00:00Z")))
+                    .isEqualTo(TripStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("기기 시간대가 아니라 여행 타임존의 오늘로 판정한다")
+        void derivedFromTripTimezoneNotDeviceZone() {
+            // 2026-10-23 16:00 UTC — 서울/UTC로는 아직 10/23이지만 도쿄는 이미 10/24 01:00이다.
+            Clock justBeforeMidnightUtc = utcClockAt("2026-10-23T16:00:00Z");
+
+            assertThat(LocalDate.now(justBeforeMidnightUtc)).isEqualTo(LocalDate.of(2026, 10, 23));
+            assertThat(tokyoTrip().todayAtDestination(justBeforeMidnightUtc))
+                    .isEqualTo(LocalDate.of(2026, 10, 24));
+            // 도쿄 기준으로는 여행이 이미 시작됐다. UTC로 판정했다면 예정으로 잘못 나온다.
+            assertThat(tokyoTrip().status(justBeforeMidnightUtc)).isEqualTo(TripStatus.ONGOING);
+        }
+
+        @Test
+        @DisplayName("날짜변경선 반대편(하와이) 여행도 그 지역 오늘로 판정한다")
+        void worksForZonesBehindUtc() {
+            Trip honolulu = new Trip(1L, "하와이", "호놀룰루", LocalDate.of(2026, 10, 24),
+                    LocalDate.of(2026, 10, 27), "Pacific/Honolulu", "USD");
+            // 10/24 05:00 UTC — 호놀룰루(UTC-10)는 아직 10/23 19:00이라 출발 전이다.
+            Clock clock = utcClockAt("2026-10-24T05:00:00Z");
+
+            assertThat(honolulu.todayAtDestination(clock)).isEqualTo(LocalDate.of(2026, 10, 23));
+            assertThat(honolulu.status(clock)).isEqualTo(TripStatus.UPCOMING);
+        }
+
+        @Test
+        @DisplayName("statusOn은 주어진 날짜를 오늘로 본다(목록에서 오늘을 재사용)")
+        void statusOnUsesGivenDate() {
+            Trip trip = tokyoTrip();
+            assertThat(trip.statusOn(LocalDate.of(2026, 10, 23))).isEqualTo(TripStatus.UPCOMING);
+            assertThat(trip.statusOn(LocalDate.of(2026, 10, 25))).isEqualTo(TripStatus.ONGOING);
+            assertThat(trip.statusOn(LocalDate.of(2026, 10, 28))).isEqualTo(TripStatus.COMPLETED);
+        }
+    }
+
+    @Nested
+    @DisplayName("D-day · 일차")
+    class Derived {
+
+        @Test
+        @DisplayName("D-day는 여행 타임존의 오늘에서 시작일까지 남은 일수")
+        void daysUntilStart() {
+            assertThat(tokyoTrip().daysUntilStart(utcClockAt("2026-10-20T03:00:00Z"))).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("시작 당일은 0, 시작 후에는 음수")
+        void daysUntilStartOnAndAfterStart() {
+            assertThat(tokyoTrip().daysUntilStart(utcClockAt("2026-10-24T03:00:00Z"))).isZero();
+            assertThat(tokyoTrip().daysUntilStart(utcClockAt("2026-10-26T03:00:00Z"))).isEqualTo(-2);
+        }
+
+        @Test
+        @DisplayName("총 일수는 당일을 포함한다(3박4일 = 4)")
+        void totalDaysIsInclusive() {
+            assertThat(tokyoTrip().totalDays()).isEqualTo(4);
+
+            Trip oneDay = new Trip(1L, "당일치기", "부산", LocalDate.of(2026, 10, 24),
+                    LocalDate.of(2026, 10, 24), "Asia/Seoul", "KRW");
+            assertThat(oneDay.totalDays()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("일차 번호는 시작일이 1일차")
+        void dayNumberStartsAtOne() {
+            Trip trip = tokyoTrip();
+            assertThat(trip.dayNumberOf(LocalDate.of(2026, 10, 24))).isEqualTo(1);
+            assertThat(trip.dayNumberOf(LocalDate.of(2026, 10, 27))).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("covers는 기간 경계를 포함하고 밖은 배제한다")
+        void coversIsInclusive() {
+            Trip trip = tokyoTrip();
+            assertThat(trip.covers(LocalDate.of(2026, 10, 23))).isFalse();
+            assertThat(trip.covers(LocalDate.of(2026, 10, 24))).isTrue();
+            assertThat(trip.covers(LocalDate.of(2026, 10, 27))).isTrue();
+            assertThat(trip.covers(LocalDate.of(2026, 10, 28))).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("타임존을 바꾸면 상태·D-day가 새 타임존 기준으로 다시 계산된다")
+    void statusFollowsUpdatedTimezone() {
+        Trip trip = tokyoTrip();
+        Clock clock = utcClockAt("2026-10-23T16:00:00Z");
+        assertThat(trip.status(clock)).isEqualTo(TripStatus.ONGOING);
+
+        // 같은 기간을 호놀룰루로 옮기면 그 지역은 아직 10/23이라 출발 전으로 돌아간다.
+        trip.update("하와이", "호놀룰루", trip.getStartDate(), trip.getEndDate(),
+                "Pacific/Honolulu", "USD");
+
+        assertThat(trip.status(clock)).isEqualTo(TripStatus.UPCOMING);
+        assertThat(trip.daysUntilStart(clock)).isEqualTo(1);
+    }
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TravelPlaceRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TravelPlaceRepositoryTest.java
@@ -1,0 +1,141 @@
+package ds.project.orino.domain.planner.travel.repository;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.support.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 장소 캐시 매핑과 재사용 규칙을 고정한다. 1단계에서는 쓰지 않지만(2단계부터 채운다) 테이블을
+ * 미리 만들었으므로 매핑이 맞는지는 지금 확인해 둔다 — 나중에 어긋나면 FK ALTER로 번진다.
+ */
+@RepositoryTest
+@Transactional
+class TravelPlaceRepositoryTest {
+
+    @Autowired
+    private TravelPlaceRepository placeRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        memberId = memberRepository.save(new Member("traveler", "pw")).getId();
+    }
+
+    @Test
+    @DisplayName("구글 장소는 기본 정보·상세가 그대로 저장·조회된다")
+    void savesGooglePlace() {
+        TravelPlace place = placeRepository.save(
+                TravelPlace.fromGoogle(memberId, "ChIJ8T1GpMGOGGARDYGSgpooDWw", "센소지"));
+        place.updateBasics("도쿄도 다이토구 아사쿠사 2-3-1", new BigDecimal("35.7147651"),
+                new BigDecimal("139.7966553"), "buddhist_temple", new BigDecimal("4.5"));
+        place.updateDetails("+81 3-3842-0181", "{\"weekdayText\":[\"월: 06:00~17:00\"]}",
+                "travel/places/senso-ji.jpg", "Google 사용자 제공",
+                Instant.parse("2026-08-07T00:00:00Z"));
+        placeRepository.flush();
+
+        TravelPlace found = placeRepository.findById(place.getId()).orElseThrow();
+        assertThat(found.getGooglePlaceId()).isEqualTo("ChIJ8T1GpMGOGGARDYGSgpooDWw");
+        assertThat(found.getName()).isEqualTo("센소지");
+        assertThat(found.getAddress()).isEqualTo("도쿄도 다이토구 아사쿠사 2-3-1");
+        assertThat(found.getLat()).isEqualByComparingTo("35.7147651");
+        assertThat(found.getLng()).isEqualByComparingTo("139.7966553");
+        assertThat(found.getCategory()).isEqualTo("buddhist_temple");
+        assertThat(found.getRating()).isEqualByComparingTo("4.5");
+        assertThat(found.getPhone()).isEqualTo("+81 3-3842-0181");
+        assertThat(found.getOpeningHours()).contains("06:00~17:00");
+        assertThat(found.getPhotoObjectKey()).isEqualTo("travel/places/senso-ji.jpg");
+        assertThat(found.getPhotoAttribution()).isEqualTo("Google 사용자 제공");
+        assertThat(found.isManualEntry()).isFalse();
+    }
+
+    @Test
+    @DisplayName("직접 입력한 장소는 구글 식별자 없이 저장된다")
+    void savesManualPlace() {
+        TravelPlace saved = placeRepository.save(TravelPlace.manual(memberId, "숙소 근처 골목 카페"));
+
+        TravelPlace found = placeRepository.findById(saved.getId()).orElseThrow();
+        assertThat(found.getGooglePlaceId()).isNull();
+        assertThat(found.isManualEntry()).isTrue();
+        assertThat(found.getDetailsRefreshedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("같은 구글 장소는 멤버 안에서 다시 찾아 재사용한다")
+    void findsExistingGooglePlace() {
+        placeRepository.save(TravelPlace.fromGoogle(memberId, "ChIJ_senso_ji", "센소지"));
+
+        assertThat(placeRepository.findByMemberIdAndGooglePlaceId(memberId, "ChIJ_senso_ji"))
+                .isPresent();
+        assertThat(placeRepository.findByMemberIdAndGooglePlaceId(memberId, "ChIJ_unknown"))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("장소는 멤버로 스코프된다 — 남의 장소를 재사용하지 않는다")
+    void scopedByMember() {
+        Long other = memberRepository.save(new Member("other", "pw")).getId();
+        Long id = placeRepository.save(
+                TravelPlace.fromGoogle(memberId, "ChIJ_senso_ji", "센소지")).getId();
+
+        assertThat(placeRepository.findByIdAndMemberId(id, memberId)).isPresent();
+        assertThat(placeRepository.findByIdAndMemberId(id, other)).isEmpty();
+        assertThat(placeRepository.findByMemberIdAndGooglePlaceId(other, "ChIJ_senso_ji")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("여러 일정의 장소를 id 배치로 한 번에 읽는다")
+    void findsByIdBatch() {
+        Long a = placeRepository.save(TravelPlace.fromGoogle(memberId, "ChIJ_a", "센소지")).getId();
+        Long b = placeRepository.save(TravelPlace.fromGoogle(memberId, "ChIJ_b", "우에노공원")).getId();
+        placeRepository.save(TravelPlace.fromGoogle(memberId, "ChIJ_c", "안 쓰는 곳"));
+
+        assertThat(placeRepository.findAllByIdIn(List.of(a, b)))
+                .extracting(TravelPlace::getName)
+                .containsExactlyInAnyOrder("센소지", "우에노공원");
+    }
+
+    @Test
+    @DisplayName("이름 부분일치로 직접 입력한 장소를 다시 고른다")
+    void searchesByNameFragment() {
+        placeRepository.save(TravelPlace.manual(memberId, "숙소 근처 카페"));
+        placeRepository.save(TravelPlace.manual(memberId, "역 앞 카페"));
+        placeRepository.save(TravelPlace.manual(memberId, "라멘집"));
+        Long other = memberRepository.save(new Member("other", "pw")).getId();
+        placeRepository.save(TravelPlace.manual(other, "남의 카페"));
+
+        assertThat(placeRepository.findAllByMemberIdAndNameContainingOrderByNameAsc(memberId, "카페"))
+                .extracting(TravelPlace::getName)
+                .containsExactly("숙소 근처 카페", "역 앞 카페");
+    }
+
+    @Test
+    @DisplayName("상세를 받은 적 없거나 30일이 지나면 재조회 대상이다")
+    void detailsExpireAfterTtl() {
+        TravelPlace place = placeRepository.save(
+                TravelPlace.fromGoogle(memberId, "ChIJ_senso_ji", "센소지"));
+        Instant now = Instant.parse("2026-09-06T00:00:00Z");
+
+        // 아직 상세를 받은 적 없다.
+        assertThat(place.needsDetailsRefresh(now)).isTrue();
+
+        place.updateDetails(null, "{}", null, null, Instant.parse("2026-08-07T00:00:00Z"));
+        // 30일 딱 지나기 전에는 캐시를 그대로 쓴다.
+        assertThat(place.needsDetailsRefresh(now)).isFalse();
+        assertThat(place.needsDetailsRefresh(Instant.parse("2026-09-06T00:00:01Z"))).isTrue();
+    }
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TripActivityRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TripActivityRepositoryTest.java
@@ -1,0 +1,279 @@
+package ds.project.orino.domain.planner.travel.repository;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import ds.project.orino.domain.planner.travel.entity.TripActivity;
+import ds.project.orino.domain.support.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 일정 매핑과 보드 조회 규칙을 고정한다. 핵심은 두 가지 — 벽시계 시각이 변환 없이 왕복하는지,
+ * 정렬이 시각이 아니라 {@code sortOrder}를 따르는지.
+ *
+ * <p>FK cascade(여행 삭제 → 일정 삭제)는 이 모듈이 {@code create-drop}으로 엔티티에서 스키마를
+ * 만들어(FK 없음) 검증할 수 없다 — Liquibase 스키마의 몫이라 app-api 통합 테스트·로컬 확인에서 본다.
+ */
+@RepositoryTest
+@Transactional
+class TripActivityRepositoryTest {
+
+    private static final LocalDate DAY1 = LocalDate.of(2026, 10, 24);
+    private static final LocalDate DAY2 = LocalDate.of(2026, 10, 25);
+
+    @Autowired
+    private TripActivityRepository activityRepository;
+    @Autowired
+    private TripRepository tripRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Long tripId;
+
+    @BeforeEach
+    void setUp() {
+        Long memberId = memberRepository.save(new Member("traveler", "pw")).getId();
+        tripId = tripRepository.save(new Trip(memberId, "도쿄", "도쿄", DAY1,
+                LocalDate.of(2026, 10, 27), "Asia/Tokyo", "JPY")).getId();
+    }
+
+    @Test
+    @DisplayName("일정 필드가 그대로 저장·조회된다")
+    void savesAndLoadsActivity() {
+        TripActivity saved = activityRepository.save(
+                new TripActivity(tripId, "센소지", DAY1, 0, LocalTime.of(10, 30)));
+        saved.update("센소지", LocalTime.of(10, 30), "나카미세 거리부터", "https://example.com/senso-ji");
+        activityRepository.flush();
+
+        TripActivity found = activityRepository.findById(saved.getId()).orElseThrow();
+        assertThat(found.getTripId()).isEqualTo(tripId);
+        assertThat(found.getTitle()).isEqualTo("센소지");
+        assertThat(found.getActivityDate()).isEqualTo(DAY1);
+        assertThat(found.getSortOrder()).isZero();
+        assertThat(found.getMemo()).isEqualTo("나카미세 거리부터");
+        assertThat(found.getUrl()).isEqualTo("https://example.com/senso-ji");
+        assertThat(found.getPlaceId()).isNull();
+        assertThat(found.isNotifyEnabled()).isFalse();
+        assertThat(found.getNotifyMinutes()).isNull();
+        assertThat(found.isDepartureNotifyEnabled()).isFalse();
+        assertThat(found.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("시작 시각은 벽시계 값 그대로 왕복한다(UTC 변환 없음)")
+    void startTimeRoundTripsAsWallClock() {
+        // 서버·JDBC가 UTC로 돌아도 09:00은 09:00이어야 한다. 환산이 끼면 여기서 어긋난다.
+        Long id = activityRepository.save(
+                new TripActivity(tripId, "이른 출발", DAY1, 0, LocalTime.of(9, 0))).getId();
+
+        assertThat(activityRepository.findById(id).orElseThrow().getStartTime())
+                .isEqualTo(LocalTime.of(9, 0));
+    }
+
+    @Test
+    @DisplayName("자정 직후·직전 시각도 날짜를 넘기지 않는다")
+    void keepsMidnightBoundaryTimes() {
+        Long justAfter = activityRepository.save(
+                new TripActivity(tripId, "심야 도착", DAY1, 0, LocalTime.of(0, 5))).getId();
+        Long justBefore = activityRepository.save(
+                new TripActivity(tripId, "막차", DAY1, 1, LocalTime.of(23, 55))).getId();
+
+        assertThat(activityRepository.findById(justAfter).orElseThrow().getStartTime())
+                .isEqualTo(LocalTime.of(0, 5));
+        assertThat(activityRepository.findById(justAfter).orElseThrow().getActivityDate())
+                .isEqualTo(DAY1);
+        assertThat(activityRepository.findById(justBefore).orElseThrow().getStartTime())
+                .isEqualTo(LocalTime.of(23, 55));
+    }
+
+    @Test
+    @DisplayName("보드 정렬은 시각이 아니라 sort_order를 따른다")
+    void ordersBySortOrderNotByTime() {
+        // 시각으로 정렬하면 09:00이 앞서지만, 사용자가 드래그로 정한 순서가 우선이다.
+        Long late = activityRepository.save(
+                new TripActivity(tripId, "늦은 일정", DAY1, 0, LocalTime.of(18, 0))).getId();
+        Long early = activityRepository.save(
+                new TripActivity(tripId, "이른 일정", DAY1, 1, LocalTime.of(9, 0))).getId();
+
+        assertThat(activityRepository
+                .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(tripId, DAY1))
+                .extracting(TripActivity::getId)
+                .containsExactly(late, early);
+    }
+
+    @Test
+    @DisplayName("시각 없는 일정도 순서대로 섞여 들어간다")
+    void allowsActivitiesWithoutTime() {
+        Long timed = activityRepository.save(
+                new TripActivity(tripId, "조식", DAY1, 0, LocalTime.of(8, 0))).getId();
+        Long untimed = activityRepository.save(
+                new TripActivity(tripId, "동네 산책", DAY1, 1, null)).getId();
+
+        List<TripActivity> day1 = activityRepository
+                .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(tripId, DAY1);
+
+        assertThat(day1).extracting(TripActivity::getId).containsExactly(timed, untimed);
+        assertThat(day1.get(1).getStartTime()).isNull();
+    }
+
+    @Test
+    @DisplayName("보드 조회는 보관함을 먼저, 이어서 날짜·순서대로 준다")
+    void boardQueryPutsUnscheduledFirst() {
+        Long day2 = activityRepository.save(
+                new TripActivity(tripId, "디즈니씨", DAY2, 0, null)).getId();
+        Long day1b = activityRepository.save(
+                new TripActivity(tripId, "우에노", DAY1, 1, null)).getId();
+        Long day1a = activityRepository.save(
+                new TripActivity(tripId, "센소지", DAY1, 0, null)).getId();
+        Long archived = activityRepository.save(
+                new TripActivity(tripId, "가고 싶은 라멘집", null, 0, null)).getId();
+
+        assertThat(activityRepository.findAllByTripIdOrderByActivityDateAscSortOrderAscIdAsc(tripId))
+                .extracting(TripActivity::getId)
+                .containsExactly(archived, day1a, day1b, day2);
+    }
+
+    @Test
+    @DisplayName("보관함 조회는 날짜 없는 일정만 순서대로 준다")
+    void findsUnscheduledOnly() {
+        activityRepository.save(new TripActivity(tripId, "센소지", DAY1, 0, null));
+        Long second = activityRepository.save(
+                new TripActivity(tripId, "후보 B", null, 1, null)).getId();
+        Long first = activityRepository.save(
+                new TripActivity(tripId, "후보 A", null, 0, null)).getId();
+
+        assertThat(activityRepository.findUnscheduled(tripId))
+                .extracting(TripActivity::getId)
+                .containsExactly(first, second);
+    }
+
+    @Test
+    @DisplayName("보드·보관함 조회는 다른 여행의 일정을 섞지 않는다")
+    void scopedByTrip() {
+        Long otherMember = memberRepository.save(new Member("other", "pw")).getId();
+        Long otherTrip = tripRepository.save(new Trip(otherMember, "오사카", "오사카", DAY1,
+                DAY2, "Asia/Tokyo", "JPY")).getId();
+        activityRepository.save(new TripActivity(otherTrip, "남의 일정", DAY1, 0, null));
+        activityRepository.save(new TripActivity(otherTrip, "남의 후보", null, 0, null));
+        Long mine = activityRepository.save(new TripActivity(tripId, "센소지", DAY1, 0, null)).getId();
+
+        assertThat(activityRepository.findAllByTripIdOrderByActivityDateAscSortOrderAscIdAsc(tripId))
+                .extracting(TripActivity::getId)
+                .containsExactly(mine);
+        assertThat(activityRepository.findUnscheduled(tripId)).isEmpty();
+        assertThat(activityRepository.countByTripId(tripId)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("findByIdAndTripId는 다른 여행의 일정을 넘겨주지 않는다")
+    void findByIdScopedByTrip() {
+        Long otherMember = memberRepository.save(new Member("other", "pw")).getId();
+        Long otherTrip = tripRepository.save(new Trip(otherMember, "오사카", "오사카", DAY1,
+                DAY2, "Asia/Tokyo", "JPY")).getId();
+        Long id = activityRepository.save(new TripActivity(tripId, "센소지", DAY1, 0, null)).getId();
+
+        assertThat(activityRepository.findByIdAndTripId(id, tripId)).isPresent();
+        assertThat(activityRepository.findByIdAndTripId(id, otherTrip)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("nextSortOrder는 그 날짜의 맨 뒤 순서를 준다(빈 날짜면 0)")
+    void nextSortOrderPerDate() {
+        assertThat(activityRepository.nextSortOrder(tripId, DAY1)).isZero();
+
+        activityRepository.save(new TripActivity(tripId, "센소지", DAY1, 0, null));
+        activityRepository.save(new TripActivity(tripId, "우에노", DAY1, 1, null));
+        // 다른 날짜는 자기 순서를 따로 센다.
+        activityRepository.save(new TripActivity(tripId, "디즈니씨", DAY2, 0, null));
+
+        assertThat(activityRepository.nextSortOrder(tripId, DAY1)).isEqualTo(2);
+        assertThat(activityRepository.nextSortOrder(tripId, DAY2)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("nextSortOrder는 날짜가 null이면 보관함 순서를 센다")
+    void nextSortOrderForArchive() {
+        activityRepository.save(new TripActivity(tripId, "센소지", DAY1, 0, null));
+        assertThat(activityRepository.nextSortOrder(tripId, null)).isZero();
+
+        activityRepository.save(new TripActivity(tripId, "후보 A", null, 0, null));
+
+        assertThat(activityRepository.nextSortOrder(tripId, null)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("기간이 줄면 밖으로 밀려난 일정만 골라낸다(보관함은 대상 아님)")
+    void findsActivitiesOutsideShrunkPeriod() {
+        Long before = activityRepository.save(
+                new TripActivity(tripId, "출발 전날", LocalDate.of(2026, 10, 23), 0, null)).getId();
+        Long after = activityRepository.save(
+                new TripActivity(tripId, "마지막날", LocalDate.of(2026, 10, 27), 0, null)).getId();
+        activityRepository.save(new TripActivity(tripId, "센소지", DAY1, 0, null));
+        activityRepository.save(new TripActivity(tripId, "후보 라멘집", null, 0, null));
+
+        // 기간을 10/24~10/26으로 줄였다.
+        assertThat(activityRepository.findOutsidePeriod(tripId, DAY1, LocalDate.of(2026, 10, 26)))
+                .extracting(TripActivity::getId)
+                .containsExactly(before, after);
+    }
+
+    @Test
+    @DisplayName("날짜 이동은 activity_date와 sort_order를 함께 바꾼다")
+    void moveAcrossDates() {
+        TripActivity activity = activityRepository.save(
+                new TripActivity(tripId, "센소지", DAY1, 3, LocalTime.of(10, 0)));
+
+        activity.moveTo(DAY2, 0);
+        activityRepository.flush();
+
+        TripActivity found = activityRepository.findById(activity.getId()).orElseThrow();
+        assertThat(found.getActivityDate()).isEqualTo(DAY2);
+        assertThat(found.getSortOrder()).isZero();
+        assertThat(activityRepository
+                .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(tripId, DAY1)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("보관함으로 내린 일정은 날짜 조회에서 빠지고 보관함 조회에 잡힌다")
+    void moveToArchive() {
+        TripActivity activity = activityRepository.save(
+                new TripActivity(tripId, "센소지", DAY1, 0, LocalTime.of(10, 0)));
+
+        activity.moveTo(null, 0);
+        activityRepository.flush();
+
+        assertThat(activityRepository
+                .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(tripId, DAY1)).isEmpty();
+        assertThat(activityRepository.findUnscheduled(tripId))
+                .extracting(TripActivity::getId)
+                .containsExactly(activity.getId());
+    }
+
+    @Test
+    @DisplayName("재인덱싱하면 0..n-1 순서로 다시 읽힌다")
+    void reindexesWithinDay() {
+        TripActivity a = activityRepository.save(new TripActivity(tripId, "A", DAY1, 0, null));
+        TripActivity b = activityRepository.save(new TripActivity(tripId, "B", DAY1, 1, null));
+        TripActivity c = activityRepository.save(new TripActivity(tripId, "C", DAY1, 2, null));
+
+        // C를 맨 앞으로 끌어올린 뒤 전체를 0..n-1로 재부여한다.
+        List.of(c, a, b).forEach(activity ->
+                activity.reorderTo(List.of(c, a, b).indexOf(activity)));
+        activityRepository.flush();
+
+        assertThat(activityRepository
+                .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(tripId, DAY1))
+                .extracting(TripActivity::getTitle)
+                .containsExactly("C", "A", "B");
+    }
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TripRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TripRepositoryTest.java
@@ -1,0 +1,194 @@
+package ds.project.orino.domain.planner.travel.repository;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import ds.project.orino.domain.support.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 여행 매핑과 목록 조회 규칙을 고정한다. 상태(예정/진행 중/완료)로 거르는 쿼리는 없다 —
+ * 상태는 컬럼이 아니라 여행 타임존의 오늘로 파생하는 값이라 SQL에서 판정할 수 없고,
+ * 여기서는 그 대신 쓰는 기간 비교 조회만 검증한다(파생 판정은 {@code TripTest}).
+ */
+@RepositoryTest
+@Transactional
+class TripRepositoryTest {
+
+    @Autowired
+    private TripRepository tripRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        memberId = memberRepository.save(new Member("traveler", "pw")).getId();
+    }
+
+    @Test
+    @DisplayName("여행 필드가 그대로 저장·조회되고 알림 기본값이 붙는다")
+    void savesAndLoadsTrip() {
+        Trip saved = tripRepository.save(new Trip(memberId, "도쿄 3박4일", "도쿄",
+                LocalDate.of(2026, 10, 24), LocalDate.of(2026, 10, 27), "Asia/Tokyo", "JPY"));
+
+        Trip found = tripRepository.findById(saved.getId()).orElseThrow();
+        assertThat(found.getMemberId()).isEqualTo(memberId);
+        assertThat(found.getTitle()).isEqualTo("도쿄 3박4일");
+        assertThat(found.getDestinationName()).isEqualTo("도쿄");
+        assertThat(found.getStartDate()).isEqualTo(LocalDate.of(2026, 10, 24));
+        assertThat(found.getEndDate()).isEqualTo(LocalDate.of(2026, 10, 27));
+        assertThat(found.getTimezone()).isEqualTo("Asia/Tokyo");
+        assertThat(found.getCurrency()).isEqualTo("JPY");
+        assertThat(found.getDefaultNotifyMinutes()).isEqualTo(15);
+        assertThat(found.isMorningSummaryEnabled()).isFalse();
+        // 1단계는 목적지를 수동 입력하므로 장소 참조가 비어 있다.
+        assertThat(found.getDestinationPlaceId()).isNull();
+        assertThat(found.getCreatedAt()).isNotNull();
+        assertThat(found.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("목적지 좌표(날씨 기준점)는 소수점 7자리까지 보존된다")
+    void keepsCoordinatePrecision() {
+        Trip trip = tripRepository.save(tokyoTrip());
+        trip.updateDestinationPlace(null, new BigDecimal("35.6812362"), new BigDecimal("139.7671248"));
+        tripRepository.flush();
+
+        Trip found = tripRepository.findById(trip.getId()).orElseThrow();
+        assertThat(found.getLat()).isEqualByComparingTo("35.6812362");
+        assertThat(found.getLng()).isEqualByComparingTo("139.7671248");
+    }
+
+    @Test
+    @DisplayName("findByIdAndMemberId는 다른 멤버의 여행을 넘겨주지 않는다")
+    void scopedByMember() {
+        Long other = memberRepository.save(new Member("other", "pw")).getId();
+        Long id = tripRepository.save(tokyoTrip()).getId();
+
+        assertThat(tripRepository.findByIdAndMemberId(id, memberId)).isPresent();
+        assertThat(tripRepository.findByIdAndMemberId(id, other)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("예정·진행 중 목록은 아직 끝나지 않은 여행을 시작일 오름차순으로 준다")
+    void listsUnfinishedByStartDateAsc() {
+        LocalDate today = LocalDate.of(2026, 10, 25);
+        Long ongoing = tripRepository.save(trip("도쿄", "2026-10-24", "2026-10-27")).getId();
+        Long soon = tripRepository.save(trip("오사카", "2026-11-02", "2026-11-05")).getId();
+        Long later = tripRepository.save(trip("삿포로", "2026-12-01", "2026-12-04")).getId();
+        // 어제 끝난 여행은 빠져야 한다.
+        tripRepository.save(trip("제주", "2026-10-20", "2026-10-24"));
+
+        List<Long> ids = tripRepository
+                .findAllByMemberIdAndEndDateGreaterThanEqualOrderByStartDateAscIdAsc(memberId, today)
+                .stream().map(Trip::getId).toList();
+
+        assertThat(ids).containsExactly(ongoing, soon, later);
+    }
+
+    @Test
+    @DisplayName("오늘 끝나는 여행은 아직 진행 중이라 예정·진행 중 목록에 남는다")
+    void endingTodayStaysInUnfinishedList() {
+        LocalDate today = LocalDate.of(2026, 10, 27);
+        Long endsToday = tripRepository.save(trip("도쿄", "2026-10-24", "2026-10-27")).getId();
+
+        assertThat(tripRepository
+                .findAllByMemberIdAndEndDateGreaterThanEqualOrderByStartDateAscIdAsc(memberId, today))
+                .extracting(Trip::getId)
+                .containsExactly(endsToday);
+        assertThat(tripRepository
+                .findAllByMemberIdAndEndDateLessThanOrderByEndDateDescIdDesc(memberId, today))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("완료 목록은 끝난 여행을 종료일 내림차순으로 준다")
+    void listsCompletedByEndDateDesc() {
+        LocalDate today = LocalDate.of(2026, 10, 28);
+        Long older = tripRepository.save(trip("제주", "2026-05-01", "2026-05-03")).getId();
+        Long recent = tripRepository.save(trip("도쿄", "2026-10-24", "2026-10-27")).getId();
+        tripRepository.save(trip("오사카", "2026-11-02", "2026-11-05"));    // 아직 안 감
+
+        List<Long> ids = tripRepository
+                .findAllByMemberIdAndEndDateLessThanOrderByEndDateDescIdDesc(memberId, today)
+                .stream().map(Trip::getId).toList();
+
+        assertThat(ids).containsExactly(recent, older);
+    }
+
+    @Test
+    @DisplayName("목록 조회는 다른 멤버의 여행을 섞지 않는다")
+    void listsScopedByMember() {
+        Long other = memberRepository.save(new Member("other", "pw")).getId();
+        tripRepository.save(tokyoTrip());
+        tripRepository.save(new Trip(other, "남의 여행", "파리",
+                LocalDate.of(2026, 10, 24), LocalDate.of(2026, 10, 27), "Europe/Paris", "EUR"));
+
+        assertThat(tripRepository.findAllByMemberIdOrderByStartDateDescIdDesc(memberId))
+                .extracting(Trip::getTitle)
+                .containsExactly("도쿄");
+    }
+
+    @Test
+    @DisplayName("전체 목록은 최근 여행이 위로 온다")
+    void listsAllByStartDateDesc() {
+        Long may = tripRepository.save(trip("제주", "2026-05-01", "2026-05-03")).getId();
+        Long dec = tripRepository.save(trip("삿포로", "2026-12-01", "2026-12-04")).getId();
+        Long oct = tripRepository.save(trip("도쿄", "2026-10-24", "2026-10-27")).getId();
+
+        assertThat(tripRepository.findAllByMemberIdOrderByStartDateDescIdDesc(memberId))
+                .extracting(Trip::getId)
+                .containsExactly(dec, oct, may);
+    }
+
+    @Test
+    @DisplayName("update는 기간·타임존·통화를 함께 바꾼다")
+    void updatesBasics() {
+        Trip trip = tripRepository.save(tokyoTrip());
+
+        trip.update("오사카 2박3일", "오사카", LocalDate.of(2026, 11, 2),
+                LocalDate.of(2026, 11, 4), "Asia/Tokyo", "JPY");
+        tripRepository.flush();
+
+        Trip found = tripRepository.findById(trip.getId()).orElseThrow();
+        assertThat(found.getTitle()).isEqualTo("오사카 2박3일");
+        assertThat(found.getDestinationName()).isEqualTo("오사카");
+        assertThat(found.getStartDate()).isEqualTo(LocalDate.of(2026, 11, 2));
+        assertThat(found.getEndDate()).isEqualTo(LocalDate.of(2026, 11, 4));
+        assertThat(found.totalDays()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("알림 설정(기본 시점·아침 요약)이 저장된다")
+    void updatesNotificationSettings() {
+        Trip trip = tripRepository.save(tokyoTrip());
+
+        trip.updateNotificationSettings(30, true);
+        tripRepository.flush();
+
+        Trip found = tripRepository.findById(trip.getId()).orElseThrow();
+        assertThat(found.getDefaultNotifyMinutes()).isEqualTo(30);
+        assertThat(found.isMorningSummaryEnabled()).isTrue();
+    }
+
+    private Trip tokyoTrip() {
+        return trip("도쿄", "2026-10-24", "2026-10-27");
+    }
+
+    private Trip trip(String title, String startDate, String endDate) {
+        return new Trip(memberId, title, title, LocalDate.parse(startDate),
+                LocalDate.parse(endDate), "Asia/Tokyo", "JPY");
+    }
+}


### PR DESCRIPTION
## 이슈
closes #1030

## 작업 내용

여행 모듈 BE 토대. [데이터 모델](https://github.com/wcorn/orino/wiki/Travel-Data-Model) §2.1~2.3의 세 테이블과 엔티티를 만들었다. (Epic #1029 · 1단계)

### 스키마 (`047-create-travel-tables.yaml`)
- `trip` · `trip_activity` · `travel_place` 생성 + master changelog 등록
- 인덱스: `idx_trip_member_start` · `idx_trip_member_end` · `idx_activity_trip_date_order` · `uk_place_member_google` · `idx_place_member_name`
- FK: `trip_activity → trip` ON DELETE CASCADE, `trip_activity → travel_place` ON DELETE SET NULL
- `travel_place`는 1단계에 쓰지 않지만 지금 만든다 — FK를 나중에 붙이면 ALTER가 필요하다

### 엔티티 · Repository
- `Trip` · `TripActivity` · `TravelPlace` + Repository 3종 (`domain.planner.travel`)
- `TripStatus` enum — **컬럼 없이 파생**. `LocalDate.now(ZoneId.of(trip.timezone))` 기준으로 판정하고, D-day·일차·기간 포함 여부도 같은 기준을 쓴다
- 알림 유효성(`isNotifiable`)은 DB 제약이 아니라 엔티티가 판정한다 — 시각 없는 일정·보관함 일정은 알림을 만들지 않는다

### 설계에서 바꾼 것 — `manual` → `manual_entry`

`travel_place.manual`은 **MySQL 8.4 예약어**라 그대로 쓰면 DDL과 Hibernate SQL이 모두 문법 오류로 깨진다(실제로 테스트가 깨져서 발견했고, MySQL 8.4.4 컨테이너로 예약어임을 확인했다). `manual_entry`로 교체하고 [Wiki 데이터 모델](https://github.com/wcorn/orino/wiki/Travel-Data-Model)도 함께 수정했다.

## 테스트

| 대상 | 내용 |
|---|---|
| `TripTest` | 상태 파생 — 기기 시간대가 아닌 **여행 타임존의 오늘**로 판정하는지(도쿄·호놀룰루 날짜변경선 케이스), 경계 포함, D-day·일차·타임존 변경 재계산 |
| `TripActivityTest` | 알림 유효성(시각 없음·보관함·스위치 꺼짐), 알림 시점 폴백, 보관함 이동 |
| `TripRepositoryTest` | 매핑·좌표 정밀도·멤버 스코프·목록 정렬(오늘 끝나는 여행 경계 포함) |
| `TripActivityRepositoryTest` | **벽시계 시각 왕복**(자정 경계 포함), 시각이 아닌 `sort_order` 정렬, 보관함 조회, `nextSortOrder`, 기간 축소 시 밖으로 밀려난 일정, 날짜 이동·재인덱싱 |
| `TravelPlaceRepositoryTest` | 구글/직접 입력 장소, 멤버 스코프, 배치 조회, 상세 30일 만료 |
| `TravelSchemaTest` (신규) | Hibernate `validate`가 안 보는 것 — **FK 삭제 규칙 · 인덱스 · 컬럼 타입**. 여행 삭제 cascade와 장소 삭제 SET NULL을 실제 DELETE로 확인한다 |

도메인 모듈 테스트는 `create-drop`이라 FK가 없어 cascade를 볼 수 없다. 그래서 Liquibase 스키마가 적용되는 app-api 쪽에 `TravelSchemaTest`를 뒀다 — `activity_date`가 `DATETIME`으로 바뀌거나 인덱스가 빠지면 여기서 걸린다.

`./gradlew check` 통과 (테스트 + Checkstyle 경고 0). `SchemaValidationTest`로 Liquibase 047과 엔티티 일치도 확인했다.