### PR TITLE
fix : 새벽 4시 이전에 돌리면 복습 테스트가 깨지던 문제

### DIFF
--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/mirror/ReviewMirrorIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/mirror/ReviewMirrorIntegrationTest.java
@@ -113,7 +113,7 @@ class ReviewMirrorIntegrationTest extends ApiTestSupport {
         accessTokenRepository.save(memberId, "test-access", Duration.ofMinutes(30));
 
         authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
-        today = clock.instant().atZone(TEST_ZONE).toLocalDate();
+        today = testToday(clock);
     }
 
     @Test

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/ApiTestSupport.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/ApiTestSupport.java
@@ -1,5 +1,6 @@
 package ds.project.orino.support;
 
+import ds.project.orino.common.time.StudyDay;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
@@ -39,8 +40,13 @@ public abstract class ApiTestSupport {
         return localDateTime.atZone(TEST_ZONE).toInstant();
     }
 
-    /** 사용자 시간대(Asia/Seoul) 기준 오늘 날짜. */
+    /**
+     * 앱이 "오늘"로 보는 학습일(Asia/Seoul, 04시 롤오버).
+     *
+     * <p>달력 날짜를 쓰면 자정~04:00 사이에 돌릴 때만 하루 어긋나 테스트가 깨진다 —
+     * 그 시간대엔 앱이 아직 전날을 오늘로 보기 때문이다({@link StudyDay}).
+     */
     protected static LocalDate testToday(Clock clock) {
-        return clock.instant().atZone(TEST_ZONE).toLocalDate();
+        return StudyDay.of(clock.instant(), TEST_ZONE);
     }
 }


### PR DESCRIPTION
## 이슈
closes #1055
## 작업 내용
- `ApiTestSupport.testToday()`를 `StudyDay.of()` 기준으로 교정 — 앱이 보는 학습일(04시 롤오버)과 헬퍼가 어긋나 있었다
- `ReviewMirrorIntegrationTest`가 들고 있던 같은 계산의 인라인 사본을 공용 헬퍼로 통일

테스트 코드만 바뀐다. 프로덕션 로직은 원래 맞았고, **테스트가 시간에 의존**하던 게 문제였다.

2026-08-08 03:36 KST에 `./gradlew check`를 돌려 16개 실패를 재현했고(`TodayReviews` 8 · `Flashcard` 4 · `ReviewMirror` 4), 수정 후 같은 시각에 통과를 확인했다. CI는 UTC라 매일 18:00~22:00 UTC 구간에 걸린다.