### PR TITLE
feat : 일정 보드 — 날짜 탭 · 일정 행 · 보관함 (S-04)

### DIFF
--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -64,6 +64,10 @@ export const importTripForm = () =>
   import("../pages/travel/TripFormPage").then((m) => ({
     default: m.TripFormPage,
   }));
+export const importTripBoard = () =>
+  import("../pages/travel/TripBoardPage").then((m) => ({
+    default: m.TripBoardPage,
+  }));
 // 아직 화면이 없는 여행 라우트(보드·도구·설정)가 공유하는 임시 페이지.
 export const importTravelPlaceholder = () =>
   import("../pages/travel/TravelPlaceholderPage").then((m) => ({

--- a/fe/src/app/router.test.tsx
+++ b/fe/src/app/router.test.tsx
@@ -83,10 +83,9 @@ describe("AppRouter", () => {
 
     renderApp(["/travel/trips/3/board"]);
 
+    // 보드가 실제로 열린다(선택 화면으로 튕기지 않는다).
     await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: "일정 보드" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /1일차/ })).toBeInTheDocument();
     });
     expect(screen.queryByRole("heading", { name: "어디로 갈까요" })).toBeNull();
   });

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -25,6 +25,7 @@ import {
   importRoutines,
   importTravelHome,
   importTravelPlaceholder,
+  importTripBoard,
   importTripForm,
   importTripList,
   importWeeklyPlan,
@@ -51,6 +52,7 @@ const TravelPlaceholderPage = lazy(importTravelPlaceholder);
 const TravelHomePage = lazy(importTravelHome);
 const TripListPage = lazy(importTripList);
 const TripFormPage = lazy(importTripForm);
+const TripBoardPage = lazy(importTripBoard);
 
 function RouteFallback() {
   return (
@@ -237,7 +239,11 @@ export function AppRouter() {
           />
           <Route
             path="/travel/trips/:tripId/board"
-            element={<TravelRoute title="일정 보드" />}
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <TripBoardPage />
+              </Suspense>
+            }
           />
           <Route path="/travel/tools" element={<TravelRoute title="도구" />} />
           <Route

--- a/fe/src/features/travel/api/activities.ts
+++ b/fe/src/features/travel/api/activities.ts
@@ -1,0 +1,121 @@
+import { client } from "@/shared/api";
+
+import type { TripStatus } from "../lib/tripStatus";
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export interface ActivityPlace {
+  id: number;
+  name: string;
+  address: string | null;
+  lat: number | null;
+  lng: number | null;
+}
+
+export interface Activity {
+  id: number;
+  tripId: number;
+  title: string;
+  /** null이면 미배정 보관함에 있는 일정. */
+  activityDate: string | null;
+  /** 여행 타임존의 벽시계 시각("09:00"). null이면 시각 미정. */
+  startTime: string | null;
+  place: ActivityPlace | null;
+  memo: string | null;
+  url: string | null;
+  notifyEnabled: boolean;
+  notifyMinutes: number | null;
+  departureNotifyEnabled: boolean;
+  sortOrder: number;
+  /** 사후 기록(평점·메모) 존재 여부. 기록은 4단계라 지금은 항상 false. */
+  hasLog: boolean;
+}
+
+export interface BoardDay {
+  dayIndex: number;
+  date: string;
+  weekday: string;
+  activityCount: number;
+  /** 날씨는 4단계. 지금은 항상 null. */
+  weather: unknown | null;
+}
+
+export interface BoardTrip {
+  id: number;
+  title: string;
+  timezone: string;
+  currency: string;
+  startDate: string;
+  endDate: string;
+  status: TripStatus;
+  /** 완료된 여행이면 true — 계획 편집 대신 기록을 보여준다(4단계). */
+  recordMode: boolean;
+}
+
+export interface Board {
+  trip: BoardTrip;
+  days: BoardDay[];
+  /** 이번 응답의 activities가 속한 날짜. null이면 보관함을 보고 있다. */
+  selectedDate: string | null;
+  archiveCount: number;
+  activities: Activity[];
+  /** 이동시간은 2단계. 지금은 항상 빈 배열. */
+  legs: unknown[];
+}
+
+/**
+ * 보드 단일 조회. `date`와 `archive`는 배타적이며, 둘 다 없으면 서버가 고른다
+ * (진행 중이면 여행 타임존의 오늘, 아니면 1일차).
+ */
+export async function fetchBoard(
+  tripId: number,
+  params: { date?: string; archive?: boolean },
+): Promise<Board> {
+  const { data } = await client.get<ApiEnvelope<Board>>(
+    `/travel/trips/${tripId}/board`,
+    { params: params.archive ? { archive: true } : { date: params.date } },
+  );
+  return data.data;
+}
+
+export interface ActivityWriteRequest {
+  title: string;
+  /** null이면 보관함으로 넣는다. */
+  activityDate?: string | null;
+  startTime?: string | null;
+  placeId?: number | null;
+  memo?: string | null;
+  url?: string | null;
+  notifyEnabled?: boolean;
+  notifyMinutes?: number | null;
+  departureNotifyEnabled?: boolean;
+}
+
+export async function createActivity(
+  tripId: number,
+  body: ActivityWriteRequest,
+): Promise<Activity> {
+  const { data } = await client.post<ApiEnvelope<Activity>>(
+    `/travel/trips/${tripId}/activities`,
+    body,
+  );
+  return data.data;
+}
+
+export async function updateActivity(
+  activityId: number,
+  body: ActivityWriteRequest,
+): Promise<Activity> {
+  const { data } = await client.put<ApiEnvelope<Activity>>(
+    `/travel/activities/${activityId}`,
+    body,
+  );
+  return data.data;
+}
+
+export async function deleteActivity(activityId: number): Promise<void> {
+  await client.delete(`/travel/activities/${activityId}`);
+}

--- a/fe/src/features/travel/api/travel.ts
+++ b/fe/src/features/travel/api/travel.ts
@@ -154,3 +154,7 @@ export async function fetchShrinkPreview(
   );
   return data.data;
 }
+
+export async function deleteTrip(tripId: number): Promise<void> {
+  await client.delete(`/travel/trips/${tripId}`);
+}

--- a/fe/src/features/travel/board/ActivityRow.tsx
+++ b/fe/src/features/travel/board/ActivityRow.tsx
@@ -1,0 +1,85 @@
+import { Archive, Bell, MapPin, Star, Trash2 } from "lucide-react";
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import type { Activity } from "@/features/travel/api/activities";
+
+interface ActivityRowProps {
+  activity: Activity;
+  /** 보관함을 보고 있으면 "보관함으로" 액션을 감춘다(이미 거기 있다). */
+  inArchive: boolean;
+  onArchive: (activity: Activity) => void;
+  onDelete: (activity: Activity) => void;
+}
+
+/**
+ * 일정 한 줄. 시각·본문·액션 3열 그리드다.
+ *
+ * <p>시각이 없는 일정이 정상이라(§1.1) 빈칸 대신 `──`를 둔다 — 자리를 비우면 본문이
+ * 좌우로 흔들려 목록이 읽기 어려워진다.
+ */
+export function ActivityRow({
+  activity,
+  inArchive,
+  onArchive,
+  onDelete,
+}: ActivityRowProps) {
+  return (
+    <li className="hover:bg-muted grid grid-cols-[52px_1fr_auto] items-start gap-2 rounded-lg px-2 py-2.5">
+      <span
+        className={
+          activity.startTime
+            ? "pt-px text-sm tabular-nums"
+            : "text-muted-foreground pt-px text-sm"
+        }
+      >
+        {activity.startTime ?? "──"}
+      </span>
+
+      <Link
+        to={`/travel/activities/${activity.id}`}
+        className="min-w-0 no-underline"
+      >
+        <span className="block text-[15px] leading-[1.4]">
+          {activity.title}
+        </span>
+        {activity.place && (
+          <span className="text-muted-foreground flex items-center gap-1 text-xs">
+            <MapPin className="size-3 shrink-0" />
+            <span className="truncate">{activity.place.name}</span>
+          </span>
+        )}
+      </Link>
+
+      <span className="flex items-center gap-0.5">
+        {activity.notifyEnabled && (
+          <Bell aria-label="알림 켜짐" className="text-primary size-3.5" />
+        )}
+        {activity.hasLog && (
+          <Star
+            aria-label="기록 있음"
+            className="text-muted-foreground size-3.5"
+          />
+        )}
+        {!inArchive && (
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`${activity.title} 보관함으로`}
+            onClick={() => onArchive(activity)}
+          >
+            <Archive className="size-4" />
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label={`${activity.title} 삭제`}
+          onClick={() => onDelete(activity)}
+        >
+          <Trash2 className="size-4" />
+        </Button>
+      </span>
+    </li>
+  );
+}

--- a/fe/src/features/travel/board/AddSheet.tsx
+++ b/fe/src/features/travel/board/AddSheet.tsx
@@ -1,0 +1,153 @@
+import { Archive, ArrowLeft, PenLine, Search } from "lucide-react";
+import { type FormEvent, useEffect, useState } from "react";
+
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import type { Activity } from "@/features/travel/api/activities";
+import { useBoard } from "@/features/travel/hooks/useBoard";
+
+type Mode = "menu" | "manual";
+
+interface AddSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tripId: number;
+  /** 담을 날짜. null이면 보관함에 넣는다. */
+  targetDate: string | null;
+  onCreate: (input: { title: string; startTime: string | null }) => void;
+  /** 보관함 일정을 이 날짜로 옮긴다. */
+  onPickFromArchive: (activity: Activity) => void;
+  pending?: boolean;
+}
+
+/**
+ * 일정 추가 시트. 장소 검색은 2단계라 자리만 두고 비활성이다 —
+ * 지금 감췄다가 2단계에 되살리면 "없던 게 생긴" 것처럼 보이고, 무엇이 준비 중인지도 알 수 없다.
+ */
+export function AddSheet({
+  open,
+  onOpenChange,
+  tripId,
+  targetDate,
+  onCreate,
+  onPickFromArchive,
+  pending = false,
+}: AddSheetProps) {
+  const [mode, setMode] = useState<Mode>("menu");
+  const [title, setTitle] = useState("");
+  const [startTime, setStartTime] = useState("");
+
+  // 열 때마다 처음 상태로 되돌린다 — 지난번 입력이 남아 있으면 실수로 저장된다.
+  useEffect(() => {
+    if (open) {
+      setMode("menu");
+      setTitle("");
+      setStartTime("");
+    }
+  }, [open]);
+
+  // 보관함을 보고 있을 땐 "가져오기"가 의미 없다(이미 거기 있다).
+  const canPickFromArchive = targetDate !== null;
+  const { data: archiveBoard } = useBoard(tripId, { archive: true });
+  const archived = canPickFromArchive ? (archiveBoard?.activities ?? []) : [];
+
+  const submitManual = (event: FormEvent) => {
+    event.preventDefault();
+    if (!title.trim()) return;
+    onCreate({ title: title.trim(), startTime: startTime || null });
+  };
+
+  return (
+    <BottomSheet
+      open={open}
+      onOpenChange={onOpenChange}
+      title={mode === "manual" ? "직접 입력" : "일정 추가"}
+      description={targetDate === null ? "미배정 보관함에 담습니다" : undefined}
+    >
+      {mode === "menu" ? (
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            disabled
+            className="border-border flex items-center gap-2 rounded-lg border px-3 py-2.5 text-left text-sm opacity-50"
+          >
+            <Search className="size-4 shrink-0" />
+            <span className="flex-1">장소 검색</span>
+            <span className="text-muted-foreground text-xs">준비 중</span>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setMode("manual")}
+            className="border-border hover:bg-accent flex items-center gap-2 rounded-lg border px-3 py-2.5 text-left text-sm"
+          >
+            <PenLine className="size-4 shrink-0" />
+            직접 입력
+          </button>
+
+          {canPickFromArchive && (
+            <div className="flex flex-col gap-1.5">
+              <p className="text-muted-foreground mt-2 flex items-center gap-1.5 text-xs">
+                <Archive className="size-3.5" />
+                보관함에서 가져오기
+              </p>
+              {archived.length === 0 ? (
+                <p className="text-muted-foreground px-1 text-[13px]">
+                  보관함이 비어 있어요.
+                </p>
+              ) : (
+                archived.map((activity) => (
+                  <button
+                    key={activity.id}
+                    type="button"
+                    onClick={() => onPickFromArchive(activity)}
+                    disabled={pending}
+                    className="border-border hover:bg-accent rounded-lg border px-3 py-2.5 text-left text-sm"
+                  >
+                    {activity.title}
+                  </button>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      ) : (
+        <form className="flex flex-col gap-3" onSubmit={submitManual}>
+          <FormField label="일정 제목" htmlFor="activityTitle">
+            <Input
+              id="activityTitle"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="센소지"
+              maxLength={100}
+              autoFocus
+            />
+          </FormField>
+          <FormField label="시각 (선택)" htmlFor="activityTime">
+            <Input
+              id="activityTime"
+              type="time"
+              value={startTime}
+              onChange={(e) => setStartTime(e.target.value)}
+            />
+          </FormField>
+          <div className="flex justify-between gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setMode("menu")}
+            >
+              <ArrowLeft className="size-4" />
+              뒤로
+            </Button>
+            <Button type="submit" disabled={pending || !title.trim()}>
+              추가
+            </Button>
+          </div>
+        </form>
+      )}
+    </BottomSheet>
+  );
+}

--- a/fe/src/features/travel/board/DayTabs.tsx
+++ b/fe/src/features/travel/board/DayTabs.tsx
@@ -1,0 +1,85 @@
+import { Archive } from "lucide-react";
+
+import type { BoardDay } from "@/features/travel/api/activities";
+import { formatShortDate } from "@/features/travel/lib/tripStatus";
+import { cn } from "@/lib/utils";
+
+interface DayTabsProps {
+  days: BoardDay[];
+  archiveCount: number;
+  /** 선택된 날짜. null이면 보관함 칩이 활성이다. */
+  selectedDate: string | null;
+  onSelectDate: (date: string) => void;
+  onSelectArchive: () => void;
+}
+
+/**
+ * 날짜 탭. 여행 기간의 모든 날짜 + <b>맨 뒤에 항상 보관함</b>.
+ *
+ * <p>보관함이 마지막인 이유는 날짜가 시간 순서를 갖는 반면 보관함은 "아직 날짜를 못 정한 것"
+ * 이라서다 — 중간에 끼우면 순서가 깨진 것처럼 보인다.
+ */
+export function DayTabs({
+  days,
+  archiveCount,
+  selectedDate,
+  onSelectDate,
+  onSelectArchive,
+}: DayTabsProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label="날짜"
+      className="flex gap-1.5 overflow-x-auto pb-1"
+    >
+      {days.map((day) => (
+        <Chip
+          key={day.date}
+          active={selectedDate === day.date}
+          label={`${day.dayIndex}일차`}
+          sub={`${formatShortDate(day.date)} ${day.weekday}`}
+          onClick={() => onSelectDate(day.date)}
+        />
+      ))}
+      <Chip
+        active={selectedDate === null}
+        label="보관함"
+        icon={<Archive className="size-3.5" />}
+        sub={`${archiveCount}개`}
+        onClick={onSelectArchive}
+      />
+    </div>
+  );
+}
+
+interface ChipProps {
+  active: boolean;
+  label: string;
+  sub: string;
+  icon?: React.ReactNode;
+  onClick: () => void;
+}
+
+function Chip({ active, label, sub, icon, onClick }: ChipProps) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        "flex min-w-[78px] shrink-0 flex-col items-start gap-0.5 rounded-lg border px-2.5 py-2 transition-colors",
+        active
+          ? "bg-accent text-accent-foreground border-primary"
+          : "bg-card border-border hover:bg-muted",
+      )}
+    >
+      <span className="flex items-center gap-1 text-[13px] font-semibold">
+        {icon}
+        {label}
+      </span>
+      <span className="text-muted-foreground text-[11px]">{sub}</span>
+      {/* 3행 날씨는 4단계. 예보가 없으면 그때도 이 자리를 비운다. */}
+    </button>
+  );
+}

--- a/fe/src/features/travel/hooks/useActivityMutations.ts
+++ b/fe/src/features/travel/hooks/useActivityMutations.ts
@@ -1,0 +1,56 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  type ActivityWriteRequest,
+  createActivity,
+  deleteActivity,
+  updateActivity,
+} from "../api/activities";
+import { travelKeys } from "../queryKeys";
+
+/**
+ * 일정을 건드리면 그 여행의 보드 캐시를 통째로 비운다.
+ *
+ * <p>날짜별로 캐시가 나뉘어 있는데 일정 하나를 옮기면 <b>두 날짜와 보관함 건수·날짜 탭 건수가
+ * 함께 바뀐다</b>. 보고 있는 날짜만 갱신하면 다른 탭이 옛 숫자를 들고 있게 된다.
+ * 여행 목록·요약의 일정 수도 같이 어긋나므로 함께 무효화한다.
+ */
+function useInvalidateBoard(tripId: number) {
+  const queryClient = useQueryClient();
+  return () => {
+    void queryClient.invalidateQueries({ queryKey: travelKeys.boards(tripId) });
+    void queryClient.invalidateQueries({ queryKey: travelKeys.summary });
+    void queryClient.invalidateQueries({ queryKey: ["travel", "trips"] });
+    void queryClient.invalidateQueries({ queryKey: travelKeys.trip(tripId) });
+  };
+}
+
+export function useCreateActivity(tripId: number) {
+  const invalidate = useInvalidateBoard(tripId);
+  return useMutation({
+    mutationFn: (body: ActivityWriteRequest) => createActivity(tripId, body),
+    onSuccess: invalidate,
+  });
+}
+
+export function useUpdateActivity(tripId: number) {
+  const invalidate = useInvalidateBoard(tripId);
+  return useMutation({
+    mutationFn: ({
+      activityId,
+      body,
+    }: {
+      activityId: number;
+      body: ActivityWriteRequest;
+    }) => updateActivity(activityId, body),
+    onSuccess: invalidate,
+  });
+}
+
+export function useDeleteActivity(tripId: number) {
+  const invalidate = useInvalidateBoard(tripId);
+  return useMutation({
+    mutationFn: (activityId: number) => deleteActivity(activityId),
+    onSuccess: invalidate,
+  });
+}

--- a/fe/src/features/travel/hooks/useBoard.ts
+++ b/fe/src/features/travel/hooks/useBoard.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchBoard } from "../api/activities";
+import { travelKeys } from "../queryKeys";
+
+/**
+ * 보드 단일 조회. 날짜 탭·보관함 건수·선택 날짜의 일정이 한 응답에 담겨 온다 —
+ * 오프라인 캐시(4단계)가 응답 하나로 성립해야 하기 때문이다.
+ *
+ * @param params `date`도 `archive`도 없으면 서버가 고른다(진행 중이면 현지 오늘, 아니면 1일차)
+ */
+export function useBoard(
+  tripId: number,
+  params: { date?: string; archive?: boolean },
+  options: { enabled?: boolean } = {},
+) {
+  return useQuery({
+    queryKey: travelKeys.board(
+      tripId,
+      params.archive ? "archive" : params.date,
+    ),
+    queryFn: () => fetchBoard(tripId, params),
+    staleTime: 10 * 1000,
+    enabled: options.enabled ?? true,
+  });
+}

--- a/fe/src/features/travel/queryKeys.ts
+++ b/fe/src/features/travel/queryKeys.ts
@@ -5,4 +5,8 @@ export const travelKeys = {
   summary: ["travel", "summary"] as const,
   trips: (status?: TripStatus) => ["travel", "trips", status ?? "all"] as const,
   trip: (tripId: number) => ["travel", "trip", tripId] as const,
+  /** 보드는 보는 날짜마다 따로 캐시한다. `day`는 날짜 문자열 또는 "archive". */
+  board: (tripId: number, day: string | undefined) =>
+    ["travel", "board", tripId, day ?? "default"] as const,
+  boards: (tripId: number) => ["travel", "board", tripId] as const,
 };

--- a/fe/src/pages/WorkspaceSelectPage.test.tsx
+++ b/fe/src/pages/WorkspaceSelectPage.test.tsx
@@ -110,9 +110,7 @@ describe("WorkspaceSelectPage", () => {
     await userEvent.click(travelCard);
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: "일정 보드" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /1일차/ })).toBeInTheDocument();
     });
   });
 

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -1,0 +1,467 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { AppRouter } from "@/app/router";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+const API_BASE = "https://api.orino.dev/api";
+
+const DAYS = [
+  {
+    dayIndex: 1,
+    date: "2026-10-24",
+    weekday: "토",
+    activityCount: 2,
+    weather: null,
+  },
+  {
+    dayIndex: 2,
+    date: "2026-10-25",
+    weekday: "일",
+    activityCount: 0,
+    weather: null,
+  },
+  {
+    dayIndex: 3,
+    date: "2026-10-26",
+    weekday: "월",
+    activityCount: 1,
+    weather: null,
+  },
+];
+
+const TRIP = {
+  id: 3,
+  title: "도쿄 3박 4일",
+  timezone: "Asia/Tokyo",
+  currency: "JPY",
+  startDate: "2026-10-24",
+  endDate: "2026-10-26",
+  status: "UPCOMING",
+  recordMode: false,
+};
+
+function activity(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    tripId: 3,
+    title: "센소지",
+    activityDate: "2026-10-24",
+    startTime: "09:00",
+    place: null,
+    memo: null,
+    url: null,
+    notifyEnabled: false,
+    notifyMinutes: null,
+    departureNotifyEnabled: false,
+    sortOrder: 0,
+    hasLog: false,
+    ...overrides,
+  };
+}
+
+/**
+ * 날짜별 보드를 흉내낸다. 서버처럼 `date`·`archive` 파라미터로 갈라 응답한다.
+ * `selectedDate`는 요청한 날짜(생략 시 1일차)를 그대로 돌려준다.
+ */
+function mockBoard(options: {
+  byDate?: Record<string, unknown[]>;
+  archive?: unknown[];
+  trip?: Record<string, unknown>;
+}) {
+  const byDate = options.byDate ?? {};
+  const archive = options.archive ?? [];
+  server.use(
+    http.get(`${API_BASE}/travel/trips/:tripId/board`, ({ request }) => {
+      const url = new URL(request.url);
+      const isArchive = url.searchParams.get("archive") === "true";
+      const date = url.searchParams.get("date") ?? DAYS[0].date;
+      return HttpResponse.json({
+        code: "OK",
+        data: {
+          trip: { ...TRIP, ...options.trip },
+          days: DAYS,
+          selectedDate: isArchive ? null : date,
+          archiveCount: archive.length,
+          activities: isArchive ? archive : (byDate[date] ?? []),
+          legs: [],
+        },
+      });
+    }),
+  );
+}
+
+function renderBoard(path = "/travel/trips/3/board") {
+  return renderWithRouter(
+    <Providers>
+      <AppRouter />
+    </Providers>,
+    { initialEntries: [path] },
+  );
+}
+
+describe("TripBoardPage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "valid-token" });
+  });
+
+  describe("날짜 탭", () => {
+    it("기간의 모든 날짜와 맨 뒤에 보관함 칩을 보여준다", async () => {
+      mockBoard({
+        byDate: { "2026-10-24": [activity()] },
+        archive: [activity({ id: 9 })],
+      });
+
+      renderBoard();
+
+      const tabs = await screen.findAllByRole("tab");
+      expect(tabs).toHaveLength(4);
+      expect(tabs[0]).toHaveTextContent("1일차");
+      expect(tabs[0]).toHaveTextContent("10.24 토");
+      // 보관함은 항상 마지막이고 2행에 건수를 쓴다.
+      expect(tabs[3]).toHaveTextContent("보관함");
+      expect(tabs[3]).toHaveTextContent("1개");
+    });
+
+    it("서버가 고른 날짜가 기본 선택된다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [activity()] } });
+
+      renderBoard();
+
+      const tabs = await screen.findAllByRole("tab");
+      await waitFor(() => {
+        expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+      });
+    });
+
+    it("탭을 누르면 URL에 ?day= 가 남고 그 날짜를 조회한다", async () => {
+      mockBoard({
+        byDate: {
+          "2026-10-24": [activity()],
+          "2026-10-26": [
+            activity({ id: 5, title: "디즈니씨", activityDate: "2026-10-26" }),
+          ],
+        },
+      });
+
+      renderBoard();
+      await screen.findByText("센소지");
+
+      await userEvent.click(screen.getByRole("tab", { name: /3일차/ }));
+
+      expect(await screen.findByText("디즈니씨")).toBeInTheDocument();
+      expect(screen.queryByText("센소지")).toBeNull();
+    });
+
+    it("?day= 로 직접 들어오면 그 날짜가 열린다", async () => {
+      mockBoard({
+        byDate: {
+          "2026-10-24": [activity()],
+          "2026-10-26": [
+            activity({ id: 5, title: "디즈니씨", activityDate: "2026-10-26" }),
+          ],
+        },
+      });
+
+      renderBoard("/travel/trips/3/board?day=2");
+
+      expect(await screen.findByText("디즈니씨")).toBeInTheDocument();
+      const tabs = await screen.findAllByRole("tab");
+      await waitFor(() => {
+        expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+      });
+    });
+
+    it("?day=archive 로 들어오면 보관함이 열린다", async () => {
+      mockBoard({
+        byDate: { "2026-10-24": [activity()] },
+        archive: [
+          activity({ id: 9, title: "가고 싶은 라멘집", activityDate: null }),
+        ],
+      });
+
+      renderBoard("/travel/trips/3/board?day=archive");
+
+      expect(await screen.findByText("가고 싶은 라멘집")).toBeInTheDocument();
+      const tabs = await screen.findAllByRole("tab");
+      expect(tabs[3]).toHaveAttribute("aria-selected", "true");
+    });
+  });
+
+  describe("일정 행", () => {
+    it("시각을 tabular-nums로 보여주고, 없으면 ── 로 자리를 지킨다", async () => {
+      mockBoard({
+        byDate: {
+          "2026-10-24": [
+            activity(),
+            activity({
+              id: 2,
+              title: "동네 산책",
+              startTime: null,
+              sortOrder: 1,
+            }),
+          ],
+        },
+      });
+
+      renderBoard();
+
+      expect(await screen.findByText("09:00")).toBeInTheDocument();
+      expect(screen.getByText("──")).toBeInTheDocument();
+    });
+
+    it("장소가 있으면 아래 줄에 장소명을 보여준다", async () => {
+      mockBoard({
+        byDate: {
+          "2026-10-24": [
+            activity({
+              place: {
+                id: 1,
+                name: "시부야 스카이",
+                address: null,
+                lat: null,
+                lng: null,
+              },
+            }),
+          ],
+        },
+      });
+
+      renderBoard();
+
+      expect(await screen.findByText("시부야 스카이")).toBeInTheDocument();
+    });
+
+    it("알림이 켜진 일정에 종 아이콘을 붙인다", async () => {
+      mockBoard({
+        byDate: { "2026-10-24": [activity({ notifyEnabled: true })] },
+      });
+
+      renderBoard();
+
+      expect(await screen.findByLabelText("알림 켜짐")).toBeInTheDocument();
+    });
+
+    it("일정을 누르면 상세로 간다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [activity()] } });
+
+      renderBoard();
+
+      expect(
+        await screen.findByRole("link", { name: /센소지/ }),
+      ).toHaveAttribute("href", "/travel/activities/1");
+    });
+
+    it("보관함에서는 '보관함으로' 액션을 감춘다", async () => {
+      mockBoard({
+        byDate: { "2026-10-24": [] },
+        archive: [activity({ id: 9, title: "후보", activityDate: null })],
+      });
+
+      renderBoard("/travel/trips/3/board?day=archive");
+      await screen.findByText("후보");
+
+      expect(screen.queryByLabelText("후보 보관함으로")).toBeNull();
+      expect(screen.getByLabelText("후보 삭제")).toBeInTheDocument();
+    });
+  });
+
+  describe("빈 상태", () => {
+    it("일정 없는 날짜와 빈 보관함의 문구가 다르다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [] }, archive: [] });
+
+      renderBoard();
+      expect(await screen.findByText("일정이 없어요")).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole("tab", { name: /보관함/ }));
+      expect(
+        await screen.findByText("가고 싶은 곳을 미리 담아두세요"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("일정 추가", () => {
+    it("직접 입력으로 지금 보는 날짜에 일정을 만든다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [] } });
+      const seen: Record<string, unknown>[] = [];
+      server.use(
+        http.post(
+          `${API_BASE}/travel/trips/:tripId/activities`,
+          async ({ request }) => {
+            seen.push((await request.json()) as Record<string, unknown>);
+            return HttpResponse.json({ code: "OK", data: activity() });
+          },
+        ),
+      );
+
+      renderBoard();
+      await screen.findByText("일정이 없어요");
+
+      await userEvent.click(screen.getByRole("button", { name: "일정 추가" }));
+      await userEvent.click(
+        await screen.findByRole("button", { name: /직접 입력/ }),
+      );
+      await userEvent.type(screen.getByLabelText("일정 제목"), "센소지");
+      await userEvent.type(screen.getByLabelText("시각 (선택)"), "09:00");
+      await userEvent.click(screen.getByRole("button", { name: "추가" }));
+
+      await waitFor(() => expect(seen).toHaveLength(1));
+      expect(seen[0]).toMatchObject({
+        title: "센소지",
+        activityDate: "2026-10-24",
+        startTime: "09:00",
+      });
+    });
+
+    it("장소 검색은 2단계라 비활성이지만 자리는 보여준다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [] } });
+
+      renderBoard();
+      await screen.findByText("일정이 없어요");
+      await userEvent.click(screen.getByRole("button", { name: "일정 추가" }));
+
+      const sheet = await screen.findByRole("dialog");
+      const search = within(sheet).getByRole("button", { name: /장소 검색/ });
+      expect(search).toBeDisabled();
+      expect(search).toHaveTextContent("준비 중");
+    });
+
+    it("보관함 일정을 지금 보는 날짜로 가져온다", async () => {
+      mockBoard({
+        byDate: { "2026-10-24": [] },
+        archive: [
+          activity({ id: 9, title: "가고 싶은 라멘집", activityDate: null }),
+        ],
+      });
+      const seen: Record<string, unknown>[] = [];
+      server.use(
+        http.put(`${API_BASE}/travel/activities/:id`, async ({ request }) => {
+          seen.push((await request.json()) as Record<string, unknown>);
+          return HttpResponse.json({ code: "OK", data: activity() });
+        }),
+      );
+
+      renderBoard();
+      await screen.findByText("일정이 없어요");
+      await userEvent.click(screen.getByRole("button", { name: "일정 추가" }));
+
+      const sheet = await screen.findByRole("dialog");
+      await userEvent.click(
+        await within(sheet).findByRole("button", { name: "가고 싶은 라멘집" }),
+      );
+
+      await waitFor(() => expect(seen).toHaveLength(1));
+      expect(seen[0]).toMatchObject({ activityDate: "2026-10-24" });
+    });
+
+    it("보관함을 보고 있으면 '가져오기'를 띄우지 않는다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [] }, archive: [] });
+
+      renderBoard("/travel/trips/3/board?day=archive");
+      await screen.findByText("가고 싶은 곳을 미리 담아두세요");
+      await userEvent.click(screen.getByRole("button", { name: "일정 추가" }));
+
+      const sheet = await screen.findByRole("dialog");
+      expect(within(sheet).queryByText("보관함에서 가져오기")).toBeNull();
+      expect(sheet).toHaveTextContent("미배정 보관함에 담습니다");
+    });
+  });
+
+  describe("일정 액션", () => {
+    it("보관함으로 옮기면 날짜만 비운다(삭제가 아니다)", async () => {
+      mockBoard({ byDate: { "2026-10-24": [activity()] } });
+      const seen: Record<string, unknown>[] = [];
+      server.use(
+        http.put(`${API_BASE}/travel/activities/:id`, async ({ request }) => {
+          seen.push((await request.json()) as Record<string, unknown>);
+          return HttpResponse.json({ code: "OK", data: activity() });
+        }),
+      );
+
+      renderBoard();
+      await screen.findByText("센소지");
+
+      await userEvent.click(screen.getByLabelText("센소지 보관함으로"));
+
+      await waitFor(() => expect(seen).toHaveLength(1));
+      expect(seen[0]).toMatchObject({ activityDate: null, startTime: "09:00" });
+    });
+
+    it("삭제는 확인을 받은 뒤에 요청한다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [activity()] } });
+      let deleted = false;
+      server.use(
+        http.delete(`${API_BASE}/travel/activities/:id`, () => {
+          deleted = true;
+          return HttpResponse.json({ code: "OK", data: null });
+        }),
+      );
+
+      renderBoard();
+      await screen.findByText("센소지");
+
+      await userEvent.click(screen.getByLabelText("센소지 삭제"));
+      expect(await screen.findByRole("dialog")).toHaveTextContent(
+        "일정을 삭제할까요?",
+      );
+      expect(deleted).toBe(false);
+
+      await userEvent.click(screen.getByRole("button", { name: "삭제" }));
+      await waitFor(() => expect(deleted).toBe(true));
+    });
+  });
+
+  describe("헤더", () => {
+    it("메뉴에서 여행 수정으로 간다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [] } });
+      server.use(
+        http.get(`${API_BASE}/travel/trips/:tripId`, () =>
+          HttpResponse.json({
+            code: "OK",
+            data: {
+              ...TRIP,
+              destinationName: "도쿄",
+              destinationPlaceId: null,
+              lat: null,
+              lng: null,
+              defaultNotifyMinutes: 15,
+              morningSummaryEnabled: false,
+              dDay: 78,
+              totalDays: 3,
+              activityCount: 0,
+            },
+          }),
+        ),
+      );
+
+      renderBoard();
+      await screen.findByText("일정이 없어요");
+
+      await userEvent.click(screen.getByRole("button", { name: "여행 메뉴" }));
+      await userEvent.click(
+        await screen.findByRole("menuitem", { name: "여행 수정" }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "여행 수정" }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("지도·도구는 후속 단계라 비활성이다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [] } });
+
+      renderBoard();
+      await screen.findByText("일정이 없어요");
+
+      expect(screen.getByRole("button", { name: "지도" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "도구" })).toBeDisabled();
+    });
+  });
+});

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -1,0 +1,275 @@
+import {
+  ArrowLeft,
+  Map,
+  MoreVertical,
+  Plus,
+  Search,
+  Wrench,
+} from "lucide-react";
+import { useState } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { LoadingText } from "@/components/ui/loading-text";
+import { Menu, MenuItem } from "@/components/ui/menu";
+import type { Activity } from "@/features/travel/api/activities";
+import { deleteTrip } from "@/features/travel/api/travel";
+import { ActivityRow } from "@/features/travel/board/ActivityRow";
+import { AddSheet } from "@/features/travel/board/AddSheet";
+import { DayTabs } from "@/features/travel/board/DayTabs";
+import {
+  useCreateActivity,
+  useDeleteActivity,
+  useUpdateActivity,
+} from "@/features/travel/hooks/useActivityMutations";
+import { useBoard } from "@/features/travel/hooks/useBoard";
+import { toast } from "@/shared/lib/toast";
+
+/** `?day=` 값 — 0부터 시작하는 일차 인덱스, 또는 보관함. */
+const ARCHIVE = "archive";
+
+/**
+ * S-04 일정 보드. 주 화면이다.
+ *
+ * <p><b>선택한 날짜는 URL이 소유한다</b>(`?day=0..N|archive`). 컴포넌트 상태로 들고 있으면
+ * 새로고침·뒤로가기에서 1일차로 튕겨, 현지에서 앱을 다시 열 때마다 오늘을 다시 찾아야 한다.
+ *
+ * <p>드래그 정렬·스와이프·실행취소는 #1038에서 붙는다.
+ */
+export function TripBoardPage() {
+  const { tripId: tripIdParam } = useParams();
+  const tripId = Number(tripIdParam);
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const day = searchParams.get("day");
+  const isArchive = day === ARCHIVE;
+  const dayIndex = day !== null && !isArchive ? Number(day) : null;
+
+  // 기본 조회. 날짜를 지정하지 않으면 서버가 고르고, 그 응답에 전체 날짜 탭이 들어 있다.
+  // `?day=<인덱스>`를 날짜로 바꾸려면 이 목록이 먼저 있어야 한다.
+  const { data: base, isPending } = useBoard(tripId, {});
+  const requestedDate =
+    dayIndex !== null ? base?.days[dayIndex]?.date : undefined;
+
+  // 요청한 날짜가 서버 기본값과 같으면 기본 조회를 그대로 쓴다(추가 요청 없음).
+  const needsOwnQuery =
+    isArchive ||
+    (requestedDate !== undefined && requestedDate !== base?.selectedDate);
+  const { data: dayBoard } = useBoard(
+    tripId,
+    isArchive ? { archive: true } : { date: requestedDate },
+    { enabled: needsOwnQuery },
+  );
+  const board = needsOwnQuery ? dayBoard : base;
+
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<Activity | null>(null);
+  const [deletingTrip, setDeletingTrip] = useState(false);
+
+  const createActivity = useCreateActivity(tripId);
+  const updateActivity = useUpdateActivity(tripId);
+  const removeActivity = useDeleteActivity(tripId);
+
+  if (isPending || !board) {
+    return (
+      <div className="grid min-h-[40svh] place-items-center">
+        <LoadingText />
+      </div>
+    );
+  }
+
+  const selectedDate = isArchive ? null : board.selectedDate;
+  const selectedIndex = board.days.findIndex((d) => d.date === selectedDate);
+
+  const selectDay = (date: string) => {
+    const index = board.days.findIndex((d) => d.date === date);
+    setSearchParams({ day: String(index) }, { replace: true });
+  };
+
+  const selectArchive = () =>
+    setSearchParams({ day: ARCHIVE }, { replace: true });
+
+  const addActivity = async (input: {
+    title: string;
+    startTime: string | null;
+  }) => {
+    await createActivity.mutateAsync({
+      title: input.title,
+      activityDate: selectedDate,
+      startTime: input.startTime,
+    });
+    setSheetOpen(false);
+  };
+
+  /** 보관함 일정을 지금 보고 있는 날짜로 옮긴다. */
+  const pickFromArchive = async (activity: Activity) => {
+    await updateActivity.mutateAsync({
+      activityId: activity.id,
+      body: { title: activity.title, activityDate: selectedDate },
+    });
+    setSheetOpen(false);
+  };
+
+  /** 일정을 보관함으로 내린다 — 지우는 게 아니라 날짜만 비운다. */
+  const archiveActivity = async (activity: Activity) => {
+    await updateActivity.mutateAsync({
+      activityId: activity.id,
+      body: {
+        title: activity.title,
+        activityDate: null,
+        startTime: activity.startTime,
+      },
+    });
+    toast("보관함으로 옮겼어요.", "success");
+  };
+
+  const confirmDeleteActivity = async () => {
+    if (!pendingDelete) return;
+    await removeActivity.mutateAsync(pendingDelete.id);
+    setPendingDelete(null);
+    toast("일정을 삭제했어요.", "success");
+  };
+
+  const removeTrip = async () => {
+    await deleteTrip(tripId);
+    setDeletingTrip(false);
+    toast("여행을 삭제했어요.", "success");
+    navigate("/travel/trips", { replace: true });
+  };
+
+  return (
+    <div className="mx-auto flex max-w-[720px] flex-col gap-3">
+      <header className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="뒤로"
+            onClick={() => navigate("/travel")}
+          >
+            <ArrowLeft className="size-4" />
+          </Button>
+          {/* 현지 시각·타임존 줄은 3단계(알림)와 함께 붙인다. */}
+          <h1 className="text-heading truncate font-semibold">
+            {board.trip.title}
+          </h1>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {/* 지도는 2단계, 도구는 4단계. 자리를 미리 두되 누를 수 없게 한다. */}
+          <Button variant="ghost" size="icon-sm" aria-label="지도" disabled>
+            <Map className="size-4" />
+          </Button>
+          <Button variant="ghost" size="icon-sm" aria-label="도구" disabled>
+            <Wrench className="size-4" />
+          </Button>
+          <Menu
+            trigger={
+              <Button variant="ghost" size="icon-sm" aria-label="여행 메뉴">
+                <MoreVertical className="size-4" />
+              </Button>
+            }
+          >
+            <MenuItem onClick={() => navigate(`/travel/trips/${tripId}/edit`)}>
+              여행 수정
+            </MenuItem>
+            <MenuItem disabled>알림 설정</MenuItem>
+            <MenuItem
+              variant="destructive"
+              onClick={() => setDeletingTrip(true)}
+            >
+              여행 삭제
+            </MenuItem>
+          </Menu>
+        </div>
+      </header>
+
+      <DayTabs
+        days={board.days}
+        archiveCount={board.archiveCount}
+        selectedDate={selectedDate}
+        onSelectDate={selectDay}
+        onSelectArchive={selectArchive}
+      />
+
+      {board.activities.length > 0 ? (
+        <ul className="flex flex-col">
+          {board.activities.map((activity) => (
+            <ActivityRow
+              key={activity.id}
+              activity={activity}
+              inArchive={selectedDate === null}
+              onArchive={(a) => void archiveActivity(a)}
+              onDelete={setPendingDelete}
+            />
+          ))}
+        </ul>
+      ) : (
+        <EmptyState className="min-h-[30svh]">
+          <p className="text-muted-foreground text-sm">
+            {selectedDate === null
+              ? "가고 싶은 곳을 미리 담아두세요"
+              : "일정이 없어요"}
+          </p>
+          <Button variant="outline" disabled>
+            <Search className="size-4" />
+            장소 검색
+          </Button>
+        </EmptyState>
+      )}
+
+      <div className="flex justify-center py-2 pb-6">
+        <Button
+          variant="outline"
+          size="icon-lg"
+          aria-label="일정 추가"
+          onClick={() => setSheetOpen(true)}
+        >
+          <Plus className="size-[18px]" />
+        </Button>
+      </div>
+
+      <AddSheet
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        tripId={tripId}
+        targetDate={selectedDate}
+        onCreate={(input) => void addActivity(input)}
+        onPickFromArchive={(a) => void pickFromArchive(a)}
+        pending={createActivity.isPending || updateActivity.isPending}
+      />
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+        title="일정을 삭제할까요?"
+        description={`"${pendingDelete?.title ?? ""}"이(가) 삭제됩니다.`}
+        confirmLabel="삭제"
+        destructive
+        onConfirm={() => void confirmDeleteActivity()}
+        pending={removeActivity.isPending}
+      />
+
+      <ConfirmDialog
+        open={deletingTrip}
+        onOpenChange={setDeletingTrip}
+        title="여행을 삭제할까요?"
+        description="일정과 기록이 함께 삭제됩니다. 되돌릴 수 없어요."
+        confirmLabel="삭제"
+        destructive
+        onConfirm={() => void removeTrip()}
+      />
+
+      {/* 선택된 탭 위치를 스크린리더에도 알린다. */}
+      <span className="sr-only" aria-live="polite">
+        {selectedDate === null
+          ? "보관함"
+          : `${selectedIndex + 1}일차 ${selectedDate}`}
+      </span>
+    </div>
+  );
+}

--- a/fe/src/pages/travel/TripFormPage.test.tsx
+++ b/fe/src/pages/travel/TripFormPage.test.tsx
@@ -133,10 +133,9 @@ describe("TripFormPage", () => {
       await fillNewTripForm();
       await userEvent.click(screen.getByRole("button", { name: "만들기" }));
 
+      // 만든 여행의 보드로 이동한다.
       await waitFor(() => {
-        expect(
-          screen.getByRole("heading", { name: "일정 보드" }),
-        ).toBeInTheDocument();
+        expect(screen.getByRole("tab", { name: /1일차/ })).toBeInTheDocument();
       });
     });
 

--- a/fe/src/test/mocks/handlers.ts
+++ b/fe/src/test/mocks/handlers.ts
@@ -96,6 +96,39 @@ export const handlers = [
     });
   }),
 
+  // 기본값: 일정 없는 하루짜리 보드. 보드를 거쳐가는 테스트(생성 후 이동 등)가
+  // 매번 핸들러를 세우지 않아도 되도록. 내용을 검증하는 테스트는 server.use로 덮어쓴다.
+  http.get(`${API_BASE}/travel/trips/:tripId/board`, ({ params }) => {
+    return HttpResponse.json({
+      code: "OK",
+      data: {
+        trip: {
+          id: Number(params.tripId),
+          title: "여행",
+          timezone: "Asia/Tokyo",
+          currency: "JPY",
+          startDate: "2026-10-24",
+          endDate: "2026-10-24",
+          status: "UPCOMING",
+          recordMode: false,
+        },
+        days: [
+          {
+            dayIndex: 1,
+            date: "2026-10-24",
+            weekday: "토",
+            activityCount: 0,
+            weather: null,
+          },
+        ],
+        selectedDate: "2026-10-24",
+        archiveCount: 0,
+        activities: [],
+        legs: [],
+      },
+    });
+  }),
+
   // 기본값: 빈 캘린더 피드. `/select`의 "오늘 루틴" 메타가 항상 해소되도록.
   http.get(`${API_BASE}/planner/calendar`, () => {
     return HttpResponse.json({


### PR DESCRIPTION
## 이슈
closes #1037

## 작업 내용

**주 화면.** S-04 일정 보드의 정적 부분. [화면 설계](https://github.com/wcorn/orino/wiki/Travel-UI-Design) §2.5. (Epic #1029 · 1단계)

드래그·스와이프·실행취소는 #1038이다 — 리스크가 달라 분리돼 있다.

### 선택한 날짜는 URL이 소유한다

`?day=0..N|archive`. 컴포넌트 상태로 들고 있으면 새로고침·뒤로가기에서 1일차로 튕겨, 현지에서 앱을 다시 열 때마다 오늘을 다시 찾아야 한다.

여기에 **닭과 달걀 문제**가 있다 — `?day=2`를 날짜로 바꾸려면 `days` 목록이 필요한데, 그건 보드 응답에 들어 있다. 그래서 날짜 없이 한 번 조회해 `days`를 얻고(서버가 기본 날짜를 골라 준다), 요청한 날짜가 그 기본값과 다를 때만 두 번째 조회를 한다. **기본 탭을 보는 흔한 경우엔 요청이 한 번뿐이다.**

### 일정 변경은 여행 단위로 캐시를 비운다

보드 캐시는 날짜별로 나뉘는데, 일정 하나를 옮기면 **두 날짜와 보관함 건수·날짜 탭 건수가 함께 바뀐다**. 보고 있는 날짜만 갱신하면 다른 탭이 옛 숫자를 들고 있게 된다. 여행 목록·요약의 일정 수도 어긋나므로 같이 무효화한다.

### 후속 단계 자리는 비워 두되 감추지 않는다

- 헤더 지도(2단계)·도구(4단계) 아이콘 — 자리를 두고 `disabled`
- 추가 시트의 "장소 검색"(2단계) — `disabled` + "준비 중"
- 날짜 칩 3행 날씨(4단계) · 이동시간 행(2단계) · 현지 시각 줄(3단계) — 아직 그리지 않음

지금 감췄다가 나중에 되살리면 "없던 게 생긴" 것처럼 보이고, 무엇이 준비 중인지도 알 수 없다.

### 그 밖의 판단

- **시각 없는 일정은 `──`로 자리를 지킨다.** 빈칸으로 두면 본문이 좌우로 흔들려 목록이 읽기 어렵다. 시각 없는 일정은 예외가 아니라 정상이다(§1.1)
- **보관함을 보고 있을 땐 "보관함으로" 액션과 "가져오기" 항목을 감춘다** — 이미 거기 있다
- 보관함으로 옮기기는 **날짜만 비우는 것**이라 확인 없이 바로 하고 스낵바만 띄운다. 삭제는 확인을 받는다
- 헤더 메뉴에서 **#1036의 여행 수정 화면으로 가는 진입점**이 생겼다(그전까진 URL로만 갈 수 있었다). 알림 설정은 3단계라 비활성

## 테스트 (신규 19개)

**날짜 탭 (5)** — 전 날짜 + 맨 뒤 보관함(건수 포함) · 서버가 고른 날짜 기본 선택 · 탭 전환 시 재조회 · **`?day=2` 직접 진입** · `?day=archive` 직접 진입

**일정 행 (5)** — 시각 표시와 `──` · 장소 줄 · 알림 아이콘 · 상세 링크 · **보관함에서 액션 감춤**

**빈 상태 (1)** — 날짜와 보관함 문구가 다름

**추가 (4)** — 직접 입력이 보는 날짜로 생성 · **장소 검색 비활성이지만 노출** · 보관함에서 가져오기 · 보관함 볼 땐 가져오기 없음

**액션 (2)** — 보관함으로는 **날짜만 비움(삭제 아님)** · 삭제는 확인 후 요청

**헤더 (2)** — 메뉴에서 여행 수정 이동 · 지도·도구 비활성

기존 테스트 3개는 임시 페이지의 "일정 보드" 제목을 보고 있어 실제 보드 기준으로 고쳤다. MSW에 기본 보드 핸들러를 추가해, 보드를 거쳐가는 테스트가 매번 핸들러를 세우지 않아도 되게 했다.

`npm run format:check && npm run lint && npm test && npm run build` 모두 통과 — **691개 전부 통과**.

## 로컬 확인 (bootRun + dev server + 브라우저)

여행 1건(4일) + 일정 3건 + 보관함 2건으로 확인했다.

- 날짜 탭 5개(`1일차 10.24 토` … `보관함 2개`), 1일차에 `09:00 센소지` / `── 동네 산책`
- 3일차 클릭 → URL이 `?day=2`로 바뀌고 디즈니씨만 표시
- **`?day=2`로 새로고침해도 3일차가 그대로 선택됨**
- 추가 시트에서 "가고 싶은 라멘집"을 3일차로 가져오기 → 목록에 추가되고 **보관함 칩이 2개 → 1개로 함께 갱신**(교차 무효화 확인)

## 참고

일정 상세(`/travel/activities/:id`)는 #1039다. 행을 누르면 그 경로로 가지만 아직 라우트가 없어 여행 홈으로 리다이렉트된다.