### PR TITLE
feat : 일정 기록 사진 업로드

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityLogResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityLogResponse.java
@@ -1,22 +1,27 @@
 package ds.project.orino.planner.travel.activity.dto;
 
 import ds.project.orino.domain.planner.travel.entity.TripActivityLog;
+import ds.project.orino.planner.travel.photo.dto.PhotoResponse;
 
 import java.time.Instant;
+import java.util.List;
 
 /**
  * 일정의 사후 기록. 기록이 없으면 이 객체 자체가 null이다 — 빈 값으로 채운 껍데기를
  * 내려주면 화면이 "기록 있음"과 "아직 없음"을 구분하지 못한다.
  *
+ * @param photos    업로드 순서대로. 사진이 없으면 빈 배열이다(null 아님)
  * @param updatedAt 자동 저장이라 언제 저장됐는지 화면이 보여줄 수 있어야 한다
  */
 public record ActivityLogResponse(
         Integer rating,
         String memo,
+        List<PhotoResponse> photos,
         Instant updatedAt
 ) {
 
-    public static ActivityLogResponse from(TripActivityLog log) {
-        return new ActivityLogResponse(log.getRating(), log.getMemo(), log.getUpdatedAt());
+    public static ActivityLogResponse from(TripActivityLog log, List<PhotoResponse> photos) {
+        return new ActivityLogResponse(log.getRating(), log.getMemo(),
+                photos == null ? List.of() : photos, log.getUpdatedAt());
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
@@ -8,6 +8,7 @@ import ds.project.orino.domain.planner.travel.entity.TripActivity;
 import ds.project.orino.domain.planner.travel.entity.TripActivityLog;
 import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
 import ds.project.orino.domain.planner.travel.repository.TripActivityLogRepository;
+import ds.project.orino.domain.planner.travel.repository.TripActivityPhotoRepository;
 import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
 import ds.project.orino.domain.planner.travel.repository.TripRepository;
 import ds.project.orino.planner.travel.activity.dto.ActivityLogRequest;
@@ -16,6 +17,8 @@ import ds.project.orino.planner.travel.activity.dto.ActivityPlace;
 import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
 import ds.project.orino.planner.travel.activity.dto.ActivityWriteRequest;
 import ds.project.orino.planner.travel.activity.dto.ReorderRequest;
+import ds.project.orino.planner.travel.photo.dto.PhotoResponse;
+import ds.project.orino.planner.travel.photo.service.TravelPhotoService;
 import ds.project.orino.planner.travel.push.service.NotificationScheduleService;
 import ds.project.orino.planner.travel.route.dto.LegResponse;
 import ds.project.orino.planner.travel.route.service.LegService;
@@ -54,6 +57,8 @@ public class ActivityService {
 
     private final TripActivityRepository activityRepository;
     private final TripActivityLogRepository logRepository;
+    private final TripActivityPhotoRepository photoRepository;
+    private final TravelPhotoService photoService;
     private final TripRepository tripRepository;
     private final TravelPlaceRepository placeRepository;
     private final PlaceService placeService;
@@ -63,6 +68,8 @@ public class ActivityService {
 
     public ActivityService(TripActivityRepository activityRepository,
                            TripActivityLogRepository logRepository,
+                           TripActivityPhotoRepository photoRepository,
+                           TravelPhotoService photoService,
                            TripRepository tripRepository,
                            TravelPlaceRepository placeRepository,
                            PlaceService placeService,
@@ -71,6 +78,8 @@ public class ActivityService {
                            Clock clock) {
         this.activityRepository = activityRepository;
         this.logRepository = logRepository;
+        this.photoRepository = photoRepository;
+        this.photoService = photoService;
         this.tripRepository = tripRepository;
         this.placeRepository = placeRepository;
         this.placeService = placeService;
@@ -231,13 +240,17 @@ public class ActivityService {
                 .orElseGet(() -> new TripActivityLog(activityId, null, null));
         log.update(request.rating(), request.memo());
 
-        if (log.isEmpty()) {
+        // 사진이 붙어 있으면 비어 있지 않다 — 지우면 FK CASCADE로 사진까지 날아간다.
+        boolean hasPhotos = log.getId() != null
+                && photoRepository.countByLogId(log.getId()) > 0;
+        if (log.isEmpty() && !hasPhotos) {
             if (log.getId() != null) {
                 logRepository.delete(log);
             }
             return null;
         }
-        return ActivityLogResponse.from(logRepository.save(log));
+        TripActivityLog saved = logRepository.save(log);
+        return ActivityLogResponse.from(saved, photoService.photosOf(saved.getId()));
     }
 
     // ---------------- helpers ----------------
@@ -327,7 +340,9 @@ public class ActivityService {
     private ActivityResponse toResponse(TripActivity activity) {
         return ActivityResponse.of(activity, placeOf(activity.getPlaceId()),
                 logRepository.findByActivityId(activity.getId())
-                        .map(ActivityLogResponse::from).orElse(null));
+                        .map(log -> ActivityLogResponse.from(log,
+                                photoService.photosOf(log.getId())))
+                        .orElse(null));
     }
 
     private ActivityPlace placeOf(Long placeId) {
@@ -370,8 +385,14 @@ public class ActivityService {
             return Map.of();
         }
         List<Long> ids = activities.stream().map(TripActivity::getId).toList();
-        return logRepository.findAllByActivityIdIn(ids).stream()
+        List<TripActivityLog> logs = logRepository.findAllByActivityIdIn(ids);
+        // 사진도 한 번에 읽는다 — 기록마다 조회하면 N+1이 한 겹 더 생긴다.
+        Map<Long, List<PhotoResponse>> photos = photoService.photosByLog(
+                logs.stream().map(TripActivityLog::getId).toList());
+
+        return logs.stream()
                 .collect(Collectors.toMap(TripActivityLog::getActivityId,
-                        ActivityLogResponse::from));
+                        log -> ActivityLogResponse.from(log,
+                                photos.getOrDefault(log.getId(), List.of()))));
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/controller/TravelPhotoController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/controller/TravelPhotoController.java
@@ -1,0 +1,64 @@
+package ds.project.orino.planner.travel.photo.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.travel.photo.dto.PhotoRegisterRequest;
+import ds.project.orino.planner.travel.photo.dto.PhotoResponse;
+import ds.project.orino.planner.travel.photo.dto.PhotoUploadUrlRequest;
+import ds.project.orino.planner.travel.photo.dto.PhotoUploadUrlResponse;
+import ds.project.orino.planner.travel.photo.service.TravelPhotoService;
+import ds.project.orino.planner.travel.photo.service.TravelPhotoStorageService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/travel")
+public class TravelPhotoController {
+
+    private final TravelPhotoService photoService;
+    private final TravelPhotoStorageService storageService;
+
+    public TravelPhotoController(TravelPhotoService photoService,
+                                 TravelPhotoStorageService storageService) {
+        this.photoService = photoService;
+        this.storageService = storageService;
+    }
+
+    /**
+     * presigned PUT URL 발급. 브라우저가 이 URL로 바이트를 직접 올린 뒤 {@code objectKey}를
+     * 메타 등록에 실어 보낸다.
+     */
+    @PostMapping("/activities/{activityId}/photos/upload-url")
+    public ApiResponse<PhotoUploadUrlResponse> createUploadUrl(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long activityId,
+            @Valid @RequestBody PhotoUploadUrlRequest request) {
+        // 남의 일정 경로에 올리거나, 시작 전이라 어차피 거부될 사진을 올리게 하지 않는다.
+        photoService.requireUploadable(memberId, activityId);
+        return ApiResponse.success(
+                storageService.createUploadUrl(activityId, request.contentType(), request.kind()));
+    }
+
+    /** 업로드가 끝난 사진의 메타 등록. 성공한 장만 담겨 온다. */
+    @PostMapping("/activities/{activityId}/photos")
+    public ApiResponse<List<PhotoResponse>> register(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long activityId,
+            @Valid @RequestBody PhotoRegisterRequest request) {
+        return ApiResponse.success(photoService.register(memberId, activityId, request));
+    }
+
+    @DeleteMapping("/photos/{photoId}")
+    public ApiResponse<Void> delete(@AuthenticationPrincipal Long memberId,
+                                    @PathVariable Long photoId) {
+        photoService.delete(memberId, photoId);
+        return ApiResponse.success();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/dto/PhotoRegisterRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/dto/PhotoRegisterRequest.java
@@ -1,0 +1,37 @@
+package ds.project.orino.planner.travel.photo.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * 업로드가 끝난 사진의 메타 등록.
+ *
+ * <p><b>성공한 파일만 보낸다.</b> 실패한 장은 FE가 재시도 목록에 남긴다 — 한 장이 실패했다고
+ * 이미 올라간 아홉 장을 버리게 하지 않는다(§2.5).
+ */
+public record PhotoRegisterRequest(
+
+        @NotEmpty
+        @Valid
+        List<Photo> photos
+) {
+
+    public record Photo(
+
+            @NotBlank
+            @Size(max = 512)
+            String objectKey,
+
+            /** 썸네일만 실패할 수 있다. null이면 화면이 원본을 줄여 쓴다. */
+            @Size(max = 512)
+            String thumbKey,
+
+            Integer width,
+            Integer height
+    ) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/dto/PhotoResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/dto/PhotoResponse.java
@@ -1,0 +1,23 @@
+package ds.project.orino.planner.travel.photo.dto;
+
+import ds.project.orino.domain.planner.travel.entity.TripActivityPhoto;
+
+/**
+ * 사진 한 장. <b>key가 아니라 URL을 내려준다</b> — 호스트 조립 규칙이 화면마다 흩어지면
+ * 환경이 바뀔 때 한 곳만 고쳐도 나머지가 깨진다.
+ *
+ * @param thumbUrl 썸네일이 없으면 null. 화면이 원본을 줄여 쓴다
+ */
+public record PhotoResponse(
+        Long id,
+        String url,
+        String thumbUrl,
+        Integer width,
+        Integer height
+) {
+
+    public static PhotoResponse of(TripActivityPhoto photo, String url, String thumbUrl) {
+        return new PhotoResponse(photo.getId(), url, thumbUrl,
+                photo.getWidth(), photo.getHeight());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/dto/PhotoUploadUrlRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/dto/PhotoUploadUrlRequest.java
@@ -1,0 +1,25 @@
+package ds.project.orino.planner.travel.photo.dto;
+
+import ds.project.orino.planner.lifelog.image.dto.ImageKind;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * 여행 사진 presigned 업로드 URL 발급 요청.
+ *
+ * <p>{@code image/jpeg}만 받는다 — FE가 canvas로 재인코딩해 EXIF를 떨군 결과가 JPEG이다(§1.6).
+ * 원본 형식을 그대로 허용하면 재인코딩을 건너뛴 파일이 위치정보를 달고 올라올 수 있다.
+ *
+ * @param kind 원본/썸네일. key prefix가 갈린다
+ */
+public record PhotoUploadUrlRequest(
+
+        @NotBlank
+        @Pattern(regexp = "image/jpeg", message = "지원하지 않는 이미지 형식입니다.")
+        String contentType,
+
+        @NotNull
+        ImageKind kind
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/dto/PhotoUploadUrlResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/dto/PhotoUploadUrlResponse.java
@@ -1,0 +1,15 @@
+package ds.project.orino.planner.travel.photo.dto;
+
+/**
+ * presigned 업로드 URL 발급 응답.
+ *
+ * @param uploadUrl 브라우저가 바이너리를 직접 PUT 할 presigned URL(만료 있음)
+ * @param publicUrl 업로드 후 보여줄 공개 URL
+ * @param objectKey 메타 등록(`POST /photos`)에 그대로 실어 보낼 key
+ */
+public record PhotoUploadUrlResponse(
+        String uploadUrl,
+        String publicUrl,
+        String objectKey
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/service/TravelPhotoService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/service/TravelPhotoService.java
@@ -1,0 +1,162 @@
+package ds.project.orino.planner.travel.photo.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import ds.project.orino.domain.planner.travel.entity.TripActivity;
+import ds.project.orino.domain.planner.travel.entity.TripActivityLog;
+import ds.project.orino.domain.planner.travel.entity.TripActivityPhoto;
+import ds.project.orino.domain.planner.travel.repository.TripActivityLogRepository;
+import ds.project.orino.domain.planner.travel.repository.TripActivityPhotoRepository;
+import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
+import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.photo.dto.PhotoRegisterRequest;
+import ds.project.orino.planner.travel.photo.dto.PhotoResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 기록 사진의 메타 등록·조회·삭제(§S-07).
+ *
+ * <p><b>바이트는 여기를 지나가지 않는다.</b> 브라우저가 presigned URL로 MinIO에 직접 올리고,
+ * 이 서비스는 끝난 것만 받아 적는다. 그래서 "업로드 실패"는 서버가 모르는 사건이고, FE가
+ * 성공한 장만 골라 보낸다.
+ *
+ * <p>사진은 일정이 아니라 <b>기록</b>({@link TripActivityLog})에 매달린다. 사진만 올리는
+ * 경우를 위해 기록이 없으면 빈 기록을 만든다 — 사진 열 장을 올렸는데 저장할 곳이 없다고
+ * 거절하는 것보다 낫다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class TravelPhotoService {
+
+    private final TripActivityRepository activityRepository;
+    private final TripActivityLogRepository logRepository;
+    private final TripActivityPhotoRepository photoRepository;
+    private final TripRepository tripRepository;
+    private final TravelPhotoStorageService storageService;
+    private final Clock clock;
+
+    public TravelPhotoService(TripActivityRepository activityRepository,
+                              TripActivityLogRepository logRepository,
+                              TripActivityPhotoRepository photoRepository,
+                              TripRepository tripRepository,
+                              TravelPhotoStorageService storageService,
+                              Clock clock) {
+        this.activityRepository = activityRepository;
+        this.logRepository = logRepository;
+        this.photoRepository = photoRepository;
+        this.tripRepository = tripRepository;
+        this.storageService = storageService;
+        this.clock = clock;
+    }
+
+    /**
+     * 업로드 URL 발급 전에도 소유권과 시작일을 본다 — 남의 일정 경로에 파일을 올릴 수 없어야
+     * 하고, 시작 전이라 등록이 거부될 사진을 굳이 올리게 하지도 않는다.
+     */
+    public void requireUploadable(Long memberId, Long activityId) {
+        requireTripStarted(getOwnedActivity(memberId, activityId));
+    }
+
+    @Transactional
+    public List<PhotoResponse> register(Long memberId, Long activityId,
+                                        PhotoRegisterRequest request) {
+        TripActivity activity = getOwnedActivity(memberId, activityId);
+        requireTripStarted(activity);
+        TripActivityLog log = logRepository.findByActivityId(activity.getId())
+                // 평점·메모 없이 사진만 올리는 경우. 빈 기록이지만 사진이 붙으므로 빈 게 아니다.
+                .orElseGet(() -> logRepository.save(
+                        new TripActivityLog(activity.getId(), null, null)));
+
+        long existing = photoRepository.countByLogId(log.getId());
+        if (existing + request.photos().size() > TripActivityPhoto.MAX_PHOTOS) {
+            throw new CustomException(ErrorCode.TRAVEL_PHOTO_LIMIT_EXCEEDED);
+        }
+
+        int order = photoRepository.nextSortOrder(log.getId());
+        for (PhotoRegisterRequest.Photo photo : request.photos()) {
+            photoRepository.save(new TripActivityPhoto(log.getId(), photo.objectKey(),
+                    photo.thumbKey(), photo.width(), photo.height(), order++));
+        }
+        return photosOf(log.getId());
+    }
+
+    /**
+     * 사진 행을 지우고 오브젝트도 지운다.
+     *
+     * <p>오브젝트 삭제는 best-effort다 — 실패해도 행은 지운다. 반대로 하면 화면에서 지운
+     * 사진이 새로고침에 되살아난다.
+     */
+    @Transactional
+    public void delete(Long memberId, Long photoId) {
+        TripActivityPhoto photo = photoRepository.findById(photoId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PHOTO_NOT_FOUND));
+        TripActivityLog log = logRepository.findById(photo.getLogId())
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PHOTO_NOT_FOUND));
+        // 남의 사진도 404다 — 403이면 그 id의 사진이 존재한다는 사실이 새어나간다.
+        getOwnedActivity(memberId, log.getActivityId());
+
+        photoRepository.delete(photo);
+        storageService.deleteObjects(List.of(
+                photo.getObjectKey(),
+                photo.getThumbKey() == null ? "" : photo.getThumbKey()));
+    }
+
+    /** 한 기록의 사진. 업로드 순서 그대로다. */
+    public List<PhotoResponse> photosOf(Long logId) {
+        return toResponses(photoRepository.findAllByLogIdOrderBySortOrderAscIdAsc(logId));
+    }
+
+    /**
+     * 여러 기록의 사진을 한 번에 읽어 기록별로 묶는다 — 보드가 기록 수만큼 쿼리를 날리지
+     * 않게 한다.
+     */
+    public Map<Long, List<PhotoResponse>> photosByLog(List<Long> logIds) {
+        if (logIds.isEmpty()) {
+            return Map.of();
+        }
+        return photoRepository.findAllByLogIdInOrderBySortOrderAscIdAsc(logIds).stream()
+                .collect(Collectors.groupingBy(TripActivityPhoto::getLogId,
+                        Collectors.collectingAndThen(Collectors.toList(), this::toResponses)));
+    }
+
+    private List<PhotoResponse> toResponses(List<TripActivityPhoto> photos) {
+        return photos.stream()
+                .map(photo -> PhotoResponse.of(photo,
+                        storageService.toPublicUrl(photo.getObjectKey()),
+                        storageService.toPublicUrl(photo.getThumbKey())))
+                .toList();
+    }
+
+    /**
+     * 일정 경로에는 {@code tripId}가 없으므로 여행을 거쳐 소유권을 확인한다.
+     * 남의 일정도 404다.
+     */
+    /**
+     * 기록은 여행 시작일부터다(§S-07) — 사진도 기록의 일부라 같은 규칙을 따른다.
+     * 기준은 기기 시간대가 아니라 여행 타임존의 오늘이다.
+     */
+    private void requireTripStarted(TripActivity activity) {
+        Trip trip = tripRepository.findById(activity.getTripId()).orElseThrow();
+        if (trip.todayAtDestination(clock).isBefore(trip.getStartDate())) {
+            throw new CustomException(ErrorCode.TRAVEL_LOG_BEFORE_TRIP);
+        }
+    }
+
+    private TripActivity getOwnedActivity(Long memberId, Long activityId) {
+        TripActivity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_ACTIVITY_NOT_FOUND));
+        boolean owned = tripRepository.findByIdAndMemberId(activity.getTripId(), memberId)
+                .isPresent();
+        if (!owned) {
+            throw new CustomException(ErrorCode.TRAVEL_ACTIVITY_NOT_FOUND);
+        }
+        return activity;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/service/TravelPhotoStorageService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/service/TravelPhotoStorageService.java
@@ -1,0 +1,112 @@
+package ds.project.orino.planner.travel.photo.service;
+
+import ds.project.orino.planner.image.config.ImageStorageProperties;
+import ds.project.orino.planner.lifelog.image.dto.ImageKind;
+import ds.project.orino.planner.travel.photo.dto.PhotoUploadUrlResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.UUID;
+
+/**
+ * 여행 사진의 presigned 업로드 URL 발급과 오브젝트 삭제.
+ *
+ * <p>업로드 바이트는 <b>BE를 거치지 않는다</b> — 브라우저가 presigned URL로 MinIO에 직접 PUT
+ * 한다. 사진 열 장이 서버 힙을 지나가지 않아야 한다.
+ *
+ * <p>MinIO·버킷·자격증명은 노트/일상기록 이미지와 공유한다({@link ImageStorageProperties}).
+ * 나뉘는 것은 <b>key prefix</b>뿐이라, 나중에 여행 사진만 골라 지우거나 옮길 수 있다.
+ */
+@Service
+public class TravelPhotoStorageService {
+
+    private static final Logger log = LoggerFactory.getLogger(TravelPhotoStorageService.class);
+
+    private static final String ORIGINAL_PREFIX = "travel/activities";
+    private static final String THUMB_PREFIX = "travel/thumbs";
+
+    /** FE가 canvas로 재인코딩해 올리므로 항상 JPEG이다(§1.6 EXIF 제거). */
+    private static final String EXTENSION = "jpg";
+
+    private final S3Presigner presigner;
+    private final S3Client s3Client;
+    private final ImageStorageProperties props;
+
+    public TravelPhotoStorageService(S3Presigner imageS3Presigner,
+                                     S3Client lifelogImageS3Client,
+                                     ImageStorageProperties props) {
+        this.presigner = imageS3Presigner;
+        this.s3Client = lifelogImageS3Client;
+        this.props = props;
+    }
+
+    /**
+     * 일정별 경로에 랜덤 키를 만들고 presigned PUT URL을 발급한다.
+     *
+     * <p>키에 {@code activityId}를 넣는 것은 나중에 사람이 버킷을 들여다볼 때 어느 일정의
+     * 사진인지 알기 위한 것이다. 접근 제어는 여기가 아니라 API 소유권 검사가 한다.
+     */
+    public PhotoUploadUrlResponse createUploadUrl(Long activityId, String contentType,
+                                                  ImageKind kind) {
+        String prefix = kind == ImageKind.THUMB ? THUMB_PREFIX : ORIGINAL_PREFIX;
+        String key = "%s/%d/%s.%s".formatted(prefix, activityId, UUID.randomUUID(), EXTENSION);
+
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(props.bucket())
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofSeconds(props.presignExpirySeconds()))
+                .putObjectRequest(objectRequest)
+                .build();
+
+        return new PhotoUploadUrlResponse(
+                presigner.presignPutObject(presignRequest).url().toString(),
+                toPublicUrl(key), key);
+    }
+
+    /** object key를 공개 URL로 조립한다. 호스트는 설정에서 온다 — 환경별로 갈린다. */
+    public String toPublicUrl(String objectKey) {
+        if (objectKey == null || objectKey.isBlank()) {
+            return null;
+        }
+        return "%s/%s/%s".formatted(stripTrailingSlash(props.endpoint()), props.bucket(), objectKey);
+    }
+
+    /**
+     * 오브젝트를 best-effort로 지운다. <b>DB 정합성이 우선이다</b> — 삭제 실패로 트랜잭션을
+     * 되돌리면 화면에서 지운 사진이 되살아난다. 남은 오브젝트는 용량만 차지한다.
+     */
+    public void deleteObjects(Collection<String> objectKeys) {
+        if (objectKeys == null) {
+            return;
+        }
+        for (String key : objectKeys) {
+            if (key == null || key.isBlank()) {
+                continue;
+            }
+            try {
+                s3Client.deleteObject(DeleteObjectRequest.builder()
+                        .bucket(props.bucket())
+                        .key(key)
+                        .build());
+            } catch (RuntimeException e) {
+                log.warn("여행 사진 삭제 실패(best-effort, 무시): key={}", key, e);
+            }
+        }
+    }
+
+    private String stripTrailingSlash(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+}

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/051-create-trip-activity-photo.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/051-create-trip-activity-photo.yaml
@@ -1,0 +1,85 @@
+databaseChangeLog:
+  # 일정 기록 사진 (#1092, Epic #1029 · 4단계).
+  #
+  # 바이트는 MinIO에 있고 여기엔 object key만 담는다. 공개 URL은 설정의 endpoint + bucket +
+  # key로 조립한다 - 호스트를 컬럼에 박으면 환경이 바뀔 때 전 행을 고쳐야 한다.
+  #
+  # 위치정보 컬럼을 두지 않는다(§1.6). 여행 사진의 EXIF는 FE canvas 재인코딩으로 이미
+  # 제거된 상태로 올라온다 - 쓰지 않을 위치정보를 받아 두지 않는다.
+  #
+  # 10장·15MB 제한은 애플리케이션 검증이다. DB 제약으로 표현할 수 없고, 표현하려 해도
+  # 400으로 이유를 알려주는 편이 낫다.
+
+  - changeSet:
+      id: 051-create-trip-activity-photo
+      author: wcorn
+      comment: 기록 사진 0~10장. 기록이 지워지면 함께 사라진다.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: trip_activity_photo
+      changes:
+        - createTable:
+            tableName: trip_activity_photo
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: log_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_photo_log
+                    references: trip_activity_log(id)
+                    deleteCascade: true
+              - column:
+                  name: object_key
+                  type: VARCHAR(512)
+                  constraints:
+                    nullable: false
+              # 썸네일 업로드만 실패할 수 있다. 그때는 원본을 줄여 보여준다.
+              - column:
+                  name: thumb_key
+                  type: VARCHAR(512)
+              - column:
+                  name: width
+                  type: INT
+              - column:
+                  name: height
+                  type: INT
+              - column:
+                  name: sort_order
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 051-photo-log-index
+      author: wcorn
+      comment: 한 기록의 사진을 업로드 순서대로 읽는 유일한 접근 경로.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                indexName: idx_photo_log
+      changes:
+        - createIndex:
+            tableName: trip_activity_photo
+            indexName: idx_photo_log
+            columns:
+              - column:
+                  name: log_id
+              - column:
+                  name: sort_order

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -99,3 +99,5 @@ databaseChangeLog:
       file: db/changelog/changes/049-create-push-notification.yaml
   - include:
       file: db/changelog/changes/050-create-trip-activity-log.yaml
+  - include:
+      file: db/changelog/changes/051-create-trip-activity-photo.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/photo/TravelPhotoIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/photo/TravelPhotoIntegrationTest.java
@@ -1,0 +1,309 @@
+package ds.project.orino.planner.travel.photo;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.travel.repository.TripActivityLogRepository;
+import ds.project.orino.domain.planner.travel.repository.TripActivityPhotoRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.FixedClockConfig;
+import ds.project.orino.support.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 기록 사진 통합 테스트(§S-07).
+ *
+ * <p><b>MinIO를 건드리지 않는 경로만 다룬다.</b> presigned 발급은 순수 로컬 서명이고, 오브젝트
+ * 삭제(best-effort)는 {@link TravelPhotoStorageServiceTest}가 단위로 고정한다 — 통합 테스트에서
+ * 외부 호출을 하면 네트워크에 흔들린다.
+ *
+ * <p>고정 시각 {@code 2026-01-15T02:00Z}. 진행 중 여행(1/10~1/20)과 예정 여행(10/24~)을 함께 둔다.
+ */
+@Import(FixedClockConfig.class)
+class TravelPhotoIntegrationTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TripActivityPhotoRepository photoRepository;
+    @Autowired
+    private TripActivityLogRepository logRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long activityId;
+    private long upcomingActivityId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+
+        activityId = createActivity(createTrip("2026-01-10", "2026-01-20"), "센소지", "2026-01-15");
+        upcomingActivityId =
+                createActivity(createTrip("2026-10-24", "2026-10-27"), "시부야", "2026-10-24");
+    }
+
+    @Nested
+    @DisplayName("POST /activities/{id}/photos/upload-url")
+    class UploadUrl {
+
+        @Test
+        @DisplayName("원본과 썸네일 key가 갈린 presigned URL을 발급한다")
+        void issuesPresignedUrl() throws Exception {
+            mockMvc.perform(post("/api/travel/activities/" + activityId + "/photos/upload-url")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"contentType": "image/jpeg", "kind": "ORIGINAL"}
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.objectKey")
+                            .value(org.hamcrest.Matchers.startsWith(
+                                    "travel/activities/" + activityId + "/")))
+                    .andExpect(jsonPath("$.data.uploadUrl")
+                            .value(org.hamcrest.Matchers.containsString("X-Amz-Signature")));
+        }
+
+        @Test
+        @DisplayName("JPEG이 아니면 400 — EXIF는 canvas 재인코딩으로 떨어진 상태여야 한다")
+        void rejectsNonJpeg() throws Exception {
+            mockMvc.perform(post("/api/travel/activities/" + activityId + "/photos/upload-url")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"contentType": "image/heic", "kind": "ORIGINAL"}
+                                    """))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("여행 시작 전에는 발급하지 않는다 — 어차피 등록이 거부될 사진이다")
+        void rejectsBeforeTripStart() throws Exception {
+            mockMvc.perform(post("/api/travel/activities/" + upcomingActivityId
+                            + "/photos/upload-url")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"contentType": "image/jpeg", "kind": "ORIGINAL"}
+                                    """))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-012"));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /activities/{id}/photos")
+    class Register {
+
+        @Test
+        @DisplayName("메타를 등록하면 업로드 순서대로 돌려준다")
+        void registersInOrder() throws Exception {
+            registerPhotos(photoJson("a"), photoJson("b"))
+                    .andExpect(jsonPath("$.data", hasSize(2)))
+                    .andExpect(jsonPath("$.data[0].url").value(
+                            "https://img.orino.dev/note-images/travel/activities/1/a.jpg"))
+                    .andExpect(jsonPath("$.data[0].thumbUrl").value(
+                            "https://img.orino.dev/note-images/travel/thumbs/1/a.jpg"));
+        }
+
+        @Test
+        @DisplayName("평점·메모 없이 사진만 올려도 된다 — 기록이 없으면 만들어 붙인다")
+        void createsLogWhenAbsent() throws Exception {
+            assertThat(logRepository.findByActivityId(activityId)).isEmpty();
+
+            registerPhotos(photoJson("a"));
+
+            assertThat(logRepository.findByActivityId(activityId)).isPresent();
+            mockMvc.perform(get("/api/travel/activities/" + activityId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.hasLog").value(true))
+                    .andExpect(jsonPath("$.data.log.photos", hasSize(1)));
+        }
+
+        @Test
+        @DisplayName("나눠 올려도 뒤에 붙는다 — 재시도가 앞 사진을 밀어내지 않는다")
+        void appendsAcrossRequests() throws Exception {
+            registerPhotos(photoJson("a"));
+            registerPhotos(photoJson("b"))
+                    .andExpect(jsonPath("$.data", hasSize(2)))
+                    .andExpect(jsonPath("$.data[0].url")
+                            .value(org.hamcrest.Matchers.containsString("/a.jpg")))
+                    .andExpect(jsonPath("$.data[1].url")
+                            .value(org.hamcrest.Matchers.containsString("/b.jpg")));
+        }
+
+        @Test
+        @DisplayName("10장을 넘기면 400 — 기존 장수까지 합쳐서 센다")
+        void rejectsOverLimit() throws Exception {
+            registerPhotos(IntStream.range(0, 8)
+                    .mapToObj(i -> photoJson("p" + i))
+                    .toArray(String[]::new));
+
+            mockMvc.perform(post("/api/travel/activities/" + activityId + "/photos")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"photos": [%s, %s, %s]}
+                                    """.formatted(photoJson("x"), photoJson("y"), photoJson("z"))))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-013"));
+
+            // 한 장도 들어가지 않는다 — 부분 반영이면 화면과 서버 장수가 어긋난다.
+            assertThat(photoRepository.count()).isEqualTo(8);
+        }
+
+        @Test
+        @DisplayName("썸네일이 없어도 등록된다 — 썸네일만 실패할 수 있다")
+        void allowsMissingThumb() throws Exception {
+            registerPhotos("""
+                    {"objectKey": "travel/activities/1/a.jpg", "width": 4032, "height": 3024}
+                    """)
+                    .andExpect(jsonPath("$.data[0].thumbUrl").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("빈 배열은 400 — 보낼 게 없으면 요청 자체를 하지 않는다")
+        void rejectsEmpty() throws Exception {
+            mockMvc.perform(post("/api/travel/activities/" + activityId + "/photos")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"photos": []}
+                                    """))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("남의 일정에는 등록할 수 없다 — 404로 존재조차 흘리지 않는다")
+        void rejectsForeignActivity() throws Exception {
+            memberRepository.save(MemberFixture.create("other", "password"));
+            String otherHeader =
+                    "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+
+            mockMvc.perform(post("/api/travel/activities/" + activityId + "/photos")
+                            .header(HttpHeaders.AUTHORIZATION, otherHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"photos\": [%s]}".formatted(photoJson("a"))))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("기록과의 관계")
+    class WithLog {
+
+        @Test
+        @DisplayName("평점·메모를 다 지워도 사진이 있으면 기록이 남는다 — 지우면 사진까지 날아간다")
+        void keepsLogWhenPhotosRemain() throws Exception {
+            mockMvc.perform(put("/api/travel/activities/" + activityId + "/log")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"rating": 4, "memo": "좋았다"}
+                                    """))
+                    .andExpect(status().isOk());
+            registerPhotos(photoJson("a"));
+
+            mockMvc.perform(put("/api/travel/activities/" + activityId + "/log")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"rating": null, "memo": ""}
+                                    """))
+                    .andExpect(status().isOk())
+                    // 평점·메모는 비었지만 사진이 남아 기록 자체는 살아 있다.
+                    .andExpect(jsonPath("$.data.rating").doesNotExist())
+                    .andExpect(jsonPath("$.data.photos", hasSize(1)));
+
+            assertThat(photoRepository.count()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("보드 목록에도 사진이 실린다 — 보드 응답이 곧 오프라인 캐시다")
+        void boardCarriesPhotos() throws Exception {
+            registerPhotos(photoJson("a"));
+
+            mockMvc.perform(get("/api/travel/trips/" + tripOf(activityId) + "/board")
+                            .param("date", "2026-01-15")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.activities[0].log.photos", hasSize(1)));
+        }
+    }
+
+    // ---------------- helpers ----------------
+
+    private static String photoJson(String name) {
+        return """
+                {"objectKey": "travel/activities/1/%s.jpg",
+                 "thumbKey": "travel/thumbs/1/%s.jpg",
+                 "width": 4032, "height": 3024}
+                """.formatted(name, name);
+    }
+
+    private org.springframework.test.web.servlet.ResultActions registerPhotos(String... photos)
+            throws Exception {
+        String body = "{\"photos\": [%s]}".formatted(
+                java.util.Arrays.stream(photos).collect(Collectors.joining(",")));
+        return mockMvc.perform(post("/api/travel/activities/" + activityId + "/photos")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+    }
+
+    private long createTrip(String startDate, String endDate) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "도쿄", "destinationName": "도쿄",
+                                 "startDate": "%s", "endDate": "%s",
+                                 "timezone": "Asia/Tokyo", "currency": "JPY"}
+                                """.formatted(startDate, endDate)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private long createActivity(long tripId, String title, String date) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "%s", "activityDate": "%s"}
+                                """.formatted(title, date)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private long tripOf(long id) throws Exception {
+        String body = mockMvc.perform(get("/api/travel/activities/" + id)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.tripId")).longValue();
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/photo/TravelPhotoStorageServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/photo/TravelPhotoStorageServiceTest.java
@@ -1,0 +1,105 @@
+package ds.project.orino.planner.travel.photo;
+
+import ds.project.orino.planner.image.config.ImageStorageProperties;
+import ds.project.orino.planner.lifelog.image.dto.ImageKind;
+import ds.project.orino.planner.travel.photo.dto.PhotoUploadUrlResponse;
+import ds.project.orino.planner.travel.photo.service.TravelPhotoStorageService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * key 조립 규칙과 삭제의 best-effort 계약을 고정한다. presigned 서명은 순수 로컬 계산이라
+ * 네트워크 없이 검증할 수 있다.
+ */
+class TravelPhotoStorageServiceTest {
+
+    private final ImageStorageProperties props = new ImageStorageProperties(
+            "https://img.orino.dev", "note-images", "us-east-1", "k", "s", 300);
+
+    private S3Presigner presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(props.region()))
+                .endpointOverride(URI.create(props.endpoint()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(props.accessKey(), props.secretKey())))
+                .build();
+    }
+
+    @Test
+    @DisplayName("원본과 썸네일은 다른 prefix로 갈린다 — 나중에 여행 사진만 골라 다룰 수 있어야 한다")
+    void separatesPrefixesByKind() {
+        TravelPhotoStorageService service =
+                new TravelPhotoStorageService(presigner(), mock(S3Client.class), props);
+
+        PhotoUploadUrlResponse original =
+                service.createUploadUrl(91L, "image/jpeg", ImageKind.ORIGINAL);
+        PhotoUploadUrlResponse thumb =
+                service.createUploadUrl(91L, "image/jpeg", ImageKind.THUMB);
+
+        assertThat(original.objectKey()).startsWith("travel/activities/91/").endsWith(".jpg");
+        assertThat(thumb.objectKey()).startsWith("travel/thumbs/91/").endsWith(".jpg");
+        assertThat(original.uploadUrl()).contains("X-Amz-Signature");
+    }
+
+    @Test
+    @DisplayName("공개 URL은 설정의 호스트로 조립한다 — 컬럼에 호스트를 박지 않는다")
+    void buildsPublicUrlFromConfig() {
+        TravelPhotoStorageService service =
+                new TravelPhotoStorageService(presigner(), mock(S3Client.class), props);
+
+        assertThat(service.toPublicUrl("travel/activities/91/a.jpg"))
+                .isEqualTo("https://img.orino.dev/note-images/travel/activities/91/a.jpg");
+        // 썸네일이 없는 사진이 있다 — null이 그대로 전달돼도 터지지 않아야 한다.
+        assertThat(service.toPublicUrl(null)).isNull();
+        assertThat(service.toPublicUrl("  ")).isNull();
+    }
+
+    @Test
+    @DisplayName("삭제는 유효한 키만 시도한다")
+    void deletesOnlyValidKeys() {
+        S3Client s3 = mock(S3Client.class);
+        when(s3.deleteObject(any(DeleteObjectRequest.class)))
+                .thenReturn(DeleteObjectResponse.builder().build());
+        TravelPhotoStorageService service =
+                new TravelPhotoStorageService(presigner(), s3, props);
+
+        service.deleteObjects(Arrays.asList("travel/activities/1/a.jpg", null, "  "));
+
+        verify(s3, times(1)).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    @Test
+    @DisplayName("삭제 실패를 삼킨다 — 오브젝트가 안 지워졌다고 지운 사진이 되살아나면 안 된다")
+    void swallowsDeleteFailures() {
+        S3Client s3 = mock(S3Client.class);
+        doThrow(AwsServiceException.builder().message("boom").build())
+                .when(s3).deleteObject(any(DeleteObjectRequest.class));
+        TravelPhotoStorageService service =
+                new TravelPhotoStorageService(presigner(), s3, props);
+
+        assertThatCode(() -> service.deleteObjects(List.of("a.jpg", "b.jpg")))
+                .doesNotThrowAnyException();
+        verify(s3, times(2)).deleteObject(any(DeleteObjectRequest.class));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/schema/TravelSchemaTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/schema/TravelSchemaTest.java
@@ -160,6 +160,33 @@ class TravelSchemaTest {
                 .isInstanceOf(DuplicateKeyException.class);
     }
 
+    @Test
+    @DisplayName("기록을 지우면 사진도 함께 지워진다(ON DELETE CASCADE)")
+    @Transactional
+    void deletingLogCascadesToPhotos() {
+        long memberId = insertMember("photo-cascade-member");
+        long activityId = insertActivity(insertTrip(memberId, "도쿄"));
+        insertLog(activityId, 4);
+        long logId = jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+        jdbcTemplate.update("""
+                INSERT INTO trip_activity_photo (log_id, object_key, sort_order, created_at)
+                VALUES (?, 'travel/activities/1/a.jpg', 0, NOW(6))
+                """, logId);
+
+        jdbcTemplate.update("DELETE FROM trip_activity_log WHERE id = ?", logId);
+
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM trip_activity_photo WHERE log_id = ?",
+                Integer.class, logId)).isZero();
+    }
+
+    @Test
+    @DisplayName("사진 조회 인덱스가 있다")
+    void photoIndexExists() {
+        assertThat(indexColumnsOf("trip_activity_photo", "idx_photo_log"))
+                .containsExactly("log_id", "sort_order");
+    }
+
     private long insertActivity(long tripId) {
         jdbcTemplate.update("""
                 INSERT INTO trip_activity (trip_id, title, activity_date, sort_order,

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
@@ -9,6 +9,7 @@ public class DbCleaner {
     private static final String[] TABLES_IN_FK_ORDER = {
             "push_notification",
             // FK_CHECKS=0이라 CASCADE가 안 돈다 — 자식 테이블을 직접 지워야 남지 않는다.
+            "trip_activity_photo",
             "trip_activity_log",
             "trip_activity",
             "trip",

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -52,7 +52,10 @@ public enum ErrorCode {
             "지원하지 않는 통화입니다.", 400),
     // 404가 아니다 — 일정은 실재하고, 아직 기록할 때가 아닐 뿐이다.
     TRAVEL_LOG_BEFORE_TRIP("TRAVEL-ERR-012",
-            "여행이 시작된 뒤에 기록할 수 있습니다.", 400);
+            "여행이 시작된 뒤에 기록할 수 있습니다.", 400),
+    TRAVEL_PHOTO_LIMIT_EXCEEDED("TRAVEL-ERR-013",
+            "사진은 일정당 10장까지 올릴 수 있습니다.", 400),
+    TRAVEL_PHOTO_NOT_FOUND("TRAVEL-ERR-014", "존재하지 않는 사진입니다.", 404);
 
     private final String code;
     private final String message;

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TripActivityPhoto.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TripActivityPhoto.java
@@ -1,0 +1,102 @@
+package ds.project.orino.domain.planner.travel.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+/**
+ * 기록에 붙은 사진 하나. 바이트는 MinIO에 있고 여기엔 object key만 담는다 - 공개 URL은
+ * 설정의 endpoint + bucket + key로 조립한다(호스트 하드코딩 회피).
+ *
+ * <p><b>위치정보를 담지 않는다</b>(§1.6). 여행 사진의 EXIF는 FE canvas 재인코딩으로 이미
+ * 제거된 상태로 올라온다 - 쓰지 않을 위치정보를 받아 두지 않는다. (일상기록 사진은 시각·위치
+ * 자동채움에 쓰려고 EXIF를 보존하는데, 여행은 그 요구가 없다.)
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "trip_activity_photo")
+public class TripActivityPhoto {
+
+    /** 기록 한 건에 붙일 수 있는 사진 수. 화면·검증·문서가 같은 값을 봐야 한다. */
+    public static final int MAX_PHOTOS = 10;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 일정이 아니라 <b>기록</b>에 매달린다 - 기록이 지워지면 사진도 사라진다(FK CASCADE). */
+    @Column(name = "log_id", nullable = false)
+    private Long logId;
+
+    @Column(name = "object_key", nullable = false, length = 512)
+    private String objectKey;
+
+    /** 썸네일 업로드만 실패할 수 있다. null이면 화면이 원본을 줄여 보여준다. */
+    @Column(name = "thumb_key", length = 512)
+    private String thumbKey;
+
+    private Integer width;
+
+    private Integer height;
+
+    /** 업로드 순서. 찍은 순서가 곧 보는 순서다. */
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    protected TripActivityPhoto() {
+    }
+
+    public TripActivityPhoto(Long logId, String objectKey, String thumbKey,
+                             Integer width, Integer height, int sortOrder) {
+        this.logId = logId;
+        this.objectKey = objectKey;
+        this.thumbKey = thumbKey;
+        this.width = width;
+        this.height = height;
+        this.sortOrder = sortOrder;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getLogId() {
+        return logId;
+    }
+
+    public String getObjectKey() {
+        return objectKey;
+    }
+
+    public String getThumbKey() {
+        return thumbKey;
+    }
+
+    public Integer getWidth() {
+        return width;
+    }
+
+    public Integer getHeight() {
+        return height;
+    }
+
+    public int getSortOrder() {
+        return sortOrder;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripActivityPhotoRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripActivityPhotoRepository.java
@@ -1,0 +1,25 @@
+package ds.project.orino.domain.planner.travel.repository;
+
+import ds.project.orino.domain.planner.travel.entity.TripActivityPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/** 기록 사진. 모든 접근이 {@code idx_photo_log (log_id, sort_order)}를 탄다. */
+public interface TripActivityPhotoRepository extends JpaRepository<TripActivityPhoto, Long> {
+
+    List<TripActivityPhoto> findAllByLogIdOrderBySortOrderAscIdAsc(Long logId);
+
+    /** 여러 기록의 사진을 한 번에 읽는다 - 보드가 기록 수만큼 쿼리를 날리지 않게. */
+    List<TripActivityPhoto> findAllByLogIdInOrderBySortOrderAscIdAsc(List<Long> logIds);
+
+    long countByLogId(Long logId);
+
+    /** 새 사진을 맨 뒤에 붙일 때 쓸 다음 순서값. 사진이 없으면 0. */
+    default int nextSortOrder(Long logId) {
+        return findAllByLogIdOrderBySortOrderAscIdAsc(logId).stream()
+                .mapToInt(TripActivityPhoto::getSortOrder)
+                .max()
+                .orElse(-1) + 1;
+    }
+}

--- a/fe/src/features/travel/api/activities.ts
+++ b/fe/src/features/travel/api/activities.ts
@@ -1,6 +1,7 @@
 import { client } from "@/shared/api";
 
 import type { TripStatus } from "../lib/tripStatus";
+import type { ActivityPhoto } from "./photos";
 import type { DailyWeather } from "./tools";
 
 interface ApiEnvelope<T> {
@@ -16,11 +17,17 @@ export interface ActivityPlace {
   lng: number | null;
 }
 
-/** 일정의 사후 기록(§S-07 기록 영역). 사진은 별도 리소스다. */
+/**
+ * 일정의 사후 기록(§S-07 기록 영역).
+ *
+ * <p>사진은 별도 테이블·별도 요청이다 — 업로드가 실패해도 평점·메모는 남는다. 조회에서만
+ * 함께 실려 온다.
+ */
 export interface ActivityLog {
   /** 1~5. null이면 아직 매기지 않았거나 해제한 것이다. */
   rating: number | null;
   memo: string | null;
+  photos: ActivityPhoto[];
   updatedAt: string;
 }
 

--- a/fe/src/features/travel/api/photos.ts
+++ b/fe/src/features/travel/api/photos.ts
@@ -1,0 +1,76 @@
+import axios from "axios";
+
+import { client } from "@/shared/api";
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+export type ImageKind = "ORIGINAL" | "THUMB";
+
+/** 서버가 URL로 조립해 내려준다 — 화면이 호스트를 알 필요가 없다. */
+export interface ActivityPhoto {
+  id: number;
+  url: string;
+  /** 썸네일만 실패할 수 있다. null이면 원본을 줄여 쓴다. */
+  thumbUrl: string | null;
+  width: number | null;
+  height: number | null;
+}
+
+export interface PhotoUploadUrl {
+  uploadUrl: string;
+  publicUrl: string;
+  objectKey: string;
+}
+
+export async function createPhotoUploadUrl(
+  activityId: number,
+  kind: ImageKind,
+): Promise<PhotoUploadUrl> {
+  const { data } = await client.post<ApiEnvelope<PhotoUploadUrl>>(
+    `/travel/activities/${activityId}/photos/upload-url`,
+    // 항상 JPEG이다 — canvas 재인코딩으로 EXIF를 떨군 결과가 JPEG이다.
+    { contentType: "image/jpeg", kind },
+  );
+  return data.data;
+}
+
+/**
+ * presigned URL로 바이너리를 MinIO에 직접 PUT 한다.
+ *
+ * <p>인증 헤더 없이 순수 axios로 보낸다 — 우리 API의 Authorization 헤더가 붙으면 S3 서명
+ * 검증이 깨진다.
+ */
+export async function putToPresigned(
+  uploadUrl: string,
+  body: Blob,
+): Promise<void> {
+  await axios.put(uploadUrl, body, {
+    headers: { "Content-Type": "image/jpeg" },
+  });
+}
+
+export interface PhotoMeta {
+  objectKey: string;
+  thumbKey: string | null;
+  width: number;
+  height: number;
+}
+
+/** 업로드가 끝난 사진만 등록한다. 실패한 장은 화면이 재시도 목록에 남긴다. */
+export async function registerPhotos(
+  activityId: number,
+  photos: PhotoMeta[],
+): Promise<ActivityPhoto[]> {
+  const { data } = await client.post<ApiEnvelope<ActivityPhoto[]>>(
+    `/travel/activities/${activityId}/photos`,
+    { photos },
+  );
+  return data.data;
+}
+
+export async function deletePhoto(photoId: number): Promise<void> {
+  await client.delete(`/travel/photos/${photoId}`);
+}

--- a/fe/src/features/travel/record/PhotoGrid.tsx
+++ b/fe/src/features/travel/record/PhotoGrid.tsx
@@ -1,0 +1,162 @@
+import { ImagePlus, RotateCcw, X } from "lucide-react";
+import { useId, useRef, useState } from "react";
+
+import {
+  type ActivityPhoto,
+  deletePhoto as deletePhotoRequest,
+} from "@/features/travel/api/photos";
+import { PhotoViewer } from "@/features/travel/record/PhotoViewer";
+import {
+  MAX_PHOTOS,
+  usePhotoUpload,
+} from "@/features/travel/record/usePhotoUpload";
+import { toast } from "@/shared/lib/toast";
+
+interface PhotoGridProps {
+  activityId: number;
+  photos: ActivityPhoto[];
+  onChange: (photos: ActivityPhoto[]) => void;
+  online: boolean;
+}
+
+/**
+ * 썸네일 그리드 + 추가 버튼(§S-07).
+ *
+ * <p>업로드 중인 장은 로컬 미리보기로 자리를 잡아 둔다 — 고른 사진이 잠깐 사라졌다 나타나면
+ * 눌린 건지 아닌지 알 수 없다. 실패한 장은 남겨 다시 고르게 한다.
+ */
+export function PhotoGrid({
+  activityId,
+  photos,
+  onChange,
+  online,
+}: PhotoGridProps) {
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [viewerIndex, setViewerIndex] = useState<number | null>(null);
+
+  const { pending, add, dismiss } = usePhotoUpload(
+    activityId,
+    photos.length,
+    onChange,
+  );
+
+  const full = photos.length + pending.length >= MAX_PHOTOS;
+
+  const remove = async (photo: ActivityPhoto) => {
+    // 낙관적으로 지운다 — 실패하면 되돌린다. 사진 삭제는 즉시 반응해야 한다.
+    const before = photos;
+    onChange(photos.filter((p) => p.id !== photo.id));
+    try {
+      await deletePhotoRequest(photo.id);
+    } catch {
+      onChange(before);
+      toast("사진을 지우지 못했어요.", "error");
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-4 gap-1.5">
+        {photos.map((photo, index) => (
+          <div key={photo.id} className="relative aspect-square">
+            <button
+              type="button"
+              className="size-full overflow-hidden rounded-lg"
+              aria-label={`사진 ${index + 1} 크게 보기`}
+              onClick={() => setViewerIndex(index)}
+            >
+              {/* 썸네일이 없으면 원본을 줄여 쓴다 — 썸네일만 실패할 수 있다. */}
+              <img
+                src={photo.thumbUrl ?? photo.url}
+                alt=""
+                loading="lazy"
+                className="size-full object-cover"
+              />
+            </button>
+            {online && (
+              <button
+                type="button"
+                aria-label={`사진 ${index + 1} 삭제`}
+                onClick={() => remove(photo)}
+                className="absolute top-1 right-1 rounded-full bg-black/60 p-1 text-white"
+              >
+                <X className="size-3" />
+              </button>
+            )}
+          </div>
+        ))}
+
+        {pending.map((item) => (
+          <div
+            key={item.key}
+            className="relative aspect-square overflow-hidden rounded-lg"
+          >
+            <img
+              src={item.previewUrl}
+              alt=""
+              className="size-full object-cover opacity-40"
+            />
+            {item.status === "uploading" ? (
+              <span className="absolute inset-0 grid place-items-center text-[11px] text-white">
+                올리는 중…
+              </span>
+            ) : (
+              <button
+                type="button"
+                aria-label="실패한 사진 지우기"
+                title={item.message}
+                onClick={() => dismiss(item.key)}
+                className="bg-destructive/70 absolute inset-0 grid place-items-center text-[11px] text-white"
+              >
+                <RotateCcw className="size-4" />
+              </button>
+            )}
+          </div>
+        ))}
+
+        {!full && (
+          <label
+            htmlFor={inputId}
+            className={`border-border text-muted-foreground grid aspect-square place-items-center rounded-lg border border-dashed ${
+              online ? "cursor-pointer" : "opacity-50"
+            }`}
+            aria-label="사진 추가"
+          >
+            <ImagePlus className="size-5" />
+          </label>
+        )}
+      </div>
+
+      <input
+        id={inputId}
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        disabled={!online}
+        className="sr-only"
+        onChange={(e) => {
+          const files = e.target.files;
+          if (files) void add(files);
+          // 같은 파일을 다시 고를 수 있게 비운다.
+          e.target.value = "";
+        }}
+      />
+
+      {full && (
+        <p className="text-muted-foreground text-xs">
+          사진은 {MAX_PHOTOS}장까지 올릴 수 있어요.
+        </p>
+      )}
+
+      {viewerIndex !== null && (
+        <PhotoViewer
+          photos={photos}
+          startIndex={viewerIndex}
+          onClose={() => setViewerIndex(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/fe/src/features/travel/record/PhotoViewer.tsx
+++ b/fe/src/features/travel/record/PhotoViewer.tsx
@@ -1,0 +1,100 @@
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import type { ActivityPhoto } from "@/features/travel/api/photos";
+
+/** 이 픽셀 이상 끌어야 넘긴다. 세로 스크롤하다 손가락이 흔들린 것과 구분한다. */
+const SWIPE_THRESHOLD = 50;
+
+interface PhotoViewerProps {
+  photos: ActivityPhoto[];
+  startIndex: number;
+  onClose: () => void;
+}
+
+/**
+ * 전체화면 사진 뷰어(§S-07). 좌우로 넘긴다.
+ *
+ * <p>썸네일이 아니라 <b>원본</b>을 띄운다 — 크게 보려고 연 화면이다.
+ */
+export function PhotoViewer({ photos, startIndex, onClose }: PhotoViewerProps) {
+  const [index, setIndex] = useState(startIndex);
+  const touchStartX = useRef<number | null>(null);
+
+  const clamp = (next: number) =>
+    setIndex(Math.min(photos.length - 1, Math.max(0, next)));
+
+  // 키보드로도 넘긴다 — 데스크톱에서 열어볼 수 있어야 한다.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+      if (e.key === "ArrowLeft") setIndex((i) => Math.max(0, i - 1));
+      if (e.key === "ArrowRight")
+        setIndex((i) => Math.min(photos.length - 1, i + 1));
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [photos.length, onClose]);
+
+  if (photos.length === 0) return null;
+  const photo = photos[Math.min(index, photos.length - 1)];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col bg-black/95"
+      role="dialog"
+      aria-modal="true"
+      aria-label="사진 보기"
+      onTouchStart={(e) => {
+        touchStartX.current = e.touches[0].clientX;
+      }}
+      onTouchEnd={(e) => {
+        const start = touchStartX.current;
+        touchStartX.current = null;
+        if (start === null) return;
+        const dx = e.changedTouches[0].clientX - start;
+        if (Math.abs(dx) < SWIPE_THRESHOLD) return;
+        clamp(index + (dx < 0 ? 1 : -1));
+      }}
+    >
+      <div className="flex items-center justify-between p-3 text-white">
+        <span className="text-sm tabular-nums">
+          {index + 1} / {photos.length}
+        </span>
+        <button type="button" aria-label="닫기" onClick={onClose}>
+          <X className="size-5" />
+        </button>
+      </div>
+
+      <div className="flex min-h-0 flex-1 items-center justify-center px-2">
+        {/* 그리드의 썸네일과 달리 여기서는 사진이 내용 자체다 — 이름을 준다. */}
+        <img
+          src={photo.url}
+          alt={`사진 ${index + 1}`}
+          className="max-h-full max-w-full object-contain"
+        />
+      </div>
+
+      <div className="flex items-center justify-between p-4 text-white">
+        <button
+          type="button"
+          aria-label="이전 사진"
+          disabled={index === 0}
+          onClick={() => clamp(index - 1)}
+          className="disabled:opacity-30"
+        >
+          <ChevronLeft className="size-7" />
+        </button>
+        <button
+          type="button"
+          aria-label="다음 사진"
+          disabled={index === photos.length - 1}
+          onClick={() => clamp(index + 1)}
+          className="disabled:opacity-30"
+        >
+          <ChevronRight className="size-7" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/travel/record/RecordSection.tsx
+++ b/fe/src/features/travel/record/RecordSection.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 
 import { Textarea } from "@/components/ui/textarea";
 import type { ActivityLog } from "@/features/travel/api/activities";
+import type { ActivityPhoto } from "@/features/travel/api/photos";
+import { PhotoGrid } from "@/features/travel/record/PhotoGrid";
 import { StarRating } from "@/features/travel/record/StarRating";
 import { useAutoSaveLog } from "@/features/travel/record/useAutoSaveLog";
 
@@ -17,7 +19,7 @@ interface RecordSectionProps {
 }
 
 /**
- * S-07 <b>기록 영역</b> — 평점·메모.
+ * S-07 <b>기록 영역</b> — 평점·메모·사진.
  *
  * <p><b>여행이 시작된 뒤에만 이 영역이 존재한다.</b> 호출부가 그 판단을 하고, 여기서는
  * 항상 그려진다 — 아직 겪지 않은 일에 평점을 매기는 화면은 만들지 않는다.
@@ -33,6 +35,8 @@ export function RecordSection({
 }: RecordSectionProps) {
   const [rating, setRating] = useState<number | null>(log?.rating ?? null);
   const [memo, setMemo] = useState(log?.memo ?? "");
+  // 사진은 평점·메모와 저장 경로가 달라(즉시 등록) 여기서 따로 들고 있는다.
+  const [photos, setPhotos] = useState<ActivityPhoto[]>(log?.photos ?? []);
   const { status, schedule, flush } = useAutoSaveLog(activityId, tripId);
 
   // 다른 일정으로 넘어가면 그 일정의 기록을 보여준다.
@@ -40,6 +44,10 @@ export function RecordSection({
     setRating(log?.rating ?? null);
     setMemo(log?.memo ?? "");
   }, [activityId, log?.rating, log?.memo]);
+
+  useEffect(() => {
+    setPhotos(log?.photos ?? []);
+  }, [activityId, log?.photos]);
 
   const change = (nextRating: number | null, nextMemo: string) => {
     setRating(nextRating);
@@ -83,6 +91,13 @@ export function RecordSection({
         onChange={(e) => change(rating, e.target.value)}
         // 포커스를 잃으면 디바운스를 기다리지 않는다 — 다 쓴 뒤 화면을 닫는 게 흔하다.
         onBlur={flush}
+      />
+
+      <PhotoGrid
+        activityId={activityId}
+        photos={photos}
+        onChange={setPhotos}
+        online={online}
       />
     </section>
   );

--- a/fe/src/features/travel/record/processPhoto.test.ts
+++ b/fe/src/features/travel/record/processPhoto.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { fitWithin, MAX_FILE_BYTES } from "./processPhoto";
+
+describe("사진 축소 크기", () => {
+  it("긴 변을 상한에 맞추고 비율을 지킨다", () => {
+    expect(fitWithin(4032, 3024, 2560)).toEqual({ width: 2560, height: 1920 });
+    // 세로 사진도 같은 규칙이다.
+    expect(fitWithin(3024, 4032, 480)).toEqual({ width: 360, height: 480 });
+  });
+
+  it("작은 사진은 늘리지 않는다 — 없는 화질을 만들어내지 않는다", () => {
+    expect(fitWithin(800, 600, 2560)).toEqual({ width: 800, height: 600 });
+  });
+
+  it("정사각형도 상한을 넘으면 줄인다", () => {
+    expect(fitWithin(3000, 3000, 480)).toEqual({ width: 480, height: 480 });
+  });
+
+  it("장당 상한은 15MB다", () => {
+    expect(MAX_FILE_BYTES).toBe(15 * 1024 * 1024);
+  });
+});

--- a/fe/src/features/travel/record/processPhoto.ts
+++ b/fe/src/features/travel/record/processPhoto.ts
@@ -1,0 +1,83 @@
+/** 원본으로 올릴 최대 변(px). 폰 사진을 그대로 올리면 현지 회선에서 끝나지 않는다. */
+const ORIGINAL_MAX = 2560;
+
+/** 썸네일 최대 변(px). 그리드에서 한 변이 100px 남짓이라 이 정도면 충분하다. */
+const THUMB_MAX = 480;
+
+/** 장당 상한(§2.5). 이 크기를 넘는 파일은 고르는 순간 거른다. */
+export const MAX_FILE_BYTES = 15 * 1024 * 1024;
+
+export interface ProcessedPhoto {
+  /** 재인코딩한 원본(JPEG). EXIF가 떨어진 상태다. */
+  originalBlob: Blob;
+  thumbBlob: Blob;
+  /** 재인코딩 후 크기. DB에 적히는 값이라 실제 올라간 것과 같아야 한다. */
+  width: number;
+  height: number;
+}
+
+/** 최대 변을 max로 맞춘 축소 크기(확대는 하지 않는다). 순수 계산이라 단위 테스트 대상. */
+export function fitWithin(
+  width: number,
+  height: number,
+  max: number,
+): { width: number; height: number } {
+  const longest = Math.max(width, height);
+  if (longest <= max) {
+    return { width, height };
+  }
+  const scale = max / longest;
+  return {
+    width: Math.round(width * scale),
+    height: Math.round(height * scale),
+  };
+}
+
+/**
+ * 사진 한 장을 올릴 수 있는 형태로 만든다 — 원본 재인코딩 + 썸네일.
+ *
+ * <p><b>원본도 canvas로 다시 그린다.</b> 그래야 EXIF가 떨어진다(§1.6 — 여행 사진의 위치정보를
+ * 쓰지 않으므로 애초에 서버로 보내지 않는다). 파일을 그대로 올리면 촬영 위치가 따라간다.
+ *
+ * <p>EXIF orientation은 <b>버리기 전에 적용</b>한다. 회전 플래그만 떨구면 아이폰 세로 사진이
+ * 눕는다 — 정보를 지우는 것과 그림을 망치는 것은 다르다.
+ */
+export async function processPhoto(file: File): Promise<ProcessedPhoto> {
+  const bitmap = await createImageBitmap(file, {
+    imageOrientation: "from-image",
+  });
+  try {
+    const original = fitWithin(bitmap.width, bitmap.height, ORIGINAL_MAX);
+    const thumb = fitWithin(bitmap.width, bitmap.height, THUMB_MAX);
+    const [originalBlob, thumbBlob] = await Promise.all([
+      toJpeg(bitmap, original.width, original.height, 0.85),
+      toJpeg(bitmap, thumb.width, thumb.height, 0.8),
+    ]);
+    return { originalBlob, thumbBlob, ...original };
+  } finally {
+    bitmap.close();
+  }
+}
+
+async function toJpeg(
+  bitmap: ImageBitmap,
+  width: number,
+  height: number,
+  quality: number,
+): Promise<Blob> {
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("canvas 2d context를 만들 수 없습니다.");
+  }
+  ctx.drawImage(bitmap, 0, 0, width, height);
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error("이미지 변환 실패"))),
+      "image/jpeg",
+      quality,
+    );
+  });
+}

--- a/fe/src/features/travel/record/usePhotoUpload.ts
+++ b/fe/src/features/travel/record/usePhotoUpload.ts
@@ -1,0 +1,133 @@
+import { useState } from "react";
+
+import {
+  type ActivityPhoto,
+  createPhotoUploadUrl,
+  type PhotoMeta,
+  putToPresigned,
+  registerPhotos,
+} from "@/features/travel/api/photos";
+import {
+  MAX_FILE_BYTES,
+  processPhoto,
+} from "@/features/travel/record/processPhoto";
+
+/** 일정당 사진 상한(§2.5). 서버 검증과 같은 값이다. */
+export const MAX_PHOTOS = 10;
+
+export interface PendingPhoto {
+  key: string;
+  /** 로컬 미리보기(objectURL). 업로드가 끝나면 서버 URL로 갈린다. */
+  previewUrl: string;
+  status: "uploading" | "error";
+  /** 실패 사유. 재시도할지 판단은 사용자가 한다. */
+  message?: string;
+}
+
+interface UsePhotoUploadResult {
+  pending: PendingPhoto[];
+  /** 고른 파일을 처리·업로드하고 등록까지 마친다. */
+  add: (files: FileList | File[]) => Promise<void>;
+  /** 실패한 장을 목록에서 치운다. */
+  dismiss: (key: string) => void;
+}
+
+/**
+ * 사진 업로드.
+ *
+ * <p><b>성공한 장만 등록한다.</b> 한 장이 실패했다고 이미 올라간 아홉 장을 버리지 않는다 —
+ * 현지 회선에서 열 장이 다 성공하는 일이 드물다.
+ *
+ * <p>실패한 장은 목록에 남겨 사용자가 다시 고를 수 있게 한다. 조용히 사라지면 몇 장이
+ * 빠졌는지도 모른다.
+ */
+export function usePhotoUpload(
+  activityId: number,
+  currentCount: number,
+  onUploaded: (photos: ActivityPhoto[]) => void,
+): UsePhotoUploadResult {
+  const [pending, setPending] = useState<PendingPhoto[]>([]);
+
+  const dismiss = (key: string) =>
+    setPending((prev) => {
+      const target = prev.find((p) => p.key === key);
+      if (target) URL.revokeObjectURL(target.previewUrl);
+      return prev.filter((p) => p.key !== key);
+    });
+
+  const add = async (files: FileList | File[]) => {
+    const picked = Array.from(files);
+    if (picked.length === 0) return;
+
+    // 상한을 넘는 만큼은 아예 시작하지 않는다 — 올린 뒤 서버가 거절하면 통신만 버린다.
+    const room = MAX_PHOTOS - currentCount - pending.length;
+    const accepted = picked.slice(0, Math.max(0, room));
+
+    const entries = accepted.map((file, i) => ({
+      file,
+      key: `${file.name}-${i}-${file.size}`,
+      previewUrl: URL.createObjectURL(file),
+    }));
+    setPending((prev) => [
+      ...prev,
+      ...entries.map((e) => ({
+        key: e.key,
+        previewUrl: e.previewUrl,
+        status: "uploading" as const,
+      })),
+    ]);
+
+    const uploaded: PhotoMeta[] = [];
+    for (const entry of entries) {
+      try {
+        if (entry.file.size > MAX_FILE_BYTES) {
+          throw new Error("사진이 너무 커요 (15MB까지)");
+        }
+        const processed = await processPhoto(entry.file);
+
+        const original = await createPhotoUploadUrl(activityId, "ORIGINAL");
+        await putToPresigned(original.uploadUrl, processed.originalBlob);
+
+        // 썸네일만 실패해도 사진은 살린다 — 원본을 줄여 보여주면 된다.
+        let thumbKey: string | null = null;
+        try {
+          const thumb = await createPhotoUploadUrl(activityId, "THUMB");
+          await putToPresigned(thumb.uploadUrl, processed.thumbBlob);
+          thumbKey = thumb.objectKey;
+        } catch {
+          thumbKey = null;
+        }
+
+        uploaded.push({
+          objectKey: original.objectKey,
+          thumbKey,
+          width: processed.width,
+          height: processed.height,
+        });
+        URL.revokeObjectURL(entry.previewUrl);
+        setPending((prev) => prev.filter((p) => p.key !== entry.key));
+      } catch (error) {
+        setPending((prev) =>
+          prev.map((p) =>
+            p.key === entry.key
+              ? {
+                  ...p,
+                  status: "error" as const,
+                  message:
+                    error instanceof Error && error.message
+                      ? error.message
+                      : "올리지 못했어요",
+                }
+              : p,
+          ),
+        );
+      }
+    }
+
+    if (uploaded.length > 0) {
+      onUploaded(await registerPhotos(activityId, uploaded));
+    }
+  };
+
+  return { pending, add, dismiss };
+}

--- a/fe/src/pages/travel/ActivityPhotos.test.tsx
+++ b/fe/src/pages/travel/ActivityPhotos.test.tsx
@@ -1,0 +1,237 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Providers } from "@/app/providers";
+import { AppRouter } from "@/app/router";
+import { useAuthStore } from "@/features/auth/store/authStore";
+import { useToastStore } from "@/shared/lib/toast";
+import { server } from "@/test/mocks/server";
+import { renderWithRouter } from "@/test/render";
+
+const API_BASE = "https://api.orino.dev/api";
+
+/**
+ * 업로드 경로(canvas 재인코딩)는 jsdom에서 돌지 않는다 — `createImageBitmap`도
+ * `canvas.toBlob`도 없다. 크기 계산은 `processPhoto.test.ts`가 단위로 고정하고,
+ * 여기서는 <b>이미 올라간 사진</b>의 그리드·뷰어·삭제를 본다.
+ */
+const TRIP = {
+  id: 3,
+  title: "도쿄 3박 4일",
+  destinationName: "도쿄",
+  destinationPlaceId: null,
+  startDate: "2026-08-06",
+  endDate: "2026-08-10",
+  timezone: "Asia/Tokyo",
+  currency: "JPY",
+  lat: null,
+  lng: null,
+  defaultNotifyMinutes: 15,
+  morningSummaryEnabled: false,
+  status: "ONGOING",
+  dDay: 0,
+  totalDays: 5,
+  activityCount: 1,
+};
+
+function photo(id: number) {
+  return {
+    id,
+    url: `https://img.orino.dev/note-images/travel/activities/1/${id}.jpg`,
+    // 썸네일만 실패할 수 있어 null이 정상값이다.
+    thumbUrl: `https://img.orino.dev/note-images/travel/thumbs/1/${id}.jpg` as
+      | string
+      | null,
+    width: 2560,
+    height: 1920,
+  };
+}
+
+function mock(photos: ReturnType<typeof photo>[]) {
+  server.use(
+    http.get(`${API_BASE}/travel/activities/:id`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          id: 1,
+          tripId: 3,
+          title: "센소지",
+          activityDate: "2026-08-08",
+          startTime: "09:00",
+          place: null,
+          memo: null,
+          url: null,
+          notifyEnabled: false,
+          notifyMinutes: null,
+          departureNotifyEnabled: false,
+          sortOrder: 0,
+          log: {
+            rating: 4,
+            memo: "좋았다",
+            photos,
+            updatedAt: "2026-08-08T09:00:00Z",
+          },
+          hasLog: true,
+        },
+      }),
+    ),
+    http.get(`${API_BASE}/travel/trips/:tripId`, () =>
+      HttpResponse.json({ code: "OK", data: TRIP }),
+    ),
+  );
+}
+
+function renderDetail() {
+  return renderWithRouter(
+    <Providers>
+      <AppRouter />
+    </Providers>,
+    { initialEntries: ["/travel/activities/1"] },
+  );
+}
+
+describe("기록 사진", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "valid-token" });
+    useToastStore.setState({ toasts: [] });
+    mock([photo(1), photo(2)]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("그리드", () => {
+    it("썸네일을 보여준다 — 원본을 그리드에 깔지 않는다", async () => {
+      renderDetail();
+
+      const first = await screen.findByRole("button", {
+        name: "사진 1 크게 보기",
+      });
+      // 그리드 썸네일은 장식이라 alt가 비어 있다(버튼이 이름을 갖는다).
+      expect(first.querySelector("img")).toHaveAttribute(
+        "src",
+        expect.stringContaining("/travel/thumbs/"),
+      );
+    });
+
+    it("썸네일이 없으면 원본을 줄여 쓴다 — 썸네일만 실패할 수 있다", async () => {
+      mock([{ ...photo(1), thumbUrl: null }]);
+      renderDetail();
+
+      const first = await screen.findByRole("button", {
+        name: "사진 1 크게 보기",
+      });
+      expect(first.querySelector("img")).toHaveAttribute(
+        "src",
+        expect.stringContaining("/travel/activities/"),
+      );
+    });
+
+    it("10장이 차면 추가 버튼이 사라지고 이유를 밝힌다", async () => {
+      mock(Array.from({ length: 10 }, (_, i) => photo(i + 1)));
+      renderDetail();
+
+      expect(
+        await screen.findByText("사진은 10장까지 올릴 수 있어요."),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText("사진 추가")).toBeNull();
+    });
+
+    it("오프라인이면 삭제 버튼을 감춘다 — 눌러도 실패할 버튼을 두지 않는다", async () => {
+      vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+      renderDetail();
+
+      await screen.findByRole("button", { name: "사진 1 크게 보기" });
+      expect(screen.queryByLabelText("사진 1 삭제")).toBeNull();
+    });
+  });
+
+  describe("삭제", () => {
+    it("지우면 그리드에서 바로 빠진다", async () => {
+      const deleted: string[] = [];
+      server.use(
+        http.delete(`${API_BASE}/travel/photos/:id`, ({ params }) => {
+          deleted.push(String(params.id));
+          return HttpResponse.json({ code: "OK", data: null });
+        }),
+      );
+      const user = userEvent.setup();
+      renderDetail();
+
+      await user.click(await screen.findByLabelText("사진 1 삭제"));
+
+      await waitFor(() => expect(deleted).toEqual(["1"]));
+      // 남은 한 장은 이제 "사진 1"이다 — 번호는 자리 기준이다.
+      expect(screen.getByLabelText("사진 1 삭제")).toBeInTheDocument();
+      expect(screen.queryByLabelText("사진 2 삭제")).toBeNull();
+    });
+
+    it("실패하면 되돌리고 알린다 — 지워진 줄 알고 넘어가면 안 된다", async () => {
+      server.use(
+        http.delete(`${API_BASE}/travel/photos/:id`, () =>
+          HttpResponse.json({ code: "ERR", message: "boom" }, { status: 500 }),
+        ),
+      );
+      const user = userEvent.setup();
+      renderDetail();
+
+      await user.click(await screen.findByLabelText("사진 1 삭제"));
+
+      expect(
+        await screen.findByText("사진을 지우지 못했어요."),
+      ).toBeInTheDocument();
+      // 되돌아와 두 장 그대로다.
+      expect(screen.getByLabelText("사진 2 삭제")).toBeInTheDocument();
+    });
+  });
+
+  describe("전체화면 뷰어", () => {
+    it("사진을 누르면 원본을 크게 띄운다", async () => {
+      const user = userEvent.setup();
+      renderDetail();
+
+      await user.click(
+        await screen.findByRole("button", { name: "사진 1 크게 보기" }),
+      );
+
+      const dialog = screen.getByRole("dialog", { name: "사진 보기" });
+      expect(
+        within(dialog).getByRole("img", { name: "사진 1" }),
+      ).toHaveAttribute("src", expect.stringContaining("/travel/activities/"));
+      expect(within(dialog).getByText("1 / 2")).toBeInTheDocument();
+    });
+
+    it("좌우로 넘긴다", async () => {
+      const user = userEvent.setup();
+      renderDetail();
+
+      await user.click(
+        await screen.findByRole("button", { name: "사진 1 크게 보기" }),
+      );
+      const dialog = screen.getByRole("dialog", { name: "사진 보기" });
+
+      // 첫 장에서는 이전으로 갈 수 없다.
+      expect(within(dialog).getByLabelText("이전 사진")).toBeDisabled();
+
+      await user.click(within(dialog).getByLabelText("다음 사진"));
+
+      expect(within(dialog).getByText("2 / 2")).toBeInTheDocument();
+      expect(within(dialog).getByLabelText("다음 사진")).toBeDisabled();
+    });
+
+    it("Esc로 닫는다", async () => {
+      const user = userEvent.setup();
+      renderDetail();
+
+      await user.click(
+        await screen.findByRole("button", { name: "사진 1 크게 보기" }),
+      );
+      await user.keyboard("{Escape}");
+
+      expect(screen.queryByRole("dialog", { name: "사진 보기" })).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## 이슈
closes #1092
## 작업 내용

기록 영역(#1090)에 사진을 얹었다. 일상기록(`lifelog`)의 presigned 업로드 파이프라인을 그대로 따르되 **EXIF를 제거**하는 점이 다르다 — 일상기록은 EXIF로 시각·위치를 자동채움하려고 원본을 그대로 올리지만, 여행은 사진 위치정보를 쓰지 않는다(§1.6).

### BE
- `trip_activity_photo` 마이그레이션(`051`) · 엔티티 · Repository
  - `log_id` FK CASCADE, `idx_photo_log (log_id, sort_order)`
  - **위치정보 컬럼을 두지 않는다.** 쓰지 않을 값을 받아 두지 않는다
- `POST /activities/{id}/photos/upload-url` — presigned PUT URL. 바이트가 BE를 거치지 않는다(사진 열 장이 서버 힙을 지나가면 안 된다)
  - `image/jpeg`만 받는다 — 재인코딩 결과가 JPEG이다. 원본 형식을 허용하면 재인코딩을 건너뛴 파일이 위치정보를 달고 올라온다
  - 발급 단계에서도 소유권·시작일을 본다
- `POST /activities/{id}/photos` — 업로드 끝난 것만 메타 등록. 10장 초과는 `TRAVEL-ERR-013`, **부분 반영하지 않는다**
- `DELETE /photos/{id}` — 행 삭제 + 오브젝트 best-effort 삭제. 오브젝트 삭제 실패로 트랜잭션을 되돌리면 화면에서 지운 사진이 되살아난다
- key prefix `travel/activities/` · `travel/thumbs/`. MinIO·버킷은 노트/일상기록과 공유하고 prefix만 가른다
- 응답에 key가 아니라 **URL**을 담는다 — 호스트 조립 규칙이 화면마다 흩어지면 환경이 바뀔 때 한 곳만 고쳐도 나머지가 깨진다

### 여기서 걸린 것
평점·메모를 다 비우면 기록 행을 지우는데(#1090), **사진이 붙어 있으면 CASCADE로 사진까지 날아간다.** `saveLog`가 사진 수를 보고 지울지 판단하도록 고쳤다. 통합 테스트로 고정했다.

### FE
- **원본도 canvas로 재인코딩**한다(긴 변 2560px). 그래야 EXIF가 떨어진다
  - 단 **orientation은 버리기 전에 적용**한다(`imageOrientation: "from-image"`). 회전 플래그만 떨구면 아이폰 세로 사진이 눕는다 — 정보를 지우는 것과 그림을 망치는 것은 다르다
- **성공한 장만 등록**한다. 한 장 실패로 아홉 장을 버리지 않는다. 실패한 장은 목록에 남겨 다시 고르게 한다
- 썸네일만 실패해도 사진은 살린다(`thumbKey: null` → 화면이 원본을 줄여 쓴다)
- 썸네일 그리드 + 전체화면 뷰어(좌우 버튼·터치 스와이프·키보드 ←/→·Esc)
- 삭제는 낙관적. 실패하면 되돌리고 알린다
- 오프라인이면 추가·삭제 비활성

### 테스트
- BE 통합 13건(발급 3·등록 6·기록 관계 2·스키마 2) · 스토리지 단위 4건
  - 통합 테스트는 **MinIO를 건드리지 않는 경로만** 다룬다. presigned 서명은 순수 로컬 계산이고, 오브젝트 삭제는 단위 테스트가 고정한다 — 통합에서 외부 호출을 하면 네트워크에 흔들린다
- FE 통합 9건(그리드 4·삭제 2·뷰어 3) · 단위 4건
  - 업로드 경로는 jsdom에 `createImageBitmap`도 `canvas.toBlob`도 없어 돌지 않는다. 크기 계산만 단위로 고정하고 나머지는 로컬 브라우저로 실증했다
- 게이트 통과: `./gradlew check` · FE `format:check`·`lint`·`test`(841 passed)·`build`

### 로컬 확인
검증용 MinIO를 임시로 띄우고(끝나고 제거), **EXIF를 심은 실제 사진**(3000×2000, Orientation=6, DateTimeOriginal, Make=Apple)을 브라우저에서 올려 확인
- 올라간 원본을 다시 받아 검사: `EXIF=[]` — 세 항목 모두 사라짐
- **1707×2560** — Orientation=6이 적용돼 가로가 세로로 돌았고, DB의 width/height와 실제 파일이 일치
- 94KB → 26KB(원본), 썸네일 320×480 1.6KB
- 뷰어에서 원본이 실제로 로드됨(naturalSize 1707×2560), `2 / 2`에서 다음 버튼 비활성, Esc로 닫힘
- 삭제 → 행과 오브젝트가 함께 사라짐(공개 URL 404)
- 평점·메모를 다 비워도 `hasLog: true`에 사진 1장 유지
- 시작 전 여행은 발급부터 `TRAVEL-ERR-012`, `image/heic`는 400
