### PR TITLE
feat : 일정 CRUD·정렬·보관함 API + 보드 조회

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/controller/ActivityController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/controller/ActivityController.java
@@ -1,0 +1,67 @@
+package ds.project.orino.planner.travel.activity.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
+import ds.project.orino.planner.travel.activity.dto.ActivityWriteRequest;
+import ds.project.orino.planner.travel.activity.dto.ReorderRequest;
+import ds.project.orino.planner.travel.activity.dto.ReorderResponse;
+import ds.project.orino.planner.travel.activity.service.ActivityService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/travel")
+public class ActivityController {
+
+    private final ActivityService activityService;
+
+    public ActivityController(ActivityService activityService) {
+        this.activityService = activityService;
+    }
+
+    /** 일정 추가. {@code sortOrder}는 서버가 해당 날짜 끝에 배정한다. */
+    @PostMapping("/trips/{tripId}/activities")
+    public ApiResponse<ActivityResponse> create(@AuthenticationPrincipal Long memberId,
+                                                @PathVariable Long tripId,
+                                                @Valid @RequestBody ActivityWriteRequest request) {
+        return ApiResponse.success(activityService.create(memberId, tripId, request));
+    }
+
+    @GetMapping("/activities/{activityId}")
+    public ApiResponse<ActivityResponse> detail(@AuthenticationPrincipal Long memberId,
+                                                @PathVariable Long activityId) {
+        return ApiResponse.success(activityService.detail(memberId, activityId));
+    }
+
+    /** 계획 영역 전체 수정. */
+    @PutMapping("/activities/{activityId}")
+    public ApiResponse<ActivityResponse> update(@AuthenticationPrincipal Long memberId,
+                                                @PathVariable Long activityId,
+                                                @Valid @RequestBody ActivityWriteRequest request) {
+        return ApiResponse.success(activityService.update(memberId, activityId, request));
+    }
+
+    @DeleteMapping("/activities/{activityId}")
+    public ApiResponse<Void> delete(@AuthenticationPrincipal Long memberId,
+                                    @PathVariable Long activityId) {
+        activityService.delete(memberId, activityId);
+        return ApiResponse.success();
+    }
+
+    /** 드래그 결과 반영 — 순서 변경과 날짜 이동을 한 트랜잭션으로 처리한다. */
+    @PutMapping("/trips/{tripId}/activities/order")
+    public ApiResponse<ReorderResponse> reorder(@AuthenticationPrincipal Long memberId,
+                                                @PathVariable Long tripId,
+                                                @Valid @RequestBody ReorderRequest request) {
+        activityService.reorder(memberId, tripId, request);
+        return ApiResponse.success(ReorderResponse.empty());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityPlace.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityPlace.java
@@ -1,0 +1,25 @@
+package ds.project.orino.planner.travel.activity.dto;
+
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+
+import java.math.BigDecimal;
+
+/**
+ * 일정에 붙은 장소 요약. 좌표는 지도·이동시간(2단계)이 쓴다.
+ *
+ * <p>1단계에는 장소를 만드는 경로가 없어 항상 {@code null}로 나가지만, 조립은 지금 해 둔다 —
+ * 2단계에서 장소가 생기는 순간 보드·상세가 그대로 채워진다.
+ */
+public record ActivityPlace(
+        Long id,
+        String name,
+        String address,
+        BigDecimal lat,
+        BigDecimal lng
+) {
+
+    public static ActivityPlace from(TravelPlace place) {
+        return new ActivityPlace(place.getId(), place.getName(), place.getAddress(),
+                place.getLat(), place.getLng());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityResponse.java
@@ -1,0 +1,43 @@
+package ds.project.orino.planner.travel.activity.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import ds.project.orino.domain.planner.travel.entity.TripActivity;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * 일정 하나. 보드 목록과 상세가 같은 형태를 쓴다.
+ *
+ * @param activityDate null이면 미배정 보관함에 있는 일정이다
+ * @param startTime    여행 타임존의 벽시계 시각. {@code HH:mm}로 직렬화된다
+ * @param sortOrder    같은 날짜(또는 보관함) 안에서의 순서. 정렬의 유일한 기준이다
+ * @param hasLog       사후 기록(평점·메모) 존재 여부. 기록 테이블이 4단계라 지금은 항상 false
+ */
+public record ActivityResponse(
+        Long id,
+        Long tripId,
+        String title,
+        LocalDate activityDate,
+
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime startTime,
+
+        ActivityPlace place,
+        String memo,
+        String url,
+        boolean notifyEnabled,
+        Integer notifyMinutes,
+        boolean departureNotifyEnabled,
+        int sortOrder,
+        boolean hasLog
+) {
+
+    public static ActivityResponse of(TripActivity activity, ActivityPlace place) {
+        return new ActivityResponse(activity.getId(), activity.getTripId(), activity.getTitle(),
+                activity.getActivityDate(), activity.getStartTime(), place,
+                activity.getMemo(), activity.getUrl(), activity.isNotifyEnabled(),
+                activity.getNotifyMinutes(), activity.isDepartureNotifyEnabled(),
+                activity.getSortOrder(), false);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityWriteRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityWriteRequest.java
@@ -1,0 +1,54 @@
+package ds.project.orino.planner.travel.activity.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * 일정 생성·수정 요청.
+ *
+ * <p>{@code sortOrder}를 받지 않는다 — 생성은 서버가 해당 날짜 끝에 붙이고, 순서 변경은
+ * 드래그 결과를 한 번에 반영하는 별도 엔드포인트(`/activities/order`)가 맡는다.
+ *
+ * @param activityDate 여행 기간 내 날짜. {@code null}이면 미배정 보관함으로 넣는다
+ * @param startTime    여행 타임존의 벽시계 시각({@code HH:mm}). {@code null} 허용 —
+ *                     시각 없는 일정이 정상이라 알림만 못 걸릴 뿐이다
+ */
+public record ActivityWriteRequest(
+        @NotBlank(message = "일정 제목을 입력해 주세요.")
+        @Size(max = 100, message = "일정 제목은 100자를 넘을 수 없습니다.")
+        String title,
+
+        LocalDate activityDate,
+
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime startTime,
+
+        Long placeId,
+
+        @Size(max = 1000, message = "메모는 1000자를 넘을 수 없습니다.")
+        String memo,
+
+        @Size(max = 500, message = "링크는 500자를 넘을 수 없습니다.")
+        String url,
+
+        Boolean notifyEnabled,
+
+        @Positive(message = "알림 시점은 0보다 커야 합니다.")
+        Integer notifyMinutes,
+
+        Boolean departureNotifyEnabled
+) {
+
+    public boolean notifyEnabledOrDefault() {
+        return Boolean.TRUE.equals(notifyEnabled);
+    }
+
+    public boolean departureNotifyEnabledOrDefault() {
+        return Boolean.TRUE.equals(departureNotifyEnabled);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ReorderRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ReorderRequest.java
@@ -1,0 +1,34 @@
+package ds.project.orino.planner.travel.activity.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 드래그 결과를 한 번에 반영한다. 순서 변경과 날짜 이동이 같은 요청이다.
+ *
+ * <p>영향받은 날짜의 <b>전체 순서</b>를 보낸다. 부분 갱신을 허용하면 보내지 않은 일정의
+ * {@code sortOrder}가 보낸 것과 충돌해 순서가 비결정적이 된다.
+ *
+ * @param moves 날짜별 배열. {@code date}가 {@code null}이면 미배정 보관함이다
+ */
+public record ReorderRequest(
+        @NotNull(message = "이동 정보를 보내주세요.")
+        @Valid
+        List<Move> moves
+) {
+
+    /**
+     * @param date        옮겨갈 날짜. {@code null}이면 보관함
+     * @param activityIds 그 날짜에 놓일 일정 id를 화면 순서 그대로. 이 순서가 곧 0..n-1이 된다
+     */
+    public record Move(
+            LocalDate date,
+
+            @NotNull(message = "일정 목록을 보내주세요.")
+            List<Long> activityIds
+    ) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ReorderResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ReorderResponse.java
@@ -1,0 +1,17 @@
+package ds.project.orino.planner.travel.activity.dto;
+
+import java.util.List;
+
+/**
+ * 순서 변경 결과. 재계산된 이동시간({@code legs})을 담아 드래그 직후 화면이 다시 조회하지 않고도
+ * 이동시간을 갱신할 수 있게 한다.
+ *
+ * <p>이동시간은 장소·Routes가 붙는 2단계 기능이라 1단계에서는 항상 비어 있다. 그래도 형태를
+ * 지금 맞춰 두면 2단계에서 FE 계약이 바뀌지 않는다.
+ */
+public record ReorderResponse(List<Object> legs) {
+
+    public static ReorderResponse empty() {
+        return new ReorderResponse(List.of());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
@@ -1,0 +1,253 @@
+package ds.project.orino.planner.travel.activity.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import ds.project.orino.domain.planner.travel.entity.TripActivity;
+import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
+import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.activity.dto.ActivityPlace;
+import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
+import ds.project.orino.planner.travel.activity.dto.ActivityWriteRequest;
+import ds.project.orino.planner.travel.activity.dto.ReorderRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 일정 CRUD와 드래그 결과 반영.
+ *
+ * <p>정렬 기준은 {@code sortOrder}뿐이다 — 시각으로 정렬하지 않는다. 시각 없는 일정이 정상이고,
+ * 사용자가 드래그로 정한 순서가 시각보다 우선하기 때문이다.
+ *
+ * <p>{@code activityDate}가 {@code null}이면 미배정 보관함이다. 보관함도 자기 {@code sortOrder}
+ * 열을 가진다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class ActivityService {
+
+    /**
+     * 순서 변경에서 "보내지 않은 일정"을 임시로 밀어 둘 구간. 보낸 일정(0..n-1)과 절대 겹치지
+     * 않을 만큼 크면 되고, 정규화가 끝나면 다시 0..n-1로 돌아오므로 저장되지는 않는다.
+     */
+    private static final int UNLISTED_BAND = 1_000_000;
+
+    private final TripActivityRepository activityRepository;
+    private final TripRepository tripRepository;
+    private final TravelPlaceRepository placeRepository;
+
+    public ActivityService(TripActivityRepository activityRepository,
+                           TripRepository tripRepository,
+                           TravelPlaceRepository placeRepository) {
+        this.activityRepository = activityRepository;
+        this.tripRepository = tripRepository;
+        this.placeRepository = placeRepository;
+    }
+
+    /** 새 일정은 해당 날짜(또는 보관함)의 맨 뒤에 붙인다. 클라이언트가 순서를 정하지 않는다. */
+    @Transactional
+    public ActivityResponse create(Long memberId, Long tripId, ActivityWriteRequest request) {
+        Trip trip = getOwnedTrip(memberId, tripId);
+        requireDateWithinTrip(trip, request.activityDate());
+
+        int sortOrder = activityRepository.nextSortOrder(tripId, request.activityDate());
+        TripActivity activity = new TripActivity(tripId, request.title().trim(),
+                request.activityDate(), sortOrder, request.startTime());
+        // 생성자가 안 받는 나머지 계획 필드(메모·링크·장소·알림)를 이어서 채운다.
+        activity.update(request.title().trim(), request.startTime(), request.memo(), request.url());
+        activity.updatePlace(request.placeId());
+        activity.updateNotification(request.notifyEnabledOrDefault(), request.notifyMinutes(),
+                request.departureNotifyEnabledOrDefault());
+
+        return toResponse(activityRepository.save(activity));
+    }
+
+    public ActivityResponse detail(Long memberId, Long activityId) {
+        return toResponse(getOwnedActivity(memberId, activityId));
+    }
+
+    /**
+     * 계획 영역 전체 수정. 날짜가 바뀌면 옮겨간 날짜의 맨 뒤로 붙인다 — 정확한 위치는
+     * 드래그(`/activities/order`)가 정하는 것이고, 여기서는 순서를 추측하지 않는다.
+     */
+    @Transactional
+    public ActivityResponse update(Long memberId, Long activityId, ActivityWriteRequest request) {
+        TripActivity activity = getOwnedActivity(memberId, activityId);
+        Trip trip = getTripOf(activity);
+        requireDateWithinTrip(trip, request.activityDate());
+
+        if (!Objects.equals(activity.getActivityDate(), request.activityDate())) {
+            LocalDate previousDate = activity.getActivityDate();
+            activity.moveTo(request.activityDate(),
+                    activityRepository.nextSortOrder(activity.getTripId(), request.activityDate()));
+            // 떠나온 날짜에 순서 구멍이 남는다. 0..n-1로 메워 다음 드래그가 어긋나지 않게 한다.
+            reindex(activity.getTripId(), previousDate);
+        }
+        activity.update(request.title().trim(), request.startTime(), request.memo(), request.url());
+        activity.updatePlace(request.placeId());
+        activity.updateNotification(request.notifyEnabledOrDefault(), request.notifyMinutes(),
+                request.departureNotifyEnabledOrDefault());
+
+        return toResponse(activity);
+    }
+
+    @Transactional
+    public void delete(Long memberId, Long activityId) {
+        TripActivity activity = getOwnedActivity(memberId, activityId);
+        LocalDate date = activity.getActivityDate();
+        Long tripId = activity.getTripId();
+
+        activityRepository.delete(activity);
+        activityRepository.flush();
+        reindex(tripId, date);
+    }
+
+    /**
+     * 드래그 결과를 한 번에 반영한다 — 순서 변경과 날짜 이동이 같은 요청이고 한 트랜잭션이다.
+     *
+     * <p>보낸 배열 순서대로 0..n-1을 부여한 뒤, <b>건드린 날짜 전체를 다시 0..n-1로 정규화한다.</b>
+     * 클라이언트가 실수로 일부만 보내도 순서에 구멍이나 중복이 남지 않게 하기 위한 것이다.
+     */
+    @Transactional
+    public void reorder(Long memberId, Long tripId, ReorderRequest request) {
+        Trip trip = getOwnedTrip(memberId, tripId);
+
+        Map<Long, TripActivity> targets = loadOwnedActivities(tripId, request);
+        // 옮기기 전 날짜도 정규화 대상이다 — 일정이 빠져나간 날짜에 구멍이 남는다.
+        Set<LocalDate> touchedDates = new LinkedHashSet<>();
+        targets.values().forEach(activity -> touchedDates.add(activity.getActivityDate()));
+
+        for (ReorderRequest.Move move : request.moves()) {
+            requireDateWithinTrip(trip, move.date());
+            touchedDates.add(move.date());
+            pushUnlistedBack(tripId, move.date(), Set.copyOf(move.activityIds()));
+
+            int order = 0;
+            for (Long activityId : move.activityIds()) {
+                targets.get(activityId).moveTo(move.date(), order++);
+            }
+        }
+        activityRepository.flush();
+        touchedDates.forEach(date -> reindex(tripId, date));
+    }
+
+    // ---------------- helpers ----------------
+
+    /**
+     * 요청에 담긴 일정을 전부 읽어 이 여행 소유인지 확인한다. 하나라도 남의 것이면 통째로 막는다 —
+     * 일부만 반영되면 화면 순서와 서버 순서가 어긋난 채로 남는다.
+     */
+    private Map<Long, TripActivity> loadOwnedActivities(Long tripId, ReorderRequest request) {
+        List<Long> ids = request.moves().stream()
+                .flatMap(move -> move.activityIds().stream())
+                .distinct()
+                .toList();
+        Map<Long, TripActivity> found = activityRepository.findAllById(ids).stream()
+                .filter(activity -> activity.getTripId().equals(tripId))
+                .collect(Collectors.toMap(TripActivity::getId, activity -> activity));
+        if (found.size() != ids.size()) {
+            throw new CustomException(ErrorCode.TRAVEL_ACTIVITY_NOT_FOUND);
+        }
+        return found;
+    }
+
+    /**
+     * 보낸 목록에 없는데 그 날짜에 남아 있는 일정을 뒤 구간으로 밀어 둔다.
+     *
+     * <p>이게 없으면 보낸 일정과 안 보낸 일정의 {@code sortOrder}가 겹쳐, 뒤이은 정규화에서
+     * id 순으로 뒤섞인다. 클라이언트가 "이 날짜는 이 순서로 시작한다"고 말한 이상 보낸 쪽이 앞선다.
+     */
+    private void pushUnlistedBack(Long tripId, LocalDate date, Set<Long> listedIds) {
+        activitiesOn(tripId, date).stream()
+                .filter(activity -> !listedIds.contains(activity.getId()))
+                .forEach(activity -> activity.reorderTo(UNLISTED_BAND + activity.getSortOrder()));
+    }
+
+    private List<TripActivity> activitiesOn(Long tripId, LocalDate date) {
+        return date == null
+                ? activityRepository.findUnscheduled(tripId)
+                : activityRepository.findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(tripId, date);
+    }
+
+    /** 한 날짜(또는 보관함)의 순서를 현재 순서를 유지한 채 0..n-1로 다시 매긴다. */
+    private void reindex(Long tripId, LocalDate date) {
+        List<TripActivity> ordered = activitiesOn(tripId, date);
+        int order = 0;
+        for (TripActivity activity : ordered) {
+            activity.reorderTo(order++);
+        }
+    }
+
+    private Trip getOwnedTrip(Long memberId, Long tripId) {
+        return tripRepository.findByIdAndMemberId(tripId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_TRIP_NOT_FOUND));
+    }
+
+    /**
+     * 일정 경로에는 {@code tripId}가 없으므로 여행을 거쳐 소유권을 확인한다.
+     * 남의 일정도 404다 — 403이면 그 id의 일정이 존재한다는 사실이 새어나간다.
+     */
+    private TripActivity getOwnedActivity(Long memberId, Long activityId) {
+        TripActivity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_ACTIVITY_NOT_FOUND));
+        boolean owned = tripRepository.findByIdAndMemberId(activity.getTripId(), memberId).isPresent();
+        if (!owned) {
+            throw new CustomException(ErrorCode.TRAVEL_ACTIVITY_NOT_FOUND);
+        }
+        return activity;
+    }
+
+    private Trip getTripOf(TripActivity activity) {
+        return tripRepository.findById(activity.getTripId()).orElseThrow();
+    }
+
+    /** 보관함(null)은 언제나 허용, 날짜가 있으면 여행 기간 안이어야 한다. */
+    private void requireDateWithinTrip(Trip trip, LocalDate date) {
+        if (date != null && !trip.covers(date)) {
+            throw new CustomException(ErrorCode.TRAVEL_DATE_OUT_OF_RANGE);
+        }
+    }
+
+    private ActivityResponse toResponse(TripActivity activity) {
+        return ActivityResponse.of(activity, placeOf(activity.getPlaceId()));
+    }
+
+    private ActivityPlace placeOf(Long placeId) {
+        if (placeId == null) {
+            return null;
+        }
+        return placeRepository.findById(placeId).map(ActivityPlace::from).orElse(null);
+    }
+
+    /** 여러 일정의 장소를 한 번에 붙인다(보드가 N+1로 장소를 읽지 않게). */
+    public List<ActivityResponse> toResponses(List<TripActivity> activities) {
+        List<Long> placeIds = activities.stream()
+                .map(TripActivity::getPlaceId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        Map<Long, ActivityPlace> places = placeIds.isEmpty() ? Map.of()
+                : placeRepository.findAllByIdIn(placeIds).stream()
+                        .collect(Collectors.toMap(TravelPlace::getId, ActivityPlace::from));
+
+        List<ActivityResponse> responses = new ArrayList<>();
+        for (TripActivity activity : activities) {
+            // placeId가 null인 일정이 대부분이다. Map.of()는 get(null)에 NPE를 던지므로 먼저 거른다.
+            ActivityPlace place = activity.getPlaceId() == null
+                    ? null : places.get(activity.getPlaceId());
+            responses.add(ActivityResponse.of(activity, place));
+        }
+        return responses;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/controller/BoardController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/controller/BoardController.java
@@ -1,0 +1,41 @@
+package ds.project.orino.planner.travel.board.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.travel.board.dto.BoardResponse;
+import ds.project.orino.planner.travel.board.service.BoardService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/travel")
+public class BoardController {
+
+    private final BoardService boardService;
+
+    public BoardController(BoardService boardService) {
+        this.boardService = boardService;
+    }
+
+    /**
+     * 보드 단일 조회. 날짜 탭·보관함 건수·선택된 날짜의 일정을 한 번에 준다.
+     *
+     * @param date    볼 날짜. 생략하면 진행 중인 여행은 여행 타임존의 오늘, 아니면 1일차
+     * @param archive true면 날짜 대신 미배정 보관함을 본다
+     */
+    @GetMapping("/trips/{tripId}/board")
+    public ApiResponse<BoardResponse> board(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long tripId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate date,
+            @RequestParam(required = false, defaultValue = "false") boolean archive) {
+        return ApiResponse.success(boardService.board(memberId, tripId, date, archive));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/dto/BoardResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/dto/BoardResponse.java
@@ -1,0 +1,63 @@
+package ds.project.orino.planner.travel.board.dto;
+
+import ds.project.orino.domain.planner.travel.entity.TripStatus;
+import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 보드(S-04)의 <b>단일 조회</b> 응답. 날짜 탭·보관함 건수·선택된 날짜의 일정을 한 번에 담는다.
+ *
+ * <p>화면이 N+1 호출을 하지 않게 하려는 것이고, 더 중요하게는 <b>오프라인 캐시가 응답 하나로
+ * 성립해야</b> 하기 때문이다(4단계). 응답을 쪼개면 비행기 모드에서 탭 하나만 살아난다.
+ *
+ * @param days          여행 기간에서 만든 날짜 탭 전체. 보관함 칩은 FE가 뒤에 붙인다
+ * @param selectedDate  이번 응답의 {@code activities}가 속한 날짜. {@code null}이면 보관함을 보고 있다.
+ *                      요청이 날짜를 생략했을 때 서버가 무엇을 골랐는지 FE가 알아야 탭을 강조할 수 있다
+ * @param archiveCount  미배정 보관함 일정 수(보관함 칩의 "{n}개")
+ * @param activities    선택된 날짜(또는 보관함)의 일정만. {@code sortOrder} 순
+ * @param legs          연속한 두 일정 사이 이동시간. 2단계에서 채운다 — 지금은 항상 비어 있다
+ */
+public record BoardResponse(
+        BoardTrip trip,
+        List<BoardDay> days,
+        LocalDate selectedDate,
+        long archiveCount,
+        List<ActivityResponse> activities,
+        List<Object> legs
+) {
+
+    /**
+     * @param status     여행 타임존의 오늘로 파생한 상태
+     * @param recordMode 완료된 여행이면 true — 계획 편집 대신 기록 입력을 보여준다
+     */
+    public record BoardTrip(
+            Long id,
+            String title,
+            String timezone,
+            String currency,
+            LocalDate startDate,
+            LocalDate endDate,
+            TripStatus status,
+            boolean recordMode
+    ) {
+    }
+
+    /**
+     * 날짜 탭 하나.
+     *
+     * @param dayIndex      1부터 시작하는 일차
+     * @param weekday       한국어 요일 한 글자("금")
+     * @param activityCount 그 날짜의 일정 수
+     * @param weather       날씨 요약. 4단계에서 채운다 — 지금은 항상 null
+     */
+    public record BoardDay(
+            int dayIndex,
+            LocalDate date,
+            String weekday,
+            long activityCount,
+            Object weather
+    ) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
@@ -1,0 +1,108 @@
+package ds.project.orino.planner.travel.board.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import ds.project.orino.domain.planner.travel.entity.TripActivity;
+import ds.project.orino.domain.planner.travel.entity.TripStatus;
+import ds.project.orino.domain.planner.travel.repository.ActivityDateCount;
+import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
+import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.activity.service.ActivityService;
+import ds.project.orino.planner.travel.board.dto.BoardResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 보드(S-04)의 단일 조회.
+ *
+ * <p>날짜 탭·보관함 건수·선택된 날짜의 일정을 한 응답에 담는다. 화면의 N+1 호출을 막는 것도
+ * 있지만, 진짜 이유는 <b>오프라인 캐시가 응답 하나로 성립해야</b> 한다는 것이다 —
+ * 응답을 쪼개면 비행기 모드에서 탭 하나만 살아난다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class BoardService {
+
+    private final TripRepository tripRepository;
+    private final TripActivityRepository activityRepository;
+    private final ActivityService activityService;
+    private final Clock clock;
+
+    public BoardService(TripRepository tripRepository,
+                        TripActivityRepository activityRepository,
+                        ActivityService activityService,
+                        Clock clock) {
+        this.tripRepository = tripRepository;
+        this.activityRepository = activityRepository;
+        this.activityService = activityService;
+        this.clock = clock;
+    }
+
+    /**
+     * @param date    볼 날짜. {@code null}이면 서버가 고른다(아래 {@code defaultDate})
+     * @param archive {@code true}면 날짜 대신 미배정 보관함을 본다
+     */
+    public BoardResponse board(Long memberId, Long tripId, LocalDate date, boolean archive) {
+        Trip trip = tripRepository.findByIdAndMemberId(tripId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_TRIP_NOT_FOUND));
+        TripStatus status = trip.status(clock);
+
+        LocalDate selectedDate = archive ? null : resolveSelectedDate(trip, status, date);
+        List<TripActivity> activities = selectedDate == null
+                ? activityRepository.findUnscheduled(tripId)
+                : activityRepository.findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(
+                        tripId, selectedDate);
+
+        return new BoardResponse(
+                new BoardResponse.BoardTrip(trip.getId(), trip.getTitle(), trip.getTimezone(),
+                        trip.getCurrency(), trip.getStartDate(), trip.getEndDate(), status,
+                        status == TripStatus.COMPLETED),
+                buildDays(trip),
+                selectedDate,
+                activityRepository.countUnscheduled(tripId),
+                activityService.toResponses(activities),
+                // 이동시간(legs)은 장소·Routes가 붙는 2단계에서 채운다.
+                List.of());
+    }
+
+    /**
+     * 날짜를 안 주면 — 여행 중이면 <b>여행 타임존의 오늘</b>, 아니면 1일차를 연다.
+     * 현지에서 앱을 열자마자 오늘 일정이 보여야 하고, 그 "오늘"은 기기 시간대가 아니다.
+     */
+    private LocalDate resolveSelectedDate(Trip trip, TripStatus status, LocalDate requested) {
+        if (requested != null) {
+            if (!trip.covers(requested)) {
+                throw new CustomException(ErrorCode.TRAVEL_DATE_OUT_OF_RANGE);
+            }
+            return requested;
+        }
+        return status == TripStatus.ONGOING ? trip.todayAtDestination(clock) : trip.getStartDate();
+    }
+
+    /** 기간에서 날짜 탭을 만든다. 일정이 하나도 없는 날짜도 탭은 나와야 한다. */
+    private List<BoardResponse.BoardDay> buildDays(Trip trip) {
+        Map<LocalDate, Long> counts = activityRepository.countByDate(trip.getId()).stream()
+                .collect(Collectors.toMap(ActivityDateCount::activityDate, ActivityDateCount::count));
+
+        List<BoardResponse.BoardDay> days = new ArrayList<>();
+        for (int dayIndex = 1; dayIndex <= trip.totalDays(); dayIndex++) {
+            LocalDate date = trip.getStartDate().plusDays(dayIndex - 1L);
+            days.add(new BoardResponse.BoardDay(dayIndex, date,
+                    date.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN),
+                    counts.getOrDefault(date, 0L),
+                    // 날씨는 4단계. 예보 범위 밖이면 그때도 null이 나간다.
+                    null));
+        }
+        return days;
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/activity/controller/ActivityControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/activity/controller/ActivityControllerTest.java
@@ -1,0 +1,485 @@
+package ds.project.orino.planner.travel.activity.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.travel.entity.TripActivity;
+import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.FixedClockConfig;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 일정 CRUD·순서 변경 통합 테스트.
+ *
+ * <p>고정 시각 {@code 2026-01-15T02:00Z}. 여행 기간은 2026-10-24~10-27로 두어 예정 상태에서
+ * 편집하는 상황을 본다.
+ */
+@Import(FixedClockConfig.class)
+class ActivityControllerTest extends ApiTestSupport {
+
+    private static final String DAY1 = "2026-10-24";
+    private static final String DAY2 = "2026-10-25";
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TripActivityRepository activityRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private String otherAuthHeader;
+    private long tripId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        memberRepository.save(MemberFixture.create("other", "password"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        otherAuthHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+        tripId = createTrip(authHeader);
+    }
+
+    @Nested
+    @DisplayName("POST /trips/{id}/activities")
+    class Create {
+
+        @Test
+        @DisplayName("일정을 만들면 서버가 그 날짜 맨 뒤 순서를 배정한다")
+        void appendsToEndOfDay() throws Exception {
+            createActivity("첫 일정", DAY1);
+
+            mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "둘째 일정", "activityDate": "%s", "startTime": "10:30"}
+                                    """.formatted(DAY1)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.title").value("둘째 일정"))
+                    .andExpect(jsonPath("$.data.sortOrder").value(1))
+                    .andExpect(jsonPath("$.data.startTime").value("10:30"))
+                    .andExpect(jsonPath("$.data.hasLog").value(false))
+                    .andExpect(jsonPath("$.data.place").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("날짜별로 순서를 따로 센다")
+        void sortOrderIsPerDate() throws Exception {
+            createActivity("1일차", DAY1);
+
+            mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "2일차", "activityDate": "%s"}
+                                    """.formatted(DAY2)))
+                    .andExpect(jsonPath("$.data.sortOrder").value(0));
+        }
+
+        @Test
+        @DisplayName("날짜 없이 만들면 보관함으로 들어간다")
+        void createsIntoArchive() throws Exception {
+            mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "가고 싶은 라멘집"}
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.activityDate").doesNotExist())
+                    .andExpect(jsonPath("$.data.sortOrder").value(0));
+
+            assertThat(activityRepository.findUnscheduled(tripId)).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("시각 없는 일정도 만들 수 있다")
+        void allowsMissingStartTime() throws Exception {
+            mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "동네 산책", "activityDate": "%s"}
+                                    """.formatted(DAY1)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.startTime").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("여행 기간 밖 날짜는 400")
+        void rejectsDateOutsideTrip() throws Exception {
+            mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "출발 전날", "activityDate": "2026-10-23"}
+                                    """))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-007"));
+        }
+
+        @Test
+        @DisplayName("제목이 없으면 400")
+        void rejectsBlankTitle() throws Exception {
+            mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "  ", "activityDate": "%s"}
+                                    """.formatted(DAY1)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("남의 여행에는 일정을 넣을 수 없다(404)")
+        void rejectsOtherMembersTrip() throws Exception {
+            mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "침입", "activityDate": "%s"}
+                                    """.formatted(DAY1)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-001"));
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT · DELETE /activities/{id}")
+    class UpdateAndDelete {
+
+        @Test
+        @DisplayName("계획 필드를 한 번에 수정한다")
+        void updatesPlanFields() throws Exception {
+            long id = createActivity("센소지", DAY1);
+
+            mockMvc.perform(put("/api/travel/activities/" + id)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "센소지 재방문", "activityDate": "%s",
+                                     "startTime": "09:15", "memo": "티켓 예매함",
+                                     "url": "https://example.com", "notifyEnabled": true,
+                                     "notifyMinutes": 30, "departureNotifyEnabled": true}
+                                    """.formatted(DAY1)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.title").value("센소지 재방문"))
+                    .andExpect(jsonPath("$.data.startTime").value("09:15"))
+                    .andExpect(jsonPath("$.data.memo").value("티켓 예매함"))
+                    .andExpect(jsonPath("$.data.notifyEnabled").value(true))
+                    .andExpect(jsonPath("$.data.notifyMinutes").value(30))
+                    .andExpect(jsonPath("$.data.departureNotifyEnabled").value(true));
+        }
+
+        @Test
+        @DisplayName("시각 없이 알림을 켜도 저장은 된다(알림 생성 여부는 3단계 판정)")
+        void allowsNotifyWithoutTime() throws Exception {
+            long id = createActivity("쇼핑", DAY1);
+
+            mockMvc.perform(put("/api/travel/activities/" + id)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "쇼핑", "activityDate": "%s", "notifyEnabled": true}
+                                    """.formatted(DAY1)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.notifyEnabled").value(true))
+                    .andExpect(jsonPath("$.data.startTime").doesNotExist());
+
+            assertThat(activityRepository.findById(id).orElseThrow().isNotifiable()).isFalse();
+        }
+
+        @Test
+        @DisplayName("날짜를 바꾸면 옮겨간 날짜의 맨 뒤로 붙고, 떠나온 날짜는 0..n-1로 메워진다")
+        void movingDateReindexesBothSides() throws Exception {
+            long a = createActivity("A", DAY1);
+            long b = createActivity("B", DAY1);
+            long c = createActivity("C", DAY1);
+            createActivity("기존 2일차", DAY2);
+
+            mockMvc.perform(put("/api/travel/activities/" + b)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "B", "activityDate": "%s"}
+                                    """.formatted(DAY2)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.sortOrder").value(1));
+
+            assertOrder(DAY1, List.of(a, c));
+            assertThat(activityRepository.findById(b).orElseThrow().getActivityDate())
+                    .isEqualTo(LocalDate.parse(DAY2));
+        }
+
+        @Test
+        @DisplayName("보관함으로 내리면 날짜가 비고 보관함 맨 뒤에 붙는다")
+        void movesToArchive() throws Exception {
+            createActivity("기존 보관함", null);
+            long id = createActivity("내릴 일정", DAY1);
+
+            mockMvc.perform(put("/api/travel/activities/" + id)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "내릴 일정"}
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.activityDate").doesNotExist())
+                    .andExpect(jsonPath("$.data.sortOrder").value(1));
+        }
+
+        @Test
+        @DisplayName("기간 밖으로는 옮길 수 없다(400)")
+        void rejectsMoveOutsideTrip() throws Exception {
+            long id = createActivity("센소지", DAY1);
+
+            mockMvc.perform(put("/api/travel/activities/" + id)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "센소지", "activityDate": "2026-11-01"}
+                                    """))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-007"));
+        }
+
+        @Test
+        @DisplayName("삭제하면 남은 일정의 순서가 0..n-1로 메워진다")
+        void deleteReindexesRemaining() throws Exception {
+            long a = createActivity("A", DAY1);
+            long b = createActivity("B", DAY1);
+            long c = createActivity("C", DAY1);
+
+            mockMvc.perform(delete("/api/travel/activities/" + b)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk());
+
+            assertOrder(DAY1, List.of(a, c));
+        }
+
+        @Test
+        @DisplayName("남의 일정은 조회·수정·삭제 모두 404다")
+        void otherMembersActivityIsNotFound() throws Exception {
+            long id = createActivity("센소지", DAY1);
+
+            mockMvc.perform(get("/api/travel/activities/" + id)
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-006"));
+            mockMvc.perform(put("/api/travel/activities/" + id)
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "탈취", "activityDate": "%s"}
+                                    """.formatted(DAY1)))
+                    .andExpect(status().isNotFound());
+            mockMvc.perform(delete("/api/travel/activities/" + id)
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /trips/{id}/activities/order")
+    class Reorder {
+
+        @Test
+        @DisplayName("보낸 배열 순서대로 0..n-1을 다시 매긴다")
+        void reassignsSortOrder() throws Exception {
+            long a = createActivity("A", DAY1);
+            long b = createActivity("B", DAY1);
+            long c = createActivity("C", DAY1);
+
+            reorder("""
+                    {"moves": [{"date": "%s", "activityIds": [%d, %d, %d]}]}
+                    """.formatted(DAY1, c, a, b));
+
+            assertOrder(DAY1, List.of(c, a, b));
+        }
+
+        @Test
+        @DisplayName("순서 변경과 날짜 이동이 한 요청으로 처리된다")
+        void movesAcrossDatesInOneRequest() throws Exception {
+            long a = createActivity("A", DAY1);
+            long b = createActivity("B", DAY1);
+            long c = createActivity("C", DAY2);
+
+            // A를 2일차 맨 앞으로 보내고, 1일차엔 B만 남긴다.
+            reorder("""
+                    {"moves": [
+                        {"date": "%s", "activityIds": [%d]},
+                        {"date": "%s", "activityIds": [%d, %d]}
+                    ]}
+                    """.formatted(DAY1, b, DAY2, a, c));
+
+            assertOrder(DAY1, List.of(b));
+            assertOrder(DAY2, List.of(a, c));
+        }
+
+        @Test
+        @DisplayName("보관함으로 내리고 올리는 것도 같은 요청으로 된다")
+        void movesBetweenArchiveAndDate() throws Exception {
+            long planned = createActivity("계획됨", DAY1);
+            long archived = createActivity("보관됨", null);
+
+            reorder("""
+                    {"moves": [
+                        {"date": null, "activityIds": [%d]},
+                        {"date": "%s", "activityIds": [%d]}
+                    ]}
+                    """.formatted(planned, DAY1, archived));
+
+            assertThat(activityRepository.findUnscheduled(tripId))
+                    .extracting(TripActivity::getId).containsExactly(planned);
+            assertOrder(DAY1, List.of(archived));
+        }
+
+        @Test
+        @DisplayName("일부만 보내도 남은 일정이 뒤에 붙어 순서에 구멍이 남지 않는다")
+        void normalizesEvenOnPartialArray() throws Exception {
+            long a = createActivity("A", DAY1);
+            long b = createActivity("B", DAY1);
+            long c = createActivity("C", DAY1);
+
+            // C만 보냈다 — 나머지는 뒤로 밀리되 0..n-1은 유지돼야 한다.
+            reorder("""
+                    {"moves": [{"date": "%s", "activityIds": [%d]}]}
+                    """.formatted(DAY1, c));
+
+            assertOrder(DAY1, List.of(c, a, b));
+        }
+
+        @Test
+        @DisplayName("기간 밖 날짜로는 옮길 수 없다(400)")
+        void rejectsDateOutsideTrip() throws Exception {
+            long a = createActivity("A", DAY1);
+
+            mockMvc.perform(put("/api/travel/trips/" + tripId + "/activities/order")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"moves": [{"date": "2026-12-01", "activityIds": [%d]}]}
+                                    """.formatted(a)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-007"));
+        }
+
+        @Test
+        @DisplayName("남의 일정이 섞이면 통째로 막고 아무것도 바꾸지 않는다")
+        void rejectsForeignActivityAndChangesNothing() throws Exception {
+            long a = createActivity("A", DAY1);
+            long b = createActivity("B", DAY1);
+            long foreign = createForeignActivity();
+
+            mockMvc.perform(put("/api/travel/trips/" + tripId + "/activities/order")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"moves": [{"date": "%s", "activityIds": [%d, %d, %d]}]}
+                                    """.formatted(DAY1, b, a, foreign)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-006"));
+
+            // 실패했으니 원래 순서 그대로.
+            assertOrder(DAY1, List.of(a, b));
+        }
+
+        @Test
+        @DisplayName("남의 여행 순서는 바꿀 수 없다(404)")
+        void rejectsOtherMembersTrip() throws Exception {
+            long a = createActivity("A", DAY1);
+
+            mockMvc.perform(put("/api/travel/trips/" + tripId + "/activities/order")
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"moves": [{"date": "%s", "activityIds": [%d]}]}
+                                    """.formatted(DAY1, a)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-001"));
+        }
+    }
+
+    // ---------------- helpers ----------------
+
+    private long createTrip(String header) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, header)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "도쿄", "destinationName": "도쿄",
+                                 "startDate": "2026-10-24", "endDate": "2026-10-27",
+                                 "timezone": "Asia/Tokyo", "currency": "JPY"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private long createActivity(String title, String date) throws Exception {
+        String dateField = date == null ? "" : ", \"activityDate\": \"%s\"".formatted(date);
+        String body = mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\": \"%s\"%s}".formatted(title, dateField)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    /** 다른 멤버의 여행에 속한 일정 — 소유권 검사를 실증하기 위한 것. */
+    private long createForeignActivity() throws Exception {
+        long foreignTrip = createTrip(otherAuthHeader);
+        String body = mockMvc.perform(post("/api/travel/trips/" + foreignTrip + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, otherAuthHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "남의 일정", "activityDate": "%s"}
+                                """.formatted(DAY1)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private void reorder(String body) throws Exception {
+        mockMvc.perform(put("/api/travel/trips/" + tripId + "/activities/order")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.legs").isArray());
+    }
+
+    private void assertOrder(String date, List<Long> expectedIds) {
+        List<TripActivity> ordered = activityRepository
+                .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(tripId, LocalDate.parse(date));
+        assertThat(ordered).extracting(TripActivity::getId).containsExactlyElementsOf(expectedIds);
+        // 순서 값 자체가 0..n-1이어야 다음 드래그가 어긋나지 않는다.
+        assertThat(ordered).extracting(TripActivity::getSortOrder)
+                .containsExactlyElementsOf(IntStream.range(0, expectedIds.size()).boxed().toList());
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardControllerTest.java
@@ -1,0 +1,232 @@
+package ds.project.orino.planner.travel.board.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.FixedClockConfig;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 보드 단일 조회 통합 테스트.
+ *
+ * <p>고정 시각 {@code 2026-01-15T02:00:00Z}. 날짜를 생략했을 때 서버가 무엇을 고르는지가
+ * 이 화면의 핵심이라 진행 중/예정 여행을 나눠 본다.
+ */
+@Import(FixedClockConfig.class)
+class BoardControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private String otherAuthHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        memberRepository.save(MemberFixture.create("other", "password"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        otherAuthHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+    }
+
+    @Test
+    @DisplayName("날짜 탭은 기간에서 만들어지고 일정 없는 날도 나온다")
+    void buildsDayTabsFromPeriod() throws Exception {
+        long tripId = createTrip("도쿄", "2026-10-24", "2026-10-27");
+        createActivity(tripId, "센소지", "2026-10-24");
+        createActivity(tripId, "우에노", "2026-10-24");
+
+        mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.days", hasSize(4)))
+                .andExpect(jsonPath("$.data.days[0].dayIndex").value(1))
+                .andExpect(jsonPath("$.data.days[0].date").value("2026-10-24"))
+                .andExpect(jsonPath("$.data.days[0].weekday").value("토"))
+                .andExpect(jsonPath("$.data.days[0].activityCount").value(2))
+                .andExpect(jsonPath("$.data.days[1].activityCount").value(0))
+                .andExpect(jsonPath("$.data.days[3].dayIndex").value(4))
+                // 날씨·이동시간은 각각 4·2단계라 지금은 비어 있다.
+                .andExpect(jsonPath("$.data.days[0].weather").doesNotExist())
+                .andExpect(jsonPath("$.data.legs", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("여행 정보와 기록 모드 플래그가 함께 온다")
+    void includesTripHeader() throws Exception {
+        long tripId = createTrip("도쿄", "2026-10-24", "2026-10-27");
+
+        mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.trip.title").value("도쿄"))
+                .andExpect(jsonPath("$.data.trip.timezone").value("Asia/Tokyo"))
+                .andExpect(jsonPath("$.data.trip.currency").value("JPY"))
+                .andExpect(jsonPath("$.data.trip.status").value("UPCOMING"))
+                .andExpect(jsonPath("$.data.trip.recordMode").value(false));
+    }
+
+    @Test
+    @DisplayName("완료된 여행은 기록 모드로 내려온다")
+    void completedTripIsRecordMode() throws Exception {
+        long tripId = createTrip("작년 오사카", "2025-05-01", "2025-05-03");
+
+        mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.trip.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.data.trip.recordMode").value(true));
+    }
+
+    @Test
+    @DisplayName("날짜를 생략하면 예정 여행은 1일차를 연다")
+    void defaultsToFirstDayWhenUpcoming() throws Exception {
+        long tripId = createTrip("도쿄", "2026-10-24", "2026-10-27");
+        createActivity(tripId, "1일차 일정", "2026-10-24");
+        createActivity(tripId, "2일차 일정", "2026-10-25");
+
+        mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.selectedDate").value("2026-10-24"))
+                .andExpect(jsonPath("$.data.activities", hasSize(1)))
+                .andExpect(jsonPath("$.data.activities[0].title").value("1일차 일정"));
+    }
+
+    @Test
+    @DisplayName("날짜를 생략하면 진행 중 여행은 여행 타임존의 오늘을 연다")
+    void defaultsToTodayAtDestinationWhenOngoing() throws Exception {
+        // 고정 시각 2026-01-15T02:00Z → 도쿄는 1/15, 호놀룰루는 아직 1/14다.
+        long tokyo = createTrip("도쿄", "2026-01-13", "2026-01-17", "Asia/Tokyo", "JPY");
+        createActivity(tokyo, "오늘 일정", "2026-01-15");
+        long honolulu = createTrip("하와이", "2026-01-13", "2026-01-17",
+                "Pacific/Honolulu", "USD");
+
+        mockMvc.perform(get("/api/travel/trips/" + tokyo + "/board")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.trip.status").value("ONGOING"))
+                .andExpect(jsonPath("$.data.selectedDate").value("2026-01-15"))
+                .andExpect(jsonPath("$.data.activities[0].title").value("오늘 일정"));
+
+        // 같은 순간, 같은 기간인데 현지 날짜가 하루 전이라 다른 탭이 열린다.
+        mockMvc.perform(get("/api/travel/trips/" + honolulu + "/board")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.selectedDate").value("2026-01-14"));
+    }
+
+    @Test
+    @DisplayName("date를 주면 그 날짜 일정만 sort_order 순으로 온다")
+    void returnsRequestedDateOnly() throws Exception {
+        long tripId = createTrip("도쿄", "2026-10-24", "2026-10-27");
+        createActivity(tripId, "2일차 A", "2026-10-25");
+        createActivity(tripId, "2일차 B", "2026-10-25");
+        createActivity(tripId, "1일차", "2026-10-24");
+
+        mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                        .param("date", "2026-10-25")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.selectedDate").value("2026-10-25"))
+                .andExpect(jsonPath("$.data.activities", hasSize(2)))
+                .andExpect(jsonPath("$.data.activities[0].title").value("2일차 A"))
+                .andExpect(jsonPath("$.data.activities[1].title").value("2일차 B"));
+    }
+
+    @Test
+    @DisplayName("archive=true면 보관함을 보여주고 selectedDate가 비어 있다")
+    void returnsArchive() throws Exception {
+        long tripId = createTrip("도쿄", "2026-10-24", "2026-10-27");
+        createActivity(tripId, "계획됨", "2026-10-24");
+        createActivity(tripId, "후보 A", null);
+        createActivity(tripId, "후보 B", null);
+
+        mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                        .param("archive", "true")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.selectedDate").doesNotExist())
+                .andExpect(jsonPath("$.data.archiveCount").value(2))
+                .andExpect(jsonPath("$.data.activities", hasSize(2)))
+                .andExpect(jsonPath("$.data.activities[0].title").value("후보 A"));
+    }
+
+    @Test
+    @DisplayName("보관함 건수는 어느 탭을 보든 항상 함께 온다")
+    void archiveCountAlwaysPresent() throws Exception {
+        long tripId = createTrip("도쿄", "2026-10-24", "2026-10-27");
+        createActivity(tripId, "후보", null);
+
+        mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                        .param("date", "2026-10-24")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(jsonPath("$.data.archiveCount").value(1))
+                // 보관함 일정은 날짜 탭 건수에 섞이면 안 된다.
+                .andExpect(jsonPath("$.data.days[0].activityCount").value(0));
+    }
+
+    @Test
+    @DisplayName("기간 밖 날짜를 요청하면 400")
+    void rejectsDateOutsideTrip() throws Exception {
+        long tripId = createTrip("도쿄", "2026-10-24", "2026-10-27");
+
+        mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                        .param("date", "2026-10-28")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("TRAVEL-ERR-007"));
+    }
+
+    @Test
+    @DisplayName("남의 여행 보드는 404")
+    void otherMembersBoardIsNotFound() throws Exception {
+        long tripId = createTrip("도쿄", "2026-10-24", "2026-10-27");
+
+        mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                        .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRAVEL-ERR-001"));
+    }
+
+    // ---------------- helpers ----------------
+
+    private long createTrip(String title, String start, String end) throws Exception {
+        return createTrip(title, start, end, "Asia/Tokyo", "JPY");
+    }
+
+    private long createTrip(String title, String start, String end,
+                            String timezone, String currency) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "%s", "destinationName": "%s", "startDate": "%s",
+                                 "endDate": "%s", "timezone": "%s", "currency": "%s"}
+                                """.formatted(title, title, start, end, timezone, currency)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private void createActivity(long tripId, String title, String date) throws Exception {
+        String dateField = date == null ? "" : ", \"activityDate\": \"%s\"".formatted(date);
+        mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\": \"%s\"%s}".formatted(title, dateField)))
+                .andExpect(status().isOk());
+    }
+}

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -41,7 +41,9 @@ public enum ErrorCode {
     TRAVEL_INVALID_CURRENCY("TRAVEL-ERR-004", "유효하지 않은 통화 코드입니다.", 400),
     // 기간을 줄이면 잘린 일정이 보관함으로 밀린다. 사용자가 모르고 잃지 않도록 확인을 요구한다.
     TRAVEL_ARCHIVE_CONFIRM_REQUIRED("TRAVEL-ERR-005",
-            "기간을 줄이면 일부 일정이 미배정 보관함으로 이동합니다.", 409);
+            "기간을 줄이면 일부 일정이 미배정 보관함으로 이동합니다.", 409),
+    TRAVEL_ACTIVITY_NOT_FOUND("TRAVEL-ERR-006", "존재하지 않는 일정입니다.", 404),
+    TRAVEL_DATE_OUT_OF_RANGE("TRAVEL-ERR-007", "여행 기간 밖의 날짜입니다.", 400);
 
     private final String code;
     private final String message;

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/ActivityDateCount.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/ActivityDateCount.java
@@ -1,0 +1,13 @@
+package ds.project.orino.domain.planner.travel.repository;
+
+import java.time.LocalDate;
+
+/**
+ * 날짜별 일정 수. 보드의 날짜 탭이 모든 날짜의 건수를 한 번에 필요로 해서, 날짜마다 COUNT를
+ * 날리지 않고 한 번에 묶어 센다.
+ *
+ * @param activityDate 일정 날짜(보관함은 이 집계에서 제외한다)
+ * @param count        그 날짜의 일정 수
+ */
+public record ActivityDateCount(LocalDate activityDate, long count) {
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripActivityRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripActivityRepository.java
@@ -77,6 +77,26 @@ public interface TripActivityRepository extends JpaRepository<TripActivity, Long
                             @Param("startDate") LocalDate startDate,
                             @Param("endDate") LocalDate endDate);
 
+    /** 미배정 보관함 일정 수(보관함 칩의 "{n}개"). */
+    @Query("""
+            SELECT COUNT(a) FROM TripActivity a
+            WHERE a.tripId = :tripId AND a.activityDate IS NULL
+            """)
+    long countUnscheduled(@Param("tripId") Long tripId);
+
+    /** 보드 날짜 탭의 건수 — 날짜마다 COUNT를 날리지 않고 한 번에 센다. */
+    @Query("""
+            SELECT new ds.project.orino.domain.planner.travel.repository.ActivityDateCount(
+                       a.activityDate, COUNT(a))
+            FROM TripActivity a
+            WHERE a.tripId = :tripId AND a.activityDate IS NOT NULL
+            GROUP BY a.activityDate
+            """)
+    List<ActivityDateCount> countByDate(@Param("tripId") Long tripId);
+
+    /** 순서 재부여 대상 — 여러 날짜를 한 번에 읽는다(드래그 한 번이 두 날짜를 건드린다). */
+    List<TripActivity> findAllByTripIdAndActivityDateIn(Long tripId, List<LocalDate> dates);
+
     /** 여행별 일정 수를 한 번에 센다 — 목록 화면의 N+1을 막는다. */
     @Query("""
             SELECT new ds.project.orino.domain.planner.travel.repository.TripActivityCount(


### PR DESCRIPTION
## 이슈
closes #1032

## 작업 내용

일정 CRUD·정렬·보관함 API와 보드 단일 조회. [API 설계](https://github.com/wcorn/orino/wiki/Travel-API-Spec) §3·§4. (Epic #1029 · 1단계)

| 메서드 | 경로 |
|---|---|
| GET | `/api/travel/trips/{tripId}/board?date=&archive=` |
| POST | `/api/travel/trips/{tripId}/activities` |
| GET · PUT · DELETE | `/api/travel/activities/{activityId}` |
| PUT | `/api/travel/trips/{tripId}/activities/order` |

### 보드는 한 번의 조회로 끝난다

날짜 탭 전체 · 보관함 건수 · 선택된 날짜의 일정을 한 응답에 담는다. N+1 호출을 막는 것도 있지만 진짜 이유는 **오프라인 캐시가 응답 하나로 성립해야** 한다는 것이다(4단계). 응답을 쪼개면 비행기 모드에서 탭 하나만 살아난다.

`date`를 생략하면 진행 중인 여행은 **여행 타임존의 오늘**, 아니면 1일차를 연다. 현지에서 앱을 열자마자 오늘 일정이 보여야 하고, 그 "오늘"은 기기 시간대가 아니다.

`legs`(이동시간)·`days[].weather`는 각각 2·4단계 기능이라 **필드만 두고 비워 둔다**. 그때 FE 계약이 바뀌지 않게 형태를 지금 맞췄다.

### 순서는 항상 0..n-1로 정규화한다

`sortOrder`가 정렬의 유일한 기준이라(시각으로 정렬하지 않는다) 값에 구멍이나 중복이 생기면 다음 드래그가 어긋난다. 그래서 **순서를 건드리는 모든 경로에서 영향받은 날짜를 다시 0..n-1로 매긴다** — 순서 변경·날짜 이동·삭제 전부.

순서 변경은 순서와 날짜 이동을 한 요청·한 트랜잭션으로 처리하고, 옮겨 나온 날짜까지 정규화 대상에 넣는다(일정이 빠지면 그 날짜에 구멍이 남는다).

### 스펙에서 판단이 필요했던 두 가지

**1. `selectedDate`를 응답에 추가했다.** 스펙의 보드 응답에는 없는데, `date`를 생략하면 서버가 날짜를 고르므로 FE가 어느 탭을 강조할지 알 수 없다. 규칙(진행 중이면 현지 오늘)을 FE에도 복붙하면 두 곳에서 갈라진다. `null`이면 보관함을 보고 있다는 뜻이다.

**2. 부분 배열이 와도 순서가 깨지지 않게 했다.** 스펙은 "영향받은 날짜의 전체 순서를 보낸다(부분 갱신 금지)"지만, 클라이언트가 일부만 보냈을 때 서버가 깨지면 안 된다. 보낸 일정을 0..n-1로 앞에 놓고 **보내지 않은 일정은 뒤로 밀어** 정규화한다. (그냥 두면 보낸 것과 안 보낸 것의 `sortOrder`가 겹쳐 id 순으로 뒤섞인다 — 테스트로 실제 확인했다.)

## 테스트 (31개)

**`ActivityControllerTest`**
- 생성: 날짜 끝 순서 배정 · 날짜별 독립 카운트 · 보관함 생성 · 시각 없는 일정 · 기간 밖 400 · 제목 검증 · 남의 여행 404
- 수정·삭제: 계획 필드 일괄 수정 · **시각 없이 알림을 켜도 저장은 되고 `isNotifiable()`은 false** · 날짜 이동 시 양쪽 재인덱싱 · 보관함 이동 · 기간 밖 400 · 삭제 후 순서 메움 · 남의 일정 404
- 순서 변경: 0..n-1 재부여 · 날짜 이동과 동시 처리 · 보관함↔날짜 이동 · **부분 배열 정규화** · 기간 밖 400 · 남의 일정이 섞이면 통째로 막고 아무것도 안 바꿈 · 남의 여행 404

**`BoardControllerTest`**
- 날짜 탭 생성(일정 없는 날 포함) · 여행 헤더 · 기록 모드 · `date` 생략 시 기본 탭(예정=1일차, **진행 중=여행 타임존의 오늘**) · 특정 날짜 조회 · 보관함 탭 · 보관함 건수는 항상 동반 · 기간 밖 400 · 남의 여행 404

진행 중 여행의 기본 탭은 도쿄·호놀룰루 두 여행으로 확인한다 — 같은 순간·같은 기간인데 현지 날짜가 하루 달라 다른 탭이 열린다.

순서 검증은 id 순서만이 아니라 **`sortOrder` 값이 실제로 0..n-1인지**까지 본다. 값에 구멍이 남으면 다음 드래그가 어긋나기 때문이다.

`./gradlew check` 통과 (테스트 + Checkstyle 경고 0).

## 로컬 확인 (bootRun + curl)

MySQL 8.4.4 + Redis에 `local` 프로파일로 띄워 확인했다.

- 일정 생성 시 `sortOrder`가 날짜별로 따로 매겨짐(0, 1 / 0), 보관함은 `activityDate: null`
- `startTime`이 스펙대로 **`"09:00"`**(`HH:mm`)으로 직렬화
- 보드: `days` 4개(요일 `토·일·월·화`, 일정 없는 날 `activityCount: 0`), `selectedDate: 2026-10-24`, `archiveCount: 1`, `legs: []`
- 드래그 한 번으로 1일차 정리 + 우에노를 2일차 맨 앞으로 → DB에서 `(2, 10-25, 0)`, `(3, 10-25, 1)` 확인
- 2일차 맨 앞 삭제 → 남은 일정이 `sort_order 1 → 0`으로 메워짐
- 기간 밖 날짜 조회·이동 모두 400

## 참고

`hasLog`는 기록 테이블이 4단계(Liquibase 049)라 지금은 항상 `false`, `place`는 장소 생성 경로가 2단계라 항상 `null`이다. 조립 코드는 지금 넣어 뒀으므로 해당 단계에서 채우기만 하면 된다.