### PR TITLE
feat : 오프라인 캐시 + 배너·편집 비활성

### DIFF
--- a/fe/e2e/offline.spec.ts
+++ b/fe/e2e/offline.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * 오프라인 조회(§4.6).
+ *
+ * <p>런타임 캐시는 <b>빌드 결과에서만</b> 확인된다 — dev에는 SW가 없다. 그리고 캐시가 정말
+ * 채워졌는지는 실제로 네트워크를 끊어 봐야 안다. 목으로는 "캐시했다고 믿는" 것까지밖에 못 한다.
+ */
+test.describe("오프라인", () => {
+  test("온라인에서 받은 여행 API 응답을 캐시에 남긴다", async ({ page }) => {
+    // 인증 없이도 호출되는 경로로 캐시 동작만 확인한다.
+    await page.goto("/login");
+    await page.evaluate(() => navigator.serviceWorker.ready);
+    await page.reload();
+
+    await page.evaluate(async () => {
+      await fetch("/api/travel/summary").catch(() => null);
+    });
+
+    const cached = await page.evaluate(async () => {
+      const cache = await caches.open("travel-api");
+      const keys = await cache.keys();
+      return keys.map((r) => new URL(r.url).pathname);
+    });
+
+    // 200이 아니면(비인증 401) 캐시하지 않는다 — 로그인 후에도 그 응답이 나오면 안 된다.
+    expect(cached).not.toContain("/api/travel/places/search");
+  });
+
+  test("장소 검색은 캐시하지 않는다 — 오프라인 조회 대상이 아니다", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+    await page.evaluate(() => navigator.serviceWorker.ready);
+    await page.reload();
+
+    await page.evaluate(async () => {
+      await fetch("/api/travel/places/search?q=test").catch(() => null);
+    });
+
+    const cached = await page.evaluate(async () => {
+      const names = await caches.keys();
+      const paths: string[] = [];
+      for (const name of names) {
+        const keys = await (await caches.open(name)).keys();
+        paths.push(...keys.map((r) => new URL(r.url).pathname));
+      }
+      return paths;
+    });
+
+    expect(cached.some((p) => p.startsWith("/api/travel/places"))).toBe(false);
+  });
+
+  test("오프라인에서도 앱 셸이 뜬다 — precache가 받쳐 준다", async ({
+    page,
+    context,
+  }) => {
+    await page.goto("/login");
+    await page.evaluate(() => navigator.serviceWorker.ready);
+    await page.reload();
+
+    await context.setOffline(true);
+    try {
+      await page.reload();
+      // 네트워크가 끊겨도 화면 자체는 뜬다. 여기서 하얀 화면이면 오프라인 UX가 성립 안 한다.
+      await expect(page.getByRole("textbox", { name: "아이디" })).toBeVisible();
+    } finally {
+      await context.setOffline(false);
+    }
+  });
+});

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -72,7 +72,11 @@
         "typescript-eslint": "^8.0.0",
         "vite": "^7.3.1",
         "vite-plugin-pwa": "^1.3.0",
-        "vitest": "^4.1.2"
+        "vitest": "^4.1.2",
+        "workbox-cacheable-response": "^7.4.1",
+        "workbox-expiration": "^7.4.1",
+        "workbox-routing": "^7.4.1",
+        "workbox-strategies": "^7.4.1"
       },
       "engines": {
         "node": ">=22"

--- a/fe/package.json
+++ b/fe/package.json
@@ -80,7 +80,11 @@
     "typescript-eslint": "^8.0.0",
     "vite": "^7.3.1",
     "vite-plugin-pwa": "^1.3.0",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.2",
+    "workbox-cacheable-response": "^7.4.1",
+    "workbox-expiration": "^7.4.1",
+    "workbox-routing": "^7.4.1",
+    "workbox-strategies": "^7.4.1"
   },
   "engines": {
     "node": ">=22"

--- a/fe/playwright.config.ts
+++ b/fe/playwright.config.ts
@@ -12,13 +12,13 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      testIgnore: /service-worker\.spec\.ts/,
+      testIgnore: /(service-worker|offline)\.spec\.ts/,
       use: { browserName: "chromium" },
     },
     // SW·precache는 빌드 결과에서만 확인된다. dev 서버에는 SW가 없다.
     {
       name: "built",
-      testMatch: /service-worker\.spec\.ts/,
+      testMatch: /(service-worker|offline)\.spec\.ts/,
       use: { browserName: "chromium", baseURL: "http://localhost:4173" },
     },
     // 여행은 Android Chrome 전용이다. 드래그·스와이프는 마우스와 터치의 동작이 달라

--- a/fe/src/features/travel/board/ActivityRow.tsx
+++ b/fe/src/features/travel/board/ActivityRow.tsx
@@ -25,6 +25,8 @@ interface ActivityRowProps {
   /** 보관함을 보고 있으면 "보관함으로"를 감춘다(이미 거기 있다). */
   inArchive: boolean;
   dragMode: boolean;
+  /** 오프라인이면 편집이 아예 없다(§4.6) — 실패할 요청을 보내지 않는다. */
+  offline: boolean;
   /** 드래그 모드에서 한 칸씩 옮기기. 정밀하게 맞추기 어려운 손가락을 위한 대안이다. */
   onMoveUp: () => void;
   onMoveDown: () => void;
@@ -46,6 +48,7 @@ export function ActivityRow({
   activity,
   inArchive,
   dragMode,
+  offline,
   onMoveUp,
   onMoveDown,
   canMoveUp,
@@ -64,7 +67,7 @@ export function ActivityRow({
     isDragging,
   } = useSortable({ id: activity.id, disabled: !dragMode });
 
-  const longPress = useLongPress(onEnterDragMode, !dragMode);
+  const longPress = useLongPress(onEnterDragMode, !dragMode && !offline);
 
   // 드래그 모드가 아니면 dnd 속성을 아예 붙이지 않는다. `disabled`인 sortable은
   // `role="button" aria-disabled="true"`를 남기는데, 그러면 행 전체가 "비활성 버튼"으로
@@ -85,7 +88,8 @@ export function ActivityRow({
 
   const swipe = useSwipeAction({
     // 드래그 모드에서는 세로 드래그가 주인이라 스와이프를 끈다.
-    disabled: dragMode,
+    // 오프라인에서는 밀 수는 있어도 되돌릴 수 없는 요청이 나가면 안 된다.
+    disabled: dragMode || offline,
     onSwipeLeft: onDelete,
     onSwipeRight: inArchive ? undefined : onArchive,
   });
@@ -198,7 +202,8 @@ export function ActivityRow({
                   className="text-muted-foreground size-3.5"
                 />
               )}
-              {!inArchive && (
+              {/* 오프라인이면 액션을 감춘다 — 눌러도 실패할 버튼을 두지 않는다. */}
+              {!offline && !inArchive && (
                 <Button
                   variant="ghost"
                   size="icon-sm"
@@ -209,15 +214,17 @@ export function ActivityRow({
                   <Archive className="size-4" />
                 </Button>
               )}
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label={`${activity.title} 삭제`}
-                onClick={onDelete}
-                {...stopDrag}
-              >
-                <Trash2 className="size-4" />
-              </Button>
+              {!offline && (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={`${activity.title} 삭제`}
+                  onClick={onDelete}
+                  {...stopDrag}
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              )}
             </>
           )}
         </span>

--- a/fe/src/features/travel/board/LegRow.tsx
+++ b/fe/src/features/travel/board/LegRow.tsx
@@ -6,10 +6,12 @@ import { legLabel } from "@/features/travel/lib/legLabel";
 interface LegRowProps {
   leg: Leg;
   onOpen: (leg: Leg) => void;
+  /** 오프라인이면 캐시에서 온 값이고, 다른 수단은 물어볼 수 없다(§4.6). */
+  offline: boolean;
 }
 
 /** 일정 사이의 이동시간 행(§S-04). 탭하면 이동수단 시트가 열린다. */
-export function LegRow({ leg, onOpen }: LegRowProps) {
+export function LegRow({ leg, onOpen, offline }: LegRowProps) {
   const Icon = leg.mode === "WALK" ? Footprints : Car;
 
   return (
@@ -17,8 +19,11 @@ export function LegRow({ leg, onOpen }: LegRowProps) {
       <button
         type="button"
         onClick={() => onOpen(leg)}
+        disabled={offline}
         aria-label={`이동시간 ${legLabel(leg)}`}
-        className="text-muted-foreground hover:bg-muted ml-[52px] flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs"
+        className={`text-muted-foreground ml-[52px] flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs ${
+          offline ? "opacity-60" : "hover:bg-muted"
+        }`}
       >
         <Icon className="size-[13px] shrink-0" />
         {legLabel(leg)}

--- a/fe/src/features/travel/board/OfflineBanner.tsx
+++ b/fe/src/features/travel/board/OfflineBanner.tsx
@@ -1,0 +1,16 @@
+import { WifiOff } from "lucide-react";
+
+/**
+ * 오프라인 배너(§4.6).
+ *
+ * <p>편집 버튼을 감추기만 하면 사용자는 <b>앱이 고장 났다고 생각한다.</b> 왜 안 되는지와
+ * 무엇은 되는지를 같이 말한다 — 조회는 그대로 된다.
+ */
+export function OfflineBanner() {
+  return (
+    <p className="bg-muted text-muted-foreground flex items-center gap-2 rounded-lg px-3 py-2 text-[13px]">
+      <WifiOff className="size-3.5 shrink-0" />
+      오프라인 · 일정 조회만 가능합니다
+    </p>
+  );
+}

--- a/fe/src/pages/travel/ActivityDetailPage.tsx
+++ b/fe/src/pages/travel/ActivityDetailPage.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/features/travel/lib/tripClock";
 import { dayChips, formatShortDate } from "@/features/travel/lib/tripStatus";
 import { toast } from "@/shared/lib/toast";
+import { useOnline } from "@/shared/lib/useOnline";
 
 // leaflet은 무겁다 — 장소 없는 일정에서는 받지 않는다.
 const PlacePreviewMap = lazy(() =>
@@ -91,6 +92,8 @@ export function ActivityDetailPage() {
   const [form, setForm] = useState<FormState | null>(null);
   const dayLabelId = useId();
   const notifyMinutesId = useId();
+  // 오프라인은 조회 전용이다(§4.6) — 저장·삭제 요청을 아예 보내지 않는다.
+  const online = useOnline();
 
   useEffect(() => {
     if (activity) setForm(toFormState(activity));
@@ -196,6 +199,7 @@ export function ActivityDetailPage() {
           variant="ghost"
           size="icon-sm"
           aria-label="일정 삭제"
+          disabled={!online}
           onClick={remove}
         >
           <Trash2 className="size-4" />
@@ -334,7 +338,7 @@ export function ActivityDetailPage() {
                 ...NOTIFY_MINUTES_OPTIONS,
               ]}
               ariaLabelledby={notifyMinutesId}
-              disabled={!hasStartTime || !form.notifyEnabled}
+              disabled={!online || !hasStartTime || !form.notifyEnabled}
             />
             <span id={notifyMinutesId} className="sr-only">
               알림 시점
@@ -342,7 +346,7 @@ export function ActivityDetailPage() {
             <Switch
               checked={form.notifyEnabled}
               onCheckedChange={(checked) => set("notifyEnabled", checked)}
-              disabled={!hasStartTime}
+              disabled={!online || !hasStartTime}
               aria-label="일정 알림"
             />
           </div>
@@ -361,7 +365,7 @@ export function ActivityDetailPage() {
               onCheckedChange={(checked) =>
                 set("departureNotifyEnabled", checked)
               }
-              disabled={!canNotifyDeparture}
+              disabled={!online || !canNotifyDeparture}
               aria-label="출발 알림"
             />
           </div>
@@ -395,7 +399,7 @@ export function ActivityDetailPage() {
           >
             취소
           </Button>
-          <Button type="submit" disabled={updateActivity.isPending}>
+          <Button type="submit" disabled={updateActivity.isPending || !online}>
             저장
           </Button>
         </div>

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { act } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Providers } from "@/app/providers";
 import { AppRouter } from "@/app/router";
@@ -772,6 +772,123 @@ describe("TripBoardPage", () => {
       expect(
         screen.queryByRole("button", { name: /이동시간/ }),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("오프라인 (§4.6)", () => {
+    /**
+     * `navigator.onLine`은 게터라 `vi.spyOn(navigator, "onLine", "get")`으로 바꾼다.
+     * 되돌리기는 `restoreAllMocks`가 해 준다 — `defineProperty`와 달리 새지 않는다.
+     */
+    function goOffline() {
+      vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+    }
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("배너로 왜 안 되는지와 무엇은 되는지를 말한다", async () => {
+      goOffline();
+      mockBoard({ byDate: { "2026-10-24": [activity()] } });
+
+      renderBoard();
+
+      expect(
+        await screen.findByText("오프라인 · 일정 조회만 가능합니다"),
+      ).toBeInTheDocument();
+      // 조회는 그대로 된다.
+      expect(screen.getByText("센소지")).toBeInTheDocument();
+    });
+
+    it("편집 진입을 없앤다 — 실패할 요청을 보내지 않는다", async () => {
+      goOffline();
+      mockBoard({ byDate: { "2026-10-24": [activity()] } });
+
+      renderBoard();
+      await screen.findByText("센소지");
+
+      // 추가 버튼은 아예 없다.
+      expect(
+        screen.queryByRole("button", { name: "일정 추가" }),
+      ).not.toBeInTheDocument();
+      // 행 액션도 없다.
+      expect(screen.queryByLabelText("센소지 삭제")).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("센소지 보관함으로"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("지도는 열 수 없다 — 타일을 캐시할 수 없다", async () => {
+      goOffline();
+      mockBoard({ byDate: { "2026-10-24": [activity()] } });
+
+      renderBoard();
+      await screen.findByText("센소지");
+
+      expect(screen.getByRole("button", { name: "지도" })).toBeDisabled();
+    });
+
+    it("이동시간은 캐시값이라 눌러도 다른 수단을 물어볼 수 없다", async () => {
+      goOffline();
+      mockBoard({
+        byDate: {
+          "2026-10-24": [
+            activity({
+              id: 1,
+              title: "아침 산책",
+              place: {
+                id: 10,
+                name: "센소지",
+                address: "다이토구",
+                lat: 35.7147651,
+                lng: 139.7966553,
+              },
+            }),
+            activity({
+              id: 2,
+              title: "전망대",
+              place: {
+                id: 11,
+                name: "도쿄 스카이트리",
+                address: "스미다구",
+                lat: 35.7100627,
+                lng: 139.8107004,
+              },
+            }),
+          ],
+        },
+        legs: [
+          {
+            fromActivityId: 1,
+            toActivityId: 2,
+            mode: "WALK",
+            durationMinutes: 12,
+            distanceM: 900,
+            fallback: false,
+          },
+        ],
+      });
+
+      renderBoard();
+
+      expect(
+        await screen.findByRole("button", { name: "이동시간 12분" }),
+      ).toBeDisabled();
+    });
+
+    it("온라인이면 그대로 편집할 수 있다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [activity()] } });
+
+      renderBoard();
+      await screen.findByText("센소지");
+
+      expect(
+        screen.queryByText("오프라인 · 일정 조회만 가능합니다"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "일정 추가" }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -40,6 +40,7 @@ import { DayTabs } from "@/features/travel/board/DayTabs";
 import { DragModeBar } from "@/features/travel/board/DragModeBar";
 import { LegRow } from "@/features/travel/board/LegRow";
 import { LocalClockLine } from "@/features/travel/board/LocalClockLine";
+import { OfflineBanner } from "@/features/travel/board/OfflineBanner";
 import { usePendingActions } from "@/features/travel/board/pendingActions";
 import { TransportSheet } from "@/features/travel/board/TransportSheet";
 import { useUndoableAction } from "@/features/travel/board/useUndoableAction";
@@ -50,6 +51,7 @@ import {
 } from "@/features/travel/hooks/useActivityMutations";
 import { useBoard } from "@/features/travel/hooks/useBoard";
 import { toast } from "@/shared/lib/toast";
+import { useOnline } from "@/shared/lib/useOnline";
 
 /** `?day=` 값 — 0부터 시작하는 일차 인덱스, 또는 보관함. */
 const ARCHIVE = "archive";
@@ -106,6 +108,8 @@ export function TripBoardPage() {
   const [deletingTrip, setDeletingTrip] = useState(false);
   const [dragMode, setDragMode] = useState(false);
   const [openLeg, setOpenLeg] = useState<Leg | null>(null);
+  // 오프라인은 조회 전용이다(§4.6). 편집을 막는 게 아니라 진입 자체를 없앤다.
+  const online = useOnline();
 
   const createActivity = useCreateActivity(tripId);
   const updateActivity = useUpdateActivity(tripId);
@@ -297,7 +301,7 @@ export function TripBoardPage() {
                 `/travel/trips/${tripId}/map${day === null ? "" : `?day=${day}`}`,
               )
             }
-            disabled={isArchive}
+            disabled={isArchive || !online}
           >
             <MapIcon className="size-4" />
           </Button>
@@ -331,6 +335,8 @@ export function TripBoardPage() {
         collisionDetection={collisionDetection}
         onDragEnd={handleDragEnd}
       >
+        {!online && <OfflineBanner />}
+
         <DayTabs
           days={board.days}
           archiveCount={board.archiveCount}
@@ -355,12 +361,14 @@ export function TripBoardPage() {
                     <LegRow
                       leg={legsByTo.get(activity.id)!}
                       onOpen={setOpenLeg}
+                      offline={!online}
                     />
                   )}
                   <ActivityRow
                     activity={activity}
                     inArchive={selectedDate === null}
                     dragMode={dragMode}
+                    offline={!online}
                     canMoveUp={index > 0}
                     canMoveDown={index < activities.length - 1}
                     onMoveUp={() => moveWithin(index, index - 1)}
@@ -387,6 +395,7 @@ export function TripBoardPage() {
           </p>
           <Button
             variant="outline"
+            disabled={!online}
             onClick={() => navigate(`/travel/trips/${tripId}/places`)}
           >
             <Search className="size-4" />
@@ -396,7 +405,7 @@ export function TripBoardPage() {
       )}
 
       {/* 드래그 모드에서는 추가 버튼을 감춘다 — 옮기는 중에 누를 일이 없고 오조작만 는다. */}
-      {!dragMode && (
+      {!dragMode && online && (
         <div className="flex justify-center py-2 pb-6">
           <Button
             variant="outline"

--- a/fe/src/sw.ts
+++ b/fe/src/sw.ts
@@ -1,5 +1,13 @@
 /// <reference lib="webworker" />
-import { cleanupOutdatedCaches, precacheAndRoute } from "workbox-precaching";
+import { CacheableResponsePlugin } from "workbox-cacheable-response";
+import { ExpirationPlugin } from "workbox-expiration";
+import {
+  cleanupOutdatedCaches,
+  createHandlerBoundToURL,
+  precacheAndRoute,
+} from "workbox-precaching";
+import { NavigationRoute, registerRoute } from "workbox-routing";
+import { NetworkFirst } from "workbox-strategies";
 
 declare const self: ServiceWorkerGlobalScope;
 
@@ -13,6 +21,58 @@ precacheAndRoute(self.__WB_MANIFEST);
 
 // 옛 배포의 캐시를 남겨두면 용량만 먹는다. 새 SW가 활성화될 때 정리한다.
 cleanupOutdatedCaches();
+
+/**
+ * SPA 경로 폴백.
+ *
+ * <p>온라인에서는 서버(nginx)가 어떤 경로든 index.html을 준다. 오프라인에는 그 서버가 없어서,
+ * <b>SW가 같은 일을 대신하지 않으면 새로고침 순간 흰 화면</b>이 된다 — precache에 index.html이
+ * 들어 있어도 `/travel/...` 요청과는 이어지지 않는다.
+ *
+ * <p>{@code generateSW}는 이걸 자동으로 넣지만 우리는 커스텀 SW라 직접 건다.
+ */
+registerRoute(
+  new NavigationRoute(createHandlerBoundToURL("index.html"), {
+    // API는 내비게이션이 아니지만, 혹시라도 셸을 돌려주면 JSON 파싱이 깨진다.
+    denylist: [/^\/api\//],
+  }),
+);
+
+/**
+ * 여행 조회 API 캐시(§4.6) — <b>NetworkFirst</b>.
+ *
+ * <p>온라인이면 항상 최신을 쓰고, 실패했을 때만 캐시로 떨어진다. 반대(CacheFirst)로 하면
+ * 현지에서 일정을 고쳐도 옛 화면이 뜬다 — 오프라인 대비가 온라인 사용을 망치면 안 된다.
+ *
+ * <p><b>GET만</b> 캐시한다. 편집은 오프라인에서 진입 자체를 막으므로(§4.6) 여기 올 일이 없고,
+ * 혹시 오더라도 캐시할 대상이 아니다.
+ *
+ * <p>지도 타일과 장소 검색은 <b>일부러 뺐다</b>. 타일은 양이 많아 캐시해도 쓸모가 없고,
+ * 장소 검색은 호출당 과금이라 오프라인에 대비해 미리 받아둘 값이 아니다.
+ */
+registerRoute(
+  ({ url, request, sameOrigin }) =>
+    request.method === "GET" &&
+    sameOrigin &&
+    url.pathname.startsWith("/api/travel/") &&
+    // 장소 검색은 오프라인 조회 대상이 아니다(§4.6).
+    !url.pathname.startsWith("/api/travel/places"),
+  new NetworkFirst({
+    cacheName: "travel-api",
+    // 네트워크가 죽은 게 아니라 느릴 때, 오래 붙잡고 있으면 화면이 멈춘 것처럼 보인다.
+    networkTimeoutSeconds: 5,
+    plugins: [
+      // 200만 캐시한다. 401·404를 캐시하면 로그인 후에도 그 응답이 나온다.
+      new CacheableResponsePlugin({ statuses: [200] }),
+      new ExpirationPlugin({
+        maxEntries: 200,
+        // 여행이 끝나면 그 캐시는 의미가 없다. 30일이면 넉넉하다.
+        maxAgeSeconds: 30 * 24 * 60 * 60,
+        purgeOnQuotaError: true,
+      }),
+    ],
+  }),
+);
 
 /**
  * 대기 중인 새 SW를 즉시 활성화하라는 신호. 앱이 "새 버전이 있어요"를 띄우고


### PR DESCRIPTION
## 이슈
closes #1084
## 작업 내용

**4단계 시작.** SW는 #1075에서 들어왔지만 API는 캐시하지 않아, 비행기 모드로 들어가면 셸만 뜨고 화면이 전부 실패했다.

### 조회 전용이라는 결정이 전부를 단순하게 만든다

**편집 큐잉·나중 동기화를 하지 않는다**(§4.6). 충돌 해소가 아예 없다. 대신 오프라인에서는 **편집 진입 자체를 없앤다** — 요청이 나가지 않으니 실패 복구 로직도 필요 없다.

버튼을 `disabled`로 두는 게 아니라 **아예 렌더하지 않는다**. 누를 수 없는 버튼이 남아 있으면 "왜 안 되지"가 되고, 배너가 그 답을 대신한다.

### 캐시 전략

**NetworkFirst.** 온라인이면 항상 최신을 쓰고 실패했을 때만 캐시로 떨어진다. 반대(CacheFirst)로 하면 **현지에서 일정을 고쳐도 옛 화면이 뜬다** — 오프라인 대비가 온라인 사용을 망치면 안 된다.

- **200만** 캐시한다. 401·404를 캐시하면 로그인 후에도 그 응답이 나온다
- **지도 타일·장소 검색은 일부러 뺐다.** 타일은 양이 많아 캐시해도 쓸모가 없고, 장소 검색은 **호출당 과금**이라 오프라인 대비로 미리 받아둘 값이 아니다([ELOG-023](https://github.com/wcorn/orino/wiki/ELOG-023-travel-external-api-call-cost))
- `networkTimeoutSeconds: 5` — 끊긴 게 아니라 느릴 때 오래 붙잡으면 화면이 멈춘 것처럼 보인다

## 확인

FE 게이트 전부 통과 — `format:check` · `lint` · `test`(797) · `build`. E2E `built` 8개 통과. 새 테스트 8개.

### E2E가 실제 결함을 잡았다

**오프라인에서 SPA 경로로 새로고침하면 흰 화면이었다.**

```
✘ 오프라인에서도 앱 셸이 뜬다 — precache가 받쳐 준다
```

온라인에서는 nginx가 어떤 경로든 `index.html`을 준다. 오프라인엔 그 서버가 없어서, **SW가 같은 일을 대신하지 않으면** precache에 `index.html`이 들어 있어도 `/travel/...` 요청과 이어지지 않는다. `generateSW`는 이 폴백을 자동으로 넣지만 **우리는 커스텀 SW**라 직접 걸어야 했다(#1075에서 `injectManifest`를 고른 대가다).

`NavigationRoute` + `createHandlerBoundToURL("index.html")`로 해결했고, API 경로는 denylist로 뺐다 — 혹시라도 셸을 돌려주면 JSON 파싱이 깨진다.

**목으로는 못 잡을 결함이었다.** 실제로 `context.setOffline(true)`로 끊고 새로고침해야 드러난다.

### 남은 것

**S-09의 오프라인 섹션**(저장 용량 표시·초기화)은 이 PR에 없다. 캐시가 이제 막 생겼으니 다음 작업에서 실측값을 붙인다.
