### PR TITLE
feat : 장소 검색·상세 프록시 + Redis 캐시

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityWriteRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityWriteRequest.java
@@ -30,6 +30,12 @@ public record ActivityWriteRequest(
 
         Long placeId,
 
+        /**
+         * 구글 장소를 그대로 담을 때 쓴다(S-06 "담기"). 서버가 {@code travel_place}에 upsert 한 뒤
+         * {@code placeId}로 연결한다 — 화면이 장소를 먼저 저장하고 id를 들고 오지 않아도 되게.
+         */
+        String googlePlaceId,
+
         @Size(max = 1000, message = "메모는 1000자를 넘을 수 없습니다.")
         String memo,
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
@@ -12,6 +12,7 @@ import ds.project.orino.planner.travel.activity.dto.ActivityPlace;
 import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
 import ds.project.orino.planner.travel.activity.dto.ActivityWriteRequest;
 import ds.project.orino.planner.travel.activity.dto.ReorderRequest;
+import ds.project.orino.planner.travel.place.service.PlaceService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,19 +47,37 @@ public class ActivityService {
     private final TripActivityRepository activityRepository;
     private final TripRepository tripRepository;
     private final TravelPlaceRepository placeRepository;
+    private final PlaceService placeService;
 
     public ActivityService(TripActivityRepository activityRepository,
                            TripRepository tripRepository,
-                           TravelPlaceRepository placeRepository) {
+                           TravelPlaceRepository placeRepository,
+                           PlaceService placeService) {
         this.activityRepository = activityRepository;
         this.tripRepository = tripRepository;
         this.placeRepository = placeRepository;
+        this.placeService = placeService;
+    }
+
+    /**
+     * 요청의 장소를 내부 id로 정규화한다.
+     *
+     * <p>화면은 구글 검색 결과를 그대로 "담기"로 보내므로(§5), 그때 장소를 upsert 해 id로 바꾼다.
+     * 이미 담아 둔 장소면 새로 만들지 않고 기존 것을 재사용한다 — 여행을 가로질러 같은 장소를
+     * 가리켜야 "이전 여행에서 좋았던 곳" 판정이 성립한다.
+     */
+    private Long resolvePlaceId(Long memberId, ActivityWriteRequest request) {
+        if (request.googlePlaceId() != null && !request.googlePlaceId().isBlank()) {
+            return placeService.upsertFromGoogle(memberId, request.googlePlaceId()).getId();
+        }
+        return request.placeId();
     }
 
     /** 새 일정은 해당 날짜(또는 보관함)의 맨 뒤에 붙인다. 클라이언트가 순서를 정하지 않는다. */
     @Transactional
     public ActivityResponse create(Long memberId, Long tripId, ActivityWriteRequest request) {
         Trip trip = getOwnedTrip(memberId, tripId);
+        Long placeId = resolvePlaceId(memberId, request);
         requireDateWithinTrip(trip, request.activityDate());
 
         int sortOrder = activityRepository.nextSortOrder(tripId, request.activityDate());
@@ -66,7 +85,7 @@ public class ActivityService {
                 request.activityDate(), sortOrder, request.startTime());
         // 생성자가 안 받는 나머지 계획 필드(메모·링크·장소·알림)를 이어서 채운다.
         activity.update(request.title().trim(), request.startTime(), request.memo(), request.url());
-        activity.updatePlace(request.placeId());
+        activity.updatePlace(placeId);
         activity.updateNotification(request.notifyEnabledOrDefault(), request.notifyMinutes(),
                 request.departureNotifyEnabledOrDefault());
 
@@ -86,6 +105,7 @@ public class ActivityService {
         TripActivity activity = getOwnedActivity(memberId, activityId);
         Trip trip = getTripOf(activity);
         requireDateWithinTrip(trip, request.activityDate());
+        Long placeId = resolvePlaceId(memberId, request);
 
         if (!Objects.equals(activity.getActivityDate(), request.activityDate())) {
             LocalDate previousDate = activity.getActivityDate();
@@ -95,7 +115,7 @@ public class ActivityService {
             reindex(activity.getTripId(), previousDate);
         }
         activity.update(request.title().trim(), request.startTime(), request.memo(), request.url());
-        activity.updatePlace(request.placeId());
+        activity.updatePlace(placeId);
         activity.updateNotification(request.notifyEnabledOrDefault(), request.notifyMinutes(),
                 request.departureNotifyEnabledOrDefault());
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/GooglePlacesClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/GooglePlacesClient.java
@@ -1,0 +1,198 @@
+package ds.project.orino.planner.travel.place.client;
+
+import ds.project.orino.planner.travel.place.config.PlacesProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Places API (New) 호출 래퍼.
+ *
+ * <p>필드마스크를 반드시 보낸다 — Places API는 요청한 필드에 따라 <b>과금 등급이 갈린다</b>.
+ * 전체를 받으면 쓰지도 않을 필드 때문에 비싼 등급으로 청구된다.
+ *
+ * <p>실패는 예외로 올리지 않고 빈 결과로 떨어뜨린다. 장소 검색이 안 된다고 일정 편집까지
+ * 막을 이유가 없다(§외부 API 실패는 화면이 계속 동작해야 한다).
+ */
+@Component
+public class GooglePlacesClient implements PlacesClient {
+
+    private static final Logger log = LoggerFactory.getLogger(GooglePlacesClient.class);
+
+    /** 검색 목록에 필요한 최소 필드. */
+    private static final String SEARCH_MASK = String.join(",",
+            "places.id", "places.displayName", "places.formattedAddress",
+            "places.location", "places.rating", "places.primaryTypeDisplayName");
+
+    /** 도시 검색은 타임존·국가까지 필요하다(여행의 타임존·통화를 여기서 확정한다). */
+    private static final String CITY_MASK = String.join(",",
+            "places.id", "places.displayName", "places.formattedAddress",
+            "places.location", "places.timeZone", "places.addressComponents");
+
+    /** 상세는 영업시간·전화번호가 추가된다. */
+    private static final String DETAILS_MASK = String.join(",",
+            "id", "displayName", "formattedAddress", "location", "rating",
+            "primaryTypeDisplayName", "nationalPhoneNumber", "regularOpeningHours",
+            "timeZone", "addressComponents");
+
+    private final RestClient restClient;
+    private final PlacesProperties props;
+    private final ObjectMapper objectMapper;
+
+    public GooglePlacesClient(PlacesProperties props, ObjectMapper objectMapper) {
+        this.props = props;
+        this.objectMapper = objectMapper;
+        this.restClient = RestClient.builder()
+                .baseUrl(props.baseUrl())
+                .requestFactory(requestFactory(props))
+                .build();
+    }
+
+    private static ClientHttpRequestFactory requestFactory(PlacesProperties props) {
+        var factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(props.connectTimeout());
+        factory.setReadTimeout(props.readTimeout());
+        return factory;
+    }
+
+    @Override
+    public List<PlaceResult> searchCities(String query) {
+        // 행정구역만 받아 "도쿄 라멘집"이 목적지 후보로 뜨지 않게 한다.
+        Map<String, Object> body = Map.of(
+                "textQuery", query,
+                "languageCode", props.languageCode(),
+                "maxResultCount", 5,
+                "includedType", "locality");
+        return searchText(body, CITY_MASK);
+    }
+
+    @Override
+    public List<PlaceResult> searchPlaces(String query, Coordinates bias) {
+        var body = new java.util.HashMap<String, Object>();
+        body.put("textQuery", query);
+        body.put("languageCode", props.languageCode());
+        body.put("maxResultCount", props.maxResults());
+        if (bias != null) {
+            // 편향이지 필터가 아니다 — 반경 밖 결과도 나올 수 있고, 그게 맞다.
+            body.put("locationBias", Map.of("circle", Map.of(
+                    "center", Map.of("latitude", bias.lat(), "longitude", bias.lng()),
+                    "radius", (double) props.searchRadiusM())));
+        }
+        return searchText(body, SEARCH_MASK);
+    }
+
+    @Override
+    public Optional<PlaceResult> fetchDetails(String googlePlaceId) {
+        if (!props.enabled()) {
+            return Optional.empty();
+        }
+        try {
+            JsonNode node = restClient.get()
+                    .uri("/v1/places/{id}?languageCode={lang}", googlePlaceId, props.languageCode())
+                    .header("X-Goog-Api-Key", props.apiKey())
+                    .header("X-Goog-FieldMask", DETAILS_MASK)
+                    .retrieve()
+                    .body(JsonNode.class);
+            return Optional.ofNullable(node).map(this::toResult);
+        } catch (Exception e) {
+            log.warn("Places 상세 조회 실패: placeId={}, {}", googlePlaceId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private List<PlaceResult> searchText(Map<String, Object> body, String fieldMask) {
+        if (!props.enabled()) {
+            return List.of();
+        }
+        try {
+            JsonNode root = restClient.post()
+                    .uri("/v1/places:searchText")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-Goog-Api-Key", props.apiKey())
+                    .header("X-Goog-FieldMask", fieldMask)
+                    .body(body)
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            JsonNode places = root == null ? null : root.get("places");
+            if (places == null || !places.isArray()) {
+                // 결과 없음도 정상이다(검색어가 안 맞았을 뿐).
+                return List.of();
+            }
+            List<PlaceResult> results = new ArrayList<>();
+            for (JsonNode place : places) {
+                results.add(toResult(place));
+            }
+            return results;
+        } catch (Exception e) {
+            log.warn("Places 검색 실패: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private PlaceResult toResult(JsonNode node) {
+        JsonNode location = node.get("location");
+        return new PlaceResult(
+                text(node, "id"),
+                nestedText(node, "displayName", "text"),
+                text(node, "formattedAddress"),
+                decimal(location, "latitude"),
+                decimal(location, "longitude"),
+                nestedText(node, "primaryTypeDisplayName", "text"),
+                decimal(node, "rating"),
+                text(node, "nationalPhoneNumber"),
+                rawJson(node.get("regularOpeningHours")),
+                nestedText(node, "timeZone", "id"),
+                countryCode(node.get("addressComponents")));
+    }
+
+    /** 주소 구성요소에서 국가 코드(alpha-2)를 뽑는다. 통화를 여기서 유도한다. */
+    private String countryCode(JsonNode components) {
+        if (components == null || !components.isArray()) {
+            return null;
+        }
+        for (JsonNode component : components) {
+            JsonNode types = component.get("types");
+            if (types == null) {
+                continue;
+            }
+            for (JsonNode type : types) {
+                if ("country".equals(type.asString())) {
+                    return text(component, "shortText");
+                }
+            }
+        }
+        return null;
+    }
+
+    private String rawJson(JsonNode node) {
+        return node == null || node.isNull() ? null : objectMapper.writeValueAsString(node);
+    }
+
+    private String text(JsonNode node, String field) {
+        JsonNode value = node == null ? null : node.get(field);
+        return value == null || value.isNull() ? null : value.asString();
+    }
+
+    private String nestedText(JsonNode node, String field, String child) {
+        JsonNode value = node == null ? null : node.get(field);
+        return text(value, child);
+    }
+
+    private BigDecimal decimal(JsonNode node, String field) {
+        JsonNode value = node == null ? null : node.get(field);
+        return value == null || value.isNull() ? null : value.decimalValue();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/PlaceResult.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/PlaceResult.java
@@ -1,0 +1,29 @@
+package ds.project.orino.planner.travel.place.client;
+
+import java.math.BigDecimal;
+
+/**
+ * Places 응답에서 우리가 쓰는 것만 뽑은 결과.
+ *
+ * <p>구글 응답 구조를 그대로 위로 흘리지 않는다 — 필드마스크를 바꾸거나 API 버전이 올라가도
+ * 서비스·컨트롤러가 흔들리지 않게 여기서 한 번 끊는다.
+ *
+ * @param googlePlaceId 구글 장소 식별자
+ * @param timezone      IANA 타임존. <b>Places가 직접 준다</b>(좌표→타임존 매핑이 필요 없다)
+ * @param countryCode   ISO 3166-1 alpha-2. 통화를 여기서 유도한다
+ * @param openingHours  영업시간 원본 JSON. 구조를 해석하지 않고 그대로 캐시해 FE에 넘긴다
+ */
+public record PlaceResult(
+        String googlePlaceId,
+        String name,
+        String address,
+        BigDecimal lat,
+        BigDecimal lng,
+        String category,
+        BigDecimal rating,
+        String phone,
+        String openingHours,
+        String timezone,
+        String countryCode
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/PlacesClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/PlacesClient.java
@@ -1,0 +1,30 @@
+package ds.project.orino.planner.travel.place.client;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Google Places 호출 경계. 캐시는 상위 서비스가 흡수하므로 여기선 순수 호출만 한다.
+ *
+ * <p>인터페이스로 끊어 둔 이유는 테스트다 — 통합 테스트가 실제 구글을 부르면 유료 호출이
+ * 발생하고 결과도 시점마다 달라진다.
+ */
+public interface PlacesClient {
+
+    /** 도시 단위 검색(S-03 목적지). 타임존·통화를 확정하려고 행정구역만 고른다. */
+    List<PlaceResult> searchCities(String query);
+
+    /**
+     * 일반 장소 검색(S-06).
+     *
+     * @param bias 목적지 좌표. 있으면 그 주변을 우선한다(§1.5). null이면 편향 없음
+     */
+    List<PlaceResult> searchPlaces(String query, Coordinates bias);
+
+    /** 장소 상세(영업시간·전화번호). */
+    Optional<PlaceResult> fetchDetails(String googlePlaceId);
+
+    record Coordinates(BigDecimal lat, BigDecimal lng) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/config/PlacesProperties.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/config/PlacesProperties.java
@@ -1,0 +1,40 @@
+package ds.project.orino.planner.travel.place.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * Google Places 설정.
+ *
+ * <p>{@code apiKey}가 비어 있으면 장소 기능만 꺼지고 앱은 정상 기동한다 — 2단계 전 환경이나
+ * 로컬에서 키 없이 나머지를 개발할 수 있어야 한다.
+ *
+ * @param apiKey         Places/Routes 공용 API 키(비면 기능 비활성)
+ * @param baseUrl        Places API (New) base URL
+ * @param languageCode   응답 언어
+ * @param searchTtl      검색 결과 캐시 TTL(§4.7 — 1시간)
+ * @param detailsTtl     장소 상세 유효기간(§4.7 — 30일). 지나면 재조회
+ * @param maxResults     검색 결과 개수(§S-06 — 20개)
+ * @param searchRadiusM  목적지 좌표를 중심으로 검색을 편향시킬 반경
+ * @param connectTimeout 연결 타임아웃
+ * @param readTimeout    읽기 타임아웃
+ */
+@ConfigurationProperties(prefix = "travel.places")
+public record PlacesProperties(
+        String apiKey,
+        String baseUrl,
+        String languageCode,
+        Duration searchTtl,
+        Duration detailsTtl,
+        int maxResults,
+        int searchRadiusM,
+        Duration connectTimeout,
+        Duration readTimeout
+) {
+
+    /** 키가 없으면 외부 호출을 시도하지 않는다. */
+    public boolean enabled() {
+        return apiKey != null && !apiKey.isBlank();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/controller/PlaceController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/controller/PlaceController.java
@@ -1,0 +1,59 @@
+package ds.project.orino.planner.travel.place.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.travel.place.dto.CityResponse;
+import ds.project.orino.planner.travel.place.dto.PlaceCreateRequest;
+import ds.project.orino.planner.travel.place.dto.PlaceDetail;
+import ds.project.orino.planner.travel.place.dto.PlaceSearchResult;
+import ds.project.orino.planner.travel.place.service.PlaceService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/** 장소 프록시. 브라우저가 Google API를 직접 부르지 않는다(키 비노출 + 캐시 + 응답 형태 통제). */
+@RestController
+@RequestMapping("/api/travel/places")
+public class PlaceController {
+
+    private final PlaceService placeService;
+
+    public PlaceController(PlaceService placeService) {
+        this.placeService = placeService;
+    }
+
+    /** S-03 목적지 검색. 타임존·통화를 확정해서 준다. */
+    @GetMapping("/cities")
+    public ApiResponse<List<CityResponse>> cities(@RequestParam String q) {
+        return ApiResponse.success(placeService.searchCities(q));
+    }
+
+    /** S-06 장소 검색. {@code tripId}를 주면 그 목적지 주변을 우선한다. */
+    @GetMapping("/search")
+    public ApiResponse<List<PlaceSearchResult>> search(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam String q,
+            @RequestParam(required = false) Long tripId) {
+        return ApiResponse.success(placeService.searchPlaces(memberId, q, tripId));
+    }
+
+    @GetMapping("/{placeId}")
+    public ApiResponse<PlaceDetail> detail(@AuthenticationPrincipal Long memberId,
+                                           @PathVariable Long placeId) {
+        return ApiResponse.success(placeService.detail(memberId, placeId));
+    }
+
+    /** 직접 입력(검색 결과가 없을 때). */
+    @PostMapping
+    public ApiResponse<PlaceDetail> create(@AuthenticationPrincipal Long memberId,
+                                           @Valid @RequestBody PlaceCreateRequest request) {
+        return ApiResponse.success(placeService.createManual(memberId, request));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/CityResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/CityResponse.java
@@ -1,0 +1,20 @@
+package ds.project.orino.planner.travel.place.dto;
+
+import java.math.BigDecimal;
+
+/**
+ * S-03 목적지 후보. <b>타임존·통화를 서버가 확정해서</b> 내려준다.
+ *
+ * <p>FE는 받아서 보여주기만 한다 — 사용자가 도시를 고르면 여행의 타임존·통화가 자동으로
+ * 정해지고, 화면은 "자동 지정됐어요" Alert에 이 값을 그대로 쓴다.
+ */
+public record CityResponse(
+        String googlePlaceId,
+        String name,
+        String address,
+        BigDecimal lat,
+        BigDecimal lng,
+        String timezone,
+        String currency
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceCreateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceCreateRequest.java
@@ -1,0 +1,22 @@
+package ds.project.orino.planner.travel.place.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+
+/**
+ * 직접 입력한 장소(S-06 "검색 결과가 없어요"). 구글에 없는 곳도 일정에 넣을 수 있어야 한다.
+ */
+public record PlaceCreateRequest(
+        @NotBlank(message = "장소 이름을 입력해 주세요.")
+        @Size(max = 200, message = "장소 이름은 200자를 넘을 수 없습니다.")
+        String name,
+
+        @Size(max = 500, message = "주소는 500자를 넘을 수 없습니다.")
+        String address,
+
+        BigDecimal lat,
+        BigDecimal lng
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceDetail.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceDetail.java
@@ -1,0 +1,34 @@
+package ds.project.orino.planner.travel.place.dto;
+
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+
+import java.math.BigDecimal;
+
+/**
+ * 저장된 장소 상세. 일정 상세 화면의 장소 블록이 쓴다.
+ *
+ * @param openingHours 구글 영업시간 원본 JSON. 서버가 구조를 해석하지 않고 그대로 넘긴다 —
+ *                     표기 규칙이 나라마다 달라 서버가 문자열을 만들면 오히려 어색해진다
+ */
+public record PlaceDetail(
+        Long id,
+        String googlePlaceId,
+        String name,
+        String address,
+        BigDecimal lat,
+        BigDecimal lng,
+        String category,
+        String phone,
+        BigDecimal rating,
+        String openingHours,
+        String photoUrl,
+        boolean manualEntry
+) {
+
+    public static PlaceDetail from(TravelPlace place, String photoUrl) {
+        return new PlaceDetail(place.getId(), place.getGooglePlaceId(), place.getName(),
+                place.getAddress(), place.getLat(), place.getLng(), place.getCategory(),
+                place.getPhone(), place.getRating(), place.getOpeningHours(), photoUrl,
+                place.isManualEntry());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceSearchResult.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceSearchResult.java
@@ -1,0 +1,25 @@
+package ds.project.orino.planner.travel.place.dto;
+
+import java.math.BigDecimal;
+
+/**
+ * S-06 장소 검색 결과 한 건.
+ *
+ * @param id       이미 담아 둔 장소면 내부 id, 아니면 null
+ * @param photoUrl MinIO에 캐시한 대표 사진. 사진 캐시는 별도 이슈라 지금은 항상 null
+ * @param loved    이전 여행에서 평점 4 이상을 준 곳(⭐ 좋았던 곳).
+ *                 기록 테이블이 4단계라 지금은 항상 false
+ */
+public record PlaceSearchResult(
+        Long id,
+        String googlePlaceId,
+        String name,
+        String category,
+        String address,
+        BigDecimal rating,
+        String photoUrl,
+        BigDecimal lat,
+        BigDecimal lng,
+        boolean loved
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
@@ -1,0 +1,221 @@
+package ds.project.orino.planner.travel.place.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.place.client.PlaceResult;
+import ds.project.orino.planner.travel.place.client.PlacesClient;
+import ds.project.orino.planner.travel.place.config.PlacesProperties;
+import ds.project.orino.planner.travel.place.dto.CityResponse;
+import ds.project.orino.planner.travel.place.dto.PlaceCreateRequest;
+import ds.project.orino.planner.travel.place.dto.PlaceDetail;
+import ds.project.orino.planner.travel.place.dto.PlaceSearchResult;
+import ds.project.orino.redis.planner.travel.PlaceSearchCacheRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Clock;
+import java.util.Currency;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * 장소 검색·상세 프록시. 브라우저가 Google API를 직접 부르지 않는다 —
+ * 키를 노출하지 않고, 캐시로 호출당 과금을 줄이며, 응답 형태를 우리가 정하기 위해서다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class PlaceService {
+
+    private static final Logger log = LoggerFactory.getLogger(PlaceService.class);
+
+    private final PlacesClient placesClient;
+    private final PlaceSearchCacheRepository cache;
+    private final TravelPlaceRepository placeRepository;
+    private final TripRepository tripRepository;
+    private final PlacesProperties props;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    public PlaceService(PlacesClient placesClient,
+                        PlaceSearchCacheRepository cache,
+                        TravelPlaceRepository placeRepository,
+                        TripRepository tripRepository,
+                        PlacesProperties props,
+                        ObjectMapper objectMapper,
+                        Clock clock) {
+        this.placesClient = placesClient;
+        this.cache = cache;
+        this.placeRepository = placeRepository;
+        this.tripRepository = tripRepository;
+        this.props = props;
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+    }
+
+    /**
+     * S-03 목적지 검색. 도시와 함께 <b>타임존·통화를 확정해서</b> 준다.
+     */
+    public List<CityResponse> searchCities(String query) {
+        List<PlaceResult> results = cached(
+                () -> cache.findCity(query),
+                json -> cache.saveCity(query, json, props.searchTtl()),
+                () -> placesClient.searchCities(query));
+
+        return results.stream()
+                // 타임존을 못 얻으면 목적지로 쓸 수 없다 — 여행의 모든 시각 계산이 여기서 나온다.
+                .filter(r -> r.timezone() != null)
+                .map(r -> new CityResponse(r.googlePlaceId(), r.name(), r.address(),
+                        r.lat(), r.lng(), r.timezone(), currencyOf(r.countryCode())))
+                .toList();
+    }
+
+    /**
+     * S-06 장소 검색. `tripId`를 주면 그 여행의 목적지 좌표 주변을 우선한다(§1.5).
+     */
+    public List<PlaceSearchResult> searchPlaces(Long memberId, String query, Long tripId) {
+        PlacesClient.Coordinates bias = biasOf(memberId, tripId);
+        String biasKey = bias == null ? "none" : bias.lat() + "," + bias.lng();
+
+        List<PlaceResult> results = cached(
+                () -> cache.findSearch(query, biasKey),
+                json -> cache.saveSearch(query, biasKey, json, props.searchTtl()),
+                () -> placesClient.searchPlaces(query, bias));
+
+        // 이미 담아 둔 장소는 내부 id를 실어 준다 — FE가 "담기" 대신 상태를 보여줄 수 있다.
+        Map<String, Long> savedIds = savedIdsOf(memberId, results);
+
+        return results.stream()
+                .map(r -> new PlaceSearchResult(
+                        savedIds.get(r.googlePlaceId()), r.googlePlaceId(), r.name(),
+                        r.category(), r.address(), r.rating(),
+                        // 사진 MinIO 캐시는 별도 이슈.
+                        null,
+                        r.lat(), r.lng(),
+                        // ⭐ 좋았던 곳은 기록(평점)이 있어야 판정된다 — 기록은 4단계다.
+                        false))
+                .toList();
+    }
+
+    /**
+     * 저장된 장소 상세. 캐시가 만료됐으면(§4.7 — 30일) 구글에서 다시 받아 채운다.
+     */
+    @Transactional
+    public PlaceDetail detail(Long memberId, Long placeId) {
+        TravelPlace place = placeRepository.findByIdAndMemberId(placeId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PLACE_NOT_FOUND));
+
+        if (place.getGooglePlaceId() != null && place.needsDetailsRefresh(clock.instant())) {
+            placesClient.fetchDetails(place.getGooglePlaceId()).ifPresent(fresh -> {
+                place.updateBasics(fresh.address(), fresh.lat(), fresh.lng(),
+                        fresh.category(), fresh.rating());
+                place.updateDetails(fresh.phone(), fresh.openingHours(),
+                        place.getPhotoObjectKey(), place.getPhotoAttribution(), clock.instant());
+            });
+        }
+        return PlaceDetail.from(place, null);
+    }
+
+    /**
+     * 구글 장소를 담는다. 같은 장소를 두 번 저장하지 않는다 — 이미 있으면 그걸 돌려준다
+     * (일정마다 새 행을 만들면 "이전 여행에서 좋았던 곳" 판정이 불가능해진다).
+     */
+    @Transactional
+    public TravelPlace upsertFromGoogle(Long memberId, String googlePlaceId) {
+        Optional<TravelPlace> existing =
+                placeRepository.findByMemberIdAndGooglePlaceId(memberId, googlePlaceId);
+        if (existing.isPresent()) {
+            return existing.get();
+        }
+        PlaceResult fresh = placesClient.fetchDetails(googlePlaceId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PLACE_NOT_FOUND));
+
+        TravelPlace place = TravelPlace.fromGoogle(memberId, googlePlaceId, fresh.name());
+        place.updateBasics(fresh.address(), fresh.lat(), fresh.lng(),
+                fresh.category(), fresh.rating());
+        place.updateDetails(fresh.phone(), fresh.openingHours(), null, null, clock.instant());
+        return placeRepository.save(place);
+    }
+
+    /** 직접 입력. 검색에 안 나오는 곳도 일정에 넣을 수 있어야 한다. */
+    @Transactional
+    public PlaceDetail createManual(Long memberId, PlaceCreateRequest request) {
+        TravelPlace place = TravelPlace.manual(memberId, request.name().trim());
+        place.updateBasics(request.address(), request.lat(), request.lng(), null, null);
+        return PlaceDetail.from(placeRepository.save(place), null);
+    }
+
+    // ---------------- helpers ----------------
+
+    /**
+     * 캐시에 있으면 그대로, 없으면 불러서 채운다.
+     *
+     * <p>빈 결과는 캐시하지 않는다 — 일시적 실패(타임아웃·쿼터)도 빈 목록으로 떨어지는데,
+     * 그걸 한 시간 동안 물고 있으면 복구된 뒤에도 계속 빈 화면이 된다.
+     */
+    private List<PlaceResult> cached(Supplier<Optional<String>> read,
+                                     java.util.function.Consumer<String> write,
+                                     Supplier<List<PlaceResult>> fetch) {
+        Optional<String> hit = read.get();
+        if (hit.isPresent()) {
+            try {
+                return objectMapper.readValue(hit.get(), new TypeReference<List<PlaceResult>>() {
+                });
+            } catch (Exception e) {
+                log.warn("장소 캐시 역직렬화 실패, 새로 조회한다: {}", e.getMessage());
+            }
+        }
+        List<PlaceResult> fresh = fetch.get();
+        if (!fresh.isEmpty()) {
+            write.accept(objectMapper.writeValueAsString(fresh));
+        }
+        return fresh;
+    }
+
+    /** 국가 코드 → ISO 4217. 매핑 테이블을 만들지 않고 JDK가 아는 값을 쓴다. */
+    private String currencyOf(String countryCode) {
+        if (countryCode == null || countryCode.isBlank()) {
+            return null;
+        }
+        try {
+            return Currency.getInstance(Locale.of("", countryCode)).getCurrencyCode();
+        } catch (IllegalArgumentException e) {
+            // 통화가 없는 지역(남극 등)이나 JDK가 모르는 코드. 사용자가 직접 고르면 된다.
+            return null;
+        }
+    }
+
+    private PlacesClient.Coordinates biasOf(Long memberId, Long tripId) {
+        if (tripId == null) {
+            return null;
+        }
+        Trip trip = tripRepository.findByIdAndMemberId(tripId, memberId).orElse(null);
+        if (trip == null || trip.getLat() == null || trip.getLng() == null) {
+            return null;
+        }
+        return new PlacesClient.Coordinates(trip.getLat(), trip.getLng());
+    }
+
+    private Map<String, Long> savedIdsOf(Long memberId, List<PlaceResult> results) {
+        List<String> ids = results.stream()
+                .map(PlaceResult::googlePlaceId)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        return placeRepository.findAllByMemberIdAndGooglePlaceIdIn(memberId, ids).stream()
+                .collect(Collectors.toMap(TravelPlace::getGooglePlaceId, TravelPlace::getId));
+    }
+}

--- a/be/orino-app-api/src/main/resources/application.yml
+++ b/be/orino-app-api/src/main/resources/application.yml
@@ -79,6 +79,21 @@ geocoding:
     connect-timeout: ${NOMINATIM_CONNECT_TIMEOUT:5s}
     read-timeout: ${NOMINATIM_READ_TIMEOUT:10s}
 
+travel:
+  places:
+    # 키가 없으면 장소 기능만 꺼지고 앱은 정상 기동한다(2단계 전 환경·로컬 개발용).
+    api-key: ${GOOGLE_PLACES_API_KEY:}
+    base-url: ${GOOGLE_PLACES_BASE_URL:https://places.googleapis.com}
+    language-code: ${GOOGLE_PLACES_LANGUAGE:ko}
+    # §4.7 — 검색 1시간, 장소 상세 30일.
+    search-ttl: ${GOOGLE_PLACES_SEARCH_TTL:1h}
+    details-ttl: ${GOOGLE_PLACES_DETAILS_TTL:30d}
+    max-results: ${GOOGLE_PLACES_MAX_RESULTS:20}
+    # 목적지 주변 우선(§1.5). 필터가 아니라 편향이라 반경 밖도 나올 수 있다.
+    search-radius-m: ${GOOGLE_PLACES_RADIUS_M:20000}
+    connect-timeout: ${GOOGLE_PLACES_CONNECT_TIMEOUT:5s}
+    read-timeout: ${GOOGLE_PLACES_READ_TIMEOUT:10s}
+
 management:
   tracing:
     sampling:

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
@@ -1,0 +1,393 @@
+package ds.project.orino.planner.travel.place;
+
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.planner.travel.place.client.PlaceResult;
+import ds.project.orino.planner.travel.place.client.PlacesClient;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 장소 프록시 통합 테스트. 외부 호출만 스텁으로 갈아끼우고 캐시(Redis)·저장(MySQL)은 실물을 쓴다 —
+ * 캐시가 정말 호출을 줄이는지는 실제 Redis 없이는 확인되지 않는다.
+ */
+@Import(PlaceControllerTest.StubConfig.class)
+class PlaceControllerTest extends ApiTestSupport {
+
+    /**
+     * 캐시(Redis)는 테스트 사이에 살아 있다. 지우는 대신 <b>검색어를 테스트마다 다르게</b> 둔다 —
+     * 키가 겹치지 않으면 격리가 필요 없고, 캐시 동작 자체도 그대로 검증된다.
+     */
+    private static String uniqueQuery(String label) {
+        return label + "-" + java.util.UUID.randomUUID();
+    }
+
+    @TestConfiguration
+    static class StubConfig {
+        @Bean
+        @Primary
+        PlacesClient stubPlacesClient() {
+            return new StubPlacesClient();
+        }
+    }
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TravelPlaceRepository placeRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+    @Autowired
+    private PlacesClient placesClient;
+
+    private StubPlacesClient stub;
+    private String authHeader;
+    private String otherAuthHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        stub = (StubPlacesClient) placesClient;
+        stub.reset();
+        stub.cityResults = List.of();
+        stub.placeResults = List.of();
+        stub.detailResult = Optional.empty();
+
+        memberRepository.save(MemberFixture.create());
+        memberRepository.save(MemberFixture.create("other", "password"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        otherAuthHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+    }
+
+    private static PlaceResult city(String id, String name, String tz, String country) {
+        return new PlaceResult(id, name, "일본 도쿄도", new BigDecimal("35.6762"),
+                new BigDecimal("139.6503"), null, null, null, null, tz, country);
+    }
+
+    private static PlaceResult place(String id, String name) {
+        return new PlaceResult(id, name, "도쿄도 다이토구", new BigDecimal("35.7147"),
+                new BigDecimal("139.7966"), "사찰", new BigDecimal("4.5"),
+                "+81 3-3842-0181", "{\"weekdayDescriptions\":[\"월: 06:00~17:00\"]}",
+                "Asia/Tokyo", "JP");
+    }
+
+    @Nested
+    @DisplayName("목적지 검색")
+    class Cities {
+
+        @Test
+        @DisplayName("타임존과 통화를 서버가 확정해서 준다")
+        void resolvesTimezoneAndCurrency() throws Exception {
+            stub.cityResults = List.of(city("ChIJ_tokyo", "도쿄도", "Asia/Tokyo", "JP"));
+
+            mockMvc.perform(get("/api/travel/places/cities").param("q", uniqueQuery("도쿄"))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data[0].name").value("도쿄도"))
+                    .andExpect(jsonPath("$.data[0].timezone").value("Asia/Tokyo"))
+                    // 국가 코드에서 유도한다 — 매핑 테이블을 두지 않는다.
+                    .andExpect(jsonPath("$.data[0].currency").value("JPY"));
+        }
+
+        @Test
+        @DisplayName("나라마다 통화가 달라진다")
+        void derivesCurrencyPerCountry() throws Exception {
+            stub.cityResults = List.of(
+                    city("ChIJ_paris", "파리", "Europe/Paris", "FR"),
+                    city("ChIJ_ny", "뉴욕", "America/New_York", "US"));
+
+            mockMvc.perform(get("/api/travel/places/cities").param("q", uniqueQuery("도시"))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data[0].currency").value("EUR"))
+                    .andExpect(jsonPath("$.data[1].currency").value("USD"));
+        }
+
+        @Test
+        @DisplayName("타임존을 못 얻은 후보는 버린다 — 목적지로 쓸 수 없다")
+        void dropsCandidatesWithoutTimezone() throws Exception {
+            stub.cityResults = List.of(
+                    city("ChIJ_ok", "도쿄도", "Asia/Tokyo", "JP"),
+                    city("ChIJ_bad", "어딘가", null, "JP"));
+
+            mockMvc.perform(get("/api/travel/places/cities").param("q", uniqueQuery("도쿄"))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data", hasSize(1)))
+                    .andExpect(jsonPath("$.data[0].googlePlaceId").value("ChIJ_ok"));
+        }
+
+        @Test
+        @DisplayName("같은 검색어를 다시 치면 캐시가 받아 외부 호출이 늘지 않는다")
+        void cachesCitySearch() throws Exception {
+            stub.cityResults = List.of(city("ChIJ_tokyo", "도쿄도", "Asia/Tokyo", "JP"));
+            String query = uniqueQuery("도쿄");
+
+            for (int i = 0; i < 3; i++) {
+                mockMvc.perform(get("/api/travel/places/cities").param("q", query)
+                                .header(HttpHeaders.AUTHORIZATION, authHeader))
+                        .andExpect(status().isOk());
+            }
+
+            // Places는 호출당 과금이라 이게 곧 비용이다.
+            assertThat(stub.citySearches).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("장소 검색")
+    class Search {
+
+        @Test
+        @DisplayName("검색 결과를 그대로 준다(사진·좋았던 곳은 후속 단계라 비어 있다)")
+        void returnsResults() throws Exception {
+            stub.placeResults = List.of(place("ChIJ_senso", "센소지"));
+
+            mockMvc.perform(get("/api/travel/places/search").param("q", uniqueQuery("센소지"))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data[0].name").value("센소지"))
+                    .andExpect(jsonPath("$.data[0].category").value("사찰"))
+                    .andExpect(jsonPath("$.data[0].rating").value(4.5))
+                    .andExpect(jsonPath("$.data[0].id").doesNotExist())
+                    .andExpect(jsonPath("$.data[0].photoUrl").doesNotExist())
+                    .andExpect(jsonPath("$.data[0].loved").value(false));
+        }
+
+        @Test
+        @DisplayName("이미 담아 둔 장소는 내부 id를 실어 준다")
+        void marksAlreadySavedPlaces() throws Exception {
+            Long memberId = memberRepository.findAll().get(0).getId();
+            TravelPlace saved = placeRepository.save(
+                    TravelPlace.fromGoogle(memberId, "ChIJ_senso", "센소지"));
+            stub.placeResults = List.of(place("ChIJ_senso", "센소지"));
+
+            mockMvc.perform(get("/api/travel/places/search").param("q", uniqueQuery("센소지"))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data[0].id").value(saved.getId().intValue()));
+        }
+
+        @Test
+        @DisplayName("남이 담아 둔 장소는 내 검색 결과에 id로 붙지 않는다")
+        void savedIdIsScopedByMember() throws Exception {
+            Long other = memberRepository.findAll().get(1).getId();
+            placeRepository.save(TravelPlace.fromGoogle(other, "ChIJ_senso", "센소지"));
+            stub.placeResults = List.of(place("ChIJ_senso", "센소지"));
+
+            mockMvc.perform(get("/api/travel/places/search").param("q", uniqueQuery("센소지"))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data[0].id").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("tripId를 주면 그 여행의 목적지 좌표로 검색을 편향시킨다")
+        void biasesTowardTripDestination() throws Exception {
+            long tripId = createTripWithCoordinates();
+            stub.placeResults = List.of(place("ChIJ_senso", "센소지"));
+
+            mockMvc.perform(get("/api/travel/places/search")
+                            .param("q", uniqueQuery("라멘")).param("tripId", String.valueOf(tripId))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk());
+
+            assertThat(stub.biases).hasSize(1);
+            assertThat(stub.biases.get(0)).isNotNull();
+            assertThat(stub.biases.get(0).lat()).isEqualByComparingTo("35.6762");
+        }
+
+        @Test
+        @DisplayName("tripId가 없으면 편향 없이 검색한다")
+        void searchesWithoutBias() throws Exception {
+            stub.placeResults = List.of(place("ChIJ_senso", "센소지"));
+
+            mockMvc.perform(get("/api/travel/places/search").param("q", uniqueQuery("라멘"))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk());
+
+            assertThat(stub.biases).containsExactly((PlacesClient.Coordinates) null);
+        }
+
+        @Test
+        @DisplayName("빈 결과는 캐시하지 않는다 — 일시적 실패를 한 시간 물고 있으면 안 된다")
+        void doesNotCacheEmptyResults() throws Exception {
+            String query = uniqueQuery("없는곳");
+            stub.placeResults = List.of();
+            mockMvc.perform(get("/api/travel/places/search").param("q", query)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data", hasSize(0)));
+
+            // 복구된 뒤 다시 치면 결과가 나와야 한다.
+            stub.placeResults = List.of(place("ChIJ_senso", "센소지"));
+            mockMvc.perform(get("/api/travel/places/search").param("q", query)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data", hasSize(1)));
+
+            assertThat(stub.placeSearches).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("상세 · 직접 입력")
+    class DetailAndManual {
+
+        @Test
+        @DisplayName("직접 입력한 장소가 manualEntry로 저장된다")
+        void createsManualPlace() throws Exception {
+            mockMvc.perform(post("/api/travel/places")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "숙소 근처 골목 카페", "address": "어딘가"}
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.name").value("숙소 근처 골목 카페"))
+                    .andExpect(jsonPath("$.data.manualEntry").value(true))
+                    .andExpect(jsonPath("$.data.googlePlaceId").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("이름이 없으면 400")
+        void rejectsBlankName() throws Exception {
+            mockMvc.perform(post("/api/travel/places")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "  "}
+                                    """))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("상세가 최신이면 외부를 다시 부르지 않는다")
+        void skipsRefreshWhenFresh() throws Exception {
+            Long memberId = memberRepository.findAll().get(0).getId();
+            TravelPlace saved = placeRepository.save(
+                    TravelPlace.fromGoogle(memberId, "ChIJ_senso", "센소지"));
+            saved.updateDetails("+81", "{}", null, null, java.time.Instant.now());
+            placeRepository.saveAndFlush(saved);
+
+            mockMvc.perform(get("/api/travel/places/" + saved.getId())
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.phone").value("+81"));
+
+            assertThat(stub.detailFetches).isEmpty();
+        }
+
+        @Test
+        @DisplayName("상세가 30일 지났으면 다시 받아 채운다")
+        void refreshesStaleDetails() throws Exception {
+            Long memberId = memberRepository.findAll().get(0).getId();
+            TravelPlace saved = placeRepository.save(
+                    TravelPlace.fromGoogle(memberId, "ChIJ_senso", "센소지"));
+            // 상세를 받은 적이 없으면 갱신 대상이다.
+            stub.detailResult = Optional.of(place("ChIJ_senso", "센소지"));
+
+            mockMvc.perform(get("/api/travel/places/" + saved.getId())
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.phone").value("+81 3-3842-0181"))
+                    .andExpect(jsonPath("$.data.category").value("사찰"));
+
+            assertThat(stub.detailFetches).containsExactly("ChIJ_senso");
+        }
+
+        @Test
+        @DisplayName("남의 장소는 404")
+        void otherMembersPlaceIsNotFound() throws Exception {
+            Long memberId = memberRepository.findAll().get(0).getId();
+            TravelPlace saved = placeRepository.save(
+                    TravelPlace.fromGoogle(memberId, "ChIJ_senso", "센소지"));
+
+            mockMvc.perform(get("/api/travel/places/" + saved.getId())
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-008"));
+        }
+    }
+
+    @Nested
+    @DisplayName("일정에 담기")
+    class AddToActivity {
+
+        @Test
+        @DisplayName("googlePlaceId로 담으면 장소를 저장하고 일정에 연결한다")
+        void upsertsPlaceOnCreate() throws Exception {
+            long tripId = createTripWithCoordinates();
+            stub.detailResult = Optional.of(place("ChIJ_senso", "센소지"));
+
+            mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "센소지", "activityDate": "2026-10-24",
+                                     "googlePlaceId": "ChIJ_senso"}
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.place.name").value("센소지"));
+
+            assertThat(placeRepository.findAll()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("같은 장소를 두 번 담아도 장소는 하나만 만든다")
+        void reusesExistingPlace() throws Exception {
+            long tripId = createTripWithCoordinates();
+            stub.detailResult = Optional.of(place("ChIJ_senso", "센소지"));
+
+            for (String title : List.of("아침 센소지", "저녁 센소지")) {
+                mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {"title": "%s", "activityDate": "2026-10-24",
+                                         "googlePlaceId": "ChIJ_senso"}
+                                        """.formatted(title)))
+                        .andExpect(status().isOk());
+            }
+
+            // 여행을 가로질러 같은 장소를 가리켜야 "좋았던 곳" 판정이 성립한다.
+            assertThat(placeRepository.findAll()).hasSize(1);
+            assertThat(stub.detailFetches).containsExactly("ChIJ_senso");
+        }
+    }
+
+    /** 편향 검증용 — 목적지 좌표가 있는 여행. */
+    private long createTripWithCoordinates() throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "도쿄", "destinationName": "도쿄",
+                                 "startDate": "2026-10-24", "endDate": "2026-10-27",
+                                 "timezone": "Asia/Tokyo", "currency": "JPY",
+                                 "lat": 35.6762, "lng": 139.6503}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/StubPlacesClient.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/StubPlacesClient.java
@@ -1,0 +1,52 @@
+package ds.project.orino.planner.travel.place;
+
+import ds.project.orino.planner.travel.place.client.PlaceResult;
+import ds.project.orino.planner.travel.place.client.PlacesClient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 테스트용 Places 스텁.
+ *
+ * <p>실제 구글을 부르면 <b>유료 호출이 발생하고</b> 결과도 시점마다 달라져 테스트가 흔들린다.
+ * 대신 호출 횟수를 세어 <b>캐시가 실제로 호출을 줄이는지</b>를 검증할 수 있게 한다.
+ */
+public class StubPlacesClient implements PlacesClient {
+
+    public final List<String> citySearches = new ArrayList<>();
+    public final List<String> placeSearches = new ArrayList<>();
+    public final List<Coordinates> biases = new ArrayList<>();
+    public final List<String> detailFetches = new ArrayList<>();
+
+    public List<PlaceResult> cityResults = List.of();
+    public List<PlaceResult> placeResults = List.of();
+    public Optional<PlaceResult> detailResult = Optional.empty();
+
+    @Override
+    public List<PlaceResult> searchCities(String query) {
+        citySearches.add(query);
+        return cityResults;
+    }
+
+    @Override
+    public List<PlaceResult> searchPlaces(String query, Coordinates bias) {
+        placeSearches.add(query);
+        biases.add(bias);
+        return placeResults;
+    }
+
+    @Override
+    public Optional<PlaceResult> fetchDetails(String googlePlaceId) {
+        detailFetches.add(googlePlaceId);
+        return detailResult;
+    }
+
+    public void reset() {
+        citySearches.clear();
+        placeSearches.clear();
+        biases.clear();
+        detailFetches.clear();
+    }
+}

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -43,7 +43,8 @@ public enum ErrorCode {
     TRAVEL_ARCHIVE_CONFIRM_REQUIRED("TRAVEL-ERR-005",
             "기간을 줄이면 일부 일정이 미배정 보관함으로 이동합니다.", 409),
     TRAVEL_ACTIVITY_NOT_FOUND("TRAVEL-ERR-006", "존재하지 않는 일정입니다.", 404),
-    TRAVEL_DATE_OUT_OF_RANGE("TRAVEL-ERR-007", "여행 기간 밖의 날짜입니다.", 400);
+    TRAVEL_DATE_OUT_OF_RANGE("TRAVEL-ERR-007", "여행 기간 밖의 날짜입니다.", 400),
+    TRAVEL_PLACE_NOT_FOUND("TRAVEL-ERR-008", "존재하지 않는 장소입니다.", 404);
 
     private final String code;
     private final String message;

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TravelPlaceRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TravelPlaceRepository.java
@@ -19,6 +19,9 @@ public interface TravelPlaceRepository extends JpaRepository<TravelPlace, Long> 
     /** 이미 담아둔 구글 장소인지 확인해 중복 저장을 막는다({@code uk_place_member_google}). */
     Optional<TravelPlace> findByMemberIdAndGooglePlaceId(Long memberId, String googlePlaceId);
 
+    /** 검색 결과 중 이미 담아 둔 장소를 한 번에 찾는다(결과 20개마다 조회하지 않게). */
+    List<TravelPlace> findAllByMemberIdAndGooglePlaceIdIn(Long memberId, List<String> googlePlaceIds);
+
     /** 여러 일정의 장소를 한 번에 붙일 때 쓰는 배치 조회(N+1 회피). */
     List<TravelPlace> findAllByIdIn(List<Long> ids);
 

--- a/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/travel/PlaceSearchCacheRepository.java
+++ b/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/travel/PlaceSearchCacheRepository.java
@@ -1,0 +1,50 @@
+package ds.project.orino.redis.planner.travel;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * 장소 검색 결과 캐시(§4.7 — 1시간).
+ *
+ * <p>Places는 <b>호출당 과금</b>이라 같은 검색어를 반복해서 치는 동안 계속 돈이 나간다.
+ * 여행 계획은 같은 지역을 여러 번 검색하게 되므로 캐시가 곧 비용 절감이다.
+ *
+ * <p>직렬화된 JSON 문자열을 그대로 담는다 — 직렬화는 상위 서비스가 맡아 이 모듈이 app-api
+ * 타입에 의존하지 않게 한다({@code GeocodeCacheRepository}와 같은 방식).
+ */
+@Repository
+public class PlaceSearchCacheRepository {
+
+    private static final String SEARCH_PREFIX = "travel:places:search:";
+    private static final String CITY_PREFIX = "travel:places:city:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public PlaceSearchCacheRepository(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /** 검색 캐시. 편향 좌표가 다르면 결과도 달라지므로 키에 포함한다. */
+    public Optional<String> findSearch(String query, String biasKey) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(searchKey(query, biasKey)));
+    }
+
+    public void saveSearch(String query, String biasKey, String json, Duration ttl) {
+        redisTemplate.opsForValue().set(searchKey(query, biasKey), json, ttl);
+    }
+
+    public Optional<String> findCity(String query) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(CITY_PREFIX + query));
+    }
+
+    public void saveCity(String query, String json, Duration ttl) {
+        redisTemplate.opsForValue().set(CITY_PREFIX + query, json, ttl);
+    }
+
+    private String searchKey(String query, String biasKey) {
+        return SEARCH_PREFIX + biasKey + ":" + query;
+    }
+}


### PR DESCRIPTION
## 이슈
closes #1054
## 작업 내용

브라우저가 Google Places를 직접 부르지 않게 서버가 앞에 선다. 키를 노출하지 않고, 캐시로 호출 수(=비용)를 줄이고, 응답 형태를 우리가 통제한다.

**엔드포인트** — `/api/travel/places/{cities,search,{placeId}}` + `POST /api/travel/places`(직접 입력)

**타임존·통화는 서버가 확정한다.** Places API (New)가 `timeZone`과 국가코드를 함께 주므로 좌표→IANA 매핑 라이브러리가 필요 없다. 통화는 JDK `Currency`로 국가코드에서 유도한다 — 매핑 테이블을 두지 않는다. 타임존을 못 얻은 후보는 목적지로 쓸 수 없으니 버린다.

**캐시** — 검색 1시간 / 상세 30일(§4.7). **빈 결과는 캐시하지 않는다**: 일시적 실패를 한 시간 물고 있으면 복구된 뒤에도 계속 비어 보인다.

**목적지 편향** — `tripId`를 주면 그 여행의 목적지 좌표로 검색을 편향시킨다. 필터가 아니라 편향이라 반경 밖도 나올 수 있다.

**장소 재사용** — 일정 생성 시 `googlePlaceId`로 장소를 upsert한다. 여행이 아니라 **멤버**로 스코프해야 "이전 여행에서 좋았던 곳" 판정이 성립한다.

**실패해도 여행 화면은 산다** — 외부 호출 실패는 예외 대신 빈 결과. 키가 없으면 장소 기능만 꺼지고 앱은 정상 기동한다(2단계 전 환경·로컬 개발용).

## 확인

`./gradlew check` 통과. 통합 테스트는 외부 호출만 스텁으로 갈아끼우고 캐시(Redis)·저장(MySQL)은 실물을 쓴다 — 캐시가 정말 호출을 줄이는지는 실제 Redis 없이 확인되지 않는다. 스텁이 호출 횟수를 세어 검증한다.

로컬 bootRun + **실제 Google API**로 확인한 것:

| | 결과 |
|---|---|
| 목적지 `도쿄` | 도쿄도 → `Asia/Tokyo` / `JPY` |
| 장소 `센소지` | 불교사찰, rating 4.6, 좌표 정상 |
| 같은 검색어 2회 | 256ms → **34ms** (Redis 히트) |
| Redis 키 | `travel:places:search:none:센소지`, `travel:places:city:도쿄` |
| `라멘` + tripId(도쿄) | 전부 도쿄 가게 (신주쿠·네리마·시부야) |
| `라멘` 편향 없이 | 전부 서울 가게 — 편향이 실제로 걸린다 |
| 일정에 담기 | 장소 자동 저장, 두 번 담아도 `travel_place` 1행 |
| 상세(라멘 나기) | 전화 `03-3205-1925`, 영업시간 `월요일: 24시간 영업` |
| 키 없이 기동 | 앱 정상, `cities`/`search` 빈 배열, 저장된 장소·직접 입력은 그대로 |

`openingHours`가 센소지에서 null인 건 버그가 아니다 — Google이 그 장소엔 `regularOpeningHours`를 주지 않는다(경내 상시 개방). 영업시간이 있는 가게에선 정상 파싱된다.

## 후속

사진은 이 PR에 없다. Google 사진은 URL을 그대로 저장할 수 없어(만료·과금) 서버가 받아 MinIO에 캐시해야 하므로 별도 이슈(#1058)로 뺀다.
