### PR TITLE
feat : 여행 생성·수정 화면 (S-03)

### DIFF
--- a/fe/src/app/layout/Sidebar.tsx
+++ b/fe/src/app/layout/Sidebar.tsx
@@ -37,8 +37,8 @@ interface NavItem {
 
 /** `/travel/trips/12/board` · `/travel/trips/12/map` */
 const BOARD_PATH = /^\/travel\/trips\/\d+\/(board|map)$/;
-/** `/travel/trips` · `/travel/trips/new` · `/travel/trips/12` (목록과 생성·수정 폼) */
-const TRIP_LIST_PATH = /^\/travel\/trips(\/(new|\d+))?$/;
+/** `/travel/trips` · `/travel/trips/new` · `/travel/trips/12/edit` (목록과 생성·수정 폼) */
+const TRIP_LIST_PATH = /^\/travel\/trips(\/new|\/\d+\/edit)?$/;
 
 const DAILY_NAV_ITEMS: NavItem[] = [
   { to: "/home", label: "홈", icon: Home },

--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -60,6 +60,10 @@ export const importTripList = () =>
   import("../pages/travel/TripListPage").then((m) => ({
     default: m.TripListPage,
   }));
+export const importTripForm = () =>
+  import("../pages/travel/TripFormPage").then((m) => ({
+    default: m.TripFormPage,
+  }));
 // 아직 화면이 없는 여행 라우트(보드·도구·설정)가 공유하는 임시 페이지.
 export const importTravelPlaceholder = () =>
   import("../pages/travel/TravelPlaceholderPage").then((m) => ({

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -25,6 +25,7 @@ import {
   importRoutines,
   importTravelHome,
   importTravelPlaceholder,
+  importTripForm,
   importTripList,
   importWeeklyPlan,
   importWorkspaceSelect,
@@ -49,6 +50,7 @@ const WorkspaceSelectPage = lazy(importWorkspaceSelect);
 const TravelPlaceholderPage = lazy(importTravelPlaceholder);
 const TravelHomePage = lazy(importTravelHome);
 const TripListPage = lazy(importTripList);
+const TripFormPage = lazy(importTripForm);
 
 function RouteFallback() {
   return (
@@ -214,6 +216,22 @@ export function AppRouter() {
             element={
               <Suspense fallback={<RouteFallback />}>
                 <TripListPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/travel/trips/new"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <TripFormPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/travel/trips/:tripId/edit"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <TripFormPage />
               </Suspense>
             }
           />

--- a/fe/src/features/travel/api/travel.ts
+++ b/fe/src/features/travel/api/travel.ts
@@ -103,3 +103,54 @@ export async function fetchTrip(tripId: number): Promise<TripDetail> {
   );
   return data.data;
 }
+
+/** 여행 생성·수정 요청. 전체 수정이라 두 경로가 같은 형태를 쓴다. */
+export interface TripWriteRequest {
+  /** 비우면 서버가 `destinationName`으로 채운다. */
+  title?: string;
+  destinationName: string;
+  startDate: string;
+  endDate: string;
+  timezone: string;
+  currency: string;
+  defaultNotifyMinutes?: number;
+  morningSummaryEnabled?: boolean;
+  /** 기간 단축으로 잘리는 일정을 보관함으로 옮겨도 좋다는 확인. */
+  confirmArchive?: boolean;
+}
+
+export interface ShrinkPreview {
+  movedActivityCount: number;
+}
+
+export async function createTrip(body: TripWriteRequest): Promise<TripDetail> {
+  const { data } = await client.post<ApiEnvelope<TripDetail>>(
+    "/travel/trips",
+    body,
+  );
+  return data.data;
+}
+
+export async function updateTrip(
+  tripId: number,
+  body: TripWriteRequest,
+): Promise<TripDetail> {
+  const { data } = await client.put<ApiEnvelope<TripDetail>>(
+    `/travel/trips/${tripId}`,
+    body,
+  );
+  return data.data;
+}
+
+/** 이 기간으로 바꾸면 보관함으로 갈 일정 수. 확인 모달의 문구에 그대로 들어간다. */
+export async function fetchShrinkPreview(
+  tripId: number,
+  startDate: string,
+  endDate: string,
+): Promise<ShrinkPreview> {
+  const { data } = await client.get<ApiEnvelope<ShrinkPreview>>(
+    `/travel/trips/${tripId}/shrink-preview`,
+    { params: { startDate, endDate } },
+  );
+  return data.data;
+}

--- a/fe/src/features/travel/hooks/useTripMutations.ts
+++ b/fe/src/features/travel/hooks/useTripMutations.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { createTrip, type TripWriteRequest, updateTrip } from "../api/travel";
+import { travelKeys } from "../queryKeys";
+
+/**
+ * 여행 생성·수정. 성공하면 여행 관련 캐시를 통째로 무효화한다 — 요약·목록·상세가 모두
+ * 같은 여행을 다른 각도로 보여주고 있어서, 하나만 갱신하면 화면끼리 어긋난다.
+ */
+export function useCreateTrip() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: TripWriteRequest) => createTrip(body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: travelKeys.all });
+    },
+  });
+}
+
+export function useUpdateTrip(tripId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: TripWriteRequest) => updateTrip(tripId, body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: travelKeys.all });
+    },
+  });
+}

--- a/fe/src/features/travel/lib/destinations.ts
+++ b/fe/src/features/travel/lib/destinations.ts
@@ -1,0 +1,56 @@
+/**
+ * 1단계 목적지 입력용 선택지.
+ *
+ * <p>2단계에서 목적지를 검색(Google Places)으로 고르면 서버가 좌표에서 타임존을, 국가 코드에서
+ * 통화를 정해 준다. 그때까지는 직접 고르므로, 전체 IANA 목록(400여 개) 대신 갈 만한 곳만
+ * 추린다 — 고르는 데 걸리는 시간이 곧 이 화면의 비용이다.
+ */
+export const TIMEZONE_OPTIONS = [
+  { value: "Asia/Seoul", label: "Asia/Seoul (한국)" },
+  { value: "Asia/Tokyo", label: "Asia/Tokyo (일본)" },
+  { value: "Asia/Shanghai", label: "Asia/Shanghai (중국)" },
+  { value: "Asia/Taipei", label: "Asia/Taipei (대만)" },
+  { value: "Asia/Hong_Kong", label: "Asia/Hong_Kong (홍콩)" },
+  { value: "Asia/Singapore", label: "Asia/Singapore (싱가포르)" },
+  { value: "Asia/Bangkok", label: "Asia/Bangkok (태국·베트남)" },
+  { value: "Asia/Manila", label: "Asia/Manila (필리핀)" },
+  { value: "Asia/Jakarta", label: "Asia/Jakarta (인도네시아)" },
+  { value: "Australia/Sydney", label: "Australia/Sydney (호주 동부)" },
+  { value: "Pacific/Auckland", label: "Pacific/Auckland (뉴질랜드)" },
+  { value: "Pacific/Honolulu", label: "Pacific/Honolulu (하와이)" },
+  { value: "America/Los_Angeles", label: "America/Los_Angeles (미국 서부)" },
+  { value: "America/New_York", label: "America/New_York (미국 동부)" },
+  { value: "Europe/London", label: "Europe/London (영국)" },
+  { value: "Europe/Paris", label: "Europe/Paris (서유럽)" },
+  { value: "Europe/Rome", label: "Europe/Rome (이탈리아)" },
+  { value: "Europe/Madrid", label: "Europe/Madrid (스페인)" },
+] as const;
+
+export const CURRENCY_OPTIONS = [
+  { value: "KRW", label: "KRW · 원" },
+  { value: "JPY", label: "JPY · 엔" },
+  { value: "USD", label: "USD · 달러" },
+  { value: "EUR", label: "EUR · 유로" },
+  { value: "GBP", label: "GBP · 파운드" },
+  { value: "CNY", label: "CNY · 위안" },
+  { value: "TWD", label: "TWD · 대만 달러" },
+  { value: "HKD", label: "HKD · 홍콩 달러" },
+  { value: "SGD", label: "SGD · 싱가포르 달러" },
+  { value: "THB", label: "THB · 바트" },
+  { value: "VND", label: "VND · 동" },
+  { value: "PHP", label: "PHP · 페소" },
+  { value: "IDR", label: "IDR · 루피아" },
+  { value: "AUD", label: "AUD · 호주 달러" },
+  { value: "NZD", label: "NZD · 뉴질랜드 달러" },
+] as const;
+
+/** 여행 단위 기본 알림 시점(분 전). */
+export const NOTIFY_MINUTES_OPTIONS = [
+  { value: "5", label: "5분 전" },
+  { value: "10", label: "10분 전" },
+  { value: "15", label: "15분 전" },
+  { value: "30", label: "30분 전" },
+  { value: "60", label: "1시간 전" },
+] as const;
+
+export const DEFAULT_NOTIFY_MINUTES = 15;

--- a/fe/src/pages/travel/TripFormPage.test.tsx
+++ b/fe/src/pages/travel/TripFormPage.test.tsx
@@ -1,0 +1,329 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { AppRouter } from "@/app/router";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+const API_BASE = "https://api.orino.dev/api";
+
+const TOKYO = {
+  id: 3,
+  title: "도쿄 3박 4일",
+  destinationName: "도쿄",
+  destinationPlaceId: null,
+  startDate: "2026-10-24",
+  endDate: "2026-10-27",
+  timezone: "Asia/Tokyo",
+  currency: "JPY",
+  lat: null,
+  lng: null,
+  defaultNotifyMinutes: 15,
+  morningSummaryEnabled: false,
+  status: "UPCOMING",
+  dDay: 78,
+  totalDays: 4,
+  activityCount: 13,
+};
+
+function renderApp(path: string) {
+  return renderWithRouter(
+    <Providers>
+      <AppRouter />
+    </Providers>,
+    { initialEntries: [path] },
+  );
+}
+
+function mockTripDetail(trip = TOKYO) {
+  server.use(
+    http.get(`${API_BASE}/travel/trips/:tripId`, () =>
+      HttpResponse.json({ code: "OK", data: trip }),
+    ),
+  );
+}
+
+/** 생성·수정 요청 본문을 잡아 두는 핸들러. */
+function captureWrite(method: "post" | "put") {
+  const seen: Record<string, unknown>[] = [];
+  const path =
+    method === "post"
+      ? `${API_BASE}/travel/trips`
+      : `${API_BASE}/travel/trips/:tripId`;
+  server.use(
+    http[method](path, async ({ request }) => {
+      seen.push((await request.json()) as Record<string, unknown>);
+      return HttpResponse.json({ code: "OK", data: TOKYO });
+    }),
+  );
+  return seen;
+}
+
+async function fillNewTripForm() {
+  await userEvent.type(screen.getByLabelText("목적지 도시"), "도쿄");
+  await userEvent.type(screen.getByLabelText("시작일"), "2026-10-24");
+  await userEvent.type(screen.getByLabelText("종료일"), "2026-10-27");
+}
+
+describe("TripFormPage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "valid-token" });
+  });
+
+  describe("생성", () => {
+    it("명세 순서대로 필드를 보여준다", async () => {
+      renderApp("/travel/trips/new");
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "여행 만들기" }),
+        ).toBeInTheDocument();
+      });
+      expect(screen.getByLabelText("목적지 도시")).toBeInTheDocument();
+      expect(screen.getByLabelText("여행 제목")).toBeInTheDocument();
+      expect(screen.getByLabelText("시작일")).toBeInTheDocument();
+      expect(screen.getByLabelText("종료일")).toBeInTheDocument();
+      expect(
+        screen.getByText(/여행 중에는 이 타임존을 씁니다/),
+      ).toBeInTheDocument();
+      expect(screen.getByText("기본 알림 시점")).toBeInTheDocument();
+    });
+
+    it("제목 placeholder가 입력한 목적지 이름을 따라간다", async () => {
+      renderApp("/travel/trips/new");
+
+      const destination = await screen.findByLabelText("목적지 도시");
+      await userEvent.type(destination, "오사카");
+
+      expect(screen.getByLabelText("여행 제목")).toHaveAttribute(
+        "placeholder",
+        "오사카",
+      );
+    });
+
+    it("제목을 비우면 요청에서 빼서 서버가 목적지명으로 채우게 한다", async () => {
+      const seen = captureWrite("post");
+      renderApp("/travel/trips/new");
+      await screen.findByLabelText("목적지 도시");
+
+      await fillNewTripForm();
+      await userEvent.click(screen.getByRole("button", { name: "만들기" }));
+
+      await waitFor(() => expect(seen).toHaveLength(1));
+      expect(seen[0].title).toBeUndefined();
+      expect(seen[0]).toMatchObject({
+        destinationName: "도쿄",
+        startDate: "2026-10-24",
+        endDate: "2026-10-27",
+        timezone: "Asia/Tokyo",
+        currency: "JPY",
+        defaultNotifyMinutes: 15,
+      });
+    });
+
+    it("만들면 그 여행의 보드로 간다", async () => {
+      captureWrite("post");
+      renderApp("/travel/trips/new");
+      await screen.findByLabelText("목적지 도시");
+
+      await fillNewTripForm();
+      await userEvent.click(screen.getByRole("button", { name: "만들기" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "일정 보드" }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("종료일이 시작일보다 빠르면 저장하지 않고 알려준다", async () => {
+      const seen = captureWrite("post");
+      renderApp("/travel/trips/new");
+      await screen.findByLabelText("목적지 도시");
+
+      await userEvent.type(screen.getByLabelText("목적지 도시"), "도쿄");
+      await userEvent.type(screen.getByLabelText("시작일"), "2026-10-27");
+      await userEvent.type(screen.getByLabelText("종료일"), "2026-10-24");
+      await userEvent.click(screen.getByRole("button", { name: "만들기" }));
+
+      expect(
+        await screen.findByText("종료일은 시작일보다 빠를 수 없습니다."),
+      ).toBeInTheDocument();
+      expect(seen).toHaveLength(0);
+    });
+
+    it("목적지를 비우면 저장하지 않는다", async () => {
+      const seen = captureWrite("post");
+      renderApp("/travel/trips/new");
+      await screen.findByLabelText("목적지 도시");
+
+      await userEvent.click(screen.getByRole("button", { name: "만들기" }));
+
+      expect(
+        await screen.findByText("목적지를 입력해 주세요."),
+      ).toBeInTheDocument();
+      expect(seen).toHaveLength(0);
+    });
+  });
+
+  describe("수정", () => {
+    it("기존 값으로 폼을 채운다", async () => {
+      mockTripDetail();
+      renderApp("/travel/trips/3/edit");
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("목적지 도시")).toHaveValue("도쿄");
+      });
+      expect(screen.getByLabelText("여행 제목")).toHaveValue("도쿄 3박 4일");
+      expect(screen.getByLabelText("시작일")).toHaveValue("2026-10-24");
+      expect(screen.getByLabelText("종료일")).toHaveValue("2026-10-27");
+      expect(
+        screen.getByRole("heading", { name: "여행 수정" }),
+      ).toBeInTheDocument();
+    });
+
+    it("제목이 목적지명과 같으면(자동 저장된 값) 폼을 비워 둔다", async () => {
+      mockTripDetail({ ...TOKYO, title: "도쿄" });
+      renderApp("/travel/trips/3/edit");
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("목적지 도시")).toHaveValue("도쿄");
+      });
+      expect(screen.getByLabelText("여행 제목")).toHaveValue("");
+    });
+
+    it("기간을 줄이지 않으면 확인 없이 저장한다", async () => {
+      mockTripDetail();
+      const seen = captureWrite("put");
+      renderApp("/travel/trips/3/edit");
+      await waitFor(() => {
+        expect(screen.getByLabelText("종료일")).toHaveValue("2026-10-27");
+      });
+
+      // 늘리는 방향.
+      await userEvent.clear(screen.getByLabelText("종료일"));
+      await userEvent.type(screen.getByLabelText("종료일"), "2026-10-30");
+      await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+      await waitFor(() => expect(seen).toHaveLength(1));
+      expect(seen[0].confirmArchive).toBeUndefined();
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
+  describe("기간 단축 확인", () => {
+    function mockShrinkPreview(movedActivityCount: number) {
+      server.use(
+        http.get(`${API_BASE}/travel/trips/:tripId/shrink-preview`, () =>
+          HttpResponse.json({ code: "OK", data: { movedActivityCount } }),
+        ),
+      );
+    }
+
+    it("잘리는 일정이 있으면 개수를 보여주고 확인을 받는다", async () => {
+      mockTripDetail();
+      mockShrinkPreview(4);
+      const seen = captureWrite("put");
+      renderApp("/travel/trips/3/edit");
+      await waitFor(() => {
+        expect(screen.getByLabelText("종료일")).toHaveValue("2026-10-27");
+      });
+
+      await userEvent.clear(screen.getByLabelText("종료일"));
+      await userEvent.type(screen.getByLabelText("종료일"), "2026-10-25");
+      await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+      const dialog = await screen.findByRole("dialog");
+      expect(dialog).toHaveTextContent("기간을 줄이면 일정이 이동합니다");
+      expect(dialog).toHaveTextContent(
+        "잘리는 날짜의 일정 4개가 미배정 보관함으로 이동합니다.",
+      );
+      // 확인 전에는 저장 요청이 나가지 않는다.
+      expect(seen).toHaveLength(0);
+    });
+
+    it("확인하면 confirmArchive를 실어 저장한다", async () => {
+      mockTripDetail();
+      mockShrinkPreview(4);
+      const seen = captureWrite("put");
+      renderApp("/travel/trips/3/edit");
+      await waitFor(() => {
+        expect(screen.getByLabelText("종료일")).toHaveValue("2026-10-27");
+      });
+
+      await userEvent.clear(screen.getByLabelText("종료일"));
+      await userEvent.type(screen.getByLabelText("종료일"), "2026-10-25");
+      await userEvent.click(screen.getByRole("button", { name: "저장" }));
+      await screen.findByRole("dialog");
+      await userEvent.click(
+        screen.getByRole("button", { name: "이동하고 저장" }),
+      );
+
+      await waitFor(() => expect(seen).toHaveLength(1));
+      expect(seen[0].confirmArchive).toBe(true);
+      expect(seen[0].endDate).toBe("2026-10-25");
+    });
+
+    it("시작일을 늦춰 앞쪽이 잘려도 확인을 받는다", async () => {
+      mockTripDetail();
+      mockShrinkPreview(2);
+      captureWrite("put");
+      renderApp("/travel/trips/3/edit");
+      await waitFor(() => {
+        expect(screen.getByLabelText("시작일")).toHaveValue("2026-10-24");
+      });
+
+      await userEvent.clear(screen.getByLabelText("시작일"));
+      await userEvent.type(screen.getByLabelText("시작일"), "2026-10-26");
+      await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+      expect(await screen.findByRole("dialog")).toHaveTextContent(
+        "일정 2개가 미배정 보관함으로 이동합니다.",
+      );
+    });
+
+    it("잘리는 일정이 0개면 확인 없이 바로 저장한다", async () => {
+      mockTripDetail();
+      mockShrinkPreview(0);
+      const seen = captureWrite("put");
+      renderApp("/travel/trips/3/edit");
+      await waitFor(() => {
+        expect(screen.getByLabelText("종료일")).toHaveValue("2026-10-27");
+      });
+
+      await userEvent.clear(screen.getByLabelText("종료일"));
+      await userEvent.type(screen.getByLabelText("종료일"), "2026-10-25");
+      await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+      await waitFor(() => expect(seen).toHaveLength(1));
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    it("미리보기가 실패해도 저장을 막지 않는다(서버 409가 최종 안전장치)", async () => {
+      mockTripDetail();
+      server.use(
+        http.get(`${API_BASE}/travel/trips/:tripId/shrink-preview`, () =>
+          HttpResponse.json(null, { status: 500 }),
+        ),
+      );
+      const seen = captureWrite("put");
+      // 콘솔 에러 노이즈를 줄인다(요청 실패는 의도된 경로).
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      renderApp("/travel/trips/3/edit");
+      await waitFor(() => {
+        expect(screen.getByLabelText("종료일")).toHaveValue("2026-10-27");
+      });
+
+      await userEvent.clear(screen.getByLabelText("종료일"));
+      await userEvent.type(screen.getByLabelText("종료일"), "2026-10-25");
+      await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+      await waitFor(() => expect(seen).toHaveLength(1));
+      vi.restoreAllMocks();
+    });
+  });
+});

--- a/fe/src/pages/travel/TripFormPage.tsx
+++ b/fe/src/pages/travel/TripFormPage.tsx
@@ -1,0 +1,326 @@
+import { ArrowLeft, Info } from "lucide-react";
+import { type FormEvent, useEffect, useId, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { LoadingText } from "@/components/ui/loading-text";
+import { Select } from "@/components/ui/select";
+import {
+  fetchShrinkPreview,
+  type TripDetail,
+  type TripWriteRequest,
+} from "@/features/travel/api/travel";
+import { useTrip } from "@/features/travel/hooks/useTrip";
+import {
+  useCreateTrip,
+  useUpdateTrip,
+} from "@/features/travel/hooks/useTripMutations";
+import {
+  CURRENCY_OPTIONS,
+  DEFAULT_NOTIFY_MINUTES,
+  NOTIFY_MINUTES_OPTIONS,
+  TIMEZONE_OPTIONS,
+} from "@/features/travel/lib/destinations";
+import { toast } from "@/shared/lib/toast";
+
+const TITLE_MAX = 50;
+
+interface FormState {
+  destinationName: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  timezone: string;
+  currency: string;
+  notifyMinutes: string;
+}
+
+const EMPTY: FormState = {
+  destinationName: "",
+  title: "",
+  startDate: "",
+  endDate: "",
+  timezone: "Asia/Tokyo",
+  currency: "JPY",
+  notifyMinutes: String(DEFAULT_NOTIFY_MINUTES),
+};
+
+/**
+ * S-03 여행 생성·수정. 생성과 수정이 같은 폼을 쓴다(서버도 전체 수정이다).
+ *
+ * <p>입력 순서는 명세 고정 — 목적지 → 제목 → 기간 → 자동 지정 확인 → 기본 알림 시점.
+ * 1단계는 목적지를 직접 입력하고 타임존·통화를 고르지만, 2단계에서 검색으로 바뀌어도
+ * <b>순서와 안내 문구 자리는 그대로다</b>. 입력 수단만 교체된다.
+ */
+export function TripFormPage() {
+  const { tripId } = useParams();
+  const editingId = tripId ? Number(tripId) : null;
+  const navigate = useNavigate();
+
+  const { data: trip, isPending: loadingTrip } = useTrip(editingId);
+  const createMutation = useCreateTrip();
+  const updateMutation = useUpdateTrip(editingId ?? 0);
+
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [error, setError] = useState<string | null>(null);
+  const [shrinkCount, setShrinkCount] = useState<number | null>(null);
+  const [checkingShrink, setCheckingShrink] = useState(false);
+
+  // 수정 모드는 서버 값으로 폼을 채운다.
+  useEffect(() => {
+    if (trip) setForm(toFormState(trip));
+  }, [trip]);
+
+  const timezoneLabelId = useId();
+  const currencyLabelId = useId();
+  const notifyLabelId = useId();
+
+  const pending =
+    createMutation.isPending || updateMutation.isPending || checkingShrink;
+
+  if (editingId !== null && loadingTrip) {
+    return (
+      <div className="grid min-h-[40svh] place-items-center">
+        <LoadingText />
+      </div>
+    );
+  }
+
+  const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  /** 저장 직전 검증. 서버도 같은 규칙을 보지만 왕복 없이 바로 알려주는 편이 낫다. */
+  const validate = (): string | null => {
+    if (!form.destinationName.trim()) return "목적지를 입력해 주세요.";
+    if (form.title.trim().length > TITLE_MAX)
+      return `제목은 ${TITLE_MAX}자를 넘을 수 없습니다.`;
+    if (!form.startDate || !form.endDate) return "기간을 입력해 주세요.";
+    if (form.endDate < form.startDate)
+      return "종료일은 시작일보다 빠를 수 없습니다.";
+    return null;
+  };
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    const message = validate();
+    if (message) {
+      setError(message);
+      return;
+    }
+    setError(null);
+
+    // 기간이 줄면 잘리는 일정이 생긴다. 몇 개인지 먼저 물어보고 확인을 받는다.
+    if (trip && isShrinking(trip, form)) {
+      setCheckingShrink(true);
+      try {
+        const preview = await fetchShrinkPreview(
+          trip.id,
+          form.startDate,
+          form.endDate,
+        );
+        if (preview.movedActivityCount > 0) {
+          setShrinkCount(preview.movedActivityCount);
+          return;
+        }
+      } catch {
+        // 미리보기가 실패해도 저장을 막지 않는다 — 확인 없이 보내면 서버가 409로 되돌린다.
+      } finally {
+        setCheckingShrink(false);
+      }
+    }
+    await save(false);
+  };
+
+  const save = async (confirmArchive: boolean) => {
+    const body = toRequest(form, confirmArchive);
+    try {
+      const saved =
+        editingId !== null
+          ? await updateMutation.mutateAsync(body)
+          : await createMutation.mutateAsync(body);
+      toast(
+        editingId !== null ? "여행을 수정했어요." : "여행을 만들었어요.",
+        "success",
+      );
+      navigate(`/travel/trips/${saved.id}/board`, { replace: true });
+    } catch {
+      setShrinkCount(null);
+      setError("저장하지 못했어요. 잠시 후 다시 시도해 주세요.");
+    }
+  };
+
+  return (
+    <div className="mx-auto flex max-w-[520px] flex-col gap-6">
+      <header className="flex items-center gap-2">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="뒤로"
+          onClick={() => navigate(-1)}
+        >
+          <ArrowLeft className="size-4" />
+        </Button>
+        <h1 className="text-heading font-semibold">
+          {editingId !== null ? "여행 수정" : "여행 만들기"}
+        </h1>
+      </header>
+
+      <form className="flex flex-col gap-4" onSubmit={submit} noValidate>
+        {/* 1. 목적지 — 2단계에서 이 자리가 검색으로 바뀐다. */}
+        <FormField label="목적지 도시" htmlFor="destinationName">
+          <Input
+            id="destinationName"
+            value={form.destinationName}
+            onChange={(e) => set("destinationName", e.target.value)}
+            placeholder="도쿄"
+            maxLength={100}
+          />
+        </FormField>
+
+        {/* 2. 제목 — 비우면 목적지 이름으로 저장된다. placeholder로 그걸 보여준다. */}
+        <FormField label="여행 제목" htmlFor="title">
+          <Input
+            id="title"
+            value={form.title}
+            onChange={(e) => set("title", e.target.value)}
+            placeholder={
+              form.destinationName || "비우면 목적지 이름으로 저장돼요"
+            }
+            maxLength={TITLE_MAX}
+          />
+        </FormField>
+
+        {/* 3. 기간 */}
+        <div className="flex gap-3">
+          <FormField label="시작일" htmlFor="startDate" className="flex-1">
+            <Input
+              id="startDate"
+              type="date"
+              value={form.startDate}
+              onChange={(e) => set("startDate", e.target.value)}
+            />
+          </FormField>
+          <FormField label="종료일" htmlFor="endDate" className="flex-1">
+            <Input
+              id="endDate"
+              type="date"
+              value={form.endDate}
+              onChange={(e) => set("endDate", e.target.value)}
+            />
+          </FormField>
+        </div>
+
+        <div className="flex gap-3">
+          <FormField
+            label="타임존"
+            labelId={timezoneLabelId}
+            className="min-w-0 flex-1"
+          >
+            <Select
+              value={form.timezone}
+              onValueChange={(v) => set("timezone", v)}
+              options={[...TIMEZONE_OPTIONS]}
+              ariaLabelledby={timezoneLabelId}
+            />
+          </FormField>
+          <FormField
+            label="통화"
+            labelId={currencyLabelId}
+            className="min-w-0 flex-1"
+          >
+            <Select
+              value={form.currency}
+              onValueChange={(v) => set("currency", v)}
+              options={[...CURRENCY_OPTIONS]}
+              ariaLabelledby={currencyLabelId}
+            />
+          </FormField>
+        </div>
+
+        {/* 4. 자동 지정 확인 — 2단계에서는 목적지 선택만으로 이 값이 채워진다. */}
+        <Alert variant="info">
+          <Info />
+          <AlertTitle>여행 중에는 이 타임존을 씁니다</AlertTitle>
+          <AlertDescription>
+            {form.timezone} · {form.currency} — 일정은 이 타임존의 벽시계
+            시각으로 표시됩니다.
+          </AlertDescription>
+        </Alert>
+
+        {/* 5. 기본 알림 시점 */}
+        <FormField label="기본 알림 시점" labelId={notifyLabelId}>
+          <Select
+            value={form.notifyMinutes}
+            onValueChange={(v) => set("notifyMinutes", v)}
+            options={[...NOTIFY_MINUTES_OPTIONS]}
+            ariaLabelledby={notifyLabelId}
+          />
+        </FormField>
+
+        {error && (
+          <p role="alert" className="text-destructive text-sm">
+            {error}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={() => navigate(-1)}>
+            취소
+          </Button>
+          <Button type="submit" disabled={pending}>
+            {editingId !== null ? "저장" : "만들기"}
+          </Button>
+        </div>
+      </form>
+
+      <ConfirmDialog
+        open={shrinkCount !== null}
+        onOpenChange={(open) => {
+          if (!open) setShrinkCount(null);
+        }}
+        title="기간을 줄이면 일정이 이동합니다"
+        description={`잘리는 날짜의 일정 ${shrinkCount ?? 0}개가 미배정 보관함으로 이동합니다.`}
+        // 일정이 사라지는 게 아니라 옮겨지는 것이라 destructive가 아니다.
+        confirmLabel="이동하고 저장"
+        onConfirm={() => void save(true)}
+        pending={updateMutation.isPending}
+      />
+    </div>
+  );
+}
+
+/** 기간이 어느 쪽으로든 줄었는지 — 시작일을 늦춰도 앞쪽 일정이 잘린다. */
+function isShrinking(trip: TripDetail, form: FormState): boolean {
+  return form.startDate > trip.startDate || form.endDate < trip.endDate;
+}
+
+function toFormState(trip: TripDetail): FormState {
+  return {
+    destinationName: trip.destinationName,
+    // 제목이 목적지명으로 자동 저장된 경우 폼을 비워 둔다 — 다시 저장해도 같은 값이 유지되고,
+    // 사용자에겐 "안 정했다"는 원래 상태로 보인다.
+    title: trip.title === trip.destinationName ? "" : trip.title,
+    startDate: trip.startDate,
+    endDate: trip.endDate,
+    timezone: trip.timezone,
+    currency: trip.currency,
+    notifyMinutes: String(trip.defaultNotifyMinutes),
+  };
+}
+
+function toRequest(form: FormState, confirmArchive: boolean): TripWriteRequest {
+  return {
+    title: form.title.trim() || undefined,
+    destinationName: form.destinationName.trim(),
+    startDate: form.startDate,
+    endDate: form.endDate,
+    timezone: form.timezone,
+    currency: form.currency,
+    defaultNotifyMinutes: Number(form.notifyMinutes),
+    ...(confirmArchive ? { confirmArchive: true } : {}),
+  };
+}


### PR DESCRIPTION
## 이슈
closes #1036

## 작업 내용

S-03 여행 생성·수정. [화면 설계](https://github.com/wcorn/orino/wiki/Travel-UI-Design) §2.4. (Epic #1029 · 1단계)

`/travel/trips/new` · `/travel/trips/:tripId/edit` — 서버가 전체 수정이라 두 경로가 같은 폼을 쓴다. 입력 순서는 명세 고정: **목적지 → 제목 → 기간 → 자동 지정 확인 → 기본 알림 시점**.

### 1단계 대체 UI ([D-7](https://github.com/wcorn/orino/wiki/Travel-Open-Items))

목적지 검색(Places)이 2단계라, 1단계는 목적지를 직접 입력하고 타임존·통화를 고른다. **화면 순서와 "자동 지정" Alert 자리는 그대로 뒀다** — 2단계에서 입력 수단만 검색으로 바뀌고 나머지는 건드리지 않는다.

타임존은 전체 IANA 목록(400여 개) 대신 갈 만한 곳 18개로 추렸다. 고르는 데 걸리는 시간이 곧 이 화면의 비용이고, 어차피 2단계에서 자동 지정으로 대체된다.

### 기간 단축 확인

종료일을 당기거나 **시작일을 늦추면** 잘리는 일정이 생긴다. 저장 전에 `GET /shrink-preview`로 개수를 받아 `ConfirmDialog`를 띄우고, 확인하면 `confirmArchive: true`로 저장한다.

- confirmLabel "이동하고 저장" — **destructive 아님**. 일정이 사라지는 게 아니라 보관함으로 옮겨진다
- 잘리는 일정이 0개면 확인을 건너뛴다
- **미리보기가 실패해도 저장을 막지 않는다.** 확인 없이 보내면 서버가 409로 되돌리므로 안전장치가 이중이다

### 제목 처리

비우면 서버가 목적지명으로 채운다. 그래서 요청에서 `title`을 아예 빼고, placeholder로 입력 중인 목적지 이름을 보여준다.

수정 모드에서 **제목이 목적지명과 같으면 폼을 비워 둔다** — 자동으로 채워진 값이지 사용자가 정한 제목이 아니다. 그대로 저장해도 같은 값이 유지되고, 화면에는 "아직 안 정했다"는 원래 상태로 보인다.

## 테스트 (신규 14개)

**생성 (6)** — 명세 순서대로 필드 · placeholder가 목적지를 따라감 · **제목 없으면 요청에서 제외** · 만들면 보드로 이동 · 종료일 역전 시 저장 안 함 · 목적지 필수

**수정 (3)** — 기존 값 채움 · **자동 저장된 제목은 비워 둠** · 기간을 늘리면 확인 없이 저장

**기간 단축 (5)** — 개수를 보여주고 **확인 전에는 요청이 나가지 않음** · 확인 시 `confirmArchive: true` · **시작일을 늦춰도 확인** · 0개면 확인 생략 · 미리보기 실패해도 저장 진행

`npm run format:check && npm run lint && npm test && npm run build` 모두 통과 — **672개 전부 통과**.

## 로컬 확인 (bootRun + dev server + 브라우저)

- 생성 폼이 명세 순서대로 렌더되고, 타임존을 고르면 Alert 문구(`Asia/Tokyo · JPY`)가 따라감
- 제목 없이 만들었더니 서버가 `도쿄`로 채워 저장, 보드로 이동
- 잘릴 날짜에 일정 2건을 넣고 종료일을 10/27 → 10/25로 당기니 **"잘리는 날짜의 일정 2개가 미배정 보관함으로 이동합니다."** (서버 미리보기도 2)
- "이동하고 저장" 후 DB 확인 — 기간은 `10/24~10/25`로 줄고, **잘린 2건이 삭제되지 않고 `activity_date = NULL`로 이동**(`sort_order` 0·1)

## 참고

수정 화면 진입점(보드 헤더 `MoreVertical` → 여행 수정)은 #1037에서 붙는다. 지금은 URL로만 들어갈 수 있다 — 라우트와 화면은 완성돼 있고 링크만 없는 상태다.

사이드바의 「여행 목록」 활성 판정에 `/travel/trips/:id/edit`를 추가했다(그렇지 않으면 수정 화면에서 아무 메뉴도 활성이 아니다).