### PR TITLE
fix : 지도 키에서 동작하지 않는 localhost 리퍼러 제거

### DIFF
--- a/infra/terraform/gcp-maps.tf
+++ b/infra/terraform/gcp-maps.tf
@@ -21,11 +21,18 @@ locals {
   gcp_maps_service = "maps-backend.googleapis.com"
 
   # 리퍼러 제한. 이 목록 밖에서 키를 쓰면 구글이 거부한다(gm_authFailure).
+  #
+  # localhost는 넣지 않는다 — 넣어도 동작하지 않는다. 문서가 두 가지를 못박는다:
+  # "you can't use a wildcard character in the middle of a URL"(포트 자리의 *가 여기 해당),
+  # "Internal IP addresses and localhost aren't supported."
+  # https://docs.cloud.google.com/api-keys/docs/add-restrictions-api-keys
+  #
+  # 실제로 `http://localhost:*/*`를 넣어 봤고, 키 생성은 통과하지만 브라우저에서는
+  # RefererNotAllowedMapError가 난다. 매칭되지 않는 값을 목록에 두면 "로컬은 되는 줄"
+  # 오해만 남으므로 지운다. 로컬에서 지도를 봐야 하면 별도 개발 키를 만들어야 한다.
   gcp_maps_referrers = [
     "https://orino.dev/*",
     "https://www.orino.dev/*",
-    # 로컬 확인용. 지도가 안 뜨는 이유를 로컬에서 재현할 수 있어야 한다.
-    "http://localhost:*/*",
   ]
 }
 


### PR DESCRIPTION
## 이슈
#1102
## 작업 내용

#1109에서 내가 넣은 `http://localhost:*/*`가 **동작하지 않는 값**이다. 지웠다.

[문서](https://docs.cloud.google.com/api-keys/docs/add-restrictions-api-keys)가 두 가지를 못박는다.

> you can't use a wildcard character in the middle of a URL

포트 자리의 `*`가 여기 해당한다.

> Internal IP addresses and **localhost aren't supported**.

즉 문법을 고쳐도 localhost는 애초에 안 된다.

### 실제로 확인했다

키가 발급된 뒤 로컬(`http://localhost:8899`)에서 실제 키·Map ID로 지도를 띄워 봤다.

```
Google Maps JavaScript API error: RefererNotAllowedMapError
```

키 생성 자체는 통과한다(구글이 문자열을 검증하지 않는다). 그래서 코드만 보면 "로컬도 되게 해뒀다"로 읽히는데 실제로는 절대 매칭되지 않는다. **매칭 안 되는 값을 목록에 남겨두면 오해만 남으므로** 지우고, 왜 못 넣는지를 주석으로 남겼다.

### 영향

- **프로덕션은 영향 없다.** `https://orino.dev/*`·`https://www.orino.dev/*`는 정상이다
- 로컬에서 지도를 봐야 하면 별도 개발 키가 필요하다. 지금은 만들지 않았다 — 키가 하나 더 늘고, 지도는 배포본에서 확인하면 되는 수준이라 필요해지면 그때 판단하는 게 맞다고 본다

### 검증
- `terraform fmt -check -recursive` 통과
- `terraform validate` → Success
