### PR TITLE
feat : 여행 지도 브라우저 키를 Terraform으로 발급

### DIFF
--- a/.github/workflows/fe-cd.yml
+++ b/.github/workflows/fe-cd.yml
@@ -55,6 +55,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             CACHEBUST=${{ github.sha }}
+            VITE_GOOGLE_MAPS_API_KEY=${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}
+            VITE_GOOGLE_MAPS_MAP_ID=${{ secrets.VITE_GOOGLE_MAPS_MAP_ID }}
           cache-from: type=gha,scope=fe
           cache-to: type=gha,mode=max,scope=fe
 
@@ -83,4 +85,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             CACHEBUST=${{ github.sha }}
+            VITE_GOOGLE_MAPS_API_KEY=${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}
+            VITE_GOOGLE_MAPS_MAP_ID=${{ secrets.VITE_GOOGLE_MAPS_MAP_ID }}
           cache-from: type=gha,scope=fe

--- a/fe/Dockerfile
+++ b/fe/Dockerfile
@@ -3,6 +3,13 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
+# 여행 지도 키·Map ID. Vite는 빌드 시점에 값을 박아 넣으므로 런타임 주입이 안 된다.
+# 리퍼러 제한이 걸린 공개 키라 번들에 들어가는 것이 정상이다(#1102).
+# 비어 있어도 빌드는 되고, 그때는 지도만 빠진다.
+ARG VITE_GOOGLE_MAPS_API_KEY=""
+ARG VITE_GOOGLE_MAPS_MAP_ID=""
+ENV VITE_GOOGLE_MAPS_API_KEY=$VITE_GOOGLE_MAPS_API_KEY
+ENV VITE_GOOGLE_MAPS_MAP_ID=$VITE_GOOGLE_MAPS_MAP_ID
 RUN npm run build
 
 FROM nginx:alpine

--- a/infra/terraform/gcp-maps.tf
+++ b/infra/terraform/gcp-maps.tf
@@ -1,0 +1,89 @@
+# 여행 지도(Maps JavaScript API) — #1102.
+#
+# 왜 구글 지도를 쓰게 됐나: 약관의 "No Use With Non-Google Maps"가 Places·Routes 콘텐츠를
+# 비구글 지도와 "with or near" 쓰는 것을 금지한다. 일정 상세는 주소·영업시간이, 지도 화면은
+# 이동시간이 지도 옆에 붙어 있어 지도 자체를 바꾸는 것 말고는 방법이 없었다.
+#
+# 이 키는 gcp-travel.tf의 서버 키와 **성격이 다르다**.
+#
+# | | 서버 키(Places/Routes) | 이 키(Maps JS) |
+# |---|---|---|
+# | 어디서 쓰나 | BE가 자기 이름으로 | 브라우저가 |
+# | 어떻게 지키나 | API 제한(IP 제한은 D-15로 포기) | **HTTP 리퍼러 제한** |
+# | 어디에 담기나 | SealedSecret → 파드 env | **FE 번들에 그대로 들어간다** |
+#
+# 번들에 들어간다는 것은 누구나 볼 수 있다는 뜻이다. 그래서 이 키는 비밀이 아니고,
+# 리퍼러 제한이 유일한 방어선이다 — 서버 키와 절대 섞어 쓰면 안 된다.
+
+locals {
+  # Maps JavaScript API의 서비스 이름은 'maps-backend.googleapis.com'이다.
+  # 'maps.googleapis.com'이 아니다(그건 존재하지 않는다).
+  gcp_maps_service = "maps-backend.googleapis.com"
+
+  # 리퍼러 제한. 이 목록 밖에서 키를 쓰면 구글이 거부한다(gm_authFailure).
+  gcp_maps_referrers = [
+    "https://orino.dev/*",
+    "https://www.orino.dev/*",
+    # 로컬 확인용. 지도가 안 뜨는 이유를 로컬에서 재현할 수 있어야 한다.
+    "http://localhost:*/*",
+  ]
+}
+
+resource "google_project_service" "maps_js" {
+  project = var.gcp_project_id
+  service = local.gcp_maps_service
+
+  # 서버 키와 같은 이유 — 리소스를 지운다고 API까지 끄면 운영 중인 호출이 즉시 죽는다.
+  disable_on_destroy = false
+}
+
+resource "google_apikeys_key" "travel_maps_js" {
+  project = var.gcp_project_id
+
+  # 서버 키와 달리 이 키는 처음부터 Terraform이 만든다(import 대상이 아니다).
+  # name은 키 ID다 — 바꾸면 삭제·재생성되고 키 문자열이 바뀐다.
+  name         = "orino-travel-maps-js"
+  display_name = "orino-travel-maps-js"
+
+  restrictions {
+    browser_key_restrictions {
+      allowed_referrers = local.gcp_maps_referrers
+    }
+
+    # 이 키로 부를 수 있는 것은 지도 하나뿐이다. 새면 지도 로드만 도둑맞고,
+    # Places·Routes(건당 과금이 큰 쪽)는 이 키로 못 부른다.
+    api_targets {
+      service = local.gcp_maps_service
+    }
+  }
+
+  depends_on = [google_project_service.maps_js]
+}
+
+# 키 문자열은 상태 파일에 들어간다. 출력으로 꺼내지 않는 이유는 CI 로그에 남기지 않기
+# 위해서다 — 값이 필요하면 아래로 읽는다.
+#
+#   gcloud services api-keys get-key-string \
+#     projects/202935442863/locations/global/keys/orino-travel-maps-js
+#
+# 읽은 값은 .secrets에 기록하고 GitHub Actions 시크릿(VITE_GOOGLE_MAPS_API_KEY)에 넣는다.
+# SealedSecret이 아니다 — 이 키는 클러스터가 아니라 **FE 빌드**가 쓴다.
+output "gcp_maps_js_key_name" {
+  description = "여행 지도 브라우저 키 리소스 이름 (값은 gcloud로 읽어 .secrets 참조)"
+  value       = google_apikeys_key.travel_maps_js.name
+}
+
+# ---------------------------------------------------------------------------
+# Map ID는 Terraform으로 못 만든다.
+#
+# Advanced Marker에 Map ID가 필요한데, google provider에 해당 리소스가 없다
+# (2026-08 기준. google_compute_url_map·certificate_manager_certificate_map 같은
+# 이름만 비슷한 것들뿐이다). 결제 계정 카드 등록과 같은 부류의 콘솔 작업이다.
+#
+#   콘솔 → Google Maps Platform → Map Management → Create Map ID
+#   - Map type: JavaScript
+#   - 스타일은 지정하지 않아도 된다(기본 지도로 뜬다)
+#
+# 만든 값은 .secrets에 기록하고 GitHub Actions 시크릿(VITE_GOOGLE_MAPS_MAP_ID)에 넣는다.
+# 없으면 지도는 뜨지만 **마커가 하나도 안 뜬다** — 조용히 실패하므로 잊으면 찾기 어렵다.
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
## 이슈
#1102 (Todo (c) 후속 — 키 발급)
## 작업 내용

### 다른 키는 어떻게 했나 (확인 결과)

Places/Routes 서버 키는 이미 **전부 Terraform**이다 — `infra/terraform/gcp-travel.tf`.

- API 활성화: `google_project_service`
- 키 발급·제한: `google_apikeys_key`
- 키 **값**만 `.secrets` + SealedSecret으로 따로 관리(상태 파일·CI 로그에 안 남기려고)
- apply SA에 `roles/serviceusage.apiKeysAdmin`·`serviceUsageAdmin`이 이미 있다 → 권한 추가 불필요

같은 패턴을 그대로 따랐다.

### 이 키는 서버 키와 성격이 다르다

| | 서버 키(Places/Routes) | 이 키(Maps JS) |
|---|---|---|
| 어디서 쓰나 | BE가 자기 이름으로 | 브라우저가 |
| 어떻게 지키나 | API 제한(IP 제한은 D-15로 포기) | **HTTP 리퍼러 제한** |
| 어디에 담기나 | SealedSecret → 파드 env | **FE 번들에 그대로 들어간다** |

번들에 들어간다는 건 누구나 볼 수 있다는 뜻이다. **이 키는 비밀이 아니고 리퍼러 제한이 유일한 방어선**이라, 서버 키와 섞어 쓰면 그 순간 Places/Routes까지 공개된다. 그래서 별도 키로 만들고 API 제한을 `maps-backend.googleapis.com` 하나로 묶었다 — 새어도 도둑맞는 건 지도 로드뿐이고, 건당 과금이 큰 쪽은 이 키로 못 부른다.

### FE 빌드 배선

Vite는 **빌드 시점에** 값을 박으므로 런타임 주입이 안 된다. `Dockerfile`에 `ARG`/`ENV`를 넣고 `fe-cd.yml`의 build-args로 넘긴다.

**Build image·Push image 두 단계에 똑같이** 넣었다 — 한쪽만 넣으면 레이어가 갈려 "동일 레이어 → gha 캐시 전체 히트"라는 기존 구조가 깨진다.

`SecretsUsedInArgOrEnv` 경고가 뜨는데, 이 키는 의도적으로 공개다(위 표). 무시해도 되는 경고고 Dockerfile 주석에 이유를 적어 뒀다.

### 검증
- `terraform fmt -check -recursive` 통과
- `terraform init -backend=false && terraform validate` → **Success**
- 로컬 apply는 하지 않았다(규칙대로 PR=plan, main 머지=자동 apply)
- **키가 실제로 번들에 박히는지 실측**
  - `VITE_GOOGLE_MAPS_API_KEY=test-key npm run build` → `dist/assets/googleMaps-*.js`에 값 존재
  - `docker build --target builder --build-arg …` → 이미지 안 `dist`에서도 값 확인
- `.secrets`에 값 자리와 읽는 법(`gcloud services api-keys get-key-string`)을 기록

---

## 머지 후 남는 것

### 1. 키 값을 GitHub Actions 시크릿에 넣기

apply가 키를 만들면 값을 읽어야 한다.

```
gcloud services api-keys get-key-string \
  projects/202935442863/locations/global/keys/orino-travel-maps-js
```

→ `.secrets`에 기록 + Actions 시크릿 `VITE_GOOGLE_MAPS_API_KEY`

### 2. Map ID — 이것만 콘솔 작업이다

google provider에 **Map ID 리소스가 없다**(2026-08 확인. `google_compute_url_map`·`certificate_manager_certificate_map` 처럼 이름만 비슷한 것뿐이다). 결제 계정 카드 등록과 같은 부류로, `gcp-travel.tf`에도 같은 종류의 주석이 이미 있다.

```
콘솔 → Google Maps Platform → Map Management → Create Map ID
  Map type: JavaScript   (스타일은 지정 안 해도 기본 지도로 뜬다)
```

→ Actions 시크릿 `VITE_GOOGLE_MAPS_MAP_ID`

**없으면 지도는 뜨는데 마커가 하나도 안 뜬다.** 조용히 실패해서 원인을 찾기 어려우니 잊지 말 것.

### 3. 실기기 확인

둘 다 들어가면 실기기에서 지도·번호 핀·직선·핀 탭을 확인해야 한다. 그때까지 #1102는 열어 둔다.

> 둘 다 없어도 지도만 빠지고 앱은 정상 동작한다(#1106) — 그래서 순서대로 나눠 머지해도 화면이 깨지지 않는다.
