### PR TITLE
feat : VAPID 키 SealedSecret · 구독 API · push 테이블

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/config/VapidProperties.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/config/VapidProperties.java
@@ -1,0 +1,25 @@
+package ds.project.orino.planner.travel.push.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * VAPID 설정.
+ *
+ * <p>공개키는 브라우저({@code pushManager.subscribe})에 그대로 나가므로 <b>비밀이 아니다</b>.
+ * 비밀은 개인키뿐이라 그것만 SealedSecret에 있다.
+ *
+ * <p>키가 없으면 알림 기능만 꺼지고 앱은 정상 기동한다 — 로컬에서 키 없이 나머지를 개발할 수
+ * 있어야 한다.
+ *
+ * @param publicKey  65바이트 비압축 점(base64url)
+ * @param privateKey 32바이트 스칼라(base64url)
+ * @param subject    푸시 서비스가 문제 시 연락할 곳(RFC 8292 — mailto: 또는 https)
+ */
+@ConfigurationProperties(prefix = "travel.vapid")
+public record VapidProperties(String publicKey, String privateKey, String subject) {
+
+    public boolean enabled() {
+        return publicKey != null && !publicKey.isBlank()
+                && privateKey != null && !privateKey.isBlank();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/controller/PushSubscriptionController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/controller/PushSubscriptionController.java
@@ -1,0 +1,59 @@
+package ds.project.orino.planner.travel.push.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.travel.push.config.VapidProperties;
+import ds.project.orino.planner.travel.push.dto.PushSubscriptionRequest;
+import ds.project.orino.planner.travel.push.dto.PushUnsubscribeRequest;
+import ds.project.orino.planner.travel.push.dto.VapidPublicKeyResponse;
+import ds.project.orino.planner.travel.push.service.PushSubscriptionService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 웹푸시 구독(§6). 기기가 등록·해지하고, 구독에 필요한 공개키를 받아간다. */
+@RestController
+@RequestMapping("/api/travel/push")
+public class PushSubscriptionController {
+
+    private final PushSubscriptionService subscriptionService;
+    private final VapidProperties vapidProperties;
+
+    public PushSubscriptionController(PushSubscriptionService subscriptionService,
+                                      VapidProperties vapidProperties) {
+        this.subscriptionService = subscriptionService;
+        this.vapidProperties = vapidProperties;
+    }
+
+    /**
+     * 구독에 쓸 서버 공개키. 키가 없으면 {@code null}을 준다 —
+     * FE는 그걸 보고 알림 UI를 감춘다(오류가 아니라 "아직 없음"이다).
+     */
+    @GetMapping("/public-key")
+    public ApiResponse<VapidPublicKeyResponse> publicKey() {
+        return ApiResponse.success(new VapidPublicKeyResponse(
+                vapidProperties.enabled() ? vapidProperties.publicKey() : null));
+    }
+
+    @PostMapping("/subscriptions")
+    public ApiResponse<Void> subscribe(@AuthenticationPrincipal Long memberId,
+                                       @Valid @RequestBody PushSubscriptionRequest request) {
+        subscriptionService.subscribe(memberId, request);
+        return ApiResponse.success(null);
+    }
+
+    /**
+     * 해지. 지울 대상을 {@code endpoint}로 지정한다 — 기기가 아는 것은 자기 endpoint뿐이고,
+     * 내부 id를 굳이 알려줄 이유가 없다.
+     */
+    @DeleteMapping("/subscriptions")
+    public ApiResponse<Void> unsubscribe(@AuthenticationPrincipal Long memberId,
+                                         @Valid @RequestBody PushUnsubscribeRequest request) {
+        subscriptionService.unsubscribe(memberId, request.endpoint());
+        return ApiResponse.success(null);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/dto/PushSubscriptionRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/dto/PushSubscriptionRequest.java
@@ -1,0 +1,40 @@
+package ds.project.orino.planner.travel.push.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 브라우저의 {@code PushSubscription.toJSON()}을 <b>그대로</b> 받는다.
+ *
+ * <p>모양을 바꾸지 않는 이유는 FE가 변환하지 않게 하려는 것이다 — 구독 객체를 손으로 풀어
+ * 옮기다 키 하나를 빠뜨리면, 등록은 성공하고 알림만 조용히 안 온다.
+ *
+ * @param endpoint  푸시 서비스가 준 발송 주소
+ * @param keys      구독 키. 페이로드 암호화에 쓴다
+ * @param userAgent 기기 구분용(설정 화면에서 "어느 기기"인지 보여준다). 없어도 된다
+ */
+public record PushSubscriptionRequest(
+        @NotBlank(message = "구독 주소가 필요합니다.")
+        String endpoint,
+
+        @NotNull(message = "구독 키가 필요합니다.")
+        @Valid
+        Keys keys,
+
+        String userAgent
+) {
+
+    /**
+     * @param p256dh 구독 공개키(65바이트 비압축 점, base64url)
+     * @param auth   구독 인증 비밀(16바이트, base64url)
+     */
+    public record Keys(
+            @NotBlank(message = "구독 공개키가 필요합니다.")
+            String p256dh,
+
+            @NotBlank(message = "구독 인증 비밀이 필요합니다.")
+            String auth
+    ) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/dto/PushUnsubscribeRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/dto/PushUnsubscribeRequest.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.travel.push.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 해지 요청. <b>주소만</b> 받는다.
+ *
+ * <p>기기가 구독을 지우는 시점엔 키를 이미 버렸을 수 있다. 등록과 같은 형태를 요구하면
+ * 해지할 방법이 없어진다.
+ */
+public record PushUnsubscribeRequest(
+        @NotBlank(message = "구독 주소가 필요합니다.")
+        String endpoint
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/dto/VapidPublicKeyResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/dto/VapidPublicKeyResponse.java
@@ -1,0 +1,12 @@
+package ds.project.orino.planner.travel.push.dto;
+
+/**
+ * 브라우저가 구독할 때 쓰는 서버 공개키.
+ *
+ * <p>비밀이 아니라서 그냥 내려준다. FE에 박아두지 않는 이유는 <b>한 곳에서만 관리</b>하기
+ * 위해서다 — 키를 갈면 서버 설정만 바꾸면 되고, FE 빌드를 다시 하지 않아도 된다.
+ *
+ * @param publicKey base64url. 키가 없으면 null이고 FE는 알림 UI를 감춘다
+ */
+public record VapidPublicKeyResponse(String publicKey) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/PushSubscriptionService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/PushSubscriptionService.java
@@ -1,0 +1,49 @@
+package ds.project.orino.planner.travel.push.service;
+
+import ds.project.orino.domain.planner.push.entity.PushSubscription;
+import ds.project.orino.domain.planner.push.repository.PushSubscriptionRepository;
+import ds.project.orino.planner.travel.push.dto.PushSubscriptionRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/** 구독 등록·해지. 기기 하나가 "나에게 보내도 좋다"고 등록한 주소를 관리한다. */
+@Service
+@Transactional(readOnly = true)
+public class PushSubscriptionService {
+
+    private final PushSubscriptionRepository repository;
+
+    public PushSubscriptionService(PushSubscriptionRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * 등록. 같은 기기가 다시 구독하면 <b>새 행이 아니라 갱신</b>이다.
+     *
+     * <p>브라우저는 재구독 때 키를 새로 만들어 주기도 한다. 옛 키를 그대로 두면 그 키로
+     * 암호화한 알림을 기기가 못 풀어 조용히 사라진다.
+     */
+    @Transactional
+    public void subscribe(Long memberId, PushSubscriptionRequest request) {
+        String hash = PushSubscription.hash(request.endpoint());
+        repository.findByEndpointHash(hash)
+                .ifPresentOrElse(
+                        existing -> existing.refresh(request.keys().p256dh(),
+                                request.keys().auth(), request.userAgent()),
+                        () -> repository.save(new PushSubscription(memberId, request.endpoint(),
+                                request.keys().p256dh(), request.keys().auth(),
+                                request.userAgent())));
+    }
+
+    /** 해지. 없는 구독을 지우려 해도 조용히 넘어간다 — 결과가 같다. */
+    @Transactional
+    public void unsubscribe(Long memberId, String endpoint) {
+        repository.deleteByMemberIdAndEndpointHash(memberId, PushSubscription.hash(endpoint));
+    }
+
+    public List<PushSubscription> subscriptionsOf(Long memberId) {
+        return repository.findAllByMemberId(memberId);
+    }
+}

--- a/be/orino-app-api/src/main/resources/application.yml
+++ b/be/orino-app-api/src/main/resources/application.yml
@@ -104,6 +104,13 @@ travel:
     walk-threshold-m: ${GOOGLE_ROUTES_WALK_THRESHOLD_M:1500}
     connect-timeout: ${GOOGLE_ROUTES_CONNECT_TIMEOUT:5s}
     read-timeout: ${GOOGLE_ROUTES_READ_TIMEOUT:10s}
+  vapid:
+    # 공개키는 브라우저에 그대로 나가므로 비밀이 아니다. 개인키만 SealedSecret.
+    # 둘 다 없으면 알림 기능만 꺼지고 앱은 정상 기동한다.
+    public-key: ${VAPID_PUBLIC_KEY:}
+    private-key: ${VAPID_PRIVATE_KEY:}
+    # 푸시 서비스가 문제 시 연락할 곳(RFC 8292).
+    subject: ${VAPID_SUBJECT:mailto:dsk08208@gmail.com}
 
 management:
   tracing:

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/048-create-push-subscription.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/048-create-push-subscription.yaml
@@ -1,0 +1,110 @@
+databaseChangeLog:
+  # 웹푸시 구독 (#1076, Epic #1029 · 3단계).
+  #
+  # endpoint는 푸시 서비스가 주는 URL로 수백 자에 이른다. MySQL 유니크 인덱스는 키 길이
+  # 상한이 있어 그대로 걸 수 없다 — SHA-256 해시(64자 hex)에 유니크를 건다.
+  # 같은 기기가 다시 구독하면 새 행이 아니라 그 행의 갱신이다.
+  #
+  # p256dh·auth는 브라우저가 주는 구독 키다. 이 값으로 페이로드를 종단 암호화하므로
+  # 서버가 잃어버리면 그 구독으로는 다시 보낼 수 없다(재구독만이 답).
+  #
+  # 컨벤션 — 절대시각은 DATETIME(6), 최상위 엔티티에 member_id 스코프.
+
+  - changeSet:
+      id: 048-create-push-subscription
+      author: wcorn
+      comment: 웹푸시 구독. endpoint 해시로 유니크를 건다(원본은 너무 길다).
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: push_subscription
+      changes:
+        - createTable:
+            tableName: push_subscription
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              # 푸시 서비스 엔드포인트 원본. 발송 대상 URL 그대로다.
+              - column:
+                  name: endpoint
+                  type: TEXT
+                  constraints:
+                    nullable: false
+              # endpoint의 SHA-256(hex). 유니크를 걸기 위한 것이지 비밀이 아니다.
+              - column:
+                  name: endpoint_hash
+                  type: CHAR(64)
+                  constraints:
+                    nullable: false
+              # 구독 공개키(65바이트 비압축 점, base64url). 페이로드 암호화에 쓴다.
+              - column:
+                  name: p256dh
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              # 구독 인증 비밀(16바이트, base64url).
+              - column:
+                  name: auth
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              # 기기 구분용 표시명. 없어도 된다.
+              - column:
+                  name: user_agent
+                  type: VARCHAR(500)
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 048-push-subscription-unique-endpoint
+      author: wcorn
+      comment: 같은 기기가 다시 구독하면 새 행이 아니라 갱신이어야 한다.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                indexName: uk_push_subscription_endpoint
+      changes:
+        - createIndex:
+            tableName: push_subscription
+            indexName: uk_push_subscription_endpoint
+            unique: true
+            columns:
+              - column:
+                  name: endpoint_hash
+
+  - changeSet:
+      id: 048-push-subscription-member-index
+      author: wcorn
+      comment: 발송은 "이 멤버의 구독 전부"로 조회한다.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                indexName: idx_push_subscription_member
+      changes:
+        - createIndex:
+            tableName: push_subscription
+            indexName: idx_push_subscription_member
+            columns:
+              - column:
+                  name: member_id

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -93,3 +93,5 @@ databaseChangeLog:
       file: db/changelog/changes/046-create-lifelog-tables.yaml
   - include:
       file: db/changelog/changes/047-create-travel-tables.yaml
+  - include:
+      file: db/changelog/changes/048-create-push-subscription.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/PushSubscriptionControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/PushSubscriptionControllerTest.java
@@ -1,0 +1,229 @@
+package ds.project.orino.planner.travel.push;
+
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.push.entity.PushSubscription;
+import ds.project.orino.domain.planner.push.repository.PushSubscriptionRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** 웹푸시 구독 등록·해지. */
+class PushSubscriptionControllerTest extends ApiTestSupport {
+
+    /** 실제 FCM 엔드포인트만큼 길다 — 이 길이가 유니크 인덱스를 해시로 거는 이유다. */
+    private static final String ENDPOINT =
+            "https://fcm.googleapis.com/fcm/send/dQw4w9WgXcQ:APA91bH"
+                    + "Zx7vK2mNqL8pR3sT5uV6wX9yZ0aB1cD2eF3gH4iJ5kL6mN7oP8qR9sT0uV1wX2yZ3aB4cD5eF6gH7i"
+                    + "J8kL9mN0oP1qR2sT3uV4wX5yZ6aB7cD8eF9gH0iJ1kL2mN3oP4qR5sT6uV7wX8yZ9aB0cD1eF2gH3i";
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PushSubscriptionRepository subscriptionRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private String otherAuthHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        memberRepository.save(MemberFixture.create("other", "password"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        otherAuthHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+    }
+
+    /** 브라우저의 {@code PushSubscription.toJSON()}과 같은 모양 — keys가 중첩된다. */
+    private static String body(String endpoint, String p256dh, String auth) {
+        return """
+                {"endpoint": "%s", "keys": {"p256dh": "%s", "auth": "%s"},
+                 "userAgent": "Mozilla/5.0 (Linux; Android 14)"}
+                """.formatted(endpoint, p256dh, auth);
+    }
+
+    /** 해지는 주소만 보낸다 — 기기가 키를 이미 버렸을 수 있다. */
+    private static String unsubscribeBody(String endpoint) {
+        return """
+                {"endpoint": "%s"}
+                """.formatted(endpoint);
+    }
+
+    private org.springframework.test.web.servlet.ResultActions subscribe(String header,
+                                                                        String content)
+            throws Exception {
+        return mockMvc.perform(post("/api/travel/push/subscriptions")
+                .header(HttpHeaders.AUTHORIZATION, header)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content));
+    }
+
+    @Nested
+    @DisplayName("공개키")
+    class PublicKey {
+
+        @Test
+        @DisplayName("구독에 쓸 공개키를 내려준다 — FE에 박아두지 않고 한 곳에서 관리한다")
+        void returnsPublicKey() throws Exception {
+            mockMvc.perform(get("/api/travel/push/public-key")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    // 테스트 환경엔 키가 없다. 오류가 아니라 "아직 없음"이다.
+                    .andExpect(jsonPath("$.data").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("등록")
+    class Subscribe {
+
+        @Test
+        @DisplayName("구독을 저장한다")
+        void savesSubscription() throws Exception {
+            subscribe(authHeader, body(ENDPOINT, "BExample_p256dh", "BExample_auth"))
+                    .andExpect(status().isOk());
+
+            assertThat(subscriptionRepository.findAll()).singleElement()
+                    .satisfies(saved -> {
+                        assertThat(saved.getEndpoint()).isEqualTo(ENDPOINT);
+                        assertThat(saved.getP256dh()).isEqualTo("BExample_p256dh");
+                        assertThat(saved.getEndpointHash()).hasSize(64);
+                    });
+        }
+
+        @Test
+        @DisplayName("같은 기기가 다시 구독하면 새 행이 아니라 갱신이다")
+        void refreshesInsteadOfDuplicating() throws Exception {
+            subscribe(authHeader, body(ENDPOINT, "old_p256dh", "old_auth"))
+                    .andExpect(status().isOk());
+            // 브라우저는 재구독 때 키를 새로 만들어 주기도 한다.
+            subscribe(authHeader, body(ENDPOINT, "new_p256dh", "new_auth"))
+                    .andExpect(status().isOk());
+
+            assertThat(subscriptionRepository.findAll()).singleElement()
+                    .satisfies(saved -> {
+                        // 옛 키를 두면 그 키로 암호화한 알림을 기기가 못 푼다.
+                        assertThat(saved.getP256dh()).isEqualTo("new_p256dh");
+                        assertThat(saved.getAuth()).isEqualTo("new_auth");
+                    });
+        }
+
+        @Test
+        @DisplayName("기기가 다르면 따로 저장된다 — 한 사람이 여러 기기를 쓴다")
+        void keepsSubscriptionsPerDevice() throws Exception {
+            subscribe(authHeader, body(ENDPOINT, "a", "a")).andExpect(status().isOk());
+            subscribe(authHeader, body(ENDPOINT + "-tablet", "b", "b"))
+                    .andExpect(status().isOk());
+
+            assertThat(subscriptionRepository.findAll()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("keys가 없으면 400 — 브라우저 구독 객체를 그대로 보내야 한다")
+        void rejectsMissingKeys() throws Exception {
+            subscribe(authHeader, """
+                    {"endpoint": "%s"}
+                    """.formatted(ENDPOINT))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("구독 주소가 없으면 400")
+        void rejectsBlankEndpoint() throws Exception {
+            subscribe(authHeader, body("", "a", "a")).andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("긴 User-Agent도 저장된다 — 컬럼을 넘기면 저장 자체가 실패한다")
+        void truncatesLongUserAgent() throws Exception {
+            String longAgent = "A".repeat(900);
+            mockMvc.perform(post("/api/travel/push/subscriptions")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"endpoint": "%s", "keys": {"p256dh": "a", "auth": "a"},
+                                     "userAgent": "%s"}
+                                    """.formatted(ENDPOINT, longAgent)))
+                    .andExpect(status().isOk());
+
+            assertThat(subscriptionRepository.findAll()).singleElement()
+                    .satisfies(saved -> assertThat(saved.getUserAgent()).hasSize(500));
+        }
+    }
+
+    @Nested
+    @DisplayName("해지")
+    class Unsubscribe {
+
+        @Test
+        @DisplayName("그 기기의 구독만 지운다")
+        void removesSubscription() throws Exception {
+            subscribe(authHeader, body(ENDPOINT, "a", "a")).andExpect(status().isOk());
+            subscribe(authHeader, body(ENDPOINT + "-tablet", "b", "b"))
+                    .andExpect(status().isOk());
+
+            mockMvc.perform(delete("/api/travel/push/subscriptions")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(unsubscribeBody(ENDPOINT)))
+                    .andExpect(status().isOk());
+
+            assertThat(subscriptionRepository.findAll()).singleElement()
+                    .satisfies(left -> assertThat(left.getEndpoint()).endsWith("-tablet"));
+        }
+
+        @Test
+        @DisplayName("남의 구독은 지우지 못한다")
+        void cannotRemoveOthersSubscription() throws Exception {
+            subscribe(authHeader, body(ENDPOINT, "a", "a")).andExpect(status().isOk());
+
+            mockMvc.perform(delete("/api/travel/push/subscriptions")
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(unsubscribeBody(ENDPOINT)))
+                    .andExpect(status().isOk());
+
+            assertThat(subscriptionRepository.findAll()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("없는 구독을 해지해도 조용히 넘어간다 — 결과가 같다")
+        void ignoresUnknownSubscription() throws Exception {
+            mockMvc.perform(delete("/api/travel/push/subscriptions")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(unsubscribeBody(ENDPOINT)))
+                    .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    @DisplayName("endpoint 해시")
+    class Hashing {
+
+        @Test
+        @DisplayName("같은 주소는 같은 해시, 다르면 다른 해시")
+        void isDeterministic() {
+            assertThat(PushSubscription.hash(ENDPOINT))
+                    .isEqualTo(PushSubscription.hash(ENDPOINT))
+                    .isNotEqualTo(PushSubscription.hash(ENDPOINT + "x"))
+                    .hasSize(64);
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
@@ -10,6 +10,7 @@ public class DbCleaner {
             "trip_activity",
             "trip",
             "travel_place",
+            "push_subscription",
             "holiday",
             "day_plan_block",
             "routine_check",

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/push/entity/PushSubscription.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/push/entity/PushSubscription.java
@@ -1,0 +1,149 @@
+package ds.project.orino.domain.planner.push.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.HexFormat;
+
+/**
+ * 웹푸시 구독 하나 — 기기 하나가 "나에게 보내도 좋다"고 등록한 주소.
+ *
+ * <p>{@code endpoint}는 푸시 서비스가 주는 URL로 수백 자에 이른다. MySQL 유니크 인덱스는 키
+ * 길이 상한이 있어 그대로 걸 수 없어서, SHA-256 해시에 유니크를 건다. 해시는 <b>비밀이 아니라
+ * 길이를 고정하려는 것</b>이다.
+ *
+ * <p>{@code p256dh}·{@code auth}는 브라우저가 준 구독 키다. 이 값으로 페이로드를 종단
+ * 암호화하므로 서버가 잃어버리면 그 구독으로는 다시 보낼 수 없다 — 재구독만이 답이다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "push_subscription")
+public class PushSubscription {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    /**
+     * DDL이 {@code TEXT}라 명시적으로 맞춘다. {@code @Lob}을 쓰면 Hibernate가 {@code tinytext}로
+     * 보고 validate에서 깨진다 — {@code BOOLEAN}을 {@code BIT(1)}로 맞춘 것과 같은 종류다.
+     */
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(name = "endpoint", nullable = false)
+    private String endpoint;
+
+    @Column(name = "endpoint_hash", nullable = false, length = 64)
+    private String endpointHash;
+
+    @Column(name = "p256dh", nullable = false, length = 255)
+    private String p256dh;
+
+    @Column(name = "auth", nullable = false, length = 255)
+    private String auth;
+
+    @Column(name = "user_agent", length = 500)
+    private String userAgent;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected PushSubscription() {
+    }
+
+    public PushSubscription(Long memberId, String endpoint, String p256dh,
+                            String auth, String userAgent) {
+        this.memberId = memberId;
+        this.endpoint = endpoint;
+        this.endpointHash = hash(endpoint);
+        this.p256dh = p256dh;
+        this.auth = auth;
+        this.userAgent = truncate(userAgent);
+    }
+
+    /**
+     * 같은 기기가 다시 구독했을 때. 브라우저는 키를 새로 만들어 주기도 하므로
+     * <b>덮어써야</b> 한다 — 옛 키로 암호화하면 기기가 못 푼다.
+     */
+    public void refresh(String p256dh, String auth, String userAgent) {
+        this.p256dh = p256dh;
+        this.auth = auth;
+        this.userAgent = truncate(userAgent);
+    }
+
+    /** endpoint의 SHA-256(hex). 유니크 인덱스에 쓸 고정 길이를 만든다. */
+    public static String hash(String endpoint) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(endpoint.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256을 쓸 수 없습니다.", e);
+        }
+    }
+
+    /** UA 문자열은 길이 제한이 없다 — 컬럼을 넘기면 저장 자체가 실패한다. */
+    private static String truncate(String userAgent) {
+        if (userAgent == null) {
+            return null;
+        }
+        return userAgent.length() <= 500 ? userAgent : userAgent.substring(0, 500);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public String getEndpointHash() {
+        return endpointHash;
+    }
+
+    public String getP256dh() {
+        return p256dh;
+    }
+
+    public String getAuth() {
+        return auth;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/push/repository/PushSubscriptionRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/push/repository/PushSubscriptionRepository.java
@@ -1,0 +1,19 @@
+package ds.project.orino.domain.planner.push.repository;
+
+import ds.project.orino.domain.planner.push.entity.PushSubscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PushSubscriptionRepository extends JpaRepository<PushSubscription, Long> {
+
+    /** 같은 기기의 재구독인지 확인한다. endpoint 원본이 아니라 해시로 찾는다(길이 때문). */
+    Optional<PushSubscription> findByEndpointHash(String endpointHash);
+
+    /** 발송은 "이 멤버의 구독 전부"로 조회한다. */
+    List<PushSubscription> findAllByMemberId(Long memberId);
+
+    /** 해지. 남의 구독을 지우지 않도록 멤버까지 함께 본다. */
+    void deleteByMemberIdAndEndpointHash(Long memberId, String endpointHash);
+}

--- a/infra/helm/be/templates/deployment.yaml
+++ b/infra/helm/be/templates/deployment.yaml
@@ -143,6 +143,18 @@ spec:
                   optional: true
             - name: FRONTEND_URL
               value: {{ .Values.env.FRONTEND_URL | quote }}
+            # 웹푸시 VAPID. 공개키·subject는 비밀이 아니라 values의 평문이고,
+            # 개인키만 시크릿이다. 3단계 기능이라 아직 없어도 기동돼야 한다.
+            - name: VAPID_PUBLIC_KEY
+              value: {{ .Values.env.VAPID_PUBLIC_KEY | quote }}
+            - name: VAPID_SUBJECT
+              value: {{ .Values.env.VAPID_SUBJECT | quote }}
+            - name: VAPID_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: vapid-secret
+                  key: VAPID_PRIVATE_KEY
+                  optional: true
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           lifecycle:

--- a/infra/helm/be/templates/sealedsecret-vapid.yaml
+++ b/infra/helm/be/templates/sealedsecret-vapid.yaml
@@ -1,0 +1,19 @@
+# 여행 웹푸시 VAPID 개인키 (#1076, Epic #1029 · 3단계).
+#
+# 공개키와 subject는 여기 없다 — 공개키는 브라우저(pushManager.subscribe)에 그대로 나가는
+# 값이라 비밀이 아니고, values.yaml의 평문 env로 둔다. 비밀은 개인키뿐이다.
+#
+# 개인키를 바꾸면 기존 구독이 전부 무효가 된다(기기가 다시 구독해야 알림이 온다).
+# 되도록 갈지 않는다. 원본값은 .secrets 참조(추적 제외).
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: vapid-secret
+  namespace: orino
+spec:
+  encryptedData:
+    VAPID_PRIVATE_KEY: AgBAriYuSCMYeA8DwdftNjKTGrOo53Y22dQE1UGPnUkD7TWuNaLPKlhF4jsLjPYmykomRPqvJwnfiN568cE1Gv1SVTJTsIyjJOzWZlEEQUKwz7k+gv0AfA7fcBpMWDNozcvoRQrwFexWCy9w76q51HzxR5x9lZGbDb7scUOVLtxH4nf1AuX7v9sKKOyLluelvmDVTQrD6z1vzsFtumP3osCrUcS/DIUr3vvr0btw0N2XiQATCmztij4M2RL4M1WzECgVVqX3u2ZMONCt+NQz1f6bE6hVBqIWmagmi8uwkYkfkyWZGivMV61+unVLT4bM0cRP88hHIe2g97NrmR2iMtoxX77Mc8+dDWcbu98+Qowsgf7u14lPl6v74wcqVeg+cArZkf41mryDXk1ov+Wl7WXUbGYLAo46y+jMIKTEXc8/IliFWf2kq57N9aFveXOD2MGunk+4amud0o1rSwIE7cC7DXSrh8eVRQk6NFCqs01wdCg35P9V0GN1aTju0rI3O1tgHfhXn++RyQYRVJtoJ9EQof/DIkV3WaSccCGyPO6HqxmF1jEQ9IcPMNLT/TOI+hqwBhrFVdPvkGK9YjFP5Fxsi0XiJMdfoyMrGmU0bZ6bv3kQSEry5v06Xh2IeVxiIuqQQwYIm5LWVvVFXnfr+hgxjvmWCnGa7TYMcfJVIwTyhk+NShaZHDwNkgu+3QYEsuNq73OaI5OAZdeZ5Ve9L2obuUXbYRfAmErwNCx8EAv2jVQO8xcJ1MYisVgM
+  template:
+    metadata:
+      name: vapid-secret
+      namespace: orino

--- a/infra/helm/be/values.yaml
+++ b/infra/helm/be/values.yaml
@@ -19,6 +19,11 @@ env:
   GOOGLE_REDIRECT_URI: https://api.orino.dev/api/integrations/google/oauth/callback
   # OAuth 콜백 후 리다이렉트할 FE base URL
   FRONTEND_URL: https://orino.dev
+  # 웹푸시 VAPID. 공개키는 브라우저(pushManager.subscribe)에 그대로 나가므로 비밀이 아니다.
+  # 개인키만 vapid-secret(SealedSecret)에 있다.
+  VAPID_PUBLIC_KEY: BFjJ73pwTitAU1jOyD5KW4RQg-eSGird8xwpNn1-TQiMnU-vKzI3Nntqm058ImwW5UARcykaeO6G3qIMGnngfeI
+  # 푸시 서비스가 문제 시 연락할 곳(RFC 8292). 비밀이 아니다.
+  VAPID_SUBJECT: mailto:dsk08208@gmail.com
 
 resources:
   requests:


### PR DESCRIPTION
## 이슈
closes #1076
## 작업 내용

SW가 들어왔으니(#1075) 이제 **구독을 받아 저장**한다. 그 전에 VAPID 키가 필요했다.

### VAPID 키 — 개인키만 비밀이다

`P256`(#1073)으로 키쌍을 만들어 `.secrets`에 기록하고, **키쌍이 정말 짝인지** 서명·검증으로 확인했다(공개키 65바이트 · 서명 64바이트 · 검증 통과). 어긋나면 푸시 서비스가 401을 주는데, 그때는 이미 SealedSecret까지 올라간 뒤라 되짚기 번거롭다.

- **개인키만** `vapid-secret`(SealedSecret)에 있다. `kubeseal`은 `ssh note1`에서 stdin으로 흘려보냈다 — 명령줄에 넣으면 원격 프로세스 목록에 그대로 남는다
- **공개키·subject는 `values.yaml` 평문**이다. 공개키는 브라우저에 그대로 나가므로 비밀이 아니고, subject는 연락처다
- 개인키를 바꾸면 **기존 구독이 전부 무효**가 된다(기기가 다시 구독해야 한다). 주석에 못박았다

**공개키를 FE에 박지 않고 서버가 내려준다**(`GET /push/public-key`). 키를 갈아도 서버 설정만 바꾸면 되고 FE 빌드를 다시 하지 않는다. 키가 없으면 `null`을 주고 FE는 알림 UI를 감춘다 — 오류가 아니라 "아직 없음"이다.

### 구독 저장

**`endpoint`는 수백 자라 유니크 인덱스를 그대로 걸 수 없다**(MySQL 키 길이 상한). SHA-256 해시(64자)에 건다 — 비밀이 아니라 **길이를 고정하려는 것**이다.

**같은 기기 재구독은 새 행이 아니라 갱신이다.** 브라우저는 재구독 때 키를 새로 만들어 주기도 하는데, 옛 키를 그대로 두면 그 키로 암호화한 알림을 기기가 못 풀어 조용히 사라진다.

**요청은 브라우저의 `PushSubscription.toJSON()` 모양 그대로 받는다**(`keys` 중첩). 손으로 풀어 옮기다 키 하나를 빠뜨리면 등록은 성공하고 알림만 안 온다. **해지는 주소만 받는다** — 지우는 시점엔 기기가 키를 이미 버렸을 수 있다.

## 확인

`./gradlew check` 통과. 새 테스트 12개. `helm lint` · `helm template` · `yamllint` 통과.

로컬 bootRun + 실제 키로:

```
1. 공개키 조회      200, 87자 (65바이트 base64url)
2. 구독 등록        200
3. 같은 기기 재구독  200
4. 다른 기기        200
5. 해지            200
```

DB에 남은 것은 태블릿 한 행이고 **`id=4`에서 멈췄다** — 재구독이 새 행을 만들지 않았다는 증거다(만들었다면 auto_increment가 더 올라갔다). 인덱스도 확인했다.

```
uk_push_subscription_endpoint  endpoint_hash  (unique)
idx_push_subscription_member   member_id
```

### 겪은 함정

**`@Lob`이 `tinytext`로 매핑돼 컨텍스트가 안 떴다.**

```
Schema validation: wrong column type encountered in column [endpoint]
  in table [push_subscription]; found [text], but expecting [tinytext]
```

DDL은 `TEXT`인데 Hibernate 7이 `@Lob String`을 `tinytext`로 본다. `@JdbcTypeCode(SqlTypes.LONGVARCHAR)`로 명시했다. **`BOOLEAN`을 `BIT(1)`로 맞춰야 했던 것과 같은 종류**다 — 이 프로젝트는 Liquibase + `ddl-auto: validate` 조합이라 타입이 정확히 맞아야 앱이 뜬다.

에러가 `ApplicationContext failure threshold exceeded`로 덮여 원인이 안 보였고, `--info`로 다시 돌려서야 실제 줄이 나왔다.

### 아직 안 한 것

- **발송**(스케줄러·예약)은 다음 작업이다. 이 PR은 "받을 주소를 저장"까지다
- `POST /push/test`(S-09 즉시 발송)도 발송이 붙을 때 함께 온다
