### PR TITLE
fix : 지도 없이 Places 데이터를 보여주는 화면에 출처 표기

### DIFF
--- a/fe/src/features/travel/places/DestinationSearch.tsx
+++ b/fe/src/features/travel/places/DestinationSearch.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { LoadingText } from "@/components/ui/loading-text";
 import type { City } from "@/features/travel/api/places";
 import { searchCities } from "@/features/travel/api/places";
+import { GoogleAttribution } from "@/features/travel/places/GoogleAttribution";
 
 interface DestinationSearchProps {
   /** 고른 목적지 이름. 검색창의 값이 아니라 확정된 값이다. */
@@ -143,6 +144,12 @@ export function DestinationSearch({
                 </button>
               </li>
             ))
+          )}
+          {/* 지도 없이 Places 데이터(도시명·타임존)를 보여주는 목록이라 출처를 표기한다. */}
+          {cities !== null && cities.length > 0 && (
+            <li>
+              <GoogleAttribution />
+            </li>
           )}
         </ul>
       )}

--- a/fe/src/features/travel/places/GoogleAttribution.tsx
+++ b/fe/src/features/travel/places/GoogleAttribution.tsx
@@ -1,0 +1,18 @@
+/**
+ * Google Places 데이터 출처 표기.
+ *
+ * <p><b>지도 없이 Places 데이터를 보여주는 화면에는 반드시 있어야 한다.</b>
+ * (Places API 정책 — "If your application displays Places API data on a page or view
+ * that does not also display a Google Map, you must show a Google logo with that data.")
+ *
+ * <p>로고 이미지 대신 <b>텍스트</b>를 쓴다. 정책이 공간이 좁을 때 텍스트를 허용하고
+ * ("In cases where space is limited, the text Google Maps is acceptable"), 이 앱은
+ * 폰 전용인 데다 <b>오프라인에서도 떠야</b> 해서 외부 이미지에 기댈 수 없다.
+ */
+export function GoogleAttribution() {
+  return (
+    <p className="text-muted-foreground py-2 text-center text-[11px]">
+      Google Maps
+    </p>
+  );
+}

--- a/fe/src/pages/travel/PlaceSearchPage.test.tsx
+++ b/fe/src/pages/travel/PlaceSearchPage.test.tsx
@@ -128,6 +128,34 @@ describe("PlaceSearchPage", () => {
       ).toBeInTheDocument();
     });
 
+    it("출처를 표기한다 — 지도 없이 Places 데이터를 보여주면 필수다", async () => {
+      mockSearch();
+      const user = userEvent.setup();
+      renderSearch();
+
+      await user.type(
+        await screen.findByLabelText("장소 검색"),
+        "센소지{Enter}",
+      );
+      await screen.findByText("센소지");
+
+      expect(screen.getByText("Google Maps")).toBeInTheDocument();
+    });
+
+    it("결과가 없으면 출처 표기도 없다 — 보여줄 데이터가 없다", async () => {
+      mockSearch([]);
+      const user = userEvent.setup();
+      renderSearch();
+
+      await user.type(
+        await screen.findByLabelText("장소 검색"),
+        "센소지{Enter}",
+      );
+      await screen.findByText("검색 결과가 없어요.");
+
+      expect(screen.queryByText("Google Maps")).toBeNull();
+    });
+
     it("여행 목적지 주변으로 편향시킨다", async () => {
       const calls = mockSearch();
       const user = userEvent.setup();

--- a/fe/src/pages/travel/PlaceSearchPage.tsx
+++ b/fe/src/pages/travel/PlaceSearchPage.tsx
@@ -18,6 +18,7 @@ import {
   clearRecentSearches,
   getRecentSearches,
 } from "@/features/travel/lib/recentSearches";
+import { GoogleAttribution } from "@/features/travel/places/GoogleAttribution";
 import { PickDaySheet } from "@/features/travel/places/PickDaySheet";
 import { PlaceCard } from "@/features/travel/places/PlaceCard";
 import { toast } from "@/shared/lib/toast";
@@ -198,22 +199,26 @@ export function PlaceSearchPage() {
           </Button>
         </EmptyState>
       ) : (
-        <ul className="flex flex-col gap-2 pb-6">
-          {results.map((place: PlaceSearchResult) => (
-            <PlaceCard
-              key={place.googlePlaceId}
-              place={place}
-              pending={createActivity.isPending}
-              onAdd={(p) =>
-                setTarget({
-                  kind: "google",
-                  googlePlaceId: p.googlePlaceId,
-                  name: p.name,
-                })
-              }
-            />
-          ))}
-        </ul>
+        <div className="pb-6">
+          <ul className="flex flex-col gap-2">
+            {results.map((place: PlaceSearchResult) => (
+              <PlaceCard
+                key={place.googlePlaceId}
+                place={place}
+                pending={createActivity.isPending}
+                onAdd={(p) =>
+                  setTarget({
+                    kind: "google",
+                    googlePlaceId: p.googlePlaceId,
+                    name: p.name,
+                  })
+                }
+              />
+            ))}
+          </ul>
+          {/* 지도 없이 Places 데이터를 보여주는 화면이라 출처 표기가 필수다. */}
+          <GoogleAttribution />
+        </div>
       )}
 
       <PickDaySheet


### PR DESCRIPTION
## 이슈
#1102 (Todo (b))
## 작업 내용

지도 없이 Places 데이터를 보여주는 화면에 출처를 표기한다.

> [Places API 정책](https://developers.google.com/maps/documentation/places/web-service/policies)
>
> If your application displays Places API data on a page or view that does not also display a Google Map, you must show a Google logo with that data.
>
> Attribution should take the form of the Google Maps logo whenever possible. **In cases where space is limited, the text Google Maps is acceptable.**

붙인 곳 두 군데다.

- **S-06 장소 검색** — 결과 목록 아래
- **S-03 목적지 검색** — 도시 목록 아래 (도시명·타임존·통화도 Places 응답이다)

결과가 없으면 표기도 없다 — 보여줄 Places 데이터가 없으니까.

### 로고 이미지가 아니라 텍스트인 이유

정책이 공간이 좁을 때 텍스트를 명시적으로 허용하고, 이 앱은 **오프라인에서도 떠야 한다**(§4.6). 로고 이미지를 구글 CDN에서 받으면 비행기 모드에서 깨지고, 번들에 넣으면 구글 자산을 재배포하는 셈이 된다.

### 테스트
- 2건 추가(결과가 있으면 표기 / 결과가 없으면 표기도 없음)
- 게이트 통과: `format:check` · `lint` · `test`(863 passed) · `build`

### 로컬 확인
**실제 Google Places 키**로 확인
- 장소 검색 "라멘" → 결과 20건 아래에 `Google Maps`
- 목적지 검색 "오사카" → `오사카시 Asia/Tokyo · JPY` 아래에 `Google Maps`

---

### 함께 정리된 것

**사진 기능은 넣지 않기로 했다.** 캐시가 구글 약관 허용 범위 밖이고(#1102), 캐시 없이 가면 노출당 과금이라 원래 피하려던 지점으로 돌아간다.

- PR #1100 머지하지 않고 닫음
- #1058 not planned로 닫음
- 근거·인용문·출처는 #1102에 정리

**#1102에 아직 남은 것**: 비구글 지도(OSM) 옆에 Places 콘텐츠가 붙어 있다 — 일정 상세의 이름·주소·영업시간·전화가 `PlacePreviewMap` 바로 위에 있고, 지도 화면 마커 카드에도 주소가 있다. 처음에 "좌표만 찍어 문제없다"고 적었는데 화면을 다시 보니 틀렸다. 이건 배치·지도 선택이 걸린 결정이라 별도로 정해야 한다.
