### PR TITLE
feat : S-06 장소 검색 · 담기(날짜 선택 시트)

### DIFF
--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -68,6 +68,10 @@ export const importTripBoard = () =>
   import("../pages/travel/TripBoardPage").then((m) => ({
     default: m.TripBoardPage,
   }));
+export const importPlaceSearch = () =>
+  import("../pages/travel/PlaceSearchPage").then((m) => ({
+    default: m.PlaceSearchPage,
+  }));
 export const importActivityDetail = () =>
   import("../pages/travel/ActivityDetailPage").then((m) => ({
     default: m.ActivityDetailPage,

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -20,6 +20,7 @@ import {
   importMaterialDetail,
   importMaterialList,
   importNotes,
+  importPlaceSearch,
   importPlannerCalendar,
   importReviewHub,
   importReviewSession,
@@ -54,6 +55,7 @@ const TravelHomePage = lazy(importTravelHome);
 const TripListPage = lazy(importTripList);
 const TripFormPage = lazy(importTripForm);
 const TripBoardPage = lazy(importTripBoard);
+const PlaceSearchPage = lazy(importPlaceSearch);
 const ActivityDetailPage = lazy(importActivityDetail);
 
 function RouteFallback() {
@@ -244,6 +246,14 @@ export function AppRouter() {
             element={
               <Suspense fallback={<RouteFallback />}>
                 <TripBoardPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/travel/trips/:tripId/places"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <PlaceSearchPage />
               </Suspense>
             }
           />

--- a/fe/src/features/travel/api/activities.ts
+++ b/fe/src/features/travel/api/activities.ts
@@ -94,6 +94,11 @@ export interface ActivityWriteRequest {
   activityDate?: string | null;
   startTime?: string | null;
   placeId?: number | null;
+  /**
+   * 검색 결과에서 곧바로 담을 때. 서버가 장소를 upsert해 일정에 연결하므로
+   * 프론트가 장소를 먼저 만들 필요가 없다. `placeId`와 함께 보내지 않는다.
+   */
+  googlePlaceId?: string | null;
   memo?: string | null;
   url?: string | null;
   notifyEnabled?: boolean;

--- a/fe/src/features/travel/api/places.ts
+++ b/fe/src/features/travel/api/places.ts
@@ -1,0 +1,92 @@
+import { client } from "@/shared/api";
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+/** 목적지 후보. 타임존·통화는 서버가 확정해서 준다 — 프론트가 좌표로 유추하지 않는다. */
+export interface City {
+  googlePlaceId: string;
+  name: string;
+  address: string;
+  lat: number;
+  lng: number;
+  timezone: string;
+  currency: string;
+}
+
+export interface PlaceSearchResult {
+  /** 이미 담아 둔 장소면 내부 id, 아니면 null. */
+  id: number | null;
+  googlePlaceId: string;
+  name: string;
+  category: string | null;
+  address: string | null;
+  rating: number | null;
+  /** 사진은 후속 작업(#1058)이라 지금은 항상 null. */
+  photoUrl: string | null;
+  lat: number | null;
+  lng: number | null;
+  /** 이전 여행에서 평점 4 이상을 준 곳. 기록은 4단계라 지금은 항상 false. */
+  loved: boolean;
+}
+
+export interface PlaceDetail {
+  id: number;
+  googlePlaceId: string | null;
+  name: string;
+  address: string | null;
+  lat: number | null;
+  lng: number | null;
+  category: string | null;
+  phone: string | null;
+  rating: number | null;
+  /** Google 원본 JSON 문자열. 상세 화면에서만 쓴다. */
+  openingHours: string | null;
+  photoUrl: string | null;
+  manualEntry: boolean;
+}
+
+export async function searchCities(q: string): Promise<City[]> {
+  const { data } = await client.get<ApiEnvelope<City[]>>(
+    "/travel/places/cities",
+    { params: { q } },
+  );
+  return data.data;
+}
+
+/** `tripId`를 주면 그 여행 목적지 주변을 우선한다(필터가 아니라 편향). */
+export async function searchPlaces(
+  q: string,
+  tripId?: number,
+): Promise<PlaceSearchResult[]> {
+  const { data } = await client.get<ApiEnvelope<PlaceSearchResult[]>>(
+    "/travel/places/search",
+    { params: tripId ? { q, tripId } : { q } },
+  );
+  return data.data;
+}
+
+export async function fetchPlaceDetail(placeId: number): Promise<PlaceDetail> {
+  const { data } = await client.get<ApiEnvelope<PlaceDetail>>(
+    `/travel/places/${placeId}`,
+  );
+  return data.data;
+}
+
+export interface ManualPlaceRequest {
+  name: string;
+  address?: string | null;
+}
+
+/** 검색으로 안 나오는 곳(골목 카페, 숙소)을 직접 만든다. */
+export async function createManualPlace(
+  body: ManualPlaceRequest,
+): Promise<PlaceDetail> {
+  const { data } = await client.post<ApiEnvelope<PlaceDetail>>(
+    "/travel/places",
+    body,
+  );
+  return data.data;
+}

--- a/fe/src/features/travel/board/AddSheet.tsx
+++ b/fe/src/features/travel/board/AddSheet.tsx
@@ -19,12 +19,16 @@ interface AddSheetProps {
   onCreate: (input: { title: string; startTime: string | null }) => void;
   /** 보관함 일정을 이 날짜로 옮긴다. */
   onPickFromArchive: (activity: Activity) => void;
+  /** 장소 검색(S-06)으로 나간다. */
+  onSearchPlaces: () => void;
   pending?: boolean;
 }
 
 /**
- * 일정 추가 시트. 장소 검색은 2단계라 자리만 두고 비활성이다 —
- * 지금 감췄다가 2단계에 되살리면 "없던 게 생긴" 것처럼 보이고, 무엇이 준비 중인지도 알 수 없다.
+ * 일정 추가 시트. 장소 검색 · 직접 입력 · 보관함에서 가져오기 세 갈래다.
+ *
+ * <p>장소 검색은 시트 안에 넣지 않고 화면(S-06)으로 나간다 — 결과 20개와 날짜 선택 시트가
+ * 겹쳐 뜨면 시트 위에 시트가 쌓인다.
  */
 export function AddSheet({
   open,
@@ -33,6 +37,7 @@ export function AddSheet({
   targetDate,
   onCreate,
   onPickFromArchive,
+  onSearchPlaces,
   pending = false,
 }: AddSheetProps) {
   const [mode, setMode] = useState<Mode>("menu");
@@ -70,12 +75,11 @@ export function AddSheet({
         <div className="flex flex-col gap-2">
           <button
             type="button"
-            disabled
-            className="border-border flex items-center gap-2 rounded-lg border px-3 py-2.5 text-left text-sm opacity-50"
+            onClick={onSearchPlaces}
+            className="border-border hover:bg-accent flex items-center gap-2 rounded-lg border px-3 py-2.5 text-left text-sm"
           >
             <Search className="size-4 shrink-0" />
             <span className="flex-1">장소 검색</span>
-            <span className="text-muted-foreground text-xs">준비 중</span>
           </button>
 
           <button

--- a/fe/src/features/travel/hooks/usePlaceSearch.ts
+++ b/fe/src/features/travel/hooks/usePlaceSearch.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { searchPlaces } from "../api/places";
+import { travelKeys } from "../queryKeys";
+
+/**
+ * 장소 검색.
+ *
+ * <p>호출 하나가 곧 비용이라(Places는 호출당 과금) 타이핑마다 부르지 않는다.
+ * 검색은 사용자가 <b>제출</b>했을 때만 일어난다 — `q`가 비면 아무것도 부르지 않는다.
+ */
+export function usePlaceSearch(q: string, tripId?: number) {
+  return useQuery({
+    queryKey: travelKeys.placeSearch(q, tripId),
+    queryFn: () => searchPlaces(q, tripId),
+    enabled: q.trim().length > 0,
+    // 서버가 1시간 캐시하지만, 뒤로 갔다 오는 동안 다시 부를 이유는 없다.
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/fe/src/features/travel/lib/recentSearches.ts
+++ b/fe/src/features/travel/lib/recentSearches.ts
@@ -1,0 +1,56 @@
+const STORAGE_KEY = "orino.travel.recentPlaceSearches";
+const LIMIT = 5;
+
+/**
+ * 최근 검색어(§S-06). 여행마다 따로 남긴다 — 도쿄 여행의 "라멘"이 다음 여행 화면에
+ * 떠 있으면 방해만 된다.
+ *
+ * <p>서버에 두지 않는 이유: 기기 하나에서만 쓰는 편의 기능이고, 저장할 만큼의 값도 아니다.
+ * 사파리 프라이빗 모드처럼 저장이 막힌 환경에서도 검색 자체는 되어야 하므로 실패는 삼킨다.
+ */
+function read(): Record<string, string[]> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : {};
+    return parsed && typeof parsed === "object"
+      ? (parsed as Record<string, string[]>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+export function getRecentSearches(tripId: number): string[] {
+  const entry = read()[String(tripId)];
+  return Array.isArray(entry) ? entry.slice(0, LIMIT) : [];
+}
+
+/** 이미 있던 검색어는 맨 앞으로 올린다(지우고 다시 넣는다). */
+export function addRecentSearch(tripId: number, query: string): string[] {
+  const trimmed = query.trim();
+  if (!trimmed) return getRecentSearches(tripId);
+
+  const all = read();
+  const key = String(tripId);
+  const next = [
+    trimmed,
+    ...(all[key] ?? []).filter((q) => q !== trimmed),
+  ].slice(0, LIMIT);
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...all, [key]: next }));
+  } catch {
+    // 저장 실패는 검색을 막을 이유가 아니다.
+  }
+  return next;
+}
+
+export function clearRecentSearches(tripId: number): void {
+  const all = read();
+  delete all[String(tripId)];
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+  } catch {
+    // 위와 같다.
+  }
+}

--- a/fe/src/features/travel/places/PickDaySheet.tsx
+++ b/fe/src/features/travel/places/PickDaySheet.tsx
@@ -1,0 +1,68 @@
+import { Archive, CalendarDays } from "lucide-react";
+
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import type { BoardDay } from "@/features/travel/api/activities";
+
+interface PickDaySheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** 담을 대상 이름. 시트 설명에 그대로 들어간다. */
+  placeName: string | null;
+  days: BoardDay[];
+  /** 날짜를 고르면 그 날짜, 보관함을 고르면 null. */
+  onPick: (date: string | null) => void;
+  pending?: boolean;
+}
+
+/**
+ * 담을 날짜를 고르는 시트(§S-06). `1일차`~`N일차` 또는 `보관함`.
+ *
+ * <p>보관함이 선택지에 있어야 하는 이유: 여행 계획은 "가고 싶다"가 "언제 갈지"보다 먼저 정해진다.
+ * 날짜를 강제하면 정하지 못한 곳을 아예 담지 못하게 된다.
+ */
+export function PickDaySheet({
+  open,
+  onOpenChange,
+  placeName,
+  days,
+  onPick,
+  pending = false,
+}: PickDaySheetProps) {
+  return (
+    <BottomSheet
+      open={open}
+      onOpenChange={onOpenChange}
+      title="어느 날에 담을까요?"
+      description={placeName ?? undefined}
+    >
+      <div className="flex flex-col gap-2">
+        {days.map((day) => (
+          <button
+            key={day.date}
+            type="button"
+            onClick={() => onPick(day.date)}
+            disabled={pending}
+            className="border-border hover:bg-accent flex items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left text-sm disabled:opacity-50"
+          >
+            <CalendarDays className="text-muted-foreground size-4 shrink-0" />
+            <span className="flex-1">{day.dayIndex}일차</span>
+            <span className="text-muted-foreground text-xs">
+              {day.date.slice(5)} ({day.weekday})
+            </span>
+          </button>
+        ))}
+
+        <button
+          type="button"
+          onClick={() => onPick(null)}
+          disabled={pending}
+          className="border-border hover:bg-accent mt-1 flex items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left text-sm disabled:opacity-50"
+        >
+          <Archive className="text-muted-foreground size-4 shrink-0" />
+          <span className="flex-1">보관함</span>
+          <span className="text-muted-foreground text-xs">날짜는 나중에</span>
+        </button>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/fe/src/features/travel/places/PlaceCard.tsx
+++ b/fe/src/features/travel/places/PlaceCard.tsx
@@ -1,0 +1,72 @@
+import { Image as ImageIcon, Star } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { PlaceSearchResult } from "@/features/travel/api/places";
+
+interface PlaceCardProps {
+  place: PlaceSearchResult;
+  onAdd: (place: PlaceSearchResult) => void;
+  pending?: boolean;
+}
+
+/** 카테고리 · 평점 · 주소를 한 줄로 — 셋 다 없을 수 있어 있는 것만 잇는다. */
+function metaLine(place: PlaceSearchResult): string {
+  return [
+    place.category,
+    place.rating === null ? null : `★ ${place.rating.toFixed(1)}`,
+    place.address,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+/**
+ * 검색 결과 카드(§S-06).
+ *
+ * <p>사진과 `좋았던 곳` 배지는 응답 필드가 이미 있고 서버가 채우기 시작하면 그대로 뜬다
+ * (사진 #1058, 평점 기록은 4단계). 그때 이 컴포넌트는 손대지 않는다.
+ */
+export function PlaceCard({ place, onAdd, pending = false }: PlaceCardProps) {
+  const meta = metaLine(place);
+
+  return (
+    <li className="border-border bg-card flex items-center gap-3 rounded-xl border p-2.5">
+      {place.photoUrl ? (
+        <img
+          src={place.photoUrl}
+          alt=""
+          className="size-16 shrink-0 rounded-lg object-cover"
+        />
+      ) : (
+        <div className="bg-muted flex size-16 shrink-0 items-center justify-center rounded-lg">
+          <ImageIcon className="text-muted-foreground size-[18px]" />
+        </div>
+      )}
+
+      <div className="min-w-0 flex-1">
+        <p className="flex items-center gap-1.5 text-[15px] font-medium">
+          <span className="truncate">{place.name}</span>
+          {place.loved && (
+            <Badge variant="warning" className="shrink-0 gap-0.5">
+              <Star className="size-[11px]" />
+              좋았던 곳
+            </Badge>
+          )}
+        </p>
+        {meta && (
+          <p className="text-muted-foreground truncate text-xs">{meta}</p>
+        )}
+      </div>
+
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => onAdd(place)}
+        disabled={pending}
+      >
+        담기
+      </Button>
+    </li>
+  );
+}

--- a/fe/src/features/travel/queryKeys.ts
+++ b/fe/src/features/travel/queryKeys.ts
@@ -10,4 +10,8 @@ export const travelKeys = {
     ["travel", "board", tripId, day ?? "default"] as const,
   boards: (tripId: number) => ["travel", "board", tripId] as const,
   activity: (activityId: number) => ["travel", "activity", activityId] as const,
+  /** 장소 검색. 서버가 이미 캐시하지만, 뒤로 갔다 오면 결과가 그대로 있어야 한다. */
+  placeSearch: (q: string, tripId?: number) =>
+    ["travel", "places", "search", tripId ?? "none", q] as const,
+  citySearch: (q: string) => ["travel", "places", "cities", q] as const,
 };

--- a/fe/src/pages/travel/PlaceSearchPage.test.tsx
+++ b/fe/src/pages/travel/PlaceSearchPage.test.tsx
@@ -1,0 +1,356 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { AppRouter } from "@/app/router";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { useToastStore } from "@/shared/lib/toast";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+const API_BASE = "https://api.orino.dev/api";
+
+const DAYS = [
+  {
+    dayIndex: 1,
+    date: "2026-10-24",
+    weekday: "토",
+    activityCount: 0,
+    weather: null,
+  },
+  {
+    dayIndex: 2,
+    date: "2026-10-25",
+    weekday: "일",
+    activityCount: 0,
+    weather: null,
+  },
+];
+
+function place(overrides: Record<string, unknown> = {}) {
+  return {
+    id: null,
+    googlePlaceId: "ChIJ_senso",
+    name: "센소지",
+    category: "불교사찰",
+    address: "도쿄도 다이토구",
+    rating: 4.6,
+    photoUrl: null,
+    lat: 35.7147,
+    lng: 139.7966,
+    loved: false,
+    ...overrides,
+  };
+}
+
+function mockBoard() {
+  server.use(
+    http.get(`${API_BASE}/travel/trips/:tripId/board`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          trip: {
+            id: 3,
+            title: "도쿄",
+            timezone: "Asia/Tokyo",
+            currency: "JPY",
+            startDate: "2026-10-24",
+            endDate: "2026-10-25",
+            status: "UPCOMING",
+            recordMode: false,
+          },
+          days: DAYS,
+          selectedDate: DAYS[0].date,
+          archiveCount: 0,
+          activities: [],
+          legs: [],
+        },
+      }),
+    ),
+  );
+}
+
+/** 검색 응답. 호출된 URL을 모아 편향(tripId)이 실렸는지 확인할 수 있게 한다. */
+function mockSearch(results: unknown[] = [place()]) {
+  const calls: URL[] = [];
+  server.use(
+    http.get(`${API_BASE}/travel/places/search`, ({ request }) => {
+      calls.push(new URL(request.url));
+      return HttpResponse.json({ code: "OK", data: results });
+    }),
+  );
+  return calls;
+}
+
+function renderSearch(path = "/travel/trips/3/places") {
+  return renderWithRouter(
+    <Providers>
+      <AppRouter />
+    </Providers>,
+    { initialEntries: [path] },
+  );
+}
+
+describe("PlaceSearchPage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "valid-token" });
+    useToastStore.setState({ toasts: [] });
+    localStorage.clear();
+    mockBoard();
+  });
+
+  describe("검색", () => {
+    it("제출하기 전에는 검색하지 않는다 — 호출 하나가 곧 비용이다", async () => {
+      const calls = mockSearch();
+      const user = userEvent.setup();
+      renderSearch();
+
+      await user.type(await screen.findByLabelText("장소 검색"), "센소");
+
+      expect(calls).toHaveLength(0);
+    });
+
+    it("제출하면 결과를 카테고리·평점·주소와 함께 보여준다", async () => {
+      mockSearch();
+      const user = userEvent.setup();
+      renderSearch();
+
+      await user.type(
+        await screen.findByLabelText("장소 검색"),
+        "센소지{Enter}",
+      );
+
+      expect(await screen.findByText("센소지")).toBeInTheDocument();
+      expect(
+        screen.getByText("불교사찰 · ★ 4.6 · 도쿄도 다이토구"),
+      ).toBeInTheDocument();
+    });
+
+    it("여행 목적지 주변으로 편향시킨다", async () => {
+      const calls = mockSearch();
+      const user = userEvent.setup();
+      renderSearch();
+
+      await user.type(await screen.findByLabelText("장소 검색"), "라멘{Enter}");
+      await screen.findByText("센소지");
+
+      expect(calls[0].searchParams.get("q")).toBe("라멘");
+      expect(calls[0].searchParams.get("tripId")).toBe("3");
+    });
+
+    it("URL의 검색어로 들어오면 곧바로 결과를 보여준다 — 담고 뒤로 와도 남아 있어야 한다", async () => {
+      mockSearch();
+      renderSearch("/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80");
+
+      expect(await screen.findByText("센소지")).toBeInTheDocument();
+      expect(await screen.findByLabelText("장소 검색")).toHaveValue("센소지");
+    });
+
+    it("검색이 실패해도 화면이 죽지 않는다", async () => {
+      server.use(
+        http.get(`${API_BASE}/travel/places/search`, () =>
+          HttpResponse.json({ code: "ERR" }, { status: 500 }),
+        ),
+      );
+      renderSearch("/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80");
+
+      expect(await screen.findByText(/검색하지 못했어요/)).toBeInTheDocument();
+    });
+  });
+
+  describe("최근 검색어", () => {
+    it("검색어가 비었을 때만 칩으로 보여주고, 누르면 그 검색어로 검색한다", async () => {
+      mockSearch();
+      const user = userEvent.setup();
+      renderSearch();
+
+      const input = await screen.findByLabelText("장소 검색");
+      await user.type(input, "센소지{Enter}");
+      await screen.findByText("센소지");
+
+      // 검색어를 지우면 최근 검색어가 다시 드러난다.
+      await user.clear(input);
+      await user.click(screen.getByRole("button", { name: "뒤로" }));
+      renderSearch();
+
+      const chip = await screen.findByRole("button", { name: /센소지/ });
+      await user.click(chip);
+
+      expect(
+        await screen.findByText("불교사찰 · ★ 4.6 · 도쿄도 다이토구"),
+      ).toBeInTheDocument();
+    });
+
+    it("지우기를 누르면 사라진다", async () => {
+      mockSearch();
+      const user = userEvent.setup();
+      renderSearch();
+
+      await user.type(
+        await screen.findByLabelText("장소 검색"),
+        "센소지{Enter}",
+      );
+      await screen.findByText("센소지");
+      renderSearch();
+
+      await user.click(await screen.findByRole("button", { name: /지우기/ }));
+
+      expect(
+        await screen.findByText("가고 싶은 곳을 검색해 보세요"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("담기", () => {
+    it("날짜를 고르면 googlePlaceId로 일정을 만든다 — 프론트가 장소를 먼저 만들지 않는다", async () => {
+      mockSearch();
+      const bodies: unknown[] = [];
+      server.use(
+        http.post(
+          `${API_BASE}/travel/trips/:tripId/activities`,
+          async ({ request }) => {
+            bodies.push(await request.json());
+            return HttpResponse.json({ code: "OK", data: { id: 11 } });
+          },
+        ),
+      );
+      const user = userEvent.setup();
+      renderSearch("/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80");
+
+      await user.click(await screen.findByRole("button", { name: "담기" }));
+      await user.click(await screen.findByRole("button", { name: /2일차/ }));
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      expect(bodies[0]).toMatchObject({
+        title: "센소지",
+        activityDate: "2026-10-25",
+        googlePlaceId: "ChIJ_senso",
+      });
+      expect(await screen.findByText("2일차에 담았어요")).toBeInTheDocument();
+    });
+
+    it("보관함을 고르면 날짜 없이 담는다 — 갈지는 정했는데 언제인지는 아직일 때", async () => {
+      mockSearch();
+      const bodies: unknown[] = [];
+      server.use(
+        http.post(
+          `${API_BASE}/travel/trips/:tripId/activities`,
+          async ({ request }) => {
+            bodies.push(await request.json());
+            return HttpResponse.json({ code: "OK", data: { id: 11 } });
+          },
+        ),
+      );
+      const user = userEvent.setup();
+      renderSearch("/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80");
+
+      await user.click(await screen.findByRole("button", { name: "담기" }));
+      await user.click(await screen.findByRole("button", { name: /보관함/ }));
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      expect(bodies[0]).toMatchObject({ activityDate: null });
+      expect(await screen.findByText("보관함에 담았어요")).toBeInTheDocument();
+    });
+
+    it("담기가 실패하면 알려준다", async () => {
+      mockSearch();
+      server.use(
+        http.post(`${API_BASE}/travel/trips/:tripId/activities`, () =>
+          HttpResponse.json({ code: "ERR" }, { status: 500 }),
+        ),
+      );
+      const user = userEvent.setup();
+      renderSearch("/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80");
+
+      await user.click(await screen.findByRole("button", { name: "담기" }));
+      await user.click(await screen.findByRole("button", { name: /1일차/ }));
+
+      expect(await screen.findByText(/담지 못했어요/)).toBeInTheDocument();
+    });
+  });
+
+  describe("결과가 없을 때", () => {
+    it("직접 입력으로 장소를 만들고 곧바로 날짜를 묻는다", async () => {
+      mockSearch([]);
+      server.use(
+        http.post(`${API_BASE}/travel/places`, () =>
+          HttpResponse.json({
+            code: "OK",
+            data: { id: 7, name: "숙소 근처 골목 카페", manualEntry: true },
+          }),
+        ),
+      );
+      const bodies: unknown[] = [];
+      server.use(
+        http.post(
+          `${API_BASE}/travel/trips/:tripId/activities`,
+          async ({ request }) => {
+            bodies.push(await request.json());
+            return HttpResponse.json({ code: "OK", data: { id: 12 } });
+          },
+        ),
+      );
+      const user = userEvent.setup();
+      renderSearch("/travel/trips/3/places?q=%EA%B3%A8%EB%AA%A9");
+
+      await user.click(
+        await screen.findByRole("button", { name: /직접 입력/ }),
+      );
+      await user.type(
+        screen.getByLabelText("장소 이름"),
+        "숙소 근처 골목 카페",
+      );
+      await user.click(screen.getByRole("button", { name: "만들기" }));
+
+      // 장소만 만들고 끝나면 어디에도 보이지 않는다 — 바로 날짜를 물어야 한다.
+      await user.click(await screen.findByRole("button", { name: /1일차/ }));
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      expect(bodies[0]).toMatchObject({
+        title: "숙소 근처 골목 카페",
+        placeId: 7,
+        activityDate: "2026-10-24",
+      });
+    });
+  });
+
+  describe("좋았던 곳 배지", () => {
+    it("loved가 true면 배지를 보여준다", async () => {
+      mockSearch([place({ loved: true })]);
+      renderSearch("/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80");
+
+      expect(await screen.findByText("좋았던 곳")).toBeInTheDocument();
+    });
+
+    it("기본값(false)에서는 배지가 없다 — 평점 기록은 4단계다", async () => {
+      mockSearch();
+      renderSearch("/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80");
+
+      await screen.findByText("센소지");
+      expect(screen.queryByText("좋았던 곳")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("보드에서 들어오기", () => {
+    it("일정 추가 시트의 장소 검색이 이 화면으로 데려온다", async () => {
+      const user = userEvent.setup();
+      renderWithRouter(
+        <Providers>
+          <AppRouter />
+        </Providers>,
+        { initialEntries: ["/travel/trips/3/board"] },
+      );
+
+      await user.click(
+        await screen.findByRole("button", { name: "일정 추가" }),
+      );
+      await user.click(
+        await screen.findByRole("button", { name: "장소 검색" }),
+      );
+
+      expect(await screen.findByLabelText("장소 검색")).toBeInTheDocument();
+    });
+  });
+});

--- a/fe/src/pages/travel/PlaceSearchPage.tsx
+++ b/fe/src/pages/travel/PlaceSearchPage.tsx
@@ -1,0 +1,262 @@
+import { ArrowLeft, Clock, Pencil, Search, X } from "lucide-react";
+import { type FormEvent, useEffect, useState } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { LoadingText } from "@/components/ui/loading-text";
+import type { PlaceSearchResult } from "@/features/travel/api/places";
+import { createManualPlace } from "@/features/travel/api/places";
+import { useCreateActivity } from "@/features/travel/hooks/useActivityMutations";
+import { useBoard } from "@/features/travel/hooks/useBoard";
+import { usePlaceSearch } from "@/features/travel/hooks/usePlaceSearch";
+import {
+  addRecentSearch,
+  clearRecentSearches,
+  getRecentSearches,
+} from "@/features/travel/lib/recentSearches";
+import { PickDaySheet } from "@/features/travel/places/PickDaySheet";
+import { PlaceCard } from "@/features/travel/places/PlaceCard";
+import { toast } from "@/shared/lib/toast";
+
+/** 담기 대상 — 검색 결과이거나, 직접 입력해서 방금 만든 장소. */
+type Target =
+  | { kind: "google"; googlePlaceId: string; name: string }
+  | { kind: "manual"; placeId: number; name: string };
+
+/**
+ * S-06 장소 검색.
+ *
+ * <p><b>검색어는 URL이 소유한다</b>(`?q=`). 담고 나서 뒤로 오거나 새로고침해도 결과가 그대로
+ * 남아야 한다 — 현지에서 여러 곳을 연달아 담을 때 매번 다시 치게 하면 쓸 수 없다.
+ *
+ * <p>타이핑마다 검색하지 않는다. Places는 호출당 과금이라 자동완성처럼 부르면 비용이 검색어
+ * 길이에 비례한다. 제출(엔터·버튼)했을 때만 부른다.
+ */
+export function PlaceSearchPage() {
+  const { tripId: tripIdParam } = useParams();
+  const tripId = Number(tripIdParam);
+  const navigate = useNavigate();
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const query = searchParams.get("q") ?? "";
+  const [draft, setDraft] = useState(query);
+
+  const [recent, setRecent] = useState<string[]>(() =>
+    Number.isFinite(tripId) ? getRecentSearches(tripId) : [],
+  );
+  const [target, setTarget] = useState<Target | null>(null);
+  const [manualOpen, setManualOpen] = useState(false);
+  const [manualName, setManualName] = useState("");
+  const [manualAddress, setManualAddress] = useState("");
+
+  // 뒤로 가기로 검색어가 바뀌면 입력창도 따라가야 한다.
+  useEffect(() => setDraft(query), [query]);
+
+  const { data: places, isPending, isError } = usePlaceSearch(query, tripId);
+  const { data: board } = useBoard(tripId, {});
+  const createActivity = useCreateActivity(tripId);
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    setRecent(addRecentSearch(tripId, trimmed));
+    setSearchParams({ q: trimmed });
+  };
+
+  const searchFor = (q: string) => {
+    setRecent(addRecentSearch(tripId, q));
+    setSearchParams({ q });
+  };
+
+  const add = (date: string | null) => {
+    if (!target) return;
+    createActivity.mutate(
+      {
+        title: target.name,
+        activityDate: date,
+        ...(target.kind === "google"
+          ? { googlePlaceId: target.googlePlaceId }
+          : { placeId: target.placeId }),
+      },
+      {
+        onSuccess: () => {
+          const where =
+            date === null
+              ? "보관함"
+              : `${board?.days.find((d) => d.date === date)?.dayIndex ?? ""}일차`;
+          toast(`${where}에 담았어요`, "success");
+          setTarget(null);
+        },
+        onError: () =>
+          toast("담지 못했어요. 잠시 후 다시 시도해 주세요", "error"),
+      },
+    );
+  };
+
+  const submitManual = async (event: FormEvent) => {
+    event.preventDefault();
+    const name = manualName.trim();
+    if (!name) return;
+    try {
+      const place = await createManualPlace({
+        name,
+        address: manualAddress.trim() || null,
+      });
+      setManualOpen(false);
+      setManualName("");
+      setManualAddress("");
+      // 만들자마자 날짜를 물어야 한다 — 장소만 만들어 두면 어디에도 보이지 않는다.
+      setTarget({ kind: "manual", placeId: place.id, name: place.name });
+    } catch {
+      toast("장소를 만들지 못했어요", "error");
+    }
+  };
+
+  const results = places ?? [];
+
+  return (
+    <div className="mx-auto flex w-full max-w-[520px] flex-col gap-3 px-4 pt-3">
+      <form className="flex items-center gap-2" onSubmit={submit}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="뒤로"
+          onClick={() => navigate(`/travel/trips/${tripId}/board`)}
+        >
+          <ArrowLeft className="size-4" />
+        </Button>
+        <Search className="text-muted-foreground size-4 shrink-0" />
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="장소 검색"
+          aria-label="장소 검색"
+          maxLength={100}
+          autoFocus
+        />
+      </form>
+
+      {query === "" ? (
+        recent.length === 0 ? (
+          <EmptyState className="min-h-[30svh]">
+            <p className="text-muted-foreground text-sm">
+              가고 싶은 곳을 검색해 보세요
+            </p>
+          </EmptyState>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <p className="text-muted-foreground text-xs">최근 검색어</p>
+              <button
+                type="button"
+                onClick={() => {
+                  clearRecentSearches(tripId);
+                  setRecent([]);
+                }}
+                className="text-muted-foreground hover:text-foreground flex items-center gap-0.5 text-xs"
+              >
+                <X className="size-3" />
+                지우기
+              </button>
+            </div>
+            <ul className="flex flex-wrap gap-1.5">
+              {recent.map((q) => (
+                <li key={q}>
+                  <button
+                    type="button"
+                    onClick={() => searchFor(q)}
+                    className="border-border bg-card hover:bg-accent flex items-center gap-1 rounded-full border px-2.5 py-1 text-[13px]"
+                  >
+                    <Clock className="text-muted-foreground size-3" />
+                    {q}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )
+      ) : isPending ? (
+        <LoadingText />
+      ) : isError ? (
+        <EmptyState className="min-h-[30svh]">
+          <p className="text-muted-foreground text-sm">
+            검색하지 못했어요. 잠시 후 다시 시도해 주세요.
+          </p>
+        </EmptyState>
+      ) : results.length === 0 ? (
+        <EmptyState className="min-h-[30svh]">
+          <p className="text-muted-foreground text-sm">검색 결과가 없어요.</p>
+          <Button variant="outline" onClick={() => setManualOpen(true)}>
+            <Pencil className="size-4" />
+            직접 입력
+          </Button>
+        </EmptyState>
+      ) : (
+        <ul className="flex flex-col gap-2 pb-6">
+          {results.map((place: PlaceSearchResult) => (
+            <PlaceCard
+              key={place.googlePlaceId}
+              place={place}
+              pending={createActivity.isPending}
+              onAdd={(p) =>
+                setTarget({
+                  kind: "google",
+                  googlePlaceId: p.googlePlaceId,
+                  name: p.name,
+                })
+              }
+            />
+          ))}
+        </ul>
+      )}
+
+      <PickDaySheet
+        open={target !== null}
+        onOpenChange={(open) => !open && setTarget(null)}
+        placeName={target?.name ?? null}
+        days={board?.days ?? []}
+        onPick={add}
+        pending={createActivity.isPending}
+      />
+
+      <BottomSheet
+        open={manualOpen}
+        onOpenChange={setManualOpen}
+        title="직접 입력"
+        description="검색으로 안 나오는 곳을 직접 만듭니다"
+      >
+        <form className="flex flex-col gap-3" onSubmit={submitManual}>
+          <FormField label="장소 이름" htmlFor="manualPlaceName">
+            <Input
+              id="manualPlaceName"
+              value={manualName}
+              onChange={(e) => setManualName(e.target.value)}
+              placeholder="숙소 근처 골목 카페"
+              maxLength={200}
+              autoFocus
+            />
+          </FormField>
+          <FormField label="주소 (선택)" htmlFor="manualPlaceAddress">
+            <Input
+              id="manualPlaceAddress"
+              value={manualAddress}
+              onChange={(e) => setManualAddress(e.target.value)}
+              maxLength={300}
+            />
+          </FormField>
+          <div className="flex justify-end">
+            <Button type="submit" disabled={!manualName.trim()}>
+              만들기
+            </Button>
+          </div>
+        </form>
+      </BottomSheet>
+    </div>
+  );
+}

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -339,7 +339,7 @@ describe("TripBoardPage", () => {
       });
     });
 
-    it("장소 검색은 2단계라 비활성이지만 자리는 보여준다", async () => {
+    it("장소 검색은 시트 안이 아니라 검색 화면으로 나간다", async () => {
       mockBoard({ byDate: { "2026-10-24": [] } });
 
       renderBoard();
@@ -347,9 +347,12 @@ describe("TripBoardPage", () => {
       await userEvent.click(screen.getByRole("button", { name: "일정 추가" }));
 
       const sheet = await screen.findByRole("dialog");
-      const search = within(sheet).getByRole("button", { name: /장소 검색/ });
-      expect(search).toBeDisabled();
-      expect(search).toHaveTextContent("준비 중");
+      await userEvent.click(
+        within(sheet).getByRole("button", { name: /장소 검색/ }),
+      );
+
+      // 결과 20개와 날짜 선택 시트가 시트 위에 쌓이지 않게 화면을 바꾼다.
+      expect(await screen.findByLabelText("장소 검색")).toBeInTheDocument();
     });
 
     it("보관함 일정을 지금 보는 날짜로 가져온다", async () => {

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -349,7 +349,10 @@ export function TripBoardPage() {
               ? "가고 싶은 곳을 미리 담아두세요"
               : "일정이 없어요"}
           </p>
-          <Button variant="outline" disabled>
+          <Button
+            variant="outline"
+            onClick={() => navigate(`/travel/trips/${tripId}/places`)}
+          >
             <Search className="size-4" />
             장소 검색
           </Button>
@@ -377,6 +380,7 @@ export function TripBoardPage() {
         targetDate={selectedDate}
         onCreate={(input) => void addActivity(input)}
         onPickFromArchive={(a) => void pickFromArchive(a)}
+        onSearchPlaces={() => navigate(`/travel/trips/${tripId}/places`)}
         pending={createActivity.isPending || updateActivity.isPending}
       />
 


### PR DESCRIPTION
## 이슈
closes #1059
## 작업 내용

#1054의 서버 프록시에 화면을 붙여 **실제 장소로 일정을 담을 수 있게** 했다. 보드의 일정 추가 시트에서 `준비 중`이던 장소 검색이 살아났다.

`/travel/trips/:tripId/places` — 검색 → 결과 카드 → `담기` → 날짜 선택 시트(`1일차`~`N일차` / `보관함`).

**타이핑마다 검색하지 않는다.** Places는 호출당 과금이라 자동완성처럼 부르면 비용이 검색어 길이에 비례한다. 제출(엔터)했을 때만 부른다.

**검색어는 URL이 소유한다**(`?q=`). 담고 뒤로 오거나 새로고침해도 결과가 그대로 남는다 — 현지에서 여러 곳을 연달아 담을 때 매번 다시 치게 하면 쓸 수 없다.

**날짜 선택 시트에 보관함이 있다.** 여행 계획은 "가고 싶다"가 "언제 갈지"보다 먼저 정해진다. 날짜를 강제하면 정하지 못한 곳을 아예 담지 못한다.

**직접 입력은 만들자마자 날짜를 묻는다.** 장소만 만들고 끝나면 어디에도 보이지 않는다.

**장소 검색은 시트 안이 아니라 화면으로 나간다.** 결과 20개와 날짜 선택 시트가 겹치면 시트 위에 시트가 쌓인다.

담기는 `googlePlaceId`를 실어 보낸다 — 서버가 장소를 upsert해 일정에 연결하므로 프론트가 장소를 먼저 만들지 않는다. 검색은 `tripId`를 함께 보내 목적지 주변으로 편향시킨다.

### 지금 비어 있는 자리

사진(`photoUrl`)과 `⭐ 좋았던 곳` 배지는 필드가 이미 응답에 있고 렌더링도 넣었다. 서버가 채우기 시작하면(사진 #1058, 평점 기록은 4단계) 이 화면은 손대지 않아도 된다.

## 확인

FE 게이트 전부 통과 — `format:check` · `lint` · `test`(736 passed) · `build`. 새 통합 테스트 14개(MSW).

로컬에서 BE·FE를 함께 띄우고 **실제 Google 응답**으로 확인:

| | 결과 |
|---|---|
| `라멘` 검색 | 20개 전부 도쿄 가게 (신주쿠·시부야·세타가야) — 편향이 실제로 걸린다 |
| 담기 → 2일차 | `2일차에 담았어요` 토스트, 보드 2일차에 `라멘 나기` |
| 결과 없는 검색어 | `검색 결과가 없어요.` + `직접 입력` |
| 직접 입력 | 만든 직후 날짜 시트 → 보관함에 담김 |
| 최근 검색어 | 다시 들어와도 `라멘` 칩이 남아 있음 |
| DB | 구글 장소는 `google_place_id` 있고 `manual_entry=0`, 직접 입력은 반대 |

보드 테스트 하나(`장소 검색은 2단계라 비활성이지만 자리는 보여준다`)는 기능이 살아났으니 함께 바꿨다 — 이제 검색 화면으로 나가는지를 확인한다.