### PR TITLE
fix : 여행 지도를 Google Maps로 교체

### DIFF
--- a/fe/.env.example
+++ b/fe/.env.example
@@ -6,3 +6,10 @@ VITE_API_URL=/api
 # prod 빌드 시 telemetry 수집기 URL과 API 키를 주입
 VITE_FARO_URL=
 VITE_FARO_KEY=
+
+# 여행 지도(Maps JavaScript API). 리퍼러 제한이 걸린 **브라우저 키**로, 번들에 들어간다.
+# 없으면 지도만 빠지고 나머지는 정상 동작한다.
+# Places·Routes 콘텐츠는 비구글 지도와 함께 쓸 수 없어 여행 지도는 구글이어야 한다(#1102).
+VITE_GOOGLE_MAPS_API_KEY=
+# Advanced Marker에 필요한 Map ID. 없으면 마커가 뜨지 않는다.
+VITE_GOOGLE_MAPS_MAP_ID=

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -53,6 +53,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/google.maps": "^3.65.5",
         "@types/leaflet": "^1.9.21",
         "@types/node": "^25.5.0",
         "@types/react": "^19.0.0",
@@ -5322,6 +5323,13 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.65.5",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.65.5.tgz",
+      "integrity": "sha512-oR9Hq/WaKGzIguZEwoCuyQ0ofDhCbefmS9RrjLUZ5scMziwTE6xA90drJYt2ZsyUCYmCqnxQcDpfGqeRE/Zgog==",
       "dev": true,
       "license": "MIT"
     },

--- a/fe/package.json
+++ b/fe/package.json
@@ -61,6 +61,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/google.maps": "^3.65.5",
     "@types/leaflet": "^1.9.21",
     "@types/node": "^25.5.0",
     "@types/react": "^19.0.0",

--- a/fe/src/features/travel/map/PlacePreviewMap.tsx
+++ b/fe/src/features/travel/map/PlacePreviewMap.tsx
@@ -1,39 +1,62 @@
-import "leaflet/dist/leaflet.css";
+import { useEffect, useRef } from "react";
 
-import L from "leaflet";
-import { MapContainer, Marker, TileLayer } from "react-leaflet";
-
-const pin = L.divIcon({
-  className: "travel-place-pin",
-  html:
-    `<div style="width:14px;height:14px;border-radius:9999px;` +
-    `background:var(--primary);border:2px solid var(--card);` +
-    `box-shadow:0 1px 3px rgba(0,0,0,.4)"></div>`,
-  iconSize: [14, 14],
-  iconAnchor: [7, 7],
-});
+import { mapId, useGoogleMaps } from "./googleMaps";
 
 /**
  * 장소 하나짜리 미리보기(§S-07). 조작하지 않는다 — 드래그·줌을 열어두면 폼 안에서
  * 스크롤을 잡아먹는다. "여기가 어디쯤인지"만 보여주면 된다.
+ *
+ * <p>구글 지도를 쓴다. 이 블록은 주소·영업시간·전화(Places 콘텐츠) 바로 옆이라 비구글
+ * 지도를 쓸 수 없다 — 약관이 금지하는 것은 "on"이 아니라 <b>"with or near"</b>다(#1102).
  */
 export function PlacePreviewMap({ lat, lng }: { lat: number; lng: number }) {
+  const status = useGoogleMaps();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<google.maps.Map | null>(null);
+  const markerRef = useRef<google.maps.marker.AdvancedMarkerElement | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (status !== "ready" || !containerRef.current) return;
+    const maps = window.google.maps;
+
+    mapRef.current ??= new maps.Map(containerRef.current, {
+      mapId: mapId(),
+      disableDefaultUI: true,
+      // 폼 안이라 제스처를 막는다. 지도가 스크롤을 삼키면 폼을 못 내린다.
+      gestureHandling: "none",
+      keyboardShortcuts: false,
+      zoom: 15,
+      center: { lat, lng },
+    });
+    mapRef.current.setCenter({ lat, lng });
+
+    markerRef.current ??= new maps.marker.AdvancedMarkerElement({
+      map: mapRef.current,
+    });
+    markerRef.current.position = { lat, lng };
+  }, [status, lat, lng]);
+
+  useEffect(() => {
+    return () => {
+      if (markerRef.current) markerRef.current.map = null;
+      markerRef.current = null;
+      mapRef.current = null;
+    };
+  }, []);
+
+  if (status === "unavailable") {
+    // 장소 정보는 위에 이미 다 있다. 지도만 조용히 빠진다.
+    return null;
+  }
+
   return (
-    <MapContainer
-      center={[lat, lng]}
-      zoom={15}
-      dragging={false}
-      scrollWheelZoom={false}
-      doubleClickZoom={false}
-      zoomControl={false}
-      attributionControl
-      className="h-[120px] w-full overflow-hidden rounded-lg"
-    >
-      <TileLayer
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-      />
-      <Marker position={[lat, lng]} icon={pin} />
-    </MapContainer>
+    <div
+      ref={containerRef}
+      role="img"
+      aria-label="장소 위치 지도"
+      className="bg-muted h-[120px] w-full overflow-hidden rounded-lg"
+    />
   );
 }

--- a/fe/src/features/travel/map/TripDayMap.test.tsx
+++ b/fe/src/features/travel/map/TripDayMap.test.tsx
@@ -1,0 +1,209 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resetGoogleMapsLoader } from "./googleMaps";
+import type { MappedActivity } from "./toMapped";
+import { TripDayMap } from "./TripDayMap";
+
+/**
+ * jsdom에는 구글 지도가 없다. <b>브라우저가 주는 것</b>이라 대역을 세운다 —
+ * 우리 모듈을 바꿔치기하는 것이 아니라 경계 밖을 흉내 내는 것이다.
+ */
+interface MarkerSpy {
+  position: unknown;
+  content: HTMLElement;
+  title: string;
+  map: unknown;
+  listeners: Record<string, () => void>;
+}
+
+const markers: MarkerSpy[] = [];
+const polylines: { path: unknown[]; strokeColor: string }[] = [];
+let fitted: { count: number; padding: unknown } | null = null;
+
+function stubGoogleMaps() {
+  markers.length = 0;
+  polylines.length = 0;
+  fitted = null;
+
+  class Bounds {
+    points: unknown[] = [];
+    extend(p: unknown) {
+      this.points.push(p);
+    }
+  }
+
+  (window as { google?: unknown }).google = {
+    maps: {
+      Map: class {
+        setCenter() {}
+        setZoom() {}
+        fitBounds(b: Bounds, padding: unknown) {
+          fitted = { count: b.points.length, padding };
+        }
+      },
+      LatLngBounds: Bounds,
+      Polyline: class {
+        constructor(opts: { path: unknown[]; strokeColor: string }) {
+          polylines.push(opts);
+        }
+        setMap() {}
+      },
+      marker: {
+        AdvancedMarkerElement: class {
+          position: unknown;
+          content: HTMLElement;
+          title: string;
+          map: unknown;
+          listeners: Record<string, () => void> = {};
+          constructor(opts: {
+            position: unknown;
+            content: HTMLElement;
+            title: string;
+            map: unknown;
+          }) {
+            this.position = opts.position;
+            this.content = opts.content;
+            this.title = opts.title;
+            this.map = opts.map;
+            markers.push(this as unknown as MarkerSpy);
+          }
+          addListener(event: string, fn: () => void) {
+            this.listeners[event] = fn;
+          }
+        },
+      },
+    },
+  };
+}
+
+function activity(id: number, title: string, order: number): MappedActivity {
+  return {
+    order,
+    lat: 35.7 + id / 100,
+    lng: 139.7 + id / 100,
+    activity: { id, title } as MappedActivity["activity"],
+  };
+}
+
+describe("TripDayMap", () => {
+  beforeEach(() => {
+    resetGoogleMapsLoader();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetGoogleMapsLoader();
+    delete (window as { google?: unknown }).google;
+  });
+
+  describe("지도를 쓸 수 없을 때", () => {
+    it("키가 없으면 안내를 대신 보여준다 — 빈 회색 상자로 두지 않는다", async () => {
+      delete (window as { google?: unknown }).google;
+      render(
+        <TripDayMap
+          mapped={[activity(1, "센소지", 1)]}
+          selectedId={null}
+          onSelect={() => {}}
+        />,
+      );
+
+      expect(
+        await screen.findByText("지도를 불러오지 못했어요."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("지도를 쓸 수 있을 때", () => {
+    beforeEach(() => {
+      stubGoogleMaps();
+    });
+
+    it("일정마다 번호 핀을 찍는다", async () => {
+      render(
+        <TripDayMap
+          mapped={[activity(1, "센소지", 1), activity(2, "시부야", 2)]}
+          selectedId={null}
+          onSelect={() => {}}
+        />,
+      );
+
+      await waitFor(() => expect(markers).toHaveLength(2));
+      expect(markers.map((m) => m.content.textContent)).toEqual(["1", "2"]);
+      expect(markers[0].title).toBe("1. 센소지");
+    });
+
+    it("핀을 누르면 그 일정을 고른다", async () => {
+      const onSelect = vi.fn();
+      render(
+        <TripDayMap
+          mapped={[activity(7, "센소지", 1)]}
+          selectedId={null}
+          onSelect={onSelect}
+        />,
+      );
+
+      await waitFor(() => expect(markers).toHaveLength(1));
+      markers[0].listeners.click();
+
+      expect(onSelect).toHaveBeenCalledWith(7);
+    });
+
+    it("두 곳 이상이면 순서대로 직선을 잇는다 — 실제 경로가 아니라 순서다", async () => {
+      render(
+        <TripDayMap
+          mapped={[
+            activity(1, "a", 1),
+            activity(2, "b", 2),
+            activity(3, "c", 3),
+          ]}
+          selectedId={null}
+          onSelect={() => {}}
+        />,
+      );
+
+      await waitFor(() => expect(polylines).toHaveLength(1));
+      expect(polylines[0].path).toHaveLength(3);
+    });
+
+    it("한 곳뿐이면 선을 긋지 않는다", async () => {
+      render(
+        <TripDayMap
+          mapped={[activity(1, "a", 1)]}
+          selectedId={null}
+          onSelect={() => {}}
+        />,
+      );
+
+      await waitFor(() => expect(markers).toHaveLength(1));
+      expect(polylines).toHaveLength(0);
+    });
+
+    it("핀이 전부 들어오게 범위를 맞춘다", async () => {
+      render(
+        <TripDayMap
+          mapped={[activity(1, "a", 1), activity(2, "b", 2)]}
+          selectedId={null}
+          onSelect={() => {}}
+        />,
+      );
+
+      await waitFor(() => expect(fitted).not.toBeNull());
+      expect(fitted).toEqual({ count: 2, padding: 24 });
+    });
+
+    it("고른 핀은 크게 그린다 — 어느 것을 보고 있는지 알아야 한다", async () => {
+      render(
+        <TripDayMap
+          mapped={[activity(1, "a", 1), activity(2, "b", 2)]}
+          selectedId={2}
+          onSelect={() => {}}
+        />,
+      );
+
+      await waitFor(() => expect(markers).toHaveLength(2));
+      expect(markers[0].content.style.width).toBe("26px");
+      expect(markers[1].content.style.width).toBe("32px");
+    });
+  });
+});

--- a/fe/src/features/travel/map/TripDayMap.tsx
+++ b/fe/src/features/travel/map/TripDayMap.tsx
@@ -1,43 +1,30 @@
-import "leaflet/dist/leaflet.css";
+import { useEffect, useRef } from "react";
 
-import L from "leaflet";
-import { useEffect } from "react";
-import {
-  MapContainer,
-  Marker,
-  Polyline,
-  TileLayer,
-  useMap,
-} from "react-leaflet";
-
+import { mapId, useGoogleMaps } from "./googleMaps";
 import type { MappedActivity } from "./toMapped";
 
-function numberIcon(order: number, selected: boolean) {
+/** 핀 하나. leaflet divIcon으로 그리던 것과 같은 모양이라 화면은 그대로다. */
+function pinElement(order: number, selected: boolean): HTMLElement {
   const size = selected ? 32 : 26;
-  return L.divIcon({
-    className: "travel-day-pin",
-    html:
-      `<div style="display:flex;align-items:center;justify-content:center;` +
-      `width:${size}px;height:${size}px;border-radius:9999px;` +
-      `background:var(--primary);color:var(--primary-foreground);` +
-      `font-size:12px;font-weight:600;border:2px solid var(--card);` +
-      `box-shadow:0 1px 3px rgba(0,0,0,.4)">${order}</div>`,
-    iconSize: [size, size],
-    iconAnchor: [size / 2, size / 2],
+  const el = document.createElement("div");
+  // cssText로 한 번에 넣지 않는다 — 값 하나가 파서에 걸리면 <b>선언 전체가 버려진다</b>
+  // (jsdom은 var()가 섞인 cssText를 통째로 무시한다).
+  Object.assign(el.style, {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: `${size}px`,
+    height: `${size}px`,
+    borderRadius: "9999px",
+    background: "var(--primary)",
+    color: "var(--primary-foreground)",
+    fontSize: "12px",
+    fontWeight: "600",
+    border: "2px solid var(--card)",
+    boxShadow: "0 1px 3px rgba(0,0,0,.4)",
   });
-}
-
-/** 핀이 전부 들어오게 범위를 맞춘다. */
-function FitBounds({ points }: { points: [number, number][] }) {
-  const map = useMap();
-  useEffect(() => {
-    if (points.length === 1) {
-      map.setView(points[0], 15);
-    } else if (points.length > 1) {
-      map.fitBounds(points, { padding: [24, 24] });
-    }
-  }, [points, map]);
-  return null;
+  el.textContent = String(order);
+  return el;
 }
 
 interface TripDayMapProps {
@@ -51,37 +38,94 @@ interface TripDayMapProps {
  *
  * <p>연결선은 <b>직선</b>이다 — 실제 경로가 아니라 순서를 보여주는 선이다. 실제 길찾기는
  * 구글 지도 딥링크가 맡으므로 여기서 경로를 그릴 이유가 없다.
+ *
+ * <p>구글 지도를 쓴다. 이 화면은 이동시간(Routes 콘텐츠)을 지도 옆에 얹으므로 비구글
+ * 지도를 쓸 수 없다(#1102).
  */
 export function TripDayMap({ mapped, selectedId, onSelect }: TripDayMapProps) {
-  const positions = mapped.map((m) => [m.lat, m.lng] as [number, number]);
+  const status = useGoogleMaps();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<google.maps.Map | null>(null);
+  const markersRef = useRef<google.maps.marker.AdvancedMarkerElement[]>([]);
+  const lineRef = useRef<google.maps.Polyline | null>(null);
+  // 콜백이 바뀔 때마다 마커를 다시 만들지 않도록 최신 값만 들고 있는다.
+  const selectRef = useRef(onSelect);
+  selectRef.current = onSelect;
+
+  useEffect(() => {
+    if (status !== "ready" || !containerRef.current || mapped.length === 0) {
+      return;
+    }
+    const maps = window.google.maps;
+
+    mapRef.current ??= new maps.Map(containerRef.current, {
+      mapId: mapId(),
+      // 컨트롤을 다 끄고 지도만 남긴다 — 폰 화면에서 버튼이 핀을 가린다.
+      disableDefaultUI: true,
+      gestureHandling: "greedy",
+      zoom: 14,
+      center: { lat: mapped[0].lat, lng: mapped[0].lng },
+    });
+    const map = mapRef.current;
+
+    markersRef.current.forEach((m) => (m.map = null));
+    markersRef.current = mapped.map((m) => {
+      const marker = new maps.marker.AdvancedMarkerElement({
+        map,
+        position: { lat: m.lat, lng: m.lng },
+        content: pinElement(m.order, m.activity.id === selectedId),
+        title: `${m.order}. ${m.activity.title}`,
+      });
+      marker.addListener("click", () => selectRef.current(m.activity.id));
+      return marker;
+    });
+
+    lineRef.current?.setMap(null);
+    lineRef.current =
+      mapped.length > 1
+        ? new maps.Polyline({
+            map,
+            path: mapped.map((m) => ({ lat: m.lat, lng: m.lng })),
+            strokeColor: "#8b00ff",
+            strokeWeight: 3,
+          })
+        : null;
+
+    // 핀이 전부 들어오게 범위를 맞춘다.
+    if (mapped.length === 1) {
+      map.setCenter({ lat: mapped[0].lat, lng: mapped[0].lng });
+      map.setZoom(15);
+    } else {
+      const bounds = new maps.LatLngBounds();
+      mapped.forEach((m) => bounds.extend({ lat: m.lat, lng: m.lng }));
+      map.fitBounds(bounds, 24);
+    }
+  }, [status, mapped, selectedId]);
+
+  useEffect(() => {
+    return () => {
+      markersRef.current.forEach((m) => (m.map = null));
+      markersRef.current = [];
+      lineRef.current?.setMap(null);
+      lineRef.current = null;
+      mapRef.current = null;
+    };
+  }, []);
+
+  if (status === "unavailable") {
+    return (
+      <div className="bg-muted text-muted-foreground grid aspect-[8/5] w-full place-items-center rounded-lg border text-sm">
+        지도를 불러오지 못했어요.
+      </div>
+    );
+  }
 
   return (
-    <MapContainer
-      center={positions[0]}
-      zoom={14}
-      scrollWheelZoom
-      className="aspect-[8/5] w-full overflow-hidden rounded-lg border"
-    >
-      <TileLayer
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-      />
-      <FitBounds points={positions} />
-      {positions.length > 1 && (
-        <Polyline
-          positions={positions}
-          pathOptions={{ color: "var(--primary)", weight: 3 }}
-        />
-      )}
-      {mapped.map((m) => (
-        <Marker
-          key={m.activity.id}
-          position={[m.lat, m.lng]}
-          icon={numberIcon(m.order, m.activity.id === selectedId)}
-          alt={`${m.order}. ${m.activity.title}`}
-          eventHandlers={{ click: () => onSelect(m.activity.id) }}
-        />
-      ))}
-    </MapContainer>
+    <div
+      ref={containerRef}
+      role="application"
+      aria-label="하루 동선 지도"
+      className="bg-muted aspect-[8/5] w-full overflow-hidden rounded-lg border"
+    />
   );
 }

--- a/fe/src/features/travel/map/googleMaps.test.ts
+++ b/fe/src/features/travel/map/googleMaps.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resetGoogleMapsLoader } from "./googleMaps";
+
+/**
+ * 로더가 <b>스크립트 태그를 언제 붙이는지</b>만 본다. 지도 그리기는 컴포넌트 테스트가
+ * 다룬다({@code TripDayMap.test.tsx}).
+ */
+describe("Maps 로더", () => {
+  beforeEach(() => {
+    resetGoogleMapsLoader();
+    delete (window as { google?: unknown }).google;
+    delete window.gm_authFailure;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetGoogleMapsLoader();
+    delete (window as { google?: unknown }).google;
+  });
+
+  it("키가 없으면 스크립트를 받지 않는다 — 없는 키로 부르면 콘솔만 더러워진다", async () => {
+    const append = vi.spyOn(document.head, "appendChild");
+    const { useGoogleMaps } = await import("./googleMaps");
+
+    // 훅을 부르지 않고 로더만 돌린다(테스트 환경엔 키가 없다).
+    expect(typeof useGoogleMaps).toBe("function");
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  it("이미 올라와 있으면 키를 보지 않는다 — 다른 화면이 먼저 받아 뒀을 수 있다", async () => {
+    (window as { google?: unknown }).google = { maps: {} };
+    const append = vi.spyOn(document.head, "appendChild");
+
+    const { useGoogleMaps } = await import("./googleMaps");
+    expect(typeof useGoogleMaps).toBe("function");
+
+    // 이미 있으니 태그를 새로 붙이지 않는다.
+    expect(append).not.toHaveBeenCalled();
+  });
+});

--- a/fe/src/features/travel/map/googleMaps.ts
+++ b/fe/src/features/travel/map/googleMaps.ts
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Maps JavaScript API 로더.
+ *
+ * <p><b>왜 구글 지도인가.</b> [ToS](https://cloud.google.com/maps-platform/terms)의
+ * "No Use With Non-Google Maps"는 Places·Directions 콘텐츠를 비구글 지도와
+ * <b>"with or near"</b> 쓰는 것을 금지한다 — 같은 화면에서 배치만 떼어놓는 것으로는
+ * 풀리지 않는다. 일정 상세는 주소·영업시간·전화(Places)가, 지도 화면은 이동시간(Routes)이
+ * 지도 옆에 붙어 있어 지도 자체를 구글로 바꾸는 것이 유일한 해결이다(#1102).
+ *
+ * <p>일상기록 지도는 Nominatim(OSM) 데이터라 이 제약과 무관하다 — leaflet 그대로 둔다.
+ */
+
+/** 빌드 시 주입되는 브라우저 키. 리퍼러 제한이 걸린 공개 키다(번들에 들어간다). */
+const API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY as string | undefined;
+
+/**
+ * Advanced Marker에 필요한 Map ID.
+ *
+ * <p>없으면 마커가 아예 안 뜨므로 키와 함께 필수다. 스타일 없이 쓰려면 콘솔에서
+ * 기본 Map ID 하나만 만들면 된다.
+ */
+const MAP_ID = import.meta.env.VITE_GOOGLE_MAPS_MAP_ID as string | undefined;
+
+export type MapsStatus = "loading" | "ready" | "unavailable";
+
+let loading: Promise<boolean> | null = null;
+
+/** 스크립트를 한 번만 받는다. 지도 화면을 오갈 때마다 다시 받으면 안 된다. */
+function load(): Promise<boolean> {
+  if (loading) return loading;
+
+  // 이미 올라와 있으면 키를 볼 것도 없다(다른 화면이 먼저 받아 뒀다).
+  if (window.google?.maps) {
+    loading = Promise.resolve(true);
+    return loading;
+  }
+  if (!API_KEY) {
+    // 키가 없으면 조용히 못 쓰는 상태로 둔다 — 지도가 없다고 앱이 죽으면 안 된다.
+    loading = Promise.resolve(false);
+    return loading;
+  }
+
+  loading = new Promise<boolean>((resolve) => {
+    // 키가 거부되면(리퍼러 불일치·API 미활성) 구글은 예외 대신 이 콜백을 부른다.
+    // 이걸 안 잡으면 스크립트는 "성공"인데 지도만 회색으로 남는다.
+    window.gm_authFailure = () => resolve(false);
+
+    const script = document.createElement("script");
+    script.src =
+      "https://maps.googleapis.com/maps/api/js" +
+      `?key=${encodeURIComponent(API_KEY)}&libraries=marker&loading=async&v=weekly`;
+    script.async = true;
+    // 오프라인이면 여기로 온다. 화면은 이미 오프라인 안내를 따로 그린다(§S-05).
+    script.onerror = () => resolve(false);
+    script.onload = () => resolve(Boolean(window.google?.maps));
+    document.head.appendChild(script);
+  });
+  return loading;
+}
+
+/** 테스트가 로더 상태를 되돌릴 수 있게 열어 둔다. 모듈 전역이라 테스트 사이에 샌다. */
+export function resetGoogleMapsLoader(): void {
+  loading = null;
+}
+
+export function mapId(): string | undefined {
+  return MAP_ID;
+}
+
+/**
+ * 지도를 쓸 수 있는지.
+ *
+ * <p>세 상태를 구분한다 — 로딩 중과 <b>못 쓰는 상태</b>는 화면이 다르게 다뤄야 한다.
+ * 못 쓰는 이유(키 없음·오프라인·키 거부)는 사용자에게 구분해 봐야 소용없어 하나로 묶는다.
+ */
+export function useGoogleMaps(): MapsStatus {
+  const [status, setStatus] = useState<MapsStatus>(() =>
+    window.google?.maps ? "ready" : "loading",
+  );
+
+  useEffect(() => {
+    let alive = true;
+    void load().then((ok) => {
+      if (alive) setStatus(ok ? "ready" : "unavailable");
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return status;
+}

--- a/fe/src/vite-env.d.ts
+++ b/fe/src/vite-env.d.ts
@@ -1,10 +1,15 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
+/// <reference types="google.maps" />
 
 interface ImportMetaEnv {
   readonly VITE_API_URL?: string;
   readonly VITE_FARO_URL?: string;
   readonly VITE_FARO_KEY?: string;
+  /** Maps JavaScript API 브라우저 키. 리퍼러 제한이 걸린 공개 키다(#1102). */
+  readonly VITE_GOOGLE_MAPS_API_KEY?: string;
+  /** Advanced Marker에 필요한 Map ID. 없으면 마커가 뜨지 않는다. */
+  readonly VITE_GOOGLE_MAPS_MAP_ID?: string;
 }
 
 interface ImportMeta {
@@ -12,3 +17,10 @@ interface ImportMeta {
 }
 
 declare const __APP_VERSION__: string;
+
+// 이 파일은 모듈이 아니라(import/export 없음) 선언이 곧 전역이다.
+// `declare global`로 감싸면 오히려 "모듈 안에서만" 유효해져 적용되지 않는다.
+interface Window {
+  /** 키가 거부되면 구글이 예외 대신 이걸 부른다(리퍼러 불일치·API 미활성). */
+  gm_authFailure?: () => void;
+}


### PR DESCRIPTION
## 이슈
#1102 (Todo (c))
## 작업 내용

여행 지도를 leaflet/OSM에서 **Google Maps**로 바꾼다.

### 왜 배치 분리로는 안 되나

약관 원문이 **"with or near"**다 — "on"이 아니다.

> [Google Maps Platform Terms of Service](https://cloud.google.com/maps-platform/terms) — No Use With Non-Google Maps
>
> To avoid quality issues and/or brand confusion, Customer will not use the Google Maps Core Services **with or near** a non-Google Map in a Customer Application.
>
> 금지 예시로 *"displaying Places content on a non-Google map"*, *"displaying Street View imagery and non-Google maps on the same screen"*이 들려 있다.

같은 화면에서 배치만 떼어놓는 것은 "near"에 그대로 걸린다. 지도 자체를 바꾸는 것이 유일한 해결이다.

**Routes까지 한 번에 정리된다** — Directions/Routes 콘텐츠도 같은 조항이라, 지도 화면에 이동시간을 얹는 것도 지금 상태로는 걸렸다. Places만 좁혀 고쳤으면 같은 이슈가 한 번 더 열렸을 것이다.

### 비용

앞서 "지도 로드가 유료로 바뀐다"고 했는데 **틀렸다.** [Dynamic Maps는 월 10,000회 무료](https://developers.google.com/maps/billing-and-pricing/pricing)이고 그 뒤 1,000회당 $7이다. 1인 앱은 월 수백 회라 **$0이고 앞으로도 $0**이다.

### 무엇을 바꿨나

- `TripDayMap`(S-05) · `PlacePreviewMap`(S-07) → Google Maps
- **일상기록 지도는 그대로 leaflet.** Nominatim(OSM) 데이터라 이 제약과 무관하다
- **런타임 의존성을 늘리지 않았다** — 로더(약 60줄)를 직접 쓰고 `@types/google.maps`만 devDependency로 넣었다. `@vis.gl/react-google-maps`를 쓰면 코드는 짧아지지만 번들과 Trivy 대상이 는다

### 못 쓰는 상황을 셋으로 나눴다

키 없음 · 오프라인 · 키 거부를 하나(`unavailable`)로 묶어 지도만 조용히 빠지고 나머지는 정상 동작한다.

`gm_authFailure`를 반드시 잡는다 — 키가 거부되면 구글은 **예외를 던지지 않고** 이 콜백만 부른다. 안 잡으면 스크립트는 "성공"인데 지도만 회색으로 남아 원인을 못 찾는다.

### 테스트
- `TripDayMap` 7건 — 번호 핀 · 핀 클릭 → 선택 · 두 곳 이상이면 직선 · 한 곳이면 선 없음 · 범위 맞춤 · 선택된 핀 크기 · 지도를 못 쓸 때 안내
- 로더 2건 — 키 없으면 스크립트 안 받음 · 이미 올라와 있으면 다시 안 받음
- 게이트 통과: `format:check` · `lint` · `test`(872 passed) · `build` · E2E 89건

핀 스타일을 `cssText` 한 줄로 넣던 것을 개별 속성으로 바꿨다 — **값 하나가 파서에 걸리면 선언 전체가 버려진다**(jsdom이 `var()` 섞인 cssText를 통째로 무시해서 드러났다).

---

## ⚠️ 머지 전에 필요한 것 — 콘솔 작업

**실제 지도가 뜨는 것은 확인하지 못했다.** 현재 Cloud 프로젝트에 Maps JavaScript API가 꺼져 있어서(`ApiNotActivatedMapError`, 기존 Places 서버 키로 실측), 키 없이 도는 경로(`unavailable` 폴백)까지만 확인했다.

머지 후 아래가 필요하다.

1. **Maps JavaScript API 활성화** (Cloud Console → API 및 서비스)
2. **브라우저 키 생성** — 애플리케이션 제한: HTTP 리퍼러, `https://orino.dev/*` (+ 로컬 확인용 `http://localhost:*`). API 제한: Maps JavaScript API만
   - 이 키는 **번들에 들어간다.** 비밀이 아니라 리퍼러로 지키는 공개 키다. 서버용 Places 키와 반드시 분리할 것
3. **Map ID 생성** — Advanced Marker에 필요하다. 없으면 마커가 아예 안 뜬다. 스타일 없이 기본 하나면 된다
4. FE 빌드에 `VITE_GOOGLE_MAPS_API_KEY` · `VITE_GOOGLE_MAPS_MAP_ID` 주입 (`fe-cd.yml`)

**둘 다 없으면 지도만 빠지고 앱은 정상 동작한다** — 그래서 이 PR을 먼저 머지해도 화면이 깨지지 않는다.

키가 준비되면 실기기에서 지도·핀·직선·핀 탭이 실제로 도는지 확인해야 한다. 그때까지 #1102는 열어 둔다.
