### PR TITLE
feat : 여행 CRUD API

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/controller/TripController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/controller/TripController.java
@@ -1,0 +1,91 @@
+package ds.project.orino.planner.travel.trip.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.domain.planner.travel.entity.TripStatus;
+import ds.project.orino.planner.travel.trip.dto.ShrinkPreviewResponse;
+import ds.project.orino.planner.travel.trip.dto.TravelSummaryResponse;
+import ds.project.orino.planner.travel.trip.dto.TripDetail;
+import ds.project.orino.planner.travel.trip.dto.TripListResponse;
+import ds.project.orino.planner.travel.trip.dto.TripWriteRequest;
+import ds.project.orino.planner.travel.trip.service.TripService;
+import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/travel")
+public class TripController {
+
+    private final TripService tripService;
+
+    public TripController(TripService tripService) {
+        this.tripService = tripService;
+    }
+
+    /** `/select` 카드와 여행 홈(S-01)이 함께 쓰는 요약. */
+    @GetMapping("/summary")
+    public ApiResponse<TravelSummaryResponse> summary(@AuthenticationPrincipal Long memberId) {
+        return ApiResponse.success(tripService.summary(memberId));
+    }
+
+    /** 여행 목록(S-02). {@code status} 생략 시 전체. 정렬은 서버가 확정한다. */
+    @GetMapping("/trips")
+    public ApiResponse<TripListResponse> list(@AuthenticationPrincipal Long memberId,
+                                              @RequestParam(required = false) TripStatus status) {
+        return ApiResponse.success(tripService.list(memberId, status));
+    }
+
+    @PostMapping("/trips")
+    public ApiResponse<TripDetail> create(@AuthenticationPrincipal Long memberId,
+                                          @Valid @RequestBody TripWriteRequest request) {
+        return ApiResponse.success(tripService.create(memberId, request));
+    }
+
+    @GetMapping("/trips/{tripId}")
+    public ApiResponse<TripDetail> detail(@AuthenticationPrincipal Long memberId,
+                                          @PathVariable Long tripId) {
+        return ApiResponse.success(tripService.detail(memberId, tripId));
+    }
+
+    /**
+     * 전체 수정. 기간이 줄어 일정이 잘리는데 {@code confirmArchive}가 없으면 409로 거부하고
+     * 이동 예정 건수를 함께 돌려준다.
+     */
+    @PutMapping("/trips/{tripId}")
+    public ApiResponse<TripDetail> update(@AuthenticationPrincipal Long memberId,
+                                          @PathVariable Long tripId,
+                                          @Valid @RequestBody TripWriteRequest request) {
+        return ApiResponse.success(tripService.update(memberId, tripId, request));
+    }
+
+    @DeleteMapping("/trips/{tripId}")
+    public ApiResponse<Void> delete(@AuthenticationPrincipal Long memberId,
+                                    @PathVariable Long tripId) {
+        tripService.delete(memberId, tripId);
+        return ApiResponse.success();
+    }
+
+    /** 기간 단축 확인 모달용 — 이 기간으로 바꾸면 보관함으로 갈 일정 수. */
+    @GetMapping("/trips/{tripId}/shrink-preview")
+    public ApiResponse<ShrinkPreviewResponse> shrinkPreview(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long tripId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate endDate) {
+        return ApiResponse.success(
+                tripService.shrinkPreview(memberId, tripId, startDate, endDate));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/ShrinkPreviewResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/ShrinkPreviewResponse.java
@@ -1,0 +1,11 @@
+package ds.project.orino.planner.travel.trip.dto;
+
+/**
+ * 기간을 줄였을 때 보관함으로 밀려날 일정 수. 확인 모달의 "일정 {n}개가 미배정 보관함으로
+ * 이동합니다."에 그대로 들어간다.
+ *
+ * <p>기간 단축을 확인 없이 시도했을 때의 409 응답에도 같은 형태로 실린다 — 클라이언트가
+ * 미리보기를 건너뛰었더라도 같은 숫자를 보고 다시 물어볼 수 있어야 한다.
+ */
+public record ShrinkPreviewResponse(long movedActivityCount) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TravelSummaryResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TravelSummaryResponse.java
@@ -1,0 +1,43 @@
+package ds.project.orino.planner.travel.trip.dto;
+
+import java.time.LocalDate;
+
+/**
+ * 워크스페이스 선택 화면(`/select`)의 여행 카드와 여행 홈(S-01)이 함께 쓰는 요약.
+ *
+ * <p>세 필드가 전부 {@code null}이면 FE는 "여행 만들기" 단일 버튼만 그린다.
+ *
+ * @param ongoing         진행 중 여행. 보드로 바로 들어가는 용도라 최소 정보만 담는다
+ * @param next            다음 예정 여행(진행 중이 있어도 별개로 내려간다)
+ * @param recentCompleted 가장 최근에 끝난 여행
+ */
+public record TravelSummaryResponse(
+        OngoingTrip ongoing,
+        NextTrip next,
+        CompletedTrip recentCompleted
+) {
+
+    /** 진행 중 여행 — 탭하면 곧장 보드로 간다. */
+    public record OngoingTrip(Long id, String title, String boardPath) {
+
+        public static OngoingTrip of(Long id, String title) {
+            return new OngoingTrip(id, title, "/travel/trips/%d/board".formatted(id));
+        }
+    }
+
+    /** 예정 여행 — D-day 카운트다운 카드. */
+    public record NextTrip(
+            Long id,
+            String title,
+            String destinationName,
+            LocalDate startDate,
+            LocalDate endDate,
+            long dDay,
+            long activityCount
+    ) {
+    }
+
+    /** 완료 여행 — 돌아보기 카드. */
+    public record CompletedTrip(Long id, String title, LocalDate endDate, long activityCount) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripDetail.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripDetail.java
@@ -1,0 +1,30 @@
+package ds.project.orino.planner.travel.trip.dto;
+
+import ds.project.orino.domain.planner.travel.entity.TripStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 여행 상세. 수정 화면(S-03)이 폼을 그대로 채울 수 있도록 저장된 값을 전부 내려주고,
+ * 파생값({@code status}·{@code dDay}·{@code totalDays})을 덧붙인다.
+ */
+public record TripDetail(
+        Long id,
+        String title,
+        String destinationName,
+        Long destinationPlaceId,
+        LocalDate startDate,
+        LocalDate endDate,
+        String timezone,
+        String currency,
+        BigDecimal lat,
+        BigDecimal lng,
+        int defaultNotifyMinutes,
+        boolean morningSummaryEnabled,
+        TripStatus status,
+        long dDay,
+        int totalDays,
+        long activityCount
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripListResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripListResponse.java
@@ -1,0 +1,17 @@
+package ds.project.orino.planner.travel.trip.dto;
+
+import java.util.List;
+
+/**
+ * 여행 목록 화면(S-02) 응답.
+ *
+ * @param counts 탭 라벨 뒤 건수. {@code status} 필터와 무관하게 항상 전체 기준으로 센다 —
+ *               필터된 목록에서 세면 탭을 옮길 때마다 다른 탭의 숫자가 0이 된다
+ * @param trips  필터·정렬이 적용된 목록
+ */
+public record TripListResponse(TripCounts counts, List<TripSummary> trips) {
+
+    /** 상태별 여행 수. */
+    public record TripCounts(long upcoming, long ongoing, long completed) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripSummary.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripSummary.java
@@ -1,0 +1,24 @@
+package ds.project.orino.planner.travel.trip.dto;
+
+import ds.project.orino.domain.planner.travel.entity.TripStatus;
+
+import java.time.LocalDate;
+
+/**
+ * 여행 목록 카드 하나.
+ *
+ * @param status        저장된 값이 아니라 여행 타임존의 오늘로 파생한 상태
+ * @param dDay          시작일까지 남은 일수. 시작 당일 0, 이미 시작했으면 음수
+ * @param activityCount 보관함을 포함한 전체 일정 수
+ */
+public record TripSummary(
+        Long id,
+        String title,
+        String destinationName,
+        LocalDate startDate,
+        LocalDate endDate,
+        TripStatus status,
+        long dDay,
+        long activityCount
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripWriteRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripWriteRequest.java
@@ -1,0 +1,74 @@
+package ds.project.orino.planner.travel.trip.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 여행 생성·수정 요청. 생성과 수정이 같은 필드를 쓰므로(전체 수정) 한 타입으로 둔다.
+ *
+ * <p>날짜는 여행 타임존의 벽시계 값이다 — UTC 오프셋을 붙이지 않는다.
+ *
+ * @param title                  최대 50자. 비우면 {@code destinationName}으로 채워 저장한다
+ * @param destinationName        목적지 표시명(필수)
+ * @param destinationPlaceId     2단계~. 1단계는 생략한다
+ * @param timezone               IANA 타임존 ID. 상태·D-day·알림 환산의 기준이라 값 검증을 한다
+ * @param currency               ISO 4217 3자리
+ * @param lat                    목적지 좌표(날씨 기준점)
+ * @param defaultNotifyMinutes   여행 단위 기본 알림 시점(분 전). 생략 시 기존값 유지
+ * @param morningSummaryEnabled  아침 요약 알림. 생략 시 기존값 유지
+ * @param confirmArchive         기간 단축으로 잘리는 일정을 보관함으로 옮겨도 좋다는 확인.
+ *                               없으면 서버가 409로 거부한다
+ */
+public record TripWriteRequest(
+        @Size(max = 50, message = "제목은 50자를 넘을 수 없습니다.")
+        String title,
+
+        @NotBlank(message = "목적지를 입력해 주세요.")
+        @Size(max = 100, message = "목적지는 100자를 넘을 수 없습니다.")
+        String destinationName,
+
+        Long destinationPlaceId,
+
+        @NotNull(message = "시작일을 입력해 주세요.")
+        LocalDate startDate,
+
+        @NotNull(message = "종료일을 입력해 주세요.")
+        LocalDate endDate,
+
+        @NotBlank(message = "시간대를 입력해 주세요.")
+        String timezone,
+
+        @NotBlank(message = "통화를 입력해 주세요.")
+        String currency,
+
+        BigDecimal lat,
+        BigDecimal lng,
+
+        @Positive(message = "알림 시점은 0보다 커야 합니다.")
+        Integer defaultNotifyMinutes,
+
+        Boolean morningSummaryEnabled,
+        Boolean confirmArchive
+) {
+
+    /** 제목 컬럼 길이. 목적지명(100자)으로 채울 때 넘칠 수 있어 여기서 자른다. */
+    private static final int TITLE_MAX = 50;
+
+    /** 제목 미입력 시 목적지명으로 채운다 — 제목 없는 여행 카드를 만들지 않는다. */
+    public String resolvedTitle() {
+        if (title != null && !title.isBlank()) {
+            return title.trim();
+        }
+        String fallback = destinationName.trim();
+        return fallback.length() <= TITLE_MAX ? fallback : fallback.substring(0, TITLE_MAX);
+    }
+
+    public boolean archiveConfirmed() {
+        return Boolean.TRUE.equals(confirmArchive);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/service/TripService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/service/TripService.java
@@ -1,0 +1,284 @@
+package ds.project.orino.planner.travel.trip.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import ds.project.orino.domain.planner.travel.entity.TripActivity;
+import ds.project.orino.domain.planner.travel.entity.TripStatus;
+import ds.project.orino.domain.planner.travel.repository.TripActivityCount;
+import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
+import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.trip.dto.ShrinkPreviewResponse;
+import ds.project.orino.planner.travel.trip.dto.TravelSummaryResponse;
+import ds.project.orino.planner.travel.trip.dto.TripDetail;
+import ds.project.orino.planner.travel.trip.dto.TripListResponse;
+import ds.project.orino.planner.travel.trip.dto.TripSummary;
+import ds.project.orino.planner.travel.trip.dto.TripWriteRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.Currency;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * 여행 CRUD와 기간 단축 처리.
+ *
+ * <p>상태(예정/진행 중/완료)와 D-day는 <b>저장하지 않고 매 조회 시 파생한다</b>. 기준은 기기
+ * 시간대가 아니라 각 여행의 타임존이라, 목록에서도 여행마다 자기 타임존으로 따로 판정한다
+ * (도쿄 여행과 하와이 여행이 같은 순간에 서로 다른 "오늘"을 갖는다).
+ *
+ * <p>기간을 줄이면 잘려나간 일정을 <b>지우지 않고 보관함으로 옮긴다</b>. 사용자가 모르고 일정을
+ * 잃는 일이 없도록, 확인({@code confirmArchive}) 없이 들어온 단축 요청은 409로 되돌려보낸다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class TripService {
+
+    private final TripRepository tripRepository;
+    private final TripActivityRepository activityRepository;
+    private final Clock clock;
+
+    public TripService(TripRepository tripRepository,
+                       TripActivityRepository activityRepository,
+                       Clock clock) {
+        this.tripRepository = tripRepository;
+        this.activityRepository = activityRepository;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public TripDetail create(Long memberId, TripWriteRequest request) {
+        validate(request);
+        Trip trip = new Trip(memberId, request.resolvedTitle(), request.destinationName().trim(),
+                request.startDate(), request.endDate(), request.timezone(),
+                normalizedCurrency(request.currency()));
+        applyOptionalSettings(trip, request);
+        return detailOf(tripRepository.save(trip));
+    }
+
+    public TripListResponse list(Long memberId, TripStatus status) {
+        List<Trip> all = tripRepository.findAllByMemberIdOrderByStartDateDescIdDesc(memberId);
+        // 건수는 필터와 무관하게 전체 기준으로 센다 — 탭을 옮길 때마다 다른 탭 숫자가 0이 되면 안 된다.
+        TripListResponse.TripCounts counts = countByStatus(all);
+
+        List<Trip> filtered = status == null ? all
+                : all.stream().filter(trip -> statusOf(trip) == status).toList();
+        List<Trip> sorted = sortForDisplay(filtered);
+
+        Map<Long, Long> activityCounts = activityCountsOf(sorted);
+        List<TripSummary> summaries = sorted.stream()
+                .map(trip -> summaryOf(trip, activityCounts.getOrDefault(trip.getId(), 0L)))
+                .toList();
+        return new TripListResponse(counts, summaries);
+    }
+
+    public TripDetail detail(Long memberId, Long tripId) {
+        return detailOf(getOwned(memberId, tripId));
+    }
+
+    /**
+     * 전체 수정. 기간이 줄어 잘리는 일정이 있으면 확인을 요구하고, 확인이 왔을 때만
+     * 보관함으로 옮긴다. 확인 요청(409)에는 이동 예정 건수를 실어 보낸다.
+     */
+    @Transactional
+    public TripDetail update(Long memberId, Long tripId, TripWriteRequest request) {
+        validate(request);
+        Trip trip = getOwned(memberId, tripId);
+
+        long movedCount = activityRepository.countOutsidePeriod(
+                tripId, request.startDate(), request.endDate());
+        if (movedCount > 0 && !request.archiveConfirmed()) {
+            throw CustomException.withData(ErrorCode.TRAVEL_ARCHIVE_CONFIRM_REQUIRED,
+                    new ShrinkPreviewResponse(movedCount));
+        }
+
+        // 타임존이 바뀌어도 일정의 벽시계 시각은 건드리지 않는다 — 09:00은 어디서든 09:00이다.
+        trip.update(request.resolvedTitle(), request.destinationName().trim(),
+                request.startDate(), request.endDate(), request.timezone(),
+                normalizedCurrency(request.currency()));
+        applyOptionalSettings(trip, request);
+
+        if (movedCount > 0) {
+            archiveActivitiesOutsidePeriod(trip);
+        }
+        return detailOf(trip);
+    }
+
+    /** 기간을 이렇게 바꾸면 몇 개가 보관함으로 가는지. 생략한 날짜는 현재 값을 쓴다. */
+    public ShrinkPreviewResponse shrinkPreview(Long memberId, Long tripId,
+                                               LocalDate startDate, LocalDate endDate) {
+        Trip trip = getOwned(memberId, tripId);
+        LocalDate newStart = startDate != null ? startDate : trip.getStartDate();
+        LocalDate newEnd = endDate != null ? endDate : trip.getEndDate();
+        requireValidPeriod(newStart, newEnd);
+        return new ShrinkPreviewResponse(
+                activityRepository.countOutsidePeriod(tripId, newStart, newEnd));
+    }
+
+    /** 여행 삭제 — 일정은 FK CASCADE로 함께 정리된다. */
+    @Transactional
+    public void delete(Long memberId, Long tripId) {
+        tripRepository.delete(getOwned(memberId, tripId));
+    }
+
+    /** `/select` 카드와 여행 홈(S-01)이 함께 쓰는 요약. 셋 다 없으면 전부 null이다. */
+    public TravelSummaryResponse summary(Long memberId) {
+        List<Trip> all = tripRepository.findAllByMemberIdOrderByStartDateDescIdDesc(memberId);
+
+        Trip ongoing = all.stream()
+                .filter(trip -> statusOf(trip) == TripStatus.ONGOING)
+                .min(Comparator.comparing(Trip::getStartDate).thenComparing(Trip::getId))
+                .orElse(null);
+        Trip next = all.stream()
+                .filter(trip -> statusOf(trip) == TripStatus.UPCOMING)
+                .min(Comparator.comparing(Trip::getStartDate).thenComparing(Trip::getId))
+                .orElse(null);
+        Trip completed = all.stream()
+                .filter(trip -> statusOf(trip) == TripStatus.COMPLETED)
+                .max(Comparator.comparing(Trip::getEndDate).thenComparing(Trip::getId))
+                .orElse(null);
+
+        Map<Long, Long> counts = activityCountsOf(
+                Stream.of(next, completed).filter(Objects::nonNull).toList());
+
+        return new TravelSummaryResponse(
+                ongoing == null ? null
+                        : TravelSummaryResponse.OngoingTrip.of(ongoing.getId(), ongoing.getTitle()),
+                next == null ? null : new TravelSummaryResponse.NextTrip(
+                        next.getId(), next.getTitle(), next.getDestinationName(),
+                        next.getStartDate(), next.getEndDate(), next.daysUntilStart(clock),
+                        counts.getOrDefault(next.getId(), 0L)),
+                completed == null ? null : new TravelSummaryResponse.CompletedTrip(
+                        completed.getId(), completed.getTitle(), completed.getEndDate(),
+                        counts.getOrDefault(completed.getId(), 0L)));
+    }
+
+    // ---------------- helpers ----------------
+
+    private Trip getOwned(Long memberId, Long tripId) {
+        // 소유권 실패도 404 — 403이면 "그 id의 여행은 존재한다"가 새어나간다.
+        return tripRepository.findByIdAndMemberId(tripId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_TRIP_NOT_FOUND));
+    }
+
+    /**
+     * 기간 밖 일정을 보관함 맨 뒤로 붙인다. 비운 날짜는 통째로 사라지므로 재인덱싱할 대상이
+     * 없고, 보관함만 0..n-1이 이어지도록 순서를 새로 부여한다.
+     */
+    private void archiveActivitiesOutsidePeriod(Trip trip) {
+        List<TripActivity> outside = activityRepository.findOutsidePeriod(
+                trip.getId(), trip.getStartDate(), trip.getEndDate());
+        int nextOrder = activityRepository.nextSortOrder(trip.getId(), null);
+        for (TripActivity activity : outside) {
+            activity.moveTo(null, nextOrder++);
+        }
+    }
+
+    private void applyOptionalSettings(Trip trip, TripWriteRequest request) {
+        if (request.destinationPlaceId() != null || request.lat() != null || request.lng() != null) {
+            trip.updateDestinationPlace(request.destinationPlaceId(), request.lat(), request.lng());
+        }
+        // 생략된 값은 기존 설정을 유지한다(수정 화면이 알림 설정을 안 보낼 수 있다).
+        int notifyMinutes = request.defaultNotifyMinutes() != null
+                ? request.defaultNotifyMinutes() : trip.getDefaultNotifyMinutes();
+        boolean morningSummary = request.morningSummaryEnabled() != null
+                ? request.morningSummaryEnabled() : trip.isMorningSummaryEnabled();
+        trip.updateNotificationSettings(notifyMinutes, morningSummary);
+    }
+
+    private void validate(TripWriteRequest request) {
+        requireValidPeriod(request.startDate(), request.endDate());
+        requireValidTimezone(request.timezone());
+        requireValidCurrency(request.currency());
+    }
+
+    private void requireValidPeriod(LocalDate startDate, LocalDate endDate) {
+        if (endDate.isBefore(startDate)) {
+            throw new CustomException(ErrorCode.TRAVEL_INVALID_PERIOD);
+        }
+    }
+
+    /**
+     * IANA 지역 ID만 받는다. {@code ZoneId.of}는 {@code "UTC+09:00"} 같은 오프셋도 통과시키는데,
+     * 오프셋은 서머타임을 모르므로 알림 시각 환산이 계절에 따라 어긋난다.
+     */
+    private void requireValidTimezone(String timezone) {
+        if (!ZoneId.getAvailableZoneIds().contains(timezone)) {
+            throw new CustomException(ErrorCode.TRAVEL_INVALID_TIMEZONE);
+        }
+    }
+
+    private void requireValidCurrency(String currency) {
+        try {
+            Currency.getInstance(normalizedCurrency(currency));
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.TRAVEL_INVALID_CURRENCY);
+        }
+    }
+
+    private String normalizedCurrency(String currency) {
+        return currency.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private TripStatus statusOf(Trip trip) {
+        return trip.status(clock);
+    }
+
+    /**
+     * 표시 순서 — 예정·진행 중은 다가오는 순(시작일 오름차순), 완료는 최근 순(종료일 내림차순).
+     * 방향이 반대라 하나의 Comparator로 묶지 않고 두 덩어리로 나눠 이어 붙인다.
+     * 필터 없이 전체를 볼 때는 앞으로 갈 여행이 먼저, 지나간 여행이 뒤로 온다.
+     */
+    private List<Trip> sortForDisplay(List<Trip> trips) {
+        Stream<Trip> upcoming = trips.stream()
+                .filter(trip -> statusOf(trip) != TripStatus.COMPLETED)
+                .sorted(Comparator.comparing(Trip::getStartDate).thenComparing(Trip::getId));
+        Stream<Trip> completed = trips.stream()
+                .filter(trip -> statusOf(trip) == TripStatus.COMPLETED)
+                .sorted(Comparator.comparing(Trip::getEndDate).reversed()
+                        .thenComparing(Trip::getId));
+        return Stream.concat(upcoming, completed).toList();
+    }
+
+    private Map<Long, Long> activityCountsOf(List<Trip> trips) {
+        if (trips.isEmpty()) {
+            return Map.of();
+        }
+        List<Long> tripIds = trips.stream().map(Trip::getId).toList();
+        return activityRepository.countByTripIds(tripIds).stream()
+                .collect(Collectors.toMap(TripActivityCount::tripId, TripActivityCount::count));
+    }
+
+    private TripSummary summaryOf(Trip trip, long activityCount) {
+        return new TripSummary(trip.getId(), trip.getTitle(), trip.getDestinationName(),
+                trip.getStartDate(), trip.getEndDate(), statusOf(trip),
+                trip.daysUntilStart(clock), activityCount);
+    }
+
+    private TripDetail detailOf(Trip trip) {
+        return new TripDetail(trip.getId(), trip.getTitle(), trip.getDestinationName(),
+                trip.getDestinationPlaceId(), trip.getStartDate(), trip.getEndDate(),
+                trip.getTimezone(), trip.getCurrency(), trip.getLat(), trip.getLng(),
+                trip.getDefaultNotifyMinutes(), trip.isMorningSummaryEnabled(),
+                statusOf(trip), trip.daysUntilStart(clock), trip.totalDays(),
+                activityRepository.countByTripId(trip.getId()));
+    }
+
+    private TripListResponse.TripCounts countByStatus(List<Trip> trips) {
+        Map<TripStatus, Long> byStatus = trips.stream()
+                .collect(Collectors.groupingBy(this::statusOf, Collectors.counting()));
+        return new TripListResponse.TripCounts(
+                byStatus.getOrDefault(TripStatus.UPCOMING, 0L),
+                byStatus.getOrDefault(TripStatus.ONGOING, 0L),
+                byStatus.getOrDefault(TripStatus.COMPLETED, 0L));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/trip/controller/TripControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/trip/controller/TripControllerTest.java
@@ -1,0 +1,604 @@
+package ds.project.orino.planner.travel.trip.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.travel.entity.TripActivity;
+import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.FixedClockConfig;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 여행 CRUD 통합 테스트.
+ *
+ * <p>고정 시각은 {@code 2026-01-15T02:00:00Z}. 상태·D-day는 저장값이 아니라 이 시각과 각 여행의
+ * 타임존으로 파생되므로, 날짜를 이 기준 전후로 놓아 세 상태를 모두 만든다.
+ */
+@Import(FixedClockConfig.class)
+class TripControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TripActivityRepository activityRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private String otherAuthHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        memberRepository.save(MemberFixture.create("other", "password"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        otherAuthHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+    }
+
+    @Nested
+    @DisplayName("POST /trips")
+    class Create {
+
+        @Test
+        @DisplayName("여행을 만들면 상태·D-day가 파생돼 함께 온다")
+        void createsTrip() throws Exception {
+            mockMvc.perform(post("/api/travel/trips")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(tripBody("도쿄 3박4일", "도쿄", "2026-10-24", "2026-10-27")))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.title").value("도쿄 3박4일"))
+                    .andExpect(jsonPath("$.data.destinationName").value("도쿄"))
+                    .andExpect(jsonPath("$.data.timezone").value("Asia/Tokyo"))
+                    .andExpect(jsonPath("$.data.currency").value("JPY"))
+                    .andExpect(jsonPath("$.data.status").value("UPCOMING"))
+                    .andExpect(jsonPath("$.data.dDay").value(282))
+                    .andExpect(jsonPath("$.data.totalDays").value(4))
+                    .andExpect(jsonPath("$.data.activityCount").value(0))
+                    .andExpect(jsonPath("$.data.defaultNotifyMinutes").value(15));
+        }
+
+        @Test
+        @DisplayName("제목을 비우면 목적지명으로 채워 저장한다")
+        void fallsBackToDestinationName() throws Exception {
+            mockMvc.perform(post("/api/travel/trips")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "  ", "destinationName": "오사카",
+                                     "startDate": "2026-10-24", "endDate": "2026-10-27",
+                                     "timezone": "Asia/Tokyo", "currency": "JPY"}
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.title").value("오사카"));
+        }
+
+        @Test
+        @DisplayName("통화는 소문자로 보내도 대문자로 저장된다")
+        void normalizesCurrency() throws Exception {
+            mockMvc.perform(post("/api/travel/trips")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"destinationName": "도쿄", "startDate": "2026-10-24",
+                                     "endDate": "2026-10-27", "timezone": "Asia/Tokyo",
+                                     "currency": "jpy"}
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.currency").value("JPY"));
+        }
+
+        @Test
+        @DisplayName("종료일이 시작일보다 빠르면 400")
+        void rejectsInvertedPeriod() throws Exception {
+            mockMvc.perform(post("/api/travel/trips")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(tripBody("도쿄", "도쿄", "2026-10-27", "2026-10-24")))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-002"));
+        }
+
+        @Test
+        @DisplayName("IANA ID가 아닌 시간대는 400 — 오프셋 표기도 거부한다")
+        void rejectsNonIanaTimezone() throws Exception {
+            mockMvc.perform(post("/api/travel/trips")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"destinationName": "도쿄", "startDate": "2026-10-24",
+                                     "endDate": "2026-10-27", "timezone": "UTC+09:00",
+                                     "currency": "JPY"}
+                                    """))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-003"));
+        }
+
+        @Test
+        @DisplayName("ISO 4217이 아닌 통화는 400")
+        void rejectsUnknownCurrency() throws Exception {
+            mockMvc.perform(post("/api/travel/trips")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"destinationName": "도쿄", "startDate": "2026-10-24",
+                                     "endDate": "2026-10-27", "timezone": "Asia/Tokyo",
+                                     "currency": "ZZZ"}
+                                    """))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-004"));
+        }
+
+        @Test
+        @DisplayName("제목이 50자를 넘으면 400")
+        void rejectsTooLongTitle() throws Exception {
+            mockMvc.perform(post("/api/travel/trips")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(tripBody("가".repeat(51), "도쿄", "2026-10-24", "2026-10-27")))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 파생")
+    class StatusDerivation {
+
+        @Test
+        @DisplayName("기간에 따라 예정·진행 중·완료가 갈린다")
+        void derivesThreeStatuses() throws Exception {
+            createTrip("예정", "도쿄", "2026-10-24", "2026-10-27");
+            createTrip("진행중", "오사카", "2026-01-14", "2026-01-16");
+            createTrip("완료", "제주", "2025-12-01", "2025-12-03");
+
+            mockMvc.perform(get("/api/travel/trips")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.counts.upcoming").value(1))
+                    .andExpect(jsonPath("$.data.counts.ongoing").value(1))
+                    .andExpect(jsonPath("$.data.counts.completed").value(1));
+        }
+
+        @Test
+        @DisplayName("기기 시간대가 아니라 여행 타임존의 오늘로 판정한다")
+        void usesTripTimezoneNotDeviceZone() throws Exception {
+            // 고정 시각 2026-01-15T02:00Z — 도쿄는 이미 1/15 11:00, 호놀룰루는 아직 1/14 16:00.
+            // 같은 1/15 시작 여행이 목적지에 따라 진행 중/예정으로 갈려야 한다.
+            long tokyo = createTrip("도쿄", "도쿄", "2026-01-15", "2026-01-18",
+                    "Asia/Tokyo", "JPY");
+            long honolulu = createTrip("하와이", "호놀룰루", "2026-01-15", "2026-01-18",
+                    "Pacific/Honolulu", "USD");
+
+            mockMvc.perform(get("/api/travel/trips/" + tokyo)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.status").value("ONGOING"))
+                    .andExpect(jsonPath("$.data.dDay").value(0));
+            mockMvc.perform(get("/api/travel/trips/" + honolulu)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.status").value("UPCOMING"))
+                    .andExpect(jsonPath("$.data.dDay").value(1));
+        }
+
+        @Test
+        @DisplayName("status로 거르면 목록만 줄고 탭 건수는 전체 기준을 유지한다")
+        void filterDoesNotAffectCounts() throws Exception {
+            createTrip("예정", "도쿄", "2026-10-24", "2026-10-27");
+            createTrip("완료", "제주", "2025-12-01", "2025-12-03");
+
+            mockMvc.perform(get("/api/travel/trips").param("status", "UPCOMING")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.trips", hasSize(1)))
+                    .andExpect(jsonPath("$.data.trips[0].title").value("예정"))
+                    .andExpect(jsonPath("$.data.counts.upcoming").value(1))
+                    .andExpect(jsonPath("$.data.counts.completed").value(1));
+        }
+
+        @Test
+        @DisplayName("정렬은 예정·진행 중이 시작일 오름차순으로 먼저, 완료가 종료일 내림차순으로 뒤에")
+        void ordersUpcomingFirstThenCompleted() throws Exception {
+            createTrip("나중예정", "삿포로", "2026-12-01", "2026-12-04");
+            createTrip("오래된완료", "제주", "2025-06-01", "2025-06-03");
+            createTrip("곧예정", "도쿄", "2026-10-24", "2026-10-27");
+            createTrip("최근완료", "부산", "2025-12-01", "2025-12-03");
+
+            mockMvc.perform(get("/api/travel/trips")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.trips[0].title").value("곧예정"))
+                    .andExpect(jsonPath("$.data.trips[1].title").value("나중예정"))
+                    .andExpect(jsonPath("$.data.trips[2].title").value("최근완료"))
+                    .andExpect(jsonPath("$.data.trips[3].title").value("오래된완료"));
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /trips/{id} — 기간 단축")
+    class Shrink {
+
+        @Test
+        @DisplayName("기간을 줄여도 잘리는 일정이 없으면 그대로 수정된다")
+        void updatesWhenNothingIsCut() throws Exception {
+            long tripId = createTrip("도쿄", "도쿄", "2026-10-24", "2026-10-27");
+            addActivity(tripId, "센소지", LocalDate.of(2026, 10, 24));
+
+            mockMvc.perform(put("/api/travel/trips/" + tripId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(tripBody("도쿄 단축", "도쿄", "2026-10-24", "2026-10-25")))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.endDate").value("2026-10-25"))
+                    .andExpect(jsonPath("$.data.totalDays").value(2));
+        }
+
+        @Test
+        @DisplayName("확인 없이 기간을 줄이면 409로 거부하고 이동 예정 건수를 준다")
+        void rejectsShrinkWithoutConfirmation() throws Exception {
+            long tripId = createTrip("도쿄", "도쿄", "2026-10-24", "2026-10-27");
+            addActivity(tripId, "센소지", LocalDate.of(2026, 10, 26));
+            addActivity(tripId, "우에노", LocalDate.of(2026, 10, 27));
+            addActivity(tripId, "남는 일정", LocalDate.of(2026, 10, 24));
+
+            mockMvc.perform(put("/api/travel/trips/" + tripId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(tripBody("도쿄", "도쿄", "2026-10-24", "2026-10-25")))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-005"))
+                    .andExpect(jsonPath("$.data.movedActivityCount").value(2));
+
+            // 거부됐으니 기간도 일정도 그대로여야 한다.
+            mockMvc.perform(get("/api/travel/trips/" + tripId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.endDate").value("2026-10-27"));
+        }
+
+        @Test
+        @DisplayName("confirmArchive=true면 잘린 일정을 지우지 않고 보관함으로 옮긴다")
+        void archivesCutActivitiesOnConfirm() throws Exception {
+            long tripId = createTrip("도쿄", "도쿄", "2026-10-24", "2026-10-27");
+            addActivity(tripId, "남는 일정", LocalDate.of(2026, 10, 24));
+            addActivity(tripId, "잘리는 A", LocalDate.of(2026, 10, 26));
+            addActivity(tripId, "잘리는 B", LocalDate.of(2026, 10, 27));
+
+            mockMvc.perform(put("/api/travel/trips/" + tripId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "도쿄", "destinationName": "도쿄",
+                                     "startDate": "2026-10-24", "endDate": "2026-10-25",
+                                     "timezone": "Asia/Tokyo", "currency": "JPY",
+                                     "confirmArchive": true}
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.endDate").value("2026-10-25"))
+                    // 삭제가 아니라 이동이므로 총 개수는 그대로다.
+                    .andExpect(jsonPath("$.data.activityCount").value(3));
+
+            assertArchived(tripId, "잘리는 A", "잘리는 B");
+        }
+
+        @Test
+        @DisplayName("보관함으로 옮긴 일정은 기존 보관함 뒤에 0..n-1로 이어 붙는다")
+        void archivedActivitiesGetSequentialOrder() throws Exception {
+            long tripId = createTrip("도쿄", "도쿄", "2026-10-24", "2026-10-27");
+            addActivity(tripId, "원래 보관함", null);
+            addActivity(tripId, "잘리는 A", LocalDate.of(2026, 10, 26));
+            addActivity(tripId, "잘리는 B", LocalDate.of(2026, 10, 27));
+
+            shrinkWithConfirm(tripId, "2026-10-24", "2026-10-25");
+
+            assertThatArchiveOrderIs(tripId, "원래 보관함", "잘리는 A", "잘리는 B");
+        }
+
+        @Test
+        @DisplayName("시작일을 늦춰 앞이 잘려도 보관함으로 간다")
+        void archivesWhenStartDateMovesLater() throws Exception {
+            long tripId = createTrip("도쿄", "도쿄", "2026-10-24", "2026-10-27");
+            addActivity(tripId, "첫날 일정", LocalDate.of(2026, 10, 24));
+            addActivity(tripId, "남는 일정", LocalDate.of(2026, 10, 27));
+
+            shrinkWithConfirm(tripId, "2026-10-26", "2026-10-27");
+
+            assertArchived(tripId, "첫날 일정");
+        }
+
+        @Test
+        @DisplayName("보관함 일정은 기간을 줄여도 건드리지 않는다")
+        void archivedActivitiesAreNotCounted() throws Exception {
+            long tripId = createTrip("도쿄", "도쿄", "2026-10-24", "2026-10-27");
+            addActivity(tripId, "보관함 후보", null);
+
+            // 잘릴 게 없으므로 확인 없이도 통과해야 한다.
+            mockMvc.perform(put("/api/travel/trips/" + tripId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(tripBody("도쿄", "도쿄", "2026-10-24", "2026-10-25")))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("기간을 늘리는 수정은 확인 없이 통과한다")
+        void extendingPeriodNeedsNoConfirmation() throws Exception {
+            long tripId = createTrip("도쿄", "도쿄", "2026-10-24", "2026-10-27");
+            addActivity(tripId, "센소지", LocalDate.of(2026, 10, 26));
+
+            mockMvc.perform(put("/api/travel/trips/" + tripId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(tripBody("도쿄", "도쿄", "2026-10-24", "2026-10-30")))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.endDate").value("2026-10-30"));
+        }
+
+        @Test
+        @DisplayName("타임존을 바꿔도 일정의 벽시계 시각은 그대로다")
+        void timezoneChangeKeepsWallClockTimes() throws Exception {
+            long tripId = createTrip("도쿄", "도쿄", "2026-10-24", "2026-10-27");
+            long activityId = addActivity(tripId, "09시 출발", LocalDate.of(2026, 10, 24),
+                    LocalTime.of(9, 0));
+
+            mockMvc.perform(put("/api/travel/trips/" + tripId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "하와이", "destinationName": "호놀룰루",
+                                     "startDate": "2026-10-24", "endDate": "2026-10-27",
+                                     "timezone": "Pacific/Honolulu", "currency": "USD"}
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.timezone").value("Pacific/Honolulu"));
+
+            TripActivity activity = activityRepository.findById(activityId).orElseThrow();
+            assertThat(activity.getStartTime())
+                    .isEqualTo(LocalTime.of(9, 0));
+            assertThat(activity.getActivityDate())
+                    .isEqualTo(LocalDate.of(2026, 10, 24));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /trips/{id}/shrink-preview")
+    class ShrinkPreview {
+
+        @Test
+        @DisplayName("바꾸려는 기간으로 이동할 일정 수를 미리 준다")
+        void previewsMovedCount() throws Exception {
+            long tripId = createTrip("도쿄", "도쿄", "2026-10-24", "2026-10-27");
+            addActivity(tripId, "A", LocalDate.of(2026, 10, 26));
+            addActivity(tripId, "B", LocalDate.of(2026, 10, 27));
+            addActivity(tripId, "남음", LocalDate.of(2026, 10, 24));
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/shrink-preview")
+                            .param("startDate", "2026-10-24")
+                            .param("endDate", "2026-10-25")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.movedActivityCount").value(2));
+        }
+
+        @Test
+        @DisplayName("생략한 날짜는 현재 기간을 그대로 쓴다")
+        void fillsOmittedDatesFromTrip() throws Exception {
+            long tripId = createTrip("도쿄", "도쿄", "2026-10-24", "2026-10-27");
+            addActivity(tripId, "마지막날", LocalDate.of(2026, 10, 27));
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/shrink-preview")
+                            .param("endDate", "2026-10-26")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.movedActivityCount").value(1));
+        }
+
+        @Test
+        @DisplayName("미리보기는 일정을 옮기지 않는다")
+        void previewDoesNotMutate() throws Exception {
+            long tripId = createTrip("도쿄", "도쿄", "2026-10-24", "2026-10-27");
+            addActivity(tripId, "마지막날", LocalDate.of(2026, 10, 27));
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/shrink-preview")
+                            .param("endDate", "2026-10-25")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk());
+
+            assertThat(
+                            activityRepository.findUnscheduled(tripId))
+                    .isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /summary")
+    class Summary {
+
+        @Test
+        @DisplayName("여행이 없으면 세 필드가 전부 null이다")
+        void emptySummary() throws Exception {
+            mockMvc.perform(get("/api/travel/summary")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.ongoing").doesNotExist())
+                    .andExpect(jsonPath("$.data.next").doesNotExist())
+                    .andExpect(jsonPath("$.data.recentCompleted").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("진행 중·다음 예정·최근 완료를 각각 하나씩 준다")
+        void picksOnePerBucket() throws Exception {
+            long ongoing = createTrip("진행중", "오사카", "2026-01-14", "2026-01-16");
+            long soon = createTrip("곧", "도쿄", "2026-10-24", "2026-10-27");
+            createTrip("나중", "삿포로", "2026-12-01", "2026-12-04");
+            long recent = createTrip("최근완료", "부산", "2025-12-01", "2025-12-03");
+            createTrip("오래된완료", "제주", "2025-06-01", "2025-06-03");
+            addActivity(soon, "센소지", LocalDate.of(2026, 10, 24));
+
+            mockMvc.perform(get("/api/travel/summary")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.ongoing.id").value((int) ongoing))
+                    .andExpect(jsonPath("$.data.ongoing.boardPath")
+                            .value("/travel/trips/%d/board".formatted(ongoing)))
+                    .andExpect(jsonPath("$.data.next.id").value((int) soon))
+                    .andExpect(jsonPath("$.data.next.dDay").value(282))
+                    .andExpect(jsonPath("$.data.next.activityCount").value(1))
+                    .andExpect(jsonPath("$.data.recentCompleted.id").value((int) recent));
+        }
+    }
+
+    @Nested
+    @DisplayName("소유권")
+    class Ownership {
+
+        @Test
+        @DisplayName("남의 여행은 조회·수정·삭제 모두 404다(403이 아니다)")
+        void otherMembersTripIsNotFound() throws Exception {
+            long tripId = createTrip("도쿄", "도쿄", "2026-10-24", "2026-10-27");
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId)
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-001"));
+            mockMvc.perform(put("/api/travel/trips/" + tripId)
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(tripBody("탈취", "도쿄", "2026-10-24", "2026-10-27")))
+                    .andExpect(status().isNotFound());
+            mockMvc.perform(delete("/api/travel/trips/" + tripId)
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
+                    .andExpect(status().isNotFound());
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/shrink-preview")
+                            .param("endDate", "2026-10-25")
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("목록·요약에 남의 여행이 섞이지 않는다")
+        void listsAreScopedByMember() throws Exception {
+            createTrip("내 여행", "도쿄", "2026-10-24", "2026-10-27");
+
+            mockMvc.perform(get("/api/travel/trips")
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.trips", hasSize(0)))
+                    .andExpect(jsonPath("$.data.counts.upcoming").value(0));
+            mockMvc.perform(get("/api/travel/summary")
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
+                    .andExpect(jsonPath("$.data.next").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("인증 없이는 401")
+        void requiresAuthentication() throws Exception {
+            mockMvc.perform(get("/api/travel/trips"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Test
+    @DisplayName("DELETE /trips/{id} - 여행을 지우면 일정도 함께 사라진다")
+    void deleteCascadesToActivities() throws Exception {
+        long tripId = createTrip("도쿄", "도쿄", "2026-10-24", "2026-10-27");
+        addActivity(tripId, "센소지", LocalDate.of(2026, 10, 24));
+
+        mockMvc.perform(delete("/api/travel/trips/" + tripId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/travel/trips/" + tripId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isNotFound());
+        assertThat(activityRepository.countByTripId(tripId))
+                .isZero();
+    }
+
+    // ---------------- helpers ----------------
+
+    private static String tripBody(String title, String destination, String start, String end) {
+        return """
+                {"title": "%s", "destinationName": "%s", "startDate": "%s", "endDate": "%s",
+                 "timezone": "Asia/Tokyo", "currency": "JPY"}
+                """.formatted(title, destination, start, end);
+    }
+
+    private long createTrip(String title, String destination, String start, String end)
+            throws Exception {
+        return createTrip(title, destination, start, end, "Asia/Tokyo", "JPY");
+    }
+
+    private long createTrip(String title, String destination, String start, String end,
+                            String timezone, String currency) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "%s", "destinationName": "%s", "startDate": "%s",
+                                 "endDate": "%s", "timezone": "%s", "currency": "%s"}
+                                """.formatted(title, destination, start, end, timezone, currency)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    /** 일정 API는 #1032에서 나오므로 여기서는 리포지토리로 직접 넣는다. */
+    private long addActivity(long tripId, String title, LocalDate date) {
+        return addActivity(tripId, title, date, null);
+    }
+
+    private long addActivity(long tripId, String title, LocalDate date, LocalTime startTime) {
+        int order = activityRepository.nextSortOrder(tripId, date);
+        return activityRepository.save(
+                new TripActivity(tripId, title, date, order, startTime)).getId();
+    }
+
+    private void shrinkWithConfirm(long tripId, String start, String end) throws Exception {
+        mockMvc.perform(put("/api/travel/trips/" + tripId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "도쿄", "destinationName": "도쿄",
+                                 "startDate": "%s", "endDate": "%s",
+                                 "timezone": "Asia/Tokyo", "currency": "JPY",
+                                 "confirmArchive": true}
+                                """.formatted(start, end)))
+                .andExpect(status().isOk());
+    }
+
+    private void assertArchived(long tripId, String... titles) {
+        assertThat(activityRepository.findUnscheduled(tripId))
+                .extracting(TripActivity::getTitle)
+                .containsExactlyInAnyOrder(titles);
+    }
+
+    private void assertThatArchiveOrderIs(long tripId, String... titles) {
+        assertThat(activityRepository.findUnscheduled(tripId))
+                .extracting(TripActivity::getTitle)
+                .containsExactly(titles);
+        assertThat(activityRepository.findUnscheduled(tripId))
+                .extracting(TripActivity::getSortOrder)
+                .containsExactly(0, 1, 2);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Component;
 public class DbCleaner {
 
     private static final String[] TABLES_IN_FK_ORDER = {
+            "trip_activity",
+            "trip",
+            "travel_place",
             "holiday",
             "day_plan_block",
             "routine_check",

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/CustomException.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/CustomException.java
@@ -4,23 +4,46 @@ public class CustomException extends RuntimeException {
 
     private final ErrorCode errorCode;
 
+    /**
+     * 클라이언트가 다음 행동을 정하는 데 쓸 부가 값. 대부분의 에러는 비어 있다.
+     * 응답에는 값이 있을 때만 실린다({@link ErrorResponse}).
+     */
+    private final Object data;
+
     public CustomException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+        this(errorCode, errorCode.getMessage(), null);
     }
 
     /** 사용자에게 어디가 틀렸는지 알려야 하는 경우(예: 수식 문법 오류)에 상세를 덧붙인다. */
     public CustomException(ErrorCode errorCode, String detail) {
-        super(errorCode.getMessage(detail));
-        this.errorCode = errorCode;
+        this(errorCode, errorCode.getMessage(detail), null);
     }
 
     public CustomException(ErrorCode errorCode, Throwable cause) {
         super(errorCode.getMessage(cause), cause);
         this.errorCode = errorCode;
+        this.data = null;
+    }
+
+    private CustomException(ErrorCode errorCode, String message, Object data) {
+        super(message);
+        this.errorCode = errorCode;
+        this.data = data;
+    }
+
+    /**
+     * 값을 실어 보내는 에러. 예: 기간 단축 확인(409)에서 보관함으로 이동할 일정 개수 —
+     * 클라이언트가 메시지 문자열을 파싱해 숫자를 뽑게 두지 않는다.
+     */
+    public static CustomException withData(ErrorCode errorCode, Object data) {
+        return new CustomException(errorCode, errorCode.getMessage(), data);
     }
 
     public ErrorCode getErrorCode() {
         return errorCode;
+    }
+
+    public Object getData() {
+        return data;
     }
 }

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -31,7 +31,17 @@ public enum ErrorCode {
     LIFELOG_MOMENT_NOT_FOUND("LIFELOG-ERR-002", "존재하지 않는 기록입니다.", 404),
     LIFELOG_EMPTY_MOMENT("LIFELOG-ERR-003", "본문이나 사진 중 하나는 있어야 합니다.", 400),
     LIFELOG_INVALID_COORDINATE("LIFELOG-ERR-004", "위도와 경도는 함께 지정해야 합니다.", 400),
-    LIFELOG_FLOW_NOT_FOUND("LIFELOG-ERR-005", "존재하지 않는 흐름입니다.", 404);
+    LIFELOG_FLOW_NOT_FOUND("LIFELOG-ERR-005", "존재하지 않는 흐름입니다.", 404),
+
+    // TRAVEL (여행)
+    // 소유권 실패도 404다 — 403으로 답하면 "그 id의 여행은 있다"는 사실이 새어나간다.
+    TRAVEL_TRIP_NOT_FOUND("TRAVEL-ERR-001", "존재하지 않는 여행입니다.", 404),
+    TRAVEL_INVALID_PERIOD("TRAVEL-ERR-002", "종료일은 시작일보다 빠를 수 없습니다.", 400),
+    TRAVEL_INVALID_TIMEZONE("TRAVEL-ERR-003", "유효하지 않은 시간대입니다.", 400),
+    TRAVEL_INVALID_CURRENCY("TRAVEL-ERR-004", "유효하지 않은 통화 코드입니다.", 400),
+    // 기간을 줄이면 잘린 일정이 보관함으로 밀린다. 사용자가 모르고 잃지 않도록 확인을 요구한다.
+    TRAVEL_ARCHIVE_CONFIRM_REQUIRED("TRAVEL-ERR-005",
+            "기간을 줄이면 일부 일정이 미배정 보관함으로 이동합니다.", 409);
 
     private final String code;
     private final String message;

--- a/be/orino-core-web/src/main/java/ds/project/orino/core/web/DataErrorResponse.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/web/DataErrorResponse.java
@@ -1,0 +1,20 @@
+package ds.project.orino.core.web;
+
+import ds.project.orino.common.exception.CustomException;
+
+/**
+ * 값을 함께 실어 보내는 에러 응답. 클라이언트가 다음 행동을 정하려면 숫자가 필요한 경우에 쓴다 —
+ * 기간 단축 확인(409)의 "보관함으로 이동할 일정 개수"가 그 예다.
+ *
+ * <p>{@code ErrorResponse}에 필드를 더하지 않고 별도 타입으로 둔 이유가 둘 있다.
+ * 하나는 {@code orino-common}이 의존성 없는 순수 Java 모듈이라 Jackson 애너테이션
+ * ({@code @JsonInclude})을 쓸 수 없다는 것, 다른 하나는 필드를 더하면 값이 없는 대다수 에러에도
+ * {@code "data": null}이 붙어 <b>전 엔드포인트의 에러 형태가 바뀐다</b>는 것이다.
+ * 값이 있을 때만 이 타입으로 응답하므로 기존 에러 응답은 그대로다.
+ */
+public record DataErrorResponse(String code, String message, Object data) {
+
+    public static DataErrorResponse of(CustomException e) {
+        return new DataErrorResponse(e.getErrorCode().getCode(), e.getMessage(), e.getData());
+    }
+}

--- a/be/orino-core-web/src/main/java/ds/project/orino/core/web/GlobalExceptionHandler.java
+++ b/be/orino-core-web/src/main/java/ds/project/orino/core/web/GlobalExceptionHandler.java
@@ -28,10 +28,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+    public ResponseEntity<?> handleCustomException(CustomException e) {
         log.error("handleCustomException: {}", e.getErrorCode().toString());
-        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
-                .body(ErrorResponse.of(e));
+        // 값을 실은 에러만 data가 붙은 형태로 나간다. 나머지는 기존 {code, message} 그대로.
+        Object body = e.getData() != null ? DataErrorResponse.of(e) : ErrorResponse.of(e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(body);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripActivityCount.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripActivityCount.java
@@ -1,0 +1,10 @@
+package ds.project.orino.domain.planner.travel.repository;
+
+/**
+ * 여행별 일정 수. 목록 화면이 여행마다 COUNT를 날리지 않도록 한 번에 묶어 세는 용도다.
+ *
+ * @param tripId 여행 id
+ * @param count  보관함을 포함한 전체 일정 수
+ */
+public record TripActivityCount(Long tripId, long count) {
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripActivityRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripActivityRepository.java
@@ -63,4 +63,27 @@ public interface TripActivityRepository extends JpaRepository<TripActivity, Long
                                          @Param("endDate") LocalDate endDate);
 
     long countByTripId(Long tripId);
+
+    /**
+     * 기간 밖으로 밀려난 일정 수. 확인 모달·409 응답이 개수만 필요로 해서 목록 없이 센다.
+     */
+    @Query("""
+            SELECT COUNT(a) FROM TripActivity a
+            WHERE a.tripId = :tripId
+              AND a.activityDate IS NOT NULL
+              AND (a.activityDate < :startDate OR a.activityDate > :endDate)
+            """)
+    long countOutsidePeriod(@Param("tripId") Long tripId,
+                            @Param("startDate") LocalDate startDate,
+                            @Param("endDate") LocalDate endDate);
+
+    /** 여행별 일정 수를 한 번에 센다 — 목록 화면의 N+1을 막는다. */
+    @Query("""
+            SELECT new ds.project.orino.domain.planner.travel.repository.TripActivityCount(
+                       a.tripId, COUNT(a))
+            FROM TripActivity a
+            WHERE a.tripId IN :tripIds
+            GROUP BY a.tripId
+            """)
+    List<TripActivityCount> countByTripIds(@Param("tripIds") List<Long> tripIds);
 }


### PR DESCRIPTION
## 이슈
closes #1031

## 작업 내용

여행 CRUD API. [API 설계](https://github.com/wcorn/orino/wiki/Travel-API-Spec) §2. (Epic #1029 · 1단계)

| 메서드 | 경로 | 설명 |
|---|---|---|
| GET | `/api/travel/summary` | `/select` 카드 + 여행 홈(S-01) 공용 |
| GET | `/api/travel/trips?status=` | 목록(S-02). 생략 시 전체 |
| POST | `/api/travel/trips` | 생성 |
| GET · PUT · DELETE | `/api/travel/trips/{tripId}` | 상세 · 전체 수정 · 삭제 |
| GET | `/api/travel/trips/{tripId}/shrink-preview?startDate=&endDate=` | 기간 단축 확인 모달용 |

### 상태는 저장하지 않는다

`status`·`dDay`는 컬럼이 아니라 **각 여행의 타임존 기준 오늘**로 매 조회 시 파생한다. 목록에서도 여행마다 자기 타임존으로 따로 판정하므로, 같은 순간에 도쿄 여행은 `ONGOING`이고 하와이 여행은 `UPCOMING`일 수 있다.

그래서 `status`로 거르는 SQL이 없다 — 전체를 읽어 애플리케이션에서 판정하고, 정렬만 서버가 확정한다(예정·진행 중은 시작일 오름차순으로 앞에, 완료는 종료일 내림차순으로 뒤에). 탭 건수(`counts`)는 필터와 무관하게 항상 전체 기준으로 센다. 필터된 목록에서 세면 탭을 옮길 때마다 다른 탭 숫자가 0이 된다.

### 기간 단축 = 삭제가 아니라 이동

기간을 줄이면 잘려나간 일정을 보관함(`activity_date = NULL`)으로 옮긴다. `confirmArchive` 없이 들어온 단축 요청은 **409로 거부하고 이동 예정 건수를 함께 돌려준다.**

### 에러 응답에 값 싣기 (공용 코드 변경)

409가 건수를 함께 줘야 하는데 기존 에러 봉투는 `{code, message}`뿐이었다. 두 가지를 고려해 `ErrorResponse`에 필드를 더하지 않고 `DataErrorResponse`를 따로 뒀다.

- `orino-common`은 의존성 없는 순수 Java 모듈이라 `@JsonInclude`를 쓸 수 없다
- 필드를 더하면 값이 없는 대다수 에러에도 `"data": null`이 붙어 **전 엔드포인트의 에러 형태가 바뀐다**

값이 있을 때만 이 타입으로 응답하므로 기존 에러 응답은 그대로다(로컬에서 404 응답이 `{code, message}`인 것까지 확인).

### 검증

- `endDate >= startDate` → `TRAVEL-ERR-002`
- **타임존은 IANA 지역 ID만** → `TRAVEL-ERR-003`. `ZoneId.of`는 `UTC+09:00` 같은 오프셋도 통과시키는데, 오프셋은 서머타임을 몰라 알림 시각 환산이 계절에 따라 어긋난다
- 통화는 ISO 4217(소문자 입력은 대문자로 정규화) → `TRAVEL-ERR-004`
- 제목 50자. 미입력 시 `destinationName`으로 채우되 **50자로 자른다** — 목적지명은 100자까지 허용이라 그대로 넣으면 컬럼을 넘친다
- 소유권 실패도 404(`TRAVEL-ERR-001`) — 403이면 "그 id의 여행은 존재한다"가 새어나간다

## 테스트

`TripControllerTest` — MockMvc + TestContainers, 고정 시각(`2026-01-15T02:00Z`)으로 상태 파생을 결정적으로 검증한다.

- **생성**: 파생값 동반, 제목 폴백, 통화 정규화, 기간·타임존·통화·제목 길이 검증 4종
- **상태 파생**: 세 상태 분기 · **기기 시간대가 아닌 여행 타임존으로 판정**(같은 1/15 시작 여행이 도쿄=진행 중, 호놀룰루=예정) · 필터가 탭 건수를 건드리지 않음 · 정렬 순서
- **기간 단축**: 확인 없으면 409 + 건수(그리고 아무것도 안 바뀜) · 확인 시 삭제가 아닌 이동 · 보관함 뒤에 0..n-1로 이어 붙음 · 시작일 단축 · 보관함 일정은 대상 아님 · 기간 연장은 확인 불필요 · **타임존을 바꿔도 벽시계 시각 유지**
- **미리보기**: 건수, 생략한 날짜는 현재 기간 사용, 미리보기가 데이터를 바꾸지 않음
- **소유권**: 조회·수정·삭제·미리보기 모두 404, 목록·요약 스코프, 미인증 401
- **삭제**: 일정까지 함께 정리

`./gradlew check` 통과 (테스트 + Checkstyle 경고 0).

## 로컬 확인 (bootRun + curl)

MySQL 8.4.4 + Redis 컨테이너에 `local` 프로파일로 띄워 확인했다.

- 여행 없을 때 `summary` 세 필드 전부 `null`
- 제목 생략 생성 → `"도쿄"`로 채워짐, `dDay: 78`(실제 오늘 기준)
- `shrink-preview` → `movedActivityCount: 2`
- 확인 없이 PUT → **409 + `data.movedActivityCount: 2`**, 기간은 그대로
- `confirmArchive: true` → 200, `activityCount`는 4로 유지되고 DB에서 잘린 2건이 `activity_date = NULL`, `sort_order` 1·2로 기존 보관함(0) 뒤에 붙음
- 도쿄 → 호놀룰루 타임존 변경 후에도 일정 시각 `09:00:00` 그대로
- 404 응답에 `data` 필드가 붙지 않음

## 참고

일정 API는 #1032에서 나오므로, 테스트·로컬 확인의 일정 데이터는 리포지토리·SQL로 직접 넣었다.