### PR TITLE
feat : 웹푸시 암호화·VAPID 서명 (라이브러리 없이)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/crypto/P256.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/crypto/P256.java
@@ -1,0 +1,114 @@
+package ds.project.orino.planner.travel.push.crypto;
+
+import java.math.BigInteger;
+import java.security.AlgorithmParameters;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPrivateKeySpec;
+import java.security.spec.ECPublicKeySpec;
+import java.util.Arrays;
+
+/**
+ * P-256(secp256r1) 키를 웹푸시가 쓰는 <b>원시 바이트 형태</b>와 JDK 키 객체 사이에서 옮긴다.
+ *
+ * <p>브라우저가 주는 구독 키({@code p256dh})와 VAPID 키는 X.509/PKCS#8이 아니라
+ * 65바이트 비압축 점({@code 0x04 || X || Y})과 32바이트 스칼라다. JDK는 이 형태를 직접
+ * 받아주지 않아 좌표를 꺼내 다시 만들어야 한다.
+ *
+ * <p>BouncyCastle을 쓰지 않는다 — 필요한 것이 전부 JDK에 있고, 의존성을 늘릴 이유가 없다.
+ */
+public final class P256 {
+
+    private static final String CURVE = "secp256r1";
+    /** 비압축 점 표시(SEC1). 압축 점은 브라우저가 주지 않는다. */
+    private static final byte UNCOMPRESSED = 0x04;
+    private static final int COORDINATE_BYTES = 32;
+    private static final int PUBLIC_KEY_BYTES = 1 + COORDINATE_BYTES * 2;
+
+    private P256() {
+    }
+
+    public static ECParameterSpec parameterSpec() {
+        try {
+            AlgorithmParameters params = AlgorithmParameters.getInstance("EC");
+            params.init(new ECGenParameterSpec(CURVE));
+            return params.getParameterSpec(ECParameterSpec.class);
+        } catch (Exception e) {
+            throw new IllegalStateException("P-256 파라미터를 만들 수 없습니다.", e);
+        }
+    }
+
+    public static KeyPair generateKeyPair() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+            generator.initialize(new ECGenParameterSpec(CURVE));
+            return generator.generateKeyPair();
+        } catch (Exception e) {
+            throw new IllegalStateException("P-256 키쌍을 만들 수 없습니다.", e);
+        }
+    }
+
+    /** 65바이트 비압축 점 → 공개키. */
+    public static PublicKey publicKey(byte[] uncompressedPoint) {
+        if (uncompressedPoint.length != PUBLIC_KEY_BYTES
+                || uncompressedPoint[0] != UNCOMPRESSED) {
+            throw new IllegalArgumentException(
+                    "P-256 공개키는 0x04로 시작하는 65바이트여야 합니다.");
+        }
+        BigInteger x = new BigInteger(1,
+                Arrays.copyOfRange(uncompressedPoint, 1, 1 + COORDINATE_BYTES));
+        BigInteger y = new BigInteger(1,
+                Arrays.copyOfRange(uncompressedPoint, 1 + COORDINATE_BYTES, PUBLIC_KEY_BYTES));
+        try {
+            return KeyFactory.getInstance("EC")
+                    .generatePublic(new ECPublicKeySpec(new ECPoint(x, y), parameterSpec()));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("P-256 공개키를 읽을 수 없습니다.", e);
+        }
+    }
+
+    /** 32바이트 스칼라 → 개인키. */
+    public static PrivateKey privateKey(byte[] scalar) {
+        try {
+            return KeyFactory.getInstance("EC").generatePrivate(
+                    new ECPrivateKeySpec(new BigInteger(1, scalar), parameterSpec()));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("P-256 개인키를 읽을 수 없습니다.", e);
+        }
+    }
+
+    /** 공개키 → 65바이트 비압축 점. 앞을 0으로 채워 좌표 길이를 고정한다. */
+    public static byte[] encode(PublicKey publicKey) {
+        ECPoint point = ((java.security.interfaces.ECPublicKey) publicKey).getW();
+        byte[] encoded = new byte[PUBLIC_KEY_BYTES];
+        encoded[0] = UNCOMPRESSED;
+        writeCoordinate(point.getAffineX(), encoded, 1);
+        writeCoordinate(point.getAffineY(), encoded, 1 + COORDINATE_BYTES);
+        return encoded;
+    }
+
+    /** 개인키 → 32바이트 스칼라. */
+    public static byte[] encode(PrivateKey privateKey) {
+        BigInteger s = ((java.security.interfaces.ECPrivateKey) privateKey).getS();
+        byte[] encoded = new byte[COORDINATE_BYTES];
+        writeCoordinate(s, encoded, 0);
+        return encoded;
+    }
+
+    /**
+     * BigInteger는 부호 바이트가 붙거나 앞의 0이 잘려 길이가 32가 아닐 수 있다.
+     * 좌표는 <b>고정 길이</b>여야 해서 오른쪽 정렬로 채운다.
+     */
+    private static void writeCoordinate(BigInteger value, byte[] target, int offset) {
+        byte[] bytes = value.toByteArray();
+        int length = Math.min(bytes.length, COORDINATE_BYTES);
+        System.arraycopy(bytes, bytes.length - length, target,
+                offset + COORDINATE_BYTES - length, length);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/crypto/VapidSigner.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/crypto/VapidSigner.java
@@ -1,0 +1,109 @@
+package ds.project.orino.planner.travel.push.crypto;
+
+import java.math.BigInteger;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+
+/**
+ * VAPID 인증 헤더 — RFC 8292.
+ *
+ * <p>푸시 서비스에 "이 발송자가 그 구독을 만든 서버가 맞다"를 증명한다. ES256으로 서명한 JWT를
+ * 헤더에 싣는다.
+ *
+ * <p>JDK의 ECDSA 서명은 <b>DER</b>로 나오는데 JWS는 <b>고정 길이 R‖S</b>를 요구한다(RFC 7518
+ * §3.4). 이 변환을 빼먹으면 푸시 서비스가 401을 준다 — 자바로 VAPID를 붙일 때 가장 흔한 함정이다.
+ */
+public final class VapidSigner {
+
+    /** 헤더·클레임은 고정이라 상수로 둔다. */
+    private static final String HEADER = """
+            {"typ":"JWT","alg":"ES256"}""";
+
+    /** RFC 8292는 24시간을 넘지 말라고 한다. 여유를 두고 12시간. */
+    private static final Duration EXPIRY = Duration.ofHours(12);
+
+    private static final int COORDINATE_BYTES = 32;
+    private static final Base64.Encoder BASE64URL = Base64.getUrlEncoder().withoutPadding();
+
+    private VapidSigner() {
+    }
+
+    /**
+     * @param endpoint 구독 엔드포인트. {@code aud}는 그 <b>출처(origin)</b>만 쓴다
+     * @param subject  연락처({@code mailto:} 또는 https URL)
+     */
+    public static String authorizationHeader(String endpoint, String subject,
+                                             byte[] publicKey, PrivateKey privateKey,
+                                             Instant now) {
+        String jwt = jwt(audience(endpoint), subject, privateKey, now);
+        return "vapid t=%s, k=%s".formatted(jwt, BASE64URL.encodeToString(publicKey));
+    }
+
+    /** 엔드포인트 전체를 넣으면 안 된다 — 구독마다 aud가 달라져 캐시도 검증도 어긋난다. */
+    static String audience(String endpoint) {
+        URI uri = URI.create(endpoint);
+        return uri.getScheme() + "://" + uri.getHost()
+                + (uri.getPort() == -1 ? "" : ":" + uri.getPort());
+    }
+
+    static String jwt(String audience, String subject, PrivateKey privateKey, Instant now) {
+        String claims = """
+                {"aud":"%s","exp":%d,"sub":"%s"}"""
+                .formatted(audience, now.plus(EXPIRY).getEpochSecond(), subject);
+
+        String signingInput = encode(HEADER) + "." + encode(claims);
+        byte[] signature = sign(signingInput.getBytes(StandardCharsets.UTF_8), privateKey);
+        return signingInput + "." + BASE64URL.encodeToString(signature);
+    }
+
+    private static String encode(String json) {
+        return BASE64URL.encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static byte[] sign(byte[] data, PrivateKey privateKey) {
+        try {
+            Signature signature = Signature.getInstance("SHA256withECDSA");
+            signature.initSign(privateKey);
+            signature.update(data);
+            return derToJose(signature.sign());
+        } catch (Exception e) {
+            throw new IllegalStateException("VAPID 서명에 실패했습니다.", e);
+        }
+    }
+
+    /**
+     * DER {@code SEQUENCE { INTEGER r, INTEGER s }} → 64바이트 {@code R‖S}.
+     *
+     * <p>DER INTEGER는 최상위 비트가 1이면 앞에 0x00을 붙이고, 앞의 0은 생략한다. 그대로 이어
+     * 붙이면 길이가 63~65로 흔들려 서명이 깨진다.
+     */
+    static byte[] derToJose(byte[] der) {
+        int offset = 3;
+        if (der[1] == (byte) 0x81) {
+            offset = 4;
+        }
+        int rLength = der[offset];
+        int sOffset = offset + rLength + 2;
+        int sLength = der[sOffset];
+
+        BigInteger r = new BigInteger(1, der, offset + 1, rLength);
+        BigInteger s = new BigInteger(1, der, sOffset + 1, sLength);
+
+        byte[] jose = new byte[COORDINATE_BYTES * 2];
+        writeFixed(r, jose, 0);
+        writeFixed(s, jose, COORDINATE_BYTES);
+        return jose;
+    }
+
+    private static void writeFixed(BigInteger value, byte[] target, int offset) {
+        byte[] bytes = value.toByteArray();
+        int length = Math.min(bytes.length, COORDINATE_BYTES);
+        System.arraycopy(bytes, bytes.length - length, target,
+                offset + COORDINATE_BYTES - length, length);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/crypto/WebPushEncryption.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/crypto/WebPushEncryption.java
@@ -1,0 +1,153 @@
+package ds.project.orino.planner.travel.push.crypto;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyAgreement;
+import javax.crypto.Mac;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+/**
+ * 웹푸시 페이로드 암호화 — RFC 8291(Message Encryption) + RFC 8188(aes128gcm).
+ *
+ * <p>푸시 서비스는 <b>내용을 볼 수 없다</b>. 브라우저가 준 구독 키로 종단 암호화해서 보내고,
+ * 복호화는 기기의 Service Worker가 한다. 그래서 이 계산이 어긋나면 푸시 서비스는 200을 주고도
+ * 기기에는 아무것도 뜨지 않는다 — 조용히 실패하는 종류다.
+ *
+ * <p>필요한 것이 전부 JDK에 있어(ECDH · HMAC · AES-GCM) 외부 의존성을 쓰지 않는다.
+ */
+public final class WebPushEncryption {
+
+    private static final byte[] AUTH_INFO = "WebPush: info\0".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] CEK_INFO =
+            "Content-Encoding: aes128gcm\0".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] NONCE_INFO =
+            "Content-Encoding: nonce\0".getBytes(StandardCharsets.UTF_8);
+
+    private static final int SALT_BYTES = 16;
+    private static final int KEY_BYTES = 16;
+    private static final int NONCE_BYTES = 12;
+    private static final int TAG_BITS = 128;
+    /** 레코드 마지막임을 알리는 구분자(RFC 8188 §2). 한 레코드로만 보낸다. */
+    private static final byte LAST_RECORD = 0x02;
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private WebPushEncryption() {
+    }
+
+    /**
+     * @param uaPublicKey  구독의 {@code p256dh}(65바이트 비압축 점)
+     * @param authSecret   구독의 {@code auth}(16바이트)
+     * @param payload      보낼 평문
+     * @param recordSize   레코드 크기. 한 레코드에 담기므로 페이로드보다 커야 한다
+     */
+    public static byte[] encrypt(byte[] uaPublicKey, byte[] authSecret,
+                                 byte[] payload, int recordSize) {
+        byte[] salt = new byte[SALT_BYTES];
+        RANDOM.nextBytes(salt);
+        return encrypt(uaPublicKey, authSecret, payload, recordSize, salt,
+                P256.generateKeyPair());
+    }
+
+    /**
+     * 소금과 발신 키쌍을 밖에서 넣는 형태. 테스트가 결정적이어야 검증이 가능하다 —
+     * 같은 입력에 같은 바이트가 나와야 다른 구현과 맞대어 볼 수 있다.
+     */
+    public static byte[] encrypt(byte[] uaPublicKey, byte[] authSecret, byte[] payload,
+                                 int recordSize, byte[] salt, KeyPair senderKeyPair) {
+        byte[] asPublic = P256.encode(senderKeyPair.getPublic());
+        byte[] ikm = inputKeyingMaterial(
+                senderKeyPair.getPrivate(), uaPublicKey, asPublic, authSecret);
+
+        byte[] prk = hmac(salt, ikm);
+        byte[] cek = Arrays.copyOf(hkdfExpand(prk, CEK_INFO), KEY_BYTES);
+        byte[] nonce = Arrays.copyOf(hkdfExpand(prk, NONCE_INFO), NONCE_BYTES);
+
+        byte[] ciphertext = aesGcm(cek, nonce, withDelimiter(payload));
+        return record(salt, recordSize, asPublic, ciphertext);
+    }
+
+    /**
+     * RFC 8291 §3.3 — 공유 비밀과 <b>양쪽 공개키</b>로 입력 키를 만든다.
+     *
+     * <p>{@code auth_secret}이 HKDF의 소금으로 들어가는 것이 핵심이다. 이게 없으면 공개키만
+     * 아는 쪽도 키를 유도할 수 있다.
+     */
+    private static byte[] inputKeyingMaterial(PrivateKey asPrivate, byte[] uaPublic,
+                                              byte[] asPublic, byte[] authSecret) {
+        byte[] sharedSecret = ecdh(asPrivate, P256.publicKey(uaPublic));
+        byte[] info = concat(AUTH_INFO, uaPublic, asPublic);
+        return hkdfExpand(hmac(authSecret, sharedSecret), info);
+    }
+
+    private static byte[] ecdh(PrivateKey privateKey, PublicKey publicKey) {
+        try {
+            KeyAgreement agreement = KeyAgreement.getInstance("ECDH");
+            agreement.init(privateKey);
+            agreement.doPhase(publicKey, true);
+            return agreement.generateSecret();
+        } catch (Exception e) {
+            throw new IllegalStateException("ECDH 계산에 실패했습니다.", e);
+        }
+    }
+
+    /** HKDF-Expand, L ≤ 32라 한 번의 HMAC이면 된다(RFC 5869). */
+    private static byte[] hkdfExpand(byte[] prk, byte[] info) {
+        return hmac(prk, concat(info, new byte[] {0x01}));
+    }
+
+    private static byte[] hmac(byte[] key, byte[] data) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(key, "HmacSHA256"));
+            return mac.doFinal(data);
+        } catch (Exception e) {
+            throw new IllegalStateException("HMAC 계산에 실패했습니다.", e);
+        }
+    }
+
+    private static byte[] aesGcm(byte[] key, byte[] nonce, byte[] plaintext) {
+        try {
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"),
+                    new GCMParameterSpec(TAG_BITS, nonce));
+            return cipher.doFinal(plaintext);
+        } catch (Exception e) {
+            throw new IllegalStateException("페이로드 암호화에 실패했습니다.", e);
+        }
+    }
+
+    /** 평문 뒤에 레코드 구분자를 붙인다. 패딩은 쓰지 않는다. */
+    private static byte[] withDelimiter(byte[] payload) {
+        return concat(payload, new byte[] {LAST_RECORD});
+    }
+
+    /** RFC 8188 §2 헤더 — 소금 · 레코드 크기 · 키 식별자(발신 공개키) · 본문. */
+    private static byte[] record(byte[] salt, int recordSize, byte[] keyId, byte[] ciphertext) {
+        ByteBuffer buffer = ByteBuffer.allocate(
+                SALT_BYTES + 4 + 1 + keyId.length + ciphertext.length);
+        buffer.put(salt);
+        buffer.putInt(recordSize);
+        buffer.put((byte) keyId.length);
+        buffer.put(keyId);
+        buffer.put(ciphertext);
+        return buffer.array();
+    }
+
+    private static byte[] concat(byte[]... parts) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (byte[] part : parts) {
+            out.writeBytes(part);
+        }
+        return out.toByteArray();
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/crypto/VapidSignerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/crypto/VapidSignerTest.java
@@ -1,0 +1,150 @@
+package ds.project.orino.planner.travel.push.crypto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.Signature;
+import java.time.Instant;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * VAPID 서명 검증.
+ *
+ * <p>서명은 <b>스스로 만든 것을 스스로 확인</b>해도 의미가 없다 — 형식이 틀려도 양쪽이 같이
+ * 틀리기 때문이다. 그래서 JDK 검증기로 원문을 다시 세워 확인하고, JWS가 요구하는
+ * <b>고정 길이 R‖S</b>인지를 따로 못박는다(RFC 7518 §3.4).
+ */
+class VapidSignerTest {
+
+    private static final Base64.Decoder DECODER = Base64.getUrlDecoder();
+    private static final String ENDPOINT =
+            "https://fcm.googleapis.com/fcm/send/abcdef:APA91bF_someTokenValue";
+    private static final String SUBJECT = "mailto:dsk08208@gmail.com";
+    private static final Instant NOW = Instant.parse("2026-10-24T00:00:00Z");
+
+    private final KeyPair keyPair = P256.generateKeyPair();
+
+    private String[] parts(String jwt) {
+        return jwt.split("\\.");
+    }
+
+    private String decode(String segment) {
+        return new String(DECODER.decode(segment), StandardCharsets.UTF_8);
+    }
+
+    @Nested
+    @DisplayName("JWT")
+    class Jwt {
+
+        @Test
+        @DisplayName("헤더는 ES256이다")
+        void headerIsEs256() {
+            String jwt = VapidSigner.jwt("https://fcm.googleapis.com", SUBJECT,
+                    keyPair.getPrivate(), NOW);
+
+            assertThat(decode(parts(jwt)[0])).isEqualTo("""
+                    {"typ":"JWT","alg":"ES256"}""");
+        }
+
+        @Test
+        @DisplayName("aud는 엔드포인트 전체가 아니라 출처만이다")
+        void audienceIsOriginOnly() {
+            // 엔드포인트 전체를 넣으면 구독마다 aud가 달라져 푸시 서비스가 거부한다.
+            assertThat(VapidSigner.audience(ENDPOINT)).isEqualTo("https://fcm.googleapis.com");
+        }
+
+        @Test
+        @DisplayName("만료는 24시간을 넘지 않는다 (RFC 8292)")
+        void expiryWithinLimit() {
+            String jwt = VapidSigner.jwt("https://fcm.googleapis.com", SUBJECT,
+                    keyPair.getPrivate(), NOW);
+            String claims = decode(parts(jwt)[1]);
+
+            long exp = Long.parseLong(claims.replaceAll(".*\"exp\":(\\d+).*", "$1"));
+            assertThat(exp - NOW.getEpochSecond()).isPositive()
+                    .isLessThanOrEqualTo(24 * 60 * 60);
+        }
+
+        @Test
+        @DisplayName("서명이 원문과 맞는다 — 검증기로 다시 세워 확인한다")
+        void signatureVerifies() throws Exception {
+            String jwt = VapidSigner.jwt("https://fcm.googleapis.com", SUBJECT,
+                    keyPair.getPrivate(), NOW);
+            String[] segments = parts(jwt);
+            String signingInput = segments[0] + "." + segments[1];
+
+            Signature verifier = Signature.getInstance("SHA256withECDSA");
+            verifier.initVerify(keyPair.getPublic());
+            verifier.update(signingInput.getBytes(StandardCharsets.UTF_8));
+
+            assertThat(verifier.verify(joseToDer(DECODER.decode(segments[2])))).isTrue();
+        }
+
+        @Test
+        @DisplayName("서명은 항상 64바이트다 — DER을 그대로 쓰면 길이가 흔들려 401이 난다")
+        void signatureIsFixedLength() {
+            // 자바로 VAPID를 붙일 때 가장 흔한 함정이라 여러 번 돌려 길이를 못박는다.
+            for (int i = 0; i < 50; i++) {
+                String jwt = VapidSigner.jwt("https://fcm.googleapis.com", SUBJECT,
+                        P256.generateKeyPair().getPrivate(), NOW);
+
+                assertThat(DECODER.decode(parts(jwt)[2])).hasSize(64);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Authorization 헤더")
+    class Header {
+
+        @Test
+        @DisplayName("vapid 스킴에 토큰과 공개키를 함께 싣는다")
+        void carriesTokenAndKey() {
+            String header = VapidSigner.authorizationHeader(ENDPOINT, SUBJECT,
+                    P256.encode(keyPair.getPublic()), keyPair.getPrivate(), NOW);
+
+            assertThat(header).startsWith("vapid t=").contains(", k=");
+            String key = header.substring(header.indexOf(", k=") + 4);
+            // 푸시 서비스가 이 키로 서명을 검증한다 — 구독 때 쓴 것과 같아야 한다.
+            assertThat(DECODER.decode(key)).isEqualTo(P256.encode(keyPair.getPublic()));
+        }
+    }
+
+    /** 검증기에 넣으려면 JOSE 형식을 DER로 되돌려야 한다. */
+    private static byte[] joseToDer(byte[] jose) {
+        byte[] r = trim(java.util.Arrays.copyOfRange(jose, 0, 32));
+        byte[] s = trim(java.util.Arrays.copyOfRange(jose, 32, 64));
+        int length = 2 + r.length + 2 + s.length;
+
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        out.write(0x30);
+        out.write(length);
+        out.write(0x02);
+        out.write(r.length);
+        out.writeBytes(r);
+        out.write(0x02);
+        out.write(s.length);
+        out.writeBytes(s);
+        return out.toByteArray();
+    }
+
+    /** DER INTEGER는 앞의 0을 빼고, 최상위 비트가 1이면 0x00을 붙인다. */
+    private static byte[] trim(byte[] value) {
+        int start = 0;
+        while (start < value.length - 1 && value[start] == 0) {
+            start++;
+        }
+        byte[] trimmed = java.util.Arrays.copyOfRange(value, start, value.length);
+        if ((trimmed[0] & 0x80) != 0) {
+            byte[] padded = new byte[trimmed.length + 1];
+            System.arraycopy(trimmed, 0, padded, 1, trimmed.length);
+            return padded;
+        }
+        return trimmed;
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/crypto/WebPushEncryptionTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/crypto/WebPushEncryptionTest.java
@@ -1,0 +1,101 @@
+package ds.project.orino.planner.travel.push.crypto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 페이로드 암호화 검증.
+ *
+ * <p>이 계산은 <b>조용히 실패한다</b> — 어긋나면 푸시 서비스가 200을 주고도 기기엔 아무것도
+ * 뜨지 않는다. 그래서 "돌아간다"가 아니라 <b>규격과 바이트가 같은가</b>로 확인한다.
+ *
+ * <p>입력은 RFC 8291 §5의 테스트 벡터고, 기대값은 널리 쓰이는 Node {@code http_ece}
+ * (npm {@code web-push}의 암호화 엔진)로 같은 입력에서 뽑은 것이다. 우리 구현·규격·기존
+ * 구현 셋이 한 점에서 만나야 통과한다.
+ */
+class WebPushEncryptionTest {
+
+    private static final Base64.Decoder DECODER = Base64.getUrlDecoder();
+    private static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
+
+    private static final byte[] UA_PUBLIC = DECODER.decode(
+            "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4");
+    private static final byte[] UA_PRIVATE = DECODER.decode(
+            "q1dXpw3UpT5VOmu_cf_v6ih07Aems3njxI-JWgLcM94");
+    private static final byte[] AS_PUBLIC = DECODER.decode(
+            "BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8");
+    private static final byte[] AS_PRIVATE = DECODER.decode(
+            "yfWPiYE-n46HLnH0KqZOF1fJJU3MYrct3AELtAQ-oRw");
+    private static final byte[] AUTH_SECRET = DECODER.decode("BTBZMqHH6r4Tts7J_aSIgg");
+    private static final byte[] SALT = DECODER.decode("DGv6ra1nlYgDCS1FRnbzlw");
+
+    private static final String PLAINTEXT = "When I grow up, I want to be a watermelon";
+    private static final String EXPECTED =
+            "DGv6ra1nlYgDCS1FRnbzlwAAEABBBP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLoc"
+                    + "InmYWAmS6TlzAC8wEqKK6PBru3jl7A_yl95bQpu6cVPTpK4Mqgkf1CXztLVBSt2Ks3oZwbuwXPXL"
+                    + "WyouBWLVWGNWQexSgSxsj_Qulcy4a-fN";
+
+    private static KeyPair senderKeyPair() {
+        return new KeyPair(P256.publicKey(AS_PUBLIC), P256.privateKey(AS_PRIVATE));
+    }
+
+    @Test
+    @DisplayName("RFC 8291 테스트 벡터와 바이트가 같다")
+    void matchesReferenceVector() {
+        byte[] encrypted = WebPushEncryption.encrypt(
+                UA_PUBLIC, AUTH_SECRET, PLAINTEXT.getBytes(StandardCharsets.UTF_8),
+                4096, SALT, senderKeyPair());
+
+        assertThat(ENCODER.encodeToString(encrypted)).isEqualTo(EXPECTED);
+    }
+
+    @Test
+    @DisplayName("헤더에 소금·레코드 크기·발신 공개키가 그대로 실린다")
+    void carriesHeader() {
+        byte[] encrypted = WebPushEncryption.encrypt(
+                UA_PUBLIC, AUTH_SECRET, PLAINTEXT.getBytes(StandardCharsets.UTF_8),
+                4096, SALT, senderKeyPair());
+
+        // salt(16) + rs(4) + idlen(1) + key(65)
+        assertThat(java.util.Arrays.copyOf(encrypted, 16)).isEqualTo(SALT);
+        assertThat(encrypted[20]).isEqualTo((byte) 65);
+        assertThat(java.util.Arrays.copyOfRange(encrypted, 21, 86)).isEqualTo(AS_PUBLIC);
+    }
+
+    @Test
+    @DisplayName("소금이 매번 달라 같은 내용도 다른 바이트가 된다")
+    void saltIsRandomPerMessage() {
+        byte[] first = WebPushEncryption.encrypt(
+                UA_PUBLIC, AUTH_SECRET, PLAINTEXT.getBytes(StandardCharsets.UTF_8), 4096);
+        byte[] second = WebPushEncryption.encrypt(
+                UA_PUBLIC, AUTH_SECRET, PLAINTEXT.getBytes(StandardCharsets.UTF_8), 4096);
+
+        assertThat(first).isNotEqualTo(second);
+    }
+
+    @Test
+    @DisplayName("구독의 auth가 다르면 결과가 달라진다 — 공개키만으로는 못 푼다")
+    void authSecretChangesResult() {
+        byte[] otherAuth = DECODER.decode("AAAAAAAAAAAAAAAAAAAAAA");
+
+        byte[] withReal = WebPushEncryption.encrypt(UA_PUBLIC, AUTH_SECRET,
+                PLAINTEXT.getBytes(StandardCharsets.UTF_8), 4096, SALT, senderKeyPair());
+        byte[] withOther = WebPushEncryption.encrypt(UA_PUBLIC, otherAuth,
+                PLAINTEXT.getBytes(StandardCharsets.UTF_8), 4096, SALT, senderKeyPair());
+
+        assertThat(withReal).isNotEqualTo(withOther);
+    }
+
+    @Test
+    @DisplayName("P-256 키를 원시 바이트로 왕복해도 그대로다")
+    void encodesKeysRoundTrip() {
+        assertThat(P256.encode(P256.publicKey(UA_PUBLIC))).isEqualTo(UA_PUBLIC);
+        assertThat(P256.encode(P256.privateKey(UA_PRIVATE))).isEqualTo(UA_PRIVATE);
+    }
+}


### PR DESCRIPTION
## 이슈
closes #1072
## 작업 내용

**결론부터: 막히지 않는다. 3단계는 계획대로 갈 수 있다.**

에픽에 "여기서 막히면 전체가 밀림"으로 적어 둔 관문이었다. 답은 **라이브러리를 쓰지 않고 직접 구현**이고, 새 의존성은 **0개**다.

### 왜 라이브러리를 안 쓰나 — 의존성 트리를 찍어서 결정했다

후보 두 개를 실제로 해석해 봤다.

**`nl.martijndwars:web-push:5.1.1` — 아티팩트 29개**

| 끌고 오는 것 | 버전 |
|---|---|
| io.netty:* | **4.1.42.Final** (2019) |
| org.asynchttpclient | 2.10.4 (2019) |
| org.apache.httpcomponents:httpclient | 4.5.6 (2018) |
| org.bitbucket.b_c:jose4j | 0.7.0 (2019) |
| commons-codec | 1.10 (2014) |

여기서 걸렸다. **이 프로젝트는 이미 Netty 4.2.16을 쓴다.**

```
io.netty:netty-buffer:4.1.126.Final -> 4.2.16.Final
io.netty:netty-codec:4.1.126.Final  -> 4.2.16.Final
```

Netty 4.1 → 4.2는 **호환이 깨지는 메이저 변경**이다(`netty-codec`이 `netty-codec-base` 등으로 쪼개짐). BOM이 4.2로 끌어올리면 4.1 시절 컴파일된 async-http-client 2.10.4가 런타임에 깨질 수 있고, 4.1로 내리면 앱 전체가 깨진다. **어느 쪽으로도 안전하지 않다.**

2014~2019년 아티팩트 29개는 Trivy 관점에서도 부담이다 — **우리가 못 올리는** 이행 의존성이다.

**`com.interaso:webpush:1.2.0` — 아티팩트 3개.** 훨씬 깔끔하지만 순수 Java 코드베이스에 `kotlin-stdlib`가 들어온다.

**직접 구현.** 웹푸시 발송은 본질적으로 "200바이트를 암호화해서 POST"고, 필요한 원시 연산이 전부 JDK에 있다 — ECDH(P-256) · HMAC-SHA256 · AES-GCM · ECDSA. HKDF도 출력이 32바이트 이하라 HMAC 한 번이면 된다.

| | martijndwars | interaso | 직접 구현 |
|---|---|---|---|
| 새 아티팩트 | 29 | 3 | **0** |
| Netty 4.2 충돌 | **있음** | 없음 | 없음 |
| Kotlin 유입 | 없음 | 있음 | 없음 |
| 규격 검증 | 라이브러리 신뢰 | 라이브러리 신뢰 | **테스트 벡터로 직접** |

### 만든 것

| 클래스 | 하는 일 |
|---|---|
| `P256` | 브라우저가 주는 원시 키(65바이트 점 · 32바이트 스칼라) ↔ JDK 키 객체 |
| `WebPushEncryption` | RFC 8291 + RFC 8188 aes128gcm 페이로드 암호화 |
| `VapidSigner` | RFC 8292 VAPID — ES256 JWT + `Authorization` 헤더 |

구현 중 걸린 함정 둘을 주석과 테스트로 못박았다.

**① ECDSA 서명 형식.** JDK는 **DER**로 내는데 JWS는 **고정 길이 64바이트 `R‖S`**를 요구한다(RFC 7518 §3.4). DER INTEGER는 최상위 비트가 1이면 `0x00`을 붙이고 앞의 0은 생략해서, 그대로 쓰면 길이가 63~65로 흔들린다. 자바 VAPID에서 가장 흔한 401 원인이라 서명 길이를 50회 반복해 고정했다.

**② `aud`는 엔드포인트 전체가 아니라 출처(origin)만.** 전체를 넣으면 구독마다 `aud`가 달라진다.

## 확인

`./gradlew check` 통과. 새 테스트 11개.

**스스로 만든 것을 스스로 확인하면 의미가 없어서** 바깥에 기준을 뒀다 — 형식이 틀려도 양쪽이 같이 틀리기 때문이다.

- **암호화**: 입력은 **RFC 8291 §5 테스트 벡터**, 기대값은 널리 쓰이는 Node `http_ece`(npm `web-push`의 암호화 엔진)로 같은 입력에서 뽑았다. **우리 구현 · 규격 · 기존 구현 셋이 한 점에서 만나야** 통과한다 → **바이트 단위 일치**
- **서명**: JDK 검증기로 원문을 다시 세워 확인

**회귀 테스트가 실제로 틀린 구현을 잡는지도 확인했다.** `"WebPush: info"`를 `"WebPush: Info"`로 **대문자 하나만** 바꾸니 그 자리에서 실패한다.

```
WebPushEncryptionTest > RFC 8291 테스트 벡터와 바이트가 같다 FAILED
```

### 아직 확인 못 한 것

**실기기 배달.** 페이로드가 규격에 맞다는 것과 안드로이드에 알림이 뜨는 것은 다른 문제다(FCM 등록 · SW 수신). 3단계 끝의 실기기 검증에서 확인한다 — #1048과 같은 성격이다.

기록: [ELOG-026](https://github.com/wcorn/orino/wiki/ELOG-026-webpush-library-spike)
