### PR TITLE
feat : 여행 홈 · 여행 목록 화면 (S-01 · S-02)

### DIFF
--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -52,7 +52,15 @@ export const importWorkspaceSelect = () =>
   import("../pages/WorkspaceSelectPage").then((m) => ({
     default: m.WorkspaceSelectPage,
   }));
-// 여행 화면은 후속 이슈에서 채운다. 지금은 라우트 자리를 잡는 임시 페이지 하나를 공유한다.
+export const importTravelHome = () =>
+  import("../pages/travel/TravelHomePage").then((m) => ({
+    default: m.TravelHomePage,
+  }));
+export const importTripList = () =>
+  import("../pages/travel/TripListPage").then((m) => ({
+    default: m.TripListPage,
+  }));
+// 아직 화면이 없는 여행 라우트(보드·도구·설정)가 공유하는 임시 페이지.
 export const importTravelPlaceholder = () =>
   import("../pages/travel/TravelPlaceholderPage").then((m) => ({
     default: m.TravelPlaceholderPage,

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -23,7 +23,9 @@ import {
   importReviewHub,
   importReviewSession,
   importRoutines,
+  importTravelHome,
   importTravelPlaceholder,
+  importTripList,
   importWeeklyPlan,
   importWorkspaceSelect,
 } from "./routeImports";
@@ -45,6 +47,8 @@ const LifelogFlowsPage = lazy(importLifelogFlows);
 const LifelogFlowDetailPage = lazy(importLifelogFlowDetail);
 const WorkspaceSelectPage = lazy(importWorkspaceSelect);
 const TravelPlaceholderPage = lazy(importTravelPlaceholder);
+const TravelHomePage = lazy(importTravelHome);
+const TripListPage = lazy(importTripList);
 
 function RouteFallback() {
   return (
@@ -197,10 +201,21 @@ export function AppRouter() {
           />
           {/* 여행 워크스페이스. 화면은 후속 이슈에서 채우고 여기서는 라우트 자리를 잡는다.
               푸시 알림 클릭이 /travel/* 딥링크로 들어오므로 선택 화면으로 되돌리지 않는다. */}
-          <Route path="/travel" element={<TravelRoute title="여행" />} />
+          <Route
+            path="/travel"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <TravelHomePage />
+              </Suspense>
+            }
+          />
           <Route
             path="/travel/trips"
-            element={<TravelRoute title="여행 목록" />}
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <TripListPage />
+              </Suspense>
+            }
           />
           <Route
             path="/travel/trips/:tripId/board"

--- a/fe/src/features/travel/api/travel.ts
+++ b/fe/src/features/travel/api/travel.ts
@@ -1,5 +1,7 @@
 import { client } from "@/shared/api";
 
+import type { TripStatus } from "../lib/tripStatus";
+
 interface ApiEnvelope<T> {
   code: string;
   data: T;
@@ -46,5 +48,58 @@ export interface TravelSummary {
 export async function fetchTravelSummary(): Promise<TravelSummary> {
   const { data } =
     await client.get<ApiEnvelope<TravelSummary>>("/travel/summary");
+  return data.data;
+}
+
+/** 여행 목록 카드 하나. `status`·`dDay`는 서버가 여행 타임존으로 파생해 준 값이다. */
+export interface TripSummary {
+  id: number;
+  title: string;
+  destinationName: string;
+  startDate: string;
+  endDate: string;
+  status: TripStatus;
+  dDay: number;
+  activityCount: number;
+}
+
+export interface TripCounts {
+  upcoming: number;
+  ongoing: number;
+  completed: number;
+}
+
+export interface TripListResponse {
+  /** 탭 라벨 뒤 건수. 필터와 무관하게 항상 전체 기준이다. */
+  counts: TripCounts;
+  trips: TripSummary[];
+}
+
+/** 여행 상세. 생성·수정 화면(#1036)이 폼을 채울 때도 쓴다. */
+export interface TripDetail extends TripSummary {
+  destinationPlaceId: number | null;
+  timezone: string;
+  currency: string;
+  lat: number | null;
+  lng: number | null;
+  defaultNotifyMinutes: number;
+  morningSummaryEnabled: boolean;
+  totalDays: number;
+}
+
+export async function fetchTrips(
+  status?: TripStatus,
+): Promise<TripListResponse> {
+  const { data } = await client.get<ApiEnvelope<TripListResponse>>(
+    "/travel/trips",
+    { params: status ? { status } : undefined },
+  );
+  return data.data;
+}
+
+export async function fetchTrip(tripId: number): Promise<TripDetail> {
+  const { data } = await client.get<ApiEnvelope<TripDetail>>(
+    `/travel/trips/${tripId}`,
+  );
   return data.data;
 }

--- a/fe/src/features/travel/hooks/useTrip.ts
+++ b/fe/src/features/travel/hooks/useTrip.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchTrip } from "../api/travel";
+import { travelKeys } from "../queryKeys";
+
+/** 여행 상세. 요약에 없는 타임존·통화·기간이 필요할 때 쓴다. */
+export function useTrip(tripId: number | null) {
+  return useQuery({
+    queryKey: travelKeys.trip(tripId ?? 0),
+    queryFn: () => fetchTrip(tripId as number),
+    enabled: tripId !== null,
+    staleTime: 30 * 1000,
+  });
+}

--- a/fe/src/features/travel/hooks/useTrips.ts
+++ b/fe/src/features/travel/hooks/useTrips.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchTrips } from "../api/travel";
+import type { TripStatus } from "../lib/tripStatus";
+import { travelKeys } from "../queryKeys";
+
+/**
+ * 여행 목록. `status`를 주면 서버가 걸러 주고, 탭 건수(`counts`)는 어느 탭을 보든
+ * 항상 전체 기준으로 온다.
+ */
+export function useTrips(status?: TripStatus) {
+  return useQuery({
+    queryKey: travelKeys.trips(status),
+    queryFn: () => fetchTrips(status),
+    staleTime: 30 * 1000,
+  });
+}

--- a/fe/src/features/travel/lib/tripStatus.test.ts
+++ b/fe/src/features/travel/lib/tripStatus.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dayChips,
+  daysUntil,
+  deriveStatus,
+  formatPeriod,
+  formatShortDate,
+  todayIn,
+  totalDays,
+} from "./tripStatus";
+
+/** 2026-10-23 16:00 UTC — 도쿄는 이미 10/24 01:00, 호놀룰루는 아직 10/23 06:00. */
+const CROSSING = new Date("2026-10-23T16:00:00Z");
+
+describe("todayIn", () => {
+  it("여행 타임존의 오늘을 준다", () => {
+    expect(todayIn("Asia/Tokyo", CROSSING)).toBe("2026-10-24");
+    expect(todayIn("Pacific/Honolulu", CROSSING)).toBe("2026-10-23");
+    expect(todayIn("UTC", CROSSING)).toBe("2026-10-23");
+  });
+
+  it("알 수 없는 타임존이면 기기 기준으로 떨어진다(화면을 죽이지 않는다)", () => {
+    expect(todayIn("Not/AZone", CROSSING)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("deriveStatus", () => {
+  const period = ["2026-10-24", "2026-10-27"] as const;
+
+  it("시작 전이면 예정, 기간 안이면 진행 중, 끝나면 완료", () => {
+    expect(
+      deriveStatus(...period, "Asia/Tokyo", new Date("2026-10-20T03:00:00Z")),
+    ).toBe("UPCOMING");
+    expect(
+      deriveStatus(...period, "Asia/Tokyo", new Date("2026-10-25T03:00:00Z")),
+    ).toBe("ONGOING");
+    expect(
+      deriveStatus(...period, "Asia/Tokyo", new Date("2026-10-28T03:00:00Z")),
+    ).toBe("COMPLETED");
+  });
+
+  it("시작일·종료일 당일도 진행 중이다(경계 포함)", () => {
+    expect(
+      deriveStatus(...period, "Asia/Tokyo", new Date("2026-10-24T03:00:00Z")),
+    ).toBe("ONGOING");
+    expect(
+      deriveStatus(...period, "Asia/Tokyo", new Date("2026-10-27T03:00:00Z")),
+    ).toBe("ONGOING");
+  });
+
+  it("기기 시간대가 아니라 여행 타임존으로 판정한다", () => {
+    // 같은 순간·같은 기간인데 목적지에 따라 갈린다.
+    expect(deriveStatus(...period, "Asia/Tokyo", CROSSING)).toBe("ONGOING");
+    expect(deriveStatus(...period, "Pacific/Honolulu", CROSSING)).toBe(
+      "UPCOMING",
+    );
+  });
+});
+
+describe("daysUntil", () => {
+  it("남은 일수를 준다 — 당일 0, 시작 후 음수", () => {
+    expect(daysUntil("2026-10-24", "Asia/Tokyo", CROSSING)).toBe(0);
+    expect(
+      daysUntil("2026-10-24", "Asia/Tokyo", new Date("2026-10-20T03:00:00Z")),
+    ).toBe(4);
+    expect(
+      daysUntil("2026-10-24", "Asia/Tokyo", new Date("2026-10-26T03:00:00Z")),
+    ).toBe(-2);
+  });
+
+  it("호놀룰루는 같은 순간에도 하루가 더 남는다", () => {
+    expect(daysUntil("2026-10-24", "Pacific/Honolulu", CROSSING)).toBe(1);
+  });
+
+  it("서머타임 경계를 넘어도 일수가 어긋나지 않는다", () => {
+    // 미국 서머타임 종료(2026-11-01) 전후. 로컬 자정으로 계산하면 하루가 25시간이라 밀린다.
+    expect(
+      daysUntil(
+        "2026-11-05",
+        "America/New_York",
+        new Date("2026-10-29T16:00:00Z"),
+      ),
+    ).toBe(7);
+  });
+});
+
+describe("totalDays · dayChips", () => {
+  it("총 일수는 당일을 포함한다", () => {
+    expect(totalDays("2026-10-24", "2026-10-27")).toBe(4);
+    expect(totalDays("2026-10-24", "2026-10-24")).toBe(1);
+  });
+
+  it("일자 칩은 1일차부터 요일과 함께 만든다", () => {
+    expect(dayChips("2026-10-24", "2026-10-27")).toEqual([
+      { dayIndex: 1, date: "2026-10-24", weekday: "토" },
+      { dayIndex: 2, date: "2026-10-25", weekday: "일" },
+      { dayIndex: 3, date: "2026-10-26", weekday: "월" },
+      { dayIndex: 4, date: "2026-10-27", weekday: "화" },
+    ]);
+  });
+
+  it("달을 넘기는 기간도 이어서 만든다", () => {
+    const chips = dayChips("2026-10-30", "2026-11-02");
+    expect(chips.map((c) => c.date)).toEqual([
+      "2026-10-30",
+      "2026-10-31",
+      "2026-11-01",
+      "2026-11-02",
+    ]);
+  });
+});
+
+describe("포맷", () => {
+  it("기간은 한 줄로, 하루짜리는 한 번만 쓴다", () => {
+    expect(formatPeriod("2026-10-24", "2026-10-27")).toBe(
+      "10월 24일 – 10월 27일",
+    );
+    expect(formatPeriod("2026-10-24", "2026-10-24")).toBe("10월 24일");
+  });
+
+  it("짧은 날짜는 월의 0을 떼고 일은 두 자리로 둔다", () => {
+    expect(formatShortDate("2026-10-24")).toBe("10.24");
+    expect(formatShortDate("2026-05-03")).toBe("5.03");
+  });
+});

--- a/fe/src/features/travel/lib/tripStatus.ts
+++ b/fe/src/features/travel/lib/tripStatus.ts
@@ -1,0 +1,113 @@
+export type TripStatus = "UPCOMING" | "ONGOING" | "COMPLETED";
+
+/**
+ * 여행 타임존 기준 오늘 날짜("YYYY-MM-DD").
+ *
+ * <p>`en-CA` 로케일이 ISO 형태로 포맷해 준다. 알 수 없는 타임존이면 기기 기준으로 떨어진다 —
+ * 화면이 죽는 것보다 하루 어긋날 가능성이 낫다.
+ */
+export function todayIn(timezone: string, now: Date = new Date()): string {
+  try {
+    return new Intl.DateTimeFormat("en-CA", { timeZone: timezone }).format(now);
+  } catch {
+    return new Intl.DateTimeFormat("en-CA").format(now);
+  }
+}
+
+/**
+ * 상태를 파생한다. BE와 같은 규칙이며 기준은 <b>여행 타임존의 오늘</b>이다.
+ *
+ * <p>서버도 같은 값을 내려주는데 여기서 다시 계산하는 이유는 <b>오프라인 캐시</b>다(4단계).
+ * 어제 받아둔 응답을 그대로 보여주면 D-day와 상태가 하루 어긋난 채 화면에 남는다.
+ */
+export function deriveStatus(
+  startDate: string,
+  endDate: string,
+  timezone: string,
+  now?: Date,
+): TripStatus {
+  // "YYYY-MM-DD"는 사전순 비교가 곧 날짜 비교다.
+  const today = todayIn(timezone, now);
+  if (today < startDate) return "UPCOMING";
+  if (today > endDate) return "COMPLETED";
+  return "ONGOING";
+}
+
+/** 시작일까지 남은 일수. 시작 당일 0, 이미 시작했으면 음수. */
+export function daysUntil(
+  startDate: string,
+  timezone: string,
+  now?: Date,
+): number {
+  return diffDays(todayIn(timezone, now), startDate);
+}
+
+/** 여행 총 일수(당일 포함). 하루짜리면 1. */
+export function totalDays(startDate: string, endDate: string): number {
+  return diffDays(startDate, endDate) + 1;
+}
+
+export interface DayChip {
+  /** 1부터 시작하는 일차. */
+  dayIndex: number;
+  /** "2026-10-24" */
+  date: string;
+  /** 한국어 요일 한 글자("금"). */
+  weekday: string;
+}
+
+/** 기간에서 일자 칩을 만든다. 일정이 없는 날짜도 칩은 나와야 한다. */
+export function dayChips(startDate: string, endDate: string): DayChip[] {
+  const chips: DayChip[] = [];
+  const count = totalDays(startDate, endDate);
+  for (let i = 0; i < count; i++) {
+    const date = addDays(startDate, i);
+    chips.push({ dayIndex: i + 1, date, weekday: weekdayOf(date) });
+  }
+  return chips;
+}
+
+/** "2026-10-24" → "10월 24일" */
+export function formatMonthDay(date: string): string {
+  const [, month, day] = date.split("-");
+  return `${Number(month)}월 ${Number(day)}일`;
+}
+
+/** "2026-10-24" → "10.24" (목록 메타처럼 좁은 자리에 쓴다) */
+export function formatShortDate(date: string): string {
+  const [, month, day] = date.split("-");
+  return `${Number(month)}.${day}`;
+}
+
+/**
+ * 기간 한 줄. "10월 24일 – 10월 27일", 하루짜리면 한 번만 쓴다.
+ */
+export function formatPeriod(startDate: string, endDate: string): string {
+  if (startDate === endDate) return formatMonthDay(startDate);
+  return `${formatMonthDay(startDate)} – ${formatMonthDay(endDate)}`;
+}
+
+const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
+
+function weekdayOf(date: string): string {
+  return WEEKDAYS[toUtcDate(date).getUTCDay()];
+}
+
+function addDays(date: string, days: number): string {
+  const d = toUtcDate(date);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function diffDays(from: string, to: string): number {
+  const ms = toUtcDate(to).getTime() - toUtcDate(from).getTime();
+  return Math.round(ms / 86_400_000);
+}
+
+/**
+ * "YYYY-MM-DD"를 UTC 자정으로 읽는다. 날짜 계산에만 쓰는 값이라 타임존을 태우지 않는다 —
+ * 로컬 자정으로 만들면 서머타임 경계에서 하루가 23·25시간이 돼 일수가 어긋난다.
+ */
+function toUtcDate(date: string): Date {
+  return new Date(`${date}T00:00:00Z`);
+}

--- a/fe/src/features/travel/queryKeys.ts
+++ b/fe/src/features/travel/queryKeys.ts
@@ -1,4 +1,8 @@
+import type { TripStatus } from "./lib/tripStatus";
+
 export const travelKeys = {
   all: ["travel"] as const,
   summary: ["travel", "summary"] as const,
+  trips: (status?: TripStatus) => ["travel", "trips", status ?? "all"] as const,
+  trip: (tripId: number) => ["travel", "trip", tripId] as const,
 };

--- a/fe/src/pages/travel/TravelHomePage.test.tsx
+++ b/fe/src/pages/travel/TravelHomePage.test.tsx
@@ -1,0 +1,201 @@
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { AppRouter } from "@/app/router";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function mockSummary(data: unknown) {
+  server.use(
+    http.get(`${API_BASE}/travel/summary`, () =>
+      HttpResponse.json({ code: "OK", data }),
+    ),
+  );
+}
+
+function mockTrip(trip: Record<string, unknown>) {
+  server.use(
+    http.get(`${API_BASE}/travel/trips/:tripId`, () =>
+      HttpResponse.json({ code: "OK", data: trip }),
+    ),
+  );
+}
+
+const TOKYO = {
+  id: 3,
+  title: "도쿄 3박 4일",
+  destinationName: "도쿄",
+  destinationPlaceId: null,
+  startDate: "2026-10-24",
+  endDate: "2026-10-27",
+  timezone: "Asia/Tokyo",
+  currency: "JPY",
+  lat: null,
+  lng: null,
+  defaultNotifyMinutes: 15,
+  morningSummaryEnabled: false,
+  status: "UPCOMING",
+  dDay: 78,
+  totalDays: 4,
+  activityCount: 13,
+};
+
+function renderApp() {
+  return renderWithRouter(
+    <Providers>
+      <AppRouter />
+    </Providers>,
+    { initialEntries: ["/travel"] },
+  );
+}
+
+describe("TravelHomePage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "valid-token" });
+  });
+
+  it("여행이 하나도 없으면 만들기 버튼만 보여준다", async () => {
+    renderApp();
+
+    await waitFor(() => {
+      expect(screen.getByText("아직 만든 여행이 없어요.")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("link", { name: /여행 만들기/ })).toHaveAttribute(
+      "href",
+      "/travel/trips/new",
+    );
+  });
+
+  it("다음 여행을 예정 배지·기간·일정 수와 함께 보여준다", async () => {
+    mockSummary({
+      ongoing: null,
+      next: {
+        id: 3,
+        title: "도쿄 3박 4일",
+        destinationName: "도쿄",
+        startDate: "2026-10-24",
+        endDate: "2026-10-27",
+        dDay: 78,
+        activityCount: 13,
+      },
+      recentCompleted: null,
+    });
+    mockTrip(TOKYO);
+
+    renderApp();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "도쿄 3박 4일" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("예정")).toBeInTheDocument();
+    expect(
+      screen.getByText("10월 24일 – 10월 27일 · 일정 13개"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Asia/Tokyo · JPY")).toBeInTheDocument();
+  });
+
+  it("일자 칩을 기간만큼 만든다(1단계는 일차·요일만)", async () => {
+    mockSummary({
+      ongoing: null,
+      next: { ...TOKYO, dDay: 78 },
+      recentCompleted: null,
+    });
+    mockTrip(TOKYO);
+
+    renderApp();
+
+    await waitFor(() => {
+      expect(screen.getByText("1일차 · 토")).toBeInTheDocument();
+    });
+    expect(screen.getByText("4일차 · 화")).toBeInTheDocument();
+    // 날씨는 4단계라 이 화면엔 온도가 없다.
+    expect(screen.queryByText(/°/)).toBeNull();
+  });
+
+  it("진행 중 여행이 있으면 진행 중 배지와 그 제목을 헤더에 쓴다", async () => {
+    mockSummary({
+      ongoing: {
+        id: 3,
+        title: "도쿄 3박 4일",
+        boardPath: "/travel/trips/3/board",
+      },
+      next: null,
+      recentCompleted: null,
+    });
+    mockTrip({ ...TOKYO, status: "ONGOING" });
+
+    renderApp();
+
+    await waitFor(() => {
+      expect(screen.getByText("진행 중")).toBeInTheDocument();
+    });
+    expect(screen.getByText("도쿄 3박 4일 여행 중이에요.")).toBeInTheDocument();
+  });
+
+  it("보드 열기 링크가 그 여행의 보드를 가리킨다", async () => {
+    mockSummary({
+      ongoing: null,
+      next: { ...TOKYO, dDay: 78 },
+      recentCompleted: null,
+    });
+    mockTrip(TOKYO);
+
+    renderApp();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /일정 보드 열기/ }),
+      ).toHaveAttribute("href", "/travel/trips/3/board");
+    });
+  });
+
+  it("최근 완료 여행은 별도 행으로 보여주고 그 보드로 보낸다", async () => {
+    mockSummary({
+      ongoing: null,
+      next: null,
+      recentCompleted: {
+        id: 2,
+        title: "오사카 2박 3일",
+        endDate: "2026-05-11",
+        activityCount: 9,
+      },
+    });
+
+    renderApp();
+
+    await waitFor(() => {
+      expect(screen.getByText("최근 완료")).toBeInTheDocument();
+    });
+    const link = screen.getByRole("link", { name: /오사카 2박 3일/ });
+    expect(link).toHaveAttribute("href", "/travel/trips/2/board");
+    expect(link).toHaveTextContent("5월 11일 종료 · 일정 9개");
+  });
+
+  it("완료 여행만 있으면 다음 여행 카드를 그리지 않는다", async () => {
+    mockSummary({
+      ongoing: null,
+      next: null,
+      recentCompleted: {
+        id: 2,
+        title: "오사카 2박 3일",
+        endDate: "2026-05-11",
+        activityCount: 9,
+      },
+    });
+
+    renderApp();
+
+    await waitFor(() => {
+      expect(screen.getByText("최근 완료")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("예정")).toBeNull();
+    expect(screen.queryByRole("link", { name: /일정 보드 열기/ })).toBeNull();
+  });
+});

--- a/fe/src/pages/travel/TravelHomePage.tsx
+++ b/fe/src/pages/travel/TravelHomePage.tsx
@@ -1,0 +1,179 @@
+import { CalendarDays, ChevronRight, Plus } from "lucide-react";
+import { Link } from "react-router-dom";
+
+import { PageHeader } from "@/components/PageHeader";
+import { Badge } from "@/components/ui/badge";
+import { buttonVariants } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { LoadingText } from "@/components/ui/loading-text";
+import type {
+  CompletedTripSummary,
+  TravelSummary,
+  TripDetail,
+} from "@/features/travel/api/travel";
+import { useTravelSummary } from "@/features/travel/hooks/useTravelSummary";
+import { useTrip } from "@/features/travel/hooks/useTrip";
+import {
+  dayChips,
+  daysUntil,
+  formatPeriod,
+} from "@/features/travel/lib/tripStatus";
+
+/**
+ * S-01 여행 홈. 다음에 갈 여행 하나를 크게 보여주고 보드로 들여보내는 것이 전부다.
+ *
+ * <p>요약이 "어떤 여행을 볼지"를 정하고, 타임존·통화·기간은 상세에서 가져온다.
+ */
+export function TravelHomePage() {
+  const { data: summary, isPending } = useTravelSummary();
+  const featuredId = summary?.ongoing?.id ?? summary?.next?.id ?? null;
+  const { data: featured } = useTrip(featuredId);
+
+  if (isPending) {
+    return (
+      <div className="grid min-h-[40svh] place-items-center">
+        <LoadingText />
+      </div>
+    );
+  }
+
+  const hasAnyTrip = Boolean(featuredId || summary?.recentCompleted);
+  if (!hasAnyTrip) {
+    return (
+      <div className="mx-auto flex max-w-[720px] flex-col gap-6">
+        <PageHeader title="여행" />
+        <EmptyState>
+          <p className="text-muted-foreground text-sm">
+            아직 만든 여행이 없어요.
+          </p>
+          <Link
+            to="/travel/trips/new"
+            className={buttonVariants({ variant: "default" })}
+          >
+            <Plus className="size-4" />
+            여행 만들기
+          </Link>
+        </EmptyState>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex max-w-[720px] flex-col gap-6">
+      <PageHeader title="여행" description={describeState(summary, featured)} />
+      {featured && <FeaturedTripCard trip={featured} />}
+      {summary?.recentCompleted && (
+        <RecentCompleted trip={summary.recentCompleted} />
+      )}
+    </div>
+  );
+}
+
+/** 헤더 설명 — 진행 중이면 그 여행을, 아니면 다음 여행까지 남은 일수를 말한다. */
+function describeState(
+  summary: TravelSummary | undefined,
+  featured: TripDetail | undefined,
+): string | undefined {
+  if (summary?.ongoing) return `${summary.ongoing.title} 여행 중이에요.`;
+  if (!featured) return undefined;
+
+  const days = daysUntil(featured.startDate, featured.timezone);
+  if (days <= 0) return "오늘 출발이에요.";
+  return `진행 중인 여행이 없어요. 다음 여행까지 ${days}일.`;
+}
+
+function FeaturedTripCard({ trip }: { trip: TripDetail }) {
+  const ongoing = trip.status === "ONGOING";
+  // 서버가 준 dDay를 그대로 쓰지 않고 여행 타임존으로 다시 계산한다 —
+  // 오프라인 캐시(4단계)로 어제 응답이 돌아와도 숫자가 맞아야 한다.
+  const days = daysUntil(trip.startDate, trip.timezone);
+  const chips = dayChips(trip.startDate, trip.endDate);
+
+  return (
+    <section className="bg-card ring-foreground/10 flex flex-col gap-4 rounded-xl py-4 ring-1">
+      <header className="grid grid-cols-[1fr_auto] items-start gap-1 px-4">
+        <div className="col-start-1 min-w-0">
+          <Badge variant={ongoing ? "success" : "info"}>
+            {ongoing ? "진행 중" : "예정"}
+          </Badge>
+          <h2 className="text-heading mt-1 font-medium">{trip.title}</h2>
+          <p className="text-muted-foreground text-sm">
+            {formatPeriod(trip.startDate, trip.endDate)} · 일정{" "}
+            {trip.activityCount}개
+          </p>
+        </div>
+        <div className="col-start-2 text-right">
+          <p className="text-display text-primary font-semibold tabular-nums">
+            {formatDDay(days)}
+          </p>
+          <p className="text-caption text-muted-foreground">
+            {trip.timezone} · {trip.currency}
+          </p>
+        </div>
+      </header>
+      <div className="px-4">
+        {/* 날씨(3행)는 4단계. 1단계는 일차·요일만 채운다. */}
+        <ul className="flex gap-2 overflow-x-auto pb-1">
+          {chips.map((chip) => (
+            <li
+              key={chip.date}
+              className="border-border min-w-[84px] shrink-0 rounded-lg border px-2.5 py-2"
+            >
+              <p className="text-caption text-muted-foreground">
+                {chip.dayIndex}일차 · {chip.weekday}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <footer className="bg-muted/50 flex items-center gap-2 rounded-b-xl border-t p-4">
+        <Link
+          to={`/travel/trips/${trip.id}/board`}
+          className={buttonVariants({ variant: "default" })}
+        >
+          <CalendarDays className="size-4" />
+          일정 보드 열기
+        </Link>
+        <Link
+          to="/travel/trips/new"
+          className={buttonVariants({ variant: "outline" })}
+        >
+          <Plus className="size-4" />
+          여행 만들기
+        </Link>
+      </footer>
+    </section>
+  );
+}
+
+/** 시작 당일은 D-DAY, 이미 시작했으면 D+n. */
+function formatDDay(days: number): string {
+  if (days > 0) return `D-${days}`;
+  if (days === 0) return "D-DAY";
+  return `D+${-days}`;
+}
+
+function RecentCompleted({ trip }: { trip: CompletedTripSummary }) {
+  return (
+    <section className="flex flex-col gap-2">
+      <h2 className="text-caption text-muted-foreground font-semibold">
+        최근 완료
+      </h2>
+      <Link
+        to={`/travel/trips/${trip.id}/board`}
+        className="bg-card ring-foreground/10 hover:ring-primary flex items-center justify-between gap-3 rounded-xl p-4 ring-1 transition-all"
+      >
+        <span className="min-w-0">
+          <span className="block truncate text-[15px] font-medium">
+            {trip.title}
+          </span>
+          <span className="text-muted-foreground block text-[13px]">
+            {formatPeriod(trip.endDate, trip.endDate)} 종료 · 일정{" "}
+            {trip.activityCount}개
+          </span>
+        </span>
+        <ChevronRight className="text-muted-foreground size-4 shrink-0" />
+      </Link>
+    </section>
+  );
+}

--- a/fe/src/pages/travel/TripListPage.test.tsx
+++ b/fe/src/pages/travel/TripListPage.test.tsx
@@ -1,0 +1,167 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { AppRouter } from "@/app/router";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+const API_BASE = "https://api.orino.dev/api";
+
+const COUNTS = { upcoming: 2, ongoing: 0, completed: 1 };
+
+function trip(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 3,
+    title: "도쿄 3박 4일",
+    destinationName: "도쿄",
+    startDate: "2026-10-24",
+    endDate: "2026-10-27",
+    status: "UPCOMING",
+    dDay: 78,
+    activityCount: 13,
+    ...overrides,
+  };
+}
+
+/** status 쿼리별로 다른 목록을 주는 핸들러. 탭 전환이 실제로 재조회하는지 본다. */
+function mockTripsByStatus(byStatus: Record<string, unknown[]>) {
+  server.use(
+    http.get(`${API_BASE}/travel/trips`, ({ request }) => {
+      const status = new URL(request.url).searchParams.get("status") ?? "all";
+      return HttpResponse.json({
+        code: "OK",
+        data: { counts: COUNTS, trips: byStatus[status] ?? [] },
+      });
+    }),
+  );
+}
+
+function renderApp() {
+  return renderWithRouter(
+    <Providers>
+      <AppRouter />
+    </Providers>,
+    { initialEntries: ["/travel/trips"] },
+  );
+}
+
+describe("TripListPage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "valid-token" });
+  });
+
+  it("탭 라벨 뒤에 전체 기준 건수를 보여준다", async () => {
+    mockTripsByStatus({ UPCOMING: [trip()] });
+
+    renderApp();
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /예정/ })).toHaveTextContent(
+        "예정2",
+      );
+    });
+    expect(screen.getByRole("tab", { name: /진행 중/ })).toHaveTextContent(
+      "진행 중0",
+    );
+    expect(screen.getByRole("tab", { name: /완료/ })).toHaveTextContent(
+      "완료1",
+    );
+  });
+
+  it("메타를 한 문자열로 그려 숫자와 단위가 갈라지지 않는다", async () => {
+    mockTripsByStatus({ UPCOMING: [trip({ activityCount: 6 })] });
+
+    renderApp();
+
+    // "도쿄 · 10.24 – 10.27 · 일정 6개"가 통째로 한 노드여야 한다.
+    expect(
+      await screen.findByText("도쿄 · 10.24 – 10.27 · 일정 6개"),
+    ).toBeInTheDocument();
+  });
+
+  it("카드를 누르면 그 여행의 보드로 간다", async () => {
+    mockTripsByStatus({ UPCOMING: [trip()] });
+
+    renderApp();
+
+    const row = await screen.findByRole("link", { name: /도쿄 3박 4일/ });
+    expect(row).toHaveAttribute("href", "/travel/trips/3/board");
+  });
+
+  it("기본 탭은 예정이고 정렬 안내를 함께 보여준다", async () => {
+    mockTripsByStatus({ UPCOMING: [trip()] });
+
+    renderApp();
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /예정/ })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+    expect(screen.getByText("시작일 오름차순")).toBeInTheDocument();
+  });
+
+  it("완료 탭으로 옮기면 그 목록을 다시 받아오고 정렬 안내가 바뀐다", async () => {
+    mockTripsByStatus({
+      UPCOMING: [trip()],
+      COMPLETED: [
+        trip({
+          id: 2,
+          title: "오사카 2박 3일",
+          destinationName: "오사카",
+          startDate: "2026-05-09",
+          endDate: "2026-05-11",
+          status: "COMPLETED",
+          activityCount: 9,
+        }),
+      ],
+    });
+
+    renderApp();
+    await screen.findByRole("link", { name: /도쿄 3박 4일/ });
+
+    await userEvent.click(screen.getByRole("tab", { name: /완료/ }));
+
+    expect(
+      await screen.findByRole("link", { name: /오사카 2박 3일/ }),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("종료일 내림차순")).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("link", { name: /도쿄 3박 4일/ })).toBeNull();
+  });
+
+  it("빈 탭은 만들기 버튼이 있는 빈 상태를 보여준다", async () => {
+    mockTripsByStatus({ UPCOMING: [] });
+
+    renderApp();
+
+    await waitFor(() => {
+      expect(screen.getByText("예정 여행이 없어요.")).toBeInTheDocument();
+    });
+    const panel = screen.getByRole("tabpanel");
+    expect(
+      within(panel).getByRole("link", { name: /여행 만들기/ }),
+    ).toHaveAttribute("href", "/travel/trips/new");
+  });
+
+  it("헤더의 여행 만들기 버튼은 항상 있다", async () => {
+    mockTripsByStatus({ UPCOMING: [trip()] });
+
+    renderApp();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "여행 목록" }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getAllByRole("link", { name: /여행 만들기/ })[0],
+    ).toHaveAttribute("href", "/travel/trips/new");
+  });
+});

--- a/fe/src/pages/travel/TripListPage.tsx
+++ b/fe/src/pages/travel/TripListPage.tsx
@@ -1,0 +1,126 @@
+import { ChevronRight, Plus } from "lucide-react";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+import { PageHeader } from "@/components/PageHeader";
+import { buttonVariants } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { LoadingText } from "@/components/ui/loading-text";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { TripCounts, TripSummary } from "@/features/travel/api/travel";
+import { useTrips } from "@/features/travel/hooks/useTrips";
+import type { TripStatus } from "@/features/travel/lib/tripStatus";
+import { formatShortDate } from "@/features/travel/lib/tripStatus";
+
+const TABS: { value: TripStatus; label: string; countKey: keyof TripCounts }[] =
+  [
+    { value: "UPCOMING", label: "예정", countKey: "upcoming" },
+    { value: "ONGOING", label: "진행 중", countKey: "ongoing" },
+    { value: "COMPLETED", label: "완료", countKey: "completed" },
+  ];
+
+/** 정렬은 서버가 확정한다. 사용자에게 규칙을 한 줄로 알려 준다. */
+const SORT_HINT: Record<TripStatus, string> = {
+  UPCOMING: "시작일 오름차순",
+  ONGOING: "시작일 오름차순",
+  COMPLETED: "종료일 내림차순",
+};
+
+/** S-02 여행 목록. 상태 탭으로 나눠 보고, 카드를 누르면 그 여행의 보드로 간다. */
+export function TripListPage() {
+  const [status, setStatus] = useState<TripStatus>("UPCOMING");
+  const { data, isPending } = useTrips(status);
+
+  return (
+    <div className="mx-auto flex max-w-[720px] flex-col gap-6">
+      <PageHeader
+        title="여행 목록"
+        actions={
+          <Link
+            to="/travel/trips/new"
+            className={buttonVariants({ variant: "default" })}
+          >
+            <Plus className="size-4" />
+            여행 만들기
+          </Link>
+        }
+      />
+      <Tabs
+        value={status}
+        onValueChange={(value) => setStatus(value as TripStatus)}
+      >
+        <TabsList>
+          {TABS.map((tab) => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+              {/* 건수는 어느 탭을 보든 전체 기준으로 온다. */}
+              <span className="tabular-nums opacity-60">
+                {data?.counts[tab.countKey] ?? 0}
+              </span>
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {TABS.map((tab) => (
+          <TabsContent key={tab.value} value={tab.value}>
+            <div className="flex flex-col gap-3">
+              <p className="text-caption text-muted-foreground">
+                {SORT_HINT[tab.value]}
+              </p>
+              {isPending ? (
+                <div className="grid min-h-[30svh] place-items-center">
+                  <LoadingText />
+                </div>
+              ) : data && data.trips.length > 0 ? (
+                <ul className="flex flex-col gap-2">
+                  {data.trips.map((trip) => (
+                    <li key={trip.id}>
+                      <TripRow trip={trip} />
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <EmptyState className="min-h-[30svh]">
+                  <p className="text-muted-foreground text-sm">
+                    {tab.label} 여행이 없어요.
+                  </p>
+                  <Link
+                    to="/travel/trips/new"
+                    className={buttonVariants({ variant: "outline" })}
+                  >
+                    <Plus className="size-4" />
+                    여행 만들기
+                  </Link>
+                </EmptyState>
+              )}
+            </div>
+          </TabsContent>
+        ))}
+      </Tabs>
+    </div>
+  );
+}
+
+function TripRow({ trip }: { trip: TripSummary }) {
+  return (
+    <Link
+      to={`/travel/trips/${trip.id}/board`}
+      className="bg-card ring-foreground/10 hover:ring-primary flex items-center justify-between gap-3 rounded-xl p-4 ring-1 transition-all"
+    >
+      <span className="min-w-0">
+        <span className="block truncate text-[15px] font-medium">
+          {trip.title}
+        </span>
+        {/* 메타는 한 문자열이다 — 조각으로 나누면 "일정 6" / "개"처럼 숫자와 단위가 갈라진다. */}
+        <span className="text-muted-foreground block text-[13px]">
+          {metaLine(trip)}
+        </span>
+      </span>
+      <ChevronRight className="text-muted-foreground size-4 shrink-0" />
+    </Link>
+  );
+}
+
+function metaLine(trip: TripSummary): string {
+  const period = `${formatShortDate(trip.startDate)} – ${formatShortDate(trip.endDate)}`;
+  return `${trip.destinationName} · ${period} · 일정 ${trip.activityCount}개`;
+}


### PR DESCRIPTION
## 이슈
closes #1035

## 작업 내용

S-01 여행 홈 + S-02 여행 목록. [화면 설계](https://github.com/wcorn/orino/wiki/Travel-UI-Design) §2.2·§2.3. (Epic #1029 · 1단계)

`/travel`·`/travel/trips`의 임시 페이지를 실제 화면으로 교체했다. 나머지 여행 라우트(보드·도구·설정)는 그대로 임시 페이지를 쓴다.

### `lib/tripStatus.ts` — 서버가 이미 주는 값을 왜 또 계산하나

`status`·`dDay`는 BE가 내려주는데도 FE가 같은 규칙으로 다시 계산한다. 이유는 **오프라인 캐시**다(4단계). 어제 받아둔 응답을 그대로 그리면 D-day가 하루 어긋난 채 화면에 남는다. 날짜에 의존하는 값은 그릴 때 다시 구해야 맞는다.

- `todayIn(timezone)` — `Intl.DateTimeFormat("en-CA")`로 **여행 타임존의 오늘**을 얻는다. 기기 시간대가 아니다
- `deriveStatus` · `daysUntil` · `dayChips` · 기간 포맷
- 날짜 계산은 전부 **UTC 자정 기준**이다. 로컬 자정으로 만들면 서머타임 경계에서 하루가 23·25시간이 돼 일수가 밀린다(테스트로 고정)

### S-01 `/travel`

요약(`/travel/summary`)이 "어떤 여행을 볼지"를 정하고, 타임존·통화·기간은 상세(`/travel/trips/{id}`)에서 가져온다 — 요약에는 그 정보가 없다.

- 예정/진행 중 배지 · 제목 · 기간·일정 수 · D-day(`text-display tabular-nums text-primary`) · `Asia/Tokyo · JPY`
- 일자 칩 가로 스크롤 — **날씨는 4단계**라 1단계는 일차·요일만 채운다(자리는 그대로 둔다)
- 최근 완료 행 → 그 여행 보드(기록 모드)
- 여행이 하나도 없으면 `EmptyState` + 만들기 버튼 하나

시작 당일은 `D-DAY`, 이미 시작했으면 `D+n`으로 쓴다(설계에 없어 채운 부분).

### S-02 `/travel/trips`

- 탭 3개 + 라벨 뒤 건수 `opacity-60 tabular-nums`. 건수는 **어느 탭을 보든 전체 기준**이라 탭을 옮겨도 다른 탭 숫자가 0이 되지 않는다
- 정렬 안내 — 예정·진행 중 "시작일 오름차순", 완료 "종료일 내림차순"
- 카드 메타는 **한 문자열로 조립**한다. 조각으로 나누면 좁은 화면에서 `일정 6` / `개`처럼 숫자와 단위가 갈라진다
- 빈 탭도 `EmptyState` + 만들기 버튼

## 테스트 (신규 27개)

**`tripStatus.test.ts` (13)** — 타임존별 오늘 · 알 수 없는 타임존 폴백 · 상태 3분기와 경계 포함 · **같은 순간에 도쿄는 진행 중, 호놀룰루는 예정** · D-day(당일 0·시작 후 음수) · **서머타임 경계에서도 일수 유지** · 일자 칩(달 넘김 포함) · 기간 포맷

**`TravelHomePage.test.tsx` (7)** — 빈 상태 · 예정 카드(배지·기간·일정 수·타임존·통화) · 일자 칩(**온도 없음** 확인) · 진행 중 배지와 헤더 문구 · 보드 링크 · 최근 완료 행 · 완료만 있을 때 카드 미표시

**`TripListPage.test.tsx` (7)** — 전체 기준 건수 · **메타가 한 노드** · 카드 링크 · 기본 탭·정렬 안내 · 탭 전환 시 재조회와 안내 변경 · 빈 탭 · 헤더 버튼

`npm run format:check && npm run lint && npm test && npm run build` 모두 통과 — **658개 전부 통과**.

## 로컬 확인 (bootRun + dev server + 브라우저)

여행 3건(예정 2 · 완료 1)과 일정 3건을 실제로 만들어 확인했다.

- **S-01**: `예정` 배지, `도쿄 3박 4일`, `10월 24일 – 10월 27일 · 일정 3개`, **D-77**(서버도 77), `Asia/Tokyo · JPY`, 일자 칩 4개가 `1일차 · 토` … `4일차 · 화`로 요일까지 정확. 최근 완료 행에 `5월 11일 종료 · 일정 0개`
- **S-02**: 탭 건수 `예정 2 · 진행 중 0 · 완료 1`, 메타 `도쿄 · 10.24 – 10.27 · 일정 3개`가 한 줄로, 완료 탭 전환 시 안내가 "종료일 내림차순"으로 바뀌고 목록도 교체, 진행 중 빈 탭은 EmptyState

## 참고

`/travel/trips/new`(생성 화면)는 #1036에서 만든다. 지금은 링크만 걸려 있어 누르면 여행 홈으로 리다이렉트된다.