### PR TITLE
feat : 일정 기록 영역 - 평점·메모

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/controller/ActivityController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/controller/ActivityController.java
@@ -1,6 +1,8 @@
 package ds.project.orino.planner.travel.activity.controller;
 
 import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.travel.activity.dto.ActivityLogRequest;
+import ds.project.orino.planner.travel.activity.dto.ActivityLogResponse;
 import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
 import ds.project.orino.planner.travel.activity.dto.ActivityWriteRequest;
 import ds.project.orino.planner.travel.activity.dto.ReorderRequest;
@@ -54,6 +56,18 @@ public class ActivityController {
                                     @PathVariable Long activityId) {
         activityService.delete(memberId, activityId);
         return ApiResponse.success();
+    }
+
+    /**
+     * 기록(평점·메모) 저장. 사진과 분리된 요청이라 사진 업로드가 실패해도 이건 남는다.
+     *
+     * <p>둘 다 비우면 기록을 지우고 {@code data: null}을 돌려준다.
+     */
+    @PutMapping("/activities/{activityId}/log")
+    public ApiResponse<ActivityLogResponse> saveLog(@AuthenticationPrincipal Long memberId,
+                                                    @PathVariable Long activityId,
+                                                    @Valid @RequestBody ActivityLogRequest request) {
+        return ApiResponse.success(activityService.saveLog(memberId, activityId, request));
     }
 
     /** 드래그 결과 반영 — 순서 변경과 날짜 이동을 한 트랜잭션으로 처리한다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityLogRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityLogRequest.java
@@ -1,0 +1,23 @@
+package ds.project.orino.planner.travel.activity.dto;
+
+import ds.project.orino.domain.planner.travel.entity.TripActivityLog;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 기록 저장 요청(§8). 사진과 분리된 요청이다.
+ *
+ * <p><b>둘 다 null을 허용한다.</b> 별을 해제하거나 메모를 지우는 것도 정당한 입력이라,
+ * "빈 값이면 무시"로 만들면 한 번 매긴 별을 되돌릴 방법이 없어진다.
+ */
+public record ActivityLogRequest(
+
+        @Min(TripActivityLog.MIN_RATING)
+        @Max(TripActivityLog.MAX_RATING)
+        Integer rating,
+
+        @Size(max = TripActivityLog.MAX_MEMO_LENGTH)
+        String memo
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityLogResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityLogResponse.java
@@ -1,0 +1,22 @@
+package ds.project.orino.planner.travel.activity.dto;
+
+import ds.project.orino.domain.planner.travel.entity.TripActivityLog;
+
+import java.time.Instant;
+
+/**
+ * 일정의 사후 기록. 기록이 없으면 이 객체 자체가 null이다 — 빈 값으로 채운 껍데기를
+ * 내려주면 화면이 "기록 있음"과 "아직 없음"을 구분하지 못한다.
+ *
+ * @param updatedAt 자동 저장이라 언제 저장됐는지 화면이 보여줄 수 있어야 한다
+ */
+public record ActivityLogResponse(
+        Integer rating,
+        String memo,
+        Instant updatedAt
+) {
+
+    public static ActivityLogResponse from(TripActivityLog log) {
+        return new ActivityLogResponse(log.getRating(), log.getMemo(), log.getUpdatedAt());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityResponse.java
@@ -12,7 +12,8 @@ import java.time.LocalTime;
  * @param activityDate null이면 미배정 보관함에 있는 일정이다
  * @param startTime    여행 타임존의 벽시계 시각. {@code HH:mm}로 직렬화된다
  * @param sortOrder    같은 날짜(또는 보관함) 안에서의 순서. 정렬의 유일한 기준이다
- * @param hasLog       사후 기록(평점·메모) 존재 여부. 기록 테이블이 4단계라 지금은 항상 false
+ * @param log          사후 기록(평점·메모). 아직 기록이 없으면 null
+ * @param hasLog       기록 존재 여부. 목록은 {@code log}를 다 펼치지 않고 이 표시만 쓴다
  */
 public record ActivityResponse(
         Long id,
@@ -30,14 +31,21 @@ public record ActivityResponse(
         Integer notifyMinutes,
         boolean departureNotifyEnabled,
         int sortOrder,
+        ActivityLogResponse log,
         boolean hasLog
 ) {
 
-    public static ActivityResponse of(TripActivity activity, ActivityPlace place) {
+    public static ActivityResponse of(TripActivity activity, ActivityPlace place,
+                                      ActivityLogResponse log) {
         return new ActivityResponse(activity.getId(), activity.getTripId(), activity.getTitle(),
                 activity.getActivityDate(), activity.getStartTime(), place,
                 activity.getMemo(), activity.getUrl(), activity.isNotifyEnabled(),
                 activity.getNotifyMinutes(), activity.isDepartureNotifyEnabled(),
-                activity.getSortOrder(), false);
+                activity.getSortOrder(), log, log != null);
+    }
+
+    /** 기록이 아직 없는(또는 필요 없는) 자리에서 쓴다. */
+    public static ActivityResponse of(TripActivity activity, ActivityPlace place) {
+        return of(activity, place, null);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
@@ -5,9 +5,13 @@ import ds.project.orino.common.exception.ErrorCode;
 import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.entity.Trip;
 import ds.project.orino.domain.planner.travel.entity.TripActivity;
+import ds.project.orino.domain.planner.travel.entity.TripActivityLog;
 import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.domain.planner.travel.repository.TripActivityLogRepository;
 import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
 import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.activity.dto.ActivityLogRequest;
+import ds.project.orino.planner.travel.activity.dto.ActivityLogResponse;
 import ds.project.orino.planner.travel.activity.dto.ActivityPlace;
 import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
 import ds.project.orino.planner.travel.activity.dto.ActivityWriteRequest;
@@ -19,6 +23,7 @@ import ds.project.orino.planner.travel.place.service.PlaceService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -48,24 +53,30 @@ public class ActivityService {
     private static final int UNLISTED_BAND = 1_000_000;
 
     private final TripActivityRepository activityRepository;
+    private final TripActivityLogRepository logRepository;
     private final TripRepository tripRepository;
     private final TravelPlaceRepository placeRepository;
     private final PlaceService placeService;
     private final LegService legService;
     private final NotificationScheduleService notificationService;
+    private final Clock clock;
 
     public ActivityService(TripActivityRepository activityRepository,
+                           TripActivityLogRepository logRepository,
                            TripRepository tripRepository,
                            TravelPlaceRepository placeRepository,
                            PlaceService placeService,
                            LegService legService,
-                           NotificationScheduleService notificationService) {
+                           NotificationScheduleService notificationService,
+                           Clock clock) {
         this.activityRepository = activityRepository;
+        this.logRepository = logRepository;
         this.tripRepository = tripRepository;
         this.placeRepository = placeRepository;
         this.placeService = placeService;
         this.legService = legService;
         this.notificationService = notificationService;
+        this.clock = clock;
     }
 
     /**
@@ -201,7 +212,42 @@ public class ActivityService {
                 .toList();
     }
 
+    /**
+     * 기록(평점·메모) upsert(§S-07 기록 영역).
+     *
+     * <p><b>여행이 시작되기 전에는 거부한다.</b> 아직 겪지 않은 일에 평점을 매길 수 없고,
+     * 화면에도 그 영역이 없다 — 그래도 요청이 오면 화면과 서버 중 하나가 틀린 것이니
+     * 조용히 받아 두지 않는다. 404가 아니라 400인 이유는 일정이 실재하기 때문이다.
+     *
+     * <p>둘 다 비면 행을 지운다. 남겨 두면 {@code hasLog}가 계속 참이라 목록에 기록 표시가
+     * 남는데, 사용자가 보기엔 다 지운 상태다.
+     */
+    @Transactional
+    public ActivityLogResponse saveLog(Long memberId, Long activityId, ActivityLogRequest request) {
+        TripActivity activity = getOwnedActivity(memberId, activityId);
+        requireTripStarted(getTripOf(activity));
+
+        TripActivityLog log = logRepository.findByActivityId(activityId)
+                .orElseGet(() -> new TripActivityLog(activityId, null, null));
+        log.update(request.rating(), request.memo());
+
+        if (log.isEmpty()) {
+            if (log.getId() != null) {
+                logRepository.delete(log);
+            }
+            return null;
+        }
+        return ActivityLogResponse.from(logRepository.save(log));
+    }
+
     // ---------------- helpers ----------------
+
+    /** 기록은 여행 시작일부터다. 기준은 기기 시간대가 아니라 여행 타임존의 오늘이다. */
+    private void requireTripStarted(Trip trip) {
+        if (trip.todayAtDestination(clock).isBefore(trip.getStartDate())) {
+            throw new CustomException(ErrorCode.TRAVEL_LOG_BEFORE_TRIP);
+        }
+    }
 
     /**
      * 요청에 담긴 일정을 전부 읽어 이 여행 소유인지 확인한다. 하나라도 남의 것이면 통째로 막는다 —
@@ -279,7 +325,9 @@ public class ActivityService {
     }
 
     private ActivityResponse toResponse(TripActivity activity) {
-        return ActivityResponse.of(activity, placeOf(activity.getPlaceId()));
+        return ActivityResponse.of(activity, placeOf(activity.getPlaceId()),
+                logRepository.findByActivityId(activity.getId())
+                        .map(ActivityLogResponse::from).orElse(null));
     }
 
     private ActivityPlace placeOf(Long placeId) {
@@ -299,14 +347,31 @@ public class ActivityService {
         Map<Long, ActivityPlace> places = placeIds.isEmpty() ? Map.of()
                 : placeRepository.findAllByIdIn(placeIds).stream()
                         .collect(Collectors.toMap(TravelPlace::getId, ActivityPlace::from));
+        Map<Long, ActivityLogResponse> logs = logsOf(activities);
 
         List<ActivityResponse> responses = new ArrayList<>();
         for (TripActivity activity : activities) {
             // placeId가 null인 일정이 대부분이다. Map.of()는 get(null)에 NPE를 던지므로 먼저 거른다.
             ActivityPlace place = activity.getPlaceId() == null
                     ? null : places.get(activity.getPlaceId());
-            responses.add(ActivityResponse.of(activity, place));
+            responses.add(ActivityResponse.of(activity, place, logs.get(activity.getId())));
         }
         return responses;
+    }
+
+    /**
+     * 일정들의 기록을 한 번에 읽는다. 건건이 조회하면 보드 한 번에 일정 수만큼 쿼리가 나간다.
+     *
+     * <p>목록에도 기록을 통째로 실어 보낸다 — 보드 응답이 곧 오프라인 캐시라(§S-04),
+     * {@code hasLog}만 내려주면 비행기 모드에서 "기록 있음"만 뜨고 내용은 못 본다.
+     */
+    private Map<Long, ActivityLogResponse> logsOf(List<TripActivity> activities) {
+        if (activities.isEmpty()) {
+            return Map.of();
+        }
+        List<Long> ids = activities.stream().map(TripActivity::getId).toList();
+        return logRepository.findAllByActivityIdIn(ids).stream()
+                .collect(Collectors.toMap(TripActivityLog::getActivityId,
+                        ActivityLogResponse::from));
     }
 }

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/050-create-trip-activity-log.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/050-create-trip-activity-log.yaml
@@ -1,0 +1,57 @@
+databaseChangeLog:
+  # 일정 사후 기록 - 평점·메모 (#1090, Epic #1029 · 4단계).
+  #
+  # 사진(trip_activity_photo)과 분리된 테이블이다. 사진 업로드가 실패해도 평점·메모는
+  # 독립적으로 저장돼야 한다 - 여행 중 회선에서 사진 몇 장 실패했다고 "야경이 좋았다"가
+  # 같이 날아가면 안 된다.
+  #
+  # activity_id UNIQUE - 일정당 기록은 최대 1건이다. 여러 벌을 남기는 요구가 없고,
+  # UNIQUE가 없으면 저장 재시도가 중복 행을 만든다.
+
+  - changeSet:
+      id: 050-create-trip-activity-log
+      author: wcorn
+      comment: 일정당 최대 1건의 사후 기록(평점·메모).
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: trip_activity_log
+      changes:
+        - createTable:
+            tableName: trip_activity_log
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: activity_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uk_log_activity
+                    foreignKeyName: fk_log_activity
+                    references: trip_activity(id)
+                    deleteCascade: true
+              - column:
+                  name: memo
+                  type: VARCHAR(2000)
+              # 1~5. 별을 해제할 수 있어야 해서 NULL을 허용한다.
+              - column:
+                  name: rating
+                  type: TINYINT
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -97,3 +97,5 @@ databaseChangeLog:
       file: db/changelog/changes/048-create-push-subscription.yaml
   - include:
       file: db/changelog/changes/049-create-push-notification.yaml
+  - include:
+      file: db/changelog/changes/050-create-trip-activity-log.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/activity/controller/ActivityLogTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/activity/controller/ActivityLogTest.java
@@ -1,0 +1,254 @@
+package ds.project.orino.planner.travel.activity.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.travel.repository.TripActivityLogRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.FixedClockConfig;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 기록(평점·메모) 통합 테스트(§S-07 기록 영역).
+ *
+ * <p>고정 시각 {@code 2026-01-15T02:00Z}. 여행 두 개를 만든다 — <b>진행 중</b>(1/10~1/20)과
+ * <b>예정</b>(10/24~10/27). 기록이 시작일 기준으로 갈리는 기능이라 두 상태가 다 필요하다.
+ */
+@Import(FixedClockConfig.class)
+class ActivityLogTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TripActivityLogRepository logRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long ongoingActivityId;
+    private long upcomingActivityId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        long ongoingTrip = createTrip("2026-01-10", "2026-01-20");
+        ongoingActivityId = createActivity(ongoingTrip, "센소지", "2026-01-15");
+        long upcomingTrip = createTrip("2026-10-24", "2026-10-27");
+        upcomingActivityId = createActivity(upcomingTrip, "시부야", "2026-10-24");
+    }
+
+    @Nested
+    @DisplayName("PUT /activities/{id}/log")
+    class SaveLog {
+
+        @Test
+        @DisplayName("평점과 메모를 저장한다")
+        void savesRatingAndMemo() throws Exception {
+            saveLog(ongoingActivityId, """
+                    {"rating": 4, "memo": "야경이 좋았다"}
+                    """)
+                    .andExpect(jsonPath("$.data.rating").value(4))
+                    .andExpect(jsonPath("$.data.memo").value("야경이 좋았다"));
+
+            assertThat(logRepository.findByActivityId(ongoingActivityId)).isPresent();
+        }
+
+        @Test
+        @DisplayName("다시 저장하면 덮어쓴다 — 일정당 기록은 하나다")
+        void upsertsInsteadOfAppending() throws Exception {
+            saveLog(ongoingActivityId, """
+                    {"rating": 2, "memo": "그냥 그랬다"}
+                    """);
+            saveLog(ongoingActivityId, """
+                    {"rating": 5, "memo": "다시 가고 싶다"}
+                    """)
+                    .andExpect(jsonPath("$.data.rating").value(5));
+
+            assertThat(logRepository.count()).isEqualTo(1);
+            assertThat(logRepository.findByActivityId(ongoingActivityId).orElseThrow().getMemo())
+                    .isEqualTo("다시 가고 싶다");
+        }
+
+        @Test
+        @DisplayName("평점만 지울 수 있다 — 잘못 누른 별을 되돌릴 방법이 있어야 한다")
+        void clearsRatingButKeepsMemo() throws Exception {
+            saveLog(ongoingActivityId, """
+                    {"rating": 1, "memo": "메모는 남긴다"}
+                    """);
+
+            saveLog(ongoingActivityId, """
+                    {"rating": null, "memo": "메모는 남긴다"}
+                    """)
+                    .andExpect(jsonPath("$.data.rating").doesNotExist())
+                    .andExpect(jsonPath("$.data.memo").value("메모는 남긴다"));
+        }
+
+        @Test
+        @DisplayName("평점·메모를 모두 비우면 기록 자체가 사라진다 — 빈 기록은 기록이 아니다")
+        void removesLogWhenEverythingCleared() throws Exception {
+            saveLog(ongoingActivityId, """
+                    {"rating": 3, "memo": "적어둔다"}
+                    """);
+
+            saveLog(ongoingActivityId, """
+                    {"rating": null, "memo": "  "}
+                    """)
+                    .andExpect(jsonPath("$.data").doesNotExist());
+
+            assertThat(logRepository.findByActivityId(ongoingActivityId)).isEmpty();
+            mockMvc.perform(get("/api/travel/activities/" + ongoingActivityId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.hasLog").value(false));
+        }
+
+        @Test
+        @DisplayName("여행 시작 전에는 400 — 일정은 실재하니 404가 아니다")
+        void rejectsBeforeTripStart() throws Exception {
+            mockMvc.perform(put("/api/travel/activities/" + upcomingActivityId + "/log")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"rating": 5, "memo": "가지도 않았는데"}
+                                    """))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-012"));
+
+            assertThat(logRepository.findByActivityId(upcomingActivityId)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("평점 범위를 벗어나면 400")
+        void rejectsRatingOutOfRange() throws Exception {
+            mockMvc.perform(put("/api/travel/activities/" + ongoingActivityId + "/log")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"rating": 6}
+                                    """))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("남의 일정에는 기록할 수 없다 — 404로 존재조차 흘리지 않는다")
+        void rejectsForeignActivity() throws Exception {
+            memberRepository.save(MemberFixture.create("other", "password"));
+            String otherHeader =
+                    "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+
+            mockMvc.perform(put("/api/travel/activities/" + ongoingActivityId + "/log")
+                            .header(HttpHeaders.AUTHORIZATION, otherHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"rating": 5}
+                                    """))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("조회에 기록이 붙는다")
+    class ReadBack {
+
+        @Test
+        @DisplayName("상세에 기록이 그대로 실린다")
+        void detailCarriesLog() throws Exception {
+            saveLog(ongoingActivityId, """
+                    {"rating": 5, "memo": "최고"}
+                    """);
+
+            mockMvc.perform(get("/api/travel/activities/" + ongoingActivityId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.hasLog").value(true))
+                    .andExpect(jsonPath("$.data.log.rating").value(5))
+                    .andExpect(jsonPath("$.data.log.memo").value("최고"));
+        }
+
+        @Test
+        @DisplayName("보드 목록에도 기록이 실린다 — 보드 응답이 곧 오프라인 캐시다")
+        void boardCarriesLog() throws Exception {
+            saveLog(ongoingActivityId, """
+                    {"rating": 4, "memo": "야경"}
+                    """);
+
+            long tripId = tripOf(ongoingActivityId);
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                            .param("date", "2026-01-15")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.activities[0].hasLog").value(true))
+                    .andExpect(jsonPath("$.data.activities[0].log.memo").value("야경"));
+        }
+
+        @Test
+        @DisplayName("기록이 없으면 log는 null이고 hasLog는 false다")
+        void absentLogIsNull() throws Exception {
+            mockMvc.perform(get("/api/travel/activities/" + ongoingActivityId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.log").doesNotExist())
+                    .andExpect(jsonPath("$.data.hasLog").value(false));
+        }
+    }
+
+    // ---------------- helpers ----------------
+
+    private org.springframework.test.web.servlet.ResultActions saveLog(long activityId, String body)
+            throws Exception {
+        return mockMvc.perform(put("/api/travel/activities/" + activityId + "/log")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+    }
+
+    private long createTrip(String startDate, String endDate) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "도쿄", "destinationName": "도쿄",
+                                 "startDate": "%s", "endDate": "%s",
+                                 "timezone": "Asia/Tokyo", "currency": "JPY"}
+                                """.formatted(startDate, endDate)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private long createActivity(long tripId, String title, String date) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "%s", "activityDate": "%s"}
+                                """.formatted(title, date)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private long tripOf(long activityId) throws Exception {
+        String body = mockMvc.perform(get("/api/travel/activities/" + activityId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.tripId")).longValue();
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/schema/TravelSchemaTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/schema/TravelSchemaTest.java
@@ -4,6 +4,7 @@ import ds.project.orino.support.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * 여행 스키마(047)에서 Hibernate {@code validate}가 봐주지 않는 것들을 고정한다 —
@@ -125,6 +127,54 @@ class TravelSchemaTest {
         assertThat(columnTypeOf("trip_activity", "notify_enabled")).isEqualTo("bit");
         assertThat(columnTypeOf("trip_activity", "departure_notify_enabled")).isEqualTo("bit");
         assertThat(columnTypeOf("travel_place", "manual_entry")).isEqualTo("bit");
+    }
+
+    @Test
+    @DisplayName("일정을 지우면 기록도 함께 지워진다(ON DELETE CASCADE)")
+    @Transactional
+    void deletingActivityCascadesToLog() {
+        long memberId = insertMember("log-cascade-member");
+        long tripId = insertTrip(memberId, "도쿄");
+        long activityId = insertActivity(tripId);
+        jdbcTemplate.update("""
+                INSERT INTO trip_activity_log (activity_id, memo, rating, created_at, updated_at)
+                VALUES (?, '야경이 좋았다', 4, NOW(6), NOW(6))
+                """, activityId);
+
+        jdbcTemplate.update("DELETE FROM trip_activity WHERE id = ?", activityId);
+
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM trip_activity_log WHERE activity_id = ?",
+                Integer.class, activityId)).isZero();
+    }
+
+    @Test
+    @DisplayName("일정당 기록은 하나뿐이다 — UNIQUE가 없으면 저장 재시도가 중복 행을 만든다")
+    @Transactional
+    void logIsUniquePerActivity() {
+        long memberId = insertMember("log-unique-member");
+        long activityId = insertActivity(insertTrip(memberId, "도쿄"));
+        insertLog(activityId, 4);
+
+        assertThatThrownBy(() -> insertLog(activityId, 5))
+                .isInstanceOf(DuplicateKeyException.class);
+    }
+
+    private long insertActivity(long tripId) {
+        jdbcTemplate.update("""
+                INSERT INTO trip_activity (trip_id, title, activity_date, sort_order,
+                                           notify_enabled, departure_notify_enabled,
+                                           created_at, updated_at)
+                VALUES (?, '센소지', '2026-10-24', 0, b'0', b'0', NOW(6), NOW(6))
+                """, tripId);
+        return jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+    }
+
+    private void insertLog(long activityId, int rating) {
+        jdbcTemplate.update("""
+                INSERT INTO trip_activity_log (activity_id, rating, created_at, updated_at)
+                VALUES (?, ?, NOW(6), NOW(6))
+                """, activityId, rating);
     }
 
     private long insertMember(String username) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
@@ -8,6 +8,8 @@ public class DbCleaner {
 
     private static final String[] TABLES_IN_FK_ORDER = {
             "push_notification",
+            // FK_CHECKS=0이라 CASCADE가 안 돈다 — 자식 테이블을 직접 지워야 남지 않는다.
+            "trip_activity_log",
             "trip_activity",
             "trip",
             "travel_place",

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -49,7 +49,10 @@ public enum ErrorCode {
             "두 일정 사이의 이동시간을 계산할 수 없습니다.", 400),
     TRAVEL_FX_UNAVAILABLE("TRAVEL-ERR-010", "환율을 가져올 수 없습니다.", 503),
     TRAVEL_FX_UNSUPPORTED_CURRENCY("TRAVEL-ERR-011",
-            "지원하지 않는 통화입니다.", 400);
+            "지원하지 않는 통화입니다.", 400),
+    // 404가 아니다 — 일정은 실재하고, 아직 기록할 때가 아닐 뿐이다.
+    TRAVEL_LOG_BEFORE_TRIP("TRAVEL-ERR-012",
+            "여행이 시작된 뒤에 기록할 수 있습니다.", 400);
 
     private final String code;
     private final String message;

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TripActivityLog.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TripActivityLog.java
@@ -1,0 +1,123 @@
+package ds.project.orino.domain.planner.travel.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+/**
+ * 일정 1건에 대한 사후 기록 - 평점·메모(§S-07 기록 영역).
+ *
+ * <p><b>사진과 분리된 테이블이다.</b> 사진 업로드가 실패해도 평점·메모는 독립적으로
+ * 저장돼야 한다 - 여행 중 회선에서 사진 몇 장이 실패했다고 적어둔 감상이 같이 날아가면
+ * 다시 적을 마음이 들지 않는다.
+ *
+ * <p><b>평점은 null이 될 수 있다.</b> 잘못 누른 별을 되돌릴 방법이 없으면 별점은 함정이
+ * 된다. "안 매김"과 "1점"은 다른 값이다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "trip_activity_log")
+public class TripActivityLog {
+
+    /** 별 개수의 상한. 화면(별 5개)과 검증이 같은 값을 봐야 한다. */
+    public static final int MAX_RATING = 5;
+
+    public static final int MIN_RATING = 1;
+
+    /** 메모 길이 상한. 컬럼 길이와 같아야 한다 - 넘치면 DB가 잘라내지 않고 터진다. */
+    public static final int MAX_MEMO_LENGTH = 2000;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 일정당 최대 1건(UNIQUE). 일정이 지워지면 기록도 함께 사라진다(FK CASCADE). */
+    @Column(name = "activity_id", nullable = false, unique = true)
+    private Long activityId;
+
+    @Column(length = MAX_MEMO_LENGTH)
+    private String memo;
+
+    /**
+     * 1~5. null이면 아직 매기지 않았거나 해제한 것이다.
+     *
+     * <p>컬럼은 {@code TINYINT}인데 {@code Integer}의 기본 매핑은 {@code INTEGER}라
+     * {@code ddl-auto: validate}가 타입 불일치로 컨텍스트를 통째로 못 띄운다. 필드를
+     * {@code Byte}로 바꾸면 호출부마다 캐스팅이 번지므로 매핑 쪽을 맞춘다.
+     */
+    @JdbcTypeCode(SqlTypes.TINYINT)
+    private Integer rating;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected TripActivityLog() {
+    }
+
+    public TripActivityLog(Long activityId, Integer rating, String memo) {
+        this.activityId = activityId;
+        update(rating, memo);
+    }
+
+    /**
+     * 평점·메모 덮어쓰기. 둘 다 null이 될 수 있다 - 별을 해제하거나 메모를 지우는 것도
+     * 정당한 입력이라 "빈 값이면 무시"하면 지울 방법이 사라진다.
+     */
+    public void update(Integer rating, String memo) {
+        this.rating = rating;
+        this.memo = blankToNull(memo);
+    }
+
+    /**
+     * 아무것도 남지 않은 기록인지. 별을 해제하고 메모까지 지우면 빈 행이 남는데,
+     * 그 상태로 두면 {@code hasLog}가 계속 true라 목록에 기록 표시가 남는다.
+     */
+    public boolean isEmpty() {
+        return rating == null && memo == null;
+    }
+
+    /** 공백만 남은 메모는 없는 것과 같다 - 저장해두면 빈 기록이 있는 것처럼 보인다. */
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getActivityId() {
+        return activityId;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    public Integer getRating() {
+        return rating;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripActivityLogRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripActivityLogRepository.java
@@ -1,0 +1,19 @@
+package ds.project.orino.domain.planner.travel.repository;
+
+import ds.project.orino.domain.planner.travel.entity.TripActivityLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/** 일정 사후 기록. 일정당 최대 1건이라 조회는 항상 단건이다. */
+public interface TripActivityLogRepository extends JpaRepository<TripActivityLog, Long> {
+
+    Optional<TripActivityLog> findByActivityId(Long activityId);
+
+    /**
+     * 여러 일정의 기록을 한 번에 읽는다 — 보드는 일정 수만큼 행을 그리는데 기록을 건건이
+     * 조회하면 그대로 N+1이 된다.
+     */
+    List<TripActivityLog> findAllByActivityIdIn(List<Long> activityIds);
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/entity/TripActivityLogTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/entity/TripActivityLogTest.java
@@ -1,0 +1,47 @@
+package ds.project.orino.domain.planner.travel.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TripActivityLogTest {
+
+    @Test
+    @DisplayName("공백만 남은 메모는 없는 것과 같다 — 저장해두면 빈 기록이 있는 것처럼 보인다")
+    void blankMemoBecomesNull() {
+        TripActivityLog log = new TripActivityLog(1L, 4, "   ");
+
+        assertThat(log.getMemo()).isNull();
+    }
+
+    @Test
+    @DisplayName("평점을 null로 덮어쓸 수 있다 — 잘못 누른 별을 되돌릴 방법이 있어야 한다")
+    void ratingCanBeCleared() {
+        TripActivityLog log = new TripActivityLog(1L, 5, "좋았다");
+
+        log.update(null, "좋았다");
+
+        assertThat(log.getRating()).isNull();
+        assertThat(log.getMemo()).isEqualTo("좋았다");
+    }
+
+    @Test
+    @DisplayName("평점도 메모도 없으면 빈 기록이다")
+    void emptyWhenNothingLeft() {
+        TripActivityLog log = new TripActivityLog(1L, 3, "적어둔다");
+
+        assertThat(log.isEmpty()).isFalse();
+
+        log.update(null, "");
+
+        assertThat(log.isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("둘 중 하나만 있어도 빈 기록이 아니다")
+    void notEmptyWithEitherValue() {
+        assertThat(new TripActivityLog(1L, 1, null).isEmpty()).isFalse();
+        assertThat(new TripActivityLog(1L, null, "메모만").isEmpty()).isFalse();
+    }
+}

--- a/fe/src/features/travel/api/activities.ts
+++ b/fe/src/features/travel/api/activities.ts
@@ -16,6 +16,14 @@ export interface ActivityPlace {
   lng: number | null;
 }
 
+/** 일정의 사후 기록(§S-07 기록 영역). 사진은 별도 리소스다. */
+export interface ActivityLog {
+  /** 1~5. null이면 아직 매기지 않았거나 해제한 것이다. */
+  rating: number | null;
+  memo: string | null;
+  updatedAt: string;
+}
+
 export interface Activity {
   id: number;
   tripId: number;
@@ -31,7 +39,8 @@ export interface Activity {
   notifyMinutes: number | null;
   departureNotifyEnabled: boolean;
   sortOrder: number;
-  /** 사후 기록(평점·메모) 존재 여부. 기록은 4단계라 지금은 항상 false. */
+  /** 아직 기록이 없으면 null. */
+  log: ActivityLog | null;
   hasLog: boolean;
 }
 
@@ -146,6 +155,28 @@ export async function updateActivity(
 
 export async function deleteActivity(activityId: number): Promise<void> {
   await client.delete(`/travel/activities/${activityId}`);
+}
+
+export interface ActivityLogRequest {
+  rating: number | null;
+  memo: string | null;
+}
+
+/**
+ * 기록(평점·메모) 저장. 사진과 분리된 요청이라 사진 업로드가 실패해도 이건 남는다.
+ *
+ * <p>둘 다 비우면 서버가 기록을 지우고 null을 돌려준다 — "다 지웠다"와 "빈 기록이 있다"는
+ * 다른 상태다.
+ */
+export async function saveActivityLog(
+  activityId: number,
+  body: ActivityLogRequest,
+): Promise<ActivityLog | null> {
+  const { data } = await client.put<ApiEnvelope<ActivityLog | null>>(
+    `/travel/activities/${activityId}/log`,
+    body,
+  );
+  return data.data ?? null;
 }
 
 /**

--- a/fe/src/features/travel/map/toMapped.test.ts
+++ b/fe/src/features/travel/map/toMapped.test.ts
@@ -18,6 +18,7 @@ function activity(id: number, place: Activity["place"] = null): Activity {
     notifyMinutes: null,
     departureNotifyEnabled: false,
     sortOrder: id,
+    log: null,
     hasLog: false,
   };
 }

--- a/fe/src/features/travel/record/RecordSection.tsx
+++ b/fe/src/features/travel/record/RecordSection.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+
+import { Textarea } from "@/components/ui/textarea";
+import type { ActivityLog } from "@/features/travel/api/activities";
+import { StarRating } from "@/features/travel/record/StarRating";
+import { useAutoSaveLog } from "@/features/travel/record/useAutoSaveLog";
+
+/** 서버 컬럼 길이와 같다. 넘치면 저장이 400으로 튕긴다. */
+const RECORD_MEMO_MAX = 2000;
+
+interface RecordSectionProps {
+  activityId: number;
+  tripId: number;
+  log: ActivityLog | null;
+  /** 오프라인이면 저장할 수 없다(§S-07). */
+  online: boolean;
+}
+
+/**
+ * S-07 <b>기록 영역</b> — 평점·메모.
+ *
+ * <p><b>여행이 시작된 뒤에만 이 영역이 존재한다.</b> 호출부가 그 판단을 하고, 여기서는
+ * 항상 그려진다 — 아직 겪지 않은 일에 평점을 매기는 화면은 만들지 않는다.
+ *
+ * <p>저장은 자동이다. 현지에서 "저장" 버튼을 찾게 하지 않는다. 계획 영역과 요청이
+ * 분리돼 있어 계획을 저장하지 않아도 기록만 남는다.
+ */
+export function RecordSection({
+  activityId,
+  tripId,
+  log,
+  online,
+}: RecordSectionProps) {
+  const [rating, setRating] = useState<number | null>(log?.rating ?? null);
+  const [memo, setMemo] = useState(log?.memo ?? "");
+  const { status, schedule, flush } = useAutoSaveLog(activityId, tripId);
+
+  // 다른 일정으로 넘어가면 그 일정의 기록을 보여준다.
+  useEffect(() => {
+    setRating(log?.rating ?? null);
+    setMemo(log?.memo ?? "");
+  }, [activityId, log?.rating, log?.memo]);
+
+  const change = (nextRating: number | null, nextMemo: string) => {
+    setRating(nextRating);
+    setMemo(nextMemo);
+    schedule({ rating: nextRating, memo: nextMemo.trim() || null });
+  };
+
+  return (
+    <section className="flex flex-col gap-3 border-t pt-5">
+      <div className="flex items-center gap-2">
+        <h2 className="text-caption text-muted-foreground flex-1 font-semibold">
+          기록
+        </h2>
+        {/* 자동 저장이라 저장 여부가 눈에 보여야 한다. */}
+        <span className="text-muted-foreground text-xs" aria-live="polite">
+          {!online
+            ? "오프라인"
+            : status === "saving"
+              ? "저장 중…"
+              : status === "saved"
+                ? "저장됨"
+                : status === "error"
+                  ? "저장 실패"
+                  : ""}
+        </span>
+      </div>
+
+      <StarRating
+        value={rating}
+        onChange={(next) => change(next, memo)}
+        disabled={!online}
+      />
+
+      <Textarea
+        aria-label="기록 메모"
+        rows={4}
+        value={memo}
+        placeholder="어땠나요?"
+        maxLength={RECORD_MEMO_MAX}
+        disabled={!online}
+        onChange={(e) => change(rating, e.target.value)}
+        // 포커스를 잃으면 디바운스를 기다리지 않는다 — 다 쓴 뒤 화면을 닫는 게 흔하다.
+        onBlur={flush}
+      />
+    </section>
+  );
+}

--- a/fe/src/features/travel/record/StarRating.tsx
+++ b/fe/src/features/travel/record/StarRating.tsx
@@ -1,0 +1,45 @@
+import { Star } from "lucide-react";
+
+/** 별 5개(§S-07). 서버 검증(1~5)과 같은 값이다. */
+export const MAX_RATING = 5;
+
+interface StarRatingProps {
+  /** null이면 아직 매기지 않은 것이다. 0이 아니다 — 0점 평가는 없다. */
+  value: number | null;
+  onChange: (value: number | null) => void;
+  disabled?: boolean;
+}
+
+/**
+ * 별점.
+ *
+ * <p><b>누른 별을 다시 누르면 해제된다.</b> 되돌릴 방법이 없으면 별점은 함정이 된다 —
+ * 잘못 눌러 1점이 박힌 일정을 "안 매김"으로 되돌릴 길이 있어야 한다.
+ */
+export function StarRating({ value, onChange, disabled }: StarRatingProps) {
+  return (
+    <div className="flex items-center gap-0.5" role="group" aria-label="평점">
+      {Array.from({ length: MAX_RATING }, (_, i) => i + 1).map((star) => {
+        const filled = value !== null && star <= value;
+        return (
+          <button
+            key={star}
+            type="button"
+            disabled={disabled}
+            // 같은 별을 다시 누르면 해제.
+            onClick={() => onChange(value === star ? null : star)}
+            aria-label={`${star}점`}
+            aria-pressed={filled}
+            className="disabled:opacity-50"
+          >
+            <Star
+              className={`size-7 ${
+                filled ? "fill-warning text-warning" : "text-muted-foreground"
+              }`}
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/fe/src/features/travel/record/useAutoSaveLog.ts
+++ b/fe/src/features/travel/record/useAutoSaveLog.ts
@@ -1,0 +1,102 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  type ActivityLog,
+  type ActivityLogRequest,
+  saveActivityLog,
+} from "@/features/travel/api/activities";
+import { travelKeys } from "@/features/travel/queryKeys";
+
+export type LogSaveStatus = "idle" | "saving" | "saved" | "error";
+
+/**
+ * 여행 중에 "저장" 버튼을 찾게 하지 않는다. 짧게 잡으면 한 글자마다 요청이 나가고,
+ * 길게 잡으면 화면을 닫을 때 놓친다.
+ */
+const DEBOUNCE_MS = 1000;
+
+interface UseAutoSaveLogResult {
+  status: LogSaveStatus;
+  schedule: (patch: ActivityLogRequest) => void;
+  /** 화면을 떠나기 전에 대기 중인 저장을 즉시 보낸다. */
+  flush: () => void;
+}
+
+/**
+ * 기록(평점·메모) 자동 저장.
+ *
+ * <p><b>보류 중인 값을 ref로 들고 언마운트에서 flush한다.</b> 뒤로 가기가 디바운스보다
+ * 빠른 게 정상이라, 타이머에만 기대면 방금 누른 별이 조용히 사라진다.
+ */
+export function useAutoSaveLog(
+  activityId: number,
+  tripId: number | null,
+): UseAutoSaveLogResult {
+  const queryClient = useQueryClient();
+  const [status, setStatus] = useState<LogSaveStatus>("idle");
+  const pendingRef = useRef<ActivityLogRequest | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 최신 값을 ref로도 들고 있어야 언마운트 클린업이 옛 클로저를 보지 않는다.
+  const contextRef = useRef({ activityId, tripId, queryClient });
+  contextRef.current = { activityId, tripId, queryClient };
+
+  const send = useCallback(async (body: ActivityLogRequest) => {
+    const {
+      activityId: id,
+      tripId: trip,
+      queryClient: qc,
+    } = contextRef.current;
+    setStatus("saving");
+    try {
+      const log: ActivityLog | null = await saveActivityLog(id, body);
+      // 상세 캐시를 직접 갱신한다 — 재조회하면 방금 친 글자가 서버 값으로 덮인다.
+      qc.setQueryData(travelKeys.activity(id), (prev: unknown) =>
+        prev ? { ...prev, log, hasLog: log !== null } : prev,
+      );
+      // 보드는 기록 표시를 쓰므로 다음 조회 때 새로 받게 둔다.
+      if (trip !== null) {
+        void qc.invalidateQueries({ queryKey: travelKeys.boards(trip) });
+      }
+      setStatus("saved");
+    } catch {
+      setStatus("error");
+    }
+  }, []);
+
+  const fire = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    const pending = pendingRef.current;
+    pendingRef.current = null;
+    if (pending) void send(pending);
+  }, [send]);
+
+  const schedule = useCallback(
+    (patch: ActivityLogRequest) => {
+      pendingRef.current = patch;
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(fire, DEBOUNCE_MS);
+    },
+    [fire],
+  );
+
+  // 화면을 떠날 때 대기 중인 값을 보낸다. 타이머만 끄면 그 입력은 사라진다.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      const pending = pendingRef.current;
+      pendingRef.current = null;
+      if (pending) {
+        const { activityId: id } = contextRef.current;
+        void saveActivityLog(id, pending).catch(() => {
+          // 화면이 이미 사라진 뒤라 알릴 곳이 없다. 다음 진입에서 서버 값이 보인다.
+        });
+      }
+    };
+  }, []);
+
+  return { status, schedule, flush: fire };
+}

--- a/fe/src/pages/travel/ActivityDetailPage.test.tsx
+++ b/fe/src/pages/travel/ActivityDetailPage.test.tsx
@@ -46,6 +46,7 @@ function activity(overrides: Record<string, unknown> = {}) {
     notifyMinutes: null,
     departureNotifyEnabled: false,
     sortOrder: 0,
+    log: null,
     hasLog: false,
     ...overrides,
   };

--- a/fe/src/pages/travel/ActivityDetailPage.tsx
+++ b/fe/src/pages/travel/ActivityDetailPage.tsx
@@ -40,6 +40,7 @@ import {
   toWallClockTime,
 } from "@/features/travel/lib/tripClock";
 import { dayChips, formatShortDate } from "@/features/travel/lib/tripStatus";
+import { RecordSection } from "@/features/travel/record/RecordSection";
 import { toast } from "@/shared/lib/toast";
 import { useOnline } from "@/shared/lib/useOnline";
 
@@ -70,13 +71,13 @@ interface FormState {
 }
 
 /**
- * S-07 일정 상세·편집의 <b>계획 영역</b>.
+ * S-07 일정 상세·편집.
  *
- * <p>알림 영역은 3단계, 기록 영역은 4단계다. 자리를 비워 두지 않고 아예 렌더하지 않는다 —
- * 빈 껍데기는 "고장난 화면"으로 읽힌다.
+ * <p>계획·알림 영역은 <b>명시적 저장</b>이다(자동 저장 아님). 날짜·시각을 고치는 도중의
+ * 중간 상태가 그대로 저장되면 보드의 순서와 알림이 사용자가 의도하지 않은 시점에 흔들린다.
  *
- * <p>저장은 명시적이다(자동 저장 아님). 날짜·시각을 고치는 도중의 중간 상태가 그대로
- * 저장되면 보드의 순서와 알림이 사용자가 의도하지 않은 시점에 흔들린다.
+ * <p>기록 영역은 반대로 <b>자동 저장</b>이고 form 밖에 있다 — 현지에서 저장 버튼을 찾게
+ * 하지 않고, 계획을 저장하지 않아도 기록만 남아야 한다. 여행 시작 전에는 아예 없다.
  */
 export function ActivityDetailPage() {
   const { activityId: activityIdParam } = useParams();
@@ -107,6 +108,9 @@ export function ActivityDetailPage() {
     );
   }
 
+  // 기록은 여행 시작일부터다. 상태는 서버가 여행 타임존으로 판정해 내려준 값이라
+  // 기기 시간대로 다시 계산하지 않는다 — 저장 거부 규칙과 같은 기준이어야 한다.
+  const tripStarted = trip !== undefined && trip.status !== "UPCOMING";
   const mapsUrl = activity.place ? placeDirectionsUrl(activity.place) : null;
   const openingToday = todayOpeningHours(placeDetail?.openingHours ?? null);
 
@@ -404,6 +408,20 @@ export function ActivityDetailPage() {
           </Button>
         </div>
       </form>
+
+      {/*
+        기록 영역(§S-07)은 여행 시작일 이후에만 존재한다 — 아직 겪지 않은 일에 평점을
+        매길 수 없다. 계획 form 밖에 둔 것은 저장 경로가 다르기 때문이다(자동 저장,
+        사진과도 분리된 요청). 안에 두면 Enter 한 번이 계획까지 저장한다.
+      */}
+      {tripStarted && (
+        <RecordSection
+          activityId={activityId}
+          tripId={activity.tripId}
+          log={activity.log}
+          online={online}
+        />
+      )}
     </div>
   );
 }

--- a/fe/src/pages/travel/ActivityRecord.test.tsx
+++ b/fe/src/pages/travel/ActivityRecord.test.tsx
@@ -1,0 +1,228 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { AppRouter } from "@/app/router";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+const API_BASE = "https://api.orino.dev/api";
+
+/** 디바운스(1초)보다 넉넉히 기다린다. */
+const SAVE_TIMEOUT = 4000;
+
+function trip(status = "ONGOING") {
+  return {
+    id: 3,
+    title: "도쿄 3박 4일",
+    destinationName: "도쿄",
+    destinationPlaceId: null,
+    startDate: "2026-08-06",
+    endDate: "2026-08-10",
+    timezone: "Asia/Tokyo",
+    currency: "JPY",
+    lat: null,
+    lng: null,
+    defaultNotifyMinutes: 15,
+    morningSummaryEnabled: false,
+    status,
+    dDay: 0,
+    totalDays: 5,
+    activityCount: 1,
+  };
+}
+
+function activity(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    tripId: 3,
+    title: "센소지",
+    activityDate: "2026-08-08",
+    startTime: "09:00",
+    place: null,
+    memo: null,
+    url: null,
+    notifyEnabled: false,
+    notifyMinutes: null,
+    departureNotifyEnabled: false,
+    sortOrder: 0,
+    log: null,
+    hasLog: false,
+    ...overrides,
+  };
+}
+
+function mock({
+  status = "ONGOING",
+  ...activityOverrides
+}: Record<string, unknown> = {}) {
+  server.use(
+    http.get(`${API_BASE}/travel/activities/:id`, () =>
+      HttpResponse.json({ code: "OK", data: activity(activityOverrides) }),
+    ),
+    http.get(`${API_BASE}/travel/trips/:tripId`, () =>
+      HttpResponse.json({ code: "OK", data: trip(status as string) }),
+    ),
+  );
+}
+
+/** 기록 저장 요청 본문을 잡아 둔다. */
+function captureLogSave() {
+  const seen: Record<string, unknown>[] = [];
+  server.use(
+    http.put(`${API_BASE}/travel/activities/:id/log`, async ({ request }) => {
+      const body = (await request.json()) as Record<string, unknown>;
+      seen.push(body);
+      const empty = body.rating === null && !body.memo;
+      return HttpResponse.json({
+        code: "OK",
+        data: empty ? null : { ...body, updatedAt: "2026-08-08T10:00:00Z" },
+      });
+    }),
+  );
+  return seen;
+}
+
+function renderDetail() {
+  return renderWithRouter(
+    <Providers>
+      <AppRouter />
+    </Providers>,
+    { initialEntries: ["/travel/activities/1"] },
+  );
+}
+
+describe("일정 기록 영역", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "valid-token" });
+    mock();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("노출 조건", () => {
+    it("여행이 시작된 뒤에만 보인다 — 겪지 않은 일에 평점을 매길 수 없다", async () => {
+      mock({ status: "UPCOMING" });
+      renderDetail();
+
+      await screen.findByRole("heading", { name: "센소지" });
+
+      expect(screen.queryByRole("group", { name: "평점" })).toBeNull();
+    });
+
+    it("여행이 끝난 뒤에도 보인다 — 기록은 돌아와서 적는 게 보통이다", async () => {
+      mock({ status: "COMPLETED" });
+      renderDetail();
+
+      expect(
+        await screen.findByRole("group", { name: "평점" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("평점", () => {
+    it("별을 누르면 그 점수로 저장한다", async () => {
+      const saved = captureLogSave();
+      const user = userEvent.setup();
+      renderDetail();
+
+      await user.click(await screen.findByRole("button", { name: "4점" }));
+
+      await waitFor(
+        () => expect(saved).toContainEqual({ rating: 4, memo: null }),
+        { timeout: SAVE_TIMEOUT },
+      );
+    });
+
+    it("같은 별을 다시 누르면 해제된다 — 잘못 누른 별을 되돌릴 수 있어야 한다", async () => {
+      const saved = captureLogSave();
+      const user = userEvent.setup();
+      mock({
+        log: { rating: 3, memo: null, updatedAt: "2026-08-08T09:00:00Z" },
+      });
+      renderDetail();
+
+      const third = await screen.findByRole("button", { name: "3점" });
+      expect(third).toHaveAttribute("aria-pressed", "true");
+
+      await user.click(third);
+
+      expect(third).toHaveAttribute("aria-pressed", "false");
+      await waitFor(
+        () => expect(saved).toContainEqual({ rating: null, memo: null }),
+        { timeout: SAVE_TIMEOUT },
+      );
+    });
+
+    it("기존 기록을 그대로 보여준다", async () => {
+      mock({
+        log: {
+          rating: 5,
+          memo: "야경이 좋았다",
+          updatedAt: "2026-08-08T09:00:00Z",
+        },
+        hasLog: true,
+      });
+      renderDetail();
+
+      expect(await screen.findByLabelText("기록 메모")).toHaveValue(
+        "야경이 좋았다",
+      );
+      expect(screen.getByRole("button", { name: "5점" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+  });
+
+  describe("메모", () => {
+    it("타이핑이 멎으면 한 번만 저장한다 — 글자마다 요청하지 않는다", async () => {
+      const saved = captureLogSave();
+      const user = userEvent.setup();
+      renderDetail();
+
+      await user.type(await screen.findByLabelText("기록 메모"), "좋았다");
+
+      await waitFor(
+        () => expect(saved).toContainEqual({ rating: null, memo: "좋았다" }),
+        { timeout: SAVE_TIMEOUT },
+      );
+      expect(saved).toHaveLength(1);
+    });
+
+    it("계획 저장과 별개다 — 계획을 저장하지 않아도 기록만 남는다", async () => {
+      const planSaves: unknown[] = [];
+      server.use(
+        http.put(`${API_BASE}/travel/activities/:id`, async ({ request }) => {
+          planSaves.push(await request.json());
+          return HttpResponse.json({ code: "OK", data: activity() });
+        }),
+      );
+      const saved = captureLogSave();
+      const user = userEvent.setup();
+      renderDetail();
+
+      await user.click(await screen.findByRole("button", { name: "2점" }));
+
+      await waitFor(() => expect(saved).toHaveLength(1), {
+        timeout: SAVE_TIMEOUT,
+      });
+      expect(planSaves).toHaveLength(0);
+    });
+  });
+
+  describe("오프라인", () => {
+    it("입력을 막는다 — 저장할 수 없는 칸을 열어두지 않는다", async () => {
+      vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+      renderDetail();
+
+      expect(await screen.findByLabelText("기록 메모")).toBeDisabled();
+      expect(screen.getByRole("button", { name: "3점" })).toBeDisabled();
+    });
+  });
+});

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -63,6 +63,7 @@ function activity(overrides: Record<string, unknown> = {}) {
     notifyMinutes: null,
     departureNotifyEnabled: false,
     sortOrder: 0,
+    log: null,
     hasLog: false,
     ...overrides,
   };

--- a/fe/src/pages/travel/TripMapPage.test.tsx
+++ b/fe/src/pages/travel/TripMapPage.test.tsx
@@ -42,6 +42,7 @@ function activity(overrides: Record<string, unknown> = {}) {
     notifyMinutes: null,
     departureNotifyEnabled: false,
     sortOrder: 0,
+    log: null,
     hasLog: false,
     ...overrides,
   };


### PR DESCRIPTION
## 이슈
closes #1090
## 작업 내용

일정 상세에 **기록 영역**(평점·메모)을 붙였다. `ActivityResponse.hasLog`가 3단계 내내 `false` 고정이었는데, 그 자리를 채운다. **사진은 다음 이슈**다 — 데이터 모델이 `trip_activity_log`와 `trip_activity_photo`를 분리해 둔 이유가 사진 업로드 실패로 평점·메모까지 날아가지 않게 하려는 것이라, 요청도 테이블도 분리된 채로 둔다.

### BE
- `trip_activity_log` 마이그레이션(`050`) · 엔티티 · Repository
  - `activity_id` UNIQUE — 일정당 1건. 없으면 저장 재시도가 중복 행을 만든다
  - FK CASCADE — 일정을 지우면 기록도 사라진다
- `PUT /api/travel/activities/{id}/log` — 평점·메모 upsert
  - **여행 시작 전이면 `TRAVEL-ERR-012`(400)**. 404가 아닌 이유는 일정이 실재하기 때문이다. 판정 기준은 여행 타임존의 오늘
  - `rating` 1~5(null 허용), `memo` 2000자. 공백만 남은 메모는 null로 저장
  - **둘 다 비면 행을 지우고 `data: null`**. 빈 행을 남기면 `hasLog`가 계속 참이라 목록에 기록 표시가 남는데 사용자가 보기엔 다 지운 상태다
- `ActivityResponse.log` 추가, `hasLog`를 `log != null`로 실제 계산
  - **보드 목록에도 `log`를 통째로 싣는다.** 보드 응답이 곧 오프라인 캐시라 `hasLog`만 내려주면 비행기 모드에서 "기록 있음"만 뜨고 내용은 못 본다. 기록은 일정 목록 조회 한 번(`findAllByActivityIdIn`)으로 붙여 N+1을 피한다

### FE
- 별 5개 + 메모. **누른 별을 다시 누르면 해제** — 되돌릴 방법이 없으면 별점은 함정이 된다
- **자동 저장**(1초 디바운스). 현지에서 저장 버튼을 찾게 하지 않는다
  - 언마운트에서 대기 중인 값을 flush한다. 뒤로 가기가 디바운스보다 빠른 게 정상이라, 타이머에만 기대면 방금 누른 별이 조용히 사라진다
  - 저장 후 상세 캐시를 직접 갱신한다(재조회하면 방금 친 글자가 서버 값으로 덮인다), 보드는 invalidate
- **계획 form 밖**에 둔다 — 저장 경로가 다르고, 안에 두면 Enter 한 번이 계획까지 저장한다
- 여행 시작 전에는 영역 자체가 없다(`trip.status !== "UPCOMING"`). 오프라인이면 비활성

### 딸려온 수정
- `DbCleaner`에 `trip_activity_log` 추가. `FOREIGN_KEY_CHECKS=0`이라 CASCADE가 안 돌아 기록 행이 테스트 사이에 남았다 — 실제로 upsert 테스트가 이것 때문에 깨졌다
- `rating`이 `TINYINT`인데 `Integer` 기본 매핑은 `INTEGER`라 `ddl-auto: validate`가 컨텍스트를 통째로 못 띄웠다. `@JdbcTypeCode(SqlTypes.TINYINT)`로 해결(`BIT(1)` 불리언과 같은 부류)

### 테스트
- BE 통합 10건(저장·덮어쓰기·별만 해제·전부 비우면 삭제·시작 전 400·범위 초과 400·남의 일정 404·상세/보드에 실림·없으면 null)
- BE 스키마 2건(일정 삭제 시 CASCADE, `activity_id` UNIQUE), 엔티티 단위 4건
- FE 통합 8건(노출 조건 3상태, 별 저장·해제, 기존 기록 표시, 디바운스 1회 저장, 계획 저장과 분리, 오프라인 비활성)
- 게이트 통과: `./gradlew check` · FE `format:check`·`lint`·`test`(828 passed)·`build`

### 로컬 확인
BE + FE 띄우고 진행 중 여행(오늘~+3일)과 예정 여행(+60일)으로 확인
- 예정 여행 일정: 기록 영역이 아예 없고, API로 직접 찌르면 `TRAVEL-ERR-012`
- 진행 중 여행: 별 4개 + 메모 → "저장됨", 서버에 `{rating: 4, memo: "비 왔지만 좋았다"}` 저장 확인
- 같은 별 다시 클릭 → 별만 해제되고 메모는 남음(`{rating: null, memo: "비 왔지만 좋았다"}`)
- 전부 비우면 `hasLog: false`로 돌아감
- 보드 목록에 `log`가 실리고 행에 기록 표시(⭐)가 뜸
