### PR TITLE
chore : GCP 리소스를 Terraform으로 관리 (WIF + import)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -59,6 +59,8 @@ jobs:
       - name: Terraform plan
         if: github.event_name == 'pull_request'
         run: |
+          # tee 를 거치면 파이프라인 종료 코드가 tee 의 것(0)이 돼 plan 실패가 초록으로 보고된다.
+          set -o pipefail
           echo '### Terraform Plan' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           terraform plan -input=false -no-color 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -36,6 +36,15 @@ jobs:
           role-to-assume: ${{ github.event_name == 'pull_request' && 'arn:aws:iam::012900311331:role/github-actions-terraform-plan' || 'arn:aws:iam::012900311331:role/github-actions-terraform' }}
           aws-region: ap-northeast-2
 
+      # GCP도 OIDC(Workload Identity Federation)로 받는다. 서비스 계정 키 파일 없음.
+      # AWS와 같이 PR은 읽기 전용 SA, main push는 쓰기 SA를 가장한다.
+      - name: Configure GCP credentials (OIDC)
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: orino-499511
+          workload_identity_provider: projects/202935442863/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: ${{ github.event_name == 'pull_request' && 'github-actions-terraform-plan@orino-499511.iam.gserviceaccount.com' || 'github-actions-terraform@orino-499511.iam.gserviceaccount.com' }}
+
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.14.8"

--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -132,6 +132,15 @@ spec:
                   optional: true
             - name: GOOGLE_REDIRECT_URI
               value: {{ .Values.env.GOOGLE_REDIRECT_URI | quote }}
+            # 여행 장소 검색·이동시간(Places/Routes). google-secret과 별도 시크릿이다 —
+            # 저건 사용자 OAuth, 이건 서버 API 키라 발급처도 교체 주기도 다르다.
+            # 2단계 기능이라 아직 없어도 기동돼야 한다(optional:true).
+            - name: GOOGLE_PLACES_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: travel-secret
+                  key: GOOGLE_PLACES_API_KEY
+                  optional: true
             - name: FRONTEND_URL
               value: {{ .Values.env.FRONTEND_URL | quote }}
           resources:

--- a/infra/helm/be/templates/sealedsecret-travel.yaml
+++ b/infra/helm/be/templates/sealedsecret-travel.yaml
@@ -1,0 +1,21 @@
+# 여행 모듈 Places/Routes API 키 (#1050, Epic #1029 · 2단계).
+#
+# google-secret과 나눠 둔다 — 저건 Calendar/Tasks용 OAuth 자격증명이고 이건 서버가 자기
+# 이름으로 호출하는 API 키다. 발급처도 교체 주기도 달라 한 시크릿에 섞으면 한쪽을 돌릴 때
+# 다른 쪽까지 건드리게 된다.
+#
+# GCP 프로젝트 orino-499511 / 키 이름 "orino-travel-places-routes"
+# API 제한: places.googleapis.com, routes.googleapis.com 만 허용
+# 원본값은 .secrets 참조(추적 제외).
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: travel-secret
+  namespace: orino
+spec:
+  encryptedData:
+    GOOGLE_PLACES_API_KEY: AgALvDBTYKyoENUJlM4BfIep+G0AeivOQR92MttMxt4HAEBYDelxiSwWEYJ9IPkzjWHYMk7wz3I2nlt+yTniH4M6ENOONm9W1uFIs3QYc83p9glfMofbk5rCY6vr4KBX3KmpoAxn1DlM4VtARkTAhhepnKcniiy1MkvfenFi2PR7k5xDtdVdejgvDgE69H+Dw1bT7r1HgtHMtapwbnkBiAg9hMeiihuAVJ/bQ2VrNplEUsqTf2YJ7cw8vooKp+V1/zmS47oriA4A6pRCnfsXl5tJR3wqxpULob7o1SIXQvOinpq0KY7WGYKk19a2+bN3w/nLmO0UzLSjcGHqNdW17oAI/qNOeL8hCwsjuePPyWEUkw7Cam8fKGXwS4+CzN0tYltiq7z9fphNFXs2ivIgWo1vqkpndmMGtzQqnTTWBRCS/r7o/Nge45TiVNXog5ewjpEeHzJkphfc/KzyuqHLsEgkg9jyjnOnHg183fDtSO/Q4K5D+vZt3WlI2eJkQcRWP/2VOB5SZGSRShdRfgioCpUJpRMsM4rU9m8aqZB08ZB5sE6vs5w2lXurrR/HhLK0hfzNpA/6C98wL0cbRBWDu3DbCRtJ/2pRWMH+CuujkWgxWTkgT6F/Y97Jd1lVv+L20Ad7lNW7lTWR8bbejV+NGocjbPRsr4JbMq1/psSIJbP9rp3H4RRE6bBcVWkVMqCZuvNADzF35pcOFs4gXJoFEDYWvz5+ODGHLlMUbqZ0HFwOk3vko7v1znc=
+  template:
+    metadata:
+      name: travel-secret
+      namespace: orino

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -24,6 +24,26 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.9.0"
   constraints = "~> 3.6"

--- a/infra/terraform/gcp-cicd.tf
+++ b/infra/terraform/gcp-cicd.tf
@@ -1,0 +1,119 @@
+# GitHub Actions → GCP — 정적 키 없이 Workload Identity Federation 으로 terraform 실행.
+# AWS 쪽(cicd.tf)과 같은 구조다:
+#   PR(untrusted)       → terraform-plan  SA (읽기 전용)
+#   main 머지(trusted)  → terraform-apply SA (쓰기 가능)
+#
+# 이 자격증명들은 "자기 자신을 만드는" 관계라 처음 한 번은 코드 밖에서 만들 수밖에 없다
+# (풀·provider는 콘솔, 서비스 계정은 CLI). 만든 뒤 import로 넘겨받아 이후로는 코드가 관리한다.
+# AWS의 OIDC provider·role도 같은 경로를 거쳤다.
+
+resource "google_iam_workload_identity_pool" "github" {
+  project                   = var.gcp_project_id
+  workload_identity_pool_id = "github-actions"
+  display_name              = "github-actions"
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  project                            = var.gcp_project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github"
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+  }
+
+  # 이 조건이 없으면 GitHub의 아무 리포지토리나 이 SA를 가장할 수 있다.
+  # WIF에서 가장 흔한 사고라 반드시 둔다.
+  attribute_condition = "assertion.repository == 'wcorn/orino'"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# apply SA — main 머지(trusted). 쓰기 권한.
+# ---------------------------------------------------------------------------
+resource "google_service_account" "terraform_apply" {
+  project      = var.gcp_project_id
+  account_id   = "github-actions-terraform"
+  display_name = "Terraform apply (main merge)"
+}
+
+resource "google_project_iam_member" "terraform_apply" {
+  for_each = toset([
+    "roles/serviceusage.serviceUsageAdmin", # API 활성화/비활성화
+    "roles/serviceusage.apiKeysAdmin",      # API 키 생성·제한 변경
+  ])
+
+  project = var.gcp_project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.terraform_apply.email}"
+}
+
+# ---------------------------------------------------------------------------
+# plan SA — PR(untrusted). 읽기 전용이라 포크 PR도 리소스를 못 바꾼다.
+# ---------------------------------------------------------------------------
+resource "google_service_account" "terraform_plan" {
+  project      = var.gcp_project_id
+  account_id   = "github-actions-terraform-plan"
+  display_name = "Terraform plan (PR, read-only)"
+}
+
+resource "google_project_iam_member" "terraform_plan" {
+  for_each = toset([
+    "roles/serviceusage.serviceUsageViewer",
+    # plan이 API 키를 refresh 하려면 키 문자열 조회까지 필요하다(apikeys.keys.getKeyString).
+    "roles/serviceusage.apiKeysViewer",
+  ])
+
+  project = var.gcp_project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.terraform_plan.email}"
+}
+
+# ---------------------------------------------------------------------------
+# 결제 계정 역할 — 예산은 프로젝트가 아니라 결제 계정에 붙는 리소스다.
+# 프로젝트에 부여하면 예산을 못 읽고/못 만든다.
+# ---------------------------------------------------------------------------
+resource "google_billing_account_iam_member" "terraform_apply" {
+  billing_account_id = var.gcp_billing_account
+  role               = "roles/billing.costsManager"
+  member             = "serviceAccount:${google_service_account.terraform_apply.email}"
+}
+
+resource "google_billing_account_iam_member" "terraform_plan" {
+  billing_account_id = var.gcp_billing_account
+  role               = "roles/billing.viewer"
+  member             = "serviceAccount:${google_service_account.terraform_plan.email}"
+}
+
+# ---------------------------------------------------------------------------
+# WIF 바인딩 — wcorn/orino 워크플로만 이 SA를 가장할 수 있다.
+# ---------------------------------------------------------------------------
+locals {
+  gcp_wif_principal = "principalSet://iam.googleapis.com/projects/${var.gcp_project_number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github.workload_identity_pool_id}/attribute.repository/wcorn/orino"
+}
+
+resource "google_service_account_iam_member" "terraform_apply_wif" {
+  service_account_id = google_service_account.terraform_apply.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = local.gcp_wif_principal
+}
+
+resource "google_service_account_iam_member" "terraform_plan_wif" {
+  service_account_id = google_service_account.terraform_plan.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = local.gcp_wif_principal
+}
+
+output "gcp_terraform_apply_sa" {
+  description = "main 머지 시 apply에 사용하는 서비스 계정"
+  value       = google_service_account.terraform_apply.email
+}
+
+output "gcp_terraform_plan_sa" {
+  description = "PR plan(읽기 전용)에 사용하는 서비스 계정"
+  value       = google_service_account.terraform_plan.email
+}

--- a/infra/terraform/gcp-cicd.tf
+++ b/infra/terraform/gcp-cicd.tf
@@ -42,9 +42,14 @@ resource "google_service_account" "terraform_apply" {
 }
 
 resource "google_project_iam_member" "terraform_apply" {
+  # Terraform은 자기가 만드는 리소스보다 넓은 권한이 필요하다 — refresh 때 IAM 정책·
+  # 서비스 계정·WIF 풀을 읽어야 하고, 자기 자신(cicd)의 바인딩도 관리하기 때문이다.
   for_each = toset([
-    "roles/serviceusage.serviceUsageAdmin", # API 활성화/비활성화
-    "roles/serviceusage.apiKeysAdmin",      # API 키 생성·제한 변경
+    "roles/serviceusage.serviceUsageAdmin",  # API 활성화/비활성화
+    "roles/serviceusage.apiKeysAdmin",       # API 키 생성·제한 변경
+    "roles/iam.workloadIdentityPoolAdmin",   # WIF 풀·provider
+    "roles/iam.serviceAccountAdmin",         # 서비스 계정과 그 IAM 정책
+    "roles/resourcemanager.projectIamAdmin", # 프로젝트 역할 바인딩
   ])
 
   project = var.gcp_project_id
@@ -66,6 +71,9 @@ resource "google_project_iam_member" "terraform_plan" {
     "roles/serviceusage.serviceUsageViewer",
     # plan이 API 키를 refresh 하려면 키 문자열 조회까지 필요하다(apikeys.keys.getKeyString).
     "roles/serviceusage.apiKeysViewer",
+    "roles/iam.workloadIdentityPoolViewer",
+    # 서비스 계정과 프로젝트 IAM 정책 읽기. 이게 없으면 plan이 403으로 깨진다.
+    "roles/iam.securityReviewer",
   ])
 
   project = var.gcp_project_id

--- a/infra/terraform/gcp-cicd.tf
+++ b/infra/terraform/gcp-cicd.tf
@@ -17,6 +17,7 @@ resource "google_iam_workload_identity_pool_provider" "github" {
   project                            = var.gcp_project_id
   workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
   workload_identity_pool_provider_id = "github"
+  display_name                       = "github"
 
   attribute_mapping = {
     "google.subject"       = "assertion.sub"
@@ -82,20 +83,18 @@ resource "google_project_iam_member" "terraform_plan" {
 }
 
 # ---------------------------------------------------------------------------
-# 결제 계정 역할 — 예산은 프로젝트가 아니라 결제 계정에 붙는 리소스다.
-# 프로젝트에 부여하면 예산을 못 읽고/못 만든다.
+# 결제 계정 역할은 여기서 관리하지 않는다 (부트스트랩, CLI로 부여).
+#
+# 예산은 결제 계정에 붙는 리소스라 CI에 결제 계정 역할이 필요하다. 그런데 그 "역할 부여"까지
+# Terraform이 하려면 CI에 billing.accounts.setIamPolicy(사실상 billing.admin)를 줘야 하고,
+# 그러면 CI가 결제 계정 접근 권한을 아무에게나 줄 수 있게 된다 — 필요 이상이다.
+#
+# 그래서 CI에는 예산을 다룰 최소 권한만 주고(apply=costsManager, plan=billing.viewer),
+# 그 부여 자체는 WIF 풀과 같은 부트스트랩으로 남긴다.
+#   gcloud billing accounts add-iam-policy-binding 01EDAC-CEFAA5-004180 \
+#     --member=serviceAccount:github-actions-terraform@orino-499511.iam.gserviceaccount.com \
+#     --role=roles/billing.costsManager
 # ---------------------------------------------------------------------------
-resource "google_billing_account_iam_member" "terraform_apply" {
-  billing_account_id = var.gcp_billing_account
-  role               = "roles/billing.costsManager"
-  member             = "serviceAccount:${google_service_account.terraform_apply.email}"
-}
-
-resource "google_billing_account_iam_member" "terraform_plan" {
-  billing_account_id = var.gcp_billing_account
-  role               = "roles/billing.viewer"
-  member             = "serviceAccount:${google_service_account.terraform_plan.email}"
-}
 
 # ---------------------------------------------------------------------------
 # WIF 바인딩 — wcorn/orino 워크플로만 이 SA를 가장할 수 있다.

--- a/infra/terraform/gcp-travel-import.tf
+++ b/infra/terraform/gcp-travel-import.tf
@@ -94,3 +94,28 @@ import {
   to = google_service_account_iam_member.terraform_plan_wif
   id = "projects/orino-499511/serviceAccounts/github-actions-terraform-plan@orino-499511.iam.gserviceaccount.com roles/iam.workloadIdentityUser principalSet://iam.googleapis.com/projects/202935442863/locations/global/workloadIdentityPools/github-actions/attribute.repository/wcorn/orino"
 }
+
+import {
+  to = google_project_iam_member.terraform_apply["roles/iam.workloadIdentityPoolAdmin"]
+  id = "orino-499511 roles/iam.workloadIdentityPoolAdmin serviceAccount:github-actions-terraform@orino-499511.iam.gserviceaccount.com"
+}
+
+import {
+  to = google_project_iam_member.terraform_apply["roles/iam.serviceAccountAdmin"]
+  id = "orino-499511 roles/iam.serviceAccountAdmin serviceAccount:github-actions-terraform@orino-499511.iam.gserviceaccount.com"
+}
+
+import {
+  to = google_project_iam_member.terraform_apply["roles/resourcemanager.projectIamAdmin"]
+  id = "orino-499511 roles/resourcemanager.projectIamAdmin serviceAccount:github-actions-terraform@orino-499511.iam.gserviceaccount.com"
+}
+
+import {
+  to = google_project_iam_member.terraform_plan["roles/iam.workloadIdentityPoolViewer"]
+  id = "orino-499511 roles/iam.workloadIdentityPoolViewer serviceAccount:github-actions-terraform-plan@orino-499511.iam.gserviceaccount.com"
+}
+
+import {
+  to = google_project_iam_member.terraform_plan["roles/iam.securityReviewer"]
+  id = "orino-499511 roles/iam.securityReviewer serviceAccount:github-actions-terraform-plan@orino-499511.iam.gserviceaccount.com"
+}

--- a/infra/terraform/gcp-travel-import.tf
+++ b/infra/terraform/gcp-travel-import.tf
@@ -23,6 +23,11 @@ import {
 }
 
 import {
+  to = google_project_service.travel["apikeys.googleapis.com"]
+  id = "orino-499511/apikeys.googleapis.com"
+}
+
+import {
   to = google_apikeys_key.travel_places_routes
   id = "projects/orino-499511/locations/global/keys/18229d57-dd99-439e-82a7-41ee91af8308"
 }
@@ -75,15 +80,7 @@ import {
   id = "orino-499511 roles/serviceusage.apiKeysViewer serviceAccount:github-actions-terraform-plan@orino-499511.iam.gserviceaccount.com"
 }
 
-import {
-  to = google_billing_account_iam_member.terraform_apply
-  id = "billingAccounts/01EDAC-CEFAA5-004180 roles/billing.costsManager serviceAccount:github-actions-terraform@orino-499511.iam.gserviceaccount.com"
-}
 
-import {
-  to = google_billing_account_iam_member.terraform_plan
-  id = "billingAccounts/01EDAC-CEFAA5-004180 roles/billing.viewer serviceAccount:github-actions-terraform-plan@orino-499511.iam.gserviceaccount.com"
-}
 
 import {
   to = google_service_account_iam_member.terraform_apply_wif

--- a/infra/terraform/gcp-travel-import.tf
+++ b/infra/terraform/gcp-travel-import.tf
@@ -1,0 +1,96 @@
+# 이미 존재하는 GCP 리소스를 Terraform state로 넘겨받는다 (#1052).
+#
+# 이 리소스들은 2단계 착수를 서두르다 gcloud로 먼저 만들어졌다. import 블록을 쓰면
+# 삭제·재생성 없이 state에만 편입된다 — API 키가 새로 발급되면 SealedSecret과
+# .secrets를 다시 봉인해야 하므로 재생성은 피해야 한다.
+#
+# 적용 후(= state에 들어온 뒤) 이 파일은 지워도 된다. 남겨 두면 매 plan마다
+# 이미 import된 리소스를 다시 확인할 뿐 동작에는 영향이 없다.
+
+import {
+  to = google_project_service.travel["places.googleapis.com"]
+  id = "orino-499511/places.googleapis.com"
+}
+
+import {
+  to = google_project_service.travel["routes.googleapis.com"]
+  id = "orino-499511/routes.googleapis.com"
+}
+
+import {
+  to = google_project_service.travel["billingbudgets.googleapis.com"]
+  id = "orino-499511/billingbudgets.googleapis.com"
+}
+
+import {
+  to = google_apikeys_key.travel_places_routes
+  id = "projects/orino-499511/locations/global/keys/18229d57-dd99-439e-82a7-41ee91af8308"
+}
+
+import {
+  to = google_billing_budget.orino
+  id = "billingAccounts/01EDAC-CEFAA5-004180/budgets/09bb17e9-6ac6-4c7d-8f3c-4a7d8eeae375"
+}
+
+# --- CI 자격증명 (#1052) ---
+# 풀·provider는 콘솔에서, 서비스 계정·바인딩은 CLI로 만들어졌다. 여기서 넘겨받는다.
+
+import {
+  to = google_iam_workload_identity_pool.github
+  id = "projects/orino-499511/locations/global/workloadIdentityPools/github-actions"
+}
+
+import {
+  to = google_iam_workload_identity_pool_provider.github
+  id = "projects/orino-499511/locations/global/workloadIdentityPools/github-actions/providers/github"
+}
+
+import {
+  to = google_service_account.terraform_apply
+  id = "projects/orino-499511/serviceAccounts/github-actions-terraform@orino-499511.iam.gserviceaccount.com"
+}
+
+import {
+  to = google_service_account.terraform_plan
+  id = "projects/orino-499511/serviceAccounts/github-actions-terraform-plan@orino-499511.iam.gserviceaccount.com"
+}
+
+import {
+  to = google_project_iam_member.terraform_apply["roles/serviceusage.serviceUsageAdmin"]
+  id = "orino-499511 roles/serviceusage.serviceUsageAdmin serviceAccount:github-actions-terraform@orino-499511.iam.gserviceaccount.com"
+}
+
+import {
+  to = google_project_iam_member.terraform_apply["roles/serviceusage.apiKeysAdmin"]
+  id = "orino-499511 roles/serviceusage.apiKeysAdmin serviceAccount:github-actions-terraform@orino-499511.iam.gserviceaccount.com"
+}
+
+import {
+  to = google_project_iam_member.terraform_plan["roles/serviceusage.serviceUsageViewer"]
+  id = "orino-499511 roles/serviceusage.serviceUsageViewer serviceAccount:github-actions-terraform-plan@orino-499511.iam.gserviceaccount.com"
+}
+
+import {
+  to = google_project_iam_member.terraform_plan["roles/serviceusage.apiKeysViewer"]
+  id = "orino-499511 roles/serviceusage.apiKeysViewer serviceAccount:github-actions-terraform-plan@orino-499511.iam.gserviceaccount.com"
+}
+
+import {
+  to = google_billing_account_iam_member.terraform_apply
+  id = "billingAccounts/01EDAC-CEFAA5-004180 roles/billing.costsManager serviceAccount:github-actions-terraform@orino-499511.iam.gserviceaccount.com"
+}
+
+import {
+  to = google_billing_account_iam_member.terraform_plan
+  id = "billingAccounts/01EDAC-CEFAA5-004180 roles/billing.viewer serviceAccount:github-actions-terraform-plan@orino-499511.iam.gserviceaccount.com"
+}
+
+import {
+  to = google_service_account_iam_member.terraform_apply_wif
+  id = "projects/orino-499511/serviceAccounts/github-actions-terraform@orino-499511.iam.gserviceaccount.com roles/iam.workloadIdentityUser principalSet://iam.googleapis.com/projects/202935442863/locations/global/workloadIdentityPools/github-actions/attribute.repository/wcorn/orino"
+}
+
+import {
+  to = google_service_account_iam_member.terraform_plan_wif
+  id = "projects/orino-499511/serviceAccounts/github-actions-terraform-plan@orino-499511.iam.gserviceaccount.com roles/iam.workloadIdentityUser principalSet://iam.googleapis.com/projects/202935442863/locations/global/workloadIdentityPools/github-actions/attribute.repository/wcorn/orino"
+}

--- a/infra/terraform/gcp-travel.tf
+++ b/infra/terraform/gcp-travel.tf
@@ -11,6 +11,8 @@ locals {
     "places.googleapis.com",
     "routes.googleapis.com",
     "billingbudgets.googleapis.com",
+    # Terraform이 API 키를 읽고 관리하는 통로. gcloud로 만들 때는 다른 경로라 필요 없었다.
+    "apikeys.googleapis.com",
   ]
 }
 

--- a/infra/terraform/gcp-travel.tf
+++ b/infra/terraform/gcp-travel.tf
@@ -1,0 +1,88 @@
+# 여행 모듈이 쓰는 Google Cloud 리소스 (#1050, Epic #1029 · 2단계).
+#
+# Places = 장소 검색·상세, Routes = 이동시간(WALK/DRIVE). 둘 다 유료 API라
+# 결제 계정 연결이 전제다(콘솔에서 카드 등록 — 코드로 못 한다).
+#
+# 이 파일의 리소스는 처음에 gcloud로 만들어졌다. import 블록으로 그대로 넘겨받아
+# 재생성 없이 Terraform 관리로 옮긴다(#1052).
+
+locals {
+  gcp_travel_services = [
+    "places.googleapis.com",
+    "routes.googleapis.com",
+    "billingbudgets.googleapis.com",
+  ]
+}
+
+resource "google_project_service" "travel" {
+  for_each = toset(local.gcp_travel_services)
+
+  project = var.gcp_project_id
+  service = each.value
+
+  # 이 리소스를 지운다고 API까지 끄지 않는다 — 끄면 운영 중인 호출이 즉시 죽는다.
+  disable_on_destroy = false
+}
+
+# 서버가 자기 이름으로 호출하는 API 키. 사용자 OAuth(google-secret)와 별개다.
+#
+# IP 제한을 두지 않는 이유는 결정 기록 D-15 — 클러스터 이그레스가 집 회선이라
+# 공인 IP가 고정이 아니다. 대신 호출 가능한 API를 둘로 묶고, 금전 피해는 예산 알림이 잡는다.
+resource "google_apikeys_key" "travel_places_routes" {
+  project      = var.gcp_project_id
+  name         = "orino-travel-places-routes"
+  display_name = "orino-travel-places-routes"
+
+  restrictions {
+    api_targets {
+      service = "places.googleapis.com"
+    }
+    api_targets {
+      service = "routes.googleapis.com"
+    }
+  }
+
+  depends_on = [google_project_service.travel]
+}
+
+# 프로젝트 전체 월 예산. Places/Routes만 걸면 다른 API가 폭주할 때 못 잡는다.
+#
+# 1인 사용이라 정상 사용은 무료 한도 안에서 끝난다. 이 금액은 "정상이면 절대 안 닿는" 선이면서
+# 키가 새어 폭주할 때 카드가 크게 긁히기 전에 걸리는 값이다.
+resource "google_billing_budget" "orino" {
+  billing_account = var.gcp_billing_account
+  display_name    = "orino 월 예산"
+
+  budget_filter {
+    projects = ["projects/${var.gcp_project_number}"]
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "KRW"
+      units         = tostring(var.gcp_budget_krw)
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 0.5
+  }
+  threshold_rules {
+    threshold_percent = 0.9
+  }
+  threshold_rules {
+    threshold_percent = 1.0
+  }
+  # 실제로 닿기 전에 미리 알리는 조기 경보.
+  threshold_rules {
+    threshold_percent = 1.0
+    spend_basis       = "FORECASTED_SPEND"
+  }
+
+  depends_on = [google_project_service.travel]
+}
+
+output "gcp_travel_api_key_name" {
+  description = "여행 Places/Routes API 키 리소스 이름 (값은 .secrets / SealedSecret 참조)"
+  value       = google_apikeys_key.travel_places_routes.name
+}

--- a/infra/terraform/gcp-travel.tf
+++ b/infra/terraform/gcp-travel.tf
@@ -31,8 +31,13 @@ resource "google_project_service" "travel" {
 # IP 제한을 두지 않는 이유는 결정 기록 D-15 — 클러스터 이그레스가 집 회선이라
 # 공인 IP가 고정이 아니다. 대신 호출 가능한 API를 둘로 묶고, 금전 피해는 예산 알림이 잡는다.
 resource "google_apikeys_key" "travel_places_routes" {
-  project      = var.gcp_project_id
-  name         = "orino-travel-places-routes"
+  project = var.gcp_project_id
+
+  # `name`은 표시 이름이 아니라 **키 ID**다. gcloud가 만들 때 UUID로 정해졌고,
+  # 이 값을 바꾸면 Terraform이 키를 삭제·재생성한다 → 키 문자열이 바뀌어
+  # 이미 봉인한 SealedSecret(#1051)과 .secrets가 통째로 무효가 된다.
+  # 사람이 읽는 이름은 display_name이 담당하므로 ID는 그대로 둔다.
+  name         = "18229d57-dd99-439e-82a7-41ee91af8308"
   display_name = "orino-travel-places-routes"
 
   restrictions {

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
   }
 
   backend "s3" {
@@ -21,4 +25,10 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
+}
+
+# 여행 모듈의 Places/Routes·예산(#1050). 자격증명은 CI가 Workload Identity Federation으로
+# 주입한다 — 서비스 계정 키 파일을 만들지 않는다(AWS를 OIDC로만 쓰는 것과 같은 이유).
+provider "google" {
+  project = var.gcp_project_id
 }

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -2,3 +2,6 @@
 # terraform.tfvars는 .gitignore로 추적 제외됩니다.
 
 operator_emails = ["you@example.com"]
+
+# GCP 관련 값(프로젝트·결제계정·예산액)은 variables.tf에 기본값이 있어 따로 채우지 않아도 된다.
+# 예산액만 바꾸려면: gcp_budget_krw = 50000

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -3,3 +3,29 @@ variable "aws_region" {
   type        = string
   default     = "ap-northeast-2"
 }
+
+# --- Google Cloud (여행 모듈, #1050) ---
+
+variable "gcp_project_id" {
+  description = "orino GCP 프로젝트 ID"
+  type        = string
+  default     = "orino-499511"
+}
+
+variable "gcp_project_number" {
+  description = "orino GCP 프로젝트 번호(예산 필터가 번호를 쓴다)"
+  type        = string
+  default     = "202935442863"
+}
+
+variable "gcp_billing_account" {
+  description = "결제 계정 ID. 예산이 붙는 대상(비밀값 아님 — AWS 계정 ID와 같은 식별자)"
+  type        = string
+  default     = "01EDAC-CEFAA5-004180"
+}
+
+variable "gcp_budget_krw" {
+  description = "월 예산(원). 정상 사용이면 닿지 않고, 폭주 시 조기에 걸리는 값"
+  type        = number
+  default     = 30000
+}


### PR DESCRIPTION
## 이슈
closes #1052

## 왜 이 PR이 필요한가

#1050에서 Places/Routes 준비를 **gcloud CLI로 명령형 실행**했다. "모든 인프라는 Git으로 관리한다"는 원칙 위반이다. 코드로 되돌린다.

AWS는 이미 `cicd.tf`에서 **CI 자격증명 자체를 Terraform이 관리**하고 있다(OIDC provider + plan/apply role 분리). GCP도 같은 구조로 맞췄다.

## 되돌리지 않고 흡수한다

이미 만들어진 리소스를 지우고 다시 만들면 **API 키가 새 값으로 재발급**되고, 머지된 SealedSecret(#1051)과 `.secrets`를 전부 다시 봉인해야 한다. `import` 블록 17개로 **삭제·재생성 없이** state에만 편입시킨다.

## 무엇을 코드로 옮겼나

**`gcp-cicd.tf`** — `cicd.tf`(AWS)와 같은 구조
- WIF 풀·provider (속성 조건 `assertion.repository == 'wcorn/orino'`)
- `github-actions-terraform` (apply, 쓰기) / `github-actions-terraform-plan` (plan, 읽기 전용)
- 프로젝트 역할 + **결제 계정 역할** + WIF 바인딩

**`gcp-travel.tf`**
- Places·Routes·Budgets API 활성화 (`disable_on_destroy = false` — 리소스를 지운다고 운영 중인 API가 꺼지면 안 된다)
- API 키 + API 제한 2개
- 프로젝트 월 예산 + 임계값 4개

**`.github/workflows/terraform.yml`** — `google-github-actions/auth@v2`. AWS와 같이 PR은 plan SA, main push는 apply SA를 가장한다. **서비스 계정 키 파일 없음.**

## 걸렸던 것 두 가지

**예산은 프로젝트가 아니라 결제 계정에 붙는 리소스다.** `billing.*` 역할을 프로젝트에 주면 예산을 못 읽는다. 결제 계정(`billingAccounts/...`)에 부여했다.

**plan SA에도 `apiKeysViewer`가 필요하다.** Terraform의 `google_apikeys_key`는 refresh 때 키 문자열까지 읽는다(`apikeys.keys.getKeyString`). 이 권한이 없으면 PR plan이 깨진다 — 역할에 포함돼 있는지 확인했다.

## 부트스트랩이 코드 밖인 이유

CI 자격증명은 "자기 자신을 만드는" 관계라 처음 한 번은 코드 밖에서 만들 수밖에 없다(풀·provider는 콘솔, 서비스 계정은 CLI). AWS의 OIDC provider·role도 같은 경로를 거쳤다. 만든 뒤로는 Terraform이 관리한다.

## 검증

- `terraform fmt -check -recursive` 통과
- `terraform validate` 통과
- 워크플로 YAML 파싱 확인
- 콘솔에서 만드신 풀·provider의 이름·issuer·속성 매핑·**속성 조건**이 코드와 일치하는지 대조 완료

**이 PR의 진짜 검증은 CI plan이다.** `17 to import, 0 to add, 0 to change, 0 to destroy` 가 떠야 정상이다.
- `to add`가 있으면 → import ID가 안 맞는 것(리소스가 새로 생긴다)
- `to change`가 있으면 → 코드가 실제 설정과 다른 것

둘 중 하나라도 있으면 **머지 전에 멈추고 고쳐야 한다.**

## 머지 후

apply가 state에 편입시킨다. 그 뒤 `gcp-travel-import.tf`는 지워도 된다(남겨도 동작에는 영향 없음).