### PR TITLE
chore : compactor block-viewer 동기화 1m→1h

### DIFF
--- a/infra/helm/thanos/templates/compactor-statefulset.yaml
+++ b/infra/helm/thanos/templates/compactor-statefulset.yaml
@@ -34,6 +34,7 @@ spec:
             - --wait
             - --wait-interval={{ .Values.compactor.waitInterval }}
             - --compact.cleanup-interval={{ .Values.compactor.cleanupInterval }}
+            - --block-viewer.global.sync-block-interval={{ .Values.compactor.blockViewerSyncInterval }}
           ports:
             - name: http
               containerPort: 9090

--- a/infra/helm/thanos/values.yaml
+++ b/infra/helm/thanos/values.yaml
@@ -58,6 +58,12 @@ compactor:
   waitInterval: 1h
   # 삭제 마킹된 블록 정리 주기(기본 5m). 위와 같은 이유로 1h.
   cleanupInterval: 1h
+  # Block Viewer UI용 블록 목록 동기화 주기(기본 1m). 컴팩션 루프와 별개로
+  # 매분 돌면서 전체 블록의 마커 파일을 HEAD한다(meta.json은 메모리 캐시가
+  # 먹지만 마커 HEAD는 캐시되지 않음). #1104에서 컴팩션 루프만 잡아
+  # 44% 감소에 그친 원인 — 나머지 절반이 이 루프다.
+  # UI는 Ingress 없이 port-forward 디버깅용이라 1h면 충분하다 — #1107
+  blockViewerSyncInterval: 1h
   storageClass: longhorn
   storageSize: 10Gi
   resources:


### PR DESCRIPTION
## 이슈
closes #1107

## 작업 내용

- `compactor.blockViewerSyncInterval` values 추가 (기본 `1h`)
- compactor StatefulSet args에 `--block-viewer.global.sync-block-interval` 주입

#1105 배포 후 실측한 결과 감소폭이 **기대 93%가 아니라 44%**였다. compactor에는 독립적인 루프가 둘 있는데 #1105가 그중 하나(컴팩션 루프)만 잡았다. 이 PR이 나머지 하나를 잡는다.

### 배포 후 실측

`--wait-interval=1h`는 정상 동작한다 — 7분 뒤에도 `thanos_compact_iterations_total` = 1. 그런데 컴팩션이 멈춘 구간에서도 1분 간격 meta sync가 계속 찍혔다.

```
15:57:41  synchronized block metadata  cached=61 returned=61
15:58:41  synchronized block metadata  cached=61 returned=61
15:59:41  synchronized block metadata  cached=61 returned=61
```

컴팩션 iteration이 0회인 300초 구간을 잘라 측정:

```
exists +366   get +123   iter +6     (300초)
→ Tier2 140,832/day
```

`--block-viewer.global.sync-block-interval` 기본값 1m이 원인이다. Block Viewer UI용 블록 목록 동기화가 컴팩션 루프와 무관하게 매분 돌며 블록 61개의 마커 파일(`deletion-mark.json`, `no-compact-mark.json`)을 HEAD한다. `meta.json`은 BaseFetcher 메모리 캐시가 먹지만(`cached=61`, get 분당 ~17) 마커 HEAD는 캐시되지 않는다(분당 ~75).

### 효과

| | 최초 | #1105 후 | 이 PR 후 |
|---|---|---|---|
| 컴팩션 루프 | 289회/day | 24회/day | 24회/day |
| block-viewer 루프 | 1,440회/day | 1,440회/day | **24회/day** |
| Tier2 요청 | 279k/day | ~158k/day | **~19k/day** |
| Tier2 비용 | $3.00/월 | ~$1.69/월 | **~$0.20/월** |
| 최초 대비 | — | -44% | **-93%** |

#1104에서 목표했던 -93%가 이 PR로 비로소 달성된다.

`--web.disable`로 UI를 통째로 끄는 대안도 검토했다(절감폭 동일). compactor UI는 Ingress가 없고 ClusterIP 서비스는 ServiceMonitor 스크랩용이라 port-forward 디버깅 용도뿐이지만, 블록 상태를 눈으로 확인할 수단은 남겨두는 쪽이 낫다고 판단해 주기 조정을 택했다.

## 검증

- 플래그 실존 확인: 운영 중인 `thanos-compactor-0`에서 `thanos compact --help` — `--block-viewer.global.sync-block-interval=1m` (기본값 1m 확인)
- `yamllint -c .yamllint.yml infra/` 통과
- `helm lint infra/helm/thanos` 통과
- `helm template infra/helm/thanos | kubeconform -strict -ignore-missing-schemas` → Valid 9 / Invalid 0 (Skipped 1 = ServiceMonitor CRD)
- 렌더링 결과 args 확인

```
compact
--data-dir=/var/thanos/compact
--objstore.config-file=/etc/thanos/objstore.yml
--http-address=0.0.0.0:9090
--retention.resolution-raw=30d
--retention.resolution-5m=90d
--retention.resolution-1h=365d
--wait
--wait-interval=1h
--compact.cleanup-interval=1h
--block-viewer.global.sync-block-interval=1h
```

## 배포 후 확인 항목

- [ ] 1분 간격 `synchronized block metadata` 로그 소멸
- [ ] 정상상태 300초 재측정 — Tier2 ~19k/day 수렴
- [ ] 1~2주 뒤 CE 일 비용 확인

## 관련

- #1104 / #1105 (선행 — 컴팩션 루프)
