### PR TITLE
feat : S-03 목적지를 검색으로 고르기 (타임존·통화 자동 지정)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/GooglePlacesClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/GooglePlacesClient.java
@@ -13,9 +13,11 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Places API (New) 호출 래퍼.
@@ -39,7 +41,29 @@ public class GooglePlacesClient implements PlacesClient {
     /** 도시 검색은 타임존·국가까지 필요하다(여행의 타임존·통화를 여기서 확정한다). */
     private static final String CITY_MASK = String.join(",",
             "places.id", "places.displayName", "places.formattedAddress",
-            "places.location", "places.timeZone", "places.addressComponents");
+            "places.location", "places.timeZone", "places.addressComponents", "places.types");
+
+    /**
+     * 목적지로 인정하는 Google place type.
+     *
+     * <p>도시가 어느 단계로 잡히는지는 나라마다 다르다 — 오사카·런던·뉴욕은 {@code locality}지만
+     * 도쿄도는 {@code administrative_area_level_1}, 파리는 {@code administrative_area_level_3}다.
+     * 그래서 {@code locality} 하나로 못 걸러낸다.
+     */
+    private static final Set<String> DESTINATION_TYPES = Set.of(
+            "locality", "postal_town", "administrative_area_level_1",
+            "administrative_area_level_2", "administrative_area_level_3", "country");
+
+    /** 걸러내기 전에 받아 올 후보 수. 진짜 도시가 상위에 없을 수 있어 넉넉히 받는다. */
+    private static final int CITY_CANDIDATE_COUNT = 20;
+
+    /** 걸러낸 뒤 보여줄 수. 목적지는 하나만 고르는 것이라 길 필요가 없다. */
+    private static final int CITY_RESULT_COUNT = 5;
+
+    /** 같은 검색어에 여러 단계가 걸리면 좁은 쪽(도시)을 먼저 보여준다. */
+    private static final List<String> TYPE_PRIORITY = List.of(
+            "locality", "postal_town", "administrative_area_level_3",
+            "administrative_area_level_2", "administrative_area_level_1", "country");
 
     /** 상세는 영업시간·전화번호가 추가된다. */
     private static final String DETAILS_MASK = String.join(",",
@@ -69,13 +93,40 @@ public class GooglePlacesClient implements PlacesClient {
 
     @Override
     public List<PlaceResult> searchCities(String query) {
-        // 행정구역만 받아 "도쿄 라멘집"이 목적지 후보로 뜨지 않게 한다.
+        // includedType은 <b>힌트일 뿐</b>이라(strictTypeFiltering을 켜면 도쿄도·파리가 통째로
+        // 사라진다) 실제 걸러내기는 응답의 types로 한다. 그래서 넉넉히 받아 온다 —
+        // "파리"는 상위 5개가 전부 파리바게뜨 지점이고 진짜 파리는 그 뒤에 있다.
         Map<String, Object> body = Map.of(
                 "textQuery", query,
                 "languageCode", props.languageCode(),
-                "maxResultCount", 5,
+                "maxResultCount", CITY_CANDIDATE_COUNT,
                 "includedType", "locality");
-        return searchText(body, CITY_MASK);
+        return selectDestinations(searchText(body, CITY_MASK));
+    }
+
+    /**
+     * 받아 온 후보에서 목적지가 될 만한 것만 골라 좁은 순으로 정렬한다.
+     *
+     * <p>구글 호출과 떼어 둔다 — 걸러내기 규칙이 이 기능의 전부라 따로 검증할 수 있어야 한다.
+     */
+    static List<PlaceResult> selectDestinations(List<PlaceResult> candidates) {
+        return candidates.stream()
+                .filter(city -> city.types().stream().anyMatch(DESTINATION_TYPES::contains))
+                .sorted(Comparator.comparingInt(GooglePlacesClient::typeRank))
+                .limit(CITY_RESULT_COUNT)
+                .toList();
+    }
+
+    /** 좁은 행정구역일수록 앞. 목록에 없는 타입은 맨 뒤로 보낸다. */
+    private static int typeRank(PlaceResult city) {
+        int best = TYPE_PRIORITY.size();
+        for (String type : city.types()) {
+            int rank = TYPE_PRIORITY.indexOf(type);
+            if (rank >= 0 && rank < best) {
+                best = rank;
+            }
+        }
+        return best;
     }
 
     @Override
@@ -155,7 +206,19 @@ public class GooglePlacesClient implements PlacesClient {
                 text(node, "nationalPhoneNumber"),
                 rawJson(node.get("regularOpeningHours")),
                 nestedText(node, "timeZone", "id"),
-                countryCode(node.get("addressComponents")));
+                countryCode(node.get("addressComponents")),
+                types(node.get("types")));
+    }
+
+    private static List<String> types(JsonNode types) {
+        if (types == null || !types.isArray()) {
+            return List.of();
+        }
+        List<String> values = new ArrayList<>();
+        for (JsonNode type : types) {
+            values.add(type.asString());
+        }
+        return List.copyOf(values);
     }
 
     /** 주소 구성요소에서 국가 코드(alpha-2)를 뽑는다. 통화를 여기서 유도한다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/PlaceResult.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/PlaceResult.java
@@ -1,6 +1,7 @@
 package ds.project.orino.planner.travel.place.client;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 /**
  * Places 응답에서 우리가 쓰는 것만 뽑은 결과.
@@ -12,6 +13,7 @@ import java.math.BigDecimal;
  * @param timezone      IANA 타임존. <b>Places가 직접 준다</b>(좌표→타임존 매핑이 필요 없다)
  * @param countryCode   ISO 3166-1 alpha-2. 통화를 여기서 유도한다
  * @param openingHours  영업시간 원본 JSON. 구조를 해석하지 않고 그대로 캐시해 FE에 넘긴다
+ * @param types         Google place type 목록. 목적지 검색에서 행정구역만 골라내는 데 쓴다
  */
 public record PlaceResult(
         String googlePlaceId,
@@ -24,6 +26,12 @@ public record PlaceResult(
         String phone,
         String openingHours,
         String timezone,
-        String countryCode
+        String countryCode,
+        List<String> types
 ) {
+
+    /** {@code types}는 검색 종류에 따라 요청하지 않으므로 null이 올 수 있다. */
+    public PlaceResult {
+        types = types == null ? List.of() : List.copyOf(types);
+    }
 }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
@@ -86,14 +86,15 @@ class PlaceControllerTest extends ApiTestSupport {
 
     private static PlaceResult city(String id, String name, String tz, String country) {
         return new PlaceResult(id, name, "일본 도쿄도", new BigDecimal("35.6762"),
-                new BigDecimal("139.6503"), null, null, null, null, tz, country);
+                new BigDecimal("139.6503"), null, null, null, null, tz, country,
+                List.of("locality", "political"));
     }
 
     private static PlaceResult place(String id, String name) {
         return new PlaceResult(id, name, "도쿄도 다이토구", new BigDecimal("35.7147"),
                 new BigDecimal("139.7966"), "사찰", new BigDecimal("4.5"),
                 "+81 3-3842-0181", "{\"weekdayDescriptions\":[\"월: 06:00~17:00\"]}",
-                "Asia/Tokyo", "JP");
+                "Asia/Tokyo", "JP", List.of("tourist_attraction"));
     }
 
     @Nested

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/client/GooglePlacesClientTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/client/GooglePlacesClientTest.java
@@ -1,0 +1,90 @@
+package ds.project.orino.planner.travel.place.client;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 목적지 후보 걸러내기.
+ *
+ * <p>구글의 {@code includedType}은 힌트일 뿐이라 "파리"를 치면 파리바게뜨 지점이 먼저 온다.
+ * 실제로 걸러내는 것은 응답의 {@code types}이고, 그 규칙이 이 기능의 전부다.
+ */
+class GooglePlacesClientTest {
+
+    private static PlaceResult candidate(String name, String... types) {
+        return new PlaceResult("id-" + name, name, name + " 주소",
+                new BigDecimal("35.0"), new BigDecimal("139.0"),
+                null, null, null, null, "Asia/Seoul", "KR", List.of(types));
+    }
+
+    @Nested
+    @DisplayName("행정구역만 남긴다")
+    class Filtering {
+
+        @Test
+        @DisplayName("빵집·공원은 목적지가 아니다 — '파리'를 치면 파리바게뜨가 먼저 온다")
+        void dropsNonAdministrativePlaces() {
+            List<PlaceResult> selected = GooglePlacesClient.selectDestinations(List.of(
+                    candidate("파리", "point_of_interest", "service"),
+                    candidate("파리바게뜨 대림현대점", "bakery", "food_store"),
+                    candidate("파리15구공원", "park", "point_of_interest"),
+                    candidate("아홍디쓰멍 드 파리", "administrative_area_level_3", "political")));
+
+            assertThat(selected).extracting(PlaceResult::name)
+                    .containsExactly("아홍디쓰멍 드 파리");
+        }
+
+        @Test
+        @DisplayName("도시가 어느 단계로 잡히는지는 나라마다 다르다 — locality만으로는 못 거른다")
+        void keepsAdministrativeLevelsBesidesLocality() {
+            // 도쿄도는 admin_1, 오사카시는 locality다. 둘 다 목적지로 쓸 수 있어야 한다.
+            List<PlaceResult> selected = GooglePlacesClient.selectDestinations(List.of(
+                    candidate("도쿄도", "administrative_area_level_1", "political"),
+                    candidate("오사카시", "locality", "political")));
+
+            assertThat(selected).extracting(PlaceResult::name)
+                    .containsExactlyInAnyOrder("도쿄도", "오사카시");
+        }
+
+        @Test
+        @DisplayName("남는 게 없으면 빈 목록 — 없는 걸 지어내지 않는다")
+        void returnsEmptyWhenNothingQualifies() {
+            assertThat(GooglePlacesClient.selectDestinations(List.of(
+                    candidate("파리바게뜨", "bakery")))).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("좁은 행정구역을 먼저 보여준다")
+    class Ordering {
+
+        @Test
+        @DisplayName("도시가 도·주보다 앞선다 — 여행 목적지는 보통 도시다")
+        void narrowerFirst() {
+            List<PlaceResult> selected = GooglePlacesClient.selectDestinations(List.of(
+                    candidate("어느 나라", "country"),
+                    candidate("어느 도", "administrative_area_level_1"),
+                    candidate("어느 시", "locality")));
+
+            assertThat(selected).extracting(PlaceResult::name)
+                    .containsExactly("어느 시", "어느 도", "어느 나라");
+        }
+
+        @Test
+        @DisplayName("후보가 많아도 5개까지만 — 목적지는 하나만 고른다")
+        void capsResults() {
+            List<PlaceResult> many = List.of(
+                    candidate("A", "locality"), candidate("B", "locality"),
+                    candidate("C", "locality"), candidate("D", "locality"),
+                    candidate("E", "locality"), candidate("F", "locality"));
+
+            assertThat(GooglePlacesClient.selectDestinations(many)).hasSize(5);
+        }
+    }
+}

--- a/fe/src/features/travel/api/travel.ts
+++ b/fe/src/features/travel/api/travel.ts
@@ -113,6 +113,12 @@ export interface TripWriteRequest {
   endDate: string;
   timezone: string;
   currency: string;
+  /**
+   * 목적지 좌표. 장소 검색이 이 값으로 목적지 주변을 편향시킨다 —
+   * 없으면 현지 대신 사는 곳 근처 가게가 나온다.
+   */
+  lat?: number | null;
+  lng?: number | null;
   defaultNotifyMinutes?: number;
   morningSummaryEnabled?: boolean;
   /** 기간 단축으로 잘리는 일정을 보관함으로 옮겨도 좋다는 확인. */

--- a/fe/src/features/travel/places/DestinationSearch.tsx
+++ b/fe/src/features/travel/places/DestinationSearch.tsx
@@ -1,0 +1,151 @@
+import { MapPin, Search } from "lucide-react";
+import { type FormEvent, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { LoadingText } from "@/components/ui/loading-text";
+import type { City } from "@/features/travel/api/places";
+import { searchCities } from "@/features/travel/api/places";
+
+interface DestinationSearchProps {
+  /** 고른 목적지 이름. 검색창의 값이 아니라 확정된 값이다. */
+  value: string;
+  onSelect: (city: City) => void;
+  /** 검색을 포기하고 직접 입력으로 넘어간다. */
+  onFallback: () => void;
+}
+
+/**
+ * 목적지 도시 검색(§S-03).
+ *
+ * <p>고르면 타임존·통화·좌표가 함께 정해진다 — 서버가 확정해 주므로 프론트가 좌표에서
+ * 타임존을 유추하지 않는다.
+ *
+ * <p><b>검색이 실패해도 여행은 만들 수 있어야 한다.</b> 키가 없거나 호출이 실패하면
+ * 직접 입력으로 넘어갈 길을 그 자리에서 준다 — 여행 만들기가 외부 API에 걸려 막히면 안 된다.
+ */
+export function DestinationSearch({
+  value,
+  onSelect,
+  onFallback,
+}: DestinationSearchProps) {
+  const [draft, setDraft] = useState("");
+  const [cities, setCities] = useState<City[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const search = async (event: FormEvent) => {
+    event.preventDefault();
+    // 이 폼은 여행 만들기 폼 안에 있다 — 제출이 위로 새면 여행이 저장돼 버린다.
+    event.stopPropagation();
+    const q = draft.trim();
+    if (!q) return;
+
+    setSearching(true);
+    setFailed(false);
+    try {
+      setCities(await searchCities(q));
+    } catch {
+      setCities(null);
+      setFailed(true);
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <FormField label="목적지 도시" htmlFor="destinationSearch">
+        <div className="flex items-center gap-2">
+          <Search className="text-muted-foreground size-4 shrink-0" />
+          <Input
+            id="destinationSearch"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              // Enter가 바깥 폼으로 새면 목적지도 안 고른 채 저장된다.
+              if (e.key === "Enter") void search(e);
+            }}
+            placeholder={value || "도쿄"}
+            maxLength={100}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={(e) => void search(e)}
+            disabled={searching || !draft.trim()}
+          >
+            검색
+          </Button>
+        </div>
+      </FormField>
+
+      {value && (
+        <p className="text-muted-foreground flex items-center gap-1 text-xs">
+          <MapPin className="size-3.5" />
+          선택한 목적지: <span className="text-foreground">{value}</span>
+        </p>
+      )}
+
+      {searching && <LoadingText />}
+
+      {failed && (
+        <div className="border-border flex flex-col items-start gap-2 rounded-lg border p-3">
+          <p className="text-muted-foreground text-sm">
+            목적지를 검색하지 못했어요.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onFallback}
+          >
+            직접 입력하기
+          </Button>
+        </div>
+      )}
+
+      {cities !== null && !searching && (
+        <ul className="bg-popover border-border overflow-hidden rounded-lg border">
+          {cities.length === 0 ? (
+            <li className="flex flex-col items-start gap-2 p-3">
+              <p className="text-muted-foreground text-sm">
+                검색 결과가 없어요.
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={onFallback}
+              >
+                직접 입력하기
+              </Button>
+            </li>
+          ) : (
+            cities.map((city) => (
+              <li key={city.googlePlaceId}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onSelect(city);
+                    setCities(null);
+                    setDraft("");
+                  }}
+                  className="hover:bg-accent flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm"
+                >
+                  <MapPin className="text-muted-foreground size-3.5 shrink-0" />
+                  <span className="flex-1 truncate">{city.name}</span>
+                  <span className="text-muted-foreground shrink-0 text-xs">
+                    {city.timezone} · {city.currency}
+                  </span>
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/fe/src/pages/travel/TripFormPage.test.tsx
+++ b/fe/src/pages/travel/TripFormPage.test.tsx
@@ -63,8 +63,37 @@ function captureWrite(method: "post" | "put") {
   return seen;
 }
 
-async function fillNewTripForm() {
+const TOKYO_CITY = {
+  googlePlaceId: "ChIJ_tokyo",
+  name: "도쿄",
+  address: "일본 도쿄도",
+  lat: 35.6764225,
+  lng: 139.650027,
+  timezone: "Asia/Tokyo",
+  currency: "JPY",
+};
+
+/** 목적지 검색 응답. 호출된 검색어를 모아 둔다. */
+function mockCities(cities: unknown[] = [TOKYO_CITY]) {
+  const queries: string[] = [];
+  server.use(
+    http.get(`${API_BASE}/travel/places/cities`, ({ request }) => {
+      queries.push(new URL(request.url).searchParams.get("q") ?? "");
+      return HttpResponse.json({ code: "OK", data: cities });
+    }),
+  );
+  return queries;
+}
+
+/** 검색해서 도쿄를 고른다 — 이제 목적지를 정하는 기본 경로다. */
+async function selectTokyo() {
   await userEvent.type(screen.getByLabelText("목적지 도시"), "도쿄");
+  await userEvent.click(screen.getByRole("button", { name: "검색" }));
+  await userEvent.click(await screen.findByRole("button", { name: /도쿄/ }));
+}
+
+async function fillNewTripForm() {
+  await selectTokyo();
   await userEvent.type(screen.getByLabelText("시작일"), "2026-10-24");
   await userEvent.type(screen.getByLabelText("종료일"), "2026-10-27");
 }
@@ -72,6 +101,7 @@ async function fillNewTripForm() {
 describe("TripFormPage", () => {
   beforeEach(() => {
     useAuthStore.setState({ accessToken: "valid-token" });
+    mockCities();
   });
 
   describe("생성", () => {
@@ -93,11 +123,18 @@ describe("TripFormPage", () => {
       expect(screen.getByText("기본 알림 시점")).toBeInTheDocument();
     });
 
-    it("제목 placeholder가 입력한 목적지 이름을 따라간다", async () => {
+    it("제목 placeholder가 고른 목적지 이름을 따라간다", async () => {
+      mockCities([
+        { ...TOKYO_CITY, name: "오사카", googlePlaceId: "ChIJ_osaka" },
+      ]);
       renderApp("/travel/trips/new");
+      await screen.findByLabelText("목적지 도시");
 
-      const destination = await screen.findByLabelText("목적지 도시");
-      await userEvent.type(destination, "오사카");
+      await userEvent.type(screen.getByLabelText("목적지 도시"), "오사카");
+      await userEvent.click(screen.getByRole("button", { name: "검색" }));
+      await userEvent.click(
+        await screen.findByRole("button", { name: /오사카/ }),
+      );
 
       expect(screen.getByLabelText("여행 제목")).toHaveAttribute(
         "placeholder",
@@ -144,7 +181,7 @@ describe("TripFormPage", () => {
       renderApp("/travel/trips/new");
       await screen.findByLabelText("목적지 도시");
 
-      await userEvent.type(screen.getByLabelText("목적지 도시"), "도쿄");
+      await selectTokyo();
       await userEvent.type(screen.getByLabelText("시작일"), "2026-10-27");
       await userEvent.type(screen.getByLabelText("종료일"), "2026-10-24");
       await userEvent.click(screen.getByRole("button", { name: "만들기" }));
@@ -169,13 +206,131 @@ describe("TripFormPage", () => {
     });
   });
 
+  describe("목적지 검색", () => {
+    it("고르면 타임존·통화가 함께 정해진다 — 따로 고르게 하지 않는다", async () => {
+      renderApp("/travel/trips/new");
+      await screen.findByLabelText("목적지 도시");
+
+      // 고르기 전에는 타임존 Select가 없다(검색이 정해 주므로).
+      expect(screen.queryByLabelText("타임존")).not.toBeInTheDocument();
+
+      await selectTokyo();
+
+      expect(screen.getByText(/Asia\/Tokyo · JPY/)).toBeInTheDocument();
+    });
+
+    it("고른 도시의 좌표를 함께 보낸다 — 장소 검색이 이걸로 목적지 주변을 편향시킨다", async () => {
+      const seen = captureWrite("post");
+      renderApp("/travel/trips/new");
+      await screen.findByLabelText("목적지 도시");
+
+      await fillNewTripForm();
+      await userEvent.click(screen.getByRole("button", { name: "만들기" }));
+
+      await waitFor(() => expect(seen).toHaveLength(1));
+      expect(seen[0]).toMatchObject({
+        destinationName: "도쿄",
+        timezone: "Asia/Tokyo",
+        currency: "JPY",
+        lat: 35.6764225,
+        lng: 139.650027,
+      });
+    });
+
+    it("검색어를 서버로 보낸다", async () => {
+      const queries = mockCities();
+      renderApp("/travel/trips/new");
+      await screen.findByLabelText("목적지 도시");
+
+      await userEvent.type(screen.getByLabelText("목적지 도시"), "오사카");
+      await userEvent.click(screen.getByRole("button", { name: "검색" }));
+
+      await waitFor(() => expect(queries).toEqual(["오사카"]));
+    });
+
+    it("검색창에서 엔터를 눌러도 여행이 저장되지는 않는다", async () => {
+      const seen = captureWrite("post");
+      const queries = mockCities();
+      renderApp("/travel/trips/new");
+      await screen.findByLabelText("목적지 도시");
+
+      await userEvent.type(screen.getByLabelText("목적지 도시"), "도쿄{Enter}");
+
+      // 검색 폼이 바깥 폼 안에 있어 제출이 새면 목적지도 안 고른 채 저장된다.
+      await waitFor(() => expect(queries).toEqual(["도쿄"]));
+      expect(seen).toHaveLength(0);
+    });
+  });
+
+  describe("검색이 막혔을 때", () => {
+    it("검색이 실패해도 직접 입력으로 여행을 만들 수 있다", async () => {
+      server.use(
+        http.get(`${API_BASE}/travel/places/cities`, () =>
+          HttpResponse.json({ code: "ERR" }, { status: 500 }),
+        ),
+      );
+      const seen = captureWrite("post");
+      renderApp("/travel/trips/new");
+      await screen.findByLabelText("목적지 도시");
+
+      await userEvent.type(screen.getByLabelText("목적지 도시"), "도쿄");
+      await userEvent.click(screen.getByRole("button", { name: "검색" }));
+      await userEvent.click(
+        await screen.findByRole("button", { name: "직접 입력하기" }),
+      );
+
+      // 여행 만들기가 외부 API에 걸려 막히면 안 된다.
+      await userEvent.type(screen.getByLabelText("목적지 도시"), "도쿄");
+      await userEvent.type(screen.getByLabelText("시작일"), "2026-10-24");
+      await userEvent.type(screen.getByLabelText("종료일"), "2026-10-27");
+      await userEvent.click(screen.getByRole("button", { name: "만들기" }));
+
+      await waitFor(() => expect(seen).toHaveLength(1));
+      expect(seen[0]).toMatchObject({ destinationName: "도쿄" });
+    });
+
+    it("직접 입력에서는 타임존·통화를 고를 수 있다 — 정해 줄 사람이 없다", async () => {
+      mockCities([]);
+      renderApp("/travel/trips/new");
+      await screen.findByLabelText("목적지 도시");
+
+      await userEvent.type(screen.getByLabelText("목적지 도시"), "없는도시");
+      await userEvent.click(screen.getByRole("button", { name: "검색" }));
+      await userEvent.click(
+        await screen.findByRole("button", { name: "직접 입력하기" }),
+      );
+
+      expect(screen.getByLabelText("타임존")).toBeInTheDocument();
+      expect(screen.getByLabelText("통화")).toBeInTheDocument();
+    });
+
+    it("직접 입력에서 검색으로 되돌아올 수 있다", async () => {
+      mockCities([]);
+      renderApp("/travel/trips/new");
+      await screen.findByLabelText("목적지 도시");
+
+      await userEvent.type(screen.getByLabelText("목적지 도시"), "없는도시");
+      await userEvent.click(screen.getByRole("button", { name: "검색" }));
+      await userEvent.click(
+        await screen.findByRole("button", { name: "직접 입력하기" }),
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: "검색으로 고르기" }),
+      );
+
+      expect(screen.getByRole("button", { name: "검색" })).toBeInTheDocument();
+    });
+  });
+
   describe("수정", () => {
     it("기존 값으로 폼을 채운다", async () => {
       mockTripDetail();
       renderApp("/travel/trips/3/edit");
 
+      // 저장된 목적지는 검색창 값이 아니라 "선택한 목적지"로 드러난다 —
+      // 다시 검색하지 않는 한 그대로 유지된다.
       await waitFor(() => {
-        expect(screen.getByLabelText("목적지 도시")).toHaveValue("도쿄");
+        expect(screen.getByText(/선택한 목적지/)).toHaveTextContent("도쿄");
       });
       expect(screen.getByLabelText("여행 제목")).toHaveValue("도쿄 3박 4일");
       expect(screen.getByLabelText("시작일")).toHaveValue("2026-10-24");
@@ -190,7 +345,7 @@ describe("TripFormPage", () => {
       renderApp("/travel/trips/3/edit");
 
       await waitFor(() => {
-        expect(screen.getByLabelText("목적지 도시")).toHaveValue("도쿄");
+        expect(screen.getByText(/선택한 목적지/)).toHaveTextContent("도쿄");
       });
       expect(screen.getByLabelText("여행 제목")).toHaveValue("");
     });

--- a/fe/src/pages/travel/TripFormPage.tsx
+++ b/fe/src/pages/travel/TripFormPage.tsx
@@ -9,6 +9,7 @@ import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { LoadingText } from "@/components/ui/loading-text";
 import { Select } from "@/components/ui/select";
+import type { City } from "@/features/travel/api/places";
 import {
   fetchShrinkPreview,
   type TripDetail,
@@ -25,6 +26,7 @@ import {
   NOTIFY_MINUTES_OPTIONS,
   TIMEZONE_OPTIONS,
 } from "@/features/travel/lib/destinations";
+import { DestinationSearch } from "@/features/travel/places/DestinationSearch";
 import { toast } from "@/shared/lib/toast";
 
 const TITLE_MAX = 50;
@@ -36,6 +38,9 @@ interface FormState {
   endDate: string;
   timezone: string;
   currency: string;
+  /** 목적지 검색으로만 채워진다. 직접 입력에는 좌표가 없다. */
+  lat: number | null;
+  lng: number | null;
   notifyMinutes: string;
 }
 
@@ -46,6 +51,8 @@ const EMPTY: FormState = {
   endDate: "",
   timezone: "Asia/Tokyo",
   currency: "JPY",
+  lat: null,
+  lng: null,
   notifyMinutes: String(DEFAULT_NOTIFY_MINUTES),
 };
 
@@ -53,8 +60,12 @@ const EMPTY: FormState = {
  * S-03 여행 생성·수정. 생성과 수정이 같은 폼을 쓴다(서버도 전체 수정이다).
  *
  * <p>입력 순서는 명세 고정 — 목적지 → 제목 → 기간 → 자동 지정 확인 → 기본 알림 시점.
- * 1단계는 목적지를 직접 입력하고 타임존·통화를 고르지만, 2단계에서 검색으로 바뀌어도
- * <b>순서와 안내 문구 자리는 그대로다</b>. 입력 수단만 교체된다.
+ *
+ * <p>목적지는 <b>검색으로 고른다</b>. 고르면 타임존·통화·좌표가 함께 정해진다.
+ * 좌표가 특히 중요하다 — 장소 검색이 이 값으로 목적지 주변을 편향시킨다.
+ *
+ * <p>다만 검색은 유료 외부 API라 언제든 막힐 수 있고, 그때 여행을 아예 못 만들면 안 된다.
+ * 직접 입력 + 타임존·통화 선택을 대체 경로로 남긴다.
  */
 export function TripFormPage() {
   const { tripId } = useParams();
@@ -69,6 +80,8 @@ export function TripFormPage() {
   const [error, setError] = useState<string | null>(null);
   const [shrinkCount, setShrinkCount] = useState<number | null>(null);
   const [checkingShrink, setCheckingShrink] = useState(false);
+  // 수정 모드는 이미 목적지가 정해져 있다 — 다시 검색시키지 않고 저장된 값을 보여준다.
+  const [manual, setManual] = useState(false);
 
   // 수정 모드는 서버 값으로 폼을 채운다.
   useEffect(() => {
@@ -92,6 +105,17 @@ export function TripFormPage() {
 
   const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
     setForm((prev) => ({ ...prev, [key]: value }));
+
+  /** 목적지를 고르면 타임존·통화·좌표가 한꺼번에 정해진다. 따로 고르게 하지 않는다. */
+  const selectCity = (city: City) =>
+    setForm((prev) => ({
+      ...prev,
+      destinationName: city.name,
+      timezone: city.timezone,
+      currency: city.currency,
+      lat: city.lat,
+      lng: city.lng,
+    }));
 
   /** 저장 직전 검증. 서버도 같은 규칙을 보지만 왕복 없이 바로 알려주는 편이 낫다. */
   const validate = (): string | null => {
@@ -170,16 +194,33 @@ export function TripFormPage() {
       </header>
 
       <form className="flex flex-col gap-4" onSubmit={submit} noValidate>
-        {/* 1. 목적지 — 2단계에서 이 자리가 검색으로 바뀐다. */}
-        <FormField label="목적지 도시" htmlFor="destinationName">
-          <Input
-            id="destinationName"
+        {/* 1. 목적지 — 검색으로 고르면 타임존·통화·좌표가 함께 정해진다. */}
+        {manual ? (
+          <div className="flex flex-col gap-2">
+            <FormField label="목적지 도시" htmlFor="destinationName">
+              <Input
+                id="destinationName"
+                value={form.destinationName}
+                onChange={(e) => set("destinationName", e.target.value)}
+                placeholder="도쿄"
+                maxLength={100}
+              />
+            </FormField>
+            <button
+              type="button"
+              onClick={() => setManual(false)}
+              className="text-muted-foreground hover:text-foreground self-start text-xs underline"
+            >
+              검색으로 고르기
+            </button>
+          </div>
+        ) : (
+          <DestinationSearch
             value={form.destinationName}
-            onChange={(e) => set("destinationName", e.target.value)}
-            placeholder="도쿄"
-            maxLength={100}
+            onSelect={selectCity}
+            onFallback={() => setManual(true)}
           />
-        </FormField>
+        )}
 
         {/* 2. 제목 — 비우면 목적지 이름으로 저장된다. placeholder로 그걸 보여준다. */}
         <FormField label="여행 제목" htmlFor="title">
@@ -214,34 +255,37 @@ export function TripFormPage() {
           </FormField>
         </div>
 
-        <div className="flex gap-3">
-          <FormField
-            label="타임존"
-            labelId={timezoneLabelId}
-            className="min-w-0 flex-1"
-          >
-            <Select
-              value={form.timezone}
-              onValueChange={(v) => set("timezone", v)}
-              options={[...TIMEZONE_OPTIONS]}
-              ariaLabelledby={timezoneLabelId}
-            />
-          </FormField>
-          <FormField
-            label="통화"
-            labelId={currencyLabelId}
-            className="min-w-0 flex-1"
-          >
-            <Select
-              value={form.currency}
-              onValueChange={(v) => set("currency", v)}
-              options={[...CURRENCY_OPTIONS]}
-              ariaLabelledby={currencyLabelId}
-            />
-          </FormField>
-        </div>
+        {/* 검색으로 골랐으면 서버가 확정한 값이라 고를 것이 없다. 직접 입력일 때만 남는다. */}
+        {manual && (
+          <div className="flex gap-3">
+            <FormField
+              label="타임존"
+              labelId={timezoneLabelId}
+              className="min-w-0 flex-1"
+            >
+              <Select
+                value={form.timezone}
+                onValueChange={(v) => set("timezone", v)}
+                options={[...TIMEZONE_OPTIONS]}
+                ariaLabelledby={timezoneLabelId}
+              />
+            </FormField>
+            <FormField
+              label="통화"
+              labelId={currencyLabelId}
+              className="min-w-0 flex-1"
+            >
+              <Select
+                value={form.currency}
+                onValueChange={(v) => set("currency", v)}
+                options={[...CURRENCY_OPTIONS]}
+                ariaLabelledby={currencyLabelId}
+              />
+            </FormField>
+          </div>
+        )}
 
-        {/* 4. 자동 지정 확인 — 2단계에서는 목적지 선택만으로 이 값이 채워진다. */}
+        {/* 4. 자동 지정 확인 — 검색으로 골랐다면 이 값은 서버가 정해 준 것이다. */}
         <Alert variant="info">
           <Info />
           <AlertTitle>여행 중에는 이 타임존을 씁니다</AlertTitle>
@@ -308,6 +352,8 @@ function toFormState(trip: TripDetail): FormState {
     endDate: trip.endDate,
     timezone: trip.timezone,
     currency: trip.currency,
+    lat: trip.lat,
+    lng: trip.lng,
     notifyMinutes: String(trip.defaultNotifyMinutes),
   };
 }
@@ -320,6 +366,8 @@ function toRequest(form: FormState, confirmArchive: boolean): TripWriteRequest {
     endDate: form.endDate,
     timezone: form.timezone,
     currency: form.currency,
+    lat: form.lat,
+    lng: form.lng,
     defaultNotifyMinutes: Number(form.notifyMinutes),
     ...(confirmArchive ? { confirmArchive: true } : {}),
   };


### PR DESCRIPTION
## 이슈
closes #1061
## 작업 내용

여행 만들기에서 목적지를 **검색으로 고르면 타임존·통화·좌표가 함께 정해진다**. 1단계의 임시 목록(갈 만한 곳 18개 Select)이 빠진다.

**좌표가 이 작업의 핵심이다.** 장소 검색이 이 값으로 목적지 주변을 편향시킨다(#1059). 1단계에는 좌표가 없어 도쿄 여행에서 `라멘`을 쳐도 서울 가게가 나왔다.

**검색이 실패해도 여행은 만들 수 있어야 한다.** 유료 외부 API에 걸려 여행 만들기가 막히면 안 되므로, 직접 입력 + 타임존·통화 선택을 대체 경로로 남겼다(명세의 "1단계 대체 UI"). 되돌아오는 길도 있다.

검색창이 여행 폼 안에 있어 **엔터가 바깥 폼으로 새면 목적지도 안 고른 채 저장된다** — 막고 테스트로 고정했다.

### 목적지 후보 걸러내기 (BE 수정)

붙여 보고 나서 발견했다. **"파리"를 치면 파리바게뜨 지점들이 나왔다.**

`includedType: "locality"`는 이미 있었지만 **힌트일 뿐**이다. 그렇다고 `strictTypeFiltering`을 켜는 건 답이 아니었다 — 실제로 호출해 확인한 결과:

| 검색어 | soft locality | strict |
|---|---|---|
| 도쿄 | 도쿄도 `[admin_area_1]` | **(없음)** |
| 파리 | 파리바게뜨 대림현대점 `[bakery]` … | **(없음)** |
| 오사카 | 오사카시 `[locality]` | 오사카시 |

도시가 어느 단계로 잡히는지가 나라마다 다르다 — 오사카·런던·뉴욕은 `locality`, 도쿄도는 `administrative_area_level_1`, 파리는 `administrative_area_level_3`다. `locality` 하나로는 못 거른다.

그래서 **넉넉히 받아(20개) 응답의 `types`로 걸러내고**, 좁은 행정구역을 먼저 보여준다. "파리"는 상위 5개가 전부 파리바게뜨라 후보 수를 늘리는 게 함께 필요했다.

## 확인

`./gradlew check` · FE 게이트(`format:check` · `lint` · `test` 743 · `build`) 통과.

걸러내기는 구글 호출과 떼어 순수 로직으로 두고 단위 테스트했다(`GooglePlacesClientTest`). 기존 폼 테스트는 전부 새 검색 경로를 지나도록 바꿨고, 이번 변경 고유의 테스트 7개를 더했다.

로컬에서 **실제 Google 응답**으로:

| 검색어 | 결과 |
|---|---|
| 도쿄 | 도쿄도 (`Asia/Tokyo` / `JPY`) |
| 파리 | 아홍디쓰멍 드 파리 (`Europe/Paris` / **`EUR`**) — 파리바게뜨 사라짐 |
| 오사카 | 오사카시 (`Asia/Tokyo` / `JPY`) |
| 런던 · 뉴욕 · 방콕 | `Europe/London`/`GBP` · `America/New_York`/`USD` · `Asia/Bangkok`/`THB` |

오사카로 여행을 만들어 `lat=34.6952474, lng=135.5012079`가 저장되는 것, 그 여행에서 `라멘`을 치면 **20개가 전부 오사카 가게**(우메다·신사이바시·난바)로 나오는 것까지 확인했다. 좌표가 끝까지 이어진다.

### 남겨 둔 것

`destinationPlaceId`는 이번에도 비운다. 도시를 `travel_place`에 넣으면 "이전 여행에서 좋았던 곳" 후보에 도시가 섞이고, 지금 이 필드를 읽는 곳도 없다.

파리가 `아홍디쓰멍 드 파리`로 나오는 건 구글이 주는 이름 그대로다. 타임존·통화·좌표는 정확하고, 여행 제목은 따로 정할 수 있어 그대로 뒀다.
