### PR TITLE
feat : 순서 변경 응답 legs + 수단별 구간 조회

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/controller/ActivityController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/controller/ActivityController.java
@@ -61,7 +61,7 @@ public class ActivityController {
     public ApiResponse<ReorderResponse> reorder(@AuthenticationPrincipal Long memberId,
                                                 @PathVariable Long tripId,
                                                 @Valid @RequestBody ReorderRequest request) {
-        activityService.reorder(memberId, tripId, request);
-        return ApiResponse.success(ReorderResponse.empty());
+        return ApiResponse.success(
+                new ReorderResponse(activityService.reorder(memberId, tripId, request)));
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ReorderResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ReorderResponse.java
@@ -1,17 +1,15 @@
 package ds.project.orino.planner.travel.activity.dto;
 
+import ds.project.orino.planner.travel.route.dto.LegResponse;
+
 import java.util.List;
 
 /**
  * 순서 변경 결과. 재계산된 이동시간({@code legs})을 담아 드래그 직후 화면이 다시 조회하지 않고도
- * 이동시간을 갱신할 수 있게 한다.
+ * 이동시간을 갱신할 수 있게 한다 — 드래그는 손을 뗀 순간 결과가 보여야 하는 동작이다.
  *
- * <p>이동시간은 장소·Routes가 붙는 2단계 기능이라 1단계에서는 항상 비어 있다. 그래도 형태를
- * 지금 맞춰 두면 2단계에서 FE 계약이 바뀌지 않는다.
+ * <p>여러 날짜가 한 요청에 섞일 수 있어(날짜 이동) 건드린 날짜의 구간을 모두 담는다.
+ * 구간은 일정 id로 식별되므로 날짜가 섞여도 모호하지 않다.
  */
-public record ReorderResponse(List<Object> legs) {
-
-    public static ReorderResponse empty() {
-        return new ReorderResponse(List.of());
-    }
+public record ReorderResponse(List<LegResponse> legs) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
@@ -12,6 +12,8 @@ import ds.project.orino.planner.travel.activity.dto.ActivityPlace;
 import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
 import ds.project.orino.planner.travel.activity.dto.ActivityWriteRequest;
 import ds.project.orino.planner.travel.activity.dto.ReorderRequest;
+import ds.project.orino.planner.travel.route.dto.LegResponse;
+import ds.project.orino.planner.travel.route.service.LegService;
 import ds.project.orino.planner.travel.place.service.PlaceService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,15 +50,18 @@ public class ActivityService {
     private final TripRepository tripRepository;
     private final TravelPlaceRepository placeRepository;
     private final PlaceService placeService;
+    private final LegService legService;
 
     public ActivityService(TripActivityRepository activityRepository,
                            TripRepository tripRepository,
                            TravelPlaceRepository placeRepository,
-                           PlaceService placeService) {
+                           PlaceService placeService,
+                           LegService legService) {
         this.activityRepository = activityRepository;
         this.tripRepository = tripRepository;
         this.placeRepository = placeRepository;
         this.placeService = placeService;
+        this.legService = legService;
     }
 
     /**
@@ -140,7 +145,7 @@ public class ActivityService {
      * 클라이언트가 실수로 일부만 보내도 순서에 구멍이나 중복이 남지 않게 하기 위한 것이다.
      */
     @Transactional
-    public void reorder(Long memberId, Long tripId, ReorderRequest request) {
+    public List<LegResponse> reorder(Long memberId, Long tripId, ReorderRequest request) {
         Trip trip = getOwnedTrip(memberId, tripId);
 
         Map<Long, TripActivity> targets = loadOwnedActivities(tripId, request);
@@ -160,6 +165,14 @@ public class ActivityService {
         }
         activityRepository.flush();
         touchedDates.forEach(date -> reindex(tripId, date));
+
+        // 보관함(null)은 이동 의미가 없어 건너뛴다.
+        return touchedDates.stream()
+                .filter(java.util.Objects::nonNull)
+                .flatMap(date -> legService.legs(
+                        activityRepository.findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(
+                                tripId, date)).stream())
+                .toList();
     }
 
     // ---------------- helpers ----------------

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
@@ -75,7 +75,9 @@ public class BoardService {
                 selectedDate,
                 activityRepository.countUnscheduled(tripId),
                 activityService.toResponses(activities),
-                legService.legs(activities));
+                // 보관함은 날짜에 배정되지 않은 목록이라 순서에 이동 의미가 없다.
+                // 계산해 봐야 화면에 쓰지 않고, 호출당 과금이라 그냥 낭비다.
+                selectedDate == null ? List.of() : legService.legs(activities));
     }
 
     /**

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/controller/LegController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/controller/LegController.java
@@ -1,0 +1,38 @@
+package ds.project.orino.planner.travel.route.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.travel.route.client.TravelMode;
+import ds.project.orino.planner.travel.route.dto.LegResponse;
+import ds.project.orino.planner.travel.route.service.LegQueryService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 이동수단 시트(§S-04)가 여는 단건 조회.
+ *
+ * <p>보드는 직선거리로 정한 한쪽 수단만 내려준다. 다른 쪽을 보려면 여기로 온다 —
+ * 보드에서 둘 다 계산해 두면 아무도 안 열어 볼 값까지 미리 사게 된다(호출당 과금).
+ */
+@RestController
+@RequestMapping("/api/travel/trips/{tripId}/legs")
+public class LegController {
+
+    private final LegQueryService legQueryService;
+
+    public LegController(LegQueryService legQueryService) {
+        this.legQueryService = legQueryService;
+    }
+
+    @GetMapping
+    public ApiResponse<LegResponse> leg(@AuthenticationPrincipal Long memberId,
+                                        @PathVariable Long tripId,
+                                        @RequestParam Long from,
+                                        @RequestParam Long to,
+                                        @RequestParam TravelMode mode) {
+        return ApiResponse.success(legQueryService.leg(memberId, tripId, from, to, mode));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/service/LegQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/service/LegQueryService.java
@@ -1,0 +1,54 @@
+package ds.project.orino.planner.travel.route.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.travel.entity.TripActivity;
+import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
+import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.route.client.TravelMode;
+import ds.project.orino.planner.travel.route.dto.LegResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 이동수단 시트의 단건 구간 조회. 소유권 확인과 "정말 인접한 두 일정인가"를 여기서 본다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class LegQueryService {
+
+    private final TripRepository tripRepository;
+    private final TripActivityRepository activityRepository;
+    private final LegService legService;
+
+    public LegQueryService(TripRepository tripRepository,
+                           TripActivityRepository activityRepository,
+                           LegService legService) {
+        this.tripRepository = tripRepository;
+        this.activityRepository = activityRepository;
+        this.legService = legService;
+    }
+
+    public LegResponse leg(Long memberId, Long tripId, Long fromActivityId,
+                           Long toActivityId, TravelMode mode) {
+        tripRepository.findByIdAndMemberId(tripId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_TRIP_NOT_FOUND));
+
+        TripActivity from = activityRepository.findByIdAndTripId(fromActivityId, tripId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_ACTIVITY_NOT_FOUND));
+        LocalDate date = from.getActivityDate();
+        if (date == null) {
+            // 보관함은 날짜에 배정되지 않아 순서에 이동 의미가 없다.
+            throw new CustomException(ErrorCode.TRAVEL_LEG_NOT_AVAILABLE);
+        }
+
+        // 그 날짜의 정렬된 목록을 그대로 넘긴다 — 사이에 장소 없는 일정을 건너뛰는 규칙이
+        // 보드와 어긋나면, 시트가 화면에 없는 구간을 계산하게 된다.
+        List<TripActivity> ordered = activityRepository
+                .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(tripId, date);
+        return legService.legBetween(ordered, fromActivityId, toActivityId, mode);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/service/LegService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/service/LegService.java
@@ -1,5 +1,7 @@
 package ds.project.orino.planner.travel.route.service;
 
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
 import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.entity.TripActivity;
 import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
@@ -61,6 +63,26 @@ public class LegService {
         return legs;
     }
 
+    /**
+     * 이동수단 시트(§S-04)가 여는 단건 조회. 자동 판정되지 않은 수단은 여기서만 계산한다.
+     *
+     * <p>보드에서 두 수단을 다 계산해 두지 않는다 — 호출당 과금이라 아무도 안 열어 볼 값까지
+     * 미리 사게 된다. 시트를 열었을 때만 부르고, 보드와 <b>같은 캐시</b>를 태워 두 번째부터는
+     * 외부 호출이 없다.
+     */
+    public LegResponse legBetween(List<TripActivity> ordered, Long fromActivityId,
+                                  Long toActivityId, TravelMode mode) {
+        Map<Long, Located> located = locate(ordered).stream()
+                .collect(Collectors.toMap(Located::activityId, Function.identity()));
+        Located from = located.get(fromActivityId);
+        Located to = located.get(toActivityId);
+        if (from == null || to == null) {
+            // 좌표가 없으면 구간 자체가 성립하지 않는다 — 화면에도 이동시간 행이 없다.
+            throw new CustomException(ErrorCode.TRAVEL_LEG_NOT_AVAILABLE);
+        }
+        return leg(from, to, mode);
+    }
+
     /** 좌표를 가진 일정만 순서대로 남긴다. 장소가 있어도 좌표가 없으면(직접 입력) 뺀다. */
     private List<Located> locate(List<TripActivity> ordered) {
         List<Long> placeIds = ordered.stream()
@@ -89,10 +111,18 @@ public class LegService {
     }
 
     private LegResponse leg(Located from, Located to) {
-        int straightM = Haversine.distanceM(from.lat(), from.lng(), to.lat(), to.lng());
         // 수단은 직선거리로 정한다(§1.3). 경로 거리로 정하면 수단을 알기 위해 경로가 필요하고,
         // 경로를 얻으려면 수단이 필요해 순환한다.
-        TravelMode mode = straightM <= props.walkThresholdM() ? TravelMode.WALK : TravelMode.DRIVE;
+        return leg(from, to, autoMode(from, to));
+    }
+
+    private TravelMode autoMode(Located from, Located to) {
+        int straightM = Haversine.distanceM(from.lat(), from.lng(), to.lat(), to.lng());
+        return straightM <= props.walkThresholdM() ? TravelMode.WALK : TravelMode.DRIVE;
+    }
+
+    private LegResponse leg(Located from, Located to, TravelMode mode) {
+        int straightM = Haversine.distanceM(from.lat(), from.lng(), to.lat(), to.lng());
 
         return route(from, to, mode)
                 .map(r -> new LegResponse(from.activityId(), to.activityId(), mode,

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsRolloverTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/review/controller/TodayReviewsRolloverTest.java
@@ -1,0 +1,119 @@
+package ds.project.orino.planner.review.controller;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.flashcard.entity.Flashcard;
+import ds.project.orino.domain.planner.flashcard.repository.FlashcardRepository;
+import ds.project.orino.domain.planner.material.entity.MaterialType;
+import ds.project.orino.domain.planner.material.entity.StudyMaterial;
+import ds.project.orino.domain.planner.material.repository.StudyMaterialRepository;
+import ds.project.orino.domain.planner.review.entity.ReviewSchedule;
+import ds.project.orino.domain.planner.review.repository.ReviewScheduleRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.PreRolloverClockConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 학습일 경계(04:00)를 <b>지나는</b> 시각에서의 오늘 복습.
+ *
+ * <p>다른 복습 테스트는 전부 KST 11:00에 고정돼 있어 이 창을 아예 안 지난다. 그래서 "앱의 오늘"과
+ * "달력 오늘"이 하루 어긋나는 자정~04:00에서만 깨지는 결함이 6일간 잠복했다(#1055,
+ * <a href="https://github.com/wcorn/orino/wiki/ELOG-025-study-day-test-helper-drift">ELOG-025</a>).
+ *
+ * <p>여기서는 Clock을 KST 01:00으로 못박아 그 창을 <b>매 빌드</b> 지나가게 한다 — 벽시계가
+ * 몇 시든 상관없다.
+ */
+@Import(PreRolloverClockConfig.class)
+class TodayReviewsRolloverTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private StudyMaterialRepository studyMaterialRepository;
+    @Autowired
+    private FlashcardRepository flashcardRepository;
+    @Autowired
+    private ReviewScheduleRepository reviewScheduleRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+    @Autowired
+    private Clock clock;
+
+    private Member member;
+    private Flashcard card;
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        member = memberRepository.save(MemberFixture.create());
+        StudyMaterial material = studyMaterialRepository.save(
+                new StudyMaterial(member.getId(), "이펙티브 자바", MaterialType.BOOK));
+        card = flashcardRepository.save(new Flashcard(member.getId(), material.getId(), "Q", "A"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    private void scheduleAt(String studyDay) {
+        reviewScheduleRepository.save(new ReviewSchedule(
+                member.getId(), card.getId(), 1,
+                atTestZone(LocalDate.parse(studyDay).atTime(4, 0)), 1, new BigDecimal("2.50")));
+    }
+
+    @Test
+    @DisplayName("KST 01:00에는 달력 날짜와 학습일이 하루 다르다 — 이 어긋남이 결함의 무대였다")
+    void calendarDayAndStudyDayDiffer() {
+        assertThat(testToday(clock)).isEqualTo(LocalDate.parse(PreRolloverClockConfig.STUDY_DAY));
+        assertThat(clock.instant().atZone(TEST_ZONE).toLocalDate())
+                .isEqualTo(LocalDate.parse(PreRolloverClockConfig.CALENDAR_DAY));
+    }
+
+    @Test
+    @DisplayName("응답의 today는 달력 날짜가 아니라 학습일이다")
+    void todayIsStudyDay() throws Exception {
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.today").value(PreRolloverClockConfig.STUDY_DAY));
+    }
+
+    @Test
+    @DisplayName("새벽 1시에도 그 학습일 복습이 오늘 목록에 있다 — 자정을 넘겼다고 사라지지 않는다")
+    void includesReviewOfCurrentStudyDay() throws Exception {
+        scheduleAt(PreRolloverClockConfig.STUDY_DAY);
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews", hasSize(1)))
+                .andExpect(jsonPath("$.data.reviews[0].flashcard.id").value(card.getId()));
+    }
+
+    @Test
+    @DisplayName("다음 학습일(04:00 이후) 복습은 아직 오늘이 아니다")
+    void excludesNextStudyDay() throws Exception {
+        scheduleAt(PreRolloverClockConfig.CALENDAR_DAY);
+
+        mockMvc.perform(get("/api/planner/reviews/today")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviews", hasSize(0)));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/LegIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/LegIntegrationTest.java
@@ -133,6 +133,53 @@ class LegIntegrationTest extends ApiTestSupport {
                 .andExpect(status().isOk());
     }
 
+
+    private void addUnscheduled(String title, Long placeId) throws Exception {
+        String place = placeId == null ? "" : ", \"placeId\": %d".formatted(placeId);
+        mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "%s", "activityDate": null%s}
+                                """.formatted(title, place)))
+                .andExpect(status().isOk());
+    }
+
+    private List<Integer> activityIds() throws Exception {
+        String body = board().andReturn().getResponse().getContentAsString();
+        return com.jayway.jsonpath.JsonPath.read(body, "$.data.activities[*].id");
+    }
+
+    private List<Integer> archivedActivityIds() throws Exception {
+        String body = mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                        .param("archive", "true")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andReturn().getResponse().getContentAsString();
+        return com.jayway.jsonpath.JsonPath.read(body, "$.data.activities[*].id");
+    }
+
+    private org.springframework.test.web.servlet.ResultActions reorder(int... ids) throws Exception {
+        String list = java.util.Arrays.stream(ids).mapToObj(String::valueOf)
+                .collect(java.util.stream.Collectors.joining(", "));
+        return mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .put("/api/travel/trips/" + tripId + "/activities/order")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"moves": [{"date": "2026-10-24", "activityIds": [%s]}]}
+                                """.formatted(list)))
+                .andExpect(status().isOk());
+    }
+
+    private org.springframework.test.web.servlet.ResultActions legBetween(
+            int from, int to, String mode) throws Exception {
+        return mockMvc.perform(get("/api/travel/trips/" + tripId + "/legs")
+                .param("from", String.valueOf(from))
+                .param("to", String.valueOf(to))
+                .param("mode", mode)
+                .header(HttpHeaders.AUTHORIZATION, authHeader));
+    }
+
     @Nested
     @DisplayName("어디에 구간이 생기나")
     class Which {
@@ -315,4 +362,144 @@ class LegIntegrationTest extends ApiTestSupport {
             assertThat(tos.get(0)).isEqualTo(froms.get(1));
         }
     }
+
+    @Nested
+    @DisplayName("보관함")
+    class Archive {
+
+        @Test
+        @DisplayName("보관함에는 구간이 없다 — 순서에 이동 의미가 없는데 유료 호출을 낼 이유가 없다")
+        void archiveHasNoLegs() throws Exception {
+            Long a = placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG));
+            Long b = placeAt("스카이트리", jitter(SKYTREE_LAT), jitter(SKYTREE_LNG));
+            addUnscheduled("센소지", a);
+            addUnscheduled("스카이트리", b);
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                            .param("archive", "true")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.activities", hasSize(2)))
+                    .andExpect(jsonPath("$.data.legs", hasSize(0)));
+
+            assertThat(stub.calls).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("순서 변경 응답")
+    class Reorder {
+
+        @Test
+        @DisplayName("재계산된 구간을 함께 돌려준다 — 드래그는 손을 뗀 순간 결과가 보여야 한다")
+        void returnsRecomputedLegs() throws Exception {
+            addActivity("센소지", placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("스카이트리", placeAt("스카이트리", jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+            List<Integer> ids = activityIds();
+
+            reorder(ids.get(1), ids.get(0))
+                    .andExpect(jsonPath("$.data.legs", hasSize(1)))
+                    // 뒤집었으니 출발·도착도 뒤집혀야 한다.
+                    .andExpect(jsonPath("$.data.legs[0].fromActivityId").value(ids.get(1)))
+                    .andExpect(jsonPath("$.data.legs[0].toActivityId").value(ids.get(0)));
+        }
+
+        @Test
+        @DisplayName("구간이 없어도 빈 배열로 온다")
+        void emptyWhenNoLegs() throws Exception {
+            addActivity("점심", null);
+            addActivity("저녁", null);
+            List<Integer> ids = activityIds();
+
+            reorder(ids.get(1), ids.get(0))
+                    .andExpect(jsonPath("$.data.legs", hasSize(0)));
+        }
+    }
+
+    @Nested
+    @DisplayName("수단별 단건 조회 (이동수단 시트)")
+    class ByMode {
+
+        @Test
+        @DisplayName("자동 판정과 다른 수단도 물어볼 수 있다")
+        void asksForTheOtherMode() throws Exception {
+            addActivity("센소지", placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("신주쿠", placeAt("신주쿠", jitter(SHINJUKU_LAT), jitter(SHINJUKU_LNG)));
+            List<Integer> ids = activityIds();
+
+            // 8km라 보드는 DRIVE로 준다. 시트에서 도보를 물으면 그때 계산한다.
+            board().andExpect(jsonPath("$.data.legs[0].mode").value("DRIVE"));
+            legBetween(ids.get(0), ids.get(1), "WALK")
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.mode").value("WALK"))
+                    .andExpect(jsonPath("$.data.durationMinutes").value(12));
+
+            // 보드에서 미리 둘 다 계산하지 않는다 — 아무도 안 열어 볼 값까지 사게 된다.
+            assertThat(stub.calls).hasSize(2);
+            assertThat(stub.calls.get(0).mode()).isEqualTo(TravelMode.DRIVE);
+            assertThat(stub.calls.get(1).mode()).isEqualTo(TravelMode.WALK);
+        }
+
+        @Test
+        @DisplayName("보드와 같은 캐시를 탄다 — 시트를 다시 열어도 외부 호출이 없다")
+        void sharesCacheWithBoard() throws Exception {
+            addActivity("센소지", placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("스카이트리", placeAt("스카이트리", jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+            List<Integer> ids = activityIds();
+
+            board();
+            int afterBoard = stub.calls.size();
+            // 보드가 이미 WALK로 계산해 둔 구간이다.
+            legBetween(ids.get(0), ids.get(1), "WALK").andExpect(status().isOk());
+            legBetween(ids.get(0), ids.get(1), "WALK").andExpect(status().isOk());
+
+            assertThat(stub.calls).hasSize(afterBoard);
+        }
+
+        @Test
+        @DisplayName("좌표 없는 일정 사이는 400 — 화면에도 그 구간이 없다")
+        void rejectsWhenNoCoordinates() throws Exception {
+            addActivity("센소지", placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("점심", null);
+            List<Integer> ids = activityIds();
+
+            legBetween(ids.get(0), ids.get(1), "WALK")
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-009"));
+        }
+
+        @Test
+        @DisplayName("보관함 일정은 400 — 이동 의미가 없다")
+        void rejectsArchivedActivities() throws Exception {
+            Long a = placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG));
+            Long b = placeAt("스카이트리", jitter(SKYTREE_LAT), jitter(SKYTREE_LNG));
+            addUnscheduled("센소지", a);
+            addUnscheduled("스카이트리", b);
+            List<Integer> ids = archivedActivityIds();
+
+            legBetween(ids.get(0), ids.get(1), "WALK")
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-009"));
+        }
+
+        @Test
+        @DisplayName("남의 여행은 404")
+        void rejectsOtherMembersTrip() throws Exception {
+            addActivity("센소지", placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("스카이트리", placeAt("스카이트리", jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+            List<Integer> ids = activityIds();
+
+            memberRepository.save(MemberFixture.create("other", "password"));
+            String otherAuth = "Bearer "
+                    + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/legs")
+                            .param("from", String.valueOf(ids.get(0)))
+                            .param("to", String.valueOf(ids.get(1)))
+                            .param("mode", "WALK")
+                            .header(HttpHeaders.AUTHORIZATION, otherAuth))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
 }

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/PreRolloverClockConfig.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/PreRolloverClockConfig.java
@@ -1,0 +1,38 @@
+package ds.project.orino.support;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+/**
+ * 학습일 롤오버(04:00) <b>이전</b>으로 못박은 Clock.
+ *
+ * <p>{@link FixedClockConfig}는 KST 11:00이라 경계를 아예 지나지 않는다. 그래서 "앱의 오늘"과
+ * "달력 오늘"이 어긋나는 하루 4시간(자정~04:00)이 어떤 테스트에도 안 걸렸고, 실제로 그 창에서만
+ * 깨지는 결함이 6일간 잠복했다(#1055).
+ *
+ * <p>고정 시각 {@code 2026-01-15T16:00:00Z} = KST <b>2026-01-16 01:00</b>.
+ * 달력으로는 1/16이지만 학습일은 아직 <b>1/15</b>다.
+ */
+@TestConfiguration
+public class PreRolloverClockConfig {
+
+    /** 고정 현재 시각(UTC). KST로는 2026-01-16 01:00 — 롤오버 3시간 전. */
+    public static final Instant FIXED_NOW = Instant.parse("2026-01-15T16:00:00Z");
+
+    /** 그 시각의 학습일. 달력 날짜(1/16)와 하루 다르다. */
+    public static final String STUDY_DAY = "2026-01-15";
+
+    /** 달력 기준으로는 이 날짜다. 둘이 다르다는 것이 이 설정의 존재 이유다. */
+    public static final String CALENDAR_DAY = "2026-01-16";
+
+    @Bean
+    @Primary
+    public Clock preRolloverClock() {
+        return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+    }
+}

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -44,7 +44,9 @@ public enum ErrorCode {
             "기간을 줄이면 일부 일정이 미배정 보관함으로 이동합니다.", 409),
     TRAVEL_ACTIVITY_NOT_FOUND("TRAVEL-ERR-006", "존재하지 않는 일정입니다.", 404),
     TRAVEL_DATE_OUT_OF_RANGE("TRAVEL-ERR-007", "여행 기간 밖의 날짜입니다.", 400),
-    TRAVEL_PLACE_NOT_FOUND("TRAVEL-ERR-008", "존재하지 않는 장소입니다.", 404);
+    TRAVEL_PLACE_NOT_FOUND("TRAVEL-ERR-008", "존재하지 않는 장소입니다.", 404),
+    TRAVEL_LEG_NOT_AVAILABLE("TRAVEL-ERR-009",
+            "두 일정 사이의 이동시간을 계산할 수 없습니다.", 400);
 
     private final String code;
     private final String message;

--- a/fe/src/features/travel/api/activities.ts
+++ b/fe/src/features/travel/api/activities.ts
@@ -155,7 +155,8 @@ export interface ReorderMove {
 }
 
 /**
- * 드래그 결과를 한 번에 반영한다. 응답의 `legs`(이동시간)는 2단계에서 채워진다.
+ * 드래그 결과를 한 번에 반영한다. 응답에 **재계산된 `legs`가 담겨** 온다 —
+ * 드래그는 손을 뗀 순간 결과가 보여야 해서, 이동시간 때문에 한 번 더 왕복하지 않는다.
  *
  * <p>다른 날짜로 옮기는 것은 이 엔드포인트가 아니라 {@link updateActivity}로 한다 —
  * 서버가 대상 날짜의 맨 뒤에 붙이고 떠나온 날짜를 재인덱싱해 주기 때문에, 대상 날짜의
@@ -164,6 +165,10 @@ export interface ReorderMove {
 export async function reorderActivities(
   tripId: number,
   moves: ReorderMove[],
-): Promise<void> {
-  await client.put(`/travel/trips/${tripId}/activities/order`, { moves });
+): Promise<Leg[]> {
+  const { data } = await client.put<ApiEnvelope<{ legs: Leg[] }>>(
+    `/travel/trips/${tripId}/activities/order`,
+    { moves },
+  );
+  return data.data.legs;
 }


### PR DESCRIPTION
## 이슈
closes #1066
closes #1065
## 작업 내용

이동시간 화면(#1067 예정)을 붙이려니 BE에 빈 곳이 있어 먼저 메운다. #1065(학습일 경계 테스트)를 "다음 BE 작업에 묶는다"고 했던 게 이 PR이다.

### 1. 순서 변경 응답이 재계산된 `legs`를 담는다

API 스펙이 정의해 둔 필드인데 #1064에서 보드만 채우고 여기를 놓쳤다. 주석도 "2단계 기능이라 1단계에서는 항상 비어 있다"로 남아 거짓이 돼 있었다.

지금도 FE가 보드를 무효화해서 결과적으로 갱신되긴 했다. 하지만 **드래그는 손을 뗀 순간 결과가 보여야 하는 동작**이라, 이동시간 때문에 왕복을 한 번 더 도는 건 이 필드를 둔 이유와 어긋난다.

건드린 날짜 전체의 구간을 담는다(날짜 이동이면 두 날짜). 구간이 일정 id로 식별되므로 날짜가 섞여도 모호하지 않다.

### 2. 이동수단 시트용 단건 조회

```
GET /api/travel/trips/{tripId}/legs?from={id}&to={id}&mode=WALK
```

보드는 직선거리로 정한 **한쪽 수단만** 준다(§1.3). 시트에서 다른 쪽을 보려면 그 값이 필요하다.

**보드에서 두 수단을 미리 계산하지 않는다.** 호출당 과금이라 아무도 안 열어 볼 값까지 사게 된다([ELOG-023](https://github.com/wcorn/orino/wiki/ELOG-023-travel-external-api-call-cost)). 시트를 열었을 때만 부르고, **보드와 같은 캐시**를 태운다.

좌표가 없거나(직접 입력) 보관함 일정이면 400 `TRAVEL-ERR-009` — 화면에도 그 구간의 이동시간 행이 없다.

딥링크는 BE가 필요 없다. 좌표로 URL만 만들면 되고 항상 대중교통이다(§4.5).

### 3. 보관함에는 구간을 만들지 않는다 (같이 발견)

#1064에서 보드가 보관함에도 legs를 계산하고 있었다. 배정되지 않은 목록이라 **순서에 이동 의미가 없는데** 유료 호출만 나갔다. 화면도 이 값을 쓰지 않는다.

### 4. 학습일 04시 경계를 고정 Clock으로 상시 검증 (#1065)

[ELOG-025](https://github.com/wcorn/orino/wiki/ELOG-025-study-day-test-helper-drift)의 후속.

`StudyDay` 자체의 경계 단위 테스트는 **이미 있었다**(`StudyDayTest`가 00:00·01:00·03:59·04:00·04:01을 덮는다). 빈 곳은 **API 계층**이었다 — 기존 `FixedClockConfig`가 KST 11:00이라 어떤 통합 테스트도 그 창을 지나지 않았다.

`PreRolloverClockConfig`(KST 01:00)를 추가해 달력 날짜(1/16)와 학습일(1/15)이 어긋나는 지점을 **매 빌드** 지나게 했다. 벽시계가 몇 시든 상관없다.

## 확인

`./gradlew check` · FE 게이트(`format:check` · `lint` · `test` 743 · `build`) 통과.

**회귀 테스트가 실제로 그 버그를 잡는지 확인했다** — `testToday()`를 옛(버그) 버전으로 되돌리니 실패하고, 되돌리니 통과한다.

```
TodayReviewsRolloverTest > KST 01:00에는 달력 날짜와 학습일이 하루 다르다 FAILED
```

로컬 bootRun + **실제 Google Routes**:

```
1. 보드                    [('WALK', 25, 1.7), ('DRIVE', 28, 17.1)]

2. 순서 변경 응답            [('DRIVE', 35, 16.6), ('WALK', 25, 1.7)]
   보드 재조회               [('DRIVE', 35, 16.6), ('WALK', 25, 1.7)]  ← 같다. 왕복이 필요 없다

3. 수단별 단건 조회
   WALK   163분 11.4km  (377ms)   ← 자동 판정은 DRIVE였다. 시트에서 물어 새로 계산
   DRIVE   35분 16.6km  ( 27ms)   ← 보드가 이미 계산해 둔 것을 그대로 탄다
   WALK 재조회          ( 20ms)   ← 캐시

4. 보관함                  activities=1 legs=0
```

3번의 DRIVE가 27ms인 것이 "보드와 같은 캐시를 탄다"의 실증이다.

위키 [Travel API Spec](https://github.com/wcorn/orino/wiki/Travel-API-Spec)에 새 엔드포인트·`legs` 범위·`TRAVEL-ERR-009`를 반영했다.

FE는 `reorderActivities` 반환 타입만 `void → Leg[]`로 맞췄다. 이 값을 낙관적 갱신에 쓰는 것은 화면 작업에서 한다.
