### PR TITLE
fix : auth E2E가 실제 BE로 새던 문제 + E2E CI 편입

### DIFF
--- a/.github/workflows/fe-ci.yml
+++ b/.github/workflows/fe-ci.yml
@@ -44,3 +44,24 @@ jobs:
       - name: Build
         working-directory: fe
         run: npm run build
+
+      # E2E는 유닛 테스트가 못 보는 것을 본다 — 서비스워커·오프라인·실제 드래그.
+      # CI에 없으면 깨져도 아무도 모른다(#1098에서 실제로 그랬다).
+      - name: Install Playwright browsers
+        working-directory: fe
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E
+        working-directory: fe
+        run: npm run test:e2e
+
+      # 실패했을 때 무엇을 봤는지가 남아야 원인을 찾는다.
+      - name: Upload E2E report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            fe/playwright-report
+            fe/test-results
+          retention-days: 7

--- a/fe/e2e/auth.spec.ts
+++ b/fe/e2e/auth.spec.ts
@@ -7,9 +7,30 @@ import { expect, test } from "@playwright/test";
  * `.env.development`가 `VITE_API_URL=/api`라 앱은 Vite 프록시(`/api/...`)로 부른다.
  * 매치가 안 되면 요청이 프록시를 타고 실제 BE로 나가고, BE가 없으면 500이 온다.
  * 경로 패턴은 dev·배포 양쪽에 다 걸린다.
+ *
+ * <p><b>인증 외의 API는 통째로 막는다.</b> 개별 경로를 하나씩 막으면 화면이 새 API를
+ * 부르기 시작할 때마다 하나씩 새고, 그때 이 테스트는 <b>BE가 떠 있는 기계에서만</b>
+ * 실패한다 — 가짜 토큰을 실제 BE가 401로 거부하고 앱이 정상적으로 자동 로그아웃하기
+ * 때문이다. 실제로 그렇게 깨졌다(#1098).
+ *
+ * <p>막는 방법에 주의: 글로브 {@code **&#47;api&#47;**}는 dev에서 <b>앱 소스</b>
+ * ({@code /src/shared/api/client.ts})까지 삼켜 화면이 아예 안 뜬다. 경로 술어로 잡는다.
+ *
+ * <p>Playwright는 <b>나중에 등록한 route가 이긴다</b> — 포괄 규칙을 먼저 깔고 개별 규칙을 얹는다.
  */
 function mockAuthApi(page: import("@playwright/test").Page) {
   return Promise.all([
+    page.route(
+      (url) => url.pathname.startsWith("/api/"),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ code: "OK", data: null }),
+        });
+      },
+    ),
+
     page.route("**/api/auth/login", async (route) => {
       const body = route.request().postDataJSON();
       if (body.loginId === "admin" && body.password === "password") {
@@ -44,9 +65,7 @@ function mockAuthApi(page: import("@playwright/test").Page) {
       });
     }),
 
-    // 로그인 후 화면엔 Sidebar가 딸려 오고 복습 요약을 부른다. 안 막아두면
-    // 실제 BE가 가짜 토큰을 401로 거부하고 앱이 정상적으로 자동 로그아웃해 버린다
-    // (= BE가 떠 있으면 실패하는 테스트가 된다).
+    // 위 포괄 규칙으로도 막히지만, Sidebar가 이 응답의 <b>형태</b>에 기대므로 진짜에 가깝게 준다.
     page.route("**/api/planner/reviews/summary*", async (route) => {
       await route.fulfill({
         status: 200,

--- a/fe/playwright.config.ts
+++ b/fe/playwright.config.ts
@@ -38,7 +38,9 @@ export default defineConfig({
     {
       command: "npm run dev",
       url: "http://localhost:3000",
-      reuseExistingServer: true,
+      // 로컬에서는 이미 띄운 서버를 재사용한다. CI에는 재사용할 것이 없고, 남아 있는
+      // 서버를 잘못 붙잡으면 옛 코드를 검증하게 되므로 항상 새로 띄운다.
+      reuseExistingServer: !process.env.CI,
       timeout: 10_000,
     },
     // Service Worker는 dev에서 돌지 않는다(HMR과 싸워서 꺼 뒀다).
@@ -46,7 +48,7 @@ export default defineConfig({
     {
       command: "npm run build && npm run preview -- --port 4173",
       url: "http://localhost:4173",
-      reuseExistingServer: true,
+      reuseExistingServer: !process.env.CI,
       timeout: 120_000,
     },
   ],


### PR DESCRIPTION
## 이슈
closes #1098
## 작업 내용

### 먼저, 이슈의 진단이 틀렸다

이슈에 "`/select`에 로그아웃 버튼이 없다"고 적었는데 **틀렸다.** `/select`는 `AppHeader`를 렌더하고 거기 로그아웃 버튼이 있다. 이슈 본문을 실제 원인으로 고쳐 뒀다.

### 진짜 원인 — 테스트가 실제 BE로 샌다

`mockAuthApi()`가 인증 엔드포인트와 복습 요약만 가로챘다. 그런데 로그인 후 `/select`는 `travel/summary`·`planner/calendar`도 부른다. 그 요청들은 목을 못 만나 Vite 프록시를 타고 **실제 BE로 나갔다.**

- BE가 안 떠 있으면 → 연결 실패 → 401 아님 → **통과**
- BE가 떠 있으면 → 가짜 토큰을 401로 거부 → 인터셉터가 재발급 시도 → 목이 401 → 앱이 **정상적으로** `/login`으로 자동 로그아웃 → **실패**

즉 개발자 기계에 BE가 떠 있느냐로 결과가 뒤집혔다. 파일에 이미 "BE가 떠 있으면 실패하는 테스트가 된다"는 주석과 함께 복습 요약을 막아둔 흔적이 있는데, 여행 워크스페이스가 생기며 부르는 API가 늘었고 목록이 따라가지 못했다.

### 고친 방식

경로를 하나씩 쫓지 않고 **인증 외 `/api/`를 통째로** 막는다. 화면이 새 API를 부르기 시작해도 다시 새지 않는다.

**글로브를 쓰면 안 된다.** `**/api/**`로 막아 보니 dev에서 **앱 소스**(`/src/shared/api/client.ts`)까지 삼켜 화면이 아예 안 떴다 — 실제로 그렇게 한 번 막혔고, 가로챈 URL을 찍어 보고 알았다. 경로 술어(`url.pathname.startsWith("/api/")`)로 잡는다.

Playwright는 나중에 등록한 route가 이기므로 포괄 규칙을 먼저 깔고 개별 규칙을 얹었다.

### E2E를 CI에 넣는다

이슈의 두 번째 Todo였다. **없으면 깨져도 아무도 모른다** — 이번 건이 정확히 그랬다. E2E는 유닛이 못 보는 것(서비스워커·오프라인·실제 드래그)을 보고, 실제로 오프라인 흰 화면(#1085)과 오프라인 새로고침 로그아웃(#1095)을 잡은 것이 이 층이다.

- `Build` 뒤에 `Install Playwright browsers`(chromium만) + `E2E` 추가
- 실패 시 `playwright-report`·`test-results`를 아티팩트로 남긴다 — 무엇을 봤는지가 남아야 원인을 찾는다
- CI에서는 서버를 재사용하지 않는다(`reuseExistingServer: !process.env.CI`). 남아 있는 서버를 잘못 붙잡으면 **옛 코드를 검증**하게 된다

**남겨 둔 것 둘** — 판단이 필요해 이 PR에서 정하지 않았다.

- `retries: 0` 그대로 뒀다. 재시도를 넣으면 진짜 flaky가 초록으로 덮인다. 실제로 흔들리는 게 보이면 그때 넣는 편이 낫다고 본다
- preview용 webServer가 `npm run build`를 한 번 더 돌아 CI에서 빌드가 두 번이다(약 15초). 없애려면 CI 전용 분기가 필요해 두 번 도는 쪽을 택했다

### 검증
- auth E2E 5건 통과 — **BE가 8080에 떠 있는 상태에서** 확인했다(이 조건이 원래 실패시키던 조건이다)
- 전체 E2E 89건 통과
- `CI=true`로도 89건 통과(42초) — 서버를 새로 띄우는 CI 경로 그대로
- FE 게이트: `format:check` · `lint` · `test`(861 passed) · `build`
- 워크플로 YAML 파싱 확인
