### PR TITLE
feat : 워크스페이스 분리 — /select 페이지 + 사이드바 스위처

### DIFF
--- a/fe/src/app/layout/AppHeader.tsx
+++ b/fe/src/app/layout/AppHeader.tsx
@@ -1,0 +1,72 @@
+import { LogOut, Menu, Moon, Sun } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+import { Logo } from "@/components/brand/Logo";
+import { Button } from "@/components/ui/button";
+import { logout } from "@/features/auth/api/auth";
+import { useThemeStore } from "@/shared/lib/theme";
+
+import { useAuth } from "../providers";
+
+interface AppHeaderProps {
+  /**
+   * 모바일 사이드바 열기. 사이드바가 없는 화면(`/select`)에서는 넘기지 않으며,
+   * 그러면 메뉴 버튼도 그리지 않는다.
+   */
+  onOpenMenu?: () => void;
+}
+
+/**
+ * 앱 상단 헤더 — 로고·테마 토글·로그아웃.
+ * 사이드바 없는 `/select`도 같은 헤더를 쓰므로 레이아웃에서 분리해 둔다.
+ */
+export function AppHeader({ onOpenMenu }: AppHeaderProps) {
+  const navigate = useNavigate();
+  const { refresh } = useAuth();
+  const { theme, setTheme } = useThemeStore();
+
+  const handleLogout = async () => {
+    await logout();
+    refresh();
+    navigate("/", { replace: true });
+  };
+
+  const toggleTheme = () => {
+    const resolved =
+      theme === "system"
+        ? window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light"
+        : theme;
+    setTheme(resolved === "dark" ? "light" : "dark");
+  };
+
+  return (
+    <header className="flex items-center justify-between border-b px-6 py-3">
+      <div className="flex items-center gap-2">
+        {onOpenMenu && (
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="md:hidden"
+            aria-label="메뉴 열기"
+            onClick={onOpenMenu}
+          >
+            <Menu className="size-4" />
+          </Button>
+        )}
+        <Logo size={22} />
+      </div>
+      <div className="flex items-center gap-1">
+        <Button variant="ghost" size="icon-sm" onClick={toggleTheme}>
+          <Sun className="size-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+          <Moon className="absolute size-4 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+        </Button>
+        <Button variant="ghost" size="sm" onClick={handleLogout}>
+          <LogOut className="size-3.5" />
+          로그아웃
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/fe/src/app/layout/AppLayout.tsx
+++ b/fe/src/app/layout/AppLayout.tsx
@@ -1,20 +1,12 @@
-import { LogOut, Menu, Moon, Sun } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 
-import { Logo } from "@/components/brand/Logo";
 import { Toaster } from "@/components/Toaster";
-import { Button } from "@/components/ui/button";
-import { logout } from "@/features/auth/api/auth";
-import { useThemeStore } from "@/shared/lib/theme";
 
-import { useAuth } from "../providers";
+import { AppHeader } from "./AppHeader";
 import { Sidebar } from "./Sidebar";
 
 export function AppLayout() {
-  const navigate = useNavigate();
-  const { refresh } = useAuth();
-  const { theme, setTheme } = useThemeStore();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const { pathname } = useLocation();
 
@@ -22,48 +14,9 @@ export function AppLayout() {
     setMobileMenuOpen(false);
   }, [pathname]);
 
-  const handleLogout = async () => {
-    await logout();
-    refresh();
-    navigate("/", { replace: true });
-  };
-
-  const toggleTheme = () => {
-    const resolved =
-      theme === "system"
-        ? window.matchMedia("(prefers-color-scheme: dark)").matches
-          ? "dark"
-          : "light"
-        : theme;
-    setTheme(resolved === "dark" ? "light" : "dark");
-  };
-
   return (
     <div className="flex min-h-svh flex-col">
-      <header className="flex items-center justify-between border-b px-6 py-3">
-        <div className="flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            className="md:hidden"
-            aria-label="메뉴 열기"
-            onClick={() => setMobileMenuOpen(true)}
-          >
-            <Menu className="size-4" />
-          </Button>
-          <Logo size={22} />
-        </div>
-        <div className="flex items-center gap-1">
-          <Button variant="ghost" size="icon-sm" onClick={toggleTheme}>
-            <Sun className="size-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
-            <Moon className="absolute size-4 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
-          </Button>
-          <Button variant="ghost" size="sm" onClick={handleLogout}>
-            <LogOut className="size-3.5" />
-            로그아웃
-          </Button>
-        </div>
-      </header>
+      <AppHeader onOpenMenu={() => setMobileMenuOpen(true)} />
       <div className="flex flex-1">
         <Sidebar
           open={mobileMenuOpen}

--- a/fe/src/app/layout/Sidebar.test.tsx
+++ b/fe/src/app/layout/Sidebar.test.tsx
@@ -77,4 +77,122 @@ describe("Sidebar", () => {
       "text-primary",
     );
   });
+
+  describe("워크스페이스 스위처", () => {
+    it("일상 경로에서는 일상 메뉴를, 여행 경로에서는 여행 메뉴를 보여준다", async () => {
+      const { unmount } = renderSidebar("/home");
+      await waitFor(() => {
+        expect(
+          screen.getByRole("link", { name: /학습 자료/ }),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByRole("link", { name: /여행 목록/ })).toBeNull();
+      unmount();
+
+      renderSidebar("/travel");
+      await waitFor(() => {
+        expect(
+          screen.getByRole("link", { name: /여행 목록/ }),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByRole("link", { name: /학습 자료/ })).toBeNull();
+      expect(screen.getByRole("link", { name: /도구/ })).toBeInTheDocument();
+    });
+
+    it("현재 워크스페이스 버튼이 활성으로 표시된다", async () => {
+      const { unmount } = renderSidebar("/home");
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "일상" })).toHaveAttribute(
+          "aria-current",
+          "true",
+        );
+      });
+      expect(screen.getByRole("button", { name: "여행" })).not.toHaveAttribute(
+        "aria-current",
+      );
+      unmount();
+
+      renderSidebar("/travel/trips");
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "여행" })).toHaveAttribute(
+          "aria-current",
+          "true",
+        );
+      });
+    });
+
+    it("일상 워크스페이스에서는 여행 요약을 부르지 않는다", async () => {
+      let called = false;
+      server.use(
+        http.get(`${API_BASE}/travel/summary`, () => {
+          called = true;
+          return HttpResponse.json({
+            code: "OK",
+            data: { ongoing: null, next: null, recentCompleted: null },
+          });
+        }),
+      );
+
+      renderSidebar("/home");
+      await waitFor(() => {
+        expect(
+          screen.getByRole("link", { name: /학습 자료/ }),
+        ).toBeInTheDocument();
+      });
+
+      expect(called).toBe(false);
+    });
+
+    it("진행 중 여행이 없으면 일정 보드 링크가 여행 목록을 가리킨다", async () => {
+      renderSidebar("/travel");
+      const link = await screen.findByRole("link", { name: /일정 보드/ });
+      expect(link).toHaveAttribute("href", "/travel/trips");
+    });
+
+    it("진행 중 여행이 있으면 일정 보드 링크가 그 보드를 가리킨다", async () => {
+      server.use(
+        http.get(`${API_BASE}/travel/summary`, () =>
+          HttpResponse.json({
+            code: "OK",
+            data: {
+              ongoing: {
+                id: 3,
+                title: "도쿄",
+                boardPath: "/travel/trips/3/board",
+              },
+              next: null,
+              recentCompleted: null,
+            },
+          }),
+        ),
+      );
+
+      renderSidebar("/travel");
+
+      await waitFor(() => {
+        expect(screen.getByRole("link", { name: /일정 보드/ })).toHaveAttribute(
+          "href",
+          "/travel/trips/3/board",
+        );
+      });
+    });
+
+    it("보드 경로에서는 여행 목록이 아니라 일정 보드가 활성화된다", async () => {
+      renderSidebar("/travel/trips/3/board");
+      const board = await screen.findByRole("link", { name: /일정 보드/ });
+      expect(board.className).toContain("text-primary");
+      expect(
+        screen.getByRole("link", { name: /여행 목록/ }).className,
+      ).not.toContain("text-primary");
+    });
+
+    it("여행 목록 경로에서는 일정 보드가 아니라 여행 목록이 활성화된다", async () => {
+      renderSidebar("/travel/trips");
+      const list = await screen.findByRole("link", { name: /여행 목록/ });
+      expect(list.className).toContain("text-primary");
+      expect(
+        screen.getByRole("link", { name: /일정 보드/ }).className,
+      ).not.toContain("text-primary");
+    });
+  });
 });

--- a/fe/src/app/layout/Sidebar.tsx
+++ b/fe/src/app/layout/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import {
   BookOpen,
   CalendarDays,
@@ -5,11 +6,17 @@ import {
   CheckSquare,
   FileText,
   Home,
+  LayoutGrid,
+  Plane,
   Settings,
+  Wrench,
 } from "lucide-react";
-import { NavLink, useLocation } from "react-router-dom";
+import { NavLink, useLocation, useNavigate } from "react-router-dom";
 
 import { useReviewSummary } from "@/features/review/hooks/useReviewSummary";
+import type { TravelSummary } from "@/features/travel/api/travel";
+import { useTravelSummary } from "@/features/travel/hooks/useTravelSummary";
+import { travelKeys } from "@/features/travel/queryKeys";
 import { cn } from "@/lib/utils";
 
 interface NavItem {
@@ -21,9 +28,19 @@ interface NavItem {
    * (「플래너」처럼 상위 1탭이 여러 하위 라우트를 대표하는 경우)
    */
   activePaths?: string[];
+  /**
+   * 경로 접두어로 표현할 수 없는 활성 판정. 여행 쪽은 `/travel/trips/:id/board`처럼
+   * 중간에 id가 끼어 접두어 비교로는 「여행 목록」과 구분되지 않는다.
+   */
+  matchPath?: (pathname: string) => boolean;
 }
 
-const NAV_ITEMS: NavItem[] = [
+/** `/travel/trips/12/board` · `/travel/trips/12/map` */
+const BOARD_PATH = /^\/travel\/trips\/\d+\/(board|map)$/;
+/** `/travel/trips` · `/travel/trips/new` · `/travel/trips/12` (목록과 생성·수정 폼) */
+const TRIP_LIST_PATH = /^\/travel\/trips(\/(new|\d+))?$/;
+
+const DAILY_NAV_ITEMS: NavItem[] = [
   { to: "/home", label: "홈", icon: Home },
   { to: "/planner/materials", label: "학습 자료", icon: BookOpen },
   { to: "/notes", label: "노트", icon: FileText },
@@ -38,6 +55,35 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/integrations", label: "연동 설정", icon: Settings },
 ];
 
+/**
+ * 여행 메뉴. 「일정 보드」의 `to`는 여는 시점에 정해진다(진행 중 여행의 보드 → 없으면 목록)
+ * — 보드는 여행 없이는 열 수 없어서다. 그래서 여기서는 자리만 잡고 아래에서 채운다.
+ */
+const TRAVEL_NAV_ITEMS: NavItem[] = [
+  { to: "/travel", label: "홈", icon: Home },
+  {
+    to: "/travel/trips",
+    label: "여행 목록",
+    icon: Plane,
+    matchPath: (pathname) => TRIP_LIST_PATH.test(pathname),
+  },
+  {
+    to: "/travel/trips",
+    label: "일정 보드",
+    icon: CalendarDays,
+    // 보드·지도·일정 상세를 모두 이 항목이 대표한다.
+    matchPath: (pathname) =>
+      BOARD_PATH.test(pathname) || pathname.startsWith("/travel/activities/"),
+  },
+  { to: "/travel/tools", label: "도구", icon: Wrench },
+  { to: "/travel/settings", label: "설정", icon: Settings },
+];
+
+/** 여행 워크스페이스인지 — 경로 하나로 판정한다(별도 상태를 두면 새로고침에 어긋난다). */
+function isTravelWorkspace(pathname: string): boolean {
+  return pathname === "/travel" || pathname.startsWith("/travel/");
+}
+
 /** activePaths가 지정된 항목의 활성 여부 — 해당 경로이거나 그 하위 경로면 활성. */
 function matchesActivePaths(pathname: string, paths: string[]): boolean {
   return paths.some((p) => pathname === p || pathname.startsWith(`${p}/`));
@@ -49,9 +95,36 @@ interface SidebarProps {
 }
 
 export function Sidebar({ open, onClose }: SidebarProps) {
-  const { data } = useReviewSummary();
-  const reviewCount = data?.counts.now ?? 0;
   const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const travel = isTravelWorkspace(pathname);
+
+  const { data: reviewData } = useReviewSummary();
+  const reviewCount = reviewData?.counts.now ?? 0;
+  // 훅은 항상 호출하되(조건부 호출 금지) 일상 워크스페이스에서는 요청을 끈다 —
+  // 일상 화면이 여행 API를 부르기 시작하면 그건 일상 쪽 동작 변경이다.
+  const { data: travelData } = useTravelSummary({ enabled: travel });
+  const boardPath = travelData?.ongoing?.boardPath ?? "/travel/trips";
+
+  const navItems = travel ? TRAVEL_NAV_ITEMS : DAILY_NAV_ITEMS;
+
+  /**
+   * 여행으로 전환 — 진행 중 여행이 있으면 곧바로 그 보드로 들어간다.
+   *
+   * <p>일상에 있는 동안은 요약 쿼리가 꺼져 있어 캐시를 직접 읽는다. 로그인하면 반드시
+   * `/select`를 거치므로 대개 이미 채워져 있고, 없으면 여행 홈으로 보낸다.
+   */
+  const goToTravel = () => {
+    const cached = queryClient.getQueryData<TravelSummary>(travelKeys.summary);
+    navigate(cached?.ongoing?.boardPath ?? "/travel");
+    onClose();
+  };
+
+  const goToDaily = () => {
+    navigate("/home");
+    onClose();
+  };
 
   return (
     <>
@@ -72,19 +145,42 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           open ? "translate-x-0" : "-translate-x-full md:translate-x-0",
         )}
       >
+        <div className="p-2 pb-0">
+          <div
+            role="group"
+            aria-label="워크스페이스"
+            className="bg-muted flex gap-0.5 rounded-lg p-1"
+          >
+            <WorkspaceButton
+              label="여행"
+              icon={Plane}
+              active={travel}
+              onClick={goToTravel}
+            />
+            <WorkspaceButton
+              label="일상"
+              icon={LayoutGrid}
+              active={!travel}
+              onClick={goToDaily}
+            />
+          </div>
+        </div>
         <ul className="flex flex-col gap-0.5 p-2">
-          {NAV_ITEMS.map((item) => {
+          {navItems.map((item) => {
             const Icon = item.icon;
             const isReviewItem = item.to === "/planner/reviews";
+            const isBoardItem = item.label === "일정 보드";
             return (
-              <li key={item.to}>
+              <li key={item.label}>
                 <NavLink
-                  to={item.to}
-                  end={item.to === "/home"}
+                  to={isBoardItem ? boardPath : item.to}
+                  end={item.to === "/home" || item.to === "/travel"}
                   className={({ isActive }) => {
-                    const active = item.activePaths
-                      ? matchesActivePaths(pathname, item.activePaths)
-                      : isActive;
+                    const active = item.matchPath
+                      ? item.matchPath(pathname)
+                      : item.activePaths
+                        ? matchesActivePaths(pathname, item.activePaths)
+                        : isActive;
                     return cn(
                       "flex h-9 items-center justify-between rounded-md px-3 text-sm font-medium transition-colors",
                       active
@@ -112,5 +208,36 @@ export function Sidebar({ open, onClose }: SidebarProps) {
         </ul>
       </nav>
     </>
+  );
+}
+
+interface WorkspaceButtonProps {
+  label: string;
+  icon: typeof Home;
+  active: boolean;
+  onClick: () => void;
+}
+
+function WorkspaceButton({
+  label,
+  icon: Icon,
+  active,
+  onClick,
+}: WorkspaceButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-current={active ? "true" : undefined}
+      onClick={onClick}
+      className={cn(
+        "inline-flex h-7 flex-1 items-center justify-center gap-1.5 rounded-md text-[13px] font-medium transition-colors",
+        active
+          ? "bg-background text-foreground shadow-sm"
+          : "text-muted-foreground",
+      )}
+    >
+      <Icon className="size-3.5" />
+      {label}
+    </button>
   );
 }

--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -48,6 +48,15 @@ export const importLifelogFlowDetail = () =>
   import("../pages/LifelogFlowDetailPage").then((m) => ({
     default: m.LifelogFlowDetailPage,
   }));
+export const importWorkspaceSelect = () =>
+  import("../pages/WorkspaceSelectPage").then((m) => ({
+    default: m.WorkspaceSelectPage,
+  }));
+// 여행 화면은 후속 이슈에서 채운다. 지금은 라우트 자리를 잡는 임시 페이지 하나를 공유한다.
+export const importTravelPlaceholder = () =>
+  import("../pages/travel/TravelPlaceholderPage").then((m) => ({
+    default: m.TravelPlaceholderPage,
+  }));
 
 /**
  * 로그인 후 idle 시간에 페이지 청크를 미리 받아둔다.
@@ -66,6 +75,8 @@ export function prefetchRoutes() {
     void importPlannerCalendar().catch(ignore);
     void importHome().catch(ignore);
     void importNotes().catch(ignore);
+    // 로그인 직후 반드시 거치는 화면이라 가장 먼저 필요해진다.
+    void importWorkspaceSelect().catch(ignore);
   };
   if (typeof requestIdleCallback === "function") {
     requestIdleCallback(run);

--- a/fe/src/app/router.test.tsx
+++ b/fe/src/app/router.test.tsx
@@ -51,7 +51,7 @@ describe("AppRouter", () => {
     });
   });
 
-  it("/login 경로에서 인증 시 /home으로 리다이렉트한다", async () => {
+  it("/login 경로에서 인증 시 /select로 리다이렉트한다", async () => {
     mockEmptyTodayReviews();
     useAuthStore.setState({ accessToken: "valid-token" });
 
@@ -59,8 +59,49 @@ describe("AppRouter", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: /로그아웃/ }),
+        screen.getByRole("heading", { name: "어디로 갈까요" }),
       ).toBeInTheDocument();
+    });
+  });
+
+  it("/ 경로에서 인증 시 /select로 리다이렉트한다", async () => {
+    mockEmptyTodayReviews();
+    useAuthStore.setState({ accessToken: "valid-token" });
+
+    renderApp(["/"]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "어디로 갈까요" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("/travel 딥링크는 선택 화면으로 되돌리지 않는다 (푸시 알림 진입점)", async () => {
+    mockEmptyTodayReviews();
+    useAuthStore.setState({ accessToken: "valid-token" });
+
+    renderApp(["/travel/trips/3/board"]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "일정 보드" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("heading", { name: "어디로 갈까요" })).toBeNull();
+  });
+
+  it("/select 는 미인증 시 로그인으로 보낸다", async () => {
+    server.use(
+      http.post(`${API_BASE}/auth/reissue`, () => {
+        return HttpResponse.json(null, { status: 401 });
+      }),
+    );
+
+    renderApp(["/select"]);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("아이디")).toBeInTheDocument();
     });
   });
 
@@ -84,12 +125,11 @@ describe("AppRouter", () => {
 
     renderApp(["/home"]);
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: /로그아웃/ }),
-      ).toBeInTheDocument();
-    });
-    expect(screen.getByText("안녕하세요 👋")).toBeInTheDocument();
+    // 헤더는 lazy 페이지보다 먼저 뜨므로, 페이지 본문이 나타날 때까지 기다린다.
+    expect(await screen.findByText("안녕하세요 👋")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /로그아웃/ }),
+    ).toBeInTheDocument();
   });
 
   it("/planner/materials 경로에서 자료 목록을 렌더링한다", async () => {

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -23,7 +23,9 @@ import {
   importReviewHub,
   importReviewSession,
   importRoutines,
+  importTravelPlaceholder,
   importWeeklyPlan,
+  importWorkspaceSelect,
 } from "./routeImports";
 
 // 로그인 후에만 쓰는 페이지들은 lazy 로드해 초기 번들에서 분리한다.
@@ -41,6 +43,8 @@ const NotesPage = lazy(importNotes);
 const LifelogPage = lazy(importLifelog);
 const LifelogFlowsPage = lazy(importLifelogFlows);
 const LifelogFlowDetailPage = lazy(importLifelogFlowDetail);
+const WorkspaceSelectPage = lazy(importWorkspaceSelect);
+const TravelPlaceholderPage = lazy(importTravelPlaceholder);
 
 function RouteFallback() {
   return (
@@ -48,6 +52,15 @@ function RouteFallback() {
       <BrandMark size={40} animated />
       <LoadingText />
     </div>
+  );
+}
+
+/** 여행 라우트의 임시 화면. 후속 이슈가 각 경로의 element를 실제 페이지로 바꾼다. */
+function TravelRoute({ title }: { title: string }) {
+  return (
+    <Suspense fallback={<RouteFallback />}>
+      <TravelPlaceholderPage title={title} />
+    </Suspense>
   );
 }
 
@@ -59,6 +72,15 @@ export function AppRouter() {
         <Route path="/login" element={<LoginPage />} />
       </Route>
       <Route element={<PrivateRoute />}>
+        {/* 워크스페이스 선택 — 자체 헤더를 쓰고 사이드바가 없어 AppLayout 밖에 둔다. */}
+        <Route
+          path="/select"
+          element={
+            <Suspense fallback={<RouteFallback />}>
+              <WorkspaceSelectPage />
+            </Suspense>
+          }
+        />
         <Route element={<AppLayout />}>
           <Route
             path="/home"
@@ -173,6 +195,24 @@ export function AppRouter() {
               </Suspense>
             }
           />
+          {/* 여행 워크스페이스. 화면은 후속 이슈에서 채우고 여기서는 라우트 자리를 잡는다.
+              푸시 알림 클릭이 /travel/* 딥링크로 들어오므로 선택 화면으로 되돌리지 않는다. */}
+          <Route path="/travel" element={<TravelRoute title="여행" />} />
+          <Route
+            path="/travel/trips"
+            element={<TravelRoute title="여행 목록" />}
+          />
+          <Route
+            path="/travel/trips/:tripId/board"
+            element={<TravelRoute title="일정 보드" />}
+          />
+          <Route path="/travel/tools" element={<TravelRoute title="도구" />} />
+          <Route
+            path="/travel/settings"
+            element={<TravelRoute title="여행 설정" />}
+          />
+          {/* 아직 없는 여행 하위 경로는 랜딩이 아니라 여행 홈으로 보낸다. */}
+          <Route path="/travel/*" element={<Navigate to="/travel" replace />} />
         </Route>
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/fe/src/features/auth/components/PublicRoute.test.tsx
+++ b/fe/src/features/auth/components/PublicRoute.test.tsx
@@ -14,7 +14,7 @@ function renderWithPublicRoute() {
         <Route element={<PublicRoute />}>
           <Route path="/login" element={<div>로그인 페이지</div>} />
         </Route>
-        <Route path="/home" element={<div>홈 페이지</div>} />
+        <Route path="/select" element={<div>워크스페이스 선택</div>} />
       </Routes>
     </Providers>,
     { initialEntries: ["/login"] },
@@ -34,12 +34,12 @@ describe("PublicRoute", () => {
     });
   });
 
-  it("인증 시 /home으로 리다이렉트한다", async () => {
+  it("인증 시 /select로 리다이렉트한다 — 마지막 워크스페이스를 기억하지 않는다", async () => {
     useAuthStore.setState({ accessToken: "mock-token" });
     renderWithPublicRoute();
 
     await waitFor(() => {
-      expect(screen.getByText("홈 페이지")).toBeInTheDocument();
+      expect(screen.getByText("워크스페이스 선택")).toBeInTheDocument();
     });
   });
 });

--- a/fe/src/features/auth/components/PublicRoute.tsx
+++ b/fe/src/features/auth/components/PublicRoute.tsx
@@ -4,5 +4,7 @@ import { useAuth } from "../../../app/providers";
 
 export function PublicRoute() {
   const { isAuthenticated } = useAuth();
-  return isAuthenticated ? <Navigate to="/home" replace /> : <Outlet />;
+  // 로그인한 채로 /login에 들어오면 워크스페이스 선택으로 보낸다.
+  // 마지막에 고른 워크스페이스를 기억하지 않으므로 항상 여기서 다시 고른다.
+  return isAuthenticated ? <Navigate to="/select" replace /> : <Outlet />;
 }

--- a/fe/src/features/travel/api/travel.ts
+++ b/fe/src/features/travel/api/travel.ts
@@ -1,0 +1,50 @@
+import { client } from "@/shared/api";
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+/** 진행 중 여행 — 탭하면 곧바로 보드로 간다. */
+export interface OngoingTripSummary {
+  id: number;
+  title: string;
+  /** 서버가 조립해 주는 보드 경로. 프론트가 경로를 다시 만들지 않는다. */
+  boardPath: string;
+}
+
+/** 다음 예정 여행 — D-day 카운트다운 카드. */
+export interface NextTripSummary {
+  id: number;
+  title: string;
+  destinationName: string;
+  startDate: string;
+  endDate: string;
+  /** 시작일까지 남은 일수. 여행 타임존 기준이라 프론트에서 다시 계산하지 않는다. */
+  dDay: number;
+  activityCount: number;
+}
+
+/** 가장 최근에 끝난 여행. */
+export interface CompletedTripSummary {
+  id: number;
+  title: string;
+  endDate: string;
+  activityCount: number;
+}
+
+/**
+ * `/select` 카드와 여행 홈(S-01)이 함께 쓰는 요약.
+ * 셋 다 null이면 여행을 한 번도 만들지 않은 상태다.
+ */
+export interface TravelSummary {
+  ongoing: OngoingTripSummary | null;
+  next: NextTripSummary | null;
+  recentCompleted: CompletedTripSummary | null;
+}
+
+export async function fetchTravelSummary(): Promise<TravelSummary> {
+  const { data } =
+    await client.get<ApiEnvelope<TravelSummary>>("/travel/summary");
+  return data.data;
+}

--- a/fe/src/features/travel/hooks/useTravelSummary.ts
+++ b/fe/src/features/travel/hooks/useTravelSummary.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchTravelSummary } from "../api/travel";
+import { travelKeys } from "../queryKeys";
+
+interface Options {
+  /**
+   * 기본 true. 일상 워크스페이스에서는 false로 꺼서 여행 API를 부르지 않는다 —
+   * 사이드바처럼 두 워크스페이스가 공유하는 컴포넌트는 훅을 조건부로 호출할 수 없기 때문이다.
+   */
+  enabled?: boolean;
+}
+
+/**
+ * 여행 요약. `/select` 카드와 여행 홈·사이드바가 같은 캐시를 공유한다 — 선택 화면에서 이미
+ * 받아둔 값으로 이후 화면이 즉시 그려진다.
+ */
+export function useTravelSummary({ enabled = true }: Options = {}) {
+  return useQuery({
+    queryKey: travelKeys.summary,
+    queryFn: fetchTravelSummary,
+    staleTime: 60 * 1000,
+    enabled,
+  });
+}

--- a/fe/src/features/travel/queryKeys.ts
+++ b/fe/src/features/travel/queryKeys.ts
@@ -1,0 +1,4 @@
+export const travelKeys = {
+  all: ["travel"] as const,
+  summary: ["travel", "summary"] as const,
+};

--- a/fe/src/pages/LandingPage.test.tsx
+++ b/fe/src/pages/LandingPage.test.tsx
@@ -16,7 +16,7 @@ function renderLandingPage() {
     <Providers>
       <Routes>
         <Route path="/" element={<LandingPage />} />
-        <Route path="/home" element={<div>홈 페이지</div>} />
+        <Route path="/select" element={<div>워크스페이스 선택</div>} />
         <Route path="/login" element={<div>로그인 페이지</div>} />
       </Routes>
     </Providers>,
@@ -38,17 +38,17 @@ describe("LandingPage", () => {
     });
   });
 
-  it("인증 상태면 /home으로 리다이렉트한다", async () => {
+  it("인증 상태면 /select로 리다이렉트한다", async () => {
     useAuthStore.setState({ accessToken: "valid-token" });
 
     renderLandingPage();
 
     await waitFor(() => {
-      expect(screen.getByText("홈 페이지")).toBeInTheDocument();
+      expect(screen.getByText("워크스페이스 선택")).toBeInTheDocument();
     });
   });
 
-  it("reissue 성공으로 인증되면 /home으로 리다이렉트한다", async () => {
+  it("reissue 성공으로 인증되면 /select로 리다이렉트한다", async () => {
     server.use(
       http.post(`${API_BASE}/auth/reissue`, () => {
         return HttpResponse.json({

--- a/fe/src/pages/LandingPage.tsx
+++ b/fe/src/pages/LandingPage.tsx
@@ -10,7 +10,7 @@ export function LandingPage() {
   const { isAuthenticated } = useAuth();
 
   if (isAuthenticated) {
-    return <Navigate to="/home" replace />;
+    return <Navigate to="/select" replace />;
   }
 
   return (

--- a/fe/src/pages/LoginPage.test.tsx
+++ b/fe/src/pages/LoginPage.test.tsx
@@ -11,7 +11,7 @@ function renderLoginPage() {
   return renderWithRouter(
     <Routes>
       <Route path="/login" element={<LoginPage />} />
-      <Route path="/home" element={<div>홈 페이지</div>} />
+      <Route path="/select" element={<div>워크스페이스 선택</div>} />
     </Routes>,
     { initialEntries: ["/login"] },
   );
@@ -30,7 +30,7 @@ describe("LoginPage", () => {
     expect(screen.getByRole("button", { name: "로그인" })).toBeInTheDocument();
   });
 
-  it("로그인 성공 시 /home으로 이동한다", async () => {
+  it("로그인 성공 시 /select로 이동한다", async () => {
     const user = userEvent.setup();
     renderLoginPage();
 
@@ -39,7 +39,7 @@ describe("LoginPage", () => {
     await user.click(screen.getByRole("button", { name: "로그인" }));
 
     await waitFor(() => {
-      expect(screen.getByText("홈 페이지")).toBeInTheDocument();
+      expect(screen.getByText("워크스페이스 선택")).toBeInTheDocument();
     });
   });
 
@@ -66,7 +66,7 @@ describe("LoginPage", () => {
     await user.type(screen.getByLabelText("비밀번호"), "password{Enter}");
 
     await waitFor(() => {
-      expect(screen.getByText("홈 페이지")).toBeInTheDocument();
+      expect(screen.getByText("워크스페이스 선택")).toBeInTheDocument();
     });
   });
 });

--- a/fe/src/pages/LoginPage.tsx
+++ b/fe/src/pages/LoginPage.tsx
@@ -26,7 +26,7 @@ export function LoginPage() {
     try {
       await login({ loginId, password });
       refresh();
-      navigate("/home", { replace: true });
+      navigate("/select", { replace: true });
     } catch {
       setError("아이디 또는 비밀번호가 올바르지 않습니다.");
     } finally {

--- a/fe/src/pages/WorkspaceSelectPage.test.tsx
+++ b/fe/src/pages/WorkspaceSelectPage.test.tsx
@@ -1,0 +1,228 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { AppRouter } from "@/app/router";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function mockTravelSummary(data: unknown) {
+  server.use(
+    http.get(`${API_BASE}/travel/summary`, () =>
+      HttpResponse.json({ code: "OK", data }),
+    ),
+  );
+}
+
+function renderApp(initialEntries: string[]) {
+  return renderWithRouter(
+    <Providers>
+      <AppRouter />
+    </Providers>,
+    { initialEntries },
+  );
+}
+
+describe("WorkspaceSelectPage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "valid-token" });
+  });
+
+  it("두 워크스페이스 카드를 보여준다", async () => {
+    renderApp(["/select"]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "어디로 갈까요" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /여행/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /일상/ })).toBeInTheDocument();
+  });
+
+  it("사이드바가 없다 — 선택 화면은 앱 셸 밖이다", async () => {
+    renderApp(["/select"]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "어디로 갈까요" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("navigation", { name: "주 메뉴" })).toBeNull();
+  });
+
+  it("여행이 없으면 배지도 메타도 그리지 않는다", async () => {
+    renderApp(["/select"]);
+
+    const travelCard = await screen.findByRole("button", { name: /여행/ });
+    // 더미 텍스트 대신 빈 자리. 설명 줄만 남는다.
+    expect(travelCard).toHaveTextContent("일정 보드, 지도, 알림, 환율·날씨");
+    expect(travelCard).not.toHaveTextContent(/D-/);
+  });
+
+  it("다음 여행이 있으면 D-day 배지와 기간 메타를 보여준다", async () => {
+    mockTravelSummary({
+      ongoing: null,
+      next: {
+        id: 3,
+        title: "도쿄 3박 4일",
+        destinationName: "도쿄",
+        startDate: "2026-10-24",
+        endDate: "2026-10-27",
+        dDay: 78,
+        activityCount: 13,
+      },
+      recentCompleted: null,
+    });
+
+    renderApp(["/select"]);
+
+    const travelCard = await screen.findByRole("button", { name: /여행/ });
+    await waitFor(() => {
+      expect(travelCard).toHaveTextContent("D-78");
+    });
+    expect(travelCard).toHaveTextContent("도쿄 3박 4일 · 10.24 – 10.27");
+  });
+
+  it("진행 중 여행이 있으면 '진행 중' 배지를 보여주고 눌렀을 때 보드로 간다", async () => {
+    mockTravelSummary({
+      ongoing: {
+        id: 3,
+        title: "도쿄 3박 4일",
+        boardPath: "/travel/trips/3/board",
+      },
+      next: null,
+      recentCompleted: null,
+    });
+
+    renderApp(["/select"]);
+
+    const travelCard = await screen.findByRole("button", { name: /여행/ });
+    await waitFor(() => {
+      expect(travelCard).toHaveTextContent("진행 중");
+    });
+
+    await userEvent.click(travelCard);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "일정 보드" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("진행 중 여행이 없으면 여행 카드는 여행 홈으로 간다", async () => {
+    renderApp(["/select"]);
+
+    const travelCard = await screen.findByRole("button", { name: /여행/ });
+    await userEvent.click(travelCard);
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "여행" })).toBeInTheDocument();
+    });
+  });
+
+  it("일상 카드는 미완료 복습 수를 배지로 보여준다", async () => {
+    server.use(
+      http.get(`${API_BASE}/planner/reviews/summary`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            today: "2026-05-18",
+            counts: { now: 3, overdue: 0, upcoming: 0, doneToday: 0 },
+            estimatedMinutes: 10,
+            materials: [],
+          },
+        }),
+      ),
+    );
+
+    renderApp(["/select"]);
+
+    const dailyCard = await screen.findByRole("button", { name: /일상/ });
+    await waitFor(() => {
+      expect(dailyCard).toHaveTextContent("복습 3");
+    });
+  });
+
+  it("오늘 루틴이 있으면 개수를 메타로 보여준다", async () => {
+    server.use(
+      http.get(`${API_BASE}/planner/calendar`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: {
+            from: "2026-05-18",
+            to: "2026-05-18",
+            googleConnected: true,
+            partial: false,
+            errors: [],
+            events: [
+              routineEvent("1"),
+              routineEvent("2"),
+              // 루틴이 아닌 일정은 세지 않는다.
+              {
+                id: "plain",
+                title: "회의",
+                allDay: false,
+                start: "2026-05-18T10:00:00",
+                end: null,
+                location: null,
+                recurring: false,
+                source: "google",
+                routine: null,
+              },
+            ],
+            tasks: [],
+            reviews: [],
+          },
+        }),
+      ),
+    );
+
+    renderApp(["/select"]);
+
+    const dailyCard = await screen.findByRole("button", { name: /일상/ });
+    await waitFor(() => {
+      expect(dailyCard).toHaveTextContent("오늘 루틴 2개");
+    });
+  });
+
+  it("일상 카드를 누르면 홈으로 간다", async () => {
+    server.use(
+      http.get(`${API_BASE}/planner/reviews/today`, () =>
+        HttpResponse.json({
+          code: "OK",
+          data: { today: "2026-05-18", reviews: [] },
+        }),
+      ),
+    );
+
+    renderApp(["/select"]);
+
+    const dailyCard = await screen.findByRole("button", { name: /일상/ });
+    await userEvent.click(dailyCard);
+
+    await waitFor(() => {
+      expect(screen.getByText("안녕하세요 👋")).toBeInTheDocument();
+    });
+  });
+});
+
+function routineEvent(id: string) {
+  return {
+    id,
+    title: `루틴 ${id}`,
+    allDay: false,
+    start: "2026-05-18T08:00:00",
+    end: null,
+    location: null,
+    recurring: true,
+    source: "google",
+    routine: { type: "habit", recurringEventId: id, done: false },
+  };
+}

--- a/fe/src/pages/WorkspaceSelectPage.tsx
+++ b/fe/src/pages/WorkspaceSelectPage.tsx
@@ -1,0 +1,166 @@
+import { CalendarDays, CheckSquare, LayoutGrid, Plane } from "lucide-react";
+import type { ComponentType } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { AppHeader } from "@/app/layout/AppHeader";
+import { Toaster } from "@/components/Toaster";
+import { Badge } from "@/components/ui/badge";
+import { usePlannerCalendar } from "@/features/planner/hooks/usePlannerCalendar";
+import { useReviewSummary } from "@/features/review/hooks/useReviewSummary";
+import type { TravelSummary } from "@/features/travel/api/travel";
+import { useTravelSummary } from "@/features/travel/hooks/useTravelSummary";
+import { cn } from "@/lib/utils";
+
+/** "2026-10-24" → "10.24" */
+function shortDate(isoDate: string): string {
+  const [, month, day] = isoDate.split("-");
+  return `${Number(month)}.${day}`;
+}
+
+/**
+ * 여행 카드의 배지·메타·이동 경로를 요약에서 뽑는다.
+ * 데이터가 없으면 메타를 비운다 — 더미 텍스트를 채우지 않는다.
+ */
+function travelCardContent(summary: TravelSummary | undefined) {
+  if (summary?.ongoing) {
+    return {
+      badge: "진행 중",
+      meta: summary.ongoing.title,
+      to: summary.ongoing.boardPath,
+    };
+  }
+  if (summary?.next) {
+    const { title, startDate, endDate, dDay } = summary.next;
+    return {
+      badge: `D-${dDay}`,
+      meta: `${title} · ${shortDate(startDate)} – ${shortDate(endDate)}`,
+      to: "/travel",
+    };
+  }
+  if (summary?.recentCompleted) {
+    return { badge: null, meta: "여행 만들기", to: "/travel" };
+  }
+  // 아직 못 받았거나 여행이 하나도 없는 상태 — 둘 다 메타를 비운다.
+  return { badge: null, meta: null, to: "/travel" };
+}
+
+/** 기기 시간대 기준 오늘. 일상 워크스페이스는 여행 타임존과 무관하다. */
+function today(): string {
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${now.getFullYear()}-${month}-${day}`;
+}
+
+export function WorkspaceSelectPage() {
+  const navigate = useNavigate();
+  const { data: travel } = useTravelSummary();
+  const { data: review } = useReviewSummary();
+  // 오늘 하루치 피드에서 루틴 인스턴스만 센다. Google 미연동이면 조회가 실패하고,
+  // 그때는 메타 줄을 그리지 않는다(더미 텍스트 대신 빈 자리).
+  const { data: feed } = usePlannerCalendar(today(), today());
+
+  const reviewCount = review?.counts.now ?? 0;
+  const routineCount =
+    feed?.events.filter((event) => event.routine).length ?? 0;
+  const { badge, meta, to } = travelCardContent(travel);
+
+  const dailyMeta = routineCount > 0 ? `오늘 루틴 ${routineCount}개` : null;
+
+  return (
+    <div className="flex min-h-svh flex-col">
+      <AppHeader />
+      <main className="grid flex-1 place-items-center px-4 pt-8 pb-16">
+        <div className="flex w-full max-w-[680px] flex-col gap-6">
+          <div>
+            <h1 className="text-title font-semibold">어디로 갈까요</h1>
+            <p className="text-muted-foreground mt-1 text-sm">
+              사이드바 맨 위에서 언제든 바꿀 수 있어요.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-4">
+            <WorkspaceCard
+              title="여행"
+              description="일정 보드, 지도, 알림, 환율·날씨"
+              icon={Plane}
+              iconClassName="bg-accent text-accent-foreground"
+              badge={badge}
+              metaIcon={CalendarDays}
+              meta={meta}
+              onClick={() => navigate(to)}
+            />
+            <WorkspaceCard
+              title="일상"
+              description="학습 자료, 노트, 일상기록, 복습, 플래너"
+              icon={LayoutGrid}
+              iconClassName="bg-muted"
+              badge={reviewCount > 0 ? `복습 ${reviewCount}` : null}
+              metaIcon={CheckSquare}
+              meta={dailyMeta}
+              onClick={() => navigate("/home")}
+            />
+          </div>
+        </div>
+      </main>
+      <Toaster />
+    </div>
+  );
+}
+
+interface WorkspaceCardProps {
+  title: string;
+  description: string;
+  icon: ComponentType<{ className?: string }>;
+  iconClassName: string;
+  badge: string | null;
+  metaIcon: ComponentType<{ className?: string }>;
+  meta: string | null;
+  onClick: () => void;
+}
+
+function WorkspaceCard({
+  title,
+  description,
+  icon: Icon,
+  iconClassName,
+  badge,
+  metaIcon: MetaIcon,
+  meta,
+  onClick,
+}: WorkspaceCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "bg-card ring-foreground/10 flex flex-1 basis-[260px] flex-col gap-3.5 rounded-xl p-5 text-left ring-1",
+        "hover:ring-primary transition-all duration-150 hover:-translate-y-px",
+      )}
+    >
+      <div className="flex items-start justify-between">
+        <span
+          className={cn(
+            "grid size-10 place-items-center rounded-lg",
+            iconClassName,
+          )}
+        >
+          <Icon className="size-5" />
+        </span>
+        {badge && <Badge variant="secondary">{badge}</Badge>}
+      </div>
+      <div>
+        <p className="text-heading font-medium">{title}</p>
+        <p className="text-muted-foreground mt-0.5 text-[13px]">
+          {description}
+        </p>
+      </div>
+      {/* 데이터가 없으면 줄 자체를 그리지 않는다 — 빈 자리가 더미 텍스트보다 낫다. */}
+      {meta && (
+        <p className="text-muted-foreground flex items-center gap-1.5 text-[13px]">
+          <MetaIcon className="size-3.5" />
+          {meta}
+        </p>
+      )}
+    </button>
+  );
+}

--- a/fe/src/pages/travel/TravelPlaceholderPage.tsx
+++ b/fe/src/pages/travel/TravelPlaceholderPage.tsx
@@ -1,0 +1,23 @@
+import { PageHeader } from "@/components/PageHeader";
+
+interface TravelPlaceholderPageProps {
+  title: string;
+}
+
+/**
+ * 여행 워크스페이스 라우트 자리를 잡아두는 임시 페이지.
+ *
+ * <p>이번 작업(#1033)은 워크스페이스 분리와 이동 경로까지다. 각 화면은 후속 이슈에서
+ * 이 자리를 그대로 대체한다 — 여행 홈·목록(#1035), 생성·수정(#1036), 일정 보드(#1037),
+ * 일정 상세(#1039), 도구·설정은 3·4단계.
+ *
+ * <p>화면을 미리 그리지 않고 제목만 두는 이유는, 지금 만든 UI가 후속 이슈에서 어차피
+ * 버려지기 때문이다.
+ */
+export function TravelPlaceholderPage({ title }: TravelPlaceholderPageProps) {
+  return (
+    <div className="mx-auto flex max-w-[720px] flex-col gap-6">
+      <PageHeader title={title} description="곧 이 자리에 화면이 들어옵니다." />
+    </div>
+  );
+}

--- a/fe/src/test/mocks/handlers.ts
+++ b/fe/src/test/mocks/handlers.ts
@@ -87,4 +87,29 @@ export const handlers = [
   http.get(`${API_BASE}/planner/monthly-goals/:year/:month`, () => {
     return HttpResponse.json({ code: "OK", data: null });
   }),
+
+  // 기본값: 여행 없음. 세 필드가 전부 null이면 "여행 만들기"만 보이는 상태다.
+  http.get(`${API_BASE}/travel/summary`, () => {
+    return HttpResponse.json({
+      code: "OK",
+      data: { ongoing: null, next: null, recentCompleted: null },
+    });
+  }),
+
+  // 기본값: 빈 캘린더 피드. `/select`의 "오늘 루틴" 메타가 항상 해소되도록.
+  http.get(`${API_BASE}/planner/calendar`, () => {
+    return HttpResponse.json({
+      code: "OK",
+      data: {
+        from: "2026-05-18",
+        to: "2026-05-18",
+        googleConnected: false,
+        partial: false,
+        errors: [],
+        events: [],
+        tasks: [],
+        reviews: [],
+      },
+    });
+  }),
 ];


### PR DESCRIPTION
## 이슈
closes #1033

## 작업 내용

앱을 **일상 / 여행** 두 워크스페이스로 나눈다. [화면 설계](https://github.com/wcorn/orino/wiki/Travel-UI-Design) §1·§2.1. (Epic #1029 · 1단계)

```
로그인(/login) → 페이지 선택(/select) ─┬─ 여행
                                       └─ 일상 (현재 앱 전체 그대로)
```

| 파일 | 변경 |
|---|---|
| `pages/WorkspaceSelectPage.tsx` | 신규 — 선택 화면 |
| `pages/travel/TravelPlaceholderPage.tsx` | 신규 — 여행 라우트 자리 |
| `features/travel/` | 신규 — `GET /api/travel/summary` 클라이언트·훅 |
| `app/layout/AppHeader.tsx` | 신규 — `AppLayout`에서 분리 |
| `app/layout/Sidebar.tsx` | 스위처 + 경로로 NAV_ITEMS 분기 |
| `app/router.tsx` · `routeImports.ts` | `/select` + `/travel/*` 트리, lazy import |
| `LoginPage` · `LandingPage` · `PublicRoute` | 리다이렉트 `/home` → `/select` |

### 일상은 건드리지 않는다

`PublicRoute`까지 셋 모두 `/select`로 바꿨다 — 로그인한 채 `/login`이나 `/`로 들어와도 같은 곳에 도착해야 마지막 워크스페이스를 기억하지 않는다는 규칙이 성립한다.

**일상 화면이 여행 API를 부르기 시작하면 그것도 일상 쪽 동작 변경이다.** 사이드바는 두 워크스페이스가 공유하므로 훅을 조건부로 호출할 수 없어, `useTravelSummary({ enabled })`로 일상에서는 요청 자체를 끈다. 테스트로 호출되지 않음을 확인한다.

`AppHeader` 분리는 선택 화면이 같은 헤더를 쓰기 때문이다(설계 §2.1 "AppLayout 헤더와 동일 마크업"). 마크업은 그대로 옮겼고 기존 `AppLayout.test.tsx`가 회귀를 잡는다.

### 판단이 필요했던 세 가지

**1. 「일정 보드」 메뉴의 목적지.** 보드는 여행 없이 열 수 없어 고정 경로가 없다. 진행 중 여행의 `boardPath`, 없으면 여행 목록을 가리킨다. 활성 판정도 `/travel/trips/:id/board`처럼 중간에 id가 끼어 접두어 비교로는 「여행 목록」과 구분되지 않으므로, 여행 메뉴에는 정규식 기반 `matchPath`를 뒀다.

**2. 스위처의 "진행 중이면 보드로".** 일상에 있는 동안은 요약 쿼리가 꺼져 있어 훅 데이터가 없다. 로그인하면 반드시 `/select`를 거치므로 캐시를 직접 읽고, 비어 있으면 여행 홈으로 보낸다.

**3. 일상 카드의 "오늘 루틴 N개".** `useRoutineList()`는 등록된 루틴 **시리즈** 수라 "오늘"이 아니다. 오늘 하루치 캘린더 피드에서 루틴 인스턴스만 세도록 했다. Google 미연동이면 조회가 실패하고, 그때는 설계대로 메타 줄을 그리지 않는다.

### 여행 화면은 자리만 잡았다

`/travel` · `/travel/trips` · `/travel/trips/:tripId/board` · `/travel/tools` · `/travel/settings`를 제목만 있는 공용 임시 페이지 하나로 받는다. 지금 화면을 그리면 #1035·#1036·#1037·#1039에서 어차피 버려지기 때문이다. `/travel/*` 나머지는 랜딩이 아니라 여행 홈으로 보낸다.

**`/travel/*` 딥링크는 선택 화면으로 되돌리지 않는다** — 3단계에서 푸시 알림 클릭이 여기로 들어온다.

## 테스트

**`WorkspaceSelectPage.test.tsx` (신규 9개)** — 카드 2개 · 사이드바 없음 · 여행 없을 때 배지·메타 숨김 · D-day 배지와 기간 메타 · 진행 중이면 "진행 중" 배지 + 보드로 이동 · 진행 중 없으면 여행 홈 · 복습 배지 · 오늘 루틴 메타(루틴 아닌 일정은 제외) · 일상 카드 → 홈

**`Sidebar.test.tsx` (추가 7개)** — 경로별 메뉴 분기 · 현재 워크스페이스 활성 표시 · **일상에서 여행 요약 미호출** · 일정 보드 링크 목적지(진행 중 유무) · 보드/목록 경로의 활성 항목 구분

**`router.test.tsx` (추가 4개)** — `/login`·`/` 인증 시 `/select` · **`/travel` 딥링크 유지** · `/select` 미인증 시 로그인

기존 테스트 4개(`LandingPage` · `LoginPage` ×2 · `PublicRoute`)는 목적지가 `/home` → `/select`로 바뀌어 함께 수정했다. `router.test.tsx`의 `/home` 테스트는 헤더가 lazy 페이지보다 먼저 뜨는 잠재적 레이스가 있어 `findByText`로 고쳤다.

`npm run format:check && npm run lint && npm test && npm run build` 모두 통과 — **618개 전부 통과**(기존 일상 테스트 포함).

## 로컬 확인 (bootRun + dev server + 브라우저)

MySQL 8.4.4 + Redis + BE + Vite dev로 실제 화면을 확인했다.

- 로그인 → `/select` 도달, 사이드바 없음
- 여행 카드에 **실데이터** `D-78` 배지와 `도쿄 3박 4일 · 10.24 – 10.27` 메타
- 일상 카드는 복습 0·루틴 0이라 **배지·메타 줄 모두 없음**(더미 텍스트 없음)
- 여행 카드 → `/travel`, 사이드바가 여행 메뉴(홈·여행 목록·일정 보드·도구·설정)로 바뀜
- 스위처 「일상」 → `/home`, 기존 일상 메뉴 7개 그대로 복귀
- `/travel/trips/1/board` 직접 진입 시 선택 화면으로 튕기지 않고 보드 자리에 도착