### PR TITLE
feat : 아침 요약 알림 (현지 08:00)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/NotificationDispatchService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/NotificationDispatchService.java
@@ -1,6 +1,7 @@
 package ds.project.orino.planner.travel.push.service;
 
 import ds.project.orino.domain.planner.push.entity.NotificationStatus;
+import ds.project.orino.domain.planner.push.entity.NotificationType;
 import ds.project.orino.domain.planner.push.entity.PushNotification;
 import ds.project.orino.domain.planner.push.entity.PushSubscription;
 import ds.project.orino.domain.planner.push.repository.PushNotificationRepository;
@@ -116,14 +117,44 @@ public class NotificationDispatchService {
      * <p>탭했을 때 갈 곳({@code url})을 함께 싣는다 — SW가 이 값으로 창을 옮긴다.
      */
     private Optional<String> payloadOf(PushNotification notification) {
-        if (notification.getActivityId() == null) {
-            // 아침 요약은 다음 작업에서 붙인다.
-            return Optional.empty();
+        if (notification.getType() == NotificationType.MORNING_SUMMARY) {
+            return morningSummaryPayload(notification);
         }
         return activityRepository.findById(notification.getActivityId())
                 .map(activity -> json(title(notification, activity), body(activity),
                         "/travel/activities/" + activity.getId(),
                         "activity-" + activity.getId()));
+    }
+
+    /**
+     * 아침 요약(§4.3). <b>보내기 직전에 그날 일정을 다시 센다</b> — 예약 때만 판정하면
+     * 나중에 채운 날은 요약이 영영 안 오고, 다 지운 날엔 "일정 0개"가 간다.
+     *
+     * <p>0건이면 빈 값이라 호출부가 예약을 접는다.
+     */
+    private Optional<String> morningSummaryPayload(PushNotification notification) {
+        List<TripActivity> ordered = activityRepository
+                .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(
+                        notification.getTripId(), notification.getTargetDate());
+        if (ordered.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(json("오늘 일정", summaryBody(ordered),
+                boardPath(notification), "morning-" + notification.getTargetDate()));
+    }
+
+    /** {@code 오늘 일정 4개 · 첫 일정 09:00 숙소 체크아웃} — 시각이 없으면 제목만 붙인다. */
+    private static String summaryBody(List<TripActivity> ordered) {
+        TripActivity first = ordered.get(0);
+        String when = first.getStartTime() == null ? "" : first.getStartTime() + " ";
+        return "오늘 일정 %d개 · 첫 일정 %s%s"
+                .formatted(ordered.size(), when, first.getTitle());
+    }
+
+    /** 특정 일정이 아니라 <b>그날 보드</b>로 보낸다 — 요약이 가리키는 것은 하루 전체다. */
+    private static String boardPath(PushNotification notification) {
+        return "/travel/trips/%d/board?date=%s"
+                .formatted(notification.getTripId(), notification.getTargetDate());
     }
 
     private static String title(PushNotification notification, TripActivity activity) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/NotificationScheduleService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/NotificationScheduleService.java
@@ -37,6 +37,9 @@ import java.util.stream.Collectors;
 @Service
 public class NotificationScheduleService {
 
+    /** 아침 요약을 보내는 현지 시각(§4.3). */
+    private static final int MORNING_SUMMARY_HOUR = 8;
+
     private final PushNotificationRepository notificationRepository;
     private final TripActivityRepository activityRepository;
     private final TripRepository tripRepository;
@@ -84,11 +87,27 @@ public class NotificationScheduleService {
         cancelAll(notificationRepository.findAllByTripIdAndStatus(
                 tripId, NotificationStatus.PENDING));
 
+        ZoneId zone = ZoneId.of(trip.getTimezone());
         for (int dayIndex = 0; dayIndex < trip.totalDays(); dayIndex++) {
             LocalDate date = trip.getStartDate().plusDays(dayIndex);
             notificationRepository.saveAll(build(trip, activityRepository
                     .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(trip.getId(), date)));
+
+            if (trip.isMorningSummaryEnabled()) {
+                notificationRepository.save(PushNotification.morningSummary(
+                        trip.getMemberId(), trip.getId(), date, morningAt(date, zone)));
+            }
         }
+    }
+
+    /**
+     * 아침 요약 시각 — 그 날짜의 <b>현지</b> 08:00(§4.3).
+     *
+     * <p>그날 일정이 0건이어도 지금은 만든다. 판정은 <b>보내기 직전</b>에 한다 — 예약 때만 보면
+     * 나중에 일정을 채운 날은 영영 요약이 안 오고, 다 지운 날엔 "일정 0개"가 간다.
+     */
+    private static Instant morningAt(LocalDate date, ZoneId zone) {
+        return date.atTime(MORNING_SUMMARY_HOUR, 0).atZone(zone).toInstant();
     }
 
     /** 일정이 사라지거나 보관함으로 갔다 — 예약을 접는다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/service/TripService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/service/TripService.java
@@ -66,7 +66,11 @@ public class TripService {
                 request.startDate(), request.endDate(), request.timezone(),
                 normalizedCurrency(request.currency()));
         applyOptionalSettings(trip, request);
-        return detailOf(tripRepository.save(trip));
+        Trip saved = tripRepository.save(trip);
+        tripRepository.flush();
+        // 아침 요약은 일정이 아니라 날짜에 매달려 있어, 일정이 하나도 없어도 지금 잡힌다(§4.3).
+        notificationService.rescheduleTrip(saved.getId());
+        return detailOf(saved);
     }
 
     public TripListResponse list(Long memberId, TripStatus status) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/MorningSummaryTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/MorningSummaryTest.java
@@ -1,0 +1,254 @@
+package ds.project.orino.planner.travel.push;
+
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.push.entity.NotificationStatus;
+import ds.project.orino.domain.planner.push.entity.NotificationType;
+import ds.project.orino.domain.planner.push.entity.PushNotification;
+import ds.project.orino.domain.planner.push.entity.PushSubscription;
+import ds.project.orino.domain.planner.push.repository.PushNotificationRepository;
+import ds.project.orino.domain.planner.push.repository.PushSubscriptionRepository;
+import ds.project.orino.planner.travel.push.send.WebPushSender;
+import ds.project.orino.planner.travel.push.service.NotificationDispatchService;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.StubExternalsConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 아침 요약(§4.3).
+ *
+ * <p>앞의 둘과 다른 점은 <b>일정이 아니라 날짜에 매달려</b> 있다는 것이다. 그래서 0건 판정을
+ * 예약 때가 아니라 <b>보내기 직전</b>에 한다 — 나중에 채운 날은 요약이 와야 하고, 다 지운
+ * 날엔 "일정 0개"가 가면 안 된다.
+ */
+@Import(StubExternalsConfig.class)
+class MorningSummaryTest extends ApiTestSupport {
+
+    private static final String ENDPOINT = "https://fcm.googleapis.com/fcm/send/morning-device";
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PushSubscriptionRepository subscriptionRepository;
+    @Autowired
+    private PushNotificationRepository notificationRepository;
+    @Autowired
+    private NotificationDispatchService dispatchService;
+    @Autowired
+    private DbCleaner dbCleaner;
+    @Autowired
+    private WebPushSender sender;
+
+    private StubWebPushSender stub;
+    private String authHeader;
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        stub = (StubWebPushSender) sender;
+        stub.reset();
+
+        memberRepository.save(MemberFixture.create());
+        memberId = memberRepository.findAll().get(0).getId();
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        subscriptionRepository.save(
+                new PushSubscription(memberId, ENDPOINT, "p256dh", "auth", "Android"));
+    }
+
+    /** 과거 날짜로 만든다 — 08:00이 이미 지나 있어야 발송 대상이 된다. */
+    private long createTrip(boolean morningSummary) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "도쿄", "destinationName": "도쿄",
+                                 "startDate": "2020-01-01", "endDate": "2020-01-03",
+                                 "timezone": "Asia/Tokyo", "currency": "JPY",
+                                 "morningSummaryEnabled": %s}
+                                """.formatted(morningSummary)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private void addActivity(long tripId, String title, String date, String time)
+            throws Exception {
+        String timeField = time == null ? "" : ", \"startTime\": \"%s\"".formatted(time);
+        mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "%s", "activityDate": "%s"%s}
+                                """.formatted(title, date, timeField)))
+                .andExpect(status().isOk());
+    }
+
+    private List<PushNotification> morningNotifications() {
+        return notificationRepository.findAllByMemberIdOrderByScheduledAtAsc(memberId).stream()
+                .filter(n -> n.getType() == NotificationType.MORNING_SUMMARY)
+                .toList();
+    }
+
+    @Nested
+    @DisplayName("예약")
+    class Scheduling {
+
+        @Test
+        @DisplayName("여행 기간 모든 날짜에 현지 08:00으로 잡는다")
+        void schedulesEveryDayAtEight() throws Exception {
+            createTrip(true);
+
+            // 1/1~1/3 사흘.
+            assertThat(morningNotifications()).hasSize(3);
+            // 도쿄 08:00 = UTC 전날 23:00.
+            assertThat(morningNotifications().get(0).getScheduledAt())
+                    .isEqualTo(Instant.parse("2019-12-31T23:00:00Z"));
+        }
+
+        @Test
+        @DisplayName("일정이 하나도 없어도 잡는다 — 0건 판정은 보낼 때 한다")
+        void schedulesEvenWithoutActivities() throws Exception {
+            createTrip(true);
+
+            assertThat(morningNotifications()).hasSize(3);
+            assertThat(morningNotifications())
+                    .allSatisfy(n -> assertThat(n.getActivityId()).isNull());
+        }
+
+        @Test
+        @DisplayName("스위치가 꺼져 있으면 만들지 않는다")
+        void skipsWhenDisabled() throws Exception {
+            createTrip(false);
+
+            assertThat(morningNotifications()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("나중에 켜면 그때 잡힌다")
+        void schedulesWhenEnabledLater() throws Exception {
+            long tripId = createTrip(false);
+            assertThat(morningNotifications()).isEmpty();
+
+            mockMvc.perform(put("/api/travel/trips/" + tripId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "도쿄", "destinationName": "도쿄",
+                                     "startDate": "2020-01-01", "endDate": "2020-01-03",
+                                     "timezone": "Asia/Tokyo", "currency": "JPY",
+                                     "morningSummaryEnabled": true}
+                                    """))
+                    .andExpect(status().isOk());
+
+            assertThat(morningNotifications()).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("기간을 줄이면 잘린 날짜의 요약도 사라진다")
+        void reschedulesOnPeriodChange() throws Exception {
+            long tripId = createTrip(true);
+            assertThat(morningNotifications()).hasSize(3);
+
+            mockMvc.perform(put("/api/travel/trips/" + tripId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "도쿄", "destinationName": "도쿄",
+                                     "startDate": "2020-01-01", "endDate": "2020-01-02",
+                                     "timezone": "Asia/Tokyo", "currency": "JPY",
+                                     "morningSummaryEnabled": true, "confirmArchive": true}
+                                    """))
+                    .andExpect(status().isOk());
+
+            assertThat(morningNotifications().stream()
+                    .filter(n -> n.getStatus() == NotificationStatus.PENDING).toList())
+                    .hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("발송")
+    class Dispatch {
+
+        @Test
+        @DisplayName("개수와 첫 일정을 담아 보낸다")
+        void sendsSummary() throws Exception {
+            long tripId = createTrip(true);
+            addActivity(tripId, "숙소 체크아웃", "2020-01-01", "09:00");
+            addActivity(tripId, "센소지", "2020-01-01", "11:00");
+
+            dispatchService.dispatchDue();
+
+            assertThat(stub.sent).anySatisfy(s -> assertThat(s.payload())
+                    .contains("오늘 일정 2개 · 첫 일정 09:00 숙소 체크아웃"));
+        }
+
+        @Test
+        @DisplayName("그날 일정이 없으면 보내지 않는다 — 예약은 접힌다")
+        void skipsEmptyDay() throws Exception {
+            createTrip(true);
+
+            dispatchService.dispatchDue();
+
+            assertThat(stub.sent).isEmpty();
+            assertThat(morningNotifications())
+                    .allSatisfy(n -> assertThat(n.getStatus())
+                            .isEqualTo(NotificationStatus.CANCELED));
+        }
+
+        @Test
+        @DisplayName("예약 뒤에 일정을 채운 날도 요약이 온다 — 0건 판정을 보낼 때 하는 이유다")
+        void sendsForDayFilledAfterScheduling() throws Exception {
+            long tripId = createTrip(true);
+            // 여행을 만든 시점엔 1/2에 일정이 없었다.
+            addActivity(tripId, "나중에 넣은 일정", "2020-01-02", "10:00");
+
+            dispatchService.dispatchDue();
+
+            assertThat(stub.sent).anySatisfy(s -> assertThat(s.payload())
+                    .contains("오늘 일정 1개 · 첫 일정 10:00 나중에 넣은 일정"));
+        }
+
+        @Test
+        @DisplayName("시각 없는 일정이 첫 번째면 제목만 붙인다")
+        void handlesActivityWithoutTime() throws Exception {
+            long tripId = createTrip(true);
+            addActivity(tripId, "자유 일정", "2020-01-01", null);
+
+            dispatchService.dispatchDue();
+
+            assertThat(stub.sent).anySatisfy(s -> assertThat(s.payload())
+                    .contains("오늘 일정 1개 · 첫 일정 자유 일정"));
+        }
+
+        @Test
+        @DisplayName("탭하면 그날 보드로 간다 — 요약이 가리키는 건 하루 전체다")
+        void linksToBoard() throws Exception {
+            long tripId = createTrip(true);
+            addActivity(tripId, "센소지", "2020-01-01", "09:00");
+
+            dispatchService.dispatchDue();
+
+            assertThat(stub.sent).anySatisfy(s -> assertThat(s.payload())
+                    .contains("/travel/trips/" + tripId + "/board?date=2020-01-01"));
+        }
+    }
+}


### PR DESCRIPTION
## 이슈
closes #1080
## 작업 내용

#1079에서 일정·출발 알림이 붙었다. 마지막 종류인 **아침 요약**이다.

### 앞의 둘과 다른 점

일정 알림은 **일정에 매달려** 있어 일정이 바뀔 때 다시 짜면 된다. 아침 요약은 **날짜에 매달려** 있고 특정 일정에 묶이지 않는다(`activity_id`가 null이다). 예약 시점도 조건도 달라서 #1078에서 일부러 미뤘다.

### 0건 판정은 보낼 때 한다

기간 전체를 한 번에 예약해 두고, **보내기 직전에 그날 일정 수를 다시 센다**(§6).

예약 때만 판정하면 두 방향으로 틀린다.
- 여행을 만든 뒤 채운 날 → 요약이 **영영 안 온다**
- 일정을 다 지운 날 → **"일정 0개"** 알림이 간다

0건이면 `FAILED`가 아니라 `CANCELED`로 접는다. 보낼 게 없었을 뿐 실패한 게 아니다.

### 그 밖

- 탭하면 특정 일정이 아니라 **그날 보드**로 간다. 요약이 가리키는 것은 하루 전체다
- 여행 **생성 시점**에도 예약한다 — 일정이 하나도 없어도 아침 요약은 잡혀야 한다
- 스위치(`morningSummaryEnabled`)를 나중에 켜도 그때 잡힌다(여행 수정이 전체 재계산을 탄다)

## 확인

`./gradlew check --rerun-tasks` 통과. 새 테스트 9개.

**로컬에서 실제 스케줄러로** 확인했다. 과거 여행(1/1~1/3)을 만들고 **1/1에만** 일정을 넣은 뒤 30초 폴링을 기다렸다.

```
MORNING_SUMMARY  2020-01-01  2019-12-31 23:00:00Z  → 발송 시도  (도쿄 08:00)
MORNING_SUMMARY  2020-01-02  2020-01-01 23:00:00Z  → CANCELED   (일정 0건)
MORNING_SUMMARY  2020-01-03  2020-01-02 23:00:00Z  → CANCELED   (일정 0건)
```

그리고 **발송 경로 전체를 처음으로 끝까지 확인했다.** 로컬에 가짜 푸시 서비스를 띄워 구독을 등록하고, 서버가 실제로 보낸 요청을 받아 **Node `http_ece`로 복호화**했다 — 암호화·서명은 테스트 벡터로 검증했지만(#1073), HTTP 조립까지 이어지는지는 한 번 받아 봐야 알 수 있다.

```
Content-Encoding: aes128gcm
TTL: 3600
Authorization: vapid t=eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1...
VAPID 형식: true
복호화 성공: {"tag":"morning-2020-01-01",
             "body":"오늘 일정 2개 · 첫 일정 09:00 숙소 체크아웃",
             "title":"오늘 일정",
             "url":"/travel/trips/1/board?date=2020-01-01"}
```

명세(§4.3)의 문구 그대로 도착했고, 다른 구현이 우리가 만든 바이트를 **실제로 풀었다.**

즉시 발송(`/push/test`)도 같은 방식으로 확인했다.

### 남은 것

**실기기 배달**은 여전히 미확인이다. 가짜 서비스가 푼 것과 안드로이드 Chrome이 FCM을 거쳐 알림을 띄우는 것은 다른 문제다 — 3단계 끝 실기기 검증에서 본다.
