### PR TITLE
chore : 여행 Places/Routes API 키 SealedSecret 추가

### DIFF
--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -132,6 +132,15 @@ spec:
                   optional: true
             - name: GOOGLE_REDIRECT_URI
               value: {{ .Values.env.GOOGLE_REDIRECT_URI | quote }}
+            # 여행 장소 검색·이동시간(Places/Routes). google-secret과 별도 시크릿이다 —
+            # 저건 사용자 OAuth, 이건 서버 API 키라 발급처도 교체 주기도 다르다.
+            # 2단계 기능이라 아직 없어도 기동돼야 한다(optional:true).
+            - name: GOOGLE_PLACES_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: travel-secret
+                  key: GOOGLE_PLACES_API_KEY
+                  optional: true
             - name: FRONTEND_URL
               value: {{ .Values.env.FRONTEND_URL | quote }}
           resources:

--- a/infra/helm/be/templates/sealedsecret-travel.yaml
+++ b/infra/helm/be/templates/sealedsecret-travel.yaml
@@ -1,0 +1,21 @@
+# 여행 모듈 Places/Routes API 키 (#1050, Epic #1029 · 2단계).
+#
+# google-secret과 나눠 둔다 — 저건 Calendar/Tasks용 OAuth 자격증명이고 이건 서버가 자기
+# 이름으로 호출하는 API 키다. 발급처도 교체 주기도 달라 한 시크릿에 섞으면 한쪽을 돌릴 때
+# 다른 쪽까지 건드리게 된다.
+#
+# GCP 프로젝트 orino-499511 / 키 이름 "orino-travel-places-routes"
+# API 제한: places.googleapis.com, routes.googleapis.com 만 허용
+# 원본값은 .secrets 참조(추적 제외).
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: travel-secret
+  namespace: orino
+spec:
+  encryptedData:
+    GOOGLE_PLACES_API_KEY: AgALvDBTYKyoENUJlM4BfIep+G0AeivOQR92MttMxt4HAEBYDelxiSwWEYJ9IPkzjWHYMk7wz3I2nlt+yTniH4M6ENOONm9W1uFIs3QYc83p9glfMofbk5rCY6vr4KBX3KmpoAxn1DlM4VtARkTAhhepnKcniiy1MkvfenFi2PR7k5xDtdVdejgvDgE69H+Dw1bT7r1HgtHMtapwbnkBiAg9hMeiihuAVJ/bQ2VrNplEUsqTf2YJ7cw8vooKp+V1/zmS47oriA4A6pRCnfsXl5tJR3wqxpULob7o1SIXQvOinpq0KY7WGYKk19a2+bN3w/nLmO0UzLSjcGHqNdW17oAI/qNOeL8hCwsjuePPyWEUkw7Cam8fKGXwS4+CzN0tYltiq7z9fphNFXs2ivIgWo1vqkpndmMGtzQqnTTWBRCS/r7o/Nge45TiVNXog5ewjpEeHzJkphfc/KzyuqHLsEgkg9jyjnOnHg183fDtSO/Q4K5D+vZt3WlI2eJkQcRWP/2VOB5SZGSRShdRfgioCpUJpRMsM4rU9m8aqZB08ZB5sE6vs5w2lXurrR/HhLK0hfzNpA/6C98wL0cbRBWDu3DbCRtJ/2pRWMH+CuujkWgxWTkgT6F/Y97Jd1lVv+L20Ad7lNW7lTWR8bbejV+NGocjbPRsr4JbMq1/psSIJbP9rp3H4RRE6bBcVWkVMqCZuvNADzF35pcOFs4gXJoFEDYWvz5+ODGHLlMUbqZ0HFwOk3vko7v1znc=
+  template:
+    metadata:
+      name: travel-secret
+      namespace: orino


### PR DESCRIPTION
## 이슈
closes #1050

## 작업 내용

2단계(장소 검색·지도·이동시간) 착수 전제. Google Places/Routes 자격증명을 준비하고 클러스터에 주입한다. (Epic #1029)

### 왜 `google-secret`을 재사용하지 않았나

기존 `google-secret`은 **Calendar/Tasks용 OAuth 자격증명**(client id/secret)이다. Places/Routes는 서버가 자기 이름으로 호출하는 **API 키**라 종류가 다르다. 발급처도 교체 주기도 다르므로 한 시크릿에 섞으면 한쪽을 돌릴 때 다른 쪽까지 건드리게 된다. `travel-secret`으로 분리했다.

2단계 기능이라 아직 없어도 기동돼야 하므로 `optional: true`다(기존 google env와 같은 방식).

## 준비한 것

| 항목 | 상태 |
|---|---|
| `orino-499511` 결제 계정 | 연결됨 (유료 API라 필수) |
| Places API (New) · Routes API | 활성화 |
| API 키 `orino-travel-places-routes` | 발급 + **API 제한**(두 API만) |
| `.secrets` | 기록(추적 제외) |
| SealedSecret | `travel-secret` / ns `orino` |

키에 **API 제한**을 걸었다 — 유출되더라도 Places/Routes 밖으로는 쓸 수 없다.

## 실제 호출로 검증

발급만으로는 결제·활성화가 실제로 붙었는지 알 수 없어 직접 호출했다.

- **Places Text Search** — "센소지" 검색 → 좌표(35.7147651, 139.7966553)·주소 반환 ✅
- **Routes WALK** — 5049m / 4399s ✅
- **Routes DRIVE** — 7956m / 1074s ✅
- **Routes TRANSIT** — 빈 응답(HTTP 200)

TRANSIT은 **설계상 필요 없다.** 이동시간은 직선거리로 도보/자동차를 갈라 계산하고(§4.4), 대중교통은 구글 지도 **딥링크(URL)** 라 API 호출이 아니다. 설계가 쓰는 두 모드는 모두 정상이다.

## 검증

- `yamllint -c .yamllint.yml infra/` 통과
- `helm lint infra/helm/be` 통과
- `helm template`으로 렌더 확인 — `travel-secret` SealedSecret과 배포의 `GOOGLE_PLACES_API_KEY` env 모두 정상 생성(8개 리소스)
- `kubeconform`은 로컬 미설치라 CI가 검증한다

## 남은 것

**애플리케이션(IP) 제한 미설정.** 클러스터 이그레스가 집 회선이라 공인 IP가 바뀔 수 있어, 고정 여부를 확인한 뒤 거는 게 맞다고 판단했다. 지금은 API 제한만으로 막고 있다.

DDNS로 IP를 추적하고 있으니 그 값을 쓰거나, 변동이 잦으면 IP 제한 대신 **키 사용량 알림 + 예산 알림**으로 가는 편이 나을 수 있다. 별도로 판단이 필요해 이 PR에 넣지 않았다.