### PR TITLE
chore : Thanos compactor 폴링 주기 5m→1h (S3 GET 절감)

### DIFF
--- a/infra/helm/thanos/templates/compactor-statefulset.yaml
+++ b/infra/helm/thanos/templates/compactor-statefulset.yaml
@@ -32,6 +32,8 @@ spec:
             - --retention.resolution-5m={{ .Values.compactor.retention5m }}
             - --retention.resolution-1h={{ .Values.compactor.retention1h }}
             - --wait
+            - --wait-interval={{ .Values.compactor.waitInterval }}
+            - --compact.cleanup-interval={{ .Values.compactor.cleanupInterval }}
           ports:
             - name: http
               containerPort: 9090

--- a/infra/helm/thanos/values.yaml
+++ b/infra/helm/thanos/values.yaml
@@ -51,6 +51,13 @@ compactor:
   retentionRaw: 30d
   retention5m: 90d
   retention1h: 365d
+  # 컴팩션 루프 주기(기본 5m). 매 iteration마다 전체 블록의 meta.json GET +
+  # 마커 파일 HEAD를 캐시 없이 재조회해 S3 요청료가 발생한다
+  # (caching bucket은 store-gateway 전용이라 compactor엔 적용 안 됨).
+  # 취미 규모 단일 클러스터는 5분 주기가 무의미해 1h로 늘린다 — #1104
+  waitInterval: 1h
+  # 삭제 마킹된 블록 정리 주기(기본 5m). 위와 같은 이유로 1h.
+  cleanupInterval: 1h
   storageClass: longhorn
   storageSize: 10Gi
   resources:


### PR DESCRIPTION
## 이슈
closes #1104

## 작업 내용

- `compactor.waitInterval` · `compactor.cleanupInterval` values 추가 (기본 `1h`)
- compactor StatefulSet args에 `--wait-interval` · `--compact.cleanup-interval` 주입

기존에는 두 플래그가 없어 Thanos 기본값 5m으로 동작했다. compactor는 매 iteration마다 전체 블록의 `meta.json` GET + 마커 파일 HEAD를 **캐시 없이** 재조회하는데(caching bucket은 store-gateway 전용), 실측 결과 이것이 S3 Tier2 요청의 전부였다.

### 실측 근거

`thanos_objstore_bucket_operations_total` (클러스터 실측)

```
139,716/day  thanos-compactor     get
139,353/day  thanos-compactor     exists
  1,501/day  thanos-storegateway  get      ← 캐싱 적용 후 무해
```

합 279k/day로 Cost Explorer의 Tier2(GET/HEAD) 277k/day와 사실상 일치한다. 같은 기간 `thanos_compact_group_compactions_total` = 0 — **279k 요청 전부가 "할 일 없음"을 5분마다 재확인하는 비용**이었다.

- iteration 289회/day, 루프당 meta sync 4.3회 → meta sync 1,253회/day (약 69초마다)
- 대상 블록 61개 (loaded 31 + duplicate 12 + marked-for-deletion 18)

### 기대 효과

| | 현재 | 예상 |
|---|---|---|
| iteration | 289회/day | 24회/day |
| Tier2 요청 | 277k/day (8.57M/월) | ~23k/day (~0.7M/월) |
| Tier2 비용 | $3.00/월 | ~$0.25/월 |
| S3 합계 | $13.58/월 | ~$10.8/월 |

컴팩션·다운샘플링·retention 삭제는 주기만 늘어날 뿐 동작은 동일하다. 조회(Thanos Query)는 compactor를 거치지 않아 영향 없다.

## 검증

- 플래그 실존 확인: 운영 중인 `thanos-compactor-0`에서 `thanos compact --help` — `--wait-interval=5m`, `--compact.cleanup-interval=5m` (기본값이 5m임도 함께 확인)
- `yamllint -c .yamllint.yml infra/` 통과
- `helm lint infra/helm/thanos` 통과
- `helm template infra/helm/thanos | kubeconform -strict -ignore-missing-schemas` → Valid 9 / Invalid 0 (Skipped 1 = ServiceMonitor CRD)
- 렌더링 결과 args 확인

```
compact
--data-dir=/var/thanos/compact
--objstore.config-file=/etc/thanos/objstore.yml
--http-address=0.0.0.0:9090
--retention.resolution-raw=30d
--retention.resolution-5m=90d
--retention.resolution-1h=365d
--wait
--wait-interval=1h
--compact.cleanup-interval=1h
```

## 배포 후 확인 항목

- [ ] `rate(thanos_compact_iterations_total[2h])*86400` → 289 에서 ~24 로 감소
- [ ] `rate(thanos_objstore_bucket_operations_total{job="thanos-compactor"}[2h])*86400` 감소
- [ ] 1~2주 뒤 CE 일 비용 $0.45/day → ~$0.35/day 확인

## 남은 과제 (별도 이슈)

Tier1(PUT/LIST) $8.82/월이 여전히 최대 항목이다. 후속으로 다룰 것:
- Longhorn 백업 블록 GC 미작동 — 버킷 객체 수가 15일간 231,837 → 261,428로 단조 증가 (`retain: 7`인데 회수 없음)
- Loki `S3.List` 16.4k/day
- Tier1 미귀속 ~40k/day (Longhorn 유력, 미확증)
