### PR TITLE
feat : 날씨·환율 프록시 (Open-Meteo · ECB)

### DIFF
--- a/be/orino-app-api/build.gradle
+++ b/be/orino-app-api/build.gradle
@@ -27,5 +27,8 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
     testImplementation 'org.testcontainers:testcontainers-mysql'
     testImplementation 'com.redis:testcontainers-redis:2.2.4'
+    // orino-domain-redis는 implementation이라 그 안의 Spring Data Redis 타입이 테스트에
+    // 안 보인다. 캐시 저장소를 테스트에서 갈아끼우려면 필요하다.
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/dto/BoardResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/dto/BoardResponse.java
@@ -3,6 +3,7 @@ package ds.project.orino.planner.travel.board.dto;
 import ds.project.orino.domain.planner.travel.entity.TripStatus;
 import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
 import ds.project.orino.planner.travel.route.dto.LegResponse;
+import ds.project.orino.planner.travel.tools.dto.WeatherResponse;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -51,14 +52,14 @@ public record BoardResponse(
      * @param dayIndex      1부터 시작하는 일차
      * @param weekday       한국어 요일 한 글자("금")
      * @param activityCount 그 날짜의 일정 수
-     * @param weather       날씨 요약. 4단계에서 채운다 — 지금은 항상 null
+     * @param weather       날씨 요약. 예보 범위(16일) 밖이면 null이다
      */
     public record BoardDay(
             int dayIndex,
             LocalDate date,
             String weekday,
             long activityCount,
-            Object weather
+            WeatherResponse.DailyWeather weather
     ) {
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
@@ -11,6 +11,8 @@ import ds.project.orino.domain.planner.travel.repository.TripRepository;
 import ds.project.orino.planner.travel.activity.service.ActivityService;
 import ds.project.orino.planner.travel.board.dto.BoardResponse;
 import ds.project.orino.planner.travel.route.service.LegService;
+import ds.project.orino.planner.travel.tools.dto.WeatherResponse;
+import ds.project.orino.planner.travel.tools.service.WeatherService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,17 +40,20 @@ public class BoardService {
     private final TripActivityRepository activityRepository;
     private final ActivityService activityService;
     private final LegService legService;
+    private final WeatherService weatherService;
     private final Clock clock;
 
     public BoardService(TripRepository tripRepository,
                         TripActivityRepository activityRepository,
                         ActivityService activityService,
                         LegService legService,
+                        WeatherService weatherService,
                         Clock clock) {
         this.tripRepository = tripRepository;
         this.activityRepository = activityRepository;
         this.activityService = activityService;
         this.legService = legService;
+        this.weatherService = weatherService;
         this.clock = clock;
     }
 
@@ -98,6 +103,8 @@ public class BoardService {
     private List<BoardResponse.BoardDay> buildDays(Trip trip) {
         Map<LocalDate, Long> counts = activityRepository.countByDate(trip.getId()).stream()
                 .collect(Collectors.toMap(ActivityDateCount::activityDate, ActivityDateCount::count));
+        // 날짜 탭이 전부 필요로 하므로 여행 기간을 한 번에 받는다(§S-08).
+        Map<LocalDate, WeatherResponse.DailyWeather> weather = weatherService.dailyByDate(trip);
 
         List<BoardResponse.BoardDay> days = new ArrayList<>();
         for (int dayIndex = 1; dayIndex <= trip.totalDays(); dayIndex++) {
@@ -105,8 +112,8 @@ public class BoardService {
             days.add(new BoardResponse.BoardDay(dayIndex, date,
                     date.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN),
                     counts.getOrDefault(date, 0L),
-                    // 날씨는 4단계. 예보 범위 밖이면 그때도 null이 나간다.
-                    null));
+                    // 예보 범위(오늘부터 16일) 밖이면 null이다 — 화면이 그 자리를 비운다.
+                    weather.get(date)));
         }
         return days;
     }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/client/EcbRates.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/client/EcbRates.java
@@ -1,0 +1,45 @@
+package ds.project.orino.planner.travel.tools.client;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * ECB 고시 환율 한 벌. <b>전부 EUR 기준</b>이다.
+ *
+ * @param referenceDate 고시일. 주말·공휴일엔 직전 영업일이다
+ * @param perEur        통화 → 1 EUR당 금액. EUR 자신은 들어 있지 않다
+ */
+public record EcbRates(LocalDate referenceDate, Map<String, BigDecimal> perEur) {
+
+    private static final String EURO = "EUR";
+    /** 표시용이라 소수 6자리면 충분하다. KRW/JPY 같은 큰 비율도 감당한다. */
+    private static final MathContext PRECISION = new MathContext(10, RoundingMode.HALF_UP);
+
+    /**
+     * 교차환산 — 1 {@code base}가 몇 {@code quote}인가.
+     *
+     * <p>ECB는 EUR 기준으로만 고시하므로 JPY→KRW 같은 쌍은 직접 값이 없다.
+     * {@code (KRW/EUR) ÷ (JPY/EUR)}로 EUR을 소거한다.
+     */
+    public Optional<BigDecimal> cross(String base, String quote) {
+        Optional<BigDecimal> basePerEur = rateOf(base);
+        Optional<BigDecimal> quotePerEur = rateOf(quote);
+        if (basePerEur.isEmpty() || quotePerEur.isEmpty()
+                || basePerEur.get().signum() == 0) {
+            return Optional.empty();
+        }
+        return Optional.of(quotePerEur.get().divide(basePerEur.get(), PRECISION));
+    }
+
+    /** EUR은 고시표에 없다 — 자기 자신이라 1이다. */
+    private Optional<BigDecimal> rateOf(String currency) {
+        if (EURO.equalsIgnoreCase(currency)) {
+            return Optional.of(BigDecimal.ONE);
+        }
+        return Optional.ofNullable(perEur.get(currency.toUpperCase()));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/client/EcbRatesClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/client/EcbRatesClient.java
@@ -1,0 +1,9 @@
+package ds.project.orino.planner.travel.tools.client;
+
+import java.util.Optional;
+
+/** ECB 고시 환율 조회. 실패는 예외 대신 빈 값이다 — 환율 때문에 화면이 죽지 않는다. */
+public interface EcbRatesClient {
+
+    Optional<EcbRates> latest();
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/client/HttpEcbRatesClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/client/HttpEcbRatesClient.java
@@ -1,0 +1,102 @@
+package ds.project.orino.planner.travel.tools.client;
+
+import ds.project.orino.planner.travel.tools.config.ToolsProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import java.io.StringReader;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * ECB 일일 고시(eurofxref-daily.xml). 무료·무인증이다.
+ *
+ * <p>XML이라 파서를 쓴다. <b>외부에서 받은 XML</b>이므로 DTD·외부 엔티티를 끈다 —
+ * 켜 두면 XXE로 서버 파일을 읽히거나 내부망을 긁을 수 있다.
+ */
+@Component
+public class HttpEcbRatesClient implements EcbRatesClient {
+
+    private static final Logger log = LoggerFactory.getLogger(HttpEcbRatesClient.class);
+
+    private final RestClient restClient;
+
+    public HttpEcbRatesClient(ToolsProperties props) {
+        this.restClient = RestClient.builder()
+                .baseUrl(props.fxUrl())
+                .requestFactory(requestFactory(props))
+                .build();
+    }
+
+    private static ClientHttpRequestFactory requestFactory(ToolsProperties props) {
+        var factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(props.connectTimeout());
+        factory.setReadTimeout(props.readTimeout());
+        return factory;
+    }
+
+    @Override
+    public Optional<EcbRates> latest() {
+        try {
+            String xml = restClient.get().retrieve().body(String.class);
+            return xml == null ? Optional.empty() : parse(xml);
+        } catch (Exception e) {
+            log.warn("ECB 환율 조회 실패: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * 구조 —
+     * {@code <Cube><Cube time='2026-08-07'><Cube currency='JPY' rate='182.64'/> ... }
+     *
+     * <p>날짜를 가진 {@code Cube}가 하루치 묶음이고 그 아래가 통화별 값이다.
+     */
+    private static Optional<EcbRates> parse(String xml) throws Exception {
+        Document document = secureBuilderFactory().newDocumentBuilder()
+                .parse(new InputSource(new StringReader(xml)));
+
+        NodeList cubes = document.getElementsByTagName("Cube");
+        LocalDate referenceDate = null;
+        Map<String, BigDecimal> perEur = new LinkedHashMap<>();
+
+        for (int i = 0; i < cubes.getLength(); i++) {
+            Element cube = (Element) cubes.item(i);
+            if (cube.hasAttribute("time")) {
+                referenceDate = LocalDate.parse(cube.getAttribute("time"));
+            } else if (cube.hasAttribute("currency") && cube.hasAttribute("rate")) {
+                perEur.put(cube.getAttribute("currency"),
+                        new BigDecimal(cube.getAttribute("rate")));
+            }
+        }
+        return referenceDate == null || perEur.isEmpty()
+                ? Optional.empty()
+                : Optional.of(new EcbRates(referenceDate, Map.copyOf(perEur)));
+    }
+
+    /** XXE 차단. 외부에서 받은 XML을 파싱할 때 기본값은 안전하지 않다. */
+    private static DocumentBuilderFactory secureBuilderFactory() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        return factory;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/client/OpenMeteoClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/client/OpenMeteoClient.java
@@ -1,0 +1,139 @@
+package ds.project.orino.planner.travel.tools.client;
+
+import ds.project.orino.planner.travel.tools.config.ToolsProperties;
+import ds.project.orino.planner.travel.tools.dto.WeatherIcon;
+import ds.project.orino.planner.travel.tools.dto.WeatherResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.JsonNode;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Open-Meteo 예보. 무료·무인증이다.
+ *
+ * <p><b>날짜 범위를 지정하지 않는다.</b> Open-Meteo는 예보 범위(오늘부터 16일) 밖을 요청하면
+ * 빈 결과가 아니라 <b>에러</b>를 준다 — 여행이 아직 한참 남은 계획 단계에서는 그게 정상이므로,
+ * 범위를 요청하는 대신 <b>받을 수 있는 만큼 받아 오고</b> 걸러내는 일은 서비스가 한다.
+ *
+ * <p>응답이 열 지향이다({@code time[]}, {@code weather_code[]}가 각각 배열). 인덱스로 맞춰 읽는다.
+ */
+@Component
+public class OpenMeteoClient implements WeatherClient {
+
+    private static final Logger log = LoggerFactory.getLogger(OpenMeteoClient.class);
+
+    /** Open-Meteo가 허용하는 최대 예보 일수. */
+    private static final int FORECAST_DAYS = 16;
+
+    private final RestClient restClient;
+    private final ToolsProperties props;
+    private final Clock clock;
+
+    public OpenMeteoClient(ToolsProperties props, Clock clock) {
+        this.props = props;
+        this.clock = clock;
+        this.restClient = RestClient.builder()
+                .baseUrl(props.weatherBaseUrl())
+                .requestFactory(requestFactory(props))
+                .build();
+    }
+
+    private static ClientHttpRequestFactory requestFactory(ToolsProperties props) {
+        var factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(props.connectTimeout());
+        factory.setReadTimeout(props.readTimeout());
+        return factory;
+    }
+
+    @Override
+    public Optional<WeatherResponse> forecast(BigDecimal lat, BigDecimal lng, String timezone) {
+        try {
+            JsonNode root = restClient.get()
+                    .uri(uriBuilder -> uriBuilder.path("/v1/forecast")
+                            .queryParam("latitude", lat)
+                            .queryParam("longitude", lng)
+                            .queryParam("daily", "weather_code,temperature_2m_max,"
+                                    + "temperature_2m_min,precipitation_probability_max")
+                            .queryParam("hourly", "weather_code,temperature_2m")
+                            .queryParam("timezone", timezone)
+                            .queryParam("forecast_days", FORECAST_DAYS)
+                            .build())
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            if (root == null || root.has("error")) {
+                return Optional.empty();
+            }
+            return Optional.of(new WeatherResponse(
+                    WeatherResponse.SOURCE, WeatherResponse.LICENSE, clock.instant(),
+                    daily(root.get("daily")), hourly(root.get("hourly"))));
+        } catch (Exception e) {
+            // 날씨는 부가 정보다. 못 얻어도 보드는 그대로 떠야 한다.
+            log.warn("Open-Meteo 조회 실패: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private static List<WeatherResponse.DailyWeather> daily(JsonNode node) {
+        JsonNode times = node == null ? null : node.get("time");
+        if (times == null || !times.isArray()) {
+            return List.of();
+        }
+        List<WeatherResponse.DailyWeather> days = new ArrayList<>();
+        for (int i = 0; i < times.size(); i++) {
+            days.add(new WeatherResponse.DailyWeather(
+                    LocalDate.parse(times.get(i).asString()),
+                    icon(node.get("weather_code"), i),
+                    rounded(node.get("temperature_2m_max"), i),
+                    rounded(node.get("temperature_2m_min"), i),
+                    rounded(node.get("precipitation_probability_max"), i)));
+        }
+        return days;
+    }
+
+    /** 시간대별은 날짜로 묶어 준다 — 화면이 하루를 골라 보기 때문이다. */
+    private static Map<LocalDate, List<WeatherResponse.HourlyWeather>> hourly(JsonNode node) {
+        JsonNode times = node == null ? null : node.get("time");
+        if (times == null || !times.isArray()) {
+            return Map.of();
+        }
+        Map<LocalDate, List<WeatherResponse.HourlyWeather>> byDate = new LinkedHashMap<>();
+        for (int i = 0; i < times.size(); i++) {
+            // "2026-08-08T09:00" — 이미 여행 타임존의 벽시계 값이다(timezone 파라미터).
+            LocalDateTime at = LocalDateTime.parse(times.get(i).asString());
+            byDate.computeIfAbsent(at.toLocalDate(), key -> new ArrayList<>())
+                    .add(new WeatherResponse.HourlyWeather(
+                            at.toLocalTime().toString(),
+                            icon(node.get("weather_code"), i),
+                            rounded(node.get("temperature_2m"), i)));
+        }
+        return byDate;
+    }
+
+    private static WeatherIcon icon(JsonNode codes, int index) {
+        Integer code = rounded(codes, index);
+        return code == null ? WeatherIcon.CLOUD : WeatherIcon.fromWmoCode(code);
+    }
+
+    /** 소수 온도는 화면에서 정수로만 쓴다. 여기서 한 번 반올림해 표기가 갈리지 않게 한다. */
+    private static Integer rounded(JsonNode values, int index) {
+        if (values == null || !values.isArray() || index >= values.size()) {
+            return null;
+        }
+        JsonNode value = values.get(index);
+        return value == null || value.isNull() ? null : Math.round((float) value.asDouble());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/client/WeatherClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/client/WeatherClient.java
@@ -1,0 +1,22 @@
+package ds.project.orino.planner.travel.tools.client;
+
+import ds.project.orino.planner.travel.tools.dto.WeatherResponse;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+/**
+ * 예보 조회.
+ *
+ * <p>인터페이스로 두는 이유는 테스트다. 실제 Open-Meteo는 <b>오늘부터 16일</b>만 주므로,
+ * 여행 날짜를 고정해 둔 테스트는 시간이 지나면 전부 범위 밖이 되어 무너진다.
+ */
+public interface WeatherClient {
+
+    /**
+     * 그 좌표의 예보를 받는다. 실패하면 빈 값 — 날씨 때문에 화면이 죽으면 안 된다(§9).
+     *
+     * @param timezone 여행 타임존. 시간대별 예보를 <b>현지 벽시계</b>로 받기 위해 넘긴다
+     */
+    Optional<WeatherResponse> forecast(BigDecimal lat, BigDecimal lng, String timezone);
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/config/ToolsProperties.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/config/ToolsProperties.java
@@ -1,0 +1,25 @@
+package ds.project.orino.planner.travel.tools.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * 도구(날씨·환율) 설정.
+ *
+ * <p>둘 다 무료·무인증이라 키가 없다. 그래도 캐시를 두는 이유는 §4.7 —
+ * 남의 무료 서비스를 필요 이상으로 두드리지 않는 것도 예의다.
+ *
+ * @param weatherTtl 예보 캐시(§4.7 — 6시간). 예보 자체가 그보다 자주 안 바뀐다
+ * @param fxTtl      환율 캐시(§4.7 — 24시간). ECB는 하루 한 번 고시한다
+ */
+@ConfigurationProperties(prefix = "travel.tools")
+public record ToolsProperties(
+        String weatherBaseUrl,
+        String fxUrl,
+        Duration weatherTtl,
+        Duration fxTtl,
+        Duration connectTimeout,
+        Duration readTimeout
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/controller/ToolsController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/controller/ToolsController.java
@@ -1,0 +1,45 @@
+package ds.project.orino.planner.travel.tools.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.travel.tools.dto.ExchangeRateResponse;
+import ds.project.orino.planner.travel.tools.dto.WeatherResponse;
+import ds.project.orino.planner.travel.tools.service.ExchangeRateService;
+import ds.project.orino.planner.travel.tools.service.WeatherService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** S-08 도구 — 날씨·환율. 둘 다 무료 API의 프록시다. */
+@RestController
+@RequestMapping("/api/travel")
+public class ToolsController {
+
+    private final WeatherService weatherService;
+    private final ExchangeRateService exchangeRateService;
+
+    public ToolsController(WeatherService weatherService,
+                           ExchangeRateService exchangeRateService) {
+        this.weatherService = weatherService;
+        this.exchangeRateService = exchangeRateService;
+    }
+
+    /**
+     * 여행 기간의 예보. <b>예보 범위(16일) 밖 날짜는 아예 없다</b> — 빈 배열이 정상이고,
+     * 화면이 "예보 범위 밖"으로 처리한다.
+     */
+    @GetMapping("/trips/{tripId}/weather")
+    public ApiResponse<WeatherResponse> weather(@AuthenticationPrincipal Long memberId,
+                                                @PathVariable Long tripId) {
+        return ApiResponse.success(weatherService.forTrip(memberId, tripId));
+    }
+
+    /** 1 {@code base}당 {@code quote}. ECB 기준이라 실제 결제 환율과는 다르다(화면 고지). */
+    @GetMapping("/fx")
+    public ApiResponse<ExchangeRateResponse> fx(@RequestParam String base,
+                                                @RequestParam String quote) {
+        return ApiResponse.success(exchangeRateService.rate(base, quote));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/dto/ExchangeRateResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/dto/ExchangeRateResponse.java
@@ -1,0 +1,23 @@
+package ds.project.orino.planner.travel.tools.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * 환율(§S-08).
+ *
+ * @param rate          1 {@code base}당 {@code quote} 금액
+ * @param referenceDate ECB 고시일. <b>오늘이 아닐 수 있다</b> — 주말·공휴일엔 직전 영업일 값이다
+ */
+public record ExchangeRateResponse(
+        String base,
+        String quote,
+        BigDecimal rate,
+        String source,
+        LocalDate referenceDate,
+        Instant fetchedAt
+) {
+
+    public static final String SOURCE = "ECB";
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/dto/WeatherIcon.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/dto/WeatherIcon.java
@@ -1,0 +1,35 @@
+package ds.project.orino.planner.travel.tools.dto;
+
+/**
+ * 날씨 아이콘. WMO 코드를 네 갈래로 줄인 것이다.
+ *
+ * <p>화면이 WMO 코드(0~99)를 알 필요가 없다. 코드를 그대로 넘기면 아이콘 매핑이 FE에 흩어지고,
+ * 제공자를 바꾸면 그 매핑을 전부 다시 써야 한다. <b>여기서 한 번 끊는다.</b>
+ */
+public enum WeatherIcon {
+    CLEAR,
+    CLOUD,
+    RAIN,
+    SNOW;
+
+    /**
+     * WMO Weather interpretation code → 아이콘.
+     *
+     * <p>경계는 <a href="https://open-meteo.com/en/docs">Open-Meteo 문서</a>의 분류를 따른다.
+     * 이슬비·소나기는 전부 비로 본다 — 우산을 챙기느냐가 유일한 관심사다.
+     */
+    public static WeatherIcon fromWmoCode(int code) {
+        if (code == 0 || code == 1) {
+            return CLEAR;
+        }
+        if (code == 2 || code == 3 || code == 45 || code == 48) {
+            return CLOUD;
+        }
+        // 71~77 눈, 85~86 소낙눈.
+        if ((code >= 71 && code <= 77) || code == 85 || code == 86) {
+            return SNOW;
+        }
+        // 51~67 이슬비·비·어는비, 80~82 소나기, 95~99 뇌우.
+        return RAIN;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/dto/WeatherResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/dto/WeatherResponse.java
@@ -1,0 +1,48 @@
+package ds.project.orino.planner.travel.tools.dto;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 날씨 예보(§S-08).
+ *
+ * <p>출처·라이선스를 응답에 실어 보낸다 — Open-Meteo는 <b>표기가 필수</b>고, 화면이 빠뜨릴 수
+ * 없게 하려면 데이터와 함께 다니는 게 맞다.
+ *
+ * @param daily  일자별 요약. <b>예보 범위 밖 날짜는 아예 없다</b> — 화면이 "예보 범위 밖"으로 처리한다
+ * @param hourly 날짜별 시간대별 예보
+ */
+public record WeatherResponse(
+        String source,
+        String license,
+        Instant fetchedAt,
+        List<DailyWeather> daily,
+        Map<LocalDate, List<HourlyWeather>> hourly
+) {
+
+    public static final String SOURCE = "Open-Meteo";
+    public static final String LICENSE = "CC BY 4.0";
+
+    /** 예보를 못 얻었을 때. 오류가 아니라 "아직 모름"이다 — 화면은 그대로 뜬다. */
+    public static WeatherResponse empty(Instant fetchedAt) {
+        return new WeatherResponse(SOURCE, LICENSE, fetchedAt, List.of(), Map.of());
+    }
+
+    /**
+     * @param precipProbability 강수확률(%). 60% 이상 강조는 <b>화면 규칙</b>이라 여기서 판정하지 않는다
+     */
+    public record DailyWeather(
+            LocalDate date,
+            WeatherIcon icon,
+            Integer tempMax,
+            Integer tempMin,
+            Integer precipProbability
+    ) {
+    }
+
+    /** @param time 여행 타임존의 벽시계 시각("09:00") */
+    public record HourlyWeather(String time, WeatherIcon icon, Integer temp) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/ExchangeRateService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/ExchangeRateService.java
@@ -1,0 +1,73 @@
+package ds.project.orino.planner.travel.tools.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.travel.tools.client.EcbRates;
+import ds.project.orino.planner.travel.tools.client.EcbRatesClient;
+import ds.project.orino.planner.travel.tools.config.ToolsProperties;
+import ds.project.orino.planner.travel.tools.dto.ExchangeRateResponse;
+import ds.project.orino.redis.planner.travel.ToolsCacheRepository;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.util.Optional;
+
+/**
+ * 환율(§S-08).
+ *
+ * <p>ECB는 <b>EUR 기준으로만</b> 고시한다. JPY↔KRW 같은 쌍은 직접 값이 없어 교차환산해야
+ * 하는데, 그 계산이 화면마다 흩어지면 어디선가 반대로 나눈다. 여기서 한 번만 한다.
+ */
+@Service
+public class ExchangeRateService {
+
+    /** 표시용 자릿수. KRW/JPY(≈9.4)도 USD/KRW(≈1300)도 이 정도면 읽힌다. */
+    private static final int DISPLAY_SCALE = 4;
+
+    private final EcbRatesClient ratesClient;
+    private final ToolsCacheRepository cacheRepository;
+    private final ToolsProperties props;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    public ExchangeRateService(EcbRatesClient ratesClient,
+                               ToolsCacheRepository cacheRepository,
+                               ToolsProperties props,
+                               ObjectMapper objectMapper,
+                               Clock clock) {
+        this.ratesClient = ratesClient;
+        this.cacheRepository = cacheRepository;
+        this.props = props;
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+    }
+
+    public ExchangeRateResponse rate(String base, String quote) {
+        EcbRates rates = cached().orElseThrow(
+                () -> new CustomException(ErrorCode.TRAVEL_FX_UNAVAILABLE));
+
+        BigDecimal value = rates.cross(base, quote).orElseThrow(
+                // 고시표에 없는 통화다. 값이 없는 것과 서비스가 죽은 것은 다르다.
+                () -> new CustomException(ErrorCode.TRAVEL_FX_UNSUPPORTED_CURRENCY));
+
+        return new ExchangeRateResponse(
+                base.toUpperCase(), quote.toUpperCase(),
+                value.setScale(DISPLAY_SCALE, RoundingMode.HALF_UP),
+                ExchangeRateResponse.SOURCE, rates.referenceDate(), clock.instant());
+    }
+
+    /** 고시표는 통화쌍과 무관하게 한 벌이라 쌍마다 캐시하지 않는다. */
+    private Optional<EcbRates> cached() {
+        Optional<String> hit = cacheRepository.findRates();
+        if (hit.isPresent()) {
+            return Optional.of(objectMapper.readValue(hit.get(), EcbRates.class));
+        }
+        Optional<EcbRates> fresh = ratesClient.latest();
+        fresh.ifPresent(rates -> cacheRepository.saveRates(
+                objectMapper.writeValueAsString(rates), props.fxTtl()));
+        return fresh;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/WeatherService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/WeatherService.java
@@ -1,0 +1,109 @@
+package ds.project.orino.planner.travel.tools.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.tools.client.WeatherClient;
+import ds.project.orino.planner.travel.tools.config.ToolsProperties;
+import ds.project.orino.planner.travel.tools.dto.WeatherResponse;
+import ds.project.orino.redis.planner.travel.ToolsCacheRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * 여행 기간의 날씨(§S-08).
+ *
+ * <p>Open-Meteo는 <b>오늘부터 16일</b>만 준다. 여행이 그보다 멀면 아무 날짜도 안 나오는데,
+ * 그건 오류가 아니라 정상이다 — 화면이 "예보 범위 밖"으로 처리한다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class WeatherService {
+
+    private final TripRepository tripRepository;
+    private final WeatherClient weatherClient;
+    private final ToolsCacheRepository cacheRepository;
+    private final ToolsProperties props;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    public WeatherService(TripRepository tripRepository,
+                          WeatherClient weatherClient,
+                          ToolsCacheRepository cacheRepository,
+                          ToolsProperties props,
+                          ObjectMapper objectMapper,
+                          Clock clock) {
+        this.tripRepository = tripRepository;
+        this.weatherClient = weatherClient;
+        this.cacheRepository = cacheRepository;
+        this.props = props;
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+    }
+
+    public WeatherResponse forTrip(Long memberId, Long tripId) {
+        Trip trip = tripRepository.findByIdAndMemberId(tripId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_TRIP_NOT_FOUND));
+        return forecastOf(trip);
+    }
+
+    /**
+     * 보드가 날짜 탭에 붙일 요약. 여행 좌표가 없으면(직접 입력한 목적지) 날씨도 없다.
+     */
+    public Map<LocalDate, WeatherResponse.DailyWeather> dailyByDate(Trip trip) {
+        return forecastOf(trip).daily().stream()
+                .collect(Collectors.toMap(WeatherResponse.DailyWeather::date, day -> day));
+    }
+
+    private WeatherResponse forecastOf(Trip trip) {
+        if (trip.getLat() == null || trip.getLng() == null) {
+            return WeatherResponse.empty(clock.instant());
+        }
+        WeatherResponse forecast = cached(trip);
+        return clampToTrip(forecast, trip);
+    }
+
+    /** 예보 전체에서 <b>여행 기간</b>만 남긴다. 그 밖의 날짜는 화면이 쓸 일이 없다. */
+    private static WeatherResponse clampToTrip(WeatherResponse forecast, Trip trip) {
+        List<WeatherResponse.DailyWeather> daily = forecast.daily().stream()
+                .filter(day -> !day.date().isBefore(trip.getStartDate())
+                        && !day.date().isAfter(trip.getEndDate()))
+                .toList();
+        Map<LocalDate, List<WeatherResponse.HourlyWeather>> hourly = forecast.hourly().entrySet()
+                .stream()
+                .filter(entry -> !entry.getKey().isBefore(trip.getStartDate())
+                        && !entry.getKey().isAfter(trip.getEndDate()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        return new WeatherResponse(forecast.source(), forecast.license(),
+                forecast.fetchedAt(), daily, hourly);
+    }
+
+    /**
+     * 좌표·타임존이 키다. 기간은 넣지 않는다 — 어차피 오늘 기준 16일을 받아 오므로
+     * 기간이 달라도 같은 응답이고, 넣으면 여행마다 캐시가 갈린다.
+     */
+    private WeatherResponse cached(Trip trip) {
+        String key = "%s,%s:%s".formatted(trip.getLat(), trip.getLng(), trip.getTimezone());
+        Optional<String> hit = cacheRepository.findWeather(key);
+        if (hit.isPresent()) {
+            return objectMapper.readValue(hit.get(), new TypeReference<WeatherResponse>() { });
+        }
+        Optional<WeatherResponse> fresh =
+                weatherClient.forecast(trip.getLat(), trip.getLng(), trip.getTimezone());
+        // 실패는 캐시하지 않는다 — 6시간 동안 날씨가 통째로 비어 보인다.
+        fresh.ifPresent(response -> cacheRepository.saveWeather(
+                key, objectMapper.writeValueAsString(response), props.weatherTtl()));
+        return fresh.orElseGet(() -> WeatherResponse.empty(clock.instant()));
+    }
+}

--- a/be/orino-app-api/src/main/resources/application.yml
+++ b/be/orino-app-api/src/main/resources/application.yml
@@ -111,6 +111,15 @@ travel:
     private-key: ${VAPID_PRIVATE_KEY:}
     # 푸시 서비스가 문제 시 연락할 곳(RFC 8292).
     subject: ${VAPID_SUBJECT:mailto:dsk08208@gmail.com}
+  tools:
+    # 날씨·환율은 둘 다 무료·무인증이다. 캐시는 비용이 아니라 예의와 불필요한 재조회 방지다.
+    weather-base-url: ${OPEN_METEO_BASE_URL:https://api.open-meteo.com}
+    fx-url: ${ECB_FX_URL:https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml}
+    # §4.7 — 예보 6시간, 환율 24시간(ECB는 하루 한 번 고시).
+    weather-ttl: ${WEATHER_TTL:6h}
+    fx-ttl: ${FX_TTL:24h}
+    connect-timeout: ${TOOLS_CONNECT_TIMEOUT:5s}
+    read-timeout: ${TOOLS_READ_TIMEOUT:10s}
 
 management:
   tracing:

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/ExchangeRateServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/ExchangeRateServiceTest.java
@@ -1,0 +1,104 @@
+package ds.project.orino.planner.travel.tools;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.planner.travel.tools.config.ToolsProperties;
+import ds.project.orino.planner.travel.tools.service.ExchangeRateService;
+import ds.project.orino.redis.planner.travel.ToolsCacheRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 환율 서비스의 캐시·실패 경로.
+ *
+ * <p>고시표 캐시는 <b>통화쌍과 무관한 전역 키</b>다(원래 그래야 맞다 — 표는 하루 한 벌이다).
+ * 그래서 통합 테스트에서는 앞 테스트가 채운 캐시가 남아 상태를 통제할 수 없다. 여기서는
+ * 캐시를 직접 들고 검증한다.
+ */
+class ExchangeRateServiceTest {
+
+    /** Redis 대신 맵. 이 테스트가 확인하려는 건 "언제 다시 부르나"이지 Redis가 아니다. */
+    private static class InMemoryCache extends ToolsCacheRepository {
+        private final Map<String, String> store = new HashMap<>();
+
+        InMemoryCache() {
+            super(null);
+        }
+
+        @Override
+        public Optional<String> findRates() {
+            return Optional.ofNullable(store.get("rates"));
+        }
+
+        @Override
+        public void saveRates(String json, Duration ttl) {
+            store.put("rates", json);
+        }
+    }
+
+    private static final ToolsProperties PROPS = new ToolsProperties(
+            "https://example.test", "https://example.test/fx.xml",
+            Duration.ofHours(6), Duration.ofHours(24),
+            Duration.ofSeconds(5), Duration.ofSeconds(10));
+
+    private StubEcbRatesClient client;
+    private ExchangeRateService service;
+
+    @BeforeEach
+    void setUp() {
+        client = new StubEcbRatesClient();
+        service = new ExchangeRateService(client, new InMemoryCache(), PROPS,
+                new ObjectMapper(), Clock.fixed(Instant.parse("2026-08-08T00:00:00Z"),
+                ZoneOffset.UTC));
+    }
+
+    @Test
+    @DisplayName("고시표는 한 벌이라 통화쌍이 달라도 다시 받지 않는다")
+    void cachesRateTableAcrossPairs() {
+        service.rate("JPY", "KRW");
+        service.rate("USD", "KRW");
+        service.rate("EUR", "JPY");
+
+        assertThat(client.calls).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("고시를 못 얻으면 503 — 값이 없는 것과 서비스가 죽은 건 다르다")
+    void failsWhenUpstreamUnavailable() {
+        client.result = Optional.empty();
+
+        assertThatThrownBy(() -> service.rate("JPY", "KRW"))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("환율");
+    }
+
+    @Test
+    @DisplayName("실패는 캐시하지 않는다 — 24시간 동안 환율이 통째로 막히면 안 된다")
+    void doesNotCacheFailure() {
+        client.result = Optional.empty();
+        assertThatThrownBy(() -> service.rate("JPY", "KRW"))
+                .isInstanceOf(CustomException.class);
+
+        client.reset();
+        assertThat(service.rate("JPY", "KRW").rate()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("교차환산 결과를 표시용 자릿수로 자른다")
+    void roundsForDisplay() {
+        // 1600.00 ÷ 182.64 = 8.760402...
+        assertThat(service.rate("JPY", "KRW").rate().toPlainString()).isEqualTo("8.7604");
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/StubEcbRatesClient.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/StubEcbRatesClient.java
@@ -1,0 +1,37 @@
+package ds.project.orino.planner.travel.tools;
+
+import ds.project.orino.planner.travel.tools.client.EcbRates;
+import ds.project.orino.planner.travel.tools.client.EcbRatesClient;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+
+/** 테스트용 ECB 스텁. 실제 고시값은 매일 바뀌어 단정할 수 없다. */
+public class StubEcbRatesClient implements EcbRatesClient {
+
+    public int calls = 0;
+
+    /** 실제 고시표와 같은 형태 — EUR 기준이고 EUR 자신은 없다. */
+    public Optional<EcbRates> result = Optional.of(new EcbRates(
+            LocalDate.parse("2026-08-07"),
+            Map.of("JPY", new BigDecimal("182.64"),
+                    "KRW", new BigDecimal("1600.00"),
+                    "USD", new BigDecimal("1.1535"))));
+
+    @Override
+    public Optional<EcbRates> latest() {
+        calls++;
+        return result;
+    }
+
+    public void reset() {
+        calls = 0;
+        result = Optional.of(new EcbRates(
+                LocalDate.parse("2026-08-07"),
+                Map.of("JPY", new BigDecimal("182.64"),
+                        "KRW", new BigDecimal("1600.00"),
+                        "USD", new BigDecimal("1.1535"))));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/StubWeatherClient.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/StubWeatherClient.java
@@ -1,0 +1,44 @@
+package ds.project.orino.planner.travel.tools;
+
+import ds.project.orino.planner.travel.tools.client.WeatherClient;
+import ds.project.orino.planner.travel.tools.dto.WeatherResponse;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 테스트용 예보 스텁.
+ *
+ * <p>실제 Open-Meteo는 <b>오늘부터 16일</b>만 준다. 날짜를 고정한 테스트가 실제 API를 부르면
+ * 시간이 지나는 것만으로 무너진다 — 예보 범위 자체를 테스트가 정해야 한다.
+ */
+public class StubWeatherClient implements WeatherClient {
+
+    public final List<String> calls = new ArrayList<>();
+
+    /** 비우면 조회 실패 — 날씨가 없어도 화면이 사는지 확인할 때 쓴다. */
+    public Optional<WeatherResponse> result = Optional.of(
+            WeatherResponse.empty(Instant.parse("2026-08-08T00:00:00Z")));
+
+    @Override
+    public Optional<WeatherResponse> forecast(BigDecimal lat, BigDecimal lng, String timezone) {
+        calls.add("%s,%s:%s".formatted(lat, lng, timezone));
+        return result;
+    }
+
+    /** 주어진 날짜들에 예보가 있는 응답을 만든다. */
+    public void withDays(List<WeatherResponse.DailyWeather> daily,
+                         Map<java.time.LocalDate, List<WeatherResponse.HourlyWeather>> hourly) {
+        result = Optional.of(new WeatherResponse(WeatherResponse.SOURCE,
+                WeatherResponse.LICENSE, Instant.parse("2026-08-08T00:00:00Z"), daily, hourly));
+    }
+
+    public void reset() {
+        calls.clear();
+        result = Optional.of(WeatherResponse.empty(Instant.parse("2026-08-08T00:00:00Z")));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/ToolsControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/ToolsControllerTest.java
@@ -1,0 +1,288 @@
+package ds.project.orino.planner.travel.tools;
+
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.planner.travel.tools.client.EcbRates;
+import ds.project.orino.planner.travel.tools.client.EcbRatesClient;
+import ds.project.orino.planner.travel.tools.client.WeatherClient;
+import ds.project.orino.planner.travel.tools.dto.WeatherIcon;
+import ds.project.orino.planner.travel.tools.dto.WeatherResponse;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.StubExternalsConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** S-08 도구 — 날씨·환율 프록시. */
+@Import(StubExternalsConfig.class)
+class ToolsControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+    @Autowired
+    private WeatherClient weatherClient;
+    @Autowired
+    private EcbRatesClient ratesClient;
+
+    private StubWeatherClient weatherStub;
+    private StubEcbRatesClient ratesStub;
+    private String authHeader;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        weatherStub = (StubWeatherClient) weatherClient;
+        ratesStub = (StubEcbRatesClient) ratesClient;
+        weatherStub.reset();
+        ratesStub.reset();
+
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+    }
+
+    /**
+     * 좌표를 흔들어 캐시가 테스트 사이에 새지 않게 한다 — Redis 컨테이너는 계속 살아 있고
+     * 캐시 키가 좌표라서다.
+     */
+    private static BigDecimal jitter(String base) {
+        int nudge = Math.abs(UUID.randomUUID().hashCode() % 9000) + 1000;
+        return new BigDecimal(base).add(
+                new BigDecimal("0.0000001").multiply(BigDecimal.valueOf(nudge)));
+    }
+
+    private long createTrip(boolean withCoordinates) throws Exception {
+        String coords = withCoordinates
+                ? ", \"lat\": %s, \"lng\": %s".formatted(jitter("35.6764"), jitter("139.6500"))
+                : "";
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "도쿄", "destinationName": "도쿄",
+                                 "startDate": "2026-10-24", "endDate": "2026-10-26",
+                                 "timezone": "Asia/Tokyo", "currency": "JPY"%s}
+                                """.formatted(coords)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private static WeatherResponse.DailyWeather day(String date, WeatherIcon icon,
+                                                    int max, int min, int precip) {
+        return new WeatherResponse.DailyWeather(LocalDate.parse(date), icon, max, min, precip);
+    }
+
+    @Nested
+    @DisplayName("날씨")
+    class Weather {
+
+        @Test
+        @DisplayName("출처와 라이선스를 함께 준다 — Open-Meteo는 표기가 필수다")
+        void carriesAttribution() throws Exception {
+            long tripId = createTrip(true);
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/weather")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.source").value("Open-Meteo"))
+                    .andExpect(jsonPath("$.data.license").value("CC BY 4.0"));
+        }
+
+        @Test
+        @DisplayName("여행 기간만 남긴다 — 예보 범위 안이어도 여행 밖 날짜는 쓸 일이 없다")
+        void clampsToTripPeriod() throws Exception {
+            weatherStub.withDays(List.of(
+                    day("2026-10-23", WeatherIcon.CLEAR, 18, 9, 10),   // 여행 전날
+                    day("2026-10-24", WeatherIcon.CLEAR, 15, 8, 20),
+                    day("2026-10-25", WeatherIcon.RAIN, 14, 9, 80),
+                    day("2026-10-27", WeatherIcon.CLOUD, 16, 8, 30)),  // 여행 다음날
+                    Map.of());
+            long tripId = createTrip(true);
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/weather")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.daily", hasSize(2)))
+                    .andExpect(jsonPath("$.data.daily[0].date").value("2026-10-24"))
+                    .andExpect(jsonPath("$.data.daily[1].precipProbability").value(80));
+        }
+
+        @Test
+        @DisplayName("예보 범위 밖이면 빈 배열 — 오류가 아니다")
+        void emptyWhenOutOfRange() throws Exception {
+            long tripId = createTrip(true);
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/weather")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.daily", hasSize(0)));
+        }
+
+        @Test
+        @DisplayName("조회에 실패해도 200 — 날씨 때문에 화면이 죽지 않는다")
+        void survivesUpstreamFailure() throws Exception {
+            weatherStub.result = Optional.empty();
+            long tripId = createTrip(true);
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/weather")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.daily", hasSize(0)));
+        }
+
+        @Test
+        @DisplayName("좌표가 없으면 외부를 부르지도 않는다")
+        void skipsWithoutCoordinates() throws Exception {
+            long tripId = createTrip(false);
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/weather")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk());
+
+            assertThat(weatherStub.calls).isEmpty();
+        }
+
+        @Test
+        @DisplayName("두 번 물어도 외부 호출은 한 번 — 예보는 6시간마다 바뀐다")
+        void cachesForecast() throws Exception {
+            long tripId = createTrip(true);
+
+            for (int i = 0; i < 3; i++) {
+                mockMvc.perform(get("/api/travel/trips/" + tripId + "/weather")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader));
+            }
+
+            assertThat(weatherStub.calls).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("남의 여행은 404")
+        void rejectsOtherMembersTrip() throws Exception {
+            long tripId = createTrip(true);
+            memberRepository.save(MemberFixture.create("other", "password"));
+            String otherAuth = "Bearer "
+                    + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/weather")
+                            .header(HttpHeaders.AUTHORIZATION, otherAuth))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("보드 날짜 탭")
+    class BoardWeather {
+
+        @Test
+        @DisplayName("날짜별 요약이 탭에 붙는다 — 예보 없는 날은 null")
+        void attachesToDays() throws Exception {
+            weatherStub.withDays(List.of(
+                    day("2026-10-24", WeatherIcon.RAIN, 14, 9, 80)), Map.of());
+            long tripId = createTrip(true);
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.days[0].weather.icon").value("RAIN"))
+                    .andExpect(jsonPath("$.data.days[0].weather.precipProbability").value(80))
+                    // 예보가 없는 날짜는 비어 있다.
+                    .andExpect(jsonPath("$.data.days[1].weather").doesNotExist());
+        }
+    }
+
+    @Nested
+    @DisplayName("환율")
+    class ExchangeRate {
+
+        @Test
+        @DisplayName("EUR 기준 고시에서 교차환산한다 — JPY↔KRW는 직접 값이 없다")
+        void crossConverts() throws Exception {
+            mockMvc.perform(get("/api/travel/fx")
+                            .param("base", "JPY").param("quote", "KRW")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    // 1600.00 ÷ 182.64 = 8.7604...
+                    .andExpect(jsonPath("$.data.rate").value(8.7604))
+                    .andExpect(jsonPath("$.data.source").value("ECB"))
+                    .andExpect(jsonPath("$.data.referenceDate").value("2026-08-07"));
+        }
+
+        @Test
+        @DisplayName("EUR은 고시표에 없지만 1로 다룬다")
+        void handlesEuroItself() throws Exception {
+            mockMvc.perform(get("/api/travel/fx")
+                            .param("base", "EUR").param("quote", "JPY")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.rate").value(182.64));
+        }
+
+        @Test
+        @DisplayName("같은 통화면 1")
+        void sameCurrencyIsOne() throws Exception {
+            mockMvc.perform(get("/api/travel/fx")
+                            .param("base", "JPY").param("quote", "JPY")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.rate").value(1.0));
+        }
+
+        @Test
+        @DisplayName("고시표에 없는 통화는 400 — 값이 없는 것과 서비스가 죽은 건 다르다")
+        void rejectsUnknownCurrency() throws Exception {
+            mockMvc.perform(get("/api/travel/fx")
+                            .param("base", "JPY").param("quote", "XYZ")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-011"));
+        }
+
+        // 고시 실패·캐시 동작은 ExchangeRateServiceTest에서 본다 —
+        // 고시표 캐시는 통화쌍과 무관한 전역 키라 여기서는 상태를 통제할 수 없다.
+    }
+
+    @Nested
+    @DisplayName("교차환산 계산")
+    class Cross {
+
+        private final EcbRates rates = new EcbRates(LocalDate.parse("2026-08-07"),
+                Map.of("JPY", new BigDecimal("182.64"), "KRW", new BigDecimal("1600.00")));
+
+        @Test
+        @DisplayName("방향을 뒤집으면 역수가 된다")
+        void isReciprocal() {
+            BigDecimal forward = rates.cross("JPY", "KRW").orElseThrow();
+            BigDecimal backward = rates.cross("KRW", "JPY").orElseThrow();
+
+            assertThat(forward.multiply(backward).doubleValue()).isCloseTo(
+                    1.0, org.assertj.core.data.Offset.offset(0.0001));
+        }
+
+        @Test
+        @DisplayName("모르는 통화면 빈 값")
+        void unknownCurrency() {
+            assertThat(rates.cross("JPY", "XYZ")).isEmpty();
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/StubExternalsConfig.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/StubExternalsConfig.java
@@ -6,6 +6,10 @@ import ds.project.orino.planner.travel.push.StubWebPushSender;
 import ds.project.orino.planner.travel.push.send.WebPushSender;
 import ds.project.orino.planner.travel.route.StubRoutesClient;
 import ds.project.orino.planner.travel.route.client.RoutesClient;
+import ds.project.orino.planner.travel.tools.StubEcbRatesClient;
+import ds.project.orino.planner.travel.tools.StubWeatherClient;
+import ds.project.orino.planner.travel.tools.client.EcbRatesClient;
+import ds.project.orino.planner.travel.tools.client.WeatherClient;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
@@ -38,5 +42,17 @@ public class StubExternalsConfig {
     @Primary
     public WebPushSender stubWebPushSender() {
         return new StubWebPushSender();
+    }
+
+    @Bean
+    @Primary
+    public WeatherClient stubWeatherClient() {
+        return new StubWeatherClient();
+    }
+
+    @Bean
+    @Primary
+    public EcbRatesClient stubEcbRatesClient() {
+        return new StubEcbRatesClient();
     }
 }

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -46,7 +46,10 @@ public enum ErrorCode {
     TRAVEL_DATE_OUT_OF_RANGE("TRAVEL-ERR-007", "여행 기간 밖의 날짜입니다.", 400),
     TRAVEL_PLACE_NOT_FOUND("TRAVEL-ERR-008", "존재하지 않는 장소입니다.", 404),
     TRAVEL_LEG_NOT_AVAILABLE("TRAVEL-ERR-009",
-            "두 일정 사이의 이동시간을 계산할 수 없습니다.", 400);
+            "두 일정 사이의 이동시간을 계산할 수 없습니다.", 400),
+    TRAVEL_FX_UNAVAILABLE("TRAVEL-ERR-010", "환율을 가져올 수 없습니다.", 503),
+    TRAVEL_FX_UNSUPPORTED_CURRENCY("TRAVEL-ERR-011",
+            "지원하지 않는 통화입니다.", 400);
 
     private final String code;
     private final String message;

--- a/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/travel/ToolsCacheRepository.java
+++ b/be/orino-domain-redis/src/main/java/ds/project/orino/redis/planner/travel/ToolsCacheRepository.java
@@ -1,0 +1,45 @@
+package ds.project.orino.redis.planner.travel;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * 날씨·환율 캐시(§4.7 — 날씨 6h · 환율 24h).
+ *
+ * <p>둘 다 무료 API라 비용이 들지는 않는다. 그래도 캐시하는 이유는 둘이다 —
+ * 남의 무료 서비스를 필요 이상으로 두드리지 않는 것, 그리고 예보·고시가 그보다 자주 바뀌지
+ * 않아 <b>다시 부를 이유 자체가 없다</b>는 것.
+ */
+@Repository
+public class ToolsCacheRepository {
+
+    private static final String WEATHER_PREFIX = "travel:weather:";
+    private static final String FX_PREFIX = "travel:fx:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public ToolsCacheRepository(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /** 좌표·타임존이 다르면 예보도 다르다 — 키에 전부 넣는다. */
+    public Optional<String> findWeather(String key) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(WEATHER_PREFIX + key));
+    }
+
+    public void saveWeather(String key, String json, Duration ttl) {
+        redisTemplate.opsForValue().set(WEATHER_PREFIX + key, json, ttl);
+    }
+
+    /** 고시표는 통화쌍과 무관하게 한 벌이다 — 쌍마다 캐시하지 않는다. */
+    public Optional<String> findRates() {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(FX_PREFIX + "ecb"));
+    }
+
+    public void saveRates(String json, Duration ttl) {
+        redisTemplate.opsForValue().set(FX_PREFIX + "ecb", json, ttl);
+    }
+}


### PR DESCRIPTION
## 이슈
closes #1086
## 작업 내용

S-08 도구(환율·날씨)의 서버 쪽. 화면은 다음 작업이다.

### 무료지만 프록시를 둔다

Places/Routes와 달리 호출당 과금이 없다. 그래도 서버를 거치는 이유가 있다.

- **출처·라이선스 표기가 필수다**(Open-Meteo CC BY 4.0). 응답에 실어 보내 화면이 빠뜨릴 수 없게 한다
- **ECB는 EUR 기준으로만 고시한다.** JPY↔KRW는 교차환산이 필요하고, 그 계산이 화면마다 흩어지면 어디선가 반대로 나눈다
- **WMO 코드를 아이콘 enum으로 정규화**한다. 화면이 코드(0~99)를 알 필요가 없고, 제공자를 바꿔도 매핑을 다시 쓰지 않는다

### 실제 API를 찔러 보고 설계를 바꿨다

처음엔 여행 기간(`start_date`/`end_date`)을 그대로 요청하려 했는데, Open-Meteo는 **예보 범위 밖을 요청하면 빈 결과가 아니라 에러**를 준다.

```
{"reason":"Parameter 'start_date' is out of allowed range from 2026-05-07 to 2026-08-23","error":true}
```

10/24 여행을 8월에 조회하면 항상 이 에러다 — 계획 단계에서는 그게 **기본 상태**다. 그래서 범위를 요청하는 대신 **받을 수 있는 만큼(16일) 받아 오고 걸러내는 일은 서비스가** 한다. 여행이 멀면 `daily`가 빈 배열이고, 그건 오류가 아니다(화면이 "예보 범위 밖"으로 처리).

### 실패해도 화면은 산다

날씨 조회가 실패해도 **200**이다(§9). 그 자리만 비고 보드는 그대로 뜬다. **실패는 캐시하지 않는다** — 6시간·24시간 동안 통째로 막히면 안 된다.

### 보안

ECB는 XML이라 파서를 쓴다. **외부에서 받은 XML**이므로 DTD·외부 엔티티를 껐다 — 켜 두면 XXE로 서버 파일을 읽히거나 내부망을 긁을 수 있다.

## 확인

`./gradlew check --rerun-tasks` 통과. 새 테스트 20개.

로컬에서 **실제 Open-Meteo·ECB**로:

```
환율 (ECB 2026-08-07)
   JPY→KRW  8.9427      KRW→JPY  0.1118   (역수 관계 성립)
   EUR→KRW  1633.3      USD→KRW  1415.9515
   재조회 5ms (캐시)

날씨 — 가까운 여행(예보 범위 안)
   출처: Open-Meteo / CC BY 4.0
   2026-08-10  CLOUD  30°/23°  강수 60%
   2026-08-12  RAIN   29°/22°  강수 78%
   시간대별: 00:00 24° CLEAR, 01:00 24° CLEAR, ...

날씨 — 먼 여행(10/24, 예보 범위 밖)
   200  daily=0

보드 날짜 탭
   1 2026-08-10  CLOUD 30°/23°   ← 1단계부터 비어 있던 자리가 채워졌다
```

`EUR`은 고시표에 없지만(자기 자신) 1로 다루고, 같은 통화면 1이 나오는 것도 확인했다.

### 테스트에서 겪은 것

**고시표 캐시는 통화쌍과 무관한 전역 키다**(표는 하루 한 벌이라 그게 맞다). 그래서 통합 테스트에서는 앞 테스트가 채운 캐시가 남아 "실패하면 503"·"쌍마다 다시 받지 않는다"를 확인할 수 없었다 — 캐시가 이미 답을 갖고 있어서다.

캐시를 직접 들고 있는 **단위 테스트로 분리**했다. 그 과정에서 `orino-domain-redis`가 `implementation`이라 그 안의 타입이 app-api 테스트에 안 보이는 것도 걸려서 `testImplementation`을 더했다.
