### PR TITLE
chore : compactor progress-interval 5m→1h

### DIFF
--- a/infra/helm/thanos/templates/compactor-statefulset.yaml
+++ b/infra/helm/thanos/templates/compactor-statefulset.yaml
@@ -35,6 +35,7 @@ spec:
             - --wait-interval={{ .Values.compactor.waitInterval }}
             - --compact.cleanup-interval={{ .Values.compactor.cleanupInterval }}
             - --block-viewer.global.sync-block-interval={{ .Values.compactor.blockViewerSyncInterval }}
+            - --compact.progress-interval={{ .Values.compactor.progressInterval }}
           ports:
             - name: http
               containerPort: 9090

--- a/infra/helm/thanos/values.yaml
+++ b/infra/helm/thanos/values.yaml
@@ -64,6 +64,12 @@ compactor:
   # 44% 감소에 그친 원인 — 나머지 절반이 이 루프다.
   # UI는 Ingress 없이 port-forward 디버깅용이라 1h면 충분하다 — #1107
   blockViewerSyncInterval: 1h
+  # 컴팩션 진행률(todo) 메트릭 계산 주기(기본 5m). 위 둘과 또 별개인 루프로,
+  # 계산 1회당 exists 61 + get 123 = 184 요청을 쓴다(실측).
+  # thanos compact의 주기 플래그는 wait / cleanup / block-viewer / progress
+  # 넷뿐이며 이것이 마지막이다. "0s"로 끄면 todo 메트릭을 잃으므로
+  # 1h로 늘려 관측성은 유지한다 — #1110
+  progressInterval: 1h
   storageClass: longhorn
   storageSize: 10Gi
   resources:


### PR DESCRIPTION
## 이슈
closes #1110

## 작업 내용

- `compactor.progressInterval` values 추가 (기본 `1h`)
- compactor StatefulSet args에 `--compact.progress-interval` 주입

#1108 배포 후 실측 결과 **-93% 기대 대비 실제 -74%**였다. 1분 block-viewer 루프는 사라졌지만 5분 주기 루프가 하나 더 남아 있었다.

두 번 연속 "이걸로 끝"이라고 잘못 판단했으므로, 이번에는 `thanos compact`의 주기 플래그를 전부 열거했다.

```
--wait-interval=5m                            → 1h  (PR #1105)
--compact.cleanup-interval=5m                 → 1h  (PR #1105)
--block-viewer.global.sync-block-interval=1m  → 1h  (PR #1108)
--compact.progress-interval=5m                → 1h  (이 PR)
```

**주기 플래그는 이 넷이 전부다.** 이 PR이 마지막이다.

### 실측 근거

#1108 적용 후, 1분 간격 sync는 소멸했고 5분 간격 sync가 남았다.

```
16:22:42  synchronized block metadata  cached=61 returned=31
16:27:42  synchronized block metadata  cached=61 returned=31
```

컴팩션 iteration이 0회인 600초 구간:

```
exists +122   get +246   iter +2     (600초, sync 2회)
→ sync 1회당 exists 61 + get 123 = 184 요청  ← 실측
→ 288회/day × 184 = 52,992/day
```

`--compact.progress-interval` 기본 5m이 원인이다. `--wait` 활성 시 컴팩션·다운샘플링·retention 진행률(todo) 메트릭을 백그라운드로 계산하며 매번 메타를 재동기화한다.

### 효과

| | 최초 | PR #1105 후 | PR #1108 후 | 이 PR 후 |
|---|---|---|---|---|
| 컴팩션 루프 | 289회/day | 24회/day | 24회/day | 24회/day |
| block-viewer 루프 | 1,440회/day | 1,440회/day | 24회/day | 24회/day |
| progress 루프 | 288회/day | 288회/day | 288회/day | **24회/day** |
| **Tier2 요청** | 279,069/day | ~157,632/day | 72,192/day | **~23,600/day** |
| **Tier2 비용** | $3.00/월 | ~$1.69/월 | ~$0.78/월 | **~$0.25/월** |
| 최초 대비 | — | -44% | -74% | **-92%** |

앞 두 PR의 수치(279,069 → 157,632 → 72,192)는 모두 배포 후 실측값이다. 이 PR의 예상치도 실측된 sync당 184 요청에 24회/day를 곱한 값이며, 머지 후 동일 방식으로 재측정해 확인할 예정이다.

`"0s"`로 완전히 끄는 대안도 있으나 `thanos_compact_todo_*` 진행률 메트릭을 잃는다. 컴팩션이 밀리는지 보는 지표라 1시간 해상도로 남겨두는 편이 낫다고 판단했다.

## 검증

- 플래그·기본값 확인: 운영 중인 `thanos-compactor-0`에서 `thanos compact --help` — `--compact.progress-interval=5m`, `"0s"` 비활성화 지원 명시
- 주기 플래그 전수 확인: `--help | grep -E "^\s+--.*interval"` → 위 4개가 전부
- `yamllint -c .yamllint.yml infra/` 통과
- `helm lint infra/helm/thanos` 통과
- `helm template infra/helm/thanos | kubeconform -strict -ignore-missing-schemas` → Valid 9 / Invalid 0 (Skipped 1 = ServiceMonitor CRD)
- 렌더링 결과 args 확인

```
compact
--data-dir=/var/thanos/compact
--objstore.config-file=/etc/thanos/objstore.yml
--http-address=0.0.0.0:9090
--retention.resolution-raw=30d
--retention.resolution-5m=90d
--retention.resolution-1h=365d
--wait
--wait-interval=1h
--compact.cleanup-interval=1h
--block-viewer.global.sync-block-interval=1h
--compact.progress-interval=1h
```

## 배포 후 확인 항목

- [ ] 5분 간격 `synchronized block metadata` 로그 소멸
- [ ] 정상상태 재측정 — Tier2 ~23.6k/day 수렴
- [ ] 1~2주 뒤 CE 일 비용 확인

## 관련

- #1104 / PR #1105 (컴팩션 루프)
- #1107 / PR #1108 (block-viewer 루프)
