### PR TITLE
fix : 오프라인에서 새로고침하면 로그아웃되던 문제

### DIFF
--- a/fe/e2e/offline.spec.ts
+++ b/fe/e2e/offline.spec.ts
@@ -68,4 +68,55 @@ test.describe("오프라인", () => {
       await context.setOffline(false);
     }
   });
+
+  /**
+   * #1095 — 여기까지 와야 오프라인 캐시가 쓸모 있다.
+   *
+   * <p>위 테스트는 <b>로그인 화면</b>에서만 새로고침한다. 로그인한 상태로 새로고침하면
+   * 토큰이 사라지고 재발급도 못 해, 예전에는 로그인 화면으로 쫓겨났다 — 캐시에 일정이
+   * 다 있어도 볼 수 없었다.
+   */
+  test("로그인한 채 오프라인에서 새로고침해도 로그인 화면으로 쫓겨나지 않는다", async ({
+    page,
+    context,
+  }) => {
+    await page.route("**/api/auth/login", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ code: "OK", data: { accessToken: "t" } }),
+      }),
+    );
+    // 조회는 비어 있어도 된다 — 여기서 보는 것은 "로그인 화면으로 튕기지 않는가"다.
+    await page.route("**/api/travel/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          code: "OK",
+          data: { ongoing: null, next: null, recentCount: 0 },
+        }),
+      }),
+    );
+
+    await page.goto("/login");
+    await page.evaluate(() => navigator.serviceWorker.ready);
+    await page.reload();
+
+    await page.getByRole("textbox", { name: "아이디" }).fill("admin");
+    await page.getByLabel("비밀번호").fill("password");
+    await page.getByRole("button", { name: "로그인" }).click();
+    await page.waitForURL(/\/(select|home)/);
+
+    await context.setOffline(true);
+    try {
+      await page.reload();
+      await expect(page).not.toHaveURL(/\/login/);
+      await expect(page.getByRole("textbox", { name: "아이디" })).toHaveCount(
+        0,
+      );
+    } finally {
+      await context.setOffline(false);
+    }
+  });
 });

--- a/fe/src/app/offlineSession.test.tsx
+++ b/fe/src/app/offlineSession.test.tsx
@@ -1,0 +1,156 @@
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearSession,
+  hadSession,
+  markSession,
+} from "../features/auth/sessionMarker";
+import { useAuthStore } from "../features/auth/store/authStore";
+import { server } from "../test/mocks/server";
+import { renderWithRouter } from "../test/render";
+import { Providers, useAuth } from "./providers";
+
+const API_BASE = "https://api.orino.dev/api";
+
+function AuthStatus() {
+  const { isAuthenticated, offlineSession, loading } = useAuth();
+  if (loading) return <div>로딩 중</div>;
+  return (
+    <div>
+      <span>{isAuthenticated ? "인증됨" : "미인증"}</span>
+      {offlineSession && <span>오프라인 세션</span>}
+    </div>
+  );
+}
+
+function renderApp(path = "/home") {
+  return renderWithRouter(
+    <Providers>
+      <Routes>
+        <Route path="/home" element={<AuthStatus />} />
+        <Route path="/login" element={<AuthStatus />} />
+      </Routes>
+    </Providers>,
+    { initialEntries: [path] },
+  );
+}
+
+/** 서버에 닿지 못하는 상황. 응답이 없는 것과 401은 다른 사건이다. */
+function mockUnreachable() {
+  server.use(http.post(`${API_BASE}/auth/reissue`, () => HttpResponse.error()));
+}
+
+function mockRejected() {
+  server.use(
+    http.post(`${API_BASE}/auth/reissue`, () =>
+      HttpResponse.json(null, { status: 401 }),
+    ),
+  );
+}
+
+/**
+ * 오프라인 새로고침(#1095).
+ *
+ * <p>액세스 토큰은 메모리에만 있어 새로고침하면 사라진다. 오프라인이라 재발급도 못 하는데,
+ * 그걸 로그아웃으로 처리하면 <b>캐시에 일정이 다 있어도 로그인 화면만 보게 된다.</b>
+ */
+describe("오프라인 세션", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: null });
+    clearSession();
+  });
+
+  afterEach(() => {
+    clearSession();
+  });
+
+  it("네트워크가 없고 로그인한 적 있으면 앱을 보여준다 — 캐시로 돈다", async () => {
+    markSession();
+    mockUnreachable();
+
+    renderApp();
+
+    expect(await screen.findByText("인증됨")).toBeInTheDocument();
+    expect(screen.getByText("오프라인 세션")).toBeInTheDocument();
+  });
+
+  it("네트워크 실패로는 세션을 끝내지 않는다", async () => {
+    markSession();
+    mockUnreachable();
+
+    renderApp();
+    await screen.findByText("인증됨");
+
+    expect(hadSession()).toBe(true);
+  });
+
+  it("로그인한 적 없으면 그냥 미인증이다 — 아무나 들여보내지 않는다", async () => {
+    mockUnreachable();
+
+    renderApp();
+
+    expect(await screen.findByText("미인증")).toBeInTheDocument();
+    expect(screen.queryByText("오프라인 세션")).toBeNull();
+  });
+
+  it("서버가 거절하면 로그아웃이다 — 만료된 세션까지 살려두지 않는다", async () => {
+    markSession();
+    mockRejected();
+
+    renderApp();
+
+    expect(await screen.findByText("미인증")).toBeInTheDocument();
+    expect(hadSession()).toBe(false);
+  });
+
+  it("네트워크가 돌아오면 다시 물어본다 — 오프라인 세션은 임시 상태다", async () => {
+    markSession();
+    mockUnreachable();
+
+    renderApp();
+    await screen.findByText("오프라인 세션");
+
+    // 온라인이 되고, 이번엔 서버가 거절한다(리프레시 토큰이 실제로 만료됐던 경우).
+    mockRejected();
+    window.dispatchEvent(new Event("online"));
+
+    await waitFor(() => expect(screen.getByText("미인증")).toBeInTheDocument());
+    expect(hadSession()).toBe(false);
+  });
+
+  it("화면으로 돌아올 때도 다시 물어본다 — online 이벤트를 못 받을 수 있다", async () => {
+    markSession();
+    mockUnreachable();
+
+    renderApp();
+    await screen.findByText("오프라인 세션");
+
+    // 앱을 접어 뒀다 여는 사이에 네트워크가 돌아온 경우. online 이벤트는 안 온다.
+    mockRejected();
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await waitFor(() => expect(screen.getByText("미인증")).toBeInTheDocument());
+  });
+
+  it("돌아온 뒤 재발급에 성공하면 정상 세션이 된다", async () => {
+    markSession();
+    mockUnreachable();
+
+    renderApp();
+    await screen.findByText("오프라인 세션");
+
+    server.use(
+      http.post(`${API_BASE}/auth/reissue`, () =>
+        HttpResponse.json({ code: "OK", data: { accessToken: "fresh" } }),
+      ),
+    );
+    window.dispatchEvent(new Event("online"));
+
+    await waitFor(() => expect(screen.queryByText("오프라인 세션")).toBeNull());
+    expect(screen.getByText("인증됨")).toBeInTheDocument();
+    expect(useAuthStore.getState().accessToken).toBe("fresh");
+  });
+});

--- a/fe/src/app/providers.tsx
+++ b/fe/src/app/providers.tsx
@@ -9,6 +9,7 @@ import {
 import { useLocation } from "react-router-dom";
 
 import { reissue } from "../features/auth/api/auth";
+import { hadSession } from "../features/auth/sessionMarker";
 import { getAccessToken } from "../features/auth/store/authStore";
 import { installFocusRevalidation } from "./focusRevalidation";
 import { prefetchRoutes } from "./routeImports";
@@ -18,12 +19,18 @@ installFocusRevalidation();
 
 interface AuthContextType {
   isAuthenticated: boolean;
+  /**
+   * 토큰 없이 캐시로만 도는 상태(#1095). 네트워크가 없어 재발급을 못 했지만 이 기기에서
+   * 로그인한 적은 있는 경우다. 조회는 되고 편집은 어차피 오프라인에서 막혀 있다(§4.6).
+   */
+  offlineSession: boolean;
   loading: boolean;
   refresh: () => void;
 }
 
 const AuthContext = createContext<AuthContextType>({
   isAuthenticated: false,
+  offlineSession: false,
   loading: true,
   refresh: () => {},
 });
@@ -37,10 +44,13 @@ const PUBLIC_ROUTES = ["/", "/login"];
 function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [version, setVersion] = useState(0);
+  const [offlineSession, setOfflineSession] = useState(false);
   const { pathname } = useLocation();
+  const refresh = () => setVersion((v) => v + 1);
 
   useEffect(() => {
     if (getAccessToken()) {
+      setOfflineSession(false);
       setLoading(false);
       return;
     }
@@ -48,11 +58,40 @@ function AuthProvider({ children }: { children: ReactNode }) {
       setLoading(false);
       return;
     }
-    reissue().finally(() => setLoading(false));
+    reissue()
+      .then((result) => {
+        // 서버에 닿지 못했을 뿐이고 이 기기에서 로그인한 적이 있다면, 캐시로 돌게 둔다.
+        // 여기서 로그인 화면으로 보내면 캐시에 든 일정을 끝내 못 본다(#1095).
+        setOfflineSession(result === "offline" && hadSession());
+      })
+      .finally(() => setLoading(false));
   }, [version, pathname]);
 
-  const isAuthenticated = getAccessToken() !== null;
-  const refresh = () => setVersion((v) => v + 1);
+  // 토큰이 있거나, 없더라도 오프라인 세션이면 앱을 보여준다.
+  const isAuthenticated = getAccessToken() !== null || offlineSession;
+
+  /**
+   * 네트워크가 돌아오면 곧바로 다시 물어본다.
+   *
+   * <p>오프라인 세션은 <b>임시 상태</b>다. 리프레시 토큰이 진짜로 만료됐다면 그 사실은
+   * 온라인이 돼야 알 수 있고, 그때 정상적으로 로그아웃된다.
+   *
+   * <p><b>{@code online} 이벤트만 믿지 않는다.</b> 폰에서 앱을 접어 뒀다 다시 여는 사이에
+   * 네트워크가 돌아오면 그 이벤트를 못 받는다 — 화면에 돌아올 때도 한 번 확인한다.
+   */
+  useEffect(() => {
+    if (!offlineSession) return;
+    const retry = () => refresh();
+    const onVisible = () => {
+      if (document.visibilityState === "visible") retry();
+    };
+    window.addEventListener("online", retry);
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      window.removeEventListener("online", retry);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [offlineSession]);
 
   // 로그인 상태면 idle 시간에 페이지 청크를 미리 받아 진입 지연을 없앤다.
   useEffect(() => {
@@ -62,7 +101,9 @@ function AuthProvider({ children }: { children: ReactNode }) {
   if (loading) return null;
 
   return (
-    <AuthContext.Provider value={{ isAuthenticated, loading, refresh }}>
+    <AuthContext.Provider
+      value={{ isAuthenticated, offlineSession, loading, refresh }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/fe/src/features/auth/api/auth.test.ts
+++ b/fe/src/features/auth/api/auth.test.ts
@@ -45,7 +45,7 @@ describe("auth API", () => {
   });
 
   describe("reissue", () => {
-    it("토큰 갱신 성공 시 true를 반환하고 accessToken을 저장한다", async () => {
+    it("토큰 갱신 성공 시 ok를 반환하고 accessToken을 저장한다", async () => {
       server.use(
         http.post(`${API_BASE}/auth/reissue`, () => {
           return HttpResponse.json({
@@ -57,11 +57,11 @@ describe("auth API", () => {
 
       const result = await reissue();
 
-      expect(result).toBe(true);
+      expect(result).toBe("ok");
       expect(useAuthStore.getState().accessToken).toBe("refreshed-token");
     });
 
-    it("토큰 갱신 실패 시 false를 반환하고 accessToken을 제거한다", async () => {
+    it("서버가 거절하면 unauthorized를 반환하고 accessToken을 제거한다", async () => {
       useAuthStore.setState({ accessToken: "old-token" });
 
       server.use(
@@ -72,7 +72,7 @@ describe("auth API", () => {
 
       const result = await reissue();
 
-      expect(result).toBe(false);
+      expect(result).toBe("unauthorized");
       expect(useAuthStore.getState().accessToken).toBeNull();
     });
   });

--- a/fe/src/features/auth/api/auth.ts
+++ b/fe/src/features/auth/api/auth.ts
@@ -1,5 +1,10 @@
 import client from "../../../shared/api/client";
-import { broadcastLogout, refreshAccessToken } from "../refreshCoordinator";
+import {
+  broadcastLogout,
+  refreshAccessToken,
+  type ReissueResult,
+} from "../refreshCoordinator";
+import { clearSession, markSession } from "../sessionMarker";
 import { setAccessToken } from "../store/authStore";
 
 interface LoginRequest {
@@ -15,13 +20,15 @@ interface TokenResponse {
 export async function login(request: LoginRequest): Promise<void> {
   const { data } = await client.post<TokenResponse>("/auth/login", request);
   setAccessToken(data.data.accessToken);
+  // 이 기기에서 로그인했다는 표시. 오프라인 새로고침이 이걸 근거로 삼는다(#1095).
+  markSession();
 }
 
 /**
  * 엑세스 토큰 재발급. 코디네이터에 위임한다 — 인터셉터·앱 시작 재발급이 같은 단일 비행/Web Lock을
  * 공유해, 동시 호출이 리프레시 토큰 회전으로 서로를 무효화하는 걸 막는다.
  */
-export function reissue(): Promise<boolean> {
+export function reissue(): Promise<ReissueResult> {
   return refreshAccessToken();
 }
 
@@ -30,6 +37,8 @@ export async function logout(): Promise<void> {
     await client.post("/auth/logout");
   } finally {
     setAccessToken(null);
+    // 사용자가 직접 나간 것이다 — 오프라인이어도 이 기기의 세션은 끝났다.
+    clearSession();
     broadcastLogout();
   }
 }

--- a/fe/src/features/auth/refreshCoordinator.test.ts
+++ b/fe/src/features/auth/refreshCoordinator.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { server } from "../../test/mocks/server";
 import { refreshAccessToken } from "./refreshCoordinator";
+import { clearSession, hadSession, markSession } from "./sessionMarker";
 import { useAuthStore } from "./store/authStore";
 
 const API_BASE = "https://api.orino.dev/api";
@@ -10,6 +11,7 @@ const API_BASE = "https://api.orino.dev/api";
 describe("refreshAccessToken", () => {
   beforeEach(() => {
     useAuthStore.setState({ accessToken: null });
+    clearSession();
   });
 
   it("동시 호출을 하나의 재발급 요청으로 합친다(단일 비행)", async () => {
@@ -26,13 +28,13 @@ describe("refreshAccessToken", () => {
       refreshAccessToken(),
     ]);
 
-    expect(a).toBe(true);
-    expect(b).toBe(true);
+    expect(a).toBe("ok");
+    expect(b).toBe("ok");
     expect(calls).toBe(1); // 두 호출이 합쳐져 서버는 한 번만
     expect(useAuthStore.getState().accessToken).toBe("t1");
   });
 
-  it("실패 시 false를 반환하고 토큰을 비운다", async () => {
+  it("서버가 거절하면 unauthorized를 반환하고 토큰을 비운다", async () => {
     useAuthStore.setState({ accessToken: "old" });
     server.use(
       http.post(`${API_BASE}/auth/reissue`, () =>
@@ -42,7 +44,35 @@ describe("refreshAccessToken", () => {
 
     const ok = await refreshAccessToken();
 
-    expect(ok).toBe(false);
+    expect(ok).toBe("unauthorized");
     expect(useAuthStore.getState().accessToken).toBeNull();
+    // 서버가 판단을 내렸으니 이 기기의 세션도 끝난다.
+    expect(hadSession()).toBe(false);
+  });
+
+  it("서버에 닿지 못하면 offline이다 — 세션을 끝내지 않는다", async () => {
+    markSession();
+    server.use(
+      http.post(`${API_BASE}/auth/reissue`, () => HttpResponse.error()),
+    );
+
+    const result = await refreshAccessToken();
+
+    expect(result).toBe("offline");
+    // 네트워크가 없는 것은 로그아웃이 아니다 — 이걸 섞으면 비행기 모드에서
+    // 새로고침만 해도 로그아웃된다(#1095).
+    expect(hadSession()).toBe(true);
+  });
+
+  it("재발급에 성공하면 세션 표시를 남긴다", async () => {
+    server.use(
+      http.post(`${API_BASE}/auth/reissue`, () =>
+        HttpResponse.json({ code: "OK", data: { accessToken: "t" } }),
+      ),
+    );
+
+    await refreshAccessToken();
+
+    expect(hadSession()).toBe(true);
   });
 });

--- a/fe/src/features/auth/refreshCoordinator.ts
+++ b/fe/src/features/auth/refreshCoordinator.ts
@@ -2,7 +2,17 @@ import axios from "axios";
 
 import { API_BASE_URL } from "@/shared/api/config";
 
+import { clearSession, markSession } from "./sessionMarker";
 import { setAccessToken } from "./store/authStore";
+
+/**
+ * 재발급 결과.
+ *
+ * <p><b>실패를 둘로 나눈 것이 핵심이다.</b> 서버가 거절한 것("unauthorized")과 서버에 닿지도
+ * 못한 것("offline")은 다른 사건인데, 예전에는 둘 다 로그아웃으로 처리해 비행기 모드에서
+ * 새로고침만 해도 로그아웃됐다(#1095).
+ */
+export type ReissueResult = "ok" | "unauthorized" | "offline";
 
 /** 탭 간 재발급 직렬화용 Web Lock 이름. */
 const LOCK_NAME = "orino-auth-refresh";
@@ -35,9 +45,9 @@ channel?.addEventListener("message", (e: MessageEvent<AuthMessage>) => {
   }
 });
 
-let inFlight: Promise<boolean> | null = null;
+let inFlight: Promise<ReissueResult> | null = null;
 
-async function reissueOnce(): Promise<boolean> {
+async function reissueOnce(): Promise<ReissueResult> {
   try {
     const { data } = await axios.post<{ data: { accessToken: string } }>(
       `${API_BASE_URL}/auth/reissue`,
@@ -46,22 +56,31 @@ async function reissueOnce(): Promise<boolean> {
     );
     const token = data.data.accessToken;
     setAccessToken(token);
+    markSession();
     channel?.postMessage({ type: "token", accessToken: token } as AuthMessage);
-    return true;
-  } catch {
-    setAccessToken(null);
-    return false;
+    return "ok";
+  } catch (error) {
+    // 응답이 있으면 서버가 판단을 내린 것이다 — 그때만 로그아웃이다.
+    if (axios.isAxiosError(error) && error.response) {
+      setAccessToken(null);
+      clearSession();
+      return "unauthorized";
+    }
+    // 서버에 닿지 못했다. 토큰도 세션 표시도 건드리지 않는다 — 나중에 다시 물어보면 된다.
+    return "offline";
   }
 }
 
 /** Web Locks가 있으면 그 락 안에서 실행(브라우저당 동시 재발급 1개), 없으면 그냥 실행한다. */
-function withCrossTabLock(fn: () => Promise<boolean>): Promise<boolean> {
+function withCrossTabLock(
+  fn: () => Promise<ReissueResult>,
+): Promise<ReissueResult> {
   const locks =
     typeof navigator !== "undefined"
       ? (navigator as Navigator & { locks?: LockManager }).locks
       : undefined;
   if (locks?.request) {
-    return locks.request(LOCK_NAME, fn) as Promise<boolean>;
+    return locks.request(LOCK_NAME, fn) as Promise<ReissueResult>;
   }
   return fn();
 }
@@ -71,7 +90,7 @@ function withCrossTabLock(fn: () => Promise<boolean>): Promise<boolean> {
  * 직렬화한다. 성공하면 새 토큰을 다른 탭에도 전파한다. 인터셉터·앱 시작 재발급이 모두 이 함수를
  * 거치게 해, 리프레시 토큰 회전(단일 사용)이 동시 호출로 서로를 무효화하며 재로그인시키는 걸 막는다.
  */
-export function refreshAccessToken(): Promise<boolean> {
+export function refreshAccessToken(): Promise<ReissueResult> {
   if (inFlight) return inFlight;
   inFlight = withCrossTabLock(reissueOnce).finally(() => {
     inFlight = null;

--- a/fe/src/features/auth/sessionMarker.ts
+++ b/fe/src/features/auth/sessionMarker.ts
@@ -1,0 +1,37 @@
+/**
+ * 이 기기에서 로그인한 적이 있다는 표시.
+ *
+ * <p><b>비밀이 아니다.</b> 토큰도 사용자 정보도 아니고 "여기서 로그인한 적 있음"이라는 사실
+ * 하나뿐이라, 저장한다고 새로 드러나는 것이 없다. 액세스 토큰을 메모리에만 두는 결정은
+ * 그대로 둔다.
+ *
+ * <p>이게 필요한 이유: 오프라인에서 새로고침하면 토큰이 사라지고 재발급도 못 한다. 그때
+ * "로그인한 적 없는 사람"과 "지금 네트워크가 없을 뿐인 사람"을 구분할 근거가 이것뿐이다.
+ * 없으면 캐시에 일정이 다 있어도 로그인 화면만 보게 된다(#1095).
+ */
+const KEY = "orino.session";
+
+/** localStorage가 막힌 브라우저(사파리 프라이빗 등)에서도 앱이 죽으면 안 된다. */
+function safely<T>(fn: () => T, fallback: T): T {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}
+
+export function markSession(): void {
+  safely(() => localStorage.setItem(KEY, "1"), undefined);
+}
+
+/**
+ * 표시를 지운다. <b>서버가 거절했을 때만</b> 부른다 — 네트워크가 안 닿은 것은 로그아웃이
+ * 아니다. 그 둘을 섞으면 비행기 모드에서 로그아웃당한다.
+ */
+export function clearSession(): void {
+  safely(() => localStorage.removeItem(KEY), undefined);
+}
+
+export function hadSession(): boolean {
+  return safely(() => localStorage.getItem(KEY) === "1", false);
+}

--- a/fe/src/shared/api/client.ts
+++ b/fe/src/shared/api/client.ts
@@ -56,9 +56,14 @@ client.interceptors.response.use(
     }
 
     // 재발급은 코디네이터가 탭 내 단일 비행 + 탭 간 Web Lock으로 직렬화한다.
-    const refreshed = await refreshAccessToken();
-    if (refreshed) {
+    const result = await refreshAccessToken();
+    if (result === "ok") {
       return client(originalRequest);
+    }
+    // 재발급조차 못 닿았으면 네트워크가 없는 것이다. 로그인 화면으로 쫓아내면 캐시로
+    // 보던 화면까지 잃는다(#1095) — 그냥 실패로 돌려주고 화면이 오프라인 처리를 하게 둔다.
+    if (result === "offline") {
+      return Promise.reject(error);
     }
     window.location.href = "/login";
     return Promise.reject(error);


### PR DESCRIPTION
## 이슈
closes #1095
## 작업 내용

이슈에서 제안한 **(b) 오프라인 읽기 전용 세션**으로 갔다. 액세스 토큰을 메모리에만 두는 결정은 그대로 둔다.

### 실패를 둘로 나눈다

재발급 결과가 `boolean`에서 `"ok" | "unauthorized" | "offline"`이 됐다.

```ts
} catch (error) {
  // 응답이 있으면 서버가 판단을 내린 것이다 — 그때만 로그아웃이다.
  if (axios.isAxiosError(error) && error.response) { ...clear... return "unauthorized"; }
  // 서버에 닿지 못했다. 토큰도 세션 표시도 건드리지 않는다.
  return "offline";
}
```

인터셉터도 마찬가지다 — 재발급에 **못 닿았으면** 로그인으로 쫓아내지 않고 그냥 실패로 돌려준다. 쫓아내면 캐시로 보던 화면까지 잃는다.

### 세션 표시

`localStorage["orino.session"]`. **토큰이 아니라 "이 기기에서 로그인한 적 있음"이라는 사실 하나**다 — 저장한다고 새로 드러나는 것이 없다. 오프라인 새로고침에서 "로그인한 적 없는 사람"과 "지금 네트워크가 없을 뿐인 사람"을 가를 근거가 이것뿐이다.

로그인·재발급 성공에 남기고, **서버가 거절했을 때만** 지운다(사용자가 직접 로그아웃한 경우 포함).

### 오프라인 세션

토큰이 없어도 `offline` + 표시가 있으면 앱을 보여준다. 조회는 SW 캐시가 받고(캐시 매칭은 URL 기준이라 Authorization 헤더가 없어도 된다), 편집은 어차피 오프라인에서 막혀 있다(§4.6).

**임시 상태다.** 리프레시 토큰이 진짜로 만료됐다면 온라인이 돼야 알 수 있고, 그때 정상적으로 로그아웃된다. 그래서 `online` 이벤트와 **탭 복귀**(`visibilitychange`) 양쪽에서 다시 물어본다 — 폰에서 앱을 접어 뒀다 여는 사이에 네트워크가 돌아오면 `online`을 못 받는다.

### 테스트
- 통합 7건(오프라인+표시 있음 → 앱 노출 / 세션 유지 / 표시 없으면 미인증 / 서버 거절은 로그아웃 / 온라인 복귀 재확인 / **탭 복귀 재확인** / 복귀 후 정상 세션)
- 코디네이터 단위 4건(단일 비행, unauthorized, **offline은 세션을 안 끝냄**, 성공 시 표시)
- **E2E 추가**: 로그인한 채 오프라인 새로고침 → 로그인 화면으로 쫓겨나지 않는다
  - 이 테스트가 실제로 회귀를 잡는지 확인했다 — `hadSession()`을 `false`로 되돌려 놓고 돌리니 정확히 이 테스트만 실패했다
- 게이트 통과: `format:check` · `lint` · `test`(861 passed) · `build` · E2E `built` 프로젝트 9건

### 로컬 확인
`vite preview`(실제 SW) + BE, 실데이터로 확인
- 로그인 → 보드 → **네트워크 끊고 새로고침** → 로그인 화면 대신 **보드가 캐시로 그대로 뜬다**(도쿄 3박 4일, 날짜 탭 날씨, 센소지 일정까지)
- 오프라인 배너와 편집 차단(도구·지도 버튼)도 그대로 동작
- 리프레시 쿠키를 지워 "이미 만료된 세션"을 만들고 오프라인 새로고침 → 캐시로 보이다가, 온라인 복귀 시 `/login`으로 나가고 세션 표시도 지워짐

### 참고 — 이 PR과 무관한 기존 실패
`e2e/auth.spec.ts`의 2건(`로그인 성공 시 /select로 이동한다`, `로그인 → 로그아웃 전체 흐름`)이 실패하는데, **main에서도 똑같이 실패한다**(작업을 치우고 확인). 이 PR이 만든 것이 아니라 따로 봐야 한다.
