### PR TITLE
feat : 장소 사진을 MinIO에 캐시

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/service/TravelPhotoStorageService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/service/TravelPhotoStorageService.java
@@ -6,6 +6,7 @@ import ds.project.orino.planner.travel.photo.dto.PhotoUploadUrlResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -14,6 +15,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -32,6 +34,9 @@ public class TravelPhotoStorageService {
 
     private static final String ORIGINAL_PREFIX = "travel/activities";
     private static final String THUMB_PREFIX = "travel/thumbs";
+
+    /** 구글에서 받아 캐시한 장소 대표 사진. 사용자가 올린 사진과 섞이지 않게 나눈다. */
+    private static final String PLACE_PREFIX = "travel/places";
 
     /** FE가 canvas로 재인코딩해 올리므로 항상 JPEG이다(§1.6 EXIF 제거). */
     private static final String EXTENSION = "jpg";
@@ -73,6 +78,31 @@ public class TravelPhotoStorageService {
         return new PhotoUploadUrlResponse(
                 presigner.presignPutObject(presignRequest).url().toString(),
                 toPublicUrl(key), key);
+    }
+
+    /**
+     * 구글 장소 사진을 서버가 직접 올린다.
+     *
+     * <p>사용자 사진과 달리 <b>바이트가 서버를 지나간다</b> — 브라우저가 구글에서 받아 올 수
+     * 없기 때문이다(키가 필요하고 URL이 만료된다). 대신 장소당 한 장, 800px이라 작다.
+     *
+     * @return 저장된 object key. 실패하면 비어 있다
+     */
+    public Optional<String> uploadPlacePhoto(Long placeId, byte[] bytes) {
+        String key = "%s/%d/%s.jpg".formatted(PLACE_PREFIX, placeId, UUID.randomUUID());
+        try {
+            s3Client.putObject(PutObjectRequest.builder()
+                            .bucket(props.bucket())
+                            .key(key)
+                            .contentType("image/jpeg")
+                            .build(),
+                    RequestBody.fromBytes(bytes));
+            return Optional.of(key);
+        } catch (RuntimeException e) {
+            // 사진이 없다고 장소를 못 쓰게 만들지 않는다 — 다음 갱신 때 다시 시도한다.
+            log.warn("장소 사진 업로드 실패(무시): placeId={}, {}", placeId, e.getMessage());
+            return Optional.empty();
+        }
     }
 
     /** object key를 공개 URL로 조립한다. 호스트는 설정에서 온다 — 환경별로 갈린다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/GooglePlacesClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/GooglePlacesClient.java
@@ -65,11 +65,25 @@ public class GooglePlacesClient implements PlacesClient {
             "locality", "postal_town", "administrative_area_level_3",
             "administrative_area_level_2", "administrative_area_level_1", "country");
 
-    /** 상세는 영업시간·전화번호가 추가된다. */
+    /**
+     * 상세는 영업시간·전화번호·사진이 추가된다.
+     *
+     * <p><b>검색 마스크에는 photos를 넣지 않는다.</b> 검색 결과는 20개인데 거기까지 사진을
+     * 달면 화면 한 번에 20장을 받아야 하고, 그건 그대로 유료 호출 20번이다. 사진은 담아 둔
+     * 장소에만 붙인다.
+     */
     private static final String DETAILS_MASK = String.join(",",
             "id", "displayName", "formattedAddress", "location", "rating",
             "primaryTypeDisplayName", "nationalPhoneNumber", "regularOpeningHours",
-            "timeZone", "addressComponents");
+            "timeZone", "addressComponents", "photos");
+
+    /**
+     * 받아 올 사진의 최대 가로 픽셀.
+     *
+     * <p>장소 블록의 미리보기용이라 원본이 필요 없다. 크게 받으면 저장 용량과 전송량만
+     * 늘고, 이 사진은 오프라인 캐시에도 실린다.
+     */
+    private static final int PHOTO_MAX_WIDTH = 800;
 
     private final RestClient restClient;
     private final PlacesProperties props;
@@ -163,6 +177,45 @@ public class GooglePlacesClient implements PlacesClient {
         }
     }
 
+    /**
+     * 사진 바이트 받기 — <b>두 번 호출한다.</b>
+     *
+     * <p>구글의 media 엔드포인트는 기본적으로 CDN으로 <b>리다이렉트</b>하는데, 그 리다이렉트를
+     * 따라가면 우리 API 키가 CDN 요청에 실려 나간다. {@code skipHttpRedirect=true}로 URI만
+     * 받아 두 번째 호출에서 키 없이 내려받는다.
+     *
+     * <p>그 URI는 <b>만료된다</b>. 그래서 DB에 넣지 않고 바이트를 받아 우리 저장소에 넣는다.
+     */
+    @Override
+    public Optional<byte[]> fetchPhoto(String photoName) {
+        if (!props.enabled() || photoName == null || photoName.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            // 리소스 이름에 슬래시가 들어 있다(`places/X/photos/Y`). URI 템플릿 변수로 넘기면
+            // 슬래시가 %2F로 인코딩돼 404가 난다 — 경로로 붙여야 한다.
+            JsonNode node = restClient.get()
+                    .uri(builder -> builder.path("/v1/" + photoName + "/media")
+                            .queryParam("maxWidthPx", PHOTO_MAX_WIDTH)
+                            .queryParam("skipHttpRedirect", true)
+                            .build())
+                    .header("X-Goog-Api-Key", props.apiKey())
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            String uri = text(node, "photoUri");
+            if (uri == null) {
+                return Optional.empty();
+            }
+            byte[] bytes = RestClient.create().get().uri(uri).retrieve().body(byte[].class);
+            return Optional.ofNullable(bytes).filter(b -> b.length > 0);
+        } catch (Exception e) {
+            // 사진이 없다고 장소를 못 쓰게 만들지 않는다.
+            log.warn("Places 사진 조회 실패: photo={}, {}", photoName, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
     private List<PlaceResult> searchText(Map<String, Object> body, String fieldMask) {
         if (!props.enabled()) {
             return List.of();
@@ -207,7 +260,35 @@ public class GooglePlacesClient implements PlacesClient {
                 rawJson(node.get("regularOpeningHours")),
                 nestedText(node, "timeZone", "id"),
                 countryCode(node.get("addressComponents")),
-                types(node.get("types")));
+                types(node.get("types")),
+                photoName(node.get("photos")),
+                photoAttribution(node.get("photos")));
+    }
+
+    /** 대표 사진 하나만 쓴다 — 장소 블록에 한 장이면 충분하고, 장수만큼 유료 호출이 는다. */
+    private String photoName(JsonNode photos) {
+        JsonNode first = firstPhoto(photos);
+        return first == null ? null : text(first, "name");
+    }
+
+    /**
+     * 사진 저작자 표기. <b>구글 약관상 사진을 보여줄 때 함께 표시해야 한다</b> —
+     * 사진만 캐시하고 표기를 버리면 쓸 수 없는 사진이 된다.
+     */
+    private String photoAttribution(JsonNode photos) {
+        JsonNode first = firstPhoto(photos);
+        if (first == null) {
+            return null;
+        }
+        JsonNode authors = first.get("authorAttributions");
+        if (authors == null || !authors.isArray() || authors.isEmpty()) {
+            return null;
+        }
+        return text(authors.get(0), "displayName");
+    }
+
+    private static JsonNode firstPhoto(JsonNode photos) {
+        return photos == null || !photos.isArray() || photos.isEmpty() ? null : photos.get(0);
     }
 
     private static List<String> types(JsonNode types) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/PlaceResult.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/PlaceResult.java
@@ -14,6 +14,9 @@ import java.util.List;
  * @param countryCode   ISO 3166-1 alpha-2. 통화를 여기서 유도한다
  * @param openingHours  영업시간 원본 JSON. 구조를 해석하지 않고 그대로 캐시해 FE에 넘긴다
  * @param types         Google place type 목록. 목적지 검색에서 행정구역만 골라내는 데 쓴다
+ * @param photoName     사진 <b>리소스 이름</b>(`places/X/photos/Y`). 이미지가 아니라 참조다 —
+ *                      실제 바이트는 별도 호출로 받아야 하고 그 URL은 만료된다
+ * @param photoAttribution 사진 저작자 표기. <b>구글 약관상 사진을 보여줄 때 함께 표시해야 한다</b>
  */
 public record PlaceResult(
         String googlePlaceId,
@@ -27,7 +30,9 @@ public record PlaceResult(
         String openingHours,
         String timezone,
         String countryCode,
-        List<String> types
+        List<String> types,
+        String photoName,
+        String photoAttribution
 ) {
 
     /** {@code types}는 검색 종류에 따라 요청하지 않으므로 null이 올 수 있다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/PlacesClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/PlacesClient.java
@@ -22,8 +22,18 @@ public interface PlacesClient {
      */
     List<PlaceResult> searchPlaces(String query, Coordinates bias);
 
-    /** 장소 상세(영업시간·전화번호). */
+    /** 장소 상세(영업시간·전화번호·사진 리소스 이름). */
     Optional<PlaceResult> fetchDetails(String googlePlaceId);
+
+    /**
+     * 사진 바이트를 받는다.
+     *
+     * <p>구글이 주는 것은 리소스 이름뿐이고, 이미지 URL은 <b>만료된다</b>. 그래서 DB에 URL을
+     * 넣어 둘 수 없고, 받아서 우리 저장소에 넣는 수밖에 없다.
+     *
+     * @return 실패하면 비어 있다 — 사진이 없다고 장소를 못 쓰게 만들지 않는다
+     */
+    Optional<byte[]> fetchPhoto(String photoName);
 
     record Coordinates(BigDecimal lat, BigDecimal lng) {
     }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceDetail.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceDetail.java
@@ -9,6 +9,8 @@ import java.math.BigDecimal;
  *
  * @param openingHours 구글 영업시간 원본 JSON. 서버가 구조를 해석하지 않고 그대로 넘긴다 —
  *                     표기 규칙이 나라마다 달라 서버가 문자열을 만들면 오히려 어색해진다
+ * @param photoUrl     MinIO에 캐시한 대표 사진. 없으면 null
+ * @param photoAttribution 사진 저작자. <b>사진을 보여줄 때 함께 표시해야 한다</b>(구글 약관)
  */
 public record PlaceDetail(
         Long id,
@@ -22,6 +24,7 @@ public record PlaceDetail(
         BigDecimal rating,
         String openingHours,
         String photoUrl,
+        String photoAttribution,
         boolean manualEntry
 ) {
 
@@ -29,6 +32,6 @@ public record PlaceDetail(
         return new PlaceDetail(place.getId(), place.getGooglePlaceId(), place.getName(),
                 place.getAddress(), place.getLat(), place.getLng(), place.getCategory(),
                 place.getPhone(), place.getRating(), place.getOpeningHours(), photoUrl,
-                place.isManualEntry());
+                place.getPhotoAttribution(), place.isManualEntry());
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceSearchResult.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceSearchResult.java
@@ -6,9 +6,10 @@ import java.math.BigDecimal;
  * S-06 장소 검색 결과 한 건.
  *
  * @param id       이미 담아 둔 장소면 내부 id, 아니면 null
- * @param photoUrl MinIO에 캐시한 대표 사진. 사진 캐시는 별도 이슈라 지금은 항상 null
- * @param loved    이전 여행에서 평점 4 이상을 준 곳(⭐ 좋았던 곳).
- *                 기록 테이블이 4단계라 지금은 항상 false
+ * @param photoUrl <b>이미 담아 둔 장소</b>의 캐시된 대표 사진. 아직 담지 않은 곳은 null이다 —
+ *                 검색 결과 20개의 사진을 여기서 받으면 화면 한 번에 유료 호출 20번이다
+ * @param photoAttribution 사진 저작자. 사진을 <b>보여주는 곳마다</b> 함께 표시해야 한다(구글 약관)
+ * @param loved    이전 여행에서 평점 4 이상을 준 곳(⭐ 좋았던 곳). 판정은 별도 이슈라 지금은 false
  */
 public record PlaceSearchResult(
         Long id,
@@ -18,6 +19,7 @@ public record PlaceSearchResult(
         String address,
         BigDecimal rating,
         String photoUrl,
+        String photoAttribution,
         BigDecimal lat,
         BigDecimal lng,
         boolean loved

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
@@ -13,6 +13,7 @@ import ds.project.orino.planner.travel.place.dto.CityResponse;
 import ds.project.orino.planner.travel.place.dto.PlaceCreateRequest;
 import ds.project.orino.planner.travel.place.dto.PlaceDetail;
 import ds.project.orino.planner.travel.place.dto.PlaceSearchResult;
+import ds.project.orino.planner.travel.photo.service.TravelPhotoStorageService;
 import ds.project.orino.redis.planner.travel.PlaceSearchCacheRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +46,7 @@ public class PlaceService {
     private final TravelPlaceRepository placeRepository;
     private final TripRepository tripRepository;
     private final PlacesProperties props;
+    private final TravelPhotoStorageService storageService;
     private final ObjectMapper objectMapper;
     private final Clock clock;
 
@@ -53,6 +55,7 @@ public class PlaceService {
                         TravelPlaceRepository placeRepository,
                         TripRepository tripRepository,
                         PlacesProperties props,
+                        TravelPhotoStorageService storageService,
                         ObjectMapper objectMapper,
                         Clock clock) {
         this.placesClient = placesClient;
@@ -60,6 +63,7 @@ public class PlaceService {
         this.placeRepository = placeRepository;
         this.tripRepository = tripRepository;
         this.props = props;
+        this.storageService = storageService;
         this.objectMapper = objectMapper;
         this.clock = clock;
     }
@@ -94,17 +98,24 @@ public class PlaceService {
                 () -> placesClient.searchPlaces(query, bias));
 
         // 이미 담아 둔 장소는 내부 id를 실어 준다 — FE가 "담기" 대신 상태를 보여줄 수 있다.
-        Map<String, Long> savedIds = savedIdsOf(memberId, results);
+        Map<String, TravelPlace> saved = savedOf(memberId, results);
 
         return results.stream()
-                .map(r -> new PlaceSearchResult(
-                        savedIds.get(r.googlePlaceId()), r.googlePlaceId(), r.name(),
-                        r.category(), r.address(), r.rating(),
-                        // 사진 MinIO 캐시는 별도 이슈.
-                        null,
-                        r.lat(), r.lng(),
-                        // ⭐ 좋았던 곳은 기록(평점)이 있어야 판정된다 — 기록은 4단계다.
-                        false))
+                .map(r -> {
+                    TravelPlace place = saved.get(r.googlePlaceId());
+                    return new PlaceSearchResult(
+                            place == null ? null : place.getId(),
+                            r.googlePlaceId(), r.name(),
+                            r.category(), r.address(), r.rating(),
+                            // 이미 받아 둔 사진만 보여준다. 검색 결과 20개의 사진을 여기서
+                            // 받으면 화면 한 번에 유료 호출 20번이다.
+                            place == null ? null
+                                    : storageService.toPublicUrl(place.getPhotoObjectKey()),
+                            place == null ? null : place.getPhotoAttribution(),
+                            r.lat(), r.lng(),
+                            // ⭐ 좋았던 곳은 기록(평점) 판정이라 별도 이슈다.
+                            false);
+                })
                 .toList();
     }
 
@@ -120,11 +131,12 @@ public class PlaceService {
             placesClient.fetchDetails(place.getGooglePlaceId()).ifPresent(fresh -> {
                 place.updateBasics(fresh.address(), fresh.lat(), fresh.lng(),
                         fresh.category(), fresh.rating());
+                CachedPhoto photo = cachePhoto(place, fresh);
                 place.updateDetails(fresh.phone(), fresh.openingHours(),
-                        place.getPhotoObjectKey(), place.getPhotoAttribution(), clock.instant());
+                        photo.key(), photo.attribution(), clock.instant());
             });
         }
-        return PlaceDetail.from(place, null);
+        return PlaceDetail.from(place, storageService.toPublicUrl(place.getPhotoObjectKey()));
     }
 
     /**
@@ -145,7 +157,14 @@ public class PlaceService {
         place.updateBasics(fresh.address(), fresh.lat(), fresh.lng(),
                 fresh.category(), fresh.rating());
         place.updateDetails(fresh.phone(), fresh.openingHours(), null, null, clock.instant());
-        return placeRepository.save(place);
+        // 사진 key에 place id가 들어가므로 저장해서 id를 받은 뒤에 올린다.
+        TravelPlace saved = placeRepository.save(place);
+        CachedPhoto photo = cachePhoto(saved, fresh);
+        if (photo.key() != null) {
+            saved.updateDetails(fresh.phone(), fresh.openingHours(),
+                    photo.key(), photo.attribution(), clock.instant());
+        }
+        return saved;
     }
 
     /** 직접 입력. 검색에 안 나오는 곳도 일정에 넣을 수 있어야 한다. */
@@ -157,6 +176,33 @@ public class PlaceService {
     }
 
     // ---------------- helpers ----------------
+
+    /** 캐시된 사진 한 장. 저작자 표기는 사진과 <b>붙어 다녀야</b> 한다(구글 약관). */
+    private record CachedPhoto(String key, String attribution) {
+
+        static final CachedPhoto NONE = new CachedPhoto(null, null);
+    }
+
+    /**
+     * 구글 사진을 받아 우리 저장소에 넣는다.
+     *
+     * <p><b>이미 받아 둔 장소는 다시 받지 않는다.</b> 사진 호출은 건당 과금이고, 장소 사진이
+     * 바뀌는 일은 드물다 — 갱신 주기(§4.7 30일)가 와도 사진까지 다시 살 이유는 없다.
+     *
+     * <p>실패하면 그냥 사진이 없는 채로 둔다. 다음 갱신 때 다시 시도한다.
+     */
+    private CachedPhoto cachePhoto(TravelPlace place, PlaceResult fresh) {
+        if (place.getPhotoObjectKey() != null) {
+            return new CachedPhoto(place.getPhotoObjectKey(), place.getPhotoAttribution());
+        }
+        if (fresh.photoName() == null) {
+            return CachedPhoto.NONE;
+        }
+        return placesClient.fetchPhoto(fresh.photoName())
+                .flatMap(bytes -> storageService.uploadPlacePhoto(place.getId(), bytes))
+                .map(key -> new CachedPhoto(key, fresh.photoAttribution()))
+                .orElse(CachedPhoto.NONE);
+    }
 
     /**
      * 캐시에 있으면 그대로, 없으면 불러서 채운다.
@@ -207,7 +253,7 @@ public class PlaceService {
         return new PlacesClient.Coordinates(trip.getLat(), trip.getLng());
     }
 
-    private Map<String, Long> savedIdsOf(Long memberId, List<PlaceResult> results) {
+    private Map<String, TravelPlace> savedOf(Long memberId, List<PlaceResult> results) {
         List<String> ids = results.stream()
                 .map(PlaceResult::googlePlaceId)
                 .filter(java.util.Objects::nonNull)
@@ -216,6 +262,6 @@ public class PlaceService {
             return Map.of();
         }
         return placeRepository.findAllByMemberIdAndGooglePlaceIdIn(memberId, ids).stream()
-                .collect(Collectors.toMap(TravelPlace::getGooglePlaceId, TravelPlace::getId));
+                .collect(Collectors.toMap(TravelPlace::getGooglePlaceId, place -> place));
     }
 }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
@@ -67,6 +67,8 @@ class PlaceControllerTest extends ApiTestSupport {
         stub.cityResults = List.of();
         stub.placeResults = List.of();
         stub.detailResult = Optional.empty();
+        // 스텁은 필드를 공유한다 — 앞 테스트가 비워 뒀으면 되돌려 놓는다.
+        stub.photoResult = Optional.of(new byte[] {1, 2, 3});
 
         memberRepository.save(MemberFixture.create());
         memberRepository.save(MemberFixture.create("other", "password"));
@@ -77,14 +79,15 @@ class PlaceControllerTest extends ApiTestSupport {
     private static PlaceResult city(String id, String name, String tz, String country) {
         return new PlaceResult(id, name, "일본 도쿄도", new BigDecimal("35.6762"),
                 new BigDecimal("139.6503"), null, null, null, null, tz, country,
-                List.of("locality", "political"));
+                List.of("locality", "political"), null, null);
     }
 
     private static PlaceResult place(String id, String name) {
         return new PlaceResult(id, name, "도쿄도 다이토구", new BigDecimal("35.7147"),
                 new BigDecimal("139.7966"), "사찰", new BigDecimal("4.5"),
                 "+81 3-3842-0181", "{\"weekdayDescriptions\":[\"월: 06:00~17:00\"]}",
-                "Asia/Tokyo", "JP", List.of("tourist_attraction"));
+                "Asia/Tokyo", "JP", List.of("tourist_attraction"),
+                "places/p1/photos/ph1", "구글 사용자");
     }
 
     @Nested
@@ -153,7 +156,7 @@ class PlaceControllerTest extends ApiTestSupport {
     class Search {
 
         @Test
-        @DisplayName("검색 결과를 그대로 준다(사진·좋았던 곳은 후속 단계라 비어 있다)")
+        @DisplayName("아직 담지 않은 곳은 사진이 없다 — 검색 20건의 사진을 여기서 받지 않는다")
         void returnsResults() throws Exception {
             stub.placeResults = List.of(place("ChIJ_senso", "센소지"));
 
@@ -179,6 +182,26 @@ class PlaceControllerTest extends ApiTestSupport {
             mockMvc.perform(get("/api/travel/places/search").param("q", uniqueQuery("센소지"))
                             .header(HttpHeaders.AUTHORIZATION, authHeader))
                     .andExpect(jsonPath("$.data[0].id").value(saved.getId().intValue()));
+        }
+
+        @Test
+        @DisplayName("담아 둔 장소는 캐시된 사진을 실어 준다 — 이미 받아 둔 것은 공짜다")
+        void carriesCachedPhotoForSavedPlaces() throws Exception {
+            Long memberId = memberRepository.findAll().get(0).getId();
+            TravelPlace saved = placeRepository.save(
+                    TravelPlace.fromGoogle(memberId, "ChIJ_senso", "센소지"));
+            saved.updateDetails(null, null, "travel/places/1/a.jpg", "구글 사용자",
+                    java.time.Instant.now());
+            placeRepository.saveAndFlush(saved);
+            stub.placeResults = List.of(place("ChIJ_senso", "센소지"));
+
+            mockMvc.perform(get("/api/travel/places/search").param("q", uniqueQuery("센소지"))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data[0].photoUrl")
+                            .value(org.hamcrest.Matchers.endsWith("travel/places/1/a.jpg")));
+
+            // 검색은 사진을 새로 받지 않는다.
+            assertThat(stub.photoFetches).isEmpty();
         }
 
         @Test
@@ -304,6 +327,62 @@ class PlaceControllerTest extends ApiTestSupport {
                     .andExpect(jsonPath("$.data.category").value("사찰"));
 
             assertThat(stub.detailFetches).containsExactly("ChIJ_senso");
+        }
+
+        @Test
+        @DisplayName("상세를 받으면 사진도 받아 캐시하고 저작자 표기를 함께 준다")
+        void cachesPhotoOnRefresh() throws Exception {
+            Long memberId = memberRepository.findAll().get(0).getId();
+            TravelPlace saved = placeRepository.save(
+                    TravelPlace.fromGoogle(memberId, "ChIJ_senso", "센소지"));
+            stub.detailResult = Optional.of(place("ChIJ_senso", "센소지"));
+
+            mockMvc.perform(get("/api/travel/places/" + saved.getId())
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.photoUrl")
+                            .value(org.hamcrest.Matchers.containsString("travel/places/")))
+                    // 표기를 버리면 쓸 수 없는 사진이 된다(구글 약관).
+                    .andExpect(jsonPath("$.data.photoAttribution").value("구글 사용자"));
+
+            assertThat(stub.photoFetches).containsExactly("places/p1/photos/ph1");
+        }
+
+        @Test
+        @DisplayName("이미 받아 둔 사진은 다시 받지 않는다 — 사진 호출도 건당 과금이다")
+        void doesNotRefetchPhoto() throws Exception {
+            Long memberId = memberRepository.findAll().get(0).getId();
+            TravelPlace saved = placeRepository.save(
+                    TravelPlace.fromGoogle(memberId, "ChIJ_senso", "센소지"));
+            saved.updateDetails(null, null, "travel/places/1/old.jpg", "옛 저작자", null);
+            placeRepository.saveAndFlush(saved);
+            stub.detailResult = Optional.of(place("ChIJ_senso", "센소지"));
+
+            mockMvc.perform(get("/api/travel/places/" + saved.getId())
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.photoUrl")
+                            .value(org.hamcrest.Matchers.endsWith("travel/places/1/old.jpg")));
+
+            // 상세는 갱신됐지만(detailsRefreshedAt이 null이라 대상) 사진은 그대로다.
+            assertThat(stub.detailFetches).containsExactly("ChIJ_senso");
+            assertThat(stub.photoFetches).isEmpty();
+        }
+
+        @Test
+        @DisplayName("사진을 못 받아도 장소는 그대로 보인다")
+        void survivesPhotoFailure() throws Exception {
+            Long memberId = memberRepository.findAll().get(0).getId();
+            TravelPlace saved = placeRepository.save(
+                    TravelPlace.fromGoogle(memberId, "ChIJ_senso", "센소지"));
+            stub.detailResult = Optional.of(place("ChIJ_senso", "센소지"));
+            stub.photoResult = Optional.empty();
+
+            mockMvc.perform(get("/api/travel/places/" + saved.getId())
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.name").value("센소지"))
+                    .andExpect(jsonPath("$.data.phone").value("+81 3-3842-0181"))
+                    .andExpect(jsonPath("$.data.photoUrl").doesNotExist());
         }
 
         @Test

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/StubPlacesClient.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/StubPlacesClient.java
@@ -19,10 +19,13 @@ public class StubPlacesClient implements PlacesClient {
     public final List<String> placeSearches = new ArrayList<>();
     public final List<Coordinates> biases = new ArrayList<>();
     public final List<String> detailFetches = new ArrayList<>();
+    public final List<String> photoFetches = new ArrayList<>();
 
     public List<PlaceResult> cityResults = List.of();
     public List<PlaceResult> placeResults = List.of();
     public Optional<PlaceResult> detailResult = Optional.empty();
+    /** 사진 바이트. 비워 두면 "사진을 못 받은" 상황이 된다. */
+    public Optional<byte[]> photoResult = Optional.of(new byte[] {1, 2, 3});
 
     @Override
     public List<PlaceResult> searchCities(String query) {
@@ -43,10 +46,17 @@ public class StubPlacesClient implements PlacesClient {
         return detailResult;
     }
 
+    @Override
+    public Optional<byte[]> fetchPhoto(String photoName) {
+        photoFetches.add(photoName);
+        return photoResult;
+    }
+
     public void reset() {
         citySearches.clear();
         placeSearches.clear();
         biases.clear();
         detailFetches.clear();
+        photoFetches.clear();
     }
 }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/client/GooglePlacesClientTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/client/GooglePlacesClientTest.java
@@ -20,7 +20,7 @@ class GooglePlacesClientTest {
     private static PlaceResult candidate(String name, String... types) {
         return new PlaceResult("id-" + name, name, name + " 주소",
                 new BigDecimal("35.0"), new BigDecimal("139.0"),
-                null, null, null, null, "Asia/Seoul", "KR", List.of(types));
+                null, null, null, null, "Asia/Seoul", "KR", List.of(types), null, null);
     }
 
     @Nested

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/StubExternalsConfig.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/StubExternalsConfig.java
@@ -13,6 +13,9 @@ import ds.project.orino.planner.travel.tools.client.WeatherClient;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * 외부 호출을 전부 스텁으로 갈아끼운 설정.
@@ -54,5 +57,15 @@ public class StubExternalsConfig {
     @Primary
     public EcbRatesClient stubEcbRatesClient() {
         return new StubEcbRatesClient();
+    }
+
+    /**
+     * MinIO 대역. 장소 사진 캐시가 업로드를 시도하는데, 진짜 클라이언트를 두면 테스트가
+     * <b>실제 네트워크</b>로 나간다 — 느리고 회선에 흔들린다.
+     */
+    @Bean
+    @Primary
+    public S3Client stubS3Client() {
+        return mock(S3Client.class);
     }
 }

--- a/fe/src/features/travel/api/places.ts
+++ b/fe/src/features/travel/api/places.ts
@@ -24,8 +24,10 @@ export interface PlaceSearchResult {
   category: string | null;
   address: string | null;
   rating: number | null;
-  /** 사진은 후속 작업(#1058)이라 지금은 항상 null. */
+  /** 이미 담아 둔 장소의 캐시된 사진. 아직 담지 않은 곳은 null이다. */
   photoUrl: string | null;
+  /** 사진 저작자. **사진을 보여주는 곳마다 함께 표시해야 한다**(구글 약관). */
+  photoAttribution: string | null;
   lat: number | null;
   lng: number | null;
   /** 이전 여행에서 평점 4 이상을 준 곳. 기록은 4단계라 지금은 항상 false. */
@@ -45,6 +47,8 @@ export interface PlaceDetail {
   /** Google 원본 JSON 문자열. 상세 화면에서만 쓴다. */
   openingHours: string | null;
   photoUrl: string | null;
+  /** 사진 저작자. **사진을 보여줄 때 함께 표시해야 한다**(구글 약관). */
+  photoAttribution: string | null;
   manualEntry: boolean;
 }
 

--- a/fe/src/features/travel/places/PlaceCard.tsx
+++ b/fe/src/features/travel/places/PlaceCard.tsx
@@ -24,8 +24,10 @@ function metaLine(place: PlaceSearchResult): string {
 /**
  * 검색 결과 카드(§S-06).
  *
- * <p>사진과 `좋았던 곳` 배지는 응답 필드가 이미 있고 서버가 채우기 시작하면 그대로 뜬다
- * (사진 #1058, 평점 기록은 4단계). 그때 이 컴포넌트는 손대지 않는다.
+ * <p>사진은 <b>이미 담아 둔 장소</b>에만 붙는다 — 검색 20건의 사진을 받으면 화면 한 번에
+ * 유료 호출 20번이다. 사진이 있으면 저작자 표기를 함께 그린다(구글 약관).
+ *
+ * <p>`좋았던 곳` 배지는 응답 필드만 있고 서버가 아직 안 채운다(평점 판정은 별도 이슈).
  */
 export function PlaceCard({ place, onAdd, pending = false }: PlaceCardProps) {
   const meta = metaLine(place);
@@ -56,6 +58,15 @@ export function PlaceCard({ place, onAdd, pending = false }: PlaceCardProps) {
         </p>
         {meta && (
           <p className="text-muted-foreground truncate text-xs">{meta}</p>
+        )}
+        {/*
+          사진 저작자 표기. 툴팁이 아니라 <b>보이게</b> 그린다 — 구글 약관이 요구하는 것은
+          "표시"이고, 마우스를 올려야 보이는 것은 표시가 아니다. 폰에는 hover도 없다.
+        */}
+        {place.photoUrl && place.photoAttribution && (
+          <p className="text-muted-foreground truncate text-[11px]">
+            사진 © {place.photoAttribution}
+          </p>
         )}
       </div>
 

--- a/fe/src/pages/travel/PlaceSearchPage.test.tsx
+++ b/fe/src/pages/travel/PlaceSearchPage.test.tsx
@@ -37,7 +37,8 @@ function place(overrides: Record<string, unknown> = {}) {
     category: "불교사찰",
     address: "도쿄도 다이토구",
     rating: 4.6,
-    photoUrl: null,
+    photoUrl: null as string | null,
+    photoAttribution: null as string | null,
     lat: 35.7147,
     lng: 139.7966,
     loved: false,
@@ -126,6 +127,38 @@ describe("PlaceSearchPage", () => {
       expect(
         screen.getByText("불교사찰 · ★ 4.6 · 도쿄도 다이토구"),
       ).toBeInTheDocument();
+    });
+
+    it("사진이 있으면 저작자를 보이게 적는다 — 툴팁은 표기가 아니다", async () => {
+      mockSearch([
+        place({
+          photoUrl: "https://img.orino.dev/note-images/travel/places/1/a.jpg",
+          photoAttribution: "구글 사용자",
+        }),
+      ]);
+      const user = userEvent.setup();
+      renderSearch();
+
+      await user.type(
+        await screen.findByLabelText("장소 검색"),
+        "센소지{Enter}",
+      );
+
+      expect(await screen.findByText("사진 © 구글 사용자")).toBeInTheDocument();
+    });
+
+    it("사진이 없으면 저작자 줄도 없다 — 빈 표기를 만들지 않는다", async () => {
+      mockSearch([place({ photoUrl: null, photoAttribution: "구글 사용자" })]);
+      const user = userEvent.setup();
+      renderSearch();
+
+      await user.type(
+        await screen.findByLabelText("장소 검색"),
+        "센소지{Enter}",
+      );
+
+      await screen.findByText("센소지");
+      expect(screen.queryByText(/사진 ©/)).toBeNull();
     });
 
     it("여행 목적지 주변으로 편향시킨다", async () => {


### PR DESCRIPTION
## 이슈
closes #1058
## 작업 내용

#1054에서 비워 둔 `photoUrl`을 채운다. Google이 주는 것은 사진 **리소스 이름**이고 이미지 URL은 **만료되므로**, 서버가 받아 MinIO에 넣고 우리 URL을 내려준다.

### 호출을 아끼는 것이 설계의 전부다

- **검색 마스크에 `photos`를 넣지 않는다.** 결과 20개에 사진을 달면 화면 한 번에 유료 호출 20번이다. 사진은 **담아 둔 장소**에만 붙인다(담기·상세 갱신 시점)
- 검색 응답의 `photoUrl`은 **이미 담아 둔 장소**만 채워진다 — 이미 받아 둔 것을 보여주는 것은 공짜다
- **이미 받아 둔 장소는 다시 받지 않는다.** 사진 호출도 건당 과금이고 장소 사진이 바뀌는 일은 드물다. 상세 갱신 주기(30일)가 와도 사진까지 다시 사지 않는다
- 실패해도 장소는 그대로 보인다(사진만 없음). 다음 갱신 때 다시 시도한다

### 저작자 표기

구글 약관상 사진을 보여줄 때 저작자를 함께 표시해야 한다. `photo_attribution`을 사진과 같이 저장하고, **검색 카드에 보이게 그린다.**

처음에 `title` 툴팁으로 넣었다가 고쳤다 — 약관이 요구하는 것은 "표시"이고, 마우스를 올려야 보이는 것은 표시가 아니다. 폰에는 hover도 없다.

### API 키가 새지 않게

media 호출은 기본적으로 CDN으로 **리다이렉트**한다. 그걸 따라가면 우리 API 키가 CDN 요청에 실려 나간다. `skipHttpRedirect=true`로 URI만 받아, 두 번째 호출에서 키 없이 내려받는다.

### 로컬 검증에서 잡은 것

리소스 이름(`places/X/photos/Y`)에 슬래시가 있는데, URI 템플릿 변수로 넘기면 Spring이 `%2F`로 인코딩해 **404**가 난다. 경로로 붙여야 한다. 테스트는 스텁을 쓰니 통과했고, 실제 구글을 부르고 나서야 드러났다.

### 테스트
- 통합 5건 추가(담지 않은 곳은 사진 없음 / 담아 둔 곳은 캐시 사진 + 검색이 사진을 새로 받지 않음 / 상세에서 캐시 + 저작자 / 이미 받은 사진은 재요청 안 함 / 사진 실패해도 장소는 보임)
- FE 2건 추가(저작자가 보이게 그려짐 / 사진 없으면 표기 줄도 없음)
- 테스트에 **MinIO 대역**을 뒀다 — 진짜 클라이언트를 두면 테스트가 실제 네트워크로 나가 느리고 회선에 흔들린다
- 게이트 통과: `./gradlew check` · FE `format:check`·`lint`·`test`(863 passed)·`build`

### 로컬 확인
**실제 Google Places 키**로 BE를 띄우고 임시 MinIO를 붙여 확인(끝나고 제거)
- 담기 전 검색: `photoUrl: null` — 20건에 사진을 받지 않는다
- 담기 → 상세: `http://localhost:9000/note-images/travel/places/2/89991a29-….jpg`, 저작자 `Guanchul Guanchunao`
- 그 URL을 실제로 받아 **117,273 bytes, JPEG, 800×544** 확인
- 다시 상세를 불러도 같은 URL(사진을 새로 사지 않는다)
- 그 뒤 검색하면 담아 둔 장소라 사진과 저작자가 실린다
- BE 로그에 사진 조회·업로드 실패 0건, DB에 `photo_object_key`·`photo_attribution` 저장 확인

### ⚠️ 약관 — 앞서 적은 내용을 정정한다

처음에 "상세 갱신 주기(30일)와 함께 도는 구조라 구글의 캐싱 허용 범위 안"이라고 적었는데 **틀렸다.** 원문을 확인했다.

- 현행 [Service Specific Terms](https://cloud.google.com/maps-platform/terms/maps-service-terms) §14.3이 Places에 허용하는 캐싱은 **위경도 값 30일**뿐이고, [일반 약관](https://cloud.google.com/maps-platform/terms) §3.2.3(b)는 "Maps Service Specific Terms가 명시적으로 허용한 것 외에는 캐시하지 않는다"이다. 사진 바이트는 허용 목록에 **없다**
- [Places 정책](https://developers.google.com/maps/documentation/places/web-service/policies)도 `place_id`를 제외하면 Places 콘텐츠의 pre-fetch·cache·store를 금지한다
- [Place Photos (New)](https://developers.google.com/maps/documentation/places/web-service/place-photos)는 더 직접적이다 — **"You cannot cache a photo name. Also, the name can expire."**
- 내가 근거로 삼았던 "성능 목적 30일 캐시" 포괄 조항은 [2018년판](https://developers.google.com/maps/terms-20180207) §10.5(d)에 있던 것이고, 현행 약관에서는 삭제돼 **API별 화이트리스트 방식**으로 바뀌었다
- 게다가 이 PR의 캐시는 **30일 주기를 타지도 않는다.** "이미 받은 사진은 다시 받지 않는다"라 사실상 무기한이다 — 설명이 코드 동작과도 안 맞았다

**즉 이 구현은 캐싱 허용 범위 밖이다.** 어떻게 갈지는 아래 결정이 필요하다(#1102).
