### PR TITLE
feat : 일정 보드 드래그 정렬 + 스와이프 + 실행취소

### DIFF
--- a/fe/e2e/auth.spec.ts
+++ b/fe/e2e/auth.spec.ts
@@ -95,14 +95,15 @@ test.describe("인증 흐름", () => {
     await expect(page).toHaveURL(/\/login/);
   });
 
-  test("로그인 성공 시 /home으로 이동한다", async ({ page }) => {
+  test("로그인 성공 시 /select로 이동한다", async ({ page }) => {
     await page.goto("/login");
 
     await page.getByLabel("아이디").fill("admin");
     await page.getByLabel("비밀번호").fill("password");
     await page.getByRole("button", { name: "로그인" }).click();
 
-    await expect(page).toHaveURL(/\/home/);
+    // 로그인 직후는 항상 워크스페이스 선택이다(마지막 선택을 기억하지 않는다).
+    await expect(page).toHaveURL(/\/select/);
     // 워드마크가 글자를 쪼개 놓아(or + ı + no) getByText로는 안 잡힌다. 접근성 이름으로 찾는다.
     await expect(
       page.getByRole("img", { name: "orino" }).first(),
@@ -126,7 +127,7 @@ test.describe("인증 흐름", () => {
     await page.getByLabel("아이디").fill("admin");
     await page.getByLabel("비밀번호").fill("password");
     await page.getByRole("button", { name: "로그인" }).click();
-    await expect(page).toHaveURL(/\/home/);
+    await expect(page).toHaveURL(/\/select/);
 
     // 로그아웃
     await page.getByRole("button", { name: /로그아웃/ }).click();

--- a/fe/e2e/travel-board-drag.spec.ts
+++ b/fe/e2e/travel-board-drag.spec.ts
@@ -1,0 +1,286 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 일정 보드 드래그 정렬(#1038).
+ *
+ * 드래그는 jsdom으로 검증되지 않는다 — 포인터 좌표·롱프레스 타이밍·충돌 판정이 전부
+ * 실제 브라우저의 레이아웃에 달려 있다. 그래서 여기서는 <b>진짜 마우스 이벤트</b>로
+ * 400ms 롱프레스와 드롭을 재현하고, 서버로 나가는 순서 배열까지 확인한다.
+ *
+ * (터치 감각 자체는 Android Chrome 실기기 확인이 따로 필요하다 — 자동화로 대체할 수 없다.)
+ */
+
+const TRIP_ID = 1;
+const DAYS = [
+  {
+    dayIndex: 1,
+    date: "2026-10-24",
+    weekday: "토",
+    activityCount: 3,
+    weather: null,
+  },
+  {
+    dayIndex: 2,
+    date: "2026-10-25",
+    weekday: "일",
+    activityCount: 0,
+    weather: null,
+  },
+];
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+function activity(id: number, title: string, sortOrder: number) {
+  return {
+    id,
+    tripId: TRIP_ID,
+    title,
+    activityDate: "2026-10-24",
+    startTime: null,
+    place: null,
+    memo: null,
+    url: null,
+    notifyEnabled: false,
+    notifyMinutes: null,
+    departureNotifyEnabled: false,
+    sortOrder,
+    hasLog: false,
+  };
+}
+
+/** 서버가 받은 요청을 모아 둔다. 테스트가 "무엇이 나갔는지"를 본다. */
+interface Captured {
+  orders: { date: string | null; activityIds: number[] }[][];
+  updates: { id: string; body: Record<string, unknown> }[];
+}
+
+async function mockBoard(page: Page): Promise<Captured> {
+  const captured: Captured = { orders: [], updates: [] };
+
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/planner/reviews/summary", (route) =>
+    route.fulfill(
+      ok({
+        today: "2026-10-24",
+        counts: { now: 0, overdue: 0, upcoming: 0, doneToday: 0 },
+        estimatedMinutes: 0,
+        materials: [],
+      }),
+    ),
+  );
+  await page.route("**/api/travel/summary", (route) =>
+    route.fulfill(ok({ ongoing: null, next: null, recentCompleted: null })),
+  );
+
+  await page.route(
+    `**/api/travel/trips/${TRIP_ID}/activities/order`,
+    async (route) => {
+      const body = route.request().postDataJSON() as {
+        moves: { date: string | null; activityIds: number[] }[];
+      };
+      captured.orders.push(body.moves);
+      return route.fulfill(ok({ legs: [] }));
+    },
+  );
+
+  await page.route("**/api/travel/activities/*", async (route) => {
+    if (route.request().method() === "PUT") {
+      captured.updates.push({
+        id: route.request().url().split("/").pop() ?? "",
+        body: route.request().postDataJSON() as Record<string, unknown>,
+      });
+      return route.fulfill(ok(activity(1, "센소지", 0)));
+    }
+    return route.fulfill(ok(null));
+  });
+
+  await page.route(`**/api/travel/trips/${TRIP_ID}/board*`, (route) => {
+    const url = new URL(route.request().url());
+    const isArchive = url.searchParams.get("archive") === "true";
+    const date = url.searchParams.get("date") ?? DAYS[0].date;
+    return route.fulfill(
+      ok({
+        trip: {
+          id: TRIP_ID,
+          title: "도쿄 3박 4일",
+          timezone: "Asia/Tokyo",
+          currency: "JPY",
+          startDate: DAYS[0].date,
+          endDate: DAYS[1].date,
+          status: "UPCOMING",
+          recordMode: false,
+        },
+        days: DAYS,
+        selectedDate: isArchive ? null : date,
+        archiveCount: 0,
+        activities:
+          isArchive || date !== DAYS[0].date
+            ? []
+            : [
+                activity(1, "센소지", 0),
+                activity(2, "우에노", 1),
+                activity(3, "디즈니씨", 2),
+              ],
+        legs: [],
+      }),
+    );
+  });
+
+  return captured;
+}
+
+/** 움직이지 않고 400ms 눌러 드래그 모드에 들어간다(모드 진입은 드래그가 아니다). */
+async function enterDragMode(page: Page, rowText: string) {
+  const box = await page.getByText(rowText, { exact: true }).boundingBox();
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  await page.mouse.down();
+  await page.waitForTimeout(500);
+  await page.mouse.up();
+  await expect(
+    page.getByText(
+      "드래그 모드 · 순서를 바꾸면 이동시간과 알림을 다시 계산해요",
+    ),
+  ).toBeVisible();
+}
+
+/** 드래그 모드에서 행을 끌어 목표 위로 옮겨 놓는다. */
+async function dragRowTo(page: Page, from: string, to: string) {
+  const a = await page.getByText(from, { exact: true }).boundingBox();
+  const b = await page.getByText(to, { exact: true }).boundingBox();
+  if (!a || !b) throw new Error("행을 찾지 못했다");
+
+  await page.mouse.move(a.x + a.width / 2, a.y + a.height / 2);
+  await page.mouse.down();
+  // 여러 번 나눠 움직여야 dnd-kit의 충돌 판정이 중간 위치를 인식한다.
+  for (let i = 1; i <= 5; i++) {
+    await page.mouse.move(
+      b.x + b.width / 2,
+      a.y + a.height / 2 + ((b.y - a.y) * i) / 5,
+      { steps: 4 },
+    );
+  }
+  await page.mouse.up();
+}
+
+test.describe("일정 보드 드래그", () => {
+  test("움직이지 않고 길게 누르면 드래그 모드에 들어간다", async ({ page }) => {
+    await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByText("센소지")).toBeVisible();
+
+    await enterDragMode(page, "센소지");
+
+    // 행 우측이 이동 조작으로 바뀐다.
+    await expect(page.getByLabel("센소지 위로")).toBeVisible();
+    await expect(page.getByLabel("센소지 삭제")).toBeHidden();
+  });
+
+  test("모드에 들어온 직후의 첫 탭이 삼켜지지 않는다", async ({ page }) => {
+    const captured = await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByText("센소지")).toBeVisible();
+
+    await enterDragMode(page, "센소지");
+    // 진입 직후 한 번만 누른다 — 드래그 라이브러리가 클릭을 삼키면 여기서 걸린다.
+    await page.getByLabel("우에노 위로").click();
+
+    await expect.poll(() => captured.orders.length).toBeGreaterThan(0);
+  });
+
+  test("행을 끌어 순서를 바꾸면 그 날짜의 전체 배열이 서버로 간다", async ({
+    page,
+  }) => {
+    const captured = await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByText("센소지")).toBeVisible();
+
+    await enterDragMode(page, "센소지");
+    await dragRowTo(page, "센소지", "디즈니씨");
+
+    await expect.poll(() => captured.orders.length).toBeGreaterThan(0);
+    const moves = captured.orders[0];
+    expect(moves).toHaveLength(1);
+    expect(moves[0].date).toBe("2026-10-24");
+    // 부분이 아니라 그 날짜의 전체 순서를 보낸다.
+    expect(moves[0].activityIds).toHaveLength(3);
+    expect(moves[0].activityIds[2]).toBe(1);
+  });
+
+  test("드래그 모드에서 화살표로도 한 칸씩 옮긴다", async ({ page }) => {
+    const captured = await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByText("센소지")).toBeVisible();
+
+    await enterDragMode(page, "센소지");
+
+    await page.getByLabel("우에노 위로").click();
+
+    await expect.poll(() => captured.orders.length).toBeGreaterThan(0);
+    expect(captured.orders.at(-1)![0].activityIds.slice(0, 2)).toEqual([2, 1]);
+  });
+
+  test("날짜 탭에 떨어뜨리면 그 날짜로 옮긴다", async ({ page }) => {
+    const captured = await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByText("센소지")).toBeVisible();
+
+    await enterDragMode(page, "센소지");
+
+    const row = page.getByText("센소지", { exact: true });
+    const tab = page.getByRole("tab", { name: /2일차/ });
+    const a = await row.boundingBox();
+    const b = await tab.boundingBox();
+
+    await page.mouse.move(a!.x + a!.width / 2, a!.y + a!.height / 2);
+    await page.mouse.down();
+    for (let i = 1; i <= 6; i++) {
+      await page.mouse.move(
+        a!.x + ((b!.x + b!.width / 2 - a!.x) * i) / 6,
+        a!.y + ((b!.y + b!.height / 2 - a!.y) * i) / 6,
+        { steps: 4 },
+      );
+    }
+    await page.mouse.up();
+
+    await expect.poll(() => captured.updates.length).toBeGreaterThan(0);
+    expect(captured.updates[0].body.activityDate).toBe("2026-10-25");
+  });
+
+  test("드래그 모드에서는 행을 눌러도 상세로 가지 않는다", async ({ page }) => {
+    await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByText("센소지")).toBeVisible();
+
+    await enterDragMode(page, "센소지");
+
+    await page.getByText("센소지", { exact: true }).click();
+
+    // 상세로 이동하지 않고 보드에 머문다.
+    await expect(page).toHaveURL(new RegExp(`/travel/trips/${TRIP_ID}/board`));
+    await expect(
+      page.getByText(
+        "드래그 모드 · 순서를 바꾸면 이동시간과 알림을 다시 계산해요",
+      ),
+    ).toBeVisible();
+  });
+
+  test("완료를 누르면 드래그 모드에서 나온다", async ({ page }) => {
+    await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByText("센소지")).toBeVisible();
+
+    await enterDragMode(page, "센소지");
+    await expect(page.getByLabel("센소지 위로")).toBeVisible();
+
+    await page.getByRole("button", { name: "완료" }).click();
+
+    await expect(page.getByLabel("센소지 위로")).toBeHidden();
+    await expect(page.getByLabel("센소지 삭제")).toBeVisible();
+  });
+});

--- a/fe/e2e/travel-board-swipe.spec.ts
+++ b/fe/e2e/travel-board-swipe.spec.ts
@@ -1,0 +1,204 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 스와이프 액션 + 실행취소(#1038).
+ *
+ * 스와이프는 <b>터치 포인터</b>로만 재현된다 — 마우스는 스와이프하지 않고 버튼을 쓴다.
+ * 그래서 이 파일은 `mobile-touch` 프로젝트에서 의미가 있고, 데스크톱 실행에서는
+ * 버튼 경로만 확인한다.
+ */
+
+const TRIP_ID = 1;
+const DAY = "2026-10-24";
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+function activity(id: number, title: string, sortOrder: number) {
+  return {
+    id,
+    tripId: TRIP_ID,
+    title,
+    activityDate: DAY,
+    startTime: null,
+    place: null,
+    memo: null,
+    url: null,
+    notifyEnabled: false,
+    notifyMinutes: null,
+    departureNotifyEnabled: false,
+    sortOrder,
+    hasLog: false,
+  };
+}
+
+interface Captured {
+  deletes: string[];
+  updates: Record<string, unknown>[];
+}
+
+async function mockBoard(page: Page): Promise<Captured> {
+  const captured: Captured = { deletes: [], updates: [] };
+
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/planner/reviews/summary", (route) =>
+    route.fulfill(
+      ok({
+        today: DAY,
+        counts: { now: 0, overdue: 0, upcoming: 0, doneToday: 0 },
+        estimatedMinutes: 0,
+        materials: [],
+      }),
+    ),
+  );
+  await page.route("**/api/travel/summary", (route) =>
+    route.fulfill(ok({ ongoing: null, next: null, recentCompleted: null })),
+  );
+  await page.route("**/api/travel/activities/*", (route) => {
+    const method = route.request().method();
+    const id = route.request().url().split("/").pop() ?? "";
+    if (method === "DELETE") {
+      captured.deletes.push(id);
+      return route.fulfill(ok(null));
+    }
+    captured.updates.push(
+      route.request().postDataJSON() as Record<string, unknown>,
+    );
+    return route.fulfill(ok(activity(1, "센소지", 0)));
+  });
+  await page.route(`**/api/travel/trips/${TRIP_ID}/board*`, (route) => {
+    const isArchive = new URL(route.request().url()).searchParams.get(
+      "archive",
+    );
+    return route.fulfill(
+      ok({
+        trip: {
+          id: TRIP_ID,
+          title: "도쿄",
+          timezone: "Asia/Tokyo",
+          currency: "JPY",
+          startDate: DAY,
+          endDate: DAY,
+          status: "UPCOMING",
+          recordMode: false,
+        },
+        days: [
+          {
+            dayIndex: 1,
+            date: DAY,
+            weekday: "토",
+            activityCount: 2,
+            weather: null,
+          },
+        ],
+        selectedDate: isArchive === "true" ? null : DAY,
+        archiveCount: 0,
+        activities:
+          isArchive === "true"
+            ? []
+            : [activity(1, "센소지", 0), activity(2, "우에노", 1)],
+        legs: [],
+      }),
+    );
+  });
+
+  return captured;
+}
+
+/** 손가락으로 행을 가로로 민다. */
+async function swipeRow(page: Page, text: string, dx: number) {
+  const box = await page.getByText(text, { exact: true }).boundingBox();
+  if (!box) throw new Error("행을 찾지 못했다");
+  const y = box.y + box.height / 2;
+  const startX = box.x + box.width / 2;
+
+  await page.dispatchEvent(`text="${text}"`, "pointerdown", {
+    pointerType: "touch",
+    clientX: startX,
+    clientY: y,
+    isPrimary: true,
+  });
+  for (let i = 1; i <= 4; i++) {
+    await page.dispatchEvent(`text="${text}"`, "pointermove", {
+      pointerType: "touch",
+      clientX: startX + (dx * i) / 4,
+      clientY: y,
+      isPrimary: true,
+    });
+  }
+  await page.dispatchEvent(`text="${text}"`, "pointerup", {
+    pointerType: "touch",
+    clientX: startX + dx,
+    clientY: y,
+    isPrimary: true,
+  });
+}
+
+test.describe("스와이프 · 실행취소", () => {
+  test("왼쪽으로 밀면 삭제되고, 5초 안에는 요청이 나가지 않는다", async ({
+    page,
+  }) => {
+    const captured = await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByText("센소지")).toBeVisible();
+
+    await swipeRow(page, "센소지", -120);
+
+    // 화면에서는 즉시 사라지고 되돌릴 기회가 뜬다.
+    await expect(page.getByText("센소지", { exact: true })).toBeHidden();
+    await expect(page.getByRole("button", { name: /실행취소/ })).toBeVisible();
+    expect(captured.deletes).toHaveLength(0);
+  });
+
+  test("오른쪽으로 밀면 보관함으로 간다", async ({ page }) => {
+    const captured = await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByText("센소지")).toBeVisible();
+
+    await swipeRow(page, "센소지", 120);
+
+    await expect(page.getByText("센소지", { exact: true })).toBeHidden();
+    await expect(page.getByRole("button", { name: /실행취소/ })).toBeVisible();
+    expect(captured.updates).toHaveLength(0);
+  });
+
+  test("실행취소를 누르면 되살아나고 요청이 아예 나가지 않는다", async ({
+    page,
+  }) => {
+    const captured = await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByText("센소지")).toBeVisible();
+
+    await swipeRow(page, "센소지", -120);
+    await page.getByRole("button", { name: /실행취소/ }).click();
+
+    await expect(page.getByText("센소지", { exact: true })).toBeVisible();
+    expect(captured.deletes).toHaveLength(0);
+  });
+
+  test("그냥 두면 5초 뒤에 삭제 요청이 나간다", async ({ page }) => {
+    const captured = await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByText("센소지")).toBeVisible();
+
+    await swipeRow(page, "센소지", -120);
+
+    await expect.poll(() => captured.deletes, { timeout: 8000 }).toEqual(["1"]);
+  });
+
+  test("살짝만 밀면 아무 일도 없다", async ({ page }) => {
+    const captured = await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByText("센소지")).toBeVisible();
+
+    await swipeRow(page, "센소지", -40);
+
+    await expect(page.getByText("센소지")).toBeVisible();
+    expect(captured.deletes).toHaveLength(0);
+  });
+});

--- a/fe/playwright.config.ts
+++ b/fe/playwright.config.ts
@@ -14,6 +14,18 @@ export default defineConfig({
       name: "chromium",
       use: { browserName: "chromium" },
     },
+    // 여행은 Android Chrome 전용이다. 드래그·스와이프는 마우스와 터치의 동작이 달라
+    // 터치 입력으로도 함께 돌린다(실기기 감각까지 대신하지는 못한다).
+    {
+      name: "mobile-touch",
+      testMatch: /travel-board-.*\.spec\.ts/,
+      use: {
+        browserName: "chromium",
+        viewport: { width: 412, height: 915 },
+        hasTouch: true,
+        isMobile: true,
+      },
+    },
   ],
   webServer: {
     command: "npm run dev",

--- a/fe/src/features/travel/api/activities.ts
+++ b/fe/src/features/travel/api/activities.ts
@@ -119,3 +119,24 @@ export async function updateActivity(
 export async function deleteActivity(activityId: number): Promise<void> {
   await client.delete(`/travel/activities/${activityId}`);
 }
+
+/** 날짜 하나의 전체 순서. 부분 갱신은 보내지 않는다(순서가 비결정적이 된다). */
+export interface ReorderMove {
+  /** null이면 미배정 보관함. */
+  date: string | null;
+  activityIds: number[];
+}
+
+/**
+ * 드래그 결과를 한 번에 반영한다. 응답의 `legs`(이동시간)는 2단계에서 채워진다.
+ *
+ * <p>다른 날짜로 옮기는 것은 이 엔드포인트가 아니라 {@link updateActivity}로 한다 —
+ * 서버가 대상 날짜의 맨 뒤에 붙이고 떠나온 날짜를 재인덱싱해 주기 때문에, 대상 날짜의
+ * 기존 순서를 모르는 화면에서도 정확히 "끝에 추가"가 된다.
+ */
+export async function reorderActivities(
+  tripId: number,
+  moves: ReorderMove[],
+): Promise<void> {
+  await client.put(`/travel/trips/${tripId}/activities/order`, { moves });
+}

--- a/fe/src/features/travel/board/ActivityRow.tsx
+++ b/fe/src/features/travel/board/ActivityRow.tsx
@@ -1,85 +1,223 @@
-import { Archive, Bell, MapPin, Star, Trash2 } from "lucide-react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  Archive,
+  Bell,
+  ChevronDown,
+  ChevronUp,
+  GripVertical,
+  MapPin,
+  Star,
+  Trash2,
+} from "lucide-react";
+import type { PointerEvent as ReactPointerEvent } from "react";
 import { Link } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import type { Activity } from "@/features/travel/api/activities";
+import { cn } from "@/lib/utils";
+
+import { useLongPress } from "./useLongPress";
+import { useSwipeAction } from "./useSwipeAction";
 
 interface ActivityRowProps {
   activity: Activity;
-  /** 보관함을 보고 있으면 "보관함으로" 액션을 감춘다(이미 거기 있다). */
+  /** 보관함을 보고 있으면 "보관함으로"를 감춘다(이미 거기 있다). */
   inArchive: boolean;
-  onArchive: (activity: Activity) => void;
-  onDelete: (activity: Activity) => void;
+  dragMode: boolean;
+  /** 드래그 모드에서 한 칸씩 옮기기. 정밀하게 맞추기 어려운 손가락을 위한 대안이다. */
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onArchive: () => void;
+  onDelete: () => void;
+  /** 400ms 길게 눌러 드래그 모드로 들어간다. */
+  onEnterDragMode: () => void;
 }
 
 /**
- * 일정 한 줄. 시각·본문·액션 3열 그리드다.
+ * 일정 한 줄. 평소엔 시각·본문·액션 3열이고, 드래그 모드에서는 우측이 이동 조작으로 바뀐다.
  *
- * <p>시각이 없는 일정이 정상이라(§1.1) 빈칸 대신 `──`를 둔다 — 자리를 비우면 본문이
- * 좌우로 흔들려 목록이 읽기 어려워진다.
+ * <p>스와이프(좌=삭제, 우=보관함)와 우측 버튼은 <b>같은 동작</b>이다 — 터치에는 스와이프를,
+ * 데스크톱에는 버튼을 주되 기능을 갈라놓지 않는다.
  */
 export function ActivityRow({
   activity,
   inArchive,
+  dragMode,
+  onMoveUp,
+  onMoveDown,
+  canMoveUp,
+  canMoveDown,
   onArchive,
   onDelete,
+  onEnterDragMode,
 }: ActivityRowProps) {
+  // 드래그는 모드에 들어온 뒤에만 활성화한다 — 그 전에는 목록을 세로로 스크롤해야 한다.
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: activity.id, disabled: !dragMode });
+
+  const longPress = useLongPress(onEnterDragMode, !dragMode);
+
+  /**
+   * 버튼 위에서 시작한 포인터는 드래그로 넘기지 않는다.
+   *
+   * <p>드래그 리스너는 <b>항상 행 전체</b>에 있다 — 아무 데나 길게 눌러 모드에 들어가야 하기
+   * 때문이다. 그러면 행 안의 버튼을 눌러도 센서가 먼저 집어가 클릭이 삼켜지므로, 버튼에서만
+   * 전파를 끊는다. (모드 진입 시 리스너를 손잡이로 옮기는 방법도 있지만, 드래그 도중 활성
+   * 노드가 바뀌어 dnd-kit이 드래그 종료를 놓친다.)
+   */
+  const stopDrag = {
+    onPointerDown: (e: ReactPointerEvent) => e.stopPropagation(),
+  };
+
+  const swipe = useSwipeAction({
+    // 드래그 모드에서는 세로 드래그가 주인이라 스와이프를 끈다.
+    disabled: dragMode,
+    onSwipeLeft: onDelete,
+    onSwipeRight: inArchive ? undefined : onArchive,
+  });
+
   return (
-    <li className="hover:bg-muted grid grid-cols-[52px_1fr_auto] items-start gap-2 rounded-lg px-2 py-2.5">
-      <span
-        className={
-          activity.startTime
-            ? "pt-px text-sm tabular-nums"
-            : "text-muted-foreground pt-px text-sm"
-        }
+    <li
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn("relative touch-pan-y", isDragging && "z-10")}
+      {...attributes}
+      {...listeners}
+    >
+      <div
+        style={{ transform: `translateX(${swipe.offset}px)` }}
+        className={cn(
+          "hover:bg-muted bg-background grid grid-cols-[52px_1fr_auto] items-start gap-2 rounded-lg px-2 py-2.5",
+          !swipe.dragging && "transition-transform",
+          isDragging && "bg-card ring-primary scale-[1.01] shadow-lg ring-2",
+        )}
+        onPointerDown={(e) => {
+          longPress.onPointerDown(e);
+          swipe.onPointerDown(e);
+        }}
+        onPointerMove={(e) => {
+          longPress.onPointerMove(e);
+          swipe.onPointerMove(e);
+        }}
+        onPointerUp={() => {
+          longPress.onPointerUp();
+          swipe.onPointerUp();
+        }}
+        onPointerCancel={() => {
+          longPress.onPointerCancel();
+          swipe.onPointerUp();
+        }}
       >
-        {activity.startTime ?? "──"}
-      </span>
-
-      <Link
-        to={`/travel/activities/${activity.id}`}
-        className="min-w-0 no-underline"
-      >
-        <span className="block text-[15px] leading-[1.4]">
-          {activity.title}
-        </span>
-        {activity.place && (
-          <span className="text-muted-foreground flex items-center gap-1 text-xs">
-            <MapPin className="size-3 shrink-0" />
-            <span className="truncate">{activity.place.name}</span>
-          </span>
-        )}
-      </Link>
-
-      <span className="flex items-center gap-0.5">
-        {activity.notifyEnabled && (
-          <Bell aria-label="알림 켜짐" className="text-primary size-3.5" />
-        )}
-        {activity.hasLog && (
-          <Star
-            aria-label="기록 있음"
-            className="text-muted-foreground size-3.5"
-          />
-        )}
-        {!inArchive && (
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            aria-label={`${activity.title} 보관함으로`}
-            onClick={() => onArchive(activity)}
-          >
-            <Archive className="size-4" />
-          </Button>
-        )}
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          aria-label={`${activity.title} 삭제`}
-          onClick={() => onDelete(activity)}
+        <span
+          className={
+            activity.startTime
+              ? "pt-px text-sm tabular-nums"
+              : "text-muted-foreground pt-px text-sm"
+          }
         >
-          <Trash2 className="size-4" />
-        </Button>
-      </span>
+          {activity.startTime ?? "──"}
+        </span>
+
+        {/* 드래그 모드에서는 행을 눌러도 상세로 가지 않는다 — 옮기려던 손짓이 이동이 된다. */}
+        {dragMode ? (
+          <span className="min-w-0">
+            <span className="block text-[15px] leading-[1.4]">
+              {activity.title}
+            </span>
+          </span>
+        ) : (
+          <Link
+            to={`/travel/activities/${activity.id}`}
+            className="min-w-0 no-underline"
+          >
+            <span className="block text-[15px] leading-[1.4]">
+              {activity.title}
+            </span>
+            {activity.place && (
+              <span className="text-muted-foreground flex items-center gap-1 text-xs">
+                <MapPin className="size-3 shrink-0" />
+                <span className="truncate">{activity.place.name}</span>
+              </span>
+            )}
+          </Link>
+        )}
+
+        <span className="flex items-center gap-0.5">
+          {dragMode ? (
+            <>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label={`${activity.title} 위로`}
+                disabled={!canMoveUp}
+                onClick={onMoveUp}
+                {...stopDrag}
+              >
+                <ChevronUp className="size-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label={`${activity.title} 아래로`}
+                disabled={!canMoveDown}
+                onClick={onMoveDown}
+                {...stopDrag}
+              >
+                <ChevronDown className="size-4" />
+              </Button>
+              {/* 잡아끌 수 있다는 표시. 실제 활성 영역은 행 전체다. */}
+              <GripVertical
+                aria-hidden="true"
+                className="text-muted-foreground size-4 cursor-grab"
+              />
+            </>
+          ) : (
+            <>
+              {activity.notifyEnabled && (
+                <Bell
+                  aria-label="알림 켜짐"
+                  className="text-primary size-3.5"
+                />
+              )}
+              {activity.hasLog && (
+                <Star
+                  aria-label="기록 있음"
+                  className="text-muted-foreground size-3.5"
+                />
+              )}
+              {!inArchive && (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={`${activity.title} 보관함으로`}
+                  onClick={onArchive}
+                  {...stopDrag}
+                >
+                  <Archive className="size-4" />
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label={`${activity.title} 삭제`}
+                onClick={onDelete}
+                {...stopDrag}
+              >
+                <Trash2 className="size-4" />
+              </Button>
+            </>
+          )}
+        </span>
+      </div>
     </li>
   );
 }

--- a/fe/src/features/travel/board/DayTabs.tsx
+++ b/fe/src/features/travel/board/DayTabs.tsx
@@ -1,3 +1,4 @@
+import { useDroppable } from "@dnd-kit/core";
 import { Archive } from "lucide-react";
 
 import type { BoardDay } from "@/features/travel/api/activities";
@@ -11,6 +12,8 @@ interface DayTabsProps {
   selectedDate: string | null;
   onSelectDate: (date: string) => void;
   onSelectArchive: () => void;
+  /** 드래그 중이면 칩이 드롭 대상이 된다 — 여기로 떨어뜨리면 그 날짜로 옮긴다. */
+  droppable?: boolean;
 }
 
 /**
@@ -25,6 +28,7 @@ export function DayTabs({
   selectedDate,
   onSelectDate,
   onSelectArchive,
+  droppable = false,
 }: DayTabsProps) {
   return (
     <div
@@ -35,6 +39,7 @@ export function DayTabs({
       {days.map((day) => (
         <Chip
           key={day.date}
+          dropId={droppable ? `day:${day.date}` : undefined}
           active={selectedDate === day.date}
           label={`${day.dayIndex}일차`}
           sub={`${formatShortDate(day.date)} ${day.weekday}`}
@@ -42,6 +47,7 @@ export function DayTabs({
         />
       ))}
       <Chip
+        dropId={droppable ? "day:archive" : undefined}
         active={selectedDate === null}
         label="보관함"
         icon={<Archive className="size-3.5" />}
@@ -58,11 +64,19 @@ interface ChipProps {
   sub: string;
   icon?: React.ReactNode;
   onClick: () => void;
+  /** 있으면 드롭 대상으로 등록한다. */
+  dropId?: string;
 }
 
-function Chip({ active, label, sub, icon, onClick }: ChipProps) {
+function Chip({ active, label, sub, icon, onClick, dropId }: ChipProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: dropId ?? "",
+    disabled: !dropId,
+  });
+
   return (
     <button
+      ref={dropId ? setNodeRef : undefined}
       type="button"
       role="tab"
       aria-selected={active}
@@ -72,6 +86,8 @@ function Chip({ active, label, sub, icon, onClick }: ChipProps) {
         active
           ? "bg-accent text-accent-foreground border-primary"
           : "bg-card border-border hover:bg-muted",
+        // 이 칩 위에 떠 있다 — 놓으면 이 날짜로 간다는 걸 미리 보여준다.
+        isOver && "border-primary ring-primary bg-accent ring-2",
       )}
     >
       <span className="flex items-center gap-1 text-[13px] font-semibold">

--- a/fe/src/features/travel/board/DragModeBar.tsx
+++ b/fe/src/features/travel/board/DragModeBar.tsx
@@ -1,0 +1,23 @@
+import { Button } from "@/components/ui/button";
+
+interface DragModeBarProps {
+  onDone: () => void;
+}
+
+/**
+ * 드래그 모드 안내 바. 모드에 들어와 있다는 사실 자체와, 순서를 바꾸면 무엇이 따라 바뀌는지를
+ * 알린다 — 이동시간·알림이 조용히 재계산되면 사용자는 무엇 때문에 값이 달라졌는지 알 수 없다.
+ */
+export function DragModeBar({ onDone }: DragModeBarProps) {
+  return (
+    <div
+      role="status"
+      className="border-primary text-primary flex items-center justify-between gap-2 rounded-lg border border-dashed px-3 py-2 text-[13px]"
+    >
+      <span>드래그 모드 · 순서를 바꾸면 이동시간과 알림을 다시 계산해요</span>
+      <Button variant="ghost" size="sm" onClick={onDone}>
+        완료
+      </Button>
+    </div>
+  );
+}

--- a/fe/src/features/travel/board/useDeferredCommits.test.tsx
+++ b/fe/src/features/travel/board/useDeferredCommits.test.tsx
@@ -1,0 +1,87 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useDeferredCommits } from "./useDeferredCommits";
+
+describe("useDeferredCommits", () => {
+  it("보류하면 목록에 뜨고 실행 함수는 아직 돌지 않는다", () => {
+    const run = vi.fn();
+    const { result } = renderHook(() => useDeferredCommits());
+
+    act(() => result.current.defer(1, run));
+
+    expect(result.current.pendingIds).toEqual([1]);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("commit하면 실행하고 목록에서 뺀다", () => {
+    const run = vi.fn();
+    const { result } = renderHook(() => useDeferredCommits());
+
+    act(() => result.current.defer(1, run));
+    act(() => result.current.commit(1));
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(result.current.pendingIds).toEqual([]);
+  });
+
+  it("cancel하면 실행하지 않고 버린다 — 요청 자체가 나가지 않는다", () => {
+    const run = vi.fn();
+    const { result } = renderHook(() => useDeferredCommits());
+
+    act(() => result.current.defer(1, run));
+    act(() => result.current.cancel(1));
+
+    expect(run).not.toHaveBeenCalled();
+    expect(result.current.pendingIds).toEqual([]);
+  });
+
+  it("cancel 후 commit해도 다시 실행되지 않는다", () => {
+    const run = vi.fn();
+    const { result } = renderHook(() => useDeferredCommits());
+
+    act(() => result.current.defer(1, run));
+    act(() => result.current.cancel(1));
+    act(() => result.current.commit(1));
+
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("언마운트하면 보류 중인 것을 전부 즉시 실행한다", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { result, unmount } = renderHook(() => useDeferredCommits());
+
+    act(() => {
+      result.current.defer(1, first);
+      result.current.defer(2, second);
+    });
+    unmount();
+
+    // 화면이 사라졌는데 요청이 안 나가면 사용자는 지웠다고 믿는데 서버엔 남는다.
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("이미 commit한 것은 언마운트에서 다시 실행되지 않는다", () => {
+    const run = vi.fn();
+    const { result, unmount } = renderHook(() => useDeferredCommits());
+
+    act(() => result.current.defer(1, run));
+    act(() => result.current.commit(1));
+    unmount();
+
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("같은 id를 두 번 보류해도 목록에 한 번만 들어간다", () => {
+    const { result } = renderHook(() => useDeferredCommits());
+
+    act(() => {
+      result.current.defer(1, vi.fn());
+      result.current.defer(1, vi.fn());
+    });
+
+    expect(result.current.pendingIds).toEqual([1]);
+  });
+});

--- a/fe/src/features/travel/board/useDeferredCommits.ts
+++ b/fe/src/features/travel/board/useDeferredCommits.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * "5초 안에 되돌릴 수 있는" 동작을 보류해 둔다.
+ *
+ * <p><b>실행취소는 서버 기능이 아니다</b>(결정 기록 D-5). 소프트 삭제·복원 API를 두는 대신
+ * 화면이 요청을 5초 미루고 낙관적으로만 반영한다 — 되돌리면 요청 자체가 나가지 않으므로
+ * 서버에는 애초에 아무 일도 없었던 게 된다.
+ *
+ * <p>대신 <b>보류 중에 화면을 떠나면 즉시 보내야 한다.</b> 그냥 사라지면 사용자는 지웠다고
+ * 믿는데 서버에는 남는다.
+ */
+export function useDeferredCommits() {
+  // 렌더에 쓰는 목록(숨길 id)과 언마운트 flush에 쓰는 실행 함수를 나눠 둔다.
+  const commits = useRef(new Map<number, () => void>());
+  const [pendingIds, setPendingIds] = useState<number[]>([]);
+
+  const defer = useCallback((id: number, commit: () => void) => {
+    commits.current.set(id, commit);
+    setPendingIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
+  }, []);
+
+  /** 시간이 다 됐다 — 진짜로 보낸다. */
+  const commit = useCallback((id: number) => {
+    const run = commits.current.get(id);
+    commits.current.delete(id);
+    setPendingIds((prev) => prev.filter((p) => p !== id));
+    run?.();
+  }, []);
+
+  /** 되돌린다 — 요청을 보내지 않고 버린다. */
+  const cancel = useCallback((id: number) => {
+    commits.current.delete(id);
+    setPendingIds((prev) => prev.filter((p) => p !== id));
+  }, []);
+
+  useEffect(() => {
+    const map = commits.current;
+    return () => {
+      // 화면 이탈·언마운트 — 보류 중인 것을 전부 즉시 보낸다.
+      map.forEach((run) => run());
+      map.clear();
+    };
+  }, []);
+
+  return { defer, commit, cancel, pendingIds };
+}

--- a/fe/src/features/travel/board/useLongPress.ts
+++ b/fe/src/features/travel/board/useLongPress.ts
@@ -1,0 +1,52 @@
+import { type PointerEvent, useCallback, useEffect, useRef } from "react";
+
+/** 설계가 정한 진입 시간. 스크롤하려던 손짓과 구분되는 최소한의 길이다. */
+const HOLD_MS = 400;
+/** 이만큼 움직이면 누른 게 아니라 스크롤·스와이프다. */
+const TOLERANCE_PX = 8;
+
+/**
+ * 400ms 롱프레스 감지.
+ *
+ * <p>드래그 라이브러리의 지연 활성(`delay`)을 쓰지 않고 직접 재는 이유가 있다.
+ * dnd-kit은 <b>드래그가 끝난 직후의 클릭 한 번을 삼킨다</b> — 끌어놓은 자리에서 의도치 않은
+ * 클릭이 발생하는 걸 막는 정상 동작이다. 그런데 "길게 눌러 모드 진입"은 움직임 없이 끝나는
+ * 제스처라, 그것마저 드래그로 처리하면 사용자가 모드에 들어와 처음 누르는 버튼이 먹통이 된다.
+ *
+ * <p>그래서 진입은 이 훅이 맡고, 실제 드래그는 모드에 들어온 뒤에만 활성화한다.
+ */
+export function useLongPress(onLongPress: () => void, enabled = true) {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const origin = useRef<{ x: number; y: number } | null>(null);
+
+  const clear = useCallback(() => {
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = null;
+    origin.current = null;
+  }, []);
+
+  useEffect(() => clear, [clear]);
+
+  const onPointerDown = (event: PointerEvent<HTMLElement>) => {
+    if (!enabled) return;
+    origin.current = { x: event.clientX, y: event.clientY };
+    timer.current = setTimeout(() => {
+      onLongPress();
+      clear();
+    }, HOLD_MS);
+  };
+
+  const onPointerMove = (event: PointerEvent<HTMLElement>) => {
+    if (!origin.current) return;
+    const dx = Math.abs(event.clientX - origin.current.x);
+    const dy = Math.abs(event.clientY - origin.current.y);
+    if (dx > TOLERANCE_PX || dy > TOLERANCE_PX) clear();
+  };
+
+  return {
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: clear,
+    onPointerCancel: clear,
+  };
+}

--- a/fe/src/features/travel/board/useSwipeAction.test.tsx
+++ b/fe/src/features/travel/board/useSwipeAction.test.tsx
@@ -1,0 +1,118 @@
+import { act, renderHook } from "@testing-library/react";
+import type { PointerEvent } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useSwipeAction } from "./useSwipeAction";
+
+/** 포인터 이벤트 최소 형태. 훅이 보는 값만 담는다. */
+function pointer(x: number, y: number, pointerType = "touch") {
+  return { clientX: x, clientY: y, pointerType } as PointerEvent<HTMLElement>;
+}
+
+function swipe(
+  result: { current: ReturnType<typeof useSwipeAction> },
+  path: [number, number][],
+) {
+  act(() => result.current.onPointerDown(pointer(...path[0])));
+  for (const [x, y] of path.slice(1)) {
+    act(() => result.current.onPointerMove(pointer(x, y)));
+  }
+  act(() => result.current.onPointerUp());
+}
+
+describe("useSwipeAction", () => {
+  it("왼쪽으로 충분히 밀면 삭제가 실행된다", () => {
+    const onSwipeLeft = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeAction({ onSwipeLeft, onSwipeRight: vi.fn() }),
+    );
+
+    swipe(result, [
+      [200, 100],
+      [180, 100],
+      [110, 102],
+    ]);
+
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+  });
+
+  it("오른쪽으로 충분히 밀면 보관함이 실행된다", () => {
+    const onSwipeRight = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeAction({ onSwipeLeft: vi.fn(), onSwipeRight }),
+    );
+
+    swipe(result, [
+      [100, 100],
+      [120, 100],
+      [190, 98],
+    ]);
+
+    expect(onSwipeRight).toHaveBeenCalledTimes(1);
+  });
+
+  it("조금만 밀면 아무 일도 없고 제자리로 돌아온다", () => {
+    const onSwipeLeft = vi.fn();
+    const { result } = renderHook(() => useSwipeAction({ onSwipeLeft }));
+
+    swipe(result, [
+      [200, 100],
+      [175, 100],
+    ]);
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(result.current.offset).toBe(0);
+  });
+
+  it("세로로 움직이면 스크롤로 보고 손을 뗀다", () => {
+    const onSwipeLeft = vi.fn();
+    const { result } = renderHook(() => useSwipeAction({ onSwipeLeft }));
+
+    // 세로가 먼저 커지면 이 제스처는 스크롤이다.
+    swipe(result, [
+      [200, 100],
+      [196, 130],
+      [120, 200],
+    ]);
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(result.current.offset).toBe(0);
+  });
+
+  it("동작이 없는 방향으로는 따라가지 않는다", () => {
+    // 보관함에서는 오른쪽(보관함으로)이 없다.
+    const { result } = renderHook(() =>
+      useSwipeAction({ onSwipeLeft: vi.fn() }),
+    );
+
+    act(() => result.current.onPointerDown(pointer(100, 100)));
+    act(() => result.current.onPointerMove(pointer(160, 100)));
+
+    expect(result.current.offset).toBe(0);
+  });
+
+  it("마우스는 스와이프하지 않는다(버튼이 같은 동작을 한다)", () => {
+    const onSwipeLeft = vi.fn();
+    const { result } = renderHook(() => useSwipeAction({ onSwipeLeft }));
+
+    act(() => result.current.onPointerDown(pointer(200, 100, "mouse")));
+    act(() => result.current.onPointerMove(pointer(100, 100, "mouse")));
+    act(() => result.current.onPointerUp());
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+
+  it("드래그 모드에서는 스와이프를 끈다(세로 드래그가 주인이다)", () => {
+    const onSwipeLeft = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeAction({ disabled: true, onSwipeLeft }),
+    );
+
+    swipe(result, [
+      [200, 100],
+      [110, 100],
+    ]);
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+});

--- a/fe/src/features/travel/board/useSwipeAction.ts
+++ b/fe/src/features/travel/board/useSwipeAction.ts
@@ -1,0 +1,78 @@
+import { type PointerEvent, useRef, useState } from "react";
+
+/** 이 거리를 넘겨야 동작으로 친다. 짧은 흔들림을 삭제로 오인하지 않을 만큼은 되어야 한다. */
+const TRIGGER_PX = 72;
+/** 가로/세로 판정을 시작하는 최소 이동량. 이 전에는 방향을 정하지 않는다. */
+const DIRECTION_PX = 10;
+
+interface Options {
+  disabled?: boolean;
+  onSwipeLeft?: () => void;
+  onSwipeRight?: () => void;
+}
+
+/**
+ * 행 가로 스와이프 — 좌는 삭제, 우는 보관함.
+ *
+ * <p>세로 스크롤과 싸우지 않는 것이 핵심이다. 처음 10px에서 <b>가로가 세로보다 클 때만</b>
+ * 스와이프로 확정하고, 그 전까지는 브라우저 스크롤을 그대로 둔다. 반대 방향 동작이 없으면
+ * (예: 보관함에서 우 스와이프) 아예 따라가지 않는다.
+ *
+ * <p>포인터 이벤트만 쓴다 — 마우스·터치·펜이 같은 코드로 동작하고, 드래그 라이브러리의
+ * 세로 드래그와도 손쉽게 나눌 수 있다.
+ */
+export function useSwipeAction({
+  disabled = false,
+  onSwipeLeft,
+  onSwipeRight,
+}: Options) {
+  const start = useRef<{ x: number; y: number } | null>(null);
+  const axis = useRef<"none" | "x" | "y">("none");
+  const [offset, setOffset] = useState(0);
+  const [dragging, setDragging] = useState(false);
+
+  const reset = () => {
+    start.current = null;
+    axis.current = "none";
+    setOffset(0);
+    setDragging(false);
+  };
+
+  const onPointerDown = (event: PointerEvent<HTMLElement>) => {
+    if (disabled || event.pointerType === "mouse") return;
+    start.current = { x: event.clientX, y: event.clientY };
+    axis.current = "none";
+  };
+
+  const onPointerMove = (event: PointerEvent<HTMLElement>) => {
+    if (!start.current) return;
+    const dx = event.clientX - start.current.x;
+    const dy = event.clientY - start.current.y;
+
+    if (axis.current === "none") {
+      if (Math.abs(dx) < DIRECTION_PX && Math.abs(dy) < DIRECTION_PX) return;
+      // 세로가 더 크면 스크롤이다 — 이 제스처는 포기한다.
+      axis.current = Math.abs(dx) > Math.abs(dy) ? "x" : "y";
+      if (axis.current === "y") {
+        reset();
+        return;
+      }
+      setDragging(true);
+    }
+
+    // 동작이 없는 방향으로는 따라가지 않는다(끌리기만 하고 아무 일도 없으면 혼란스럽다).
+    if (dx < 0 && !onSwipeLeft) return;
+    if (dx > 0 && !onSwipeRight) return;
+    setOffset(dx);
+  };
+
+  const onPointerUp = () => {
+    if (axis.current === "x") {
+      if (offset <= -TRIGGER_PX) onSwipeLeft?.();
+      else if (offset >= TRIGGER_PX) onSwipeRight?.();
+    }
+    reset();
+  };
+
+  return { offset, dragging, onPointerDown, onPointerMove, onPointerUp };
+}

--- a/fe/src/features/travel/hooks/useActivityMutations.ts
+++ b/fe/src/features/travel/hooks/useActivityMutations.ts
@@ -2,8 +2,10 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import {
   type ActivityWriteRequest,
+  type Board,
   createActivity,
   deleteActivity,
+  reorderActivities,
   updateActivity,
 } from "../api/activities";
 import { travelKeys } from "../queryKeys";
@@ -52,5 +54,49 @@ export function useDeleteActivity(tripId: number) {
   return useMutation({
     mutationFn: (activityId: number) => deleteActivity(activityId),
     onSuccess: invalidate,
+  });
+}
+
+/**
+ * 같은 날짜 안의 순서 변경. <b>낙관적으로 먼저 반영하고 실패하면 되돌린다</b> —
+ * 드래그는 손을 뗀 순간 결과가 보여야 하고, 왕복을 기다리면 행이 제자리로 튀었다가
+ * 다시 움직이는 것처럼 보인다.
+ */
+export function useReorderActivities(tripId: number) {
+  const queryClient = useQueryClient();
+  const invalidate = useInvalidateBoard(tripId);
+
+  return useMutation({
+    mutationFn: ({
+      date,
+      activityIds,
+    }: {
+      date: string | null;
+      activityIds: number[];
+    }) => reorderActivities(tripId, [{ date, activityIds }]),
+
+    onMutate: async ({ date, activityIds }) => {
+      const key = travelKeys.board(tripId, date ?? "archive");
+      await queryClient.cancelQueries({ queryKey: key });
+      const snapshot = queryClient.getQueryData<Board>(key);
+      if (snapshot) {
+        const byId = new Map(snapshot.activities.map((a) => [a.id, a]));
+        queryClient.setQueryData<Board>(key, {
+          ...snapshot,
+          activities: activityIds
+            .map((id) => byId.get(id))
+            .filter((a): a is NonNullable<typeof a> => Boolean(a)),
+        });
+      }
+      return { key, snapshot };
+    },
+
+    onError: (_error, _vars, context) => {
+      if (context?.snapshot) {
+        queryClient.setQueryData(context.key, context.snapshot);
+      }
+    },
+
+    onSettled: invalidate,
   });
 }

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -1,11 +1,13 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { beforeEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Providers } from "@/app/providers";
 import { AppRouter } from "@/app/router";
 import { useAuthStore } from "@/features/auth/store/authStore";
+import { useToastStore } from "@/shared/lib/toast";
 import { server } from "@/test/mocks/server";
 import { renderWithRouter } from "@/test/render";
 
@@ -108,6 +110,9 @@ function renderBoard(path = "/travel/trips/3/board") {
 describe("TripBoardPage", () => {
   beforeEach(() => {
     useAuthStore.setState({ accessToken: "valid-token" });
+    // 스낵바는 모듈 스토어라 테스트 사이에 남는다. 이전 실행취소 스낵바가 섞이면
+    // 다음 테스트가 엉뚱한 버튼을 누른다.
+    useToastStore.setState({ toasts: [] });
   });
 
   describe("날짜 탭", () => {
@@ -372,47 +377,95 @@ describe("TripBoardPage", () => {
     });
   });
 
-  describe("일정 액션", () => {
-    it("보관함으로 옮기면 날짜만 비운다(삭제가 아니다)", async () => {
-      mockBoard({ byDate: { "2026-10-24": [activity()] } });
-      const seen: Record<string, unknown>[] = [];
+  describe("일정 액션 · 실행취소", () => {
+    /** 보류 중인 요청을 잡아 두고, 실제로 나갔는지 세는 핸들러. */
+    function captureWrites() {
+      const puts: Record<string, unknown>[] = [];
+      const deletes: string[] = [];
       server.use(
         http.put(`${API_BASE}/travel/activities/:id`, async ({ request }) => {
-          seen.push((await request.json()) as Record<string, unknown>);
+          puts.push((await request.json()) as Record<string, unknown>);
           return HttpResponse.json({ code: "OK", data: activity() });
         }),
+        http.delete(`${API_BASE}/travel/activities/:id`, ({ params }) => {
+          deletes.push(String(params.id));
+          return HttpResponse.json({ code: "OK", data: null });
+        }),
       );
+      return { puts, deletes };
+    }
+
+    it("보관함으로 옮기면 즉시 사라지지만 요청은 아직 나가지 않는다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [activity()] } });
+      const { puts } = captureWrites();
 
       renderBoard();
       await screen.findByText("센소지");
 
       await userEvent.click(screen.getByLabelText("센소지 보관함으로"));
 
-      await waitFor(() => expect(seen).toHaveLength(1));
-      expect(seen[0]).toMatchObject({ activityDate: null, startTime: "09:00" });
+      // 낙관적으로 목록에서 빠지고, 되돌릴 수 있는 스낵바가 뜬다.
+      await waitFor(() => {
+        expect(screen.queryByLabelText("센소지 보관함으로")).toBeNull();
+      });
+      expect(
+        await screen.findByRole("button", { name: /실행취소/ }),
+      ).toBeInTheDocument();
+      expect(puts).toHaveLength(0);
     });
 
-    it("삭제는 확인을 받은 뒤에 요청한다", async () => {
+    it("실행취소를 누르면 요청이 아예 나가지 않고 일정이 돌아온다", async () => {
       mockBoard({ byDate: { "2026-10-24": [activity()] } });
-      let deleted = false;
-      server.use(
-        http.delete(`${API_BASE}/travel/activities/:id`, () => {
-          deleted = true;
-          return HttpResponse.json({ code: "OK", data: null });
-        }),
-      );
+      const { puts, deletes } = captureWrites();
 
       renderBoard();
       await screen.findByText("센소지");
-
       await userEvent.click(screen.getByLabelText("센소지 삭제"));
-      expect(await screen.findByRole("dialog")).toHaveTextContent(
-        "일정을 삭제할까요?",
-      );
-      expect(deleted).toBe(false);
+      await waitFor(() => {
+        expect(screen.queryByLabelText("센소지 삭제")).toBeNull();
+      });
 
-      await userEvent.click(screen.getByRole("button", { name: "삭제" }));
-      await waitFor(() => expect(deleted).toBe(true));
+      await userEvent.click(
+        await screen.findByRole("button", { name: /실행취소/ }),
+      );
+
+      expect(await screen.findByText("센소지")).toBeInTheDocument();
+      expect(deletes).toHaveLength(0);
+      expect(puts).toHaveLength(0);
+    });
+
+    it("5초가 지나면 삭제 요청이 실제로 나간다", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      mockBoard({ byDate: { "2026-10-24": [activity()] } });
+      const { deletes } = captureWrites();
+
+      renderBoard();
+      await screen.findByText("센소지");
+      await userEvent.click(screen.getByLabelText("센소지 삭제"));
+      await screen.findByRole("button", { name: /실행취소/ });
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      await waitFor(() => expect(deletes).toEqual(["1"]));
+      vi.useRealTimers();
+    });
+
+    it("보류 중에 화면을 떠나면 요청을 즉시 보낸다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [activity()] } });
+      const { deletes } = captureWrites();
+
+      const { unmount } = renderBoard();
+      await screen.findByText("센소지");
+      await userEvent.click(screen.getByLabelText("센소지 삭제"));
+      await screen.findByRole("button", { name: /실행취소/ });
+      expect(deletes).toHaveLength(0);
+
+      // 5초를 기다리다 화면이 사라지면 영영 반영되지 않는다.
+      unmount();
+
+      await waitFor(() => expect(deletes).toEqual(["1"]));
     });
   });
 

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -452,6 +452,32 @@ describe("TripBoardPage", () => {
       vi.useRealTimers();
     });
 
+    it("보류가 풀린 뒤 요청이 실패하면 알려 주고 목록을 되돌린다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [activity()] } });
+      server.use(
+        http.delete(`${API_BASE}/travel/activities/:id`, () =>
+          HttpResponse.error(),
+        ),
+      );
+
+      // 스낵바 타이머가 등록되기 전에 가짜 시계를 켜야 앞당길 수 있다.
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      renderBoard();
+      await screen.findByText("센소지");
+      await userEvent.click(screen.getByLabelText("센소지 삭제"));
+      await screen.findByRole("button", { name: /실행취소/ });
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      // 화면에서는 이미 지운 뒤라, 실패를 알리지 않으면 서버와 어긋난 채로 남는다.
+      expect(
+        await screen.findByText("변경을 저장하지 못했어요."),
+      ).toBeInTheDocument();
+      vi.useRealTimers();
+    });
+
     it("보류 중에 화면을 떠나면 요청을 즉시 보낸다", async () => {
       mockBoard({ byDate: { "2026-10-24": [activity()] } });
       const { deletes } = captureWrites();

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -1,4 +1,20 @@
 import {
+  closestCenter,
+  type CollisionDetection,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  pointerWithin,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import {
   ArrowLeft,
   Map,
   MoreVertical,
@@ -15,20 +31,36 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { LoadingText } from "@/components/ui/loading-text";
 import { Menu, MenuItem } from "@/components/ui/menu";
 import type { Activity } from "@/features/travel/api/activities";
+// 삭제는 뮤테이션 훅이 아니라 raw 요청을 쓴다 — 화면을 떠난 뒤에 보낼 수도 있어서다.
+import { deleteActivity as deleteActivityRequest } from "@/features/travel/api/activities";
 import { deleteTrip } from "@/features/travel/api/travel";
 import { ActivityRow } from "@/features/travel/board/ActivityRow";
 import { AddSheet } from "@/features/travel/board/AddSheet";
 import { DayTabs } from "@/features/travel/board/DayTabs";
+import { DragModeBar } from "@/features/travel/board/DragModeBar";
+import { useDeferredCommits } from "@/features/travel/board/useDeferredCommits";
 import {
   useCreateActivity,
-  useDeleteActivity,
+  useReorderActivities,
   useUpdateActivity,
 } from "@/features/travel/hooks/useActivityMutations";
 import { useBoard } from "@/features/travel/hooks/useBoard";
-import { toast } from "@/shared/lib/toast";
+import { toast, toastUndo } from "@/shared/lib/toast";
 
 /** `?day=` 값 — 0부터 시작하는 일차 인덱스, 또는 보관함. */
 const ARCHIVE = "archive";
+
+/**
+ * 포인터가 들어간 대상을 먼저 본다.
+ *
+ * <p>기본 판정(사각형 겹침)은 끌고 있는 행의 큰 사각형을 기준으로 하는데, 날짜 칩은 작고
+ * 목록 위쪽에 있어 손가락이 칩 위에 있어도 바로 아래 행이 더 많이 겹쳐 이긴다.
+ * 칩에 떨어뜨리는 건 "손가락이 어디 있느냐"의 문제라 포인터를 우선한다.
+ */
+const collisionDetection: CollisionDetection = (args) => {
+  const byPointer = pointerWithin(args);
+  return byPointer.length > 0 ? byPointer : closestCenter(args);
+};
 
 /**
  * S-04 일정 보드. 주 화면이다.
@@ -36,7 +68,8 @@ const ARCHIVE = "archive";
  * <p><b>선택한 날짜는 URL이 소유한다</b>(`?day=0..N|archive`). 컴포넌트 상태로 들고 있으면
  * 새로고침·뒤로가기에서 1일차로 튕겨, 현지에서 앱을 다시 열 때마다 오늘을 다시 찾아야 한다.
  *
- * <p>드래그 정렬·스와이프·실행취소는 #1038에서 붙는다.
+ * <p>드래그는 행을 400ms 길게 눌러야 시작한다 — 목록을 세로로 스크롤하는 손짓과
+ * 행을 집어 올리는 손짓을 구분하는 유일한 방법이다.
  */
 export function TripBoardPage() {
   const { tripId: tripIdParam } = useParams();
@@ -66,12 +99,22 @@ export function TripBoardPage() {
   const board = needsOwnQuery ? dayBoard : base;
 
   const [sheetOpen, setSheetOpen] = useState(false);
-  const [pendingDelete, setPendingDelete] = useState<Activity | null>(null);
   const [deletingTrip, setDeletingTrip] = useState(false);
+  const [dragMode, setDragMode] = useState(false);
 
   const createActivity = useCreateActivity(tripId);
   const updateActivity = useUpdateActivity(tripId);
-  const removeActivity = useDeleteActivity(tripId);
+  const reorder = useReorderActivities(tripId);
+  const deferred = useDeferredCommits();
+
+  // 드래그 모드 안에서만 정렬이 켜지므로(행의 `disabled`) 여기서는 지연을 두지 않는다.
+  // 모드에 들어와 있다는 건 이미 "옮기려는 중"이라, 곧바로 잡히는 편이 자연스럽다.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
 
   if (isPending || !board) {
     return (
@@ -83,6 +126,10 @@ export function TripBoardPage() {
 
   const selectedDate = isArchive ? null : board.selectedDate;
   const selectedIndex = board.days.findIndex((d) => d.date === selectedDate);
+  // 실행취소를 기다리는 동안에는 이미 사라진 것처럼 보여야 한다(낙관적 반영).
+  const activities = board.activities.filter(
+    (a) => !deferred.pendingIds.includes(a.id),
+  );
 
   const selectDay = (date: string) => {
     const index = board.days.findIndex((d) => d.date === date);
@@ -113,24 +160,101 @@ export function TripBoardPage() {
     setSheetOpen(false);
   };
 
-  /** 일정을 보관함으로 내린다 — 지우는 게 아니라 날짜만 비운다. */
-  const archiveActivity = async (activity: Activity) => {
+  /**
+   * 보관함으로 내리기·삭제는 <b>요청을 5초 미룬다</b>. 화면에서는 즉시 사라지고,
+   * 실행취소를 누르면 요청 자체가 나가지 않는다(서버에 복원 API를 두지 않는 이유).
+   */
+  const deferAction = (
+    activity: Activity,
+    message: string,
+    run: () => Promise<unknown>,
+  ) => {
+    deferred.defer(activity.id, () => {
+      void run();
+    });
+    toastUndo(message, {
+      onUndo: () => deferred.cancel(activity.id),
+      onCommit: () => deferred.commit(activity.id),
+    });
+  };
+
+  const archiveActivity = (activity: Activity) =>
+    deferAction(
+      activity,
+      `"${activity.title}"을(를) 보관함으로 옮겼어요.`,
+      () =>
+        updateActivity.mutateAsync({
+          activityId: activity.id,
+          body: {
+            title: activity.title,
+            activityDate: null,
+            startTime: activity.startTime,
+          },
+        }),
+    );
+
+  const removeActivityDeferred = (activity: Activity) =>
+    deferAction(activity, `"${activity.title}"을(를) 삭제했어요.`, () =>
+      deleteActivityRequest(activity.id),
+    );
+
+  /** 같은 날짜 안에서 두 행의 자리를 바꾼다(드래그·화살표 공통). */
+  const moveWithin = (fromIndex: number, toIndex: number) => {
+    if (toIndex < 0 || toIndex >= activities.length) return;
+    const next = [...activities];
+    const [moved] = next.splice(fromIndex, 1);
+    next.splice(toIndex, 0, moved);
+    reorder.mutate({
+      date: selectedDate,
+      activityIds: next.map((a) => a.id),
+    });
+  };
+
+  /** 날짜 탭에 떨어뜨렸다 — 그 날짜의 맨 뒤로 보낸다. */
+  const moveToDay = async (activity: Activity, target: string | null) => {
+    if (target === selectedDate) return;
     await updateActivity.mutateAsync({
       activityId: activity.id,
       body: {
         title: activity.title,
-        activityDate: null,
+        activityDate: target,
         startTime: activity.startTime,
       },
     });
-    toast("보관함으로 옮겼어요.", "success");
+    toast(
+      target === null ? "보관함으로 옮겼어요." : "다른 날짜로 옮겼어요.",
+      "success",
+    );
   };
 
-  const confirmDeleteActivity = async () => {
-    if (!pendingDelete) return;
-    await removeActivity.mutateAsync(pendingDelete.id);
-    setPendingDelete(null);
-    toast("일정을 삭제했어요.", "success");
+  /** 행을 길게 눌렀다 — 드래그 모드로 들어간다. */
+  const enterDragMode = () => {
+    if (dragMode) return;
+    setDragMode(true);
+    // 모드에 들어왔다는 걸 손끝으로 알린다. 지원하지 않는 기기는 조용히 무시된다.
+    navigator.vibrate?.(10);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+
+    const overId = String(over.id);
+    if (overId.startsWith("day:")) {
+      const target = overId.slice(4);
+      const activity = activities.find((a) => a.id === active.id);
+      if (activity) {
+        void moveToDay(activity, target === ARCHIVE ? null : target);
+      }
+      return;
+    }
+
+    if (active.id === over.id) return;
+    const fromIndex = activities.findIndex((a) => a.id === active.id);
+    const toIndex = activities.findIndex((a) => a.id === over.id);
+    if (fromIndex < 0 || toIndex < 0) return;
+    moveWithin(fromIndex, toIndex);
+    toast("순서 변경 · 이동시간과 알림을 다시 계산했어요.", "success");
   };
 
   const removeTrip = async () => {
@@ -186,27 +310,51 @@ export function TripBoardPage() {
         </div>
       </header>
 
-      <DayTabs
-        days={board.days}
-        archiveCount={board.archiveCount}
-        selectedDate={selectedDate}
-        onSelectDate={selectDay}
-        onSelectArchive={selectArchive}
-      />
+      <DndContext
+        sensors={sensors}
+        collisionDetection={collisionDetection}
+        onDragEnd={handleDragEnd}
+      >
+        <DayTabs
+          days={board.days}
+          archiveCount={board.archiveCount}
+          selectedDate={selectedDate}
+          onSelectDate={selectDay}
+          onSelectArchive={selectArchive}
+          // 드래그가 시작된 뒤에 등록하면 그 드래그의 충돌 판정 대상에 들어가지 못한다.
+          // 드래그 중이 아닐 때는 아무 영향도 없으므로 항상 켜 둔다.
+          droppable
+        />
 
-      {board.activities.length > 0 ? (
-        <ul className="flex flex-col">
-          {board.activities.map((activity) => (
-            <ActivityRow
-              key={activity.id}
-              activity={activity}
-              inArchive={selectedDate === null}
-              onArchive={(a) => void archiveActivity(a)}
-              onDelete={setPendingDelete}
-            />
-          ))}
-        </ul>
-      ) : (
+        {activities.length > 0 && (
+          <SortableContext
+            items={activities.map((a) => a.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <ul className="flex flex-col">
+              {activities.map((activity, index) => (
+                <ActivityRow
+                  key={activity.id}
+                  activity={activity}
+                  inArchive={selectedDate === null}
+                  dragMode={dragMode}
+                  canMoveUp={index > 0}
+                  canMoveDown={index < activities.length - 1}
+                  onMoveUp={() => moveWithin(index, index - 1)}
+                  onMoveDown={() => moveWithin(index, index + 1)}
+                  onArchive={() => archiveActivity(activity)}
+                  onDelete={() => removeActivityDeferred(activity)}
+                  onEnterDragMode={enterDragMode}
+                />
+              ))}
+            </ul>
+          </SortableContext>
+        )}
+      </DndContext>
+
+      {dragMode && <DragModeBar onDone={() => setDragMode(false)} />}
+
+      {activities.length === 0 && (
         <EmptyState className="min-h-[30svh]">
           <p className="text-muted-foreground text-sm">
             {selectedDate === null
@@ -220,16 +368,19 @@ export function TripBoardPage() {
         </EmptyState>
       )}
 
-      <div className="flex justify-center py-2 pb-6">
-        <Button
-          variant="outline"
-          size="icon-lg"
-          aria-label="일정 추가"
-          onClick={() => setSheetOpen(true)}
-        >
-          <Plus className="size-[18px]" />
-        </Button>
-      </div>
+      {/* 드래그 모드에서는 추가 버튼을 감춘다 — 옮기는 중에 누를 일이 없고 오조작만 는다. */}
+      {!dragMode && (
+        <div className="flex justify-center py-2 pb-6">
+          <Button
+            variant="outline"
+            size="icon-lg"
+            aria-label="일정 추가"
+            onClick={() => setSheetOpen(true)}
+          >
+            <Plus className="size-[18px]" />
+          </Button>
+        </div>
+      )}
 
       <AddSheet
         open={sheetOpen}
@@ -239,19 +390,6 @@ export function TripBoardPage() {
         onCreate={(input) => void addActivity(input)}
         onPickFromArchive={(a) => void pickFromArchive(a)}
         pending={createActivity.isPending || updateActivity.isPending}
-      />
-
-      <ConfirmDialog
-        open={pendingDelete !== null}
-        onOpenChange={(open) => {
-          if (!open) setPendingDelete(null);
-        }}
-        title="일정을 삭제할까요?"
-        description={`"${pendingDelete?.title ?? ""}"이(가) 삭제됩니다.`}
-        confirmLabel="삭제"
-        destructive
-        onConfirm={() => void confirmDeleteActivity()}
-        pending={removeActivity.isPending}
       />
 
       <ConfirmDialog

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -14,6 +14,7 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeft,
   Map,
@@ -45,6 +46,7 @@ import {
   useUpdateActivity,
 } from "@/features/travel/hooks/useActivityMutations";
 import { useBoard } from "@/features/travel/hooks/useBoard";
+import { travelKeys } from "@/features/travel/queryKeys";
 import { toast, toastUndo } from "@/shared/lib/toast";
 
 /** `?day=` 값 — 0부터 시작하는 일차 인덱스, 또는 보관함. */
@@ -74,6 +76,7 @@ const collisionDetection: CollisionDetection = (args) => {
 export function TripBoardPage() {
   const { tripId: tripIdParam } = useParams();
   const tripId = Number(tripIdParam);
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -170,7 +173,15 @@ export function TripBoardPage() {
     run: () => Promise<unknown>,
   ) => {
     deferred.defer(activity.id, () => {
-      void run();
+      // 보류가 풀린 뒤에야 실제 요청이 나가므로, 여기서 실패하면 알려 줄 사람이 없다.
+      // 화면에서는 이미 지워진 상태라 조용히 두면 서버와 어긋난 채로 남는다.
+      void run().catch(() => {
+        toast("변경을 저장하지 못했어요.", "error");
+        // 낙관적으로 감췄던 행을 서버 상태로 되돌린다.
+        void queryClient.invalidateQueries({
+          queryKey: travelKeys.boards(tripId),
+        });
+      });
     });
     toastUndo(message, {
       onUndo: () => deferred.cancel(activity.id),


### PR DESCRIPTION
## 이슈
closes #1038

## 작업 내용

⚠️ 1단계 최대 리스크로 지목된 이슈. [화면 설계](https://github.com/wcorn/orino/wiki/Travel-UI-Design) §2.5·§3. (Epic #1029 · 1단계)

## 먼저: 리스크 판단이 하나 달라졌다

이슈는 "**dnd 라이브러리를 새로 넣기 전에** pointer 이벤트로 먼저 검증한다"고 했다. 확인해 보니 **`@dnd-kit`은 이미 이 저장소의 의존성**이고(`core`/`sortable`/`utilities`), 순서 카드 복습(`OrderingReviewCard`)·플래시카드 편집기에서 이미 터치 드래그로 쓰이고 있다. 새로 넣는 게 아니라 **이미 이 앱에서 검증된 것을 쓰는 쪽**이 손으로 만든 드래그보다 리스크가 낮다고 판단해 그대로 썼다.

대신 이슈의 의도(실제 감각을 먼저 확인)는 지켰다 — **Playwright real mouse/touch로 전 경로를 돌렸고, 그 과정에서 실제 버그를 두 개 잡았다**(아래).

## 실기기 검증에서 잡은 버그 2개

### 1. 모드에 들어온 직후 첫 탭이 삼켜졌다

dnd-kit은 **드래그가 끝난 직후의 클릭 한 번을 삼킨다.** 끌어놓은 자리에서 의도치 않은 클릭이 생기는 걸 막는 정상 동작이다. 그런데 "길게 눌러 모드 진입"은 움직임 없이 끝나는 제스처라, 그것까지 드래그로 처리하면 **모드에 들어와 처음 누르는 버튼(위/아래 화살표, 완료)이 먹통**이 된다.

→ **모드 진입과 드래그를 분리했다.** 진입은 자체 `useLongPress`(400ms)가 맡고, dnd 정렬은 `useSortable({ disabled: !dragMode })`로 **모드 안에서만** 켠다. 모드 밖에서는 dnd가 아예 관여하지 않아 세로 스크롤도 방해받지 않는다.

부수 효과로 UX가 더 나아졌다 — 모드 안에서는 지연 없이(`distance: 8`) 바로 잡히고, 모드 밖에서는 400ms를 채워야 하니 스크롤과 섞이지 않는다.

### 2. 날짜 탭에 떨어뜨려도 반응하지 않았다

기본 충돌 판정(사각형 겹침)은 끌고 있는 **행의 큰 사각형**을 기준으로 하는데, 날짜 칩은 작고 목록 위쪽에 있어 손가락이 칩 위에 있어도 바로 아래 행이 더 많이 겹쳐 이긴다.

→ 칩에 떨어뜨리는 건 "손가락이 어디 있느냐"의 문제라 **`pointerWithin` 우선, 없으면 `closestCenter`** 로 바꿨다. 그리고 탭은 **항상** 드롭 대상으로 등록한다 — 드래그가 시작된 뒤에 등록하면 그 드래그의 판정 대상에 못 들어간다.

## 실행취소 — 서버 기능이 아니다

[D-5](https://github.com/wcorn/orino/wiki/Travel-Open-Items) 대로 소프트 삭제·복원 API를 두지 않는다. `useDeferredCommits`가 요청을 5초 보류하고 화면에서만 먼저 지운다. **되돌리면 요청 자체가 나가지 않으므로 서버에는 애초에 아무 일도 없었던 게 된다.**

대신 **보류 중에 화면을 떠나면 즉시 보낸다**(언마운트 flush). 그냥 사라지면 사용자는 지웠다고 믿는데 서버에는 남는다. 이 경로는 삭제 요청을 뮤테이션 훅이 아니라 raw API로 잡아 둬서, 컴포넌트가 사라진 뒤에도 나간다.

## 그 밖

- **스와이프**(`useSwipeAction`) — 처음 10px에서 가로가 세로보다 클 때만 스와이프로 확정한다. 그 전엔 브라우저 스크롤을 그대로 둔다. 동작이 없는 방향(보관함에서 우 스와이프)으로는 따라가지도 않는다. 마우스는 스와이프하지 않고 버튼을 쓴다
- **순서 변경은 낙관적**이다. 손을 뗀 순간 결과가 보여야 하고, 왕복을 기다리면 행이 제자리로 튀었다가 다시 움직이는 것처럼 보인다. 실패하면 스냅샷으로 롤백
- **다른 날짜로 옮기기는 `/order`가 아니라 `PUT /activities/{id}`** 를 쓴다 — 서버가 대상 날짜의 맨 뒤에 붙이고 떠나온 날짜를 재인덱싱해 주므로, 대상 날짜의 기존 순서를 모르는 화면에서도 정확히 "끝에 추가"가 된다
- 화살표(위/아래)는 손가락으로 정밀하게 맞추기 어려운 경우의 대안이자 키보드 경로다

## 테스트

**단위 (신규 15개)** — `useDeferredCommits` 7개(보류·commit·cancel·취소 후 commit 무시·**언마운트 flush**·중복 방지), `useSwipeAction` 8개(좌/우 임계값·짧은 스와이프·**세로면 스크롤로 양보**·동작 없는 방향·마우스 제외·드래그 모드에서 비활성)

**통합** — 보관함/삭제가 **즉시 사라지되 요청은 나가지 않음**, 실행취소 시 되살아나고 요청 0건, 5초 뒤 실제 발송, **언마운트 시 즉시 발송**

**E2E (신규 12개 × 2 프로젝트)** — 움직이지 않는 롱프레스로 진입 · **진입 직후 첫 탭이 삼켜지지 않음**(위 버그의 회귀 테스트) · 드래그 시 그 날짜의 **전체 배열** 전송 · 화살표 이동 · **날짜 탭 드롭** · 드래그 모드에서 상세 이동 안 함 · 완료로 나가기 · 스와이프 좌/우·실행취소·5초 발송·짧은 스와이프

`playwright.config.ts`에 **`mobile-touch` 프로젝트**(412×915, `hasTouch`)를 추가해 여행 보드 스펙을 터치 입력으로도 돌린다. 스와이프는 터치 포인터로만 재현된다.

**`npm run format:check && npm run lint && npm test && npm run build` 통과 — 단위 707개.** E2E는 80개 전부 통과.

## 곁다리로 고친 것

`e2e/auth.spec.ts` 2개가 깨져 있었다. #1033에서 로그인 목적지를 `/home` → `/select`로 바꿨는데 **FE 게이트(`npm test`)는 vitest만 돌려 E2E를 보지 않아** 지나쳤다. 이번에 전체 E2E를 돌리며 발견해 함께 고쳤다.

## 남은 것: 실기기 확인은 대신할 수 없다

터치 에뮬레이션까지가 자동화의 한계다. **Android Chrome 실기기에서 확인이 필요한 것**:

1. 400ms가 실제로 자연스러운지 (짧으면 스크롤하다 모드 진입, 길면 답답하다)
2. 롱프레스 중 브라우저의 기본 동작(텍스트 선택·컨텍스트 메뉴)이 끼어들지 않는지
3. `navigator.vibrate(10)` 피드백 세기
4. 스와이프 임계값 72px이 손가락에 맞는지
5. 드래그 중 목록이 화면 밖으로 나갈 때 자동 스크롤 감각

1·4는 상수 하나만 바꾸면 되고, 2는 필요하면 `touch-action`·`user-select`를 조여야 한다.