### PR TITLE
feat : 일정 사이 이동시간 계산 (직선거리 판정 + Routes)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/dto/BoardResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/dto/BoardResponse.java
@@ -2,6 +2,7 @@ package ds.project.orino.planner.travel.board.dto;
 
 import ds.project.orino.domain.planner.travel.entity.TripStatus;
 import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
+import ds.project.orino.planner.travel.route.dto.LegResponse;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,7 +18,7 @@ import java.util.List;
  *                      요청이 날짜를 생략했을 때 서버가 무엇을 골랐는지 FE가 알아야 탭을 강조할 수 있다
  * @param archiveCount  미배정 보관함 일정 수(보관함 칩의 "{n}개")
  * @param activities    선택된 날짜(또는 보관함)의 일정만. {@code sortOrder} 순
- * @param legs          연속한 두 일정 사이 이동시간. 2단계에서 채운다 — 지금은 항상 비어 있다
+ * @param legs          연속한 두 일정 사이 이동시간(§4.4). 장소 없는 일정은 건너뛴다
  */
 public record BoardResponse(
         BoardTrip trip,
@@ -25,7 +26,7 @@ public record BoardResponse(
         LocalDate selectedDate,
         long archiveCount,
         List<ActivityResponse> activities,
-        List<Object> legs
+        List<LegResponse> legs
 ) {
 
     /**

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
@@ -10,6 +10,7 @@ import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
 import ds.project.orino.domain.planner.travel.repository.TripRepository;
 import ds.project.orino.planner.travel.activity.service.ActivityService;
 import ds.project.orino.planner.travel.board.dto.BoardResponse;
+import ds.project.orino.planner.travel.route.service.LegService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,15 +37,18 @@ public class BoardService {
     private final TripRepository tripRepository;
     private final TripActivityRepository activityRepository;
     private final ActivityService activityService;
+    private final LegService legService;
     private final Clock clock;
 
     public BoardService(TripRepository tripRepository,
                         TripActivityRepository activityRepository,
                         ActivityService activityService,
+                        LegService legService,
                         Clock clock) {
         this.tripRepository = tripRepository;
         this.activityRepository = activityRepository;
         this.activityService = activityService;
+        this.legService = legService;
         this.clock = clock;
     }
 
@@ -71,8 +75,7 @@ public class BoardService {
                 selectedDate,
                 activityRepository.countUnscheduled(tripId),
                 activityService.toResponses(activities),
-                // 이동시간(legs)은 장소·Routes가 붙는 2단계에서 채운다.
-                List.of());
+                legService.legs(activities));
     }
 
     /**

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/client/GoogleRoutesClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/client/GoogleRoutesClient.java
@@ -1,0 +1,110 @@
+package ds.project.orino.planner.travel.route.client;
+
+import ds.project.orino.planner.travel.route.config.RoutesProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.JsonNode;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Optional;
+
+/** Google Routes {@code computeRoutes}. 실패는 예외 대신 빈 값으로 돌려준다. */
+@Component
+public class GoogleRoutesClient implements RoutesClient {
+
+    private static final Logger log = LoggerFactory.getLogger(GoogleRoutesClient.class);
+
+    /** 필드마스크가 곧 과금 등급이다 — 소요 시간과 거리만 받는다(경로 폴리라인은 쓰지 않는다). */
+    private static final String FIELD_MASK = "routes.duration,routes.distanceMeters";
+
+    private final RestClient restClient;
+    private final RoutesProperties props;
+
+    public GoogleRoutesClient(RoutesProperties props) {
+        this.props = props;
+        this.restClient = RestClient.builder()
+                .baseUrl(props.baseUrl())
+                .requestFactory(requestFactory(props))
+                .build();
+    }
+
+    private static ClientHttpRequestFactory requestFactory(RoutesProperties props) {
+        var factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(props.connectTimeout());
+        factory.setReadTimeout(props.readTimeout());
+        return factory;
+    }
+
+    @Override
+    public Optional<Route> route(Coordinates origin, Coordinates destination, TravelMode mode) {
+        if (!props.enabled()) {
+            return Optional.empty();
+        }
+        try {
+            JsonNode root = restClient.post()
+                    .uri("/directions/v2:computeRoutes")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-Goog-Api-Key", props.apiKey())
+                    .header("X-Goog-FieldMask", FIELD_MASK)
+                    .body(body(origin, destination, mode))
+                    .retrieve()
+                    .body(JsonNode.class);
+            return parse(root);
+        } catch (Exception e) {
+            // 경로를 못 얻는 건 흔한 일이다(섬·해외 구간). 직선거리로 대체된다.
+            log.warn("Routes 조회 실패: mode={}, {}", mode, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private Map<String, Object> body(Coordinates origin, Coordinates destination, TravelMode mode) {
+        return Map.of(
+                "origin", waypoint(origin),
+                "destination", waypoint(destination),
+                "travelMode", mode.name(),
+                "languageCode", props.languageCode(),
+                "units", "METRIC");
+    }
+
+    private static Map<String, Object> waypoint(Coordinates c) {
+        return Map.of("location", Map.of("latLng",
+                Map.of("latitude", c.lat(), "longitude", c.lng())));
+    }
+
+    private static Optional<Route> parse(JsonNode root) {
+        JsonNode routes = root == null ? null : root.get("routes");
+        if (routes == null || !routes.isArray() || routes.isEmpty()) {
+            // 경로 없음도 정상 응답이다(빈 routes 배열).
+            return Optional.empty();
+        }
+        JsonNode first = routes.get(0);
+        Integer seconds = durationSeconds(first.get("duration"));
+        JsonNode meters = first.get("distanceMeters");
+        if (seconds == null || meters == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new Route(seconds, meters.asInt()));
+    }
+
+    /** {@code duration}은 {@code "1074s"} 형태의 문자열로 온다. */
+    private static Integer durationSeconds(JsonNode duration) {
+        if (duration == null || duration.isNull()) {
+            return null;
+        }
+        String text = duration.asString();
+        if (text == null || !text.endsWith("s")) {
+            return null;
+        }
+        try {
+            return new BigDecimal(text.substring(0, text.length() - 1)).intValue();
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/client/RoutesClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/client/RoutesClient.java
@@ -1,0 +1,26 @@
+package ds.project.orino.planner.travel.route.client;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+/**
+ * 두 지점 사이 경로 조회.
+ *
+ * <p>구현을 갈아끼울 수 있게 인터페이스로 둔다 — 테스트에서 실제 구글을 부르면 유료 호출이
+ * 발생하고, 무엇보다 호출 횟수를 세어 <b>캐시가 실제로 호출을 줄이는지</b> 확인할 수 없다.
+ */
+public interface RoutesClient {
+
+    /** 경로를 못 얻으면 빈 값. 예외를 던지지 않는다 — 이동시간 때문에 보드가 죽으면 안 된다. */
+    Optional<Route> route(Coordinates origin, Coordinates destination, TravelMode mode);
+
+    record Coordinates(BigDecimal lat, BigDecimal lng) {
+    }
+
+    /**
+     * @param durationSeconds 구글이 준 소요 시간
+     * @param distanceM       실제 경로 거리(직선거리가 아니다)
+     */
+    record Route(int durationSeconds, int distanceM) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/client/TravelMode.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/client/TravelMode.java
@@ -1,0 +1,12 @@
+package ds.project.orino.planner.travel.route.client;
+
+/**
+ * 앱이 계산하는 이동수단(§1.3).
+ *
+ * <p>대중교통은 없다. 환승·요금·실시간 지연을 우리가 다시 그릴 이유가 없고, 명세도 처음부터
+ * 구글 지도 딥링크로 넘기기로 되어 있다. (도쿄 구간 TRANSIT은 실제로 빈 결과를 준다.)
+ */
+public enum TravelMode {
+    WALK,
+    DRIVE
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/config/RoutesProperties.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/config/RoutesProperties.java
@@ -1,0 +1,35 @@
+package ds.project.orino.planner.travel.route.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * Google Routes 설정. API 키는 Places와 같은 것을 쓴다(같은 GCP 프로젝트의 제한 키).
+ *
+ * <p>{@code apiKey}가 비면 이동시간만 직선거리로 대체되고 보드는 그대로 뜬다 —
+ * 이동시간 때문에 일정이 안 보이면 안 된다.
+ *
+ * @param apiKey         Places/Routes 공용 API 키(비면 fallback으로만 동작)
+ * @param baseUrl        Routes API base URL
+ * @param languageCode   응답 언어
+ * @param cacheTtl       구간 캐시 TTL. 같은 두 지점 사이 거리는 잘 변하지 않는다
+ * @param walkThresholdM 이 직선거리 이하면 도보, 초과면 자동차(§1.3 — 1.5km)
+ * @param connectTimeout 연결 타임아웃
+ * @param readTimeout    읽기 타임아웃
+ */
+@ConfigurationProperties(prefix = "travel.routes")
+public record RoutesProperties(
+        String apiKey,
+        String baseUrl,
+        String languageCode,
+        Duration cacheTtl,
+        int walkThresholdM,
+        Duration connectTimeout,
+        Duration readTimeout
+) {
+
+    public boolean enabled() {
+        return apiKey != null && !apiKey.isBlank();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/dto/LegResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/dto/LegResponse.java
@@ -1,0 +1,22 @@
+package ds.project.orino.planner.travel.route.dto;
+
+import ds.project.orino.planner.travel.route.client.TravelMode;
+
+/**
+ * 연속한 두 일정 사이 이동(§4.4). 보드 응답에 실려 일정 리스트에 항상 표시된다.
+ *
+ * @param fromActivityId  출발 일정
+ * @param toActivityId    도착 일정. 사이에 장소 없는 일정이 끼면 건너뛴 결과다
+ * @param durationMinutes 소요 시간(분). {@code fallback}이면 null — 거리만 안다
+ * @param distanceM       거리(m). 경로 거리이고, {@code fallback}이면 직선거리다
+ * @param fallback        Routes를 못 얻어 직선거리로 대체했다. FE는 {@code 약 N.Nkm}로 보여준다
+ */
+public record LegResponse(
+        Long fromActivityId,
+        Long toActivityId,
+        TravelMode mode,
+        Integer durationMinutes,
+        int distanceM,
+        boolean fallback
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/service/Haversine.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/service/Haversine.java
@@ -1,0 +1,31 @@
+package ds.project.orino.planner.travel.route.service;
+
+import java.math.BigDecimal;
+
+/**
+ * 두 좌표 사이 직선거리(m).
+ *
+ * <p>두 곳에 쓴다 — <b>이동수단을 정하는 기준</b>(1.5km 이하 도보)과, Routes가 실패했을 때
+ * 보여줄 <b>대체값</b>이다. 어느 쪽도 정밀도가 중요하지 않아 지구를 구로 본다.
+ */
+public final class Haversine {
+
+    /** 지구 평균 반지름(m). */
+    private static final double EARTH_RADIUS_M = 6_371_000;
+
+    private Haversine() {
+    }
+
+    public static int distanceM(BigDecimal lat1, BigDecimal lng1,
+                                BigDecimal lat2, BigDecimal lng2) {
+        double phi1 = Math.toRadians(lat1.doubleValue());
+        double phi2 = Math.toRadians(lat2.doubleValue());
+        double deltaPhi = Math.toRadians(lat2.doubleValue() - lat1.doubleValue());
+        double deltaLambda = Math.toRadians(lng2.doubleValue() - lng1.doubleValue());
+
+        double a = Math.sin(deltaPhi / 2) * Math.sin(deltaPhi / 2)
+                + Math.cos(phi1) * Math.cos(phi2)
+                * Math.sin(deltaLambda / 2) * Math.sin(deltaLambda / 2);
+        return (int) Math.round(EARTH_RADIUS_M * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a)));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/service/LegService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/service/LegService.java
@@ -1,0 +1,141 @@
+package ds.project.orino.planner.travel.route.service;
+
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.entity.TripActivity;
+import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.planner.travel.route.client.RoutesClient;
+import ds.project.orino.planner.travel.route.client.TravelMode;
+import ds.project.orino.planner.travel.route.config.RoutesProperties;
+import ds.project.orino.planner.travel.route.dto.LegResponse;
+import ds.project.orino.redis.planner.travel.RouteCacheRepository;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 연속한 두 일정 사이 이동시간(§4.4).
+ *
+ * <p>일정 리스트에 항상 표시된다 — 현지에서 계획을 따라갈 수 있는지는 "다음 장소까지 얼마나
+ * 걸리는지"가 가른다.
+ */
+@Service
+public class LegService {
+
+    private final TravelPlaceRepository placeRepository;
+    private final RoutesClient routesClient;
+    private final RouteCacheRepository cacheRepository;
+    private final RoutesProperties props;
+    private final ObjectMapper objectMapper;
+
+    public LegService(TravelPlaceRepository placeRepository,
+                      RoutesClient routesClient,
+                      RouteCacheRepository cacheRepository,
+                      RoutesProperties props,
+                      ObjectMapper objectMapper) {
+        this.placeRepository = placeRepository;
+        this.routesClient = routesClient;
+        this.cacheRepository = cacheRepository;
+        this.props = props;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 정렬된 일정 목록에서 구간을 만든다.
+     *
+     * <p><b>장소 없는 일정은 건너뛴다</b>(§4.4) — "점심"처럼 장소를 안 정한 일정이 사이에 끼어도
+     * 앞뒤 장소 사이 이동은 여전히 알고 싶다. 그걸 끊으면 정작 필요한 구간이 사라진다.
+     */
+    public List<LegResponse> legs(List<TripActivity> ordered) {
+        List<Located> located = locate(ordered);
+        List<LegResponse> legs = new ArrayList<>();
+        for (int i = 0; i + 1 < located.size(); i++) {
+            legs.add(leg(located.get(i), located.get(i + 1)));
+        }
+        return legs;
+    }
+
+    /** 좌표를 가진 일정만 순서대로 남긴다. 장소가 있어도 좌표가 없으면(직접 입력) 뺀다. */
+    private List<Located> locate(List<TripActivity> ordered) {
+        List<Long> placeIds = ordered.stream()
+                .map(TripActivity::getPlaceId)
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+        if (placeIds.isEmpty()) {
+            return List.of();
+        }
+        Map<Long, TravelPlace> places = placeRepository.findAllByIdIn(placeIds).stream()
+                .collect(Collectors.toMap(TravelPlace::getId, Function.identity()));
+
+        List<Located> located = new ArrayList<>();
+        for (TripActivity activity : ordered) {
+            if (activity.getPlaceId() == null) {
+                continue;
+            }
+            TravelPlace place = places.get(activity.getPlaceId());
+            if (place == null || place.getLat() == null || place.getLng() == null) {
+                continue;
+            }
+            located.add(new Located(activity.getId(), place.getLat(), place.getLng()));
+        }
+        return located;
+    }
+
+    private LegResponse leg(Located from, Located to) {
+        int straightM = Haversine.distanceM(from.lat(), from.lng(), to.lat(), to.lng());
+        // 수단은 직선거리로 정한다(§1.3). 경로 거리로 정하면 수단을 알기 위해 경로가 필요하고,
+        // 경로를 얻으려면 수단이 필요해 순환한다.
+        TravelMode mode = straightM <= props.walkThresholdM() ? TravelMode.WALK : TravelMode.DRIVE;
+
+        return route(from, to, mode)
+                .map(r -> new LegResponse(from.activityId(), to.activityId(), mode,
+                        Math.round(r.durationSeconds() / 60f), r.distanceM(), false))
+                // 실패해도 구간 자체는 남긴다 — 거리만이라도 알면 계획을 세울 수 있다.
+                .orElseGet(() -> new LegResponse(from.activityId(), to.activityId(), mode,
+                        null, straightM, true));
+    }
+
+    /**
+     * 캐시를 먼저 본다. 보드는 열 때마다 조회되고 날짜 탭을 넘길 때마다 다시 온다 —
+     * 캐시가 없으면 탭 하나 넘길 때마다 일정 수만큼 유료 호출이 난다.
+     */
+    private Optional<RoutesClient.Route> route(Located from, Located to, TravelMode mode) {
+        String key = legKey(from, to, mode);
+        Optional<String> hit = cacheRepository.find(key);
+        if (hit.isPresent()) {
+            return Optional.of(objectMapper.readValue(hit.get(), RoutesClient.Route.class));
+        }
+        Optional<RoutesClient.Route> fresh = routesClient.route(
+                new RoutesClient.Coordinates(from.lat(), from.lng()),
+                new RoutesClient.Coordinates(to.lat(), to.lng()),
+                mode);
+        // 실패는 캐시하지 않는다 — 일시적 실패를 붙들고 있으면 복구된 뒤에도 계속 fallback이다.
+        fresh.ifPresent(r ->
+                cacheRepository.save(key, objectMapper.writeValueAsString(r), props.cacheTtl()));
+        return fresh;
+    }
+
+    /**
+     * 좌표 쌍 + 이동수단. 일정 id를 넣지 않는다 — 순서를 바꿔도 같은 두 장소 사이 구간은
+     * 그대로 재사용되어야 한다(§4.4).
+     */
+    private static String legKey(Located from, Located to, TravelMode mode) {
+        return "%s,%s:%s,%s:%s".formatted(
+                round(from.lat()), round(from.lng()), round(to.lat()), round(to.lng()), mode);
+    }
+
+    /** 소수점 5자리(약 1m). 좌표가 미세하게 달라도 같은 구간으로 본다. */
+    private static BigDecimal round(BigDecimal value) {
+        return value.setScale(5, java.math.RoundingMode.HALF_UP).stripTrailingZeros();
+    }
+
+    private record Located(Long activityId, BigDecimal lat, BigDecimal lng) {
+    }
+}

--- a/be/orino-app-api/src/main/resources/application.yml
+++ b/be/orino-app-api/src/main/resources/application.yml
@@ -93,6 +93,17 @@ travel:
     search-radius-m: ${GOOGLE_PLACES_RADIUS_M:20000}
     connect-timeout: ${GOOGLE_PLACES_CONNECT_TIMEOUT:5s}
     read-timeout: ${GOOGLE_PLACES_READ_TIMEOUT:10s}
+  routes:
+    # Places와 같은 키다(같은 GCP 프로젝트의 제한 키). 비면 이동시간이 직선거리로만 나온다.
+    api-key: ${GOOGLE_PLACES_API_KEY:}
+    base-url: ${GOOGLE_ROUTES_BASE_URL:https://routes.googleapis.com}
+    language-code: ${GOOGLE_ROUTES_LANGUAGE:ko}
+    # 같은 두 지점 사이 거리는 잘 변하지 않는다. 보드를 열 때마다 부르지 않기 위한 캐시다.
+    cache-ttl: ${GOOGLE_ROUTES_CACHE_TTL:30d}
+    # §1.3 — 직선거리 1.5km 이하 도보, 초과 자동차.
+    walk-threshold-m: ${GOOGLE_ROUTES_WALK_THRESHOLD_M:1500}
+    connect-timeout: ${GOOGLE_ROUTES_CONNECT_TIMEOUT:5s}
+    read-timeout: ${GOOGLE_ROUTES_READ_TIMEOUT:10s}
 
 management:
   tracing:

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/LegIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/LegIntegrationTest.java
@@ -1,0 +1,318 @@
+package ds.project.orino.planner.travel.route;
+
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.planner.travel.route.client.RoutesClient;
+import ds.project.orino.planner.travel.route.client.TravelMode;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 보드의 이동시간(§4.4). 외부 호출만 스텁으로 갈아끼우고 캐시(Redis)·저장(MySQL)은 실물이다 —
+ * 캐시가 정말 호출을 줄이는지는 실제 Redis 없이 확인되지 않는다.
+ */
+@Import(LegIntegrationTest.StubConfig.class)
+class LegIntegrationTest extends ApiTestSupport {
+
+    @TestConfiguration
+    static class StubConfig {
+        @Bean
+        @Primary
+        RoutesClient stubRoutesClient() {
+            return new StubRoutesClient();
+        }
+    }
+
+    /** 센소지. */
+    private static final BigDecimal SENSOJI_LAT = new BigDecimal("35.7147651");
+    private static final BigDecimal SENSOJI_LNG = new BigDecimal("139.7966553");
+    /** 도쿄 스카이트리 — 센소지에서 약 1.3km(도보 판정 안쪽). */
+    private static final BigDecimal SKYTREE_LAT = new BigDecimal("35.7100627");
+    private static final BigDecimal SKYTREE_LNG = new BigDecimal("139.8107004");
+    /** 신주쿠 — 센소지에서 약 8km(자동차 판정). */
+    private static final BigDecimal SHINJUKU_LAT = new BigDecimal("35.6895014");
+    private static final BigDecimal SHINJUKU_LNG = new BigDecimal("139.6917337");
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TravelPlaceRepository placeRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+    @Autowired
+    private RoutesClient routesClient;
+
+    private StubRoutesClient stub;
+    private String authHeader;
+    private Long memberId;
+    private long tripId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        stub = (StubRoutesClient) routesClient;
+        stub.reset();
+
+        memberRepository.save(MemberFixture.create());
+        memberId = memberRepository.findAll().get(0).getId();
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        tripId = createTrip();
+    }
+
+    /**
+     * 좌표를 조금씩 흔들어 테스트마다 다른 캐시 키를 쓴다 — Redis 컨테이너는 테스트 사이에
+     * 살아 있어, 앞 테스트가 캐시해 둔 구간이 새어 들어오면 호출 횟수 검증이 무너진다.
+     */
+    private static BigDecimal jitter(BigDecimal base) {
+        int nudge = Math.abs(UUID.randomUUID().hashCode() % 9000) + 1000;
+        return base.add(new BigDecimal("0.0000001").multiply(BigDecimal.valueOf(nudge)));
+    }
+
+    private Long placeAt(String name, BigDecimal lat, BigDecimal lng) {
+        TravelPlace place = placeRepository.save(
+                TravelPlace.fromGoogle(memberId, "g-" + name + "-" + UUID.randomUUID(), name));
+        place.updateBasics(name + " 주소", lat, lng, null, null);
+        return placeRepository.saveAndFlush(place).getId();
+    }
+
+    private long createTrip() throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "도쿄", "destinationName": "도쿄",
+                                 "startDate": "2026-10-24", "endDate": "2026-10-27",
+                                 "timezone": "Asia/Tokyo", "currency": "JPY"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private void addActivity(String title, Long placeId) throws Exception {
+        String place = placeId == null ? "" : ", \"placeId\": %d".formatted(placeId);
+        mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "%s", "activityDate": "2026-10-24"%s}
+                                """.formatted(title, place)))
+                .andExpect(status().isOk());
+    }
+
+    private org.springframework.test.web.servlet.ResultActions board() throws Exception {
+        return mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                        .param("date", "2026-10-24")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+    }
+
+    @Nested
+    @DisplayName("어디에 구간이 생기나")
+    class Which {
+
+        @Test
+        @DisplayName("장소가 있는 연속된 두 일정 사이에 생긴다")
+        void betweenConsecutivePlaces() throws Exception {
+            addActivity("센소지", placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("스카이트리", placeAt("스카이트리", jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+
+            board()
+                    .andExpect(jsonPath("$.data.legs", hasSize(1)))
+                    .andExpect(jsonPath("$.data.legs[0].durationMinutes").value(12))
+                    .andExpect(jsonPath("$.data.legs[0].distanceM").value(900))
+                    .andExpect(jsonPath("$.data.legs[0].fallback").value(false));
+        }
+
+        @Test
+        @DisplayName("사이에 장소 없는 일정이 끼면 건너뛰고 잇는다")
+        void skipsActivitiesWithoutPlace() throws Exception {
+            addActivity("센소지", placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            // "점심"처럼 장소를 안 정한 일정이 있다고 앞뒤 이동을 모르면 안 된다.
+            addActivity("점심", null);
+            addActivity("스카이트리", placeAt("스카이트리", jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+
+            board().andExpect(jsonPath("$.data.legs", hasSize(1)));
+            assertThat(stub.calls).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("장소가 하나뿐이면 구간이 없다 — 외부를 부르지도 않는다")
+        void noLegWithSinglePlace() throws Exception {
+            addActivity("센소지", placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("점심", null);
+
+            board().andExpect(jsonPath("$.data.legs", hasSize(0)));
+            assertThat(stub.calls).isEmpty();
+        }
+
+        @Test
+        @DisplayName("좌표 없는 장소(직접 입력)는 구간에 들어가지 않는다")
+        void ignoresPlacesWithoutCoordinates() throws Exception {
+            TravelPlace manual = placeRepository.save(TravelPlace.manual(memberId, "골목 카페"));
+            addActivity("센소지", placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("골목 카페", manual.getId());
+
+            board().andExpect(jsonPath("$.data.legs", hasSize(0)));
+        }
+    }
+
+    @Nested
+    @DisplayName("이동수단은 직선거리로 정한다(§1.3)")
+    class Mode {
+
+        @Test
+        @DisplayName("1.5km 이하는 도보")
+        void walkWhenClose() throws Exception {
+            addActivity("센소지", placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("스카이트리", placeAt("스카이트리", jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+
+            board().andExpect(jsonPath("$.data.legs[0].mode").value("WALK"));
+            assertThat(stub.calls.get(0).mode()).isEqualTo(TravelMode.WALK);
+        }
+
+        @Test
+        @DisplayName("1.5km 초과는 자동차")
+        void driveWhenFar() throws Exception {
+            addActivity("센소지", placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("신주쿠", placeAt("신주쿠", jitter(SHINJUKU_LAT), jitter(SHINJUKU_LNG)));
+
+            board().andExpect(jsonPath("$.data.legs[0].mode").value("DRIVE"));
+            assertThat(stub.calls.get(0).mode()).isEqualTo(TravelMode.DRIVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("Routes가 막혔을 때")
+    class Fallback {
+
+        @Test
+        @DisplayName("구간은 남기고 직선거리로 대체한다 — 거리만이라도 알면 계획이 선다")
+        void fallsBackToStraightLine() throws Exception {
+            stub.result = Optional.empty();
+            addActivity("센소지", placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("신주쿠", placeAt("신주쿠", jitter(SHINJUKU_LAT), jitter(SHINJUKU_LNG)));
+
+            board()
+                    .andExpect(jsonPath("$.data.legs", hasSize(1)))
+                    .andExpect(jsonPath("$.data.legs[0].fallback").value(true))
+                    .andExpect(jsonPath("$.data.legs[0].durationMinutes").doesNotExist())
+                    // 수단은 여전히 정해진다(직선거리로 판정하므로).
+                    .andExpect(jsonPath("$.data.legs[0].mode").value("DRIVE"))
+                    .andExpect(jsonPath("$.data.legs[0].distanceM").isNumber());
+        }
+
+        @Test
+        @DisplayName("실패는 캐시하지 않는다 — 복구된 뒤에도 계속 fallback이면 안 된다")
+        void doesNotCacheFailure() throws Exception {
+            Long from = placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG));
+            Long to = placeAt("스카이트리", jitter(SKYTREE_LAT), jitter(SKYTREE_LNG));
+            addActivity("센소지", from);
+            addActivity("스카이트리", to);
+
+            stub.result = Optional.empty();
+            board().andExpect(jsonPath("$.data.legs[0].fallback").value(true));
+
+            stub.result = Optional.of(new RoutesClient.Route(720, 900));
+            board().andExpect(jsonPath("$.data.legs[0].fallback").value(false));
+
+            assertThat(stub.calls).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("캐시")
+    class Caching {
+
+        @Test
+        @DisplayName("보드를 다시 열어도 외부 호출이 늘지 않는다 — 탭을 넘길 때마다 과금될 순 없다")
+        void reusesCachedLeg() throws Exception {
+            addActivity("센소지", placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("스카이트리", placeAt("스카이트리", jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+
+            for (int i = 0; i < 3; i++) {
+                board().andExpect(jsonPath("$.data.legs[0].durationMinutes").value(12));
+            }
+
+            assertThat(stub.calls).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("순서를 뒤집으면 다른 구간이라 새로 부른다 — 일방통행이면 경로가 다르다")
+        void reversedOrderIsDifferentLeg() throws Exception {
+            BigDecimal aLat = jitter(SENSOJI_LAT);
+            BigDecimal aLng = jitter(SENSOJI_LNG);
+            addActivity("센소지", placeAt("센소지", aLat, aLng));
+            addActivity("스카이트리", placeAt("스카이트리",
+                    jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+
+            String body = board().andReturn().getResponse().getContentAsString();
+            List<Integer> ids = com.jayway.jsonpath.JsonPath.read(body, "$.data.activities[*].id");
+            assertThat(stub.calls).hasSize(1);
+            assertThat(stub.calls.get(0).origin().lat()).isEqualByComparingTo(aLat);
+
+            mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                            .put("/api/travel/trips/" + tripId + "/activities/order")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"moves": [{"date": "2026-10-24",
+                                                "activityIds": [%d, %d]}]}
+                                    """.formatted(ids.get(1), ids.get(0))))
+                    .andExpect(status().isOk());
+            board();
+
+            // 캐시 키에 방향이 들어 있어야 반대 구간을 따로 잡는다.
+            assertThat(stub.calls).hasSize(2);
+            assertThat(stub.calls.get(1).destination().lat()).isEqualByComparingTo(aLat);
+        }
+    }
+
+    @Nested
+    @DisplayName("여러 구간")
+    class Multiple {
+
+        @Test
+        @DisplayName("일정이 셋이면 구간은 둘 — 리스트 사이사이에 들어간다")
+        void chainsAcrossActivities() throws Exception {
+            addActivity("센소지", placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("스카이트리", placeAt("스카이트리", jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+            addActivity("신주쿠", placeAt("신주쿠", jitter(SHINJUKU_LAT), jitter(SHINJUKU_LNG)));
+
+            String body = board()
+                    .andExpect(jsonPath("$.data.legs", hasSize(2)))
+                    .andReturn().getResponse().getContentAsString();
+
+            List<Integer> froms = com.jayway.jsonpath.JsonPath.read(body, "$.data.legs[*].fromActivityId");
+            List<Integer> tos = com.jayway.jsonpath.JsonPath.read(body, "$.data.legs[*].toActivityId");
+            // 앞 구간의 도착이 뒤 구간의 출발이다.
+            assertThat(tos.get(0)).isEqualTo(froms.get(1));
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/StubRoutesClient.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/StubRoutesClient.java
@@ -1,0 +1,36 @@
+package ds.project.orino.planner.travel.route;
+
+import ds.project.orino.planner.travel.route.client.RoutesClient;
+import ds.project.orino.planner.travel.route.client.TravelMode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 테스트용 Routes 스텁.
+ *
+ * <p>호출 인자를 기록해 <b>수단 판정이 실제로 어떻게 내려졌는지</b>와
+ * <b>캐시가 호출을 줄이는지</b>를 확인할 수 있게 한다.
+ */
+public class StubRoutesClient implements RoutesClient {
+
+    public record Call(Coordinates origin, Coordinates destination, TravelMode mode) {
+    }
+
+    public final List<Call> calls = new ArrayList<>();
+
+    /** 비우면 경로 없음 — fallback 경로를 탄다. */
+    public Optional<Route> result = Optional.of(new Route(720, 900));
+
+    @Override
+    public Optional<Route> route(Coordinates origin, Coordinates destination, TravelMode mode) {
+        calls.add(new Call(origin, destination, mode));
+        return result;
+    }
+
+    public void reset() {
+        calls.clear();
+        result = Optional.of(new Route(720, 900));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/service/HaversineTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/service/HaversineTest.java
@@ -1,0 +1,48 @@
+package ds.project.orino.planner.travel.route.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 직선거리. 이동수단 판정(1.5km)과 Routes 실패 시 대체값 둘 다 이 값에 걸려 있다.
+ */
+class HaversineTest {
+
+    private static int between(String lat1, String lng1, String lat2, String lng2) {
+        return Haversine.distanceM(new BigDecimal(lat1), new BigDecimal(lng1),
+                new BigDecimal(lat2), new BigDecimal(lng2));
+    }
+
+    @Test
+    @DisplayName("같은 지점은 0m")
+    void samePointIsZero() {
+        assertThat(between("35.7147", "139.7966", "35.7147", "139.7966")).isZero();
+    }
+
+    @Test
+    @DisplayName("센소지 → 도쿄 스카이트리는 약 1.2km (실제 직선 1.2km)")
+    void shortDistanceWithinTokyo() {
+        // 도보 판정(1.5km)이 갈리는 구간이라 여기가 틀리면 수단이 통째로 바뀐다.
+        int meters = between("35.7147", "139.7966", "35.7101", "139.8107");
+        assertThat(meters).isBetween(1_200, 1_400);
+    }
+
+    @Test
+    @DisplayName("서울 → 도쿄는 약 1,160km")
+    void longDistanceAcrossCountries() {
+        int meters = between("37.5665", "126.9780", "35.6762", "139.6503");
+        assertThat(meters).isBetween(1_140_000, 1_180_000);
+    }
+
+    @Test
+    @DisplayName("방향이 반대여도 거리는 같다")
+    void isSymmetric() {
+        int forward = between("35.7147", "139.7966", "35.6762", "139.6503");
+        int backward = between("35.6762", "139.6503", "35.7147", "139.7966");
+        assertThat(forward).isEqualTo(backward);
+    }
+}

--- a/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/travel/RouteCacheRepository.java
+++ b/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/travel/RouteCacheRepository.java
@@ -1,0 +1,37 @@
+package ds.project.orino.redis.planner.travel;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * 구간 이동시간 캐시.
+ *
+ * <p>보드는 열 때마다 조회되는데, 같은 두 지점 사이 거리는 잘 변하지 않는다. 캐시가 없으면
+ * <b>날짜 탭을 넘길 때마다 유료 호출이 일정 수만큼 난다</b>.
+ *
+ * <p>키를 여행·일정이 아니라 <b>좌표 쌍과 이동수단</b>으로 잡는다. 그래야 일정 순서를 바꿔도
+ * 같은 두 장소 사이 구간은 그대로 재사용되고(§4.4 "순서·장소가 바뀌기 전까지 재조회 안 함"),
+ * 여러 여행이 같은 구간을 공유한다.
+ */
+@Repository
+public class RouteCacheRepository {
+
+    private static final String PREFIX = "travel:routes:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public RouteCacheRepository(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public Optional<String> find(String legKey) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(PREFIX + legKey));
+    }
+
+    public void save(String legKey, String json, Duration ttl) {
+        redisTemplate.opsForValue().set(PREFIX + legKey, json, ttl);
+    }
+}

--- a/fe/src/features/travel/api/activities.ts
+++ b/fe/src/features/travel/api/activities.ts
@@ -55,6 +55,21 @@ export interface BoardTrip {
   recordMode: boolean;
 }
 
+/** 앱이 계산하는 이동수단. 대중교통은 계산하지 않는다 — 구글 지도 딥링크가 맡는다. */
+export type TravelMode = "WALK" | "DRIVE";
+
+export interface Leg {
+  fromActivityId: number;
+  toActivityId: number;
+  mode: TravelMode;
+  /** `fallback`이면 null — 거리만 안다. */
+  durationMinutes: number | null;
+  /** 경로 거리. `fallback`이면 직선거리다. */
+  distanceM: number;
+  /** Routes를 못 얻어 직선거리로 대체했다. 화면은 `약 N.Nkm`로 보여준다. */
+  fallback: boolean;
+}
+
 export interface Board {
   trip: BoardTrip;
   days: BoardDay[];
@@ -62,8 +77,8 @@ export interface Board {
   selectedDate: string | null;
   archiveCount: number;
   activities: Activity[];
-  /** 이동시간은 2단계. 지금은 항상 빈 배열. */
-  legs: unknown[];
+  /** 연속한 두 일정 사이 이동. 장소 없는 일정은 건너뛴 결과다. */
+  legs: Leg[];
 }
 
 /**


### PR DESCRIPTION
## 이슈
closes #1063
## 작업 내용

보드 응답의 `legs`가 비어 있던 자리를 채운다. 일정 리스트에 **항상 표시**되는 값이라, "다음 장소까지 얼마나 걸리는지"가 현지에서 계획을 따라갈 수 있는지를 가른다.

**장소 없는 일정은 건너뛴다**(§4.4). "점심"처럼 장소를 안 정한 일정이 사이에 끼어도 앞뒤 장소 사이 이동은 여전히 알고 싶다. 거기서 끊으면 정작 필요한 구간이 사라진다.

**이동수단은 직선거리로 정한다**(§1.3 — 1.5km 이하 도보, 초과 자동차). 경로 거리로 정하면 수단을 알기 위해 경로가 필요하고, 경로를 얻으려면 수단이 필요해 순환한다.

**캐시 키를 좌표 쌍 + 수단으로 잡았다.** 여행·일정 id를 넣지 않는다 — 순서를 바꿔도 같은 두 장소 사이 구간은 그대로 재사용되어야 하고(§4.4 "순서·장소가 바뀌기 전까지 재조회 안 함"), 여러 여행이 같은 구간을 공유한다. 캐시가 없으면 **날짜 탭을 넘길 때마다 일정 수만큼 유료 호출**이 난다.

**실패해도 구간은 남긴다.** Routes를 못 얻으면 `fallback: true` + 직선거리로 내려준다 — 거리만이라도 알면 계획이 선다. 실패 자체는 캐시하지 않는다(일시적 실패를 붙들면 복구된 뒤에도 계속 fallback이다).

**대중교통은 계산하지 않는다.** 환승·요금·실시간 지연을 우리가 다시 그릴 이유가 없고, 명세도 처음부터 구글 지도 딥링크로 넘기기로 되어 있다(§1.3). 2단계 착수 전 확인에서 Routes TRANSIT은 도쿄 구간에 실제로 빈 결과를 줬다.

## 확인

`./gradlew check` 통과. 통합 테스트는 외부 호출만 스텁으로 갈아끼우고 캐시(Redis)·저장(MySQL)은 실물을 쓴다 — 캐시가 정말 호출을 줄이는지는 실제 Redis 없이 확인되지 않는다. 스텁이 호출 인자를 기록해 **수단 판정이 어떻게 내려졌는지**까지 검증한다.

로컬 bootRun + **실제 Google Routes**:

```
1회차 (Routes 실호출)  (482ms)
   센소지    → 스카이트리  WALK    25분   1.7km  fallback=False
   스카이트리 → 신주쿠     DRIVE   28분  17.1km  fallback=False
2회차 (Redis 캐시)     (24ms)
   (동일)
```

- 센소지와 신주쿠 사이에 **장소 없는 "점심"을 끼워** 두었고, 구간이 스카이트리→신주쿠로 이어졌다
- 직선 1.3km 구간은 `WALK`, 8km 구간은 `DRIVE`로 갈렸다
- 캐시로 **482ms → 24ms**
- fallback: 서울 경복궁 → 도쿄 센소지(바다를 건너 자동차 경로가 없다) → `DRIVE — 1161.4km fallback=True`

FE는 `Board.legs` 타입만 `unknown[]`에서 실제 타입으로 바꿨다. 화면에 그리는 것은 다음 작업이다.
