### PR TITLE
chore : bottom-sheet 컴포넌트 + Toaster 실행취소 확장

### DIFF
--- a/fe/src/components/Toaster.test.tsx
+++ b/fe/src/components/Toaster.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { toast, toastUndo, useToastStore } from "@/shared/lib/toast";
+
+import { Toaster } from "./Toaster";
+
+describe("Toaster", () => {
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("일반 알림은 메시지와 닫기 버튼만 보여준다", async () => {
+    render(<Toaster />);
+
+    act(() => {
+      toast("저장했어요", "success");
+    });
+
+    expect(await screen.findByText("저장했어요")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "알림 닫기" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /실행취소/ })).toBeNull();
+  });
+
+  it("실행취소 스낵바는 액션 버튼과 남은 초를 보여준다", async () => {
+    render(<Toaster />);
+
+    act(() => {
+      toastUndo("일정을 삭제했어요", { onUndo: () => {} });
+    });
+
+    const undo = await screen.findByRole("button", { name: /실행취소/ });
+    // 5초 카운트다운. 렌더 시점에 따라 5 또는 4로 보일 수 있다.
+    expect(undo.textContent).toMatch(/실행취소\s*[45]/);
+  });
+
+  it("실행취소를 누르면 onUndo가 실행되고 onCommit은 실행되지 않는다", async () => {
+    const onUndo = vi.fn();
+    const onCommit = vi.fn();
+    render(<Toaster />);
+
+    act(() => {
+      toastUndo("일정을 삭제했어요", { onUndo, onCommit });
+    });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /실행취소/ }),
+    );
+
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    expect(onCommit).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.queryByText("일정을 삭제했어요")).toBeNull();
+    });
+  });
+
+  it("그냥 두면 시간이 다 된 뒤 onCommit이 실행된다", async () => {
+    vi.useFakeTimers();
+    const onUndo = vi.fn();
+    const onCommit = vi.fn();
+    render(<Toaster />);
+
+    act(() => {
+      toastUndo("일정을 삭제했어요", { onUndo, onCommit, durationMs: 5000 });
+    });
+    expect(screen.getByText("일정을 삭제했어요")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onUndo).not.toHaveBeenCalled();
+    expect(screen.queryByText("일정을 삭제했어요")).toBeNull();
+  });
+
+  it("닫기 버튼으로 닫으면 onCommit이 실행되지 않는다", async () => {
+    const onCommit = vi.fn();
+    render(<Toaster />);
+
+    act(() => {
+      toastUndo("일정을 삭제했어요", { onUndo: () => {}, onCommit });
+    });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "알림 닫기" }),
+    );
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("액션 없는 알림은 카운트다운을 그리지 않는다", async () => {
+    render(<Toaster />);
+
+    act(() => {
+      toast("저장했어요");
+    });
+
+    const row = await screen.findByRole("status");
+    expect(row.textContent).toBe("저장했어요");
+  });
+
+  it("여러 개가 쌓여도 각자 자기 액션을 실행한다", async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    render(<Toaster />);
+
+    act(() => {
+      toastUndo("첫 번째", { onUndo: first });
+      toastUndo("두 번째", { onUndo: second });
+    });
+
+    const buttons = await screen.findAllByRole("button", { name: /실행취소/ });
+    expect(buttons).toHaveLength(2);
+
+    await userEvent.click(buttons[1]);
+
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+    expect(screen.getByText("첫 번째")).toBeInTheDocument();
+  });
+});

--- a/fe/src/components/Toaster.tsx
+++ b/fe/src/components/Toaster.tsx
@@ -1,8 +1,9 @@
 import { X } from "lucide-react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { useToastStore } from "@/shared/lib/toast";
+import { type ToastItem, useToastStore } from "@/shared/lib/toast";
 
 const VARIANT_STYLES: Record<string, string> = {
   info: "bg-background border-border text-foreground",
@@ -12,7 +13,6 @@ const VARIANT_STYLES: Record<string, string> = {
 
 export function Toaster() {
   const toasts = useToastStore((state) => state.toasts);
-  const dismiss = useToastStore((state) => state.dismiss);
 
   return (
     <div
@@ -20,28 +20,91 @@ export function Toaster() {
       aria-label="알림"
       className="pointer-events-none fixed right-4 bottom-4 z-[60] flex flex-col gap-2"
     >
-      {toasts.map((toast) => (
-        <div
-          key={toast.id}
-          role="status"
-          aria-live="polite"
-          className={cn(
-            "pointer-events-auto flex w-72 max-w-[calc(100vw-2rem)] items-start justify-between gap-2 rounded-lg border px-3 py-2 text-sm shadow-md",
-            VARIANT_STYLES[toast.variant],
-          )}
-        >
-          <span className="flex-1">{toast.message}</span>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={() => dismiss(toast.id)}
-            aria-label="알림 닫기"
-            className="size-6 shrink-0 opacity-70 hover:opacity-100"
-          >
-            <X className="size-3.5" />
-          </Button>
-        </div>
+      {toasts.map((item) => (
+        <ToastRow key={item.id} item={item} />
       ))}
     </div>
   );
+}
+
+function ToastRow({ item }: { item: ToastItem }) {
+  const dismiss = useToastStore((state) => state.dismiss);
+  const runAction = useToastStore((state) => state.runAction);
+  const remaining = useRemainingSeconds(item);
+  const entered = useEnterTransition();
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "pointer-events-auto flex w-72 max-w-[calc(100vw-2rem)] items-start justify-between gap-2 rounded-lg border px-3 py-2 text-sm shadow-md",
+        // fade + 아래에서 10px 올라오는 진입. 애니메이션 유틸리티 패키지를 더하지 않으려고
+        // 마운트 후 클래스를 뒤집는 방식으로 낸다.
+        "transition-all duration-200",
+        entered ? "translate-y-0 opacity-100" : "translate-y-[10px] opacity-0",
+        VARIANT_STYLES[item.variant],
+      )}
+    >
+      <span className="flex-1">{item.message}</span>
+      {item.action && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => runAction(item.id)}
+          className="h-6 shrink-0 px-2 font-semibold underline-offset-2 hover:underline"
+        >
+          {item.action.label}
+          {/* 남은 시간을 같이 보여줘 "언제까지 되돌릴 수 있는지"를 알린다. */}
+          {remaining !== null && (
+            <span className="ml-1 tabular-nums opacity-70">{remaining}</span>
+          )}
+        </Button>
+      )}
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={() => dismiss(item.id)}
+        aria-label="알림 닫기"
+        className="size-6 shrink-0 opacity-70 hover:opacity-100"
+      >
+        <X className="size-3.5" />
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * 액션이 있는 스낵바의 남은 초. 액션이 없으면 null(카운트다운을 그리지 않는다).
+ * 만료 자체는 store의 타이머가 처리하고 여기서는 표시만 한다 — 두 곳에서 닫으면 어긋난다.
+ */
+function useRemainingSeconds(item: ToastItem): number | null {
+  const hasAction = Boolean(item.action);
+  const [remaining, setRemaining] = useState(() => secondsLeft(item.expiresAt));
+
+  useEffect(() => {
+    if (!hasAction) return;
+    setRemaining(secondsLeft(item.expiresAt));
+    const timer = setInterval(
+      () => setRemaining(secondsLeft(item.expiresAt)),
+      250,
+    );
+    return () => clearInterval(timer);
+  }, [hasAction, item.expiresAt]);
+
+  return hasAction ? remaining : null;
+}
+
+function secondsLeft(expiresAt: number): number {
+  return Math.max(0, Math.ceil((expiresAt - Date.now()) / 1000));
+}
+
+/** 마운트 직후 한 번 true로 뒤집어 진입 트랜지션을 트리거한다. */
+function useEnterTransition(): boolean {
+  const [entered, setEntered] = useState(false);
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setEntered(true));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+  return entered;
 }

--- a/fe/src/components/ui/bottom-sheet.test.tsx
+++ b/fe/src/components/ui/bottom-sheet.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+
+import { BottomSheet } from "./bottom-sheet";
+import { Button } from "./button";
+
+function Harness({ initialOpen = false }: { initialOpen?: boolean }) {
+  const [open, setOpen] = useState(initialOpen);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>열기</Button>
+      <BottomSheet
+        open={open}
+        onOpenChange={setOpen}
+        title="어느 날짜에 담을까요"
+        description="나중에 옮길 수 있어요"
+      >
+        <Button onClick={() => setOpen(false)}>1일차</Button>
+      </BottomSheet>
+    </>
+  );
+}
+
+describe("BottomSheet", () => {
+  it("닫혀 있으면 아무것도 렌더하지 않는다", () => {
+    render(<Harness />);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("열면 제목·설명·본문이 보인다", async () => {
+    render(<Harness />);
+
+    await userEvent.click(screen.getByRole("button", { name: "열기" }));
+
+    const sheet = await screen.findByRole("dialog");
+    expect(sheet).toHaveTextContent("어느 날짜에 담을까요");
+    expect(sheet).toHaveTextContent("나중에 옮길 수 있어요");
+    expect(screen.getByRole("button", { name: "1일차" })).toBeInTheDocument();
+  });
+
+  it("ESC로 닫힌다", async () => {
+    render(<Harness initialOpen />);
+    await screen.findByRole("dialog");
+
+    await userEvent.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
+  it("본문에서 닫으면 onOpenChange로 상태가 내려간다", async () => {
+    render(<Harness initialOpen />);
+    await screen.findByRole("dialog");
+
+    await userEvent.click(screen.getByRole("button", { name: "1일차" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
+  it("열리면 포커스가 시트 안으로 들어간다", async () => {
+    render(<Harness initialOpen />);
+
+    const sheet = await screen.findByRole("dialog");
+    // 모달 여부는 base-ui가 형제 요소에 inert를 거는 방식으로 처리한다(aria-modal 아님).
+    await waitFor(() => {
+      expect(sheet.contains(document.activeElement)).toBe(true);
+    });
+  });
+
+  it("하단 정렬 + 아래에서 올라오는 모션 클래스를 갖는다", async () => {
+    render(<Harness initialOpen />);
+
+    const sheet = await screen.findByRole("dialog");
+    expect(sheet.className).toContain("bottom-0");
+    expect(sheet.className).toContain("data-[starting-style]:translate-y-full");
+    expect(sheet.className).toContain("duration-[180ms]");
+  });
+});

--- a/fe/src/components/ui/bottom-sheet.tsx
+++ b/fe/src/components/ui/bottom-sheet.tsx
@@ -1,0 +1,69 @@
+import { Dialog } from "@base-ui/react/dialog";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+// 스크림은 fade만 150ms. Modal과 달리 blur를 걸지 않는다 — 시트는 화면 하단만 덮으므로
+// 뒤 내용이 그대로 보이는 편이 "어디에서 여는 시트인지" 알기 쉽다.
+const BACKDROP_CLASS =
+  "fixed inset-0 z-50 bg-black/50 transition-opacity duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0";
+
+// 하단 정렬 + translateY(100%)→0, 180ms ease-out. 이 이상의 커스텀 모션은 두지 않는다.
+const POPUP_CLASS = [
+  "bg-background fixed inset-x-0 bottom-0 z-50 mx-auto w-full max-w-[520px]",
+  "max-h-[calc(100dvh-3rem)] overflow-y-auto rounded-t-xl border-t px-4 pt-3 pb-6 shadow-lg",
+  "transition-transform duration-[180ms] ease-out",
+  "data-[starting-style]:translate-y-full data-[ending-style]:translate-y-full",
+].join(" ");
+
+interface BottomSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** 제목 — Dialog.Title로 렌더(접근성 필수). */
+  title: ReactNode;
+  /** 제목 아래 보조 설명(선택). */
+  description?: ReactNode;
+  /** 폭 미세조정용 추가 className(선택). */
+  className?: string;
+  children?: ReactNode;
+}
+
+/**
+ * 하단에서 올라오는 시트. 모바일에서 한 손으로 고르는 선택지를 담는다
+ * (날짜 담기·이동수단·추가 메뉴).
+ *
+ * <p>`Modal`과 같은 base-ui `Dialog`를 쓰므로 포커스 트랩·ESC·스크롤 락·`aria-modal`은
+ * 그대로 따라온다. 다른 것은 정렬(하단)과 진입 모션(아래→위)뿐이다.
+ */
+export function BottomSheet({
+  open,
+  onOpenChange,
+  title,
+  description,
+  className,
+  children,
+}: BottomSheetProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className={BACKDROP_CLASS} />
+        <Dialog.Popup className={cn(POPUP_CLASS, className)}>
+          {/* 잡아끄는 손잡이 모양 — 드래그로 닫는 제스처는 넣지 않는다(스크롤과 충돌한다). */}
+          <div
+            aria-hidden="true"
+            className="bg-border mx-auto mb-3 h-1 w-9 rounded-full"
+          />
+          <Dialog.Title className="text-heading font-semibold">
+            {title}
+          </Dialog.Title>
+          {description && (
+            <Dialog.Description className="text-muted-foreground text-label mt-1">
+              {description}
+            </Dialog.Description>
+          )}
+          <div className="mt-4">{children}</div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/fe/src/shared/lib/toast.ts
+++ b/fe/src/shared/lib/toast.ts
@@ -2,33 +2,124 @@ import { create } from "zustand";
 
 export type ToastVariant = "info" | "success" | "error";
 
+export interface ToastAction {
+  /** 버튼 라벨(예: "실행취소"). */
+  label: string;
+  /** 누르면 실행하고 스낵바를 닫는다. */
+  onAction: () => void;
+}
+
 export interface ToastItem {
   id: string;
   message: string;
   variant: ToastVariant;
+  action?: ToastAction;
+  /** 이 스낵바가 사라질 때까지의 시간(ms). 남은 시간 표시에 쓴다. */
+  durationMs: number;
+  /** 사라질 시각(epoch ms). 카운트다운 계산 기준. */
+  expiresAt: number;
+  /**
+   * 액션 없이 그냥 사라졌을 때 실행할 일. 실행취소 스낵바에서
+   * "취소하지 않았으므로 이제 진짜 반영한다"를 담는다.
+   */
+  onExpire?: () => void;
+}
+
+const AUTO_DISMISS_MS = 3500;
+/** 실행취소를 줄 때의 기본 지속시간. 되돌릴 여유와 대기 사이의 절충값이다. */
+export const UNDO_DURATION_MS = 5000;
+
+let counter = 0;
+
+interface ShowOptions {
+  variant?: ToastVariant;
+  action?: ToastAction;
+  durationMs?: number;
+  onExpire?: () => void;
 }
 
 interface ToastState {
   toasts: ToastItem[];
-  show: (message: string, variant?: ToastVariant) => void;
+  show: (message: string, options?: ShowOptions) => string;
+  /** 타이머 만료로 닫기 — `onExpire`가 있으면 실행한다. */
+  expire: (id: string) => void;
+  /** 사용자가 닫거나 액션을 눌러 닫기 — `onExpire`는 실행하지 않는다. */
   dismiss: (id: string) => void;
+  runAction: (id: string) => void;
 }
-
-const AUTO_DISMISS_MS = 3500;
-
-let counter = 0;
 
 export const useToastStore = create<ToastState>((set, get) => ({
   toasts: [],
-  show: (message, variant = "info") => {
+
+  show: (message, options = {}) => {
+    const {
+      variant = "info",
+      action,
+      durationMs = action ? UNDO_DURATION_MS : AUTO_DISMISS_MS,
+      onExpire,
+    } = options;
     const id = `t-${Date.now()}-${++counter}`;
-    set((state) => ({ toasts: [...state.toasts, { id, message, variant }] }));
-    setTimeout(() => get().dismiss(id), AUTO_DISMISS_MS);
+    set((state) => ({
+      toasts: [
+        ...state.toasts,
+        {
+          id,
+          message,
+          variant,
+          action,
+          durationMs,
+          expiresAt: Date.now() + durationMs,
+          onExpire,
+        },
+      ],
+    }));
+    setTimeout(() => get().expire(id), durationMs);
+    return id;
   },
+
+  expire: (id) => {
+    const item = get().toasts.find((t) => t.id === id);
+    if (!item) return;
+    get().dismiss(id);
+    item.onExpire?.();
+  },
+
   dismiss: (id) =>
     set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) })),
+
+  runAction: (id) => {
+    const item = get().toasts.find((t) => t.id === id);
+    if (!item) return;
+    // 먼저 닫는다 — onAction이 새 스낵바를 띄우더라도 이 항목이 남지 않게.
+    get().dismiss(id);
+    item.action?.onAction();
+  },
 }));
 
 export function toast(message: string, variant: ToastVariant = "info") {
-  useToastStore.getState().show(message, variant);
+  return useToastStore.getState().show(message, { variant });
+}
+
+interface UndoOptions {
+  /** 실행취소를 누르면 실행. 되돌리는 일 자체는 호출부가 한다. */
+  onUndo: () => void;
+  /**
+   * 되돌리지 않고 시간이 다 됐을 때 실행. 삭제 요청을 이 시점까지 미뤄 두면
+   * 실행취소 시 요청 자체가 나가지 않는다(서버에 복원 API를 두지 않는 이유).
+   */
+  onCommit?: () => void;
+  durationMs?: number;
+}
+
+/**
+ * 실행취소 스낵바. 5초 안에 누르면 `onUndo`, 그냥 지나가면 `onCommit`이 실행된다.
+ * 낙관적으로 화면만 먼저 바꾸고 실제 요청은 `onCommit`에서 보내는 쓰임을 전제로 한다.
+ */
+export function toastUndo(message: string, options: UndoOptions) {
+  const { onUndo, onCommit, durationMs = UNDO_DURATION_MS } = options;
+  return useToastStore.getState().show(message, {
+    action: { label: "실행취소", onAction: onUndo },
+    durationMs,
+    onExpire: onCommit,
+  });
 }


### PR DESCRIPTION
## 이슈
closes #1034

## 작업 내용

여행 화면들이 공유할 디자인 시스템 조각 2개. 여행 전용이 아니라 **공용 DS**에 넣는다. [화면 설계](https://github.com/wcorn/orino/wiki/Travel-UI-Design) §6. (Epic #1029 · 1단계)

### 1. `components/ui/bottom-sheet.tsx` (신규)

`Modal`과 같은 base-ui `Dialog`를 쓴다 — 포커스 트랩·ESC·스크롤 락이 그대로 따라오고, 다른 것은 정렬(하단)과 진입 모션(아래→위)뿐이다. `AddSheet`/`TransportSheet`/`DatePickSheet`가 공유한다.

- `translateY(100%)→0` **180ms ease-out**, 스크림 fade 150ms. 그 이상의 커스텀 모션 없음
- 상단 핸들 `w-9 h-1 rounded-full bg-border` — **모양만이고 드래그로 닫는 제스처는 넣지 않았다.** 시트 안 스크롤과 충돌하고, 설계에도 없다
- `Modal`과 달리 스크림에 blur를 걸지 않는다. 시트는 화면 하단만 덮으므로 뒤가 보이는 편이 "어디서 연 시트인지" 알기 쉽다

### 2. Toaster 실행취소 확장

`toast.ts`에 액션 버튼 + 지속시간 + **만료 콜백**을 추가했다.

```ts
toastUndo("일정을 삭제했어요", {
  onUndo: () => restore(),      // 5초 안에 누르면
  onCommit: () => deleteApi(),  // 그냥 지나가면
});
```

`onCommit`이 핵심이다. 실제 요청을 여기까지 미뤄 두면 **실행취소 시 요청 자체가 나가지 않는다** — 서버에 소프트 삭제·복원 API를 두지 않는 이유([결정 기록 D-4](https://github.com/wcorn/orino/wiki/Travel-Open-Items))가 이 구조에 달려 있다.

닫는 경로를 셋으로 나눴다. 타이머 만료(`expire`)만 `onCommit`을 실행하고, 액션 클릭(`runAction`)과 닫기 버튼(`dismiss`)은 실행하지 않는다. 사용자가 X로 닫은 것을 "동의했다"로 읽으면 안 되기 때문이다.

소비처(일정 삭제·보관함 이동)는 #1038에서 붙인다.

### 애니메이션 유틸리티를 더하지 않았다

설계의 스낵바 모션(fade + `translateY(10px)` 200ms)은 `animate-in`/`slide-in-from-*`을 쓰면 간단하지만 그건 `tailwindcss-animate` 패키지이고 이 프로젝트에 없다. 모션 하나 때문에 의존성을 늘리는 대신 마운트 후 클래스를 뒤집는 방식으로 냈다(새 CSS·키프레임 없음).

## 테스트 (신규 13개)

**`bottom-sheet.test.tsx` (6)** — 닫힘 시 미렌더 · 제목·설명·본문 · ESC 닫기 · `onOpenChange` 전달 · 열리면 포커스가 안으로 · 하단 정렬·모션 클래스

**`Toaster.test.tsx` (7)** — 일반 알림엔 액션 없음 · 액션 버튼과 남은 초 · **실행취소 시 `onUndo`만, `onCommit` 미실행** · **만료 시 `onCommit`만** · **닫기 버튼은 `onCommit` 미실행** · 액션 없으면 카운트다운 미표시 · 여러 개가 쌓여도 각자 자기 액션 실행

`aria-modal` 대신 포커스 위치를 검증한다 — base-ui는 형제에 `inert`를 거는 방식이라 `aria-modal`을 붙이지 않는다(실제로 확인).

`npm run format:check && npm run lint && npm test && npm run build` 모두 통과 — **631개 전부 통과**. 한 번 무관한 테스트가 흔들려 전체를 3회, 신규 테스트를 3회 더 돌려 안정성을 확인했다.

## 로컬 확인 (dev server + 브라우저, 라이트·다크)

- **스낵바**: 실행취소 버튼과 `5` 카운트다운이 실제로 렌더되고 초가 줄어드는 것 확인. info·success·error 세 variant를 다크에서 확인 — 전부 시맨틱 토큰이라 대비 정상
- **시트**: 하단 정렬·핸들·스크림·포커스 진입을 다크와 라이트 양쪽에서 확인

시트는 아직 소비처가 없어 확인용으로 잠시 마운트했다가 되돌렸다(커밋에는 포함되지 않는다).