### PR TITLE
feat : S-05 지도 뷰 + 상세 장소 블록 완성

### DIFF
--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -68,6 +68,10 @@ export const importTripBoard = () =>
   import("../pages/travel/TripBoardPage").then((m) => ({
     default: m.TripBoardPage,
   }));
+export const importTripMap = () =>
+  import("../pages/travel/TripMapPage").then((m) => ({
+    default: m.TripMapPage,
+  }));
 export const importPlaceSearch = () =>
   import("../pages/travel/PlaceSearchPage").then((m) => ({
     default: m.PlaceSearchPage,

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -30,6 +30,7 @@ import {
   importTripBoard,
   importTripForm,
   importTripList,
+  importTripMap,
   importWeeklyPlan,
   importWorkspaceSelect,
 } from "./routeImports";
@@ -56,6 +57,7 @@ const TripListPage = lazy(importTripList);
 const TripFormPage = lazy(importTripForm);
 const TripBoardPage = lazy(importTripBoard);
 const PlaceSearchPage = lazy(importPlaceSearch);
+const TripMapPage = lazy(importTripMap);
 const ActivityDetailPage = lazy(importActivityDetail);
 
 function RouteFallback() {
@@ -246,6 +248,14 @@ export function AppRouter() {
             element={
               <Suspense fallback={<RouteFallback />}>
                 <TripBoardPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/travel/trips/:tripId/map"
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <TripMapPage />
               </Suspense>
             }
           />

--- a/fe/src/features/travel/hooks/usePlaceDetail.ts
+++ b/fe/src/features/travel/hooks/usePlaceDetail.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchPlaceDetail } from "../api/places";
+import { travelKeys } from "../queryKeys";
+
+/**
+ * 장소 상세(영업시간·전화). 서버가 30일 캐시하고 지나면 알아서 갱신하므로(§4.7)
+ * 프론트는 그냥 물어보면 된다 — 매번 외부를 부르는 게 아니다.
+ */
+export function usePlaceDetail(placeId: number | null) {
+  return useQuery({
+    queryKey: travelKeys.place(placeId ?? 0),
+    queryFn: () => fetchPlaceDetail(placeId!),
+    enabled: placeId !== null,
+    staleTime: 60 * 60 * 1000,
+  });
+}

--- a/fe/src/features/travel/lib/openingHours.test.ts
+++ b/fe/src/features/travel/lib/openingHours.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { todayOpeningHours } from "./openingHours";
+
+const RAW = JSON.stringify({
+  weekdayDescriptions: [
+    "월요일: 09:00~18:00",
+    "화요일: 09:00~18:00",
+    "수요일: 휴무",
+    "목요일: 09:00~18:00",
+    "금요일: 09:00~21:00",
+    "토요일: 10:00~21:00",
+    "일요일: 10:00~17:00",
+  ],
+});
+
+describe("영업시간 — 오늘 줄만", () => {
+  it("Google은 월요일부터 주고 Date는 일요일이 0이다 — 이 어긋남이 요일을 밀리게 한다", () => {
+    // 2026-08-10은 월요일.
+    expect(todayOpeningHours(RAW, new Date(2026, 7, 10))).toBe(
+      "월요일: 09:00~18:00",
+    );
+    // 2026-08-16은 일요일 — 배열의 마지막이다.
+    expect(todayOpeningHours(RAW, new Date(2026, 7, 16))).toBe(
+      "일요일: 10:00~17:00",
+    );
+  });
+
+  it("휴무일도 그대로 보여준다 — 가서 알게 되면 늦다", () => {
+    // 2026-08-12는 수요일.
+    expect(todayOpeningHours(RAW, new Date(2026, 7, 12))).toBe("수요일: 휴무");
+  });
+
+  it("영업시간이 없으면 비운다 — 상시 개방인 곳은 구글이 안 준다", () => {
+    expect(todayOpeningHours(null)).toBeNull();
+  });
+
+  it("형태가 달라지면 조용히 비운다 — 원본을 그대로 캐시하므로 언제든 바뀔 수 있다", () => {
+    expect(todayOpeningHours("not json")).toBeNull();
+    expect(todayOpeningHours(JSON.stringify({ other: 1 }))).toBeNull();
+    // 일곱 줄이 아니면 요일 매칭을 믿을 수 없다.
+    expect(
+      todayOpeningHours(JSON.stringify({ weekdayDescriptions: ["월: 종일"] })),
+    ).toBeNull();
+  });
+});

--- a/fe/src/features/travel/lib/openingHours.ts
+++ b/fe/src/features/travel/lib/openingHours.ts
@@ -1,0 +1,28 @@
+/**
+ * Google이 준 영업시간 원본에서 "오늘" 줄만 뽑는다.
+ *
+ * <p>서버는 구조를 해석하지 않고 원본 JSON을 그대로 넘긴다(§4.7) — 구글이 형태를 바꿔도
+ * 서버·DB를 손대지 않기 위해서다. 대신 해석은 여기서 하고, 못 읽으면 조용히 비운다.
+ *
+ * <p>일곱 줄을 다 보여주지 않는다. 현지에서 알고 싶은 건 "지금 열었나"뿐이고,
+ * 나머지 요일은 화면만 차지한다.
+ */
+export function todayOpeningHours(
+  raw: string | null,
+  now: Date = new Date(),
+): string | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    const descriptions = (parsed as { weekdayDescriptions?: unknown })
+      ?.weekdayDescriptions;
+    if (!Array.isArray(descriptions) || descriptions.length < 7) return null;
+
+    // Google은 월요일부터 준다. Date.getDay()는 일요일이 0이다.
+    const index = (now.getDay() + 6) % 7;
+    const line = descriptions[index];
+    return typeof line === "string" ? line : null;
+  } catch {
+    return null;
+  }
+}

--- a/fe/src/features/travel/map/PlacePreviewMap.tsx
+++ b/fe/src/features/travel/map/PlacePreviewMap.tsx
@@ -1,0 +1,39 @@
+import "leaflet/dist/leaflet.css";
+
+import L from "leaflet";
+import { MapContainer, Marker, TileLayer } from "react-leaflet";
+
+const pin = L.divIcon({
+  className: "travel-place-pin",
+  html:
+    `<div style="width:14px;height:14px;border-radius:9999px;` +
+    `background:var(--primary);border:2px solid var(--card);` +
+    `box-shadow:0 1px 3px rgba(0,0,0,.4)"></div>`,
+  iconSize: [14, 14],
+  iconAnchor: [7, 7],
+});
+
+/**
+ * 장소 하나짜리 미리보기(§S-07). 조작하지 않는다 — 드래그·줌을 열어두면 폼 안에서
+ * 스크롤을 잡아먹는다. "여기가 어디쯤인지"만 보여주면 된다.
+ */
+export function PlacePreviewMap({ lat, lng }: { lat: number; lng: number }) {
+  return (
+    <MapContainer
+      center={[lat, lng]}
+      zoom={15}
+      dragging={false}
+      scrollWheelZoom={false}
+      doubleClickZoom={false}
+      zoomControl={false}
+      attributionControl
+      className="h-[120px] w-full overflow-hidden rounded-lg"
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      <Marker position={[lat, lng]} icon={pin} />
+    </MapContainer>
+  );
+}

--- a/fe/src/features/travel/map/TripDayMap.tsx
+++ b/fe/src/features/travel/map/TripDayMap.tsx
@@ -1,0 +1,87 @@
+import "leaflet/dist/leaflet.css";
+
+import L from "leaflet";
+import { useEffect } from "react";
+import {
+  MapContainer,
+  Marker,
+  Polyline,
+  TileLayer,
+  useMap,
+} from "react-leaflet";
+
+import type { MappedActivity } from "./toMapped";
+
+function numberIcon(order: number, selected: boolean) {
+  const size = selected ? 32 : 26;
+  return L.divIcon({
+    className: "travel-day-pin",
+    html:
+      `<div style="display:flex;align-items:center;justify-content:center;` +
+      `width:${size}px;height:${size}px;border-radius:9999px;` +
+      `background:var(--primary);color:var(--primary-foreground);` +
+      `font-size:12px;font-weight:600;border:2px solid var(--card);` +
+      `box-shadow:0 1px 3px rgba(0,0,0,.4)">${order}</div>`,
+    iconSize: [size, size],
+    iconAnchor: [size / 2, size / 2],
+  });
+}
+
+/** 핀이 전부 들어오게 범위를 맞춘다. */
+function FitBounds({ points }: { points: [number, number][] }) {
+  const map = useMap();
+  useEffect(() => {
+    if (points.length === 1) {
+      map.setView(points[0], 15);
+    } else if (points.length > 1) {
+      map.fitBounds(points, { padding: [24, 24] });
+    }
+  }, [points, map]);
+  return null;
+}
+
+interface TripDayMapProps {
+  mapped: MappedActivity[];
+  selectedId: number | null;
+  onSelect: (activityId: number) => void;
+}
+
+/**
+ * 하루 동선(§S-05).
+ *
+ * <p>연결선은 <b>직선</b>이다 — 실제 경로가 아니라 순서를 보여주는 선이다. 실제 길찾기는
+ * 구글 지도 딥링크가 맡으므로 여기서 경로를 그릴 이유가 없다.
+ */
+export function TripDayMap({ mapped, selectedId, onSelect }: TripDayMapProps) {
+  const positions = mapped.map((m) => [m.lat, m.lng] as [number, number]);
+
+  return (
+    <MapContainer
+      center={positions[0]}
+      zoom={14}
+      scrollWheelZoom
+      className="aspect-[8/5] w-full overflow-hidden rounded-lg border"
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      <FitBounds points={positions} />
+      {positions.length > 1 && (
+        <Polyline
+          positions={positions}
+          pathOptions={{ color: "var(--primary)", weight: 3 }}
+        />
+      )}
+      {mapped.map((m) => (
+        <Marker
+          key={m.activity.id}
+          position={[m.lat, m.lng]}
+          icon={numberIcon(m.order, m.activity.id === selectedId)}
+          alt={`${m.order}. ${m.activity.title}`}
+          eventHandlers={{ click: () => onSelect(m.activity.id) }}
+        />
+      ))}
+    </MapContainer>
+  );
+}

--- a/fe/src/features/travel/map/toMapped.test.ts
+++ b/fe/src/features/travel/map/toMapped.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import type { Activity } from "@/features/travel/api/activities";
+
+import { toMapped } from "./toMapped";
+
+function activity(id: number, place: Activity["place"] = null): Activity {
+  return {
+    id,
+    tripId: 1,
+    title: `일정 ${id}`,
+    activityDate: "2026-10-24",
+    startTime: null,
+    place,
+    memo: null,
+    url: null,
+    notifyEnabled: false,
+    notifyMinutes: null,
+    departureNotifyEnabled: false,
+    sortOrder: id,
+    hasLog: false,
+  };
+}
+
+const SENSOJI = {
+  id: 10,
+  name: "센소지",
+  address: "다이토구",
+  lat: 35.7147651,
+  lng: 139.7966553,
+};
+const SKYTREE = {
+  id: 11,
+  name: "스카이트리",
+  address: "스미다구",
+  lat: 35.7100627,
+  lng: 139.8107004,
+};
+
+describe("지도에 올릴 일정 고르기", () => {
+  it("번호를 지도 표시 순서로 다시 매긴다 — 리스트 순번을 쓰면 1·3번만 뜬다", () => {
+    const mapped = toMapped([
+      activity(1, SENSOJI),
+      activity(2), // 장소 없음 — 지도에 없다
+      activity(3, SKYTREE),
+    ]);
+
+    expect(mapped.map((m) => m.order)).toEqual([1, 2]);
+    expect(mapped.map((m) => m.activity.id)).toEqual([1, 3]);
+  });
+
+  it("좌표 없는 장소(직접 입력)는 뺀다 — 찍을 곳이 없다", () => {
+    const manual = {
+      id: 12,
+      name: "골목 카페",
+      address: null,
+      lat: null,
+      lng: null,
+    };
+
+    expect(toMapped([activity(1, manual)])).toHaveLength(0);
+  });
+
+  it("리스트 순서를 그대로 지킨다 — 동선은 순서가 전부다", () => {
+    const mapped = toMapped([activity(5, SKYTREE), activity(6, SENSOJI)]);
+
+    expect(mapped.map((m) => m.activity.id)).toEqual([5, 6]);
+  });
+
+  it("장소가 하나도 없으면 빈 배열", () => {
+    expect(toMapped([activity(1), activity(2)])).toHaveLength(0);
+  });
+});

--- a/fe/src/features/travel/map/toMapped.ts
+++ b/fe/src/features/travel/map/toMapped.ts
@@ -1,0 +1,27 @@
+import type { Activity } from "@/features/travel/api/activities";
+
+/** 지도에 올릴 수 있는 일정 — 좌표 있는 장소가 붙은 것만. */
+export interface MappedActivity {
+  activity: Activity;
+  lat: number;
+  lng: number;
+  /** 지도 표시 순서(1부터). 장소 없는 일정이 빠지므로 리스트 순번과 다를 수 있다. */
+  order: number;
+}
+
+/**
+ * 좌표가 있는 일정만 순서대로 남기고 번호를 <b>다시</b> 매긴다.
+ *
+ * <p>리스트 순번을 그대로 쓰면 지도에 1·3·4번만 뜬다 — 2번이 어디 갔는지 알 수 없고,
+ * 지도에서 세는 순서와도 어긋난다.
+ */
+export function toMapped(activities: Activity[]): MappedActivity[] {
+  return activities
+    .filter((a) => a.place?.lat != null && a.place.lng != null)
+    .map((activity, index) => ({
+      activity,
+      lat: activity.place!.lat!,
+      lng: activity.place!.lng!,
+      order: index + 1,
+    }));
+}

--- a/fe/src/features/travel/queryKeys.ts
+++ b/fe/src/features/travel/queryKeys.ts
@@ -14,4 +14,5 @@ export const travelKeys = {
   placeSearch: (q: string, tripId?: number) =>
     ["travel", "places", "search", tripId ?? "none", q] as const,
   citySearch: (q: string) => ["travel", "places", "cities", q] as const,
+  place: (placeId: number) => ["travel", "place", placeId] as const,
 };

--- a/fe/src/pages/travel/ActivityDetailPage.tsx
+++ b/fe/src/pages/travel/ActivityDetailPage.tsx
@@ -1,5 +1,19 @@
-import { ArrowLeft, MapPin, Navigation, Trash2 } from "lucide-react";
-import { type FormEvent, useEffect, useId, useState } from "react";
+import {
+  ArrowLeft,
+  Clock,
+  MapPin,
+  Navigation,
+  Phone,
+  Trash2,
+} from "lucide-react";
+import {
+  type FormEvent,
+  lazy,
+  Suspense,
+  useEffect,
+  useId,
+  useState,
+} from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
@@ -15,14 +29,23 @@ import {
 import { useUndoableAction } from "@/features/travel/board/useUndoableAction";
 import { useActivity } from "@/features/travel/hooks/useActivity";
 import { useUpdateActivity } from "@/features/travel/hooks/useActivityMutations";
+import { usePlaceDetail } from "@/features/travel/hooks/usePlaceDetail";
 import { useTrip } from "@/features/travel/hooks/useTrip";
 import { placeDirectionsUrl } from "@/features/travel/lib/mapsLink";
+import { todayOpeningHours } from "@/features/travel/lib/openingHours";
 import {
   toTimeInputValue,
   toWallClockTime,
 } from "@/features/travel/lib/tripClock";
 import { dayChips, formatShortDate } from "@/features/travel/lib/tripStatus";
 import { toast } from "@/shared/lib/toast";
+
+// leaflet은 무겁다 — 장소 없는 일정에서는 받지 않는다.
+const PlacePreviewMap = lazy(() =>
+  import("@/features/travel/map/PlacePreviewMap").then((m) => ({
+    default: m.PlacePreviewMap,
+  })),
+);
 
 const MEMO_MAX = 1000;
 const URL_MAX = 500;
@@ -54,6 +77,7 @@ export function ActivityDetailPage() {
   const navigate = useNavigate();
 
   const { data: activity, isPending } = useActivity(activityId);
+  const { data: placeDetail } = usePlaceDetail(activity?.place?.id ?? null);
   const { data: trip } = useTrip(activity?.tripId ?? null);
   const updateActivity = useUpdateActivity(activity?.tripId ?? 0);
   const undoable = useUndoableAction(activity?.tripId ?? 0);
@@ -74,6 +98,7 @@ export function ActivityDetailPage() {
   }
 
   const mapsUrl = activity.place ? placeDirectionsUrl(activity.place) : null;
+  const openingToday = todayOpeningHours(placeDetail?.openingHours ?? null);
 
   /**
    * 이 일정이 속한 탭으로 돌아간다.
@@ -202,11 +227,7 @@ export function ActivityDetailPage() {
           </FormField>
         </div>
 
-        {/*
-          장소 블록의 나머지(지도 미리보기·영업시간·전화)는 지도 뷰(S-05)와 함께 온다.
-          길찾기는 좌표만 있으면 되고 현지에서 가장 자주 누르는 버튼이라 먼저 붙인다.
-        */}
-        {activity.place && mapsUrl && (
+        {activity.place && (
           <div className="border-border bg-card flex flex-col gap-2.5 rounded-xl border p-3">
             <div className="flex items-start gap-1.5">
               <MapPin className="text-primary mt-0.5 size-[15px] shrink-0" />
@@ -219,17 +240,49 @@ export function ActivityDetailPage() {
                 )}
               </div>
             </div>
+
+            {/* 영업시간·전화는 상세 조회에서 온다. 서버가 30일 캐시한다(§4.7). */}
+            {openingToday && (
+              <p className="text-muted-foreground flex items-center gap-1 text-xs">
+                <Clock className="size-[11px] shrink-0" />
+                {openingToday}
+              </p>
+            )}
+            {placeDetail?.phone && (
+              <a
+                href={`tel:${placeDetail.phone}`}
+                className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs"
+              >
+                <Phone className="size-[11px] shrink-0" />
+                {placeDetail.phone}
+              </a>
+            )}
+
+            {/* 좌표가 없으면(직접 입력) 지도도 길찾기도 없다. */}
+            {activity.place.lat !== null && activity.place.lng !== null && (
+              <Suspense
+                fallback={<div className="bg-muted h-[120px] rounded-lg" />}
+              >
+                <PlacePreviewMap
+                  lat={activity.place.lat}
+                  lng={activity.place.lng}
+                />
+              </Suspense>
+            )}
+
             {/* 앱 내 이동시간이 도보/자동차여도 딥링크는 항상 대중교통이다(§4.5). */}
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="w-full"
-              onClick={() => window.open(mapsUrl, "_blank", "noopener")}
-            >
-              <Navigation className="size-3.5" />
-              구글 지도에서 길찾기 (대중교통)
-            </Button>
+            {mapsUrl && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="w-full"
+                onClick={() => window.open(mapsUrl, "_blank", "noopener")}
+              >
+                <Navigation className="size-3.5" />
+                구글 지도에서 길찾기 (대중교통)
+              </Button>
+            )}
           </div>
         )}
 

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -569,14 +569,22 @@ describe("TripBoardPage", () => {
       });
     });
 
-    it("지도·도구는 후속 단계라 비활성이다", async () => {
+    it("도구는 후속 단계라 비활성이다", async () => {
       mockBoard({ byDate: { "2026-10-24": [] } });
 
       renderBoard();
       await screen.findByText("일정이 없어요");
 
-      expect(screen.getByRole("button", { name: "지도" })).toBeDisabled();
       expect(screen.getByRole("button", { name: "도구" })).toBeDisabled();
+    });
+
+    it("보관함에서는 지도를 열 수 없다 — 배정되지 않은 목록엔 동선이 없다", async () => {
+      mockBoard({ archive: [activity()] });
+
+      renderBoard("/travel/trips/3/board?day=archive");
+      await screen.findByText("센소지");
+
+      expect(screen.getByRole("button", { name: "지도" })).toBeDisabled();
     });
   });
 

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -281,10 +281,21 @@ export function TripBoardPage() {
           </h1>
         </div>
         <div className="flex shrink-0 items-center gap-1">
-          {/* 지도는 2단계, 도구는 4단계. 자리를 미리 두되 누를 수 없게 한다. */}
-          <Button variant="ghost" size="icon-sm" aria-label="지도" disabled>
+          {/* 보던 날짜를 그대로 들고 간다 — 지도가 답하는 질문은 "오늘 이 순서가 말이 되나"다. */}
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="지도"
+            onClick={() =>
+              navigate(
+                `/travel/trips/${tripId}/map${day === null ? "" : `?day=${day}`}`,
+              )
+            }
+            disabled={isArchive}
+          >
             <MapIcon className="size-4" />
           </Button>
+          {/* 도구는 4단계. 자리를 미리 두되 누를 수 없게 한다. */}
           <Button variant="ghost" size="icon-sm" aria-label="도구" disabled>
             <Wrench className="size-4" />
           </Button>

--- a/fe/src/pages/travel/TripMapPage.test.tsx
+++ b/fe/src/pages/travel/TripMapPage.test.tsx
@@ -1,0 +1,217 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { AppRouter } from "@/app/router";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+const API_BASE = "https://api.orino.dev/api";
+
+const DAYS = [
+  {
+    dayIndex: 1,
+    date: "2026-10-24",
+    weekday: "토",
+    activityCount: 2,
+    weather: null,
+  },
+  {
+    dayIndex: 2,
+    date: "2026-10-25",
+    weekday: "일",
+    activityCount: 1,
+    weather: null,
+  },
+];
+
+function activity(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    tripId: 3,
+    title: "아침 산책",
+    activityDate: "2026-10-24",
+    startTime: "09:00",
+    place: null,
+    memo: null,
+    url: null,
+    notifyEnabled: false,
+    notifyMinutes: null,
+    departureNotifyEnabled: false,
+    sortOrder: 0,
+    hasLog: false,
+    ...overrides,
+  };
+}
+
+const SENSOJI = {
+  id: 10,
+  name: "센소지",
+  address: "다이토구",
+  lat: 35.7147651,
+  lng: 139.7966553,
+};
+
+function mockBoard(byDate: Record<string, unknown[]>) {
+  server.use(
+    http.get(`${API_BASE}/travel/trips/:tripId/board`, ({ request }) => {
+      const date =
+        new URL(request.url).searchParams.get("date") ?? DAYS[0].date;
+      return HttpResponse.json({
+        code: "OK",
+        data: {
+          trip: {
+            id: 3,
+            title: "도쿄",
+            timezone: "Asia/Tokyo",
+            currency: "JPY",
+            startDate: "2026-10-24",
+            endDate: "2026-10-25",
+            status: "UPCOMING",
+            recordMode: false,
+          },
+          days: DAYS,
+          selectedDate: date,
+          archiveCount: 0,
+          activities: byDate[date] ?? [],
+          legs: [],
+        },
+      });
+    }),
+  );
+}
+
+function renderMap(path = "/travel/trips/3/map") {
+  return renderWithRouter(
+    <Providers>
+      <AppRouter />
+    </Providers>,
+    { initialEntries: [path] },
+  );
+}
+
+/** 오프라인을 흉내낸다 — 지도 타일은 캐시할 수 없어 이 분기가 실제로 쓰인다. */
+function goOffline() {
+  vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+}
+
+describe("TripMapPage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "valid-token" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("헤더", () => {
+    it("몇 일차인지와 지도에 찍힌 개수를 보여준다", async () => {
+      mockBoard({
+        "2026-10-24": [
+          activity({ id: 1, place: SENSOJI }),
+          activity({ id: 2 }), // 장소 없음 — 세지 않는다
+        ],
+      });
+
+      renderMap();
+
+      expect(
+        await screen.findByRole("heading", { name: "1일차 동선" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("장소가 있는 일정 1개 · 직선 연결"),
+      ).toBeInTheDocument();
+    });
+
+    it("보던 날짜를 그대로 그린다 — 여행 전체를 겹쳐 그리면 얼룩이 된다", async () => {
+      mockBoard({
+        "2026-10-24": [activity({ id: 1, place: SENSOJI })],
+        "2026-10-25": [
+          activity({ id: 2, activityDate: "2026-10-25", place: SENSOJI }),
+          activity({ id: 3, activityDate: "2026-10-25", place: SENSOJI }),
+        ],
+      });
+
+      renderMap("/travel/trips/3/map?day=1");
+
+      expect(
+        await screen.findByRole("heading", { name: "2일차 동선" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("장소가 있는 일정 2개 · 직선 연결"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("리스트로 돌아가기", () => {
+    it("보던 날짜를 유지한 채 보드로 간다", async () => {
+      mockBoard({ "2026-10-25": [activity({ id: 2, place: SENSOJI })] });
+
+      const user = userEvent.setup();
+      renderMap("/travel/trips/3/map?day=1");
+      await screen.findByRole("heading", { name: "2일차 동선" });
+
+      await user.click(screen.getByRole("button", { name: "리스트로 전환" }));
+
+      // 날짜를 잃으면 현지에서 오늘을 다시 찾아야 한다 — 2일차 탭이 선택된 채로 돌아온다.
+      const tabs = await screen.findAllByRole("tab");
+      await waitFor(() =>
+        expect(tabs[1]).toHaveAttribute("aria-selected", "true"),
+      );
+    });
+  });
+
+  describe("빈 상태", () => {
+    it("장소가 있는 일정이 없으면 장소 검색으로 보낸다", async () => {
+      mockBoard({ "2026-10-24": [activity({ id: 1 })] });
+
+      const user = userEvent.setup();
+      renderMap();
+
+      expect(
+        await screen.findByText("장소가 있는 일정이 없어요."),
+      ).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: /장소 검색/ }));
+
+      expect(await screen.findByLabelText("장소 검색")).toBeInTheDocument();
+    });
+
+    it("오프라인이면 지도를 못 본다고 알린다 — 타일은 캐시할 수 없다", async () => {
+      goOffline();
+      mockBoard({ "2026-10-24": [activity({ id: 1, place: SENSOJI })] });
+
+      renderMap();
+
+      expect(
+        await screen.findByText("오프라인에서는 지도를 볼 수 없어요."),
+      ).toBeInTheDocument();
+      // 빈 지도를 보여주고 멈춘 것처럼 두지 않는다. 헤더와 빈 상태 양쪽에 있다.
+      expect(
+        screen.getAllByRole("button", { name: /리스트로 전환/ }),
+      ).toHaveLength(2);
+    });
+  });
+
+  describe("보드에서 들어오기", () => {
+    it("지도 버튼이 보던 날짜를 들고 간다", async () => {
+      mockBoard({ "2026-10-25": [activity({ id: 2, place: SENSOJI })] });
+
+      const user = userEvent.setup();
+      renderWithRouter(
+        <Providers>
+          <AppRouter />
+        </Providers>,
+        { initialEntries: ["/travel/trips/3/board?day=1"] },
+      );
+
+      await user.click(await screen.findByRole("button", { name: "지도" }));
+
+      expect(
+        await screen.findByRole("heading", { name: "2일차 동선" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/fe/src/pages/travel/TripMapPage.tsx
+++ b/fe/src/pages/travel/TripMapPage.tsx
@@ -1,0 +1,168 @@
+import { ArrowLeft, List, WifiOff } from "lucide-react";
+import { lazy, Suspense, useState } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { LoadingText } from "@/components/ui/loading-text";
+import { useBoard } from "@/features/travel/hooks/useBoard";
+import { toMapped } from "@/features/travel/map/toMapped";
+import { useOnline } from "@/shared/lib/useOnline";
+
+// leaflet은 무겁고 이 화면에서만 쓴다 — 보드 진입 비용에 얹지 않는다.
+const TripDayMap = lazy(() =>
+  import("@/features/travel/map/TripDayMap").then((m) => ({
+    default: m.TripDayMap,
+  })),
+);
+
+/**
+ * S-05 지도 뷰. <b>선택한 날짜의 동선만</b> 그린다.
+ *
+ * <p>여행 전체를 겹쳐 그리면 동선이 아니라 얼룩이 된다. 이 화면이 답하는 질문은
+ * "오늘 이 순서가 말이 되나"이고, 그건 하루 단위로만 성립한다.
+ */
+export function TripMapPage() {
+  const { tripId: tripIdParam } = useParams();
+  const tripId = Number(tripIdParam);
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const online = useOnline();
+
+  const day = searchParams.get("day");
+  const dayIndex = day !== null ? Number(day) : null;
+
+  const { data: base, isPending } = useBoard(tripId, {});
+  const requestedDate =
+    dayIndex !== null ? base?.days[dayIndex]?.date : undefined;
+  const needsOwnQuery =
+    requestedDate !== undefined && requestedDate !== base?.selectedDate;
+  const { data: dayBoard } = useBoard(
+    tripId,
+    { date: requestedDate },
+    { enabled: needsOwnQuery },
+  );
+  const board = needsOwnQuery ? dayBoard : base;
+
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const backToList = () => {
+    const suffix = day === null ? "" : `?day=${day}`;
+    navigate(`/travel/trips/${tripId}/board${suffix}`);
+  };
+
+  if (isPending || !board) {
+    return (
+      <div className="grid min-h-[40svh] place-items-center">
+        <LoadingText />
+      </div>
+    );
+  }
+
+  const mapped = toMapped(board.activities);
+  const selected = mapped.find((m) => m.activity.id === selectedId);
+  const dayNumber =
+    board.days.findIndex((d) => d.date === board.selectedDate) + 1;
+
+  return (
+    <div className="mx-auto flex w-full max-w-[520px] flex-col gap-3 px-4 pt-3">
+      <header className="flex items-center gap-2">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="뒤로"
+          onClick={backToList}
+        >
+          <ArrowLeft className="size-4" />
+        </Button>
+        <div className="min-w-0 flex-1">
+          <h1 className="text-heading font-semibold">{dayNumber}일차 동선</h1>
+          <p className="text-muted-foreground text-xs">
+            장소가 있는 일정 {mapped.length}개 · 직선 연결
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="리스트로 전환"
+          onClick={backToList}
+        >
+          <List className="size-4" />
+        </Button>
+      </header>
+
+      {!online ? (
+        <EmptyState className="min-h-[40svh]">
+          <WifiOff className="text-muted-foreground size-6" />
+          <p className="text-muted-foreground text-sm">
+            오프라인에서는 지도를 볼 수 없어요.
+          </p>
+          <Button variant="outline" onClick={backToList}>
+            <List className="size-4" />
+            리스트로 전환
+          </Button>
+        </EmptyState>
+      ) : mapped.length === 0 ? (
+        <EmptyState className="min-h-[40svh]">
+          <p className="text-muted-foreground text-sm">
+            장소가 있는 일정이 없어요.
+          </p>
+          <Button
+            variant="outline"
+            onClick={() => navigate(`/travel/trips/${tripId}/places`)}
+          >
+            장소 검색
+          </Button>
+        </EmptyState>
+      ) : (
+        <>
+          <Suspense
+            fallback={
+              <div className="bg-muted grid aspect-[8/5] w-full place-items-center rounded-lg border">
+                <LoadingText />
+              </div>
+            }
+          >
+            <TripDayMap
+              mapped={mapped}
+              selectedId={selectedId}
+              onSelect={setSelectedId}
+            />
+          </Suspense>
+
+          {selected && (
+            <div className="border-border bg-card flex items-center gap-3 rounded-xl border px-3.5 py-3">
+              <span className="bg-primary text-primary-foreground grid size-[26px] shrink-0 place-items-center rounded-full text-xs font-semibold">
+                {selected.order}
+              </span>
+              <div className="min-w-0 flex-1">
+                {selected.activity.startTime && (
+                  <p className="text-muted-foreground text-xs tabular-nums">
+                    {selected.activity.startTime}
+                  </p>
+                )}
+                <p className="truncate text-[15px] font-medium">
+                  {selected.activity.title}
+                </p>
+                {selected.activity.place?.address && (
+                  <p className="text-muted-foreground truncate text-xs">
+                    {selected.activity.place.address}
+                  </p>
+                )}
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  navigate(`/travel/activities/${selected.activity.id}`)
+                }
+              >
+                일정 열기
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/fe/src/shared/lib/useOnline.ts
+++ b/fe/src/shared/lib/useOnline.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+/**
+ * 온라인 여부. 지도 타일처럼 <b>캐시할 수 없는</b> 자원을 쓰는 화면이 미리 물어본다 —
+ * 네트워크가 없으면 빈 지도만 뜨고 사용자는 앱이 멈춘 줄 안다.
+ */
+export function useOnline(): boolean {
+  const [online, setOnline] = useState(() =>
+    typeof navigator === "undefined" ? true : navigator.onLine,
+  );
+
+  useEffect(() => {
+    const update = () => setOnline(navigator.onLine);
+    window.addEventListener("online", update);
+    window.addEventListener("offline", update);
+    return () => {
+      window.removeEventListener("online", update);
+      window.removeEventListener("offline", update);
+    };
+  }, []);
+
+  return online;
+}


### PR DESCRIPTION
## 이슈
closes #1070
## 작업 내용

**2단계 마지막 항목이다.** `/travel/trips/:tripId/map` — 선택한 날짜의 동선을 지도로 본다.

리스트로는 "이 순서가 동선으로 말이 되나"를 알 수 없다. 오전에 아사쿠사, 점심에 신주쿠, 오후에 다시 아사쿠사 같은 순서는 지도에서만 눈에 띈다.

기존 `features/lifelog/flow/FlowMap.tsx`와 같은 방식(react-leaflet + OSM)이라 새 의존성이 없다.

### 마커 번호는 지도 표시 순서로 다시 매긴다

리스트 순번을 그대로 쓰면 장소 없는 일정이 빠지면서 지도에 **1·3·4번만** 뜬다 — 2번이 어디 갔는지 알 수 없고, 지도에서 세는 순서와도 어긋난다.

로컬 확인에서 그대로 드러났다: 리스트 4번째 `저녁`이 지도에서는 **3번**이다(장소 없는 "점심"이 빠졌다).

### 선택한 날짜만

여행 전체를 겹쳐 그리면 동선이 아니라 얼룩이 된다. 이 화면이 답하는 질문은 "**오늘** 이 순서가 말이 되나"이고, 그건 하루 단위로만 성립한다. 보드에서 보던 날짜를 그대로 들고 오고, 돌아갈 때도 유지한다.

**보관함에서는 지도 버튼이 비활성이다** — 배정되지 않은 목록엔 동선이 없다.

### 연결선은 직선

실제 경로가 아니라 순서를 보여주는 선이다. 실제 길찾기는 구글 지도 딥링크(#1069)가 맡으므로 여기서 경로를 그릴 이유가 없다.

### 오프라인 안내는 지금 넣는다

#1069에서 보드 쪽 오프라인 처리는 4단계로 미뤘는데, 지도는 다르다. **타일은 캐시할 수 없어** 4단계 오프라인 캐시가 생겨도 지도는 여전히 못 본다. 빈 지도를 띄워 두면 앱이 멈춘 줄 안다.

### 상세 장소 블록 완성 (#1069에서 미룬 나머지)

지도 미리보기 · 영업시간 · 전화번호를 채웠다.

- **미리보기는 조작하지 않는다** — 드래그·줌을 열어두면 폼 안에서 스크롤을 잡아먹는다. "여기가 어디쯤인지"만 보여주면 된다
- **영업시간은 오늘 줄만.** 일곱 줄은 화면만 차지하고, 현지에서 알고 싶은 건 "지금 열었나"뿐이다
- Google은 **월요일부터** 주고 `Date.getDay()`는 **일요일이 0**이다. 이 어긋남을 맞추지 않으면 요일이 하루 밀린다 — 테스트로 고정했다
- 원본 JSON을 그대로 캐시하는 구조라(§4.7) 형태가 달라질 수 있다. 못 읽으면 조용히 비운다

`leaflet`은 무겁고 지도 화면에서만 쓴다 — **지연 로드**로 보드 진입 비용에 얹지 않는다.

## 확인

FE 게이트 전부 통과 — `format:check` · `lint` · `test`(771) · `build`. 새 테스트 15개.

로컬에서 BE·FE를 띄우고 **실제 OSM 타일 · 실제 Google 장소**로 확인:

| | 결과 |
|---|---|
| 지도 | 마커 1·2·3 + 직선 연결 + `© OpenStreetMap` attribution |
| 헤더 | `1일차 동선` · `장소가 있는 일정 3개 · 직선 연결` (장소 없는 "점심"은 안 셈) |
| 마커 2 탭 | 하단 카드 `전망대` + 주소 + `일정 열기` |
| **마커 3** | **`저녁`** — 리스트 4번째가 지도에선 3번, 번호 재매김이 작동한다 |
| 일정 열기 | 해당 일정 상세로 이동 |
| 상세 장소 블록 | 지도 미리보기 + **`토요일: 오전 9:00 ~ 오후 10:00`** + `0570-550-634` |

영업시간이 실제 오늘 요일(토요일) 줄로 나오는 것까지 확인했다.

### 함께 바꾼 테스트

`지도·도구는 후속 단계라 비활성이다` — 지도가 활성화됐으니 `도구`만 남기고, 대신 **보관함에서는 지도를 열 수 없다**를 새로 고정했다.
