### PR TITLE
feat : 알림 예약·재계산 + 발송 스케줄러

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
@@ -12,6 +12,7 @@ import ds.project.orino.planner.travel.activity.dto.ActivityPlace;
 import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
 import ds.project.orino.planner.travel.activity.dto.ActivityWriteRequest;
 import ds.project.orino.planner.travel.activity.dto.ReorderRequest;
+import ds.project.orino.planner.travel.push.service.NotificationScheduleService;
 import ds.project.orino.planner.travel.route.dto.LegResponse;
 import ds.project.orino.planner.travel.route.service.LegService;
 import ds.project.orino.planner.travel.place.service.PlaceService;
@@ -51,17 +52,20 @@ public class ActivityService {
     private final TravelPlaceRepository placeRepository;
     private final PlaceService placeService;
     private final LegService legService;
+    private final NotificationScheduleService notificationService;
 
     public ActivityService(TripActivityRepository activityRepository,
                            TripRepository tripRepository,
                            TravelPlaceRepository placeRepository,
                            PlaceService placeService,
-                           LegService legService) {
+                           LegService legService,
+                           NotificationScheduleService notificationService) {
         this.activityRepository = activityRepository;
         this.tripRepository = tripRepository;
         this.placeRepository = placeRepository;
         this.placeService = placeService;
         this.legService = legService;
+        this.notificationService = notificationService;
     }
 
     /**
@@ -94,7 +98,11 @@ public class ActivityService {
         activity.updateNotification(request.notifyEnabledOrDefault(), request.notifyMinutes(),
                 request.departureNotifyEnabledOrDefault());
 
-        return toResponse(activityRepository.save(activity));
+        TripActivity saved = activityRepository.save(activity);
+        activityRepository.flush();
+        // 새 일정이 앞에 들어오면 뒤 일정의 출발 시각도 바뀐다 — 날짜 전체를 다시 짠다.
+        notificationService.rescheduleDate(tripId, saved.getActivityDate());
+        return toResponse(saved);
     }
 
     public ActivityResponse detail(Long memberId, Long activityId) {
@@ -112,8 +120,10 @@ public class ActivityService {
         requireDateWithinTrip(trip, request.activityDate());
         Long placeId = resolvePlaceId(memberId, request);
 
+        LocalDate movedFrom = null;
         if (!Objects.equals(activity.getActivityDate(), request.activityDate())) {
             LocalDate previousDate = activity.getActivityDate();
+            movedFrom = previousDate;
             activity.moveTo(request.activityDate(),
                     activityRepository.nextSortOrder(activity.getTripId(), request.activityDate()));
             // 떠나온 날짜에 순서 구멍이 남는다. 0..n-1로 메워 다음 드래그가 어긋나지 않게 한다.
@@ -123,7 +133,17 @@ public class ActivityService {
         activity.updatePlace(placeId);
         activity.updateNotification(request.notifyEnabledOrDefault(), request.notifyMinutes(),
                 request.departureNotifyEnabledOrDefault());
+        activityRepository.flush();
 
+        // §4.2 트리거 — 시각·날짜·순서·장소·알림 설정이 이 한 번의 수정에 다 걸려 있다.
+        if (movedFrom != null) {
+            notificationService.rescheduleDate(activity.getTripId(), movedFrom);
+        }
+        notificationService.rescheduleDate(activity.getTripId(), activity.getActivityDate());
+        // 보관함으로 갔으면 날짜가 없어 위 재계산이 아무것도 만들지 않는다. 명시적으로 접는다.
+        if (activity.getActivityDate() == null) {
+            notificationService.cancelForActivity(activity.getId());
+        }
         return toResponse(activity);
     }
 
@@ -133,9 +153,13 @@ public class ActivityService {
         LocalDate date = activity.getActivityDate();
         Long tripId = activity.getTripId();
 
+        // 알림을 먼저 접는다 — 행이 사라진 뒤엔 어떤 일정의 예약이었는지 알 수 없다.
+        notificationService.cancelForActivity(activityId);
         activityRepository.delete(activity);
         activityRepository.flush();
         reindex(tripId, date);
+        // 빠져나간 자리 때문에 남은 일정의 출발 시각이 당겨진다.
+        notificationService.rescheduleDate(tripId, date);
     }
 
     /**
@@ -165,6 +189,8 @@ public class ActivityService {
         }
         activityRepository.flush();
         touchedDates.forEach(date -> reindex(tripId, date));
+        // 순서가 바뀌면 출발 알림의 이동시간이 바뀐다(§4.2).
+        touchedDates.forEach(date -> notificationService.rescheduleDate(tripId, date));
 
         // 보관함(null)은 이동 의미가 없어 건너뛴다.
         return touchedDates.stream()

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/NotificationScheduler.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/NotificationScheduler.java
@@ -1,0 +1,46 @@
+package ds.project.orino.planner.travel.push;
+
+import ds.project.orino.planner.travel.push.service.NotificationDispatchService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 발송 폴링(§6).
+ *
+ * <p>30초마다 예약 시각이 지난 알림을 처리한다. 정각 알림이 최대 30초 늦을 수 있는데,
+ * "15분 전 알림"에서 30초는 문제가 되지 않는다 — 대신 폴링 간격을 짧게 해 부하를 올릴 이유도
+ * 없다.
+ *
+ * <p><b>replica 1 전제다.</b> 여러 인스턴스가 돌면 같은 알림을 중복 발송한다. 그때는
+ * DB 조건부 UPDATE로 락을 넣어야 한다 —
+ * <a href="https://github.com/wcorn/orino/wiki/Travel-Open-Items">결정 기록</a> 참조.
+ *
+ * <p>{@code HolidayScheduler}와 달리 기동 시 1회 실행을 넣지 않는다. 기동 직후엔 밀린 알림이
+ * 쏟아질 수 있고, 30초 뒤 첫 폴링이 어차피 같은 일을 한다.
+ */
+@Component
+public class NotificationScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(NotificationScheduler.class);
+
+    private final NotificationDispatchService dispatchService;
+
+    public NotificationScheduler(NotificationDispatchService dispatchService) {
+        this.dispatchService = dispatchService;
+    }
+
+    @Scheduled(fixedDelayString = "${travel.push.poll-interval:30s}")
+    public void dispatch() {
+        try {
+            int sent = dispatchService.dispatchDue();
+            if (sent > 0) {
+                log.info("웹푸시 발송 {}건", sent);
+            }
+        } catch (RuntimeException e) {
+            // 폴링이 예외로 죽으면 다음 주기부터 알림이 통째로 멈춘다.
+            log.warn("웹푸시 발송 폴링 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/controller/PushSubscriptionController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/controller/PushSubscriptionController.java
@@ -5,6 +5,7 @@ import ds.project.orino.planner.travel.push.config.VapidProperties;
 import ds.project.orino.planner.travel.push.dto.PushSubscriptionRequest;
 import ds.project.orino.planner.travel.push.dto.PushUnsubscribeRequest;
 import ds.project.orino.planner.travel.push.dto.VapidPublicKeyResponse;
+import ds.project.orino.planner.travel.push.service.NotificationDispatchService;
 import ds.project.orino.planner.travel.push.service.PushSubscriptionService;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,11 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class PushSubscriptionController {
 
     private final PushSubscriptionService subscriptionService;
+    private final NotificationDispatchService dispatchService;
     private final VapidProperties vapidProperties;
 
     public PushSubscriptionController(PushSubscriptionService subscriptionService,
+                                      NotificationDispatchService dispatchService,
                                       VapidProperties vapidProperties) {
         this.subscriptionService = subscriptionService;
+        this.dispatchService = dispatchService;
         this.vapidProperties = vapidProperties;
     }
 
@@ -55,5 +59,16 @@ public class PushSubscriptionController {
                                          @Valid @RequestBody PushUnsubscribeRequest request) {
         subscriptionService.unsubscribe(memberId, request.endpoint());
         return ApiResponse.success(null);
+    }
+
+    /**
+     * 즉시 발송(S-09). 실기기 검증은 이것 없이 시작할 수 없다 — 일정을 만들고 시각이
+     * 오기를 기다릴 수는 없다.
+     *
+     * @return 실제로 전달된 구독 수. 0이면 구독이 없거나 전부 실패한 것이다
+     */
+    @PostMapping("/test")
+    public ApiResponse<Integer> test(@AuthenticationPrincipal Long memberId) {
+        return ApiResponse.success(dispatchService.sendTest(memberId));
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/send/HttpWebPushSender.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/send/HttpWebPushSender.java
@@ -1,0 +1,105 @@
+package ds.project.orino.planner.travel.push.send;
+
+import ds.project.orino.domain.planner.push.entity.PushSubscription;
+import ds.project.orino.planner.travel.push.config.VapidProperties;
+import ds.project.orino.planner.travel.push.crypto.P256;
+import ds.project.orino.planner.travel.push.crypto.VapidSigner;
+import ds.project.orino.planner.travel.push.crypto.WebPushEncryption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Base64;
+
+/**
+ * 실제 발송. 페이로드를 종단 암호화(#1073)하고 VAPID로 서명해 푸시 서비스에 POST한다.
+ *
+ * <p>JDK {@link HttpClient}만 쓴다 — 라이브러리를 안 쓰기로 한 이유가 여기서도 같다.
+ * 요청 하나에 필요한 것은 헤더 몇 개와 바이트 배열이다.
+ */
+@Component
+public class HttpWebPushSender implements WebPushSender {
+
+    private static final Logger log = LoggerFactory.getLogger(HttpWebPushSender.class);
+
+    /** 레코드 크기. 한 레코드로 보내므로 페이로드보다 넉넉해야 한다. */
+    private static final int RECORD_SIZE = 4096;
+    /** 푸시 서비스가 알림을 보관할 시간(초). 지나면 버린다 — 지난 일정 알림은 의미가 없다. */
+    private static final int TTL_SECONDS = 3600;
+
+    private static final Base64.Decoder DECODER = Base64.getUrlDecoder();
+
+    private final HttpClient httpClient;
+    private final VapidProperties props;
+    private final Clock clock;
+
+    public HttpWebPushSender(VapidProperties props, Clock clock) {
+        this.props = props;
+        this.clock = clock;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    @Override
+    public Result send(PushSubscription subscription, String payloadJson) {
+        if (!props.enabled()) {
+            return Result.failed("VAPID 키가 없습니다.");
+        }
+        try {
+            byte[] body = WebPushEncryption.encrypt(
+                    DECODER.decode(subscription.getP256dh()),
+                    DECODER.decode(subscription.getAuth()),
+                    payloadJson.getBytes(StandardCharsets.UTF_8),
+                    RECORD_SIZE);
+
+            HttpResponse<String> response = httpClient.send(
+                    request(subscription.getEndpoint(), body),
+                    HttpResponse.BodyHandlers.ofString());
+
+            return interpret(response.statusCode(), response.body());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return Result.failed("발송이 중단되었습니다.");
+        } catch (Exception e) {
+            log.warn("웹푸시 발송 실패: {}", e.getMessage());
+            return Result.failed(e.getMessage());
+        }
+    }
+
+    private HttpRequest request(String endpoint, byte[] body) {
+        PrivateKey privateKey = P256.privateKey(DECODER.decode(props.privateKey()));
+        byte[] publicKey = DECODER.decode(props.publicKey());
+
+        return HttpRequest.newBuilder(URI.create(endpoint))
+                .timeout(Duration.ofSeconds(10))
+                .header("Authorization", VapidSigner.authorizationHeader(
+                        endpoint, props.subject(), publicKey, privateKey, clock.instant()))
+                // 본문은 이미 암호화·인코딩되어 있다.
+                .header("Content-Encoding", "aes128gcm")
+                .header("Content-Type", "application/octet-stream")
+                .header("TTL", String.valueOf(TTL_SECONDS))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+    }
+
+    /**
+     * 404·410은 <b>구독이 죽은 것</b>이라 지워야 한다(§6). 그 외 실패는 일시적일 수 있어
+     * 구독을 남긴다 — 잘못 지우면 사용자가 다시 구독해야 알림이 온다.
+     */
+    private static Result interpret(int status, String body) {
+        if (status >= 200 && status < 300) {
+            return Result.ok();
+        }
+        String reason = "HTTP " + status + (body == null || body.isBlank() ? "" : ": " + body);
+        return status == 404 || status == 410 ? Result.gone(reason) : Result.failed(reason);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/send/WebPushSender.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/send/WebPushSender.java
@@ -1,0 +1,34 @@
+package ds.project.orino.planner.travel.push.send;
+
+import ds.project.orino.domain.planner.push.entity.PushSubscription;
+
+/**
+ * 구독 하나에 알림을 보낸다.
+ *
+ * <p>인터페이스로 둔다 — 테스트에서 진짜 푸시 서비스를 부르면 결과를 확인할 수도 없고,
+ * 무엇보다 <b>보냈는지 여부</b>를 세어 검증할 수 없다.
+ */
+public interface WebPushSender {
+
+    Result send(PushSubscription subscription, String payloadJson);
+
+    /**
+     * @param delivered   푸시 서비스가 받아들였다(2xx)
+     * @param subscriptionGone 410·404 — 죽은 구독이라 지워야 한다
+     * @param reason      실패 사유. 성공이면 null
+     */
+    record Result(boolean delivered, boolean subscriptionGone, String reason) {
+
+        public static Result ok() {
+            return new Result(true, false, null);
+        }
+
+        public static Result gone(String reason) {
+            return new Result(false, true, reason);
+        }
+
+        public static Result failed(String reason) {
+            return new Result(false, false, reason);
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/NotificationDispatchService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/NotificationDispatchService.java
@@ -1,0 +1,164 @@
+package ds.project.orino.planner.travel.push.service;
+
+import ds.project.orino.domain.planner.push.entity.NotificationStatus;
+import ds.project.orino.domain.planner.push.entity.PushNotification;
+import ds.project.orino.domain.planner.push.entity.PushSubscription;
+import ds.project.orino.domain.planner.push.repository.PushNotificationRepository;
+import ds.project.orino.domain.planner.push.repository.PushSubscriptionRepository;
+import ds.project.orino.domain.planner.travel.entity.TripActivity;
+import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
+import ds.project.orino.planner.travel.push.send.WebPushSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 예약 시각이 지난 알림을 실제로 보낸다.
+ *
+ * <p><b>제목은 지금 읽는다.</b> 예약할 때 저장해두면 제목만 고친 일정이 옛 제목으로 알림된다 —
+ * §4.2 재계산 트리거에 "제목 변경"이 없기 때문이다.
+ */
+@Service
+public class NotificationDispatchService {
+
+    private static final Logger log = LoggerFactory.getLogger(NotificationDispatchService.class);
+
+    private final PushNotificationRepository notificationRepository;
+    private final PushSubscriptionRepository subscriptionRepository;
+    private final TripActivityRepository activityRepository;
+    private final WebPushSender sender;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    public NotificationDispatchService(PushNotificationRepository notificationRepository,
+                                       PushSubscriptionRepository subscriptionRepository,
+                                       TripActivityRepository activityRepository,
+                                       WebPushSender sender,
+                                       ObjectMapper objectMapper,
+                                       Clock clock) {
+        this.notificationRepository = notificationRepository;
+        this.subscriptionRepository = subscriptionRepository;
+        this.activityRepository = activityRepository;
+        this.sender = sender;
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+    }
+
+    /** 보낼 때가 된 것을 전부 처리한다. 하나가 실패해도 나머지는 계속 간다. */
+    @Transactional
+    public int dispatchDue() {
+        Instant now = clock.instant();
+        List<PushNotification> due = notificationRepository
+                .findAllByStatusAndScheduledAtLessThanEqualOrderByScheduledAtAsc(
+                        NotificationStatus.PENDING, now);
+
+        int sent = 0;
+        for (PushNotification notification : due) {
+            if (dispatch(notification, now)) {
+                sent++;
+            }
+        }
+        return sent;
+    }
+
+    private boolean dispatch(PushNotification notification, Instant now) {
+        Optional<String> payload = payloadOf(notification);
+        if (payload.isEmpty()) {
+            // 일정이 사라졌는데 예약이 남은 경우. 보낼 내용이 없으니 접는다.
+            notification.cancel();
+            notificationRepository.save(notification);
+            return false;
+        }
+
+        List<PushSubscription> subscriptions =
+                subscriptionRepository.findAllByMemberId(notification.getMemberId());
+        if (subscriptions.isEmpty()) {
+            notification.markFailed("구독이 없습니다.", now);
+            notificationRepository.save(notification);
+            return false;
+        }
+
+        boolean anyDelivered = false;
+        String lastReason = null;
+        for (PushSubscription subscription : subscriptions) {
+            WebPushSender.Result result = sender.send(subscription, payload.get());
+            if (result.delivered()) {
+                anyDelivered = true;
+            } else {
+                lastReason = result.reason();
+                if (result.subscriptionGone()) {
+                    // 죽은 주소에 계속 보내면 비용만 든다(§6).
+                    subscriptionRepository.delete(subscription);
+                }
+            }
+        }
+
+        if (anyDelivered) {
+            notification.markSent(now);
+        } else {
+            notification.markFailed(lastReason, now);
+        }
+        notificationRepository.save(notification);
+        return anyDelivered;
+    }
+
+    /**
+     * 발송 시점에 조립한다. 일정이 사라졌으면 빈 값이다.
+     *
+     * <p>탭했을 때 갈 곳({@code url})을 함께 싣는다 — SW가 이 값으로 창을 옮긴다.
+     */
+    private Optional<String> payloadOf(PushNotification notification) {
+        if (notification.getActivityId() == null) {
+            // 아침 요약은 다음 작업에서 붙인다.
+            return Optional.empty();
+        }
+        return activityRepository.findById(notification.getActivityId())
+                .map(activity -> json(title(notification, activity), body(activity),
+                        "/travel/activities/" + activity.getId(),
+                        "activity-" + activity.getId()));
+    }
+
+    private static String title(PushNotification notification, TripActivity activity) {
+        return switch (notification.getType()) {
+            case DEPARTURE -> "출발할 시간이에요";
+            case MORNING_SUMMARY -> "오늘 일정";
+            case ACTIVITY -> activity.getTitle();
+        };
+    }
+
+    private static String body(TripActivity activity) {
+        String time = activity.getStartTime() == null ? "" : activity.getStartTime() + " ";
+        return time + activity.getTitle();
+    }
+
+    private String json(String title, String body, String url, String tag) {
+        return objectMapper.writeValueAsString(
+                Map.of("title", title, "body", body, "url", url, "tag", tag));
+    }
+
+    /** S-09 즉시 발송. 실기기 검증은 이것 없이 시작할 수 없다. */
+    @Transactional(readOnly = true)
+    public int sendTest(Long memberId) {
+        List<PushSubscription> subscriptions = subscriptionRepository.findAllByMemberId(memberId);
+        String payload = json("알림 테스트", "이 알림이 보이면 설정이 끝난 거예요.", "/travel", "test");
+
+        int delivered = 0;
+        for (PushSubscription subscription : subscriptions) {
+            WebPushSender.Result result = sender.send(subscription, payload);
+            if (result.delivered()) {
+                delivered++;
+            } else {
+                log.warn("테스트 발송 실패: {}", result.reason());
+            }
+        }
+        return delivered;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/NotificationScheduleService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/NotificationScheduleService.java
@@ -1,0 +1,172 @@
+package ds.project.orino.planner.travel.push.service;
+
+import ds.project.orino.domain.planner.push.entity.NotificationStatus;
+import ds.project.orino.domain.planner.push.entity.NotificationType;
+import ds.project.orino.domain.planner.push.entity.PushNotification;
+import ds.project.orino.domain.planner.push.repository.PushNotificationRepository;
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import ds.project.orino.domain.planner.travel.entity.TripActivity;
+import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
+import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.route.dto.LegResponse;
+import ds.project.orino.planner.travel.route.service.LegService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 알림 예약과 재계산(§4.2).
+ *
+ * <p>트리거가 걸리면 <b>그 일정의 대기 중 알림을 전부 접고 다시 만든다.</b> 부분 수정하지 않는
+ * 이유는 무엇이 바뀌었는지에 따라 만들 알림의 <b>종류와 개수가 달라지기</b> 때문이다 —
+ * 시각을 지우면 둘 다 사라지고, 앞 일정에 장소가 생기면 출발 알림이 새로 생긴다.
+ *
+ * <p>취소는 <b>삭제가 아니라 상태 전이</b>다. 알림이 왜 그 시각에 갔는지, 혹은 왜 안 갔는지를
+ * 나중에 추적할 수 있어야 한다.
+ */
+@Service
+public class NotificationScheduleService {
+
+    private final PushNotificationRepository notificationRepository;
+    private final TripActivityRepository activityRepository;
+    private final TripRepository tripRepository;
+    private final LegService legService;
+
+    public NotificationScheduleService(PushNotificationRepository notificationRepository,
+                                       TripActivityRepository activityRepository,
+                                       TripRepository tripRepository,
+                                       LegService legService) {
+        this.notificationRepository = notificationRepository;
+        this.activityRepository = activityRepository;
+        this.tripRepository = tripRepository;
+        this.legService = legService;
+    }
+
+    /**
+     * 한 날짜의 알림을 다시 짠다.
+     *
+     * <p>일정 하나가 아니라 <b>날짜 전체</b>를 다시 계산한다. 출발 알림은 직전 일정과의 이동시간에
+     * 걸려 있어, 하나를 옮기면 그 뒤 일정의 출발 시각도 함께 바뀐다.
+     */
+    @Transactional
+    public void rescheduleDate(Long tripId, LocalDate date) {
+        if (date == null) {
+            return;
+        }
+        Trip trip = tripRepository.findById(tripId).orElse(null);
+        if (trip == null) {
+            return;
+        }
+        List<TripActivity> ordered = activityRepository
+                .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(tripId, date);
+
+        ordered.forEach(activity -> cancelPending(activity.getId()));
+        notificationRepository.saveAll(build(trip, ordered));
+    }
+
+    /** 여행 전체를 다시 짠다 — 타임존이 바뀌면 모든 날짜의 환산 결과가 달라진다. */
+    @Transactional
+    public void rescheduleTrip(Long tripId) {
+        Trip trip = tripRepository.findById(tripId).orElse(null);
+        if (trip == null) {
+            return;
+        }
+        cancelAll(notificationRepository.findAllByTripIdAndStatus(
+                tripId, NotificationStatus.PENDING));
+
+        for (int dayIndex = 0; dayIndex < trip.totalDays(); dayIndex++) {
+            LocalDate date = trip.getStartDate().plusDays(dayIndex);
+            notificationRepository.saveAll(build(trip, activityRepository
+                    .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(trip.getId(), date)));
+        }
+    }
+
+    /** 일정이 사라지거나 보관함으로 갔다 — 예약을 접는다. */
+    @Transactional
+    public void cancelForActivity(Long activityId) {
+        cancelPending(activityId);
+    }
+
+    private void cancelPending(Long activityId) {
+        cancelAll(notificationRepository.findAllByActivityIdAndStatus(
+                activityId, NotificationStatus.PENDING));
+    }
+
+    private void cancelAll(List<PushNotification> notifications) {
+        notifications.forEach(PushNotification::cancel);
+        notificationRepository.saveAll(notifications);
+    }
+
+    /** 그 날짜의 일정들에서 만들 알림을 전부 계산한다. */
+    private List<PushNotification> build(Trip trip, List<TripActivity> ordered) {
+        ZoneId zone = ZoneId.of(trip.getTimezone());
+        // 이동시간은 출발 알림에만 쓴다. 아무도 켜지 않았으면 조회할 이유가 없다 —
+        // 일정을 저장할 때마다 유료 API를 부르게 되고, 저장이 그만큼 느려진다.
+        Map<Long, LegResponse> legsByTo = ordered.stream()
+                .anyMatch(TripActivity::isDepartureNotifyEnabled)
+                ? legService.legs(ordered).stream()
+                        .collect(Collectors.toMap(LegResponse::toActivityId, Function.identity()))
+                : Map.of();
+
+        List<PushNotification> created = new ArrayList<>();
+        for (TripActivity activity : ordered) {
+            // 시각이 없으면 어느 스위치가 켜져 있든 언제 보낼지 정할 수 없다(§1.2).
+            if (activity.getActivityDate() == null || activity.getStartTime() == null) {
+                continue;
+            }
+            Instant startAt = toInstant(activity, zone);
+
+            // 두 스위치는 독립이다 — 출발 알림만 켜 두는 것도 말이 된다.
+            if (activity.isNotifiable()) {
+                created.add(PushNotification.forActivity(trip.getMemberId(), trip.getId(),
+                        activity.getId(), NotificationType.ACTIVITY,
+                        startAt.minusSeconds(60L
+                                * activity.resolveNotifyMinutes(trip.getDefaultNotifyMinutes()))));
+            }
+
+            departureAt(activity, legsByTo.get(activity.getId()), startAt)
+                    .ifPresent(at -> created.add(PushNotification.forActivity(
+                            trip.getMemberId(), trip.getId(), activity.getId(),
+                            NotificationType.DEPARTURE, at)));
+        }
+        return created;
+    }
+
+    /**
+     * 출발 알림 시각 = 시작시각 − 이동시간 − 5분.
+     *
+     * <p><b>직전 장소 있는 일정이 없으면 만들지 않는다.</b> 어디서 출발하는지 모르면 언제
+     * 나서야 하는지도 모른다 — 화면에서도 그 경우 이 설정이 비활성이다.
+     */
+    private Optional<Instant> departureAt(TripActivity activity, LegResponse leg, Instant startAt) {
+        if (!activity.isDepartureNotifyEnabled() || leg == null
+                || leg.durationMinutes() == null) {
+            // fallback(직선거리만 아는 구간)은 소요 시간을 모른다 — 지어내지 않는다.
+            return Optional.empty();
+        }
+        return Optional.of(startAt.minusSeconds(60L
+                * (leg.durationMinutes() + PushNotification.DEPARTURE_BUFFER_MINUTES)));
+    }
+
+    /**
+     * 벽시계 시각 → UTC 절대시각.
+     *
+     * <p>이 환산이 알림의 전부다. 일정은 여행 타임존의 벽시계 값으로 저장되어 있고(§4.1),
+     * 스케줄러는 UTC로 돈다. 여기서 어긋나면 알림이 몇 시간씩 밀린다.
+     */
+    private static Instant toInstant(TripActivity activity, ZoneId zone) {
+        return LocalDateTime.of(activity.getActivityDate(), activity.getStartTime())
+                .atZone(zone)
+                .toInstant();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/service/TripService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/service/TripService.java
@@ -13,6 +13,7 @@ import ds.project.orino.planner.travel.trip.dto.TravelSummaryResponse;
 import ds.project.orino.planner.travel.trip.dto.TripDetail;
 import ds.project.orino.planner.travel.trip.dto.TripListResponse;
 import ds.project.orino.planner.travel.trip.dto.TripSummary;
+import ds.project.orino.planner.travel.push.service.NotificationScheduleService;
 import ds.project.orino.planner.travel.trip.dto.TripWriteRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,13 +46,16 @@ public class TripService {
 
     private final TripRepository tripRepository;
     private final TripActivityRepository activityRepository;
+    private final NotificationScheduleService notificationService;
     private final Clock clock;
 
     public TripService(TripRepository tripRepository,
                        TripActivityRepository activityRepository,
+                       NotificationScheduleService notificationService,
                        Clock clock) {
         this.tripRepository = tripRepository;
         this.activityRepository = activityRepository;
+        this.notificationService = notificationService;
         this.clock = clock;
     }
 
@@ -110,6 +114,10 @@ public class TripService {
         if (movedCount > 0) {
             archiveActivitiesOutsidePeriod(trip);
         }
+        tripRepository.flush();
+        // §4.2 — 타임존이 바뀌면 벽시계 시각은 그대로고 알림 시각만 전부 다시 계산된다.
+        // 기본 알림 시점·기간 변경도 같은 재계산으로 흡수된다.
+        notificationService.rescheduleTrip(trip.getId());
         return detailOf(trip);
     }
 

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/049-create-push-notification.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/049-create-push-notification.yaml
@@ -1,0 +1,126 @@
+databaseChangeLog:
+  # 예약 알림 (#1078, Epic #1029 · 3단계).
+  #
+  # payload(제목·본문)를 저장하지 않는다. 발송 시점에 trip_activity를 조인해 조립한다 —
+  # §4.2 재계산 트리거에 "제목 변경"이 없어서, 저장해두면 제목만 고친 일정이 옛 제목으로
+  # 알림된다.
+  #
+  # 재계산은 삭제가 아니라 CANCELED 전이 + 신규 INSERT다. 알림이 왜 그 시각에 갔는지
+  # (혹은 안 갔는지)를 나중에 추적할 수 있어야 한다.
+  #
+  # scheduled_at은 UTC 절대시각이다. 일정 시각은 여행 타임존의 벽시계 값이라(§4.1)
+  # trip.timezone으로 환산해 넣는다 — 타임존을 바꾸면 이 값만 다시 계산된다.
+
+  - changeSet:
+      id: 049-create-push-notification
+      author: wcorn
+      comment: 예약 알림 1건. 스케줄러가 PENDING을 폴링해 발송한다.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: push_notification
+      changes:
+        - createTable:
+            tableName: push_notification
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: member_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: trip_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_notification_trip
+                    references: trip(id)
+                    deleteCascade: true
+              # 아침 요약은 특정 일정에 매달리지 않는다 → NULL.
+              - column:
+                  name: activity_id
+                  type: BIGINT
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk_notification_activity
+                    references: trip_activity(id)
+                    deleteCascade: true
+              # ACTIVITY · DEPARTURE · MORNING_SUMMARY
+              - column:
+                  name: type
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              # 아침 요약이 가리키는 날짜. 그 외에는 NULL.
+              - column:
+                  name: target_date
+                  type: DATE
+              # UTC 절대시각. 벽시계 시각을 trip.timezone으로 환산한 결과다.
+              - column:
+                  name: scheduled_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              # PENDING · SENT · FAILED · CANCELED
+              - column:
+                  name: status
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: sent_at
+                  type: DATETIME(6)
+              - column:
+                  name: fail_reason
+                  type: VARCHAR(255)
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 049-notification-due-index
+      author: wcorn
+      comment: 스케줄러 폴링(PENDING AND scheduled_at <= now). 30초마다 도는 쿼리다.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                indexName: idx_notification_due
+      changes:
+        - createIndex:
+            tableName: push_notification
+            indexName: idx_notification_due
+            columns:
+              - column:
+                  name: status
+              - column:
+                  name: scheduled_at
+
+  - changeSet:
+      id: 049-notification-activity-index
+      author: wcorn
+      comment: 재계산 시 그 일정의 PENDING을 일괄 취소한다.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                indexName: idx_notification_activity
+      changes:
+        - createIndex:
+            tableName: push_notification
+            indexName: idx_notification_activity
+            columns:
+              - column:
+                  name: activity_id
+              - column:
+                  name: status

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -95,3 +95,5 @@ databaseChangeLog:
       file: db/changelog/changes/047-create-travel-tables.yaml
   - include:
       file: db/changelog/changes/048-create-push-subscription.yaml
+  - include:
+      file: db/changelog/changes/049-create-push-notification.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
@@ -9,15 +9,13 @@ import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.StubExternalsConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
@@ -36,7 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * 장소 프록시 통합 테스트. 외부 호출만 스텁으로 갈아끼우고 캐시(Redis)·저장(MySQL)은 실물을 쓴다 —
  * 캐시가 정말 호출을 줄이는지는 실제 Redis 없이는 확인되지 않는다.
  */
-@Import(PlaceControllerTest.StubConfig.class)
+@Import(StubExternalsConfig.class)
 class PlaceControllerTest extends ApiTestSupport {
 
     /**
@@ -47,14 +45,6 @@ class PlaceControllerTest extends ApiTestSupport {
         return label + "-" + java.util.UUID.randomUUID();
     }
 
-    @TestConfiguration
-    static class StubConfig {
-        @Bean
-        @Primary
-        PlacesClient stubPlacesClient() {
-            return new StubPlacesClient();
-        }
-    }
 
     @Autowired
     private MemberRepository memberRepository;

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/NotificationDispatchTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/NotificationDispatchTest.java
@@ -1,0 +1,260 @@
+package ds.project.orino.planner.travel.push;
+
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.push.entity.NotificationStatus;
+import ds.project.orino.domain.planner.push.entity.PushSubscription;
+import ds.project.orino.domain.planner.push.repository.PushNotificationRepository;
+import ds.project.orino.domain.planner.push.repository.PushSubscriptionRepository;
+import ds.project.orino.planner.travel.push.send.WebPushSender;
+import ds.project.orino.planner.travel.push.service.NotificationDispatchService;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.StubExternalsConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 발송(§6).
+ *
+ * <p>핵심은 <b>제목을 언제 읽느냐</b>다. 예약할 때 저장해두면 제목만 고친 일정이 옛 제목으로
+ * 알림된다 — §4.2 재계산 트리거에 "제목 변경"이 없기 때문이다.
+ */
+@Import(StubExternalsConfig.class)
+class NotificationDispatchTest extends ApiTestSupport {
+
+
+    private static final String ENDPOINT = "https://fcm.googleapis.com/fcm/send/device-a";
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PushSubscriptionRepository subscriptionRepository;
+    @Autowired
+    private PushNotificationRepository notificationRepository;
+    @Autowired
+    private NotificationDispatchService dispatchService;
+    @Autowired
+    private DbCleaner dbCleaner;
+    @Autowired
+    private WebPushSender sender;
+
+    private StubWebPushSender stub;
+    private String authHeader;
+    private Long memberId;
+    private long tripId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        stub = (StubWebPushSender) sender;
+        stub.reset();
+
+        memberRepository.save(MemberFixture.create());
+        memberId = memberRepository.findAll().get(0).getId();
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        subscriptionRepository.save(
+                new PushSubscription(memberId, ENDPOINT, "p256dh", "auth", "Android"));
+
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "도쿄", "destinationName": "도쿄",
+                                 "startDate": "2020-01-01", "endDate": "2020-01-02",
+                                 "timezone": "Asia/Tokyo", "currency": "JPY"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        tripId = ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    /** 과거 날짜로 만든다 — 예약 시각이 이미 지나 있어야 바로 발송 대상이 된다. */
+    private long addPastActivity(String title) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "%s", "activityDate": "2020-01-01",
+                                 "startTime": "09:00", "notifyEnabled": true}
+                                """.formatted(title)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    @Nested
+    @DisplayName("보낼 때가 된 알림")
+    class Due {
+
+        @Test
+        @DisplayName("보내고 SENT로 남긴다")
+        void sendsAndMarks() throws Exception {
+            addPastActivity("센소지");
+
+            assertThat(dispatchService.dispatchDue()).isEqualTo(1);
+            assertThat(stub.sent).singleElement()
+                    .satisfies(s -> assertThat(s.endpoint()).isEqualTo(ENDPOINT));
+            assertThat(notificationRepository.findAll()).singleElement()
+                    .satisfies(n -> assertThat(n.getStatus()).isEqualTo(NotificationStatus.SENT));
+        }
+
+        @Test
+        @DisplayName("제목은 발송 시점에 읽는다 — 예약 때 저장하면 옛 제목이 나간다")
+        void readsTitleAtSendTime() throws Exception {
+            long activityId = addPastActivity("옛 제목");
+
+            // 제목 변경은 §4.2 재계산 트리거가 아니다 — 예약은 그대로 남는다.
+            mockMvc.perform(put("/api/travel/activities/" + activityId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "새 제목", "activityDate": "2020-01-01",
+                                     "startTime": "09:00", "notifyEnabled": true}
+                                    """))
+                    .andExpect(status().isOk());
+
+            dispatchService.dispatchDue();
+
+            assertThat(stub.sent).isNotEmpty();
+            assertThat(stub.sent.get(0).payload()).contains("새 제목").doesNotContain("옛 제목");
+        }
+
+        @Test
+        @DisplayName("탭했을 때 갈 곳을 함께 싣는다 — SW가 이 값으로 창을 옮긴다")
+        void carriesDeepLink() throws Exception {
+            long activityId = addPastActivity("센소지");
+
+            dispatchService.dispatchDue();
+
+            assertThat(stub.sent.get(0).payload())
+                    .contains("/travel/activities/" + activityId);
+        }
+
+        @Test
+        @DisplayName("아직 시각이 안 된 알림은 건드리지 않는다")
+        void ignoresFuture() throws Exception {
+            addPastActivity("지금 갈 것");
+
+            // 먼 미래 여행을 따로 만들어 예약만 잡아 둔다.
+            String future = mockMvc.perform(post("/api/travel/trips")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "먼 여행", "destinationName": "도쿄",
+                                     "startDate": "2090-01-01", "endDate": "2090-01-02",
+                                     "timezone": "Asia/Tokyo", "currency": "JPY"}
+                                    """))
+                    .andExpect(status().isOk())
+                    .andReturn().getResponse().getContentAsString();
+            long futureTripId =
+                    ((Number) com.jayway.jsonpath.JsonPath.read(future, "$.data.id")).longValue();
+            mockMvc.perform(post("/api/travel/trips/" + futureTripId + "/activities")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "나중에 갈 것", "activityDate": "2090-01-01",
+                                     "startTime": "09:00", "notifyEnabled": true}
+                                    """))
+                    .andExpect(status().isOk());
+
+            assertThat(notificationRepository.findAll()).hasSize(2);
+            // 지난 것만 나간다.
+            assertThat(dispatchService.dispatchDue()).isEqualTo(1);
+            assertThat(stub.sent).singleElement()
+                    .satisfies(sent -> assertThat(sent.payload()).contains("지금 갈 것"));
+        }
+
+        @Test
+        @DisplayName("두 번 돌려도 다시 보내지 않는다 — SENT는 폴링에서 빠진다")
+        void doesNotResend() throws Exception {
+            addPastActivity("센소지");
+
+            assertThat(dispatchService.dispatchDue()).isEqualTo(1);
+            assertThat(dispatchService.dispatchDue()).isZero();
+            assertThat(stub.sent).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패")
+    class Failure {
+
+        @Test
+        @DisplayName("410이면 구독을 지운다 — 죽은 주소에 계속 보내면 비용만 든다")
+        void removesGoneSubscription() throws Exception {
+            stub.nextResult = WebPushSender.Result.gone("HTTP 410");
+            addPastActivity("센소지");
+
+            dispatchService.dispatchDue();
+
+            assertThat(subscriptionRepository.findAll()).isEmpty();
+            assertThat(notificationRepository.findAll()).singleElement()
+                    .satisfies(n -> assertThat(n.getStatus()).isEqualTo(NotificationStatus.FAILED));
+        }
+
+        @Test
+        @DisplayName("일시적 실패는 구독을 남긴다 — 잘못 지우면 다시 구독해야 알림이 온다")
+        void keepsSubscriptionOnTransientFailure() throws Exception {
+            stub.nextResult = WebPushSender.Result.failed("HTTP 500");
+            addPastActivity("센소지");
+
+            dispatchService.dispatchDue();
+
+            assertThat(subscriptionRepository.findAll()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("구독이 없으면 FAILED로 남긴다")
+        void failsWithoutSubscription() throws Exception {
+            subscriptionRepository.deleteAll();
+            addPastActivity("센소지");
+
+            assertThat(dispatchService.dispatchDue()).isZero();
+            assertThat(notificationRepository.findAll()).singleElement()
+                    .satisfies(n -> assertThat(n.getStatus()).isEqualTo(NotificationStatus.FAILED));
+        }
+    }
+
+    @Nested
+    @DisplayName("즉시 발송 (S-09)")
+    class TestSend {
+
+        @Test
+        @DisplayName("구독한 기기로 곧바로 보낸다 — 실기기 검증의 시작점이다")
+        void sendsImmediately() throws Exception {
+            mockMvc.perform(post("/api/travel/push/test")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").value(1));
+
+            assertThat(stub.sent).singleElement()
+                    .satisfies(s -> assertThat(s.payload()).contains("알림 테스트"));
+        }
+
+        @Test
+        @DisplayName("구독이 없으면 0을 준다 — 오류가 아니라 '보낼 곳이 없음'이다")
+        void reportsZeroWithoutSubscription() throws Exception {
+            subscriptionRepository.deleteAll();
+
+            mockMvc.perform(post("/api/travel/push/test")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").value(0));
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/NotificationScheduleTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/NotificationScheduleTest.java
@@ -1,0 +1,403 @@
+package ds.project.orino.planner.travel.push;
+
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.push.entity.NotificationStatus;
+import ds.project.orino.domain.planner.push.entity.NotificationType;
+import ds.project.orino.domain.planner.push.entity.PushNotification;
+import ds.project.orino.domain.planner.push.repository.PushNotificationRepository;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.planner.travel.route.client.RoutesClient;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.StubExternalsConfig;
+import ds.project.orino.planner.travel.route.StubRoutesClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 알림 예약과 재계산(§4.2).
+ *
+ * <p>가장 틀리기 쉬운 것은 <b>벽시계 → UTC 환산</b>이다. 일정은 여행 타임존의 벽시계 값으로
+ * 저장되는데 스케줄러는 UTC로 돈다 — 여기서 어긋나면 알림이 몇 시간씩 밀린다.
+ */
+@Import(StubExternalsConfig.class)
+class NotificationScheduleTest extends ApiTestSupport {
+
+
+    private static final BigDecimal SENSOJI_LAT = new BigDecimal("35.7147651");
+    private static final BigDecimal SENSOJI_LNG = new BigDecimal("139.7966553");
+    private static final BigDecimal SKYTREE_LAT = new BigDecimal("35.7100627");
+    private static final BigDecimal SKYTREE_LNG = new BigDecimal("139.8107004");
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TravelPlaceRepository placeRepository;
+    @Autowired
+    private PushNotificationRepository notificationRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+    @Autowired
+    private RoutesClient routesClient;
+
+    private String authHeader;
+    private Long memberId;
+    private long tripId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        ((StubRoutesClient) routesClient).reset();
+
+        memberRepository.save(MemberFixture.create());
+        memberId = memberRepository.findAll().get(0).getId();
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        tripId = createTrip("Asia/Tokyo");
+    }
+
+    private long createTrip(String timezone) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "도쿄", "destinationName": "도쿄",
+                                 "startDate": "2026-10-24", "endDate": "2026-10-27",
+                                 "timezone": "%s", "currency": "JPY",
+                                 "defaultNotifyMinutes": 15}
+                                """.formatted(timezone)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    /**
+     * 구간 캐시(Redis)는 테스트 사이에 살아 있다. 좌표가 같으면 앞 테스트가 캐시해 둔
+     * 이동시간이 새어 들어와, 스텁을 비워도 값이 나온다.
+     */
+    private static BigDecimal jitter(BigDecimal base) {
+        int nudge = Math.abs(UUID.randomUUID().hashCode() % 9000) + 1000;
+        return base.add(new BigDecimal("0.0000001").multiply(BigDecimal.valueOf(nudge)));
+    }
+
+    private Long placeAt(String name, BigDecimal lat, BigDecimal lng) {
+        TravelPlace place = placeRepository.save(
+                TravelPlace.fromGoogle(memberId, "g-" + UUID.randomUUID(), name));
+        place.updateBasics(name, jitter(lat), jitter(lng), null, null);
+        return placeRepository.saveAndFlush(place).getId();
+    }
+
+    private long addActivity(String json) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private List<PushNotification> pending() {
+        return notificationRepository.findAllByMemberIdOrderByScheduledAtAsc(memberId).stream()
+                .filter(n -> n.getStatus() == NotificationStatus.PENDING)
+                .toList();
+    }
+
+    private static Instant tokyo(String localDateTime) {
+        return LocalDateTime.parse(localDateTime).atZone(ZoneId.of("Asia/Tokyo")).toInstant();
+    }
+
+    @Nested
+    @DisplayName("일정 알림")
+    class ActivityNotification {
+
+        @Test
+        @DisplayName("시작시각 15분 전으로 예약한다 — 벽시계 시각을 여행 타임존으로 환산한다")
+        void schedulesBeforeStart() throws Exception {
+            addActivity("""
+                    {"title": "센소지", "activityDate": "2026-10-24", "startTime": "09:00",
+                     "notifyEnabled": true}
+                    """);
+
+            assertThat(pending()).singleElement().satisfies(n -> {
+                assertThat(n.getType()).isEqualTo(NotificationType.ACTIVITY);
+                // 도쿄 09:00 = UTC 00:00. 15분 전이면 UTC 2026-10-23T23:45.
+                assertThat(n.getScheduledAt()).isEqualTo(tokyo("2026-10-24T08:45"));
+                assertThat(n.getScheduledAt()).isEqualTo(Instant.parse("2026-10-23T23:45:00Z"));
+            });
+        }
+
+        @Test
+        @DisplayName("일정별 알림 시점이 여행 기본값을 이긴다")
+        void activityMinutesOverrideTripDefault() throws Exception {
+            addActivity("""
+                    {"title": "센소지", "activityDate": "2026-10-24", "startTime": "09:00",
+                     "notifyEnabled": true, "notifyMinutes": 60}
+                    """);
+
+            assertThat(pending()).singleElement().satisfies(n ->
+                    assertThat(n.getScheduledAt()).isEqualTo(tokyo("2026-10-24T08:00")));
+        }
+
+        @Test
+        @DisplayName("시각이 없으면 스위치가 켜져 있어도 만들지 않는다 — 언제 보낼지 정할 수 없다")
+        void skipsWithoutStartTime() throws Exception {
+            addActivity("""
+                    {"title": "센소지", "activityDate": "2026-10-24", "notifyEnabled": true}
+                    """);
+
+            assertThat(pending()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("알림을 끈 일정은 만들지 않는다")
+        void skipsWhenDisabled() throws Exception {
+            addActivity("""
+                    {"title": "센소지", "activityDate": "2026-10-24", "startTime": "09:00"}
+                    """);
+
+            assertThat(pending()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("출발 알림")
+    class DepartureNotification {
+
+        @Test
+        @DisplayName("시작시각 − 이동시간 − 5분")
+        void schedulesBeforeDeparture() throws Exception {
+            addActivity("""
+                    {"title": "센소지", "activityDate": "2026-10-24", "startTime": "09:00",
+                     "placeId": %d}
+                    """.formatted(placeAt("센소지", SENSOJI_LAT, SENSOJI_LNG)));
+            addActivity("""
+                    {"title": "스카이트리", "activityDate": "2026-10-24", "startTime": "11:00",
+                     "placeId": %d, "departureNotifyEnabled": true}
+                    """.formatted(placeAt("스카이트리", SKYTREE_LAT, SKYTREE_LNG)));
+
+            // 스텁이 720초(12분)를 준다 → 11:00 − 12분 − 5분 = 10:43.
+            assertThat(pending()).singleElement().satisfies(n -> {
+                assertThat(n.getType()).isEqualTo(NotificationType.DEPARTURE);
+                assertThat(n.getScheduledAt()).isEqualTo(tokyo("2026-10-24T10:43"));
+            });
+        }
+
+        @Test
+        @DisplayName("직전 장소 있는 일정이 없으면 만들지 않는다 — 어디서 출발하는지 모른다")
+        void skipsWithoutPreviousPlace() throws Exception {
+            addActivity("""
+                    {"title": "스카이트리", "activityDate": "2026-10-24", "startTime": "11:00",
+                     "placeId": %d, "departureNotifyEnabled": true}
+                    """.formatted(placeAt("스카이트리", SKYTREE_LAT, SKYTREE_LNG)));
+
+            assertThat(pending()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("이동시간을 못 얻으면 만들지 않는다 — 지어내지 않는다")
+        void skipsWhenTravelTimeUnknown() throws Exception {
+            ((StubRoutesClient) routesClient).result = java.util.Optional.empty();
+
+            addActivity("""
+                    {"title": "센소지", "activityDate": "2026-10-24", "startTime": "09:00",
+                     "placeId": %d}
+                    """.formatted(placeAt("센소지", SENSOJI_LAT, SENSOJI_LNG)));
+            addActivity("""
+                    {"title": "스카이트리", "activityDate": "2026-10-24", "startTime": "11:00",
+                     "placeId": %d, "departureNotifyEnabled": true}
+                    """.formatted(placeAt("스카이트리", SKYTREE_LAT, SKYTREE_LNG)));
+
+            assertThat(pending()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("재계산 (§4.2)")
+    class Recalculation {
+
+        @Test
+        @DisplayName("시각을 바꾸면 옛 예약은 취소되고 새로 잡힌다")
+        void reschedulesOnTimeChange() throws Exception {
+            long activityId = addActivity("""
+                    {"title": "센소지", "activityDate": "2026-10-24", "startTime": "09:00",
+                     "notifyEnabled": true}
+                    """);
+
+            mockMvc.perform(put("/api/travel/activities/" + activityId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "센소지", "activityDate": "2026-10-24",
+                                     "startTime": "14:00", "notifyEnabled": true}
+                                    """))
+                    .andExpect(status().isOk());
+
+            assertThat(pending()).singleElement().satisfies(n ->
+                    assertThat(n.getScheduledAt()).isEqualTo(tokyo("2026-10-24T13:45")));
+            // 지우지 않고 남긴다 — 왜 그 시각에 갔는지(혹은 안 갔는지) 추적할 수 있어야 한다.
+            assertThat(notificationRepository.findAll())
+                    .anySatisfy(n -> assertThat(n.getStatus())
+                            .isEqualTo(NotificationStatus.CANCELED));
+        }
+
+        @Test
+        @DisplayName("타임존을 바꾸면 벽시계 시각은 그대로고 알림 시각만 바뀐다")
+        void reschedulesOnTimezoneChange() throws Exception {
+            addActivity("""
+                    {"title": "센소지", "activityDate": "2026-10-24", "startTime": "09:00",
+                     "notifyEnabled": true}
+                    """);
+            assertThat(pending()).singleElement().satisfies(n ->
+                    assertThat(n.getScheduledAt()).isEqualTo(Instant.parse("2026-10-23T23:45:00Z")));
+
+            mockMvc.perform(put("/api/travel/trips/" + tripId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "도쿄", "destinationName": "방콕",
+                                     "startDate": "2026-10-24", "endDate": "2026-10-27",
+                                     "timezone": "Asia/Bangkok", "currency": "THB"}
+                                    """))
+                    .andExpect(status().isOk());
+
+            // 09:00은 어디서든 09:00이지만, 방콕(UTC+7) 09:00은 도쿄(UTC+9) 09:00보다 2시간 늦다.
+            // (서울로 바꾸면 아무것도 안 바뀐다 — 도쿄와 같은 UTC+9다.)
+            assertThat(pending()).singleElement().satisfies(n ->
+                    assertThat(n.getScheduledAt()).isEqualTo(Instant.parse("2026-10-24T01:45:00Z")));
+        }
+
+        @Test
+        @DisplayName("일정을 지우면 예약도 접힌다")
+        void cancelsOnDelete() throws Exception {
+            long activityId = addActivity("""
+                    {"title": "센소지", "activityDate": "2026-10-24", "startTime": "09:00",
+                     "notifyEnabled": true}
+                    """);
+            assertThat(pending()).hasSize(1);
+
+            mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                            .delete("/api/travel/activities/" + activityId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk());
+
+            assertThat(pending()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("보관함으로 옮기면 예약이 접힌다 — 날짜가 없으면 보낼 시각도 없다")
+        void cancelsOnArchive() throws Exception {
+            long activityId = addActivity("""
+                    {"title": "센소지", "activityDate": "2026-10-24", "startTime": "09:00",
+                     "notifyEnabled": true}
+                    """);
+
+            mockMvc.perform(put("/api/travel/activities/" + activityId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "센소지", "activityDate": null,
+                                     "startTime": "09:00", "notifyEnabled": true}
+                                    """))
+                    .andExpect(status().isOk());
+
+            assertThat(pending()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("알림을 끄면 예약이 사라진다")
+        void cancelsWhenDisabled() throws Exception {
+            long activityId = addActivity("""
+                    {"title": "센소지", "activityDate": "2026-10-24", "startTime": "09:00",
+                     "notifyEnabled": true}
+                    """);
+
+            mockMvc.perform(put("/api/travel/activities/" + activityId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "센소지", "activityDate": "2026-10-24",
+                                     "startTime": "09:00", "notifyEnabled": false}
+                                    """))
+                    .andExpect(status().isOk());
+
+            assertThat(pending()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("순서를 바꾸면 출발 알림이 다시 잡힌다 — 이동시간이 달라진다")
+        void reschedulesOnReorder() throws Exception {
+            long first = addActivity("""
+                    {"title": "센소지", "activityDate": "2026-10-24", "startTime": "09:00",
+                     "placeId": %d, "departureNotifyEnabled": true}
+                    """.formatted(placeAt("센소지", SENSOJI_LAT, SENSOJI_LNG)));
+            long second = addActivity("""
+                    {"title": "스카이트리", "activityDate": "2026-10-24", "startTime": "11:00",
+                     "placeId": %d, "departureNotifyEnabled": true}
+                    """.formatted(placeAt("스카이트리", SKYTREE_LAT, SKYTREE_LNG)));
+
+            // 처음엔 두 번째 일정에만 출발 알림이 붙는다(첫 일정은 앞이 없다).
+            assertThat(pending()).singleElement().satisfies(n ->
+                    assertThat(n.getActivityId()).isEqualTo(second));
+
+            mockMvc.perform(put("/api/travel/trips/" + tripId + "/activities/order")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"moves": [{"date": "2026-10-24",
+                                                "activityIds": [%d, %d]}]}
+                                    """.formatted(second, first)))
+                    .andExpect(status().isOk());
+
+            // 뒤집혔으니 이제 첫 일정 쪽에 붙는다.
+            assertThat(pending()).singleElement().satisfies(n ->
+                    assertThat(n.getActivityId()).isEqualTo(first));
+        }
+    }
+
+    @Nested
+    @DisplayName("날짜 전체 재계산")
+    class WholeDay {
+
+        @Test
+        @DisplayName("앞에 일정이 끼면 뒤 일정의 출발 시각도 다시 잡는다")
+        void recalculatesFollowingActivities() throws Exception {
+            addActivity("""
+                    {"title": "센소지", "activityDate": "2026-10-24", "startTime": "09:00",
+                     "placeId": %d}
+                    """.formatted(placeAt("센소지", SENSOJI_LAT, SENSOJI_LNG)));
+            addActivity("""
+                    {"title": "스카이트리", "activityDate": "2026-10-24", "startTime": "11:00",
+                     "placeId": %d, "departureNotifyEnabled": true}
+                    """.formatted(placeAt("스카이트리", SKYTREE_LAT, SKYTREE_LNG)));
+
+            long before = pending().size();
+            // 장소 없는 일정을 사이에 넣어도 구간은 그대로라 개수가 유지돼야 한다.
+            addActivity("""
+                    {"title": "점심", "activityDate": "2026-10-24", "startTime": "10:00"}
+                    """);
+
+            assertThat(pending()).hasSize((int) before);
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/StubWebPushSender.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/StubWebPushSender.java
@@ -1,0 +1,36 @@
+package ds.project.orino.planner.travel.push;
+
+import ds.project.orino.domain.planner.push.entity.PushSubscription;
+import ds.project.orino.planner.travel.push.send.WebPushSender;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 테스트용 발송 스텁.
+ *
+ * <p>진짜 푸시 서비스를 부르면 결과를 확인할 수도 없고, 무엇보다 <b>무엇을 보냈는지</b>를
+ * 들여다볼 수 없다. 페이로드를 그대로 모아 둔다 — 제목을 발송 시점에 조립하는지가
+ * 이 기능의 핵심이라 그걸 봐야 한다.
+ */
+public class StubWebPushSender implements WebPushSender {
+
+    public record Sent(String endpoint, String payload) {
+    }
+
+    public final List<Sent> sent = new ArrayList<>();
+
+    /** 다음 발송의 결과. 실패·죽은 구독 경로를 태울 때 바꾼다. */
+    public Result nextResult = Result.ok();
+
+    @Override
+    public Result send(PushSubscription subscription, String payloadJson) {
+        sent.add(new Sent(subscription.getEndpoint(), payloadJson));
+        return nextResult;
+    }
+
+    public void reset() {
+        sent.clear();
+        nextResult = Result.ok();
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/LegIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/LegIntegrationTest.java
@@ -9,15 +9,13 @@ import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.StubExternalsConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
@@ -37,17 +35,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * 보드의 이동시간(§4.4). 외부 호출만 스텁으로 갈아끼우고 캐시(Redis)·저장(MySQL)은 실물이다 —
  * 캐시가 정말 호출을 줄이는지는 실제 Redis 없이 확인되지 않는다.
  */
-@Import(LegIntegrationTest.StubConfig.class)
+@Import(StubExternalsConfig.class)
 class LegIntegrationTest extends ApiTestSupport {
 
-    @TestConfiguration
-    static class StubConfig {
-        @Bean
-        @Primary
-        RoutesClient stubRoutesClient() {
-            return new StubRoutesClient();
-        }
-    }
 
     /** 센소지. */
     private static final BigDecimal SENSOJI_LAT = new BigDecimal("35.7147651");

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 public class DbCleaner {
 
     private static final String[] TABLES_IN_FK_ORDER = {
+            "push_notification",
             "trip_activity",
             "trip",
             "travel_place",

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/StubExternalsConfig.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/StubExternalsConfig.java
@@ -1,0 +1,42 @@
+package ds.project.orino.support;
+
+import ds.project.orino.planner.travel.place.StubPlacesClient;
+import ds.project.orino.planner.travel.place.client.PlacesClient;
+import ds.project.orino.planner.travel.push.StubWebPushSender;
+import ds.project.orino.planner.travel.push.send.WebPushSender;
+import ds.project.orino.planner.travel.route.StubRoutesClient;
+import ds.project.orino.planner.travel.route.client.RoutesClient;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * 외부 호출을 전부 스텁으로 갈아끼운 설정.
+ *
+ * <p><b>테스트마다 다른 스텁 조합을 쓰지 않는다.</b> Spring은 설정이 조금이라도 다르면 컨텍스트를
+ * 새로 띄우고 캐시에 쌓아 둔다 — 조합이 늘수록 컨텍스트가 늘고, 각각이 EntityManagerFactory와
+ * 커넥션 풀을 물고 있어 결국 {@code OutOfMemoryError}로 무너진다(실제로 겪었다).
+ *
+ * <p>필요한 스텁만 골라 쓰고 나머지는 그대로 두면 된다. 안 쓰는 스텁은 아무 일도 하지 않는다.
+ */
+@TestConfiguration
+public class StubExternalsConfig {
+
+    @Bean
+    @Primary
+    public PlacesClient stubPlacesClient() {
+        return new StubPlacesClient();
+    }
+
+    @Bean
+    @Primary
+    public RoutesClient stubRoutesClient() {
+        return new StubRoutesClient();
+    }
+
+    @Bean
+    @Primary
+    public WebPushSender stubWebPushSender() {
+        return new StubWebPushSender();
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/push/entity/NotificationStatus.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/push/entity/NotificationStatus.java
@@ -1,0 +1,14 @@
+package ds.project.orino.domain.planner.push.entity;
+
+/**
+ * 알림 상태.
+ *
+ * <p>{@code CANCELED}가 있는 이유 — 재계산 때 지우지 않고 전이시킨다. 알림이 왜 그 시각에
+ * 갔는지, 혹은 왜 안 갔는지를 나중에 추적할 수 있어야 한다.
+ */
+public enum NotificationStatus {
+    PENDING,
+    SENT,
+    FAILED,
+    CANCELED
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/push/entity/NotificationType.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/push/entity/NotificationType.java
@@ -1,0 +1,11 @@
+package ds.project.orino.domain.planner.push.entity;
+
+/** 알림 종류(§4.2 · §4.3). */
+public enum NotificationType {
+    /** 일정 시작 전. 시작시각 − notifyMinutes. */
+    ACTIVITY,
+    /** 출발 시각. 시작시각 − 이동시간 − 5분. 직전 장소 있는 일정이 필요하다. */
+    DEPARTURE,
+    /** 여행 기간 중 매일 현지 08:00. 그날 일정이 0건이면 보내지 않는다. */
+    MORNING_SUMMARY
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/push/entity/PushNotification.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/push/entity/PushNotification.java
@@ -1,0 +1,160 @@
+package ds.project.orino.domain.planner.push.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * 예약된 알림 1건.
+ *
+ * <p><b>제목·본문을 저장하지 않는다.</b> 발송 시점에 일정을 다시 읽어 조립한다 — §4.2 재계산
+ * 트리거에 "제목 변경"이 없어서, 저장해두면 제목만 고친 일정이 옛 제목으로 알림된다.
+ *
+ * <p>{@code scheduledAt}은 <b>UTC 절대시각</b>이다. 일정 시각은 여행 타임존의 벽시계 값이라
+ * {@code trip.timezone}으로 환산해 넣는다. 타임존을 바꾸면 일정 시각은 그대로고 이 값만
+ * 다시 계산된다(§4.1).
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "push_notification")
+public class PushNotification {
+
+    /** 출발 알림의 여유. 이동시간에 더해 이만큼 앞서 알린다(§4.2). */
+    public static final int DEPARTURE_BUFFER_MINUTES = 5;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "trip_id", nullable = false)
+    private Long tripId;
+
+    /** 아침 요약은 특정 일정에 매달리지 않는다 → null. */
+    @Column(name = "activity_id")
+    private Long activityId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private NotificationType type;
+
+    /** 아침 요약이 가리키는 날짜. 그 외에는 null. */
+    @Column(name = "target_date")
+    private LocalDate targetDate;
+
+    @Column(name = "scheduled_at", nullable = false)
+    private Instant scheduledAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private NotificationStatus status = NotificationStatus.PENDING;
+
+    @Column(name = "sent_at")
+    private Instant sentAt;
+
+    @Column(name = "fail_reason", length = 255)
+    private String failReason;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    protected PushNotification() {
+    }
+
+    private PushNotification(Long memberId, Long tripId, Long activityId, NotificationType type,
+                             LocalDate targetDate, Instant scheduledAt) {
+        this.memberId = memberId;
+        this.tripId = tripId;
+        this.activityId = activityId;
+        this.type = type;
+        this.targetDate = targetDate;
+        this.scheduledAt = scheduledAt;
+    }
+
+    public static PushNotification forActivity(Long memberId, Long tripId, Long activityId,
+                                               NotificationType type, Instant scheduledAt) {
+        return new PushNotification(memberId, tripId, activityId, type, null, scheduledAt);
+    }
+
+    public static PushNotification morningSummary(Long memberId, Long tripId,
+                                                  LocalDate targetDate, Instant scheduledAt) {
+        return new PushNotification(memberId, tripId, null,
+                NotificationType.MORNING_SUMMARY, targetDate, scheduledAt);
+    }
+
+    /** 재계산·삭제로 더는 유효하지 않다. 지우지 않는 이유는 추적 가능성이다. */
+    public void cancel() {
+        this.status = NotificationStatus.CANCELED;
+    }
+
+    public void markSent(Instant sentAt) {
+        this.status = NotificationStatus.SENT;
+        this.sentAt = sentAt;
+    }
+
+    /** 이유는 컬럼 길이를 넘길 수 있다 — 넘기면 저장 자체가 실패한다. */
+    public void markFailed(String reason, Instant attemptedAt) {
+        this.status = NotificationStatus.FAILED;
+        this.sentAt = attemptedAt;
+        this.failReason = reason == null || reason.length() <= 255
+                ? reason : reason.substring(0, 255);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Long getTripId() {
+        return tripId;
+    }
+
+    public Long getActivityId() {
+        return activityId;
+    }
+
+    public NotificationType getType() {
+        return type;
+    }
+
+    public LocalDate getTargetDate() {
+        return targetDate;
+    }
+
+    public Instant getScheduledAt() {
+        return scheduledAt;
+    }
+
+    public NotificationStatus getStatus() {
+        return status;
+    }
+
+    public Instant getSentAt() {
+        return sentAt;
+    }
+
+    public String getFailReason() {
+        return failReason;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/push/repository/PushNotificationRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/push/repository/PushNotificationRepository.java
@@ -1,0 +1,23 @@
+package ds.project.orino.domain.planner.push.repository;
+
+import ds.project.orino.domain.planner.push.entity.NotificationStatus;
+import ds.project.orino.domain.planner.push.entity.PushNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface PushNotificationRepository extends JpaRepository<PushNotification, Long> {
+
+    /** 스케줄러 폴링. 30초마다 도는 쿼리라 {@code idx_notification_due}가 받쳐 준다. */
+    List<PushNotification> findAllByStatusAndScheduledAtLessThanEqualOrderByScheduledAtAsc(
+            NotificationStatus status, Instant now);
+
+    /** 재계산 시 그 일정의 대기 중 알림을 전부 접는다. */
+    List<PushNotification> findAllByActivityIdAndStatus(Long activityId, NotificationStatus status);
+
+    /** 여행 단위 재계산(타임존 변경 등). */
+    List<PushNotification> findAllByTripIdAndStatus(Long tripId, NotificationStatus status);
+
+    List<PushNotification> findAllByMemberIdOrderByScheduledAtAsc(Long memberId);
+}


### PR DESCRIPTION
## 이슈
closes #1078
## 작업 내용

암호화(#1073) · SW(#1075) · 구독(#1077)이 끝났다. 이제 **실제로 예약하고 보낸다.**

### 예약 — 접고 다시 만든다

§4.2 트리거가 걸리면 그 일정의 대기 알림을 **전부 접고 다시 만든다.** 부분 수정하지 않는 이유는 무엇이 바뀌었느냐에 따라 만들 알림의 **종류와 개수가 달라지기** 때문이다 — 시각을 지우면 둘 다 사라지고, 앞 일정에 장소가 생기면 출발 알림이 새로 생긴다.

**취소는 삭제가 아니라 상태 전이다.** 알림이 왜 그 시각에 갔는지, 혹은 왜 안 갔는지를 나중에 추적할 수 있어야 한다.

**일정 하나가 아니라 날짜 전체를 다시 계산한다.** 출발 알림은 직전 일정과의 이동시간에 걸려 있어, 하나를 옮기면 뒤 일정의 출발 시각도 함께 바뀐다.

트리거를 건 곳: 일정 생성·수정·삭제·순서 변경, 여행 수정(타임존·기본 알림 시점·기간).

### 두 스위치는 독립이다

처음엔 `notifyEnabled`가 꺼져 있으면 그 일정을 통째로 건너뛰게 짰는데, 그러면 **출발 알림만 켜 둔 경우가 사라진다.** 시각이 있는지만 공통으로 보고, 각 알림은 자기 스위치를 본다.

### 이동시간은 필요할 때만 조회한다

출발 알림에만 쓰는 값이라, 그 날짜에 아무도 안 켰으면 조회하지 않는다. 안 그러면 **일정을 저장할 때마다 유료 API를 부르고** 저장이 그만큼 느려진다.

### 발송 — 제목을 지금 읽는다

`payload`를 저장하지 않고 발송 시점에 조립한다. §4.2 트리거에 "제목 변경"이 없어서, 저장해두면 **제목만 고친 일정이 옛 제목으로 알림된다.**

- `@Scheduled(fixedDelay = 30s)`. 정각 알림이 최대 30초 늦을 수 있지만 "15분 전 알림"에서 30초는 문제가 아니고, 더 짧게 돌릴 이유도 없다
- **410·404면 구독을 지운다.** 그 외 실패는 남긴다 — 잘못 지우면 사용자가 다시 구독해야 알림이 온다
- 폴링이 예외로 죽으면 다음 주기부터 알림이 통째로 멈춘다. 삼키고 로그만 남긴다
- **replica 1 전제다.** 다중 replica가 되면 중복 발송하므로 그때 DB 조건부 UPDATE로 락을 넣는다

발송은 JDK `HttpClient`만 쓴다 — 라이브러리를 안 쓰기로 한 이유가 여기서도 같다(#1073).

`POST /api/travel/push/test`도 함께 넣었다. **실기기 검증은 이것 없이 시작할 수 없다.**

## 확인

`./gradlew check` 통과. 새 테스트 24개.

가장 조심한 것은 **벽시계 → UTC 환산**이다. 일정은 여행 타임존의 벽시계 값으로 저장되는데 스케줄러는 UTC로 돈다 — 어긋나면 알림이 몇 시간씩 밀린다.

```
도쿄 09:00 시작 · 15분 전  → 2026-10-23T23:45:00Z
타임존을 방콕(UTC+7)으로   → 2026-10-24T01:45:00Z  (벽시계 09:00은 그대로)
```

> 처음엔 이 테스트를 도쿄 → **서울**로 썼다가 값이 안 바뀌어 한참 봤다. **둘 다 UTC+9라 바뀔 게 없었다** — 구현이 아니라 테스트가 틀렸다. 오프셋이 실제로 다른 방콕으로 바꿨다.

### 겪은 함정 — 컨텍스트 폭증

새 테스트 두 개가 각자 `@TestConfiguration`을 들고 오면서 **Spring 컨텍스트가 늘었고**, 전체 실행에서 `OutOfMemoryError`가 났다. 그 여파로 커넥션이 마르면서 **무관한 `LegIntegrationTest`가 무더기로 빨개졌다.**

```
Caused by: java.lang.OutOfMemoryError
Caused by: java.sql.SQLTransientConnectionException at HikariPool.java:714
```

에러가 `ApplicationContext failure threshold exceeded`로 덮여 원인이 안 보였고, **단독 실행하면 통과해서** 더 헷갈렸다(컨텍스트가 누적되지 않는다).

외부 호출 스텁을 `StubExternalsConfig` 하나로 합쳐 네 테스트가 **한 컨텍스트를 공유**하게 했다. 조합을 달리하면 그만큼 컨텍스트가 는다.

`./gradlew check --rerun-tasks`로 재현·확인했다 — Gradle이 `UP-TO-DATE`로 건너뛰면 실패를 못 본다.

### 이번에 넣지 않은 것

**아침 요약(`MORNING_SUMMARY`)은 다음 작업이다.** 예약 시점(여행 생성·기간 변경)과 조건(그날 일정 0건이면 스킵)이 달라 섞으면 둘 다 흐려진다. 타입과 컬럼은 미리 뒀다.
