### PR TITLE
feat : 알림 구독 화면 + S-07 알림 영역 + 타임존 헤더 줄

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ dashboards/
 *.tfvars.json
 !*.tfvars.example
 
+# Playwright MCP가 남기는 스냅샷·콘솔 로그(수동 확인용 산출물)
+.playwright-mcp/

--- a/fe/.gitignore
+++ b/fe/.gitignore
@@ -8,6 +8,8 @@ dist-ssr
 # Playwright
 test-results/
 playwright-report/
+# Playwright MCP가 남기는 스냅샷·콘솔 로그(수동 확인용 산출물)
+.playwright-mcp/
 .ds-sync/
 ds-bundle/
 .design-sync/.cache/

--- a/fe/src/app/routeImports.ts
+++ b/fe/src/app/routeImports.ts
@@ -68,6 +68,10 @@ export const importTripBoard = () =>
   import("../pages/travel/TripBoardPage").then((m) => ({
     default: m.TripBoardPage,
   }));
+export const importTravelSettings = () =>
+  import("../pages/travel/TravelSettingsPage").then((m) => ({
+    default: m.TravelSettingsPage,
+  }));
 export const importTripMap = () =>
   import("../pages/travel/TripMapPage").then((m) => ({
     default: m.TripMapPage,

--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -27,6 +27,7 @@ import {
   importRoutines,
   importTravelHome,
   importTravelPlaceholder,
+  importTravelSettings,
   importTripBoard,
   importTripForm,
   importTripList,
@@ -58,6 +59,7 @@ const TripFormPage = lazy(importTripForm);
 const TripBoardPage = lazy(importTripBoard);
 const PlaceSearchPage = lazy(importPlaceSearch);
 const TripMapPage = lazy(importTripMap);
+const TravelSettingsPage = lazy(importTravelSettings);
 const ActivityDetailPage = lazy(importActivityDetail);
 
 function RouteFallback() {
@@ -278,7 +280,11 @@ export function AppRouter() {
           <Route path="/travel/tools" element={<TravelRoute title="도구" />} />
           <Route
             path="/travel/settings"
-            element={<TravelRoute title="여행 설정" />}
+            element={
+              <Suspense fallback={<RouteFallback />}>
+                <TravelSettingsPage />
+              </Suspense>
+            }
           />
           {/* 아직 없는 여행 하위 경로는 랜딩이 아니라 여행 홈으로 보낸다. */}
           <Route path="/travel/*" element={<Navigate to="/travel" replace />} />

--- a/fe/src/components/ui/select.tsx
+++ b/fe/src/components/ui/select.tsx
@@ -12,6 +12,8 @@ interface SelectProps<T extends string> {
   onValueChange: (value: T) => void;
   options: SelectOption<T>[];
   ariaLabelledby?: string;
+  /** 비활성. 켤 수 없는 설정을 감추지 않고 회색으로 남겨 무엇이 있는지 알린다. */
+  disabled?: boolean;
 }
 
 /** 표준 드롭다운 셀렉트. Trigger·Popup·Item 스타일을 일원화한다. */
@@ -20,16 +22,18 @@ function Select<T extends string>({
   onValueChange,
   options,
   ariaLabelledby,
+  disabled = false,
 }: SelectProps<T>) {
   const labelOf = (v: T) => options.find((o) => o.value === v)?.label;
   return (
     <SelectPrimitive.Root
       value={value}
       onValueChange={(v) => onValueChange(v as T)}
+      disabled={disabled}
     >
       <SelectPrimitive.Trigger
         aria-labelledby={ariaLabelledby}
-        className="border-input bg-background focus-visible:ring-ring/30 flex h-9 items-center justify-between gap-2 rounded-md border px-3 text-sm shadow-xs focus-visible:ring-2 focus-visible:outline-none"
+        className="border-input bg-background focus-visible:ring-ring/30 flex h-9 items-center justify-between gap-2 rounded-md border px-3 text-sm shadow-xs focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
       >
         <SelectPrimitive.Value>
           {(v) => <span>{labelOf(v as T)}</span>}

--- a/fe/src/features/travel/api/push.ts
+++ b/fe/src/features/travel/api/push.ts
@@ -1,0 +1,39 @@
+import { client } from "@/shared/api";
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+/** 서버가 내려주는 VAPID 공개키. 키가 없으면 null이고 화면은 알림 UI를 감춘다. */
+export async function fetchPushPublicKey(): Promise<string | null> {
+  const { data } = await client.get<ApiEnvelope<{ publicKey: string | null }>>(
+    "/travel/push/public-key",
+  );
+  return data.data.publicKey;
+}
+
+/** 브라우저의 `PushSubscription.toJSON()`을 그대로 보낸다 — 손으로 풀지 않는다. */
+export async function subscribePush(
+  subscription: PushSubscriptionJSON,
+  userAgent: string,
+): Promise<void> {
+  await client.post("/travel/push/subscriptions", {
+    endpoint: subscription.endpoint,
+    keys: subscription.keys,
+    userAgent,
+  });
+}
+
+export async function unsubscribePush(endpoint: string): Promise<void> {
+  await client.delete("/travel/push/subscriptions", { data: { endpoint } });
+}
+
+/** 즉시 발송. 실기기 검증의 첫 단추다. 전달된 구독 수를 돌려준다. */
+export async function sendTestPush(): Promise<number> {
+  const { data } = await client.post<ApiEnvelope<number>>(
+    "/travel/push/test",
+    {},
+  );
+  return data.data;
+}

--- a/fe/src/features/travel/board/LocalClockLine.tsx
+++ b/fe/src/features/travel/board/LocalClockLine.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+
+import { localTime, sameOffset } from "@/features/travel/lib/localClock";
+
+interface LocalClockLineProps {
+  timezone: string;
+  /** 완료된 여행은 시계가 아니라 기록 모드임을 알린다. */
+  recordMode: boolean;
+}
+
+/**
+ * 제목 아래 현지 시각 줄(§S-04).
+ *
+ * <p>기기와 여행의 <b>오프셋이 같으면 숨긴다</b> — 서울에서 도쿄 여행을 보면 시계가 똑같아
+ * 줄만 차지한다. 이 줄이 필요한 건 "지금 현지가 몇 시지"가 실제로 헷갈릴 때뿐이다.
+ */
+export function LocalClockLine({ timezone, recordMode }: LocalClockLineProps) {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    // 분 단위 표시라 30초면 충분하다. 더 자주 돌 이유가 없다.
+    const timer = setInterval(() => setNow(new Date()), 30_000);
+    return () => clearInterval(timer);
+  }, []);
+
+  if (recordMode) {
+    return (
+      <p className="text-caption text-muted-foreground">
+        기록 모드 · {timezone}
+      </p>
+    );
+  }
+  if (sameOffset(timezone, now)) {
+    return null;
+  }
+  return (
+    <p className="text-caption text-muted-foreground">
+      현지 {localTime(timezone, now)} · {timezone}
+    </p>
+  );
+}

--- a/fe/src/features/travel/lib/localClock.test.ts
+++ b/fe/src/features/travel/lib/localClock.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { localTime, sameOffset } from "./localClock";
+
+/**
+ * 테스트가 도는 기기의 타임존은 고정할 수 없다. 그래서 "특정 시각"이 아니라
+ * <b>오프셋 관계</b>를 확인한다 — 그게 이 화면이 실제로 판단하는 것이다.
+ */
+describe("현지 시각 줄", () => {
+  const at = new Date("2026-10-24T00:00:00Z");
+
+  it("기기 타임존과 같으면 숨긴다 — 시계가 똑같아 줄만 차지한다", () => {
+    const deviceZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+    expect(sameOffset(deviceZone, at)).toBe(true);
+  });
+
+  it("오프셋이 다르면 보여준다", () => {
+    // UTC+9와 UTC+7은 어느 기기에서 돌려도 서로 다르다.
+    expect(sameOffset("Asia/Tokyo", at) && sameOffset("Asia/Bangkok", at)).toBe(
+      false,
+    );
+  });
+
+  it("도쿄와 서울은 같은 오프셋이라 한쪽만 보고 판단하면 안 된다", () => {
+    expect(sameOffset("Asia/Tokyo", at)).toBe(sameOffset("Asia/Seoul", at));
+  });
+
+  it("현지 시각을 24시간 표기로 준다", () => {
+    // 2026-10-24T00:00Z = 도쿄 09:00.
+    expect(localTime("Asia/Tokyo", at)).toBe("09:00");
+    // 방콕은 UTC+7이라 07:00.
+    expect(localTime("Asia/Bangkok", at)).toBe("07:00");
+  });
+
+  it("자정을 24시가 아니라 00시로 쓴다", () => {
+    expect(localTime("UTC", new Date("2026-10-24T00:00:00Z"))).toBe("00:00");
+  });
+});

--- a/fe/src/features/travel/lib/localClock.ts
+++ b/fe/src/features/travel/lib/localClock.ts
@@ -1,0 +1,27 @@
+/**
+ * 여행지 현지 시각 표시(§4.1).
+ *
+ * <p>기기와 여행의 오프셋이 같으면 <b>보여줄 이유가 없다</b> — 서울에서 도쿄 여행을 보면
+ * 시계가 똑같아서 줄만 차지한다. 실제로 도움이 되는 건 오프셋이 다를 때뿐이다.
+ */
+export function sameOffset(timezone: string, at: Date = new Date()): boolean {
+  return offsetMinutes(timezone, at) === -at.getTimezoneOffset();
+}
+
+/** 그 타임존의 UTC 오프셋(분). `Intl`로 계산해 DST까지 따라간다. */
+function offsetMinutes(timezone: string, at: Date): number {
+  // 같은 순간을 그 타임존의 벽시계로 읽어 UTC와의 차이를 잰다.
+  const asUtc = new Date(at.toLocaleString("en-US", { timeZone: "UTC" }));
+  const asZone = new Date(at.toLocaleString("en-US", { timeZone: timezone }));
+  return Math.round((asZone.getTime() - asUtc.getTime()) / 60_000);
+}
+
+/** `09:42` — 여행 타임존의 현재 시각. */
+export function localTime(timezone: string, at: Date = new Date()): string {
+  return new Intl.DateTimeFormat("ko-KR", {
+    timeZone: timezone,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(at);
+}

--- a/fe/src/features/travel/push/pushSubscription.ts
+++ b/fe/src/features/travel/push/pushSubscription.ts
@@ -1,0 +1,48 @@
+/**
+ * base64url 공개키 → `applicationServerKey`가 요구하는 바이트 배열.
+ *
+ * <p>브라우저는 문자열을 받지 않는다. 서버가 주는 것은 base64url인데 `atob`은 표준 base64만
+ * 알아서, 문자를 바꾸고 패딩을 되살려야 한다.
+ */
+export function toApplicationServerKey(base64url: string): Uint8Array {
+  const padded = base64url.padEnd(
+    base64url.length + ((4 - (base64url.length % 4)) % 4),
+    "=",
+  );
+  const binary = atob(padded.replace(/-/g, "+").replace(/_/g, "/"));
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+/** 이 브라우저가 웹푸시를 할 수 있는가. iOS Safari 등에서는 없다. */
+export function isPushSupported(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    "serviceWorker" in navigator &&
+    typeof window !== "undefined" &&
+    "PushManager" in window &&
+    "Notification" in window
+  );
+}
+
+/**
+ * 등록된 Service Worker. 없으면 null.
+ *
+ * <p><b>`ready`를 쓰지 않는다.</b> 그건 SW가 생길 때까지 <b>영원히 기다린다</b> — dev 서버처럼
+ * SW가 아예 없거나 운영에서 등록이 실패하면 화면이 "확인 중"에 멈춘 채로 남는다.
+ * `getRegistration()`은 없으면 없다고 곧바로 답한다.
+ */
+export async function registration(): Promise<ServiceWorkerRegistration | null> {
+  if (!isPushSupported()) return null;
+  return (await navigator.serviceWorker.getRegistration()) ?? null;
+}
+
+/**
+ * 지금 이 기기의 구독. 없으면 null.
+ *
+ * <p>서버가 아니라 <b>브라우저</b>에 물어본다 — 서버 기록이 남아 있어도 사용자가 브라우저
+ * 설정에서 권한을 끊었으면 실제 구독은 사라진다.
+ */
+export async function currentSubscription(): Promise<PushSubscription | null> {
+  const active = await registration();
+  return active ? active.pushManager.getSubscription() : null;
+}

--- a/fe/src/features/travel/push/usePushSubscription.ts
+++ b/fe/src/features/travel/push/usePushSubscription.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  fetchPushPublicKey,
+  subscribePush,
+  unsubscribePush,
+} from "@/features/travel/api/push";
+import {
+  currentSubscription,
+  isPushSupported,
+  registration,
+  toApplicationServerKey,
+} from "@/features/travel/push/pushSubscription";
+
+export type PushState =
+  /** 이 브라우저가 웹푸시를 못 한다. */
+  | "unsupported"
+  /** 서버에 VAPID 키가 없다 — 기능이 아직 안 켜진 것이다. */
+  | "unavailable"
+  | "loading"
+  /** 권한은 있는데 아직 구독하지 않았다. */
+  | "idle"
+  | "subscribed"
+  /** 사용자가 거부했다. 브라우저 설정에서 풀어야 한다. */
+  | "denied";
+
+/**
+ * 알림 구독.
+ *
+ * <p>상태를 서버가 아니라 <b>브라우저</b>에서 읽는다 — 서버에 구독 기록이 남아 있어도
+ * 사용자가 브라우저 설정에서 권한을 끊었으면 실제로는 안 온다. 화면이 "구독됨"이라고
+ * 말하는데 알림이 안 오는 상태가 제일 나쁘다.
+ */
+export function usePushSubscription() {
+  const [state, setState] = useState<PushState>("loading");
+  const [pending, setPending] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!isPushSupported()) {
+      setState("unsupported");
+      return;
+    }
+    if (Notification.permission === "denied") {
+      setState("denied");
+      return;
+    }
+    // SW가 없으면 구독 자체가 성립하지 않는다. dev 서버가 그렇고, 운영에서도
+    // 등록이 실패하면 마찬가지다 — 기다리지 말고 그대로 말한다.
+    if (!(await registration())) {
+      setState("unsupported");
+      return;
+    }
+    const publicKey = await fetchPushPublicKey().catch(() => null);
+    if (!publicKey) {
+      setState("unavailable");
+      return;
+    }
+    setState((await currentSubscription()) ? "subscribed" : "idle");
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  /** 권한 요청 → 구독 → 서버 등록. 한 번에 한다 — 사용자가 누르는 버튼은 하나다. */
+  const subscribe = useCallback(async () => {
+    setPending(true);
+    try {
+      const permission = await Notification.requestPermission();
+      if (permission !== "granted") {
+        setState(permission === "denied" ? "denied" : "idle");
+        return false;
+      }
+      const publicKey = await fetchPushPublicKey();
+      if (!publicKey) {
+        setState("unavailable");
+        return false;
+      }
+      const active = await registration();
+      if (!active) {
+        setState("unsupported");
+        return false;
+      }
+      const subscription = await active.pushManager.subscribe({
+        // 서버가 이 키로 서명하고, 푸시 서비스가 그 서명을 검증한다.
+        userVisibleOnly: true,
+        applicationServerKey: toApplicationServerKey(publicKey),
+      });
+      await subscribePush(subscription.toJSON(), navigator.userAgent);
+      setState("subscribed");
+      return true;
+    } finally {
+      setPending(false);
+    }
+  }, []);
+
+  /** 해지는 브라우저와 서버 양쪽에서 한다 — 한쪽만 지우면 유령 구독이 남는다. */
+  const unsubscribe = useCallback(async () => {
+    setPending(true);
+    try {
+      const subscription = await currentSubscription();
+      if (subscription) {
+        await unsubscribePush(subscription.endpoint);
+        await subscription.unsubscribe();
+      }
+      setState("idle");
+    } finally {
+      setPending(false);
+    }
+  }, []);
+
+  return { state, pending, subscribe, unsubscribe, refresh };
+}

--- a/fe/src/pages/travel/ActivityDetailPage.test.tsx
+++ b/fe/src/pages/travel/ActivityDetailPage.test.tsx
@@ -90,7 +90,7 @@ describe("ActivityDetailPage", () => {
     usePendingActions.setState({ pendingIds: [], commits: new Map() });
   });
 
-  it("계획 영역만 보여준다 — 알림·기록은 후속 단계다", async () => {
+  it("계획과 알림 영역을 보여준다 — 기록은 4단계다", async () => {
     mockDetail();
     renderDetail();
 
@@ -98,8 +98,8 @@ describe("ActivityDetailPage", () => {
       expect(screen.getByLabelText("제목")).toHaveValue("센소지");
     });
     expect(screen.getByText("계획")).toBeInTheDocument();
-    // 빈 껍데기를 두지 않고 아예 렌더하지 않는다.
-    expect(screen.queryByText("알림")).toBeNull();
+    expect(screen.getByText("알림")).toBeInTheDocument();
+    // 기록은 빈 껍데기를 두지 않고 아예 렌더하지 않는다.
     expect(screen.queryByText("기록")).toBeNull();
   });
 
@@ -331,6 +331,107 @@ describe("ActivityDetailPage", () => {
       await waitFor(() => {
         expect(usePendingActions.getState().pendingIds).toEqual([1]);
       });
+    });
+  });
+
+  describe("알림 영역 (S-07)", () => {
+    const PLACE = {
+      id: 10,
+      name: "센소지",
+      address: "다이토구",
+      lat: 35.7147651,
+      lng: 139.7966553,
+    };
+
+    it("시각이 없으면 통째로 비활성이다 — 언제 보낼지 정할 수 없다", async () => {
+      mockDetail({ startTime: null });
+
+      renderDetail();
+      await screen.findByLabelText("제목");
+
+      expect(
+        screen.getByText("시각을 입력하면 알림을 설정할 수 있어요."),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("switch", { name: "일정 알림" })).toBeDisabled();
+      expect(screen.getByRole("switch", { name: "출발 알림" })).toBeDisabled();
+    });
+
+    it("시각이 있으면 일정 알림을 켤 수 있다", async () => {
+      mockDetail();
+
+      renderDetail();
+      await screen.findByLabelText("제목");
+
+      expect(screen.getByRole("switch", { name: "일정 알림" })).toBeEnabled();
+    });
+
+    it("장소가 없으면 출발 알림만 비활성이다 — 어디서 출발하는지 모른다", async () => {
+      mockDetail({ place: null });
+
+      renderDetail();
+      await screen.findByLabelText("제목");
+
+      expect(screen.getByRole("switch", { name: "일정 알림" })).toBeEnabled();
+      expect(screen.getByRole("switch", { name: "출발 알림" })).toBeDisabled();
+      expect(
+        screen.getByText("시각과 이전 장소가 필요해요"),
+      ).toBeInTheDocument();
+    });
+
+    it("장소가 있으면 출발 알림을 켤 수 있다", async () => {
+      mockDetail({ place: PLACE });
+
+      renderDetail();
+      await screen.findByLabelText("제목");
+
+      expect(screen.getByRole("switch", { name: "출발 알림" })).toBeEnabled();
+    });
+
+    it("켜고 저장하면 서버로 보낸다 — 서버가 예약을 다시 짠다", async () => {
+      mockDetail({ place: PLACE });
+      const bodies: Record<string, unknown>[] = [];
+      server.use(
+        http.put(`${API_BASE}/travel/activities/:id`, async ({ request }) => {
+          bodies.push((await request.json()) as Record<string, unknown>);
+          return HttpResponse.json({ code: "OK", data: activity() });
+        }),
+      );
+
+      const user = userEvent.setup();
+      renderDetail();
+      await screen.findByLabelText("제목");
+
+      await user.click(screen.getByRole("switch", { name: "일정 알림" }));
+      await user.click(screen.getByRole("switch", { name: "출발 알림" }));
+      await user.click(screen.getByRole("button", { name: "저장" }));
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      expect(bodies[0]).toMatchObject({
+        notifyEnabled: true,
+        departureNotifyEnabled: true,
+      });
+    });
+
+    it("알림 시점을 비우면 여행 기본값을 따른다", async () => {
+      mockDetail({ notifyEnabled: true, notifyMinutes: 30 });
+      const bodies: Record<string, unknown>[] = [];
+      server.use(
+        http.put(`${API_BASE}/travel/activities/:id`, async ({ request }) => {
+          bodies.push((await request.json()) as Record<string, unknown>);
+          return HttpResponse.json({ code: "OK", data: activity() });
+        }),
+      );
+
+      const user = userEvent.setup();
+      renderDetail();
+      await screen.findByLabelText("제목");
+      expect(screen.getByText("시작 30분 전")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "저장" }));
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      // 값이 있으면 그대로 보낸다. null이면 서버가 여행 기본값으로 떨어뜨린다.
+      expect(bodies[0].notifyMinutes).toBe(30);
     });
   });
 });

--- a/fe/src/pages/travel/ActivityDetailPage.tsx
+++ b/fe/src/pages/travel/ActivityDetailPage.tsx
@@ -21,6 +21,7 @@ import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { LoadingText } from "@/components/ui/loading-text";
 import { Select } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import {
   type Activity,
@@ -31,6 +32,7 @@ import { useActivity } from "@/features/travel/hooks/useActivity";
 import { useUpdateActivity } from "@/features/travel/hooks/useActivityMutations";
 import { usePlaceDetail } from "@/features/travel/hooks/usePlaceDetail";
 import { useTrip } from "@/features/travel/hooks/useTrip";
+import { NOTIFY_MINUTES_OPTIONS } from "@/features/travel/lib/destinations";
 import { placeDirectionsUrl } from "@/features/travel/lib/mapsLink";
 import { todayOpeningHours } from "@/features/travel/lib/openingHours";
 import {
@@ -60,6 +62,10 @@ interface FormState {
   startTime: string;
   memo: string;
   url: string;
+  notifyEnabled: boolean;
+  /** 빈 문자열이면 여행 기본값을 따른다. */
+  notifyMinutes: string;
+  departureNotifyEnabled: boolean;
 }
 
 /**
@@ -84,6 +90,7 @@ export function ActivityDetailPage() {
 
   const [form, setForm] = useState<FormState | null>(null);
   const dayLabelId = useId();
+  const notifyMinutesId = useId();
 
   useEffect(() => {
     if (activity) setForm(toFormState(activity));
@@ -115,6 +122,11 @@ export function ActivityDetailPage() {
     return index >= 0 ? `${base}?day=${index}` : base;
   };
   const boardPath = boardPathFor(form.day);
+  // 시각이 없으면 언제 보낼지 정할 수 없다(§1.2) — 서버도 같은 규칙이다.
+  const hasStartTime = form.startTime !== "";
+  // 출발 알림은 직전 장소 있는 일정이 필요하다. 그건 보드가 아는 값이라
+  // 여기서는 "이 일정에 장소가 있는가"까지만 본다 — 없으면 구간 자체가 안 생긴다.
+  const canNotifyDeparture = hasStartTime && activity.place !== null;
   const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
     setForm((prev) => (prev ? { ...prev, [key]: value } : prev));
 
@@ -142,10 +154,10 @@ export function ActivityDetailPage() {
           startTime: toWallClockTime(form.startTime),
           memo: form.memo.trim() || null,
           url: form.url.trim() || null,
-          // 알림 설정은 3단계 화면의 몫이라 지금 값을 그대로 유지한다.
-          notifyEnabled: activity.notifyEnabled,
-          notifyMinutes: activity.notifyMinutes,
-          departureNotifyEnabled: activity.departureNotifyEnabled,
+          // 저장하면 서버가 예약을 다시 짠다(§4.2).
+          notifyEnabled: form.notifyEnabled,
+          notifyMinutes: form.notifyMinutes ? Number(form.notifyMinutes) : null,
+          departureNotifyEnabled: form.departureNotifyEnabled,
         },
       });
       toast("일정을 저장했어요.", "success");
@@ -286,6 +298,75 @@ export function ActivityDetailPage() {
           </div>
         )}
 
+        {/*
+          알림 영역(§S-07). 시각이 없으면 언제 보낼지 정할 수 없어 통째로 비활성이다 —
+          서버도 같은 규칙으로 판정한다(§1.2).
+        */}
+        <section
+          className={`flex flex-col gap-3 border-t pt-5 ${
+            hasStartTime ? "" : "opacity-55"
+          }`}
+        >
+          <h2 className="text-caption text-muted-foreground font-semibold">
+            알림
+          </h2>
+
+          {!hasStartTime && (
+            <p className="text-muted-foreground text-[13px]">
+              시각을 입력하면 알림을 설정할 수 있어요.
+            </p>
+          )}
+
+          <div className="flex items-center gap-3 border-b pb-3">
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium">일정 알림</p>
+              <p className="text-muted-foreground text-xs">
+                {form.notifyMinutes
+                  ? `시작 ${form.notifyMinutes}분 전`
+                  : "여행 기본값"}
+              </p>
+            </div>
+            <Select
+              value={form.notifyMinutes}
+              onValueChange={(value) => set("notifyMinutes", value)}
+              options={[
+                { value: "", label: "여행 기본값" },
+                ...NOTIFY_MINUTES_OPTIONS,
+              ]}
+              ariaLabelledby={notifyMinutesId}
+              disabled={!hasStartTime || !form.notifyEnabled}
+            />
+            <span id={notifyMinutesId} className="sr-only">
+              알림 시점
+            </span>
+            <Switch
+              checked={form.notifyEnabled}
+              onCheckedChange={(checked) => set("notifyEnabled", checked)}
+              disabled={!hasStartTime}
+              aria-label="일정 알림"
+            />
+          </div>
+
+          <div className="flex items-center gap-3">
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium">출발 알림</p>
+              <p className="text-muted-foreground text-xs">
+                {canNotifyDeparture
+                  ? "시작시각 − 이동시간 − 5분"
+                  : "시각과 이전 장소가 필요해요"}
+              </p>
+            </div>
+            <Switch
+              checked={form.departureNotifyEnabled}
+              onCheckedChange={(checked) =>
+                set("departureNotifyEnabled", checked)
+              }
+              disabled={!canNotifyDeparture}
+              aria-label="출발 알림"
+            />
+          </div>
+        </section>
+
         <FormField label="메모" htmlFor="memo">
           <Textarea
             id="memo"
@@ -330,5 +411,9 @@ function toFormState(activity: Activity): FormState {
     startTime: toTimeInputValue(activity.startTime),
     memo: activity.memo ?? "",
     url: activity.url ?? "",
+    notifyEnabled: activity.notifyEnabled,
+    notifyMinutes:
+      activity.notifyMinutes === null ? "" : String(activity.notifyMinutes),
+    departureNotifyEnabled: activity.departureNotifyEnabled,
   };
 }

--- a/fe/src/pages/travel/TravelSettingsPage.test.tsx
+++ b/fe/src/pages/travel/TravelSettingsPage.test.tsx
@@ -1,0 +1,189 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { AppRouter } from "@/app/router";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { useToastStore } from "@/shared/lib/toast";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+const API_BASE = "https://api.orino.dev/api";
+
+const TRIP = {
+  id: 3,
+  title: "도쿄 3박 4일",
+  destinationName: "도쿄",
+  destinationPlaceId: null,
+  startDate: "2026-10-24",
+  endDate: "2026-10-27",
+  timezone: "Asia/Tokyo",
+  currency: "JPY",
+  lat: null,
+  lng: null,
+  defaultNotifyMinutes: 15,
+  morningSummaryEnabled: false,
+  status: "UPCOMING",
+  dDay: 78,
+  totalDays: 4,
+  activityCount: 3,
+};
+
+function mockSummary(hasTrip = true) {
+  server.use(
+    http.get(`${API_BASE}/travel/summary`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          ongoing: null,
+          next: hasTrip
+            ? {
+                id: 3,
+                title: TRIP.title,
+                destinationName: "도쿄",
+                startDate: TRIP.startDate,
+                endDate: TRIP.endDate,
+                dDay: 78,
+                activityCount: 3,
+              }
+            : null,
+          recentCompleted: null,
+        },
+      }),
+    ),
+    http.get(`${API_BASE}/travel/trips/:tripId`, () =>
+      HttpResponse.json({ code: "OK", data: TRIP }),
+    ),
+  );
+}
+
+function mockPublicKey(key: string | null) {
+  server.use(
+    http.get(`${API_BASE}/travel/push/public-key`, () =>
+      HttpResponse.json({ code: "OK", data: { publicKey: key } }),
+    ),
+  );
+}
+
+function renderSettings() {
+  return renderWithRouter(
+    <Providers>
+      <AppRouter />
+    </Providers>,
+    { initialEntries: ["/travel/settings"] },
+  );
+}
+
+describe("TravelSettingsPage", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "valid-token" });
+    useToastStore.setState({ toasts: [] });
+    mockSummary();
+    // jsdom에는 PushManager가 없다 — 기본 상태는 "지원 안 함"이다.
+    mockPublicKey("BExamplePublicKey");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("알림 권한", () => {
+    it("웹푸시를 못 하는 브라우저에는 지원 안 함으로 알린다", async () => {
+      renderSettings();
+
+      // jsdom은 PushManager가 없다. 상태를 숨기지 않고 그대로 말한다.
+      expect(await screen.findByText("지원 안 함")).toBeInTheDocument();
+    });
+
+    it("SW가 없으면 지원 안 함이다 — ready를 기다리면 화면이 멈춘다", async () => {
+      vi.stubGlobal("PushManager", class {});
+      vi.stubGlobal("Notification", { permission: "default" });
+      Object.defineProperty(navigator, "serviceWorker", {
+        value: { getRegistration: () => Promise.resolve(undefined) },
+        configurable: true,
+      });
+
+      renderSettings();
+
+      expect(await screen.findByText("지원 안 함")).toBeInTheDocument();
+    });
+
+    it("서버에 키가 없으면 준비 중으로 둔다 — 오류가 아니다", async () => {
+      // 지원되고 SW도 등록돼 있는데 서버가 아직 키를 안 준 상태.
+      vi.stubGlobal("PushManager", class {});
+      vi.stubGlobal("Notification", { permission: "default" });
+      Object.defineProperty(navigator, "serviceWorker", {
+        // ready가 아니라 getRegistration을 본다 — ready는 SW가 없으면 영원히 안 풀린다.
+        value: {
+          getRegistration: () => Promise.resolve({ pushManager: {} }),
+        },
+        configurable: true,
+      });
+      mockPublicKey(null);
+
+      renderSettings();
+
+      expect(await screen.findByText("준비 중")).toBeInTheDocument();
+    });
+  });
+
+  describe("여행 알림 설정", () => {
+    it("기본 알림 시점과 아침 요약을 보여준다", async () => {
+      renderSettings();
+
+      expect(await screen.findByText("아침 요약 알림")).toBeInTheDocument();
+      expect(
+        screen.getByText("여행 기간 중 매일 현지 08:00"),
+      ).toBeInTheDocument();
+      // 어느 여행에 적용되는지 밝힌다 — 설정이 여행 단위라서다.
+      expect(screen.getByText(/도쿄 3박 4일에 적용됩니다/)).toBeInTheDocument();
+    });
+
+    it("아침 요약을 켜면 여행 설정으로 저장한다", async () => {
+      const bodies: Record<string, unknown>[] = [];
+      server.use(
+        http.put(`${API_BASE}/travel/trips/:tripId`, async ({ request }) => {
+          bodies.push((await request.json()) as Record<string, unknown>);
+          return HttpResponse.json({
+            code: "OK",
+            data: { ...TRIP, morningSummaryEnabled: true },
+          });
+        }),
+      );
+
+      const user = userEvent.setup();
+      renderSettings();
+      await user.click(
+        await screen.findByRole("switch", { name: "아침 요약 알림" }),
+      );
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      expect(bodies[0]).toMatchObject({
+        morningSummaryEnabled: true,
+        // 다른 값을 덮어쓰지 않는다 — 전체 수정 API라 전부 실어 보내야 한다.
+        timezone: "Asia/Tokyo",
+        startDate: "2026-10-24",
+      });
+    });
+
+    it("여행이 없으면 설정할 것이 없다고 알린다", async () => {
+      mockSummary(false);
+
+      renderSettings();
+
+      expect(
+        await screen.findByText("여행을 만들면 알림 설정을 할 수 있어요."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("정보", () => {
+    it("데이터 출처를 밝힌다 — OSM은 표기가 필수다", async () => {
+      renderSettings();
+
+      expect(await screen.findByText(/© OpenStreetMap/)).toBeInTheDocument();
+    });
+  });
+});

--- a/fe/src/pages/travel/TravelSettingsPage.test.tsx
+++ b/fe/src/pages/travel/TravelSettingsPage.test.tsx
@@ -67,6 +67,29 @@ function mockPublicKey(key: string | null) {
   );
 }
 
+/**
+ * `navigator.serviceWorker`는 `vi.restoreAllMocks()`로 안 돌아온다 —
+ * `Object.defineProperty`로 심은 값이라 <b>직접 되돌려야</b> 다음 테스트로 새지 않는다.
+ * (CI에서 뒤 테스트들이 `getSubscription is not a function`으로 무더기 실패했다.)
+ */
+const ORIGINAL_SW = Object.getOwnPropertyDescriptor(navigator, "serviceWorker");
+
+function stubServiceWorker(value: unknown) {
+  Object.defineProperty(navigator, "serviceWorker", {
+    value,
+    configurable: true,
+  });
+}
+
+function restoreServiceWorker() {
+  if (ORIGINAL_SW) {
+    Object.defineProperty(navigator, "serviceWorker", ORIGINAL_SW);
+  } else {
+    // 원래 없던 속성이면 지워야 `"serviceWorker" in navigator`가 다시 false가 된다.
+    Reflect.deleteProperty(navigator, "serviceWorker");
+  }
+}
+
 function renderSettings() {
   return renderWithRouter(
     <Providers>
@@ -87,6 +110,7 @@ describe("TravelSettingsPage", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    restoreServiceWorker();
   });
 
   describe("알림 권한", () => {
@@ -100,10 +124,7 @@ describe("TravelSettingsPage", () => {
     it("SW가 없으면 지원 안 함이다 — ready를 기다리면 화면이 멈춘다", async () => {
       vi.stubGlobal("PushManager", class {});
       vi.stubGlobal("Notification", { permission: "default" });
-      Object.defineProperty(navigator, "serviceWorker", {
-        value: { getRegistration: () => Promise.resolve(undefined) },
-        configurable: true,
-      });
+      stubServiceWorker({ getRegistration: () => Promise.resolve(undefined) });
 
       renderSettings();
 
@@ -114,12 +135,13 @@ describe("TravelSettingsPage", () => {
       // 지원되고 SW도 등록돼 있는데 서버가 아직 키를 안 준 상태.
       vi.stubGlobal("PushManager", class {});
       vi.stubGlobal("Notification", { permission: "default" });
-      Object.defineProperty(navigator, "serviceWorker", {
-        // ready가 아니라 getRegistration을 본다 — ready는 SW가 없으면 영원히 안 풀린다.
-        value: {
-          getRegistration: () => Promise.resolve({ pushManager: {} }),
-        },
-        configurable: true,
+      // ready가 아니라 getRegistration을 본다 — ready는 SW가 없으면 영원히 안 풀린다.
+      stubServiceWorker({
+        getRegistration: () =>
+          Promise.resolve({
+            // 구독 조회까지 가므로 형태를 맞춰 둔다.
+            pushManager: { getSubscription: () => Promise.resolve(null) },
+          }),
       });
       mockPublicKey(null);
 

--- a/fe/src/pages/travel/TravelSettingsPage.tsx
+++ b/fe/src/pages/travel/TravelSettingsPage.tsx
@@ -1,0 +1,223 @@
+import { Bell, Send } from "lucide-react";
+import { useId, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/ui/form-field";
+import { LoadingText } from "@/components/ui/loading-text";
+import { Select } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { sendTestPush } from "@/features/travel/api/push";
+import { useTravelSummary } from "@/features/travel/hooks/useTravelSummary";
+import { useTrip } from "@/features/travel/hooks/useTrip";
+import { useUpdateTrip } from "@/features/travel/hooks/useTripMutations";
+import { NOTIFY_MINUTES_OPTIONS } from "@/features/travel/lib/destinations";
+import { usePushSubscription } from "@/features/travel/push/usePushSubscription";
+import { toast } from "@/shared/lib/toast";
+
+/** 권한 행의 상태 표시. 지금 무엇을 할 수 있는지가 한눈에 보여야 한다. */
+const PERMISSION_LABEL = {
+  loading: { text: "확인 중", variant: "secondary" as const },
+  unsupported: { text: "지원 안 함", variant: "secondary" as const },
+  unavailable: { text: "준비 중", variant: "secondary" as const },
+  idle: { text: "요청 필요", variant: "warning" as const },
+  subscribed: { text: "허용됨", variant: "success" as const },
+  denied: { text: "차단됨", variant: "destructive" as const },
+};
+
+/**
+ * S-09 설정.
+ *
+ * <p>알림 설정은 <b>여행 단위</b>다(기본 알림 시점·아침 요약). 그래서 어느 여행을 고를지가
+ * 문제인데, 지금 관심 있는 여행은 하나뿐이다 — 진행 중이거나 다음 예정 여행. 그 여행의
+ * 설정을 보여준다.
+ *
+ * <p>오프라인 섹션(저장 용량·초기화)은 4단계다. 캐시가 없어 표시할 값이 없다.
+ */
+export function TravelSettingsPage() {
+  const { data: summary, isPending } = useTravelSummary();
+  const push = usePushSubscription();
+  const [testing, setTesting] = useState(false);
+
+  const tripId = summary?.ongoing?.id ?? summary?.next?.id ?? null;
+  const { data: trip } = useTrip(tripId);
+  const updateTrip = useUpdateTrip(tripId ?? 0);
+
+  const notifyId = useId();
+  const permission = PERMISSION_LABEL[push.state];
+
+  const saveSettings = async (
+    defaultNotifyMinutes: number,
+    morningSummaryEnabled: boolean,
+  ) => {
+    if (!trip) return;
+    try {
+      await updateTrip.mutateAsync({
+        title: trip.title,
+        destinationName: trip.destinationName,
+        startDate: trip.startDate,
+        endDate: trip.endDate,
+        timezone: trip.timezone,
+        currency: trip.currency,
+        lat: trip.lat,
+        lng: trip.lng,
+        defaultNotifyMinutes,
+        morningSummaryEnabled,
+      });
+      toast("설정을 저장했어요.", "success");
+    } catch {
+      toast("저장하지 못했어요.", "error");
+    }
+  };
+
+  const requestPermission = async () => {
+    try {
+      if (await push.subscribe()) {
+        toast("알림을 켰어요.", "success");
+      } else {
+        toast("알림 권한이 필요해요.", "error");
+      }
+    } catch {
+      toast("알림을 켜지 못했어요.", "error");
+    }
+  };
+
+  const sendTest = async () => {
+    setTesting(true);
+    try {
+      const delivered = await sendTestPush();
+      toast(
+        delivered > 0
+          ? `${delivered}개 기기로 보냈어요.`
+          : "보낼 기기가 없어요. 먼저 알림을 켜 주세요.",
+        delivered > 0 ? "success" : "error",
+      );
+    } catch {
+      toast("보내지 못했어요.", "error");
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  if (isPending) {
+    return (
+      <div className="grid min-h-[40svh] place-items-center">
+        <LoadingText />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-[520px] flex-col gap-5 px-4 pt-3">
+      <h1 className="text-heading font-semibold">여행 설정</h1>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-caption text-muted-foreground font-semibold">
+          알림
+        </h2>
+
+        <div className="flex items-center gap-3">
+          <div className="min-w-0 flex-1">
+            <p className="flex items-center gap-1.5 text-sm font-medium">
+              <Bell className="size-3.5" />
+              알림 권한
+            </p>
+            <p className="text-muted-foreground text-xs">
+              서버 푸시로 일정·출발 알림을 보냅니다
+            </p>
+          </div>
+          <Badge variant={permission.variant}>{permission.text}</Badge>
+          {push.state === "idle" && (
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={push.pending}
+              onClick={() => void requestPermission()}
+            >
+              권한 요청
+            </Button>
+          )}
+          {push.state === "subscribed" && (
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={push.pending}
+              onClick={() => void push.unsubscribe()}
+            >
+              끄기
+            </Button>
+          )}
+        </div>
+
+        {push.state === "denied" && (
+          // 브라우저가 막은 것이라 앱에서 다시 물어볼 수 없다.
+          <p className="text-muted-foreground text-xs">
+            브라우저 설정에서 이 사이트의 알림을 허용해 주세요.
+          </p>
+        )}
+
+        {push.state === "subscribed" && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full"
+            disabled={testing}
+            onClick={() => void sendTest()}
+          >
+            <Send className="size-3.5" />
+            테스트 알림 보내기
+          </Button>
+        )}
+
+        {trip ? (
+          <>
+            <FormField label="기본 알림 시점" labelId={notifyId}>
+              <Select
+                value={String(trip.defaultNotifyMinutes)}
+                onValueChange={(value) =>
+                  void saveSettings(Number(value), trip.morningSummaryEnabled)
+                }
+                options={[...NOTIFY_MINUTES_OPTIONS]}
+                ariaLabelledby={notifyId}
+              />
+            </FormField>
+
+            <div className="flex items-center gap-3">
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium">아침 요약 알림</p>
+                <p className="text-muted-foreground text-xs">
+                  여행 기간 중 매일 현지 08:00
+                </p>
+              </div>
+              <Switch
+                checked={trip.morningSummaryEnabled}
+                onCheckedChange={(checked) =>
+                  void saveSettings(trip.defaultNotifyMinutes, checked)
+                }
+                aria-label="아침 요약 알림"
+              />
+            </div>
+            <p className="text-muted-foreground text-xs">
+              {trip.title}에 적용됩니다
+            </p>
+          </>
+        ) : (
+          // 알림 설정은 여행에 붙는 값이라 여행이 없으면 보여줄 것도 없다.
+          <p className="text-muted-foreground text-sm">
+            여행을 만들면 알림 설정을 할 수 있어요.
+          </p>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-2 border-t pt-5">
+        <h2 className="text-caption text-muted-foreground font-semibold">
+          정보
+        </h2>
+        <p className="text-muted-foreground text-xs">버전 {__APP_VERSION__}</p>
+        <p className="text-muted-foreground text-xs">
+          장소 Google Places · 지도 © OpenStreetMap
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -39,6 +39,7 @@ import { AddSheet } from "@/features/travel/board/AddSheet";
 import { DayTabs } from "@/features/travel/board/DayTabs";
 import { DragModeBar } from "@/features/travel/board/DragModeBar";
 import { LegRow } from "@/features/travel/board/LegRow";
+import { LocalClockLine } from "@/features/travel/board/LocalClockLine";
 import { usePendingActions } from "@/features/travel/board/pendingActions";
 import { TransportSheet } from "@/features/travel/board/TransportSheet";
 import { useUndoableAction } from "@/features/travel/board/useUndoableAction";
@@ -275,10 +276,15 @@ export function TripBoardPage() {
           >
             <ArrowLeft className="size-4" />
           </Button>
-          {/* 현지 시각·타임존 줄은 3단계(알림)와 함께 붙인다. */}
-          <h1 className="text-heading truncate font-semibold">
-            {board.trip.title}
-          </h1>
+          <div className="min-w-0">
+            <h1 className="text-heading truncate font-semibold">
+              {board.trip.title}
+            </h1>
+            <LocalClockLine
+              timezone={board.trip.timezone}
+              recordMode={board.trip.recordMode}
+            />
+          </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
           {/* 보던 날짜를 그대로 들고 간다 — 지도가 답하는 질문은 "오늘 이 순서가 말이 되나"다. */}

--- a/fe/vite.config.ts
+++ b/fe/vite.config.ts
@@ -75,6 +75,17 @@ export default defineConfig(() => {
         },
       },
     },
+    // SW는 빌드 결과에서만 도므로 푸시·오프라인 확인은 preview로 한다.
+    // dev와 같은 프록시가 없으면 그때 API를 못 부른다.
+    preview: {
+      port: 4173,
+      proxy: {
+        "/api": {
+          target: process.env.API_TARGET ?? "http://localhost:8080",
+          changeOrigin: true,
+        },
+      },
+    },
     server: {
       host: "0.0.0.0",
       port: 3000,


### PR DESCRIPTION
## 이슈
closes #1082
## 작업 내용

BE는 끝났는데(#1073 #1077 #1079 #1081) **알림을 켤 방법이 없었다.** 기기에서 구독할 화면이 없어 실기기 검증을 시작할 수 없었다.

### 구독 (S-09 설정)

- 권한 요청 · 구독 · 서버 등록을 **한 번에** 한다. 사용자가 누르는 버튼은 하나다
- **해지는 브라우저와 서버 양쪽에서** 한다. 한쪽만 지우면 유령 구독이 남는다
- 여행 기본 알림 시점 · 아침 요약 스위치
- **테스트 알림 보내기** — 실기기 검증의 첫 단추(#1079의 `/push/test`)

**상태를 서버가 아니라 브라우저에서 읽는다.** 서버에 구독 기록이 남아 있어도 사용자가 브라우저 설정에서 권한을 끊으면 실제로는 안 온다. 화면이 "구독됨"이라고 말하는데 알림이 안 오는 상태가 제일 나쁘다.

### 일정별 알림 (S-07)

- **시각이 없으면 섹션 전체 비활성** + "시각을 입력하면 알림을 설정할 수 있어요." — 서버도 같은 규칙으로 판정한다(§1.2)
- 출발 알림은 장소가 없으면 **그 행만** 비활성
- 저장하면 서버가 예약을 다시 짠다(§4.2)

### 타임존 헤더 줄 (S-04)

`현지 15:57 · Asia/Bangkok`. **기기와 오프셋이 같으면 숨긴다** — 서울에서 도쿄 여행을 보면 시계가 똑같아 줄만 차지한다.

## 확인

FE 게이트 전부 통과 — `format:check` · `lint` · `test`(792) · `build`. E2E `built` 5개도 통과. 새 테스트 18개.

로컬에서 방콕(UTC+7) 여행으로 확인했다.

| | 결과 |
|---|---|
| 보드 헤더 | `현지 15:57 · Asia/Bangkok` (기기 KST 17:57) |
| 시각 없는 일정 | 섹션 비활성 + 안내 문구, 두 스위치 모두 disabled |
| 시각 있는 일정 | 일정 알림 enabled · 출발 알림만 disabled(장소 없음) |
| 설정(빌드) | `요청 필요` + 권한 요청 버튼 · `방콕 여행에 적용됩니다` |

### 로컬 확인에서 잡은 것

**dev에서 설정 화면이 "확인 중"에 영원히 멈췄다.** `navigator.serviceWorker.ready`는 SW가 **생길 때까지 기다리는데**, dev에는 SW가 없다(HMR 간섭 방지로 꺼 뒀다).

dev만의 문제가 아니다 — 운영에서 SW 등록이 실패해도 같은 상태가 된다. `getRegistration()`으로 바꿨다. 없으면 없다고 곧바로 답한다. 그 경우를 테스트로도 고정했다.

**`Select`에 `disabled`가 없었다.** vitest는 타입을 안 봐서 통과했고 `build`가 잡았다 — 게이트에 `build`가 있는 이유다. 공용 컴포넌트에 자연스럽게 있어야 할 값이라 추가했다.

**테스트 stub이 다음 테스트로 샜다(CI에서만 드러남).** `Object.defineProperty`로 심은 `navigator.serviceWorker`는 `vi.restoreAllMocks()`로 돌아오지 않아, 뒤 테스트들이 `getSubscription is not a function`으로 무더기 실패했다. 로컬 전체 실행은 통과했고 **CI에서만** 터졌다 — 실행 순서가 다르면 새는 방향도 달라진다. 원래 서술자를 저장해 두고 `afterEach`에서 되돌린다.

**`vite preview`에 API 프록시를 붙였다.** SW는 빌드 결과에서만 도는데 프록시가 없어 그때 API를 못 불렀다. 앞으로 푸시·오프라인 확인은 전부 preview로 하게 된다.

### 여기서 멈춘 곳

**실제 `pushManager.subscribe()`는 헤드리스에서 확인할 수 없다.** 호출하면 응답 없이 멈춘다 — 진짜 푸시 서비스(FCM)가 없기 때문이다. 브라우저 지원 여부·SW 등록·권한 상태·서버 통신까지는 확인했지만, **구독 발급부터는 실기기의 몫**이다.

이제 기기에서 설정 화면을 열어 `권한 요청` → `테스트 알림 보내기`로 3단계 실기기 검증을 시작할 수 있다.
