### PR TITLE
fix : 지도 로더가 준비 전에 ready로 판정하던 문제

### DIFF
--- a/fe/src/features/travel/map/googleMaps.test.ts
+++ b/fe/src/features/travel/map/googleMaps.test.ts
@@ -29,7 +29,7 @@ describe("Maps 로더", () => {
   });
 
   it("이미 올라와 있으면 키를 보지 않는다 — 다른 화면이 먼저 받아 뒀을 수 있다", async () => {
-    (window as { google?: unknown }).google = { maps: {} };
+    (window as { google?: unknown }).google = { maps: { Map: class {} } };
     const append = vi.spyOn(document.head, "appendChild");
 
     const { useGoogleMaps } = await import("./googleMaps");
@@ -37,5 +37,21 @@ describe("Maps 로더", () => {
 
     // 이미 있으니 태그를 새로 붙이지 않는다.
     expect(append).not.toHaveBeenCalled();
+  });
+
+  it("google.maps만 있고 생성자가 없으면 준비된 게 아니다", async () => {
+    // 프로덕션에서 터진 상태 그대로다 — 스크립트는 로드됐고 google.maps도 있는데
+    // google.maps.Map이 아직 undefined였다. 이걸 "준비됨"으로 보면
+    // `Map is not a constructor`로 죽는다.
+    (window as { google?: unknown }).google = { maps: {} };
+
+    const { useGoogleMaps } = await import("./googleMaps");
+    const { renderHook, waitFor } = await import("@testing-library/react");
+    const { result } = renderHook(() => useGoogleMaps());
+
+    // 키도 없는 테스트 환경이라 결국 unavailable로 떨어져야 한다. 중요한 건
+    // "ready"가 되지 않는다는 것이다.
+    await waitFor(() => expect(result.current).not.toBe("loading"));
+    expect(result.current).toBe("unavailable");
   });
 });

--- a/fe/src/features/travel/map/googleMaps.ts
+++ b/fe/src/features/travel/map/googleMaps.ts
@@ -25,6 +25,9 @@ const MAP_ID = import.meta.env.VITE_GOOGLE_MAPS_MAP_ID as string | undefined;
 
 export type MapsStatus = "loading" | "ready" | "unavailable";
 
+/** 구글이 준비 완료를 알릴 전역 콜백 이름. 스크립트 태그에서는 이게 유일한 신호다. */
+const READY_CALLBACK = "__orinoMapsReady";
+
 let loading: Promise<boolean> | null = null;
 
 /** 스크립트를 한 번만 받는다. 지도 화면을 오갈 때마다 다시 받으면 안 된다. */
@@ -32,7 +35,8 @@ function load(): Promise<boolean> {
   if (loading) return loading;
 
   // 이미 올라와 있으면 키를 볼 것도 없다(다른 화면이 먼저 받아 뒀다).
-  if (window.google?.maps) {
+  // `google.maps`가 있는 것만으로는 부족하다 — 생성자까지 있어야 쓸 수 있다.
+  if (typeof window.google?.maps?.Map === "function") {
     loading = Promise.resolve(true);
     return loading;
   }
@@ -47,14 +51,29 @@ function load(): Promise<boolean> {
     // 이걸 안 잡으면 스크립트는 "성공"인데 지도만 회색으로 남는다.
     window.gm_authFailure = () => resolve(false);
 
+    /**
+     * <b>`script.onload`로는 판단할 수 없다.</b> 그때 `google.maps`는 만들어져 있지만
+     * `google.maps.Map`은 아직 `undefined`라, 로드됐다고 보고 지도를 만들면
+     * `Map is not a constructor`로 죽는다(실제로 프로덕션에서 그렇게 터졌다).
+     *
+     * `loading=async`만 붙인 스크립트 태그에는 `importLibrary`조차 없다 —
+     * 그건 인라인 부트스트랩 로더가 정의하는 것이다. 스크립트 태그에서는
+     * <b>`callback`이 준비 완료를 알리는 유일한 신호</b>다.
+     */
+    window[READY_CALLBACK] = () => {
+      delete window[READY_CALLBACK];
+      // 콜백이 불렸어도 실제로 생성자가 있는지까지 본다.
+      resolve(typeof window.google?.maps?.Map === "function");
+    };
+
     const script = document.createElement("script");
     script.src =
       "https://maps.googleapis.com/maps/api/js" +
-      `?key=${encodeURIComponent(API_KEY)}&libraries=marker&loading=async&v=weekly`;
+      `?key=${encodeURIComponent(API_KEY)}&libraries=marker` +
+      `&loading=async&v=weekly&callback=${READY_CALLBACK}`;
     script.async = true;
     // 오프라인이면 여기로 온다. 화면은 이미 오프라인 안내를 따로 그린다(§S-05).
     script.onerror = () => resolve(false);
-    script.onload = () => resolve(Boolean(window.google?.maps));
     document.head.appendChild(script);
   });
   return loading;
@@ -77,7 +96,7 @@ export function mapId(): string | undefined {
  */
 export function useGoogleMaps(): MapsStatus {
   const [status, setStatus] = useState<MapsStatus>(() =>
-    window.google?.maps ? "ready" : "loading",
+    typeof window.google?.maps?.Map === "function" ? "ready" : "loading",
   );
 
   useEffect(() => {

--- a/fe/src/vite-env.d.ts
+++ b/fe/src/vite-env.d.ts
@@ -23,4 +23,6 @@ declare const __APP_VERSION__: string;
 interface Window {
   /** 키가 거부되면 구글이 예외 대신 이걸 부른다(리퍼러 불일치·API 미활성). */
   gm_authFailure?: () => void;
+  /** Maps JS가 준비되면 부르는 콜백. 이름은 googleMaps.ts의 READY_CALLBACK과 같다. */
+  __orinoMapsReady?: () => void;
 }


### PR DESCRIPTION
## 이슈
#1102 — 프로덕션 버그
## 작업 내용

일정 상세에서 장소에 좌표가 있으면 화면이 ErrorBoundary로 떨어졌다.

```
TypeError: o.Map is not a constructor
    at PlacePreviewMap.tsx:24
```

### 원인

`#1106`의 로더가 **`script.onload`로 준비 완료를 판단했다.** 그 시점에 `google.maps`는 만들어져 있지만 `google.maps.Map`은 아직 `undefined`다. 그걸 `ready`로 보고 `new maps.Map(...)`을 부르니 죽었다.

실제 리퍼러(`https://orino.dev`)로 확인한 결과:

| 로드 방식 | `google.maps` | `google.maps.Map` | `importLibrary` |
|---|---|---|---|
| `loading=async`, `onload` 시점 | 있음 | **undefined** | **없음** |
| `loading=async` + `callback=` | 있음 | `function` | `function` |

`loading=async`만 붙인 스크립트 태그에는 `importLibrary`조차 없다 — 그건 인라인 부트스트랩 로더가 정의하는 것이다. **스크립트 태그에서는 `callback`이 준비 완료를 알리는 유일한 신호다.**

### 고친 것

- `callback=__orinoMapsReady`로 준비 신호를 받는다
- `ready` 판정을 `google.maps` 존재가 아니라 **`typeof google.maps.Map === "function"`**으로 바꿨다 — 로더 진입·콜백·훅 초기값 세 군데 모두
- 콜백이 불렸더라도 생성자 유무를 한 번 더 본다

### 왜 처음에 못 잡았나

`#1106`을 검증할 때 쓴 프로브가 `callback=init`을 썼다. **실제 코드는 `onload`를 썼는데 검증은 다른 경로를 탔다.** 프로브가 통과했으니 됐다고 본 것이 잘못이었다.

이번에는 **빌드한 실제 번들을 실제 리퍼러 아래에서** 돌려 확인했다(아래).

### 테스트
- 회귀 테스트 추가 — `google.maps`는 있는데 `Map`이 없는 상태(= 터졌던 그 상태)에서 `ready`가 되지 않는지 본다
- 게이트 통과: `format:check` · `lint` · `test`(873 passed) · `build`

### 로컬 확인 — 실제 앱, 실제 리퍼러

키가 `orino.dev` 리퍼러 전용이라, 로컬 빌드를 **`https://orino.dev` 출처로** 띄워 확인했다(구글 요청은 가로채지 않으므로 리퍼러 검증은 진짜다). 프로덕션 SW가 옛 자산을 돌려주던 것도 캐시를 지워 해결했다.

- **일정 상세**(터졌던 화면): `pageerror` 0, 지도 canvas 1, `google.maps.Map` = `function`, 센소지 위치에 마커 표시
- **지도 화면(S-05)**: 번호 핀 1·2, 직선 연결, canvas 3
- **핀 탭**: 2번 핀을 누르니 하단 카드가 `2 | 23:00 | 시부야 스크램블 | 도쿄도 시부야구 | 일정 열기`로 바뀜

스크린샷 두 장(상세 미리보기, 하루 동선)에서 지도·마커·직선이 실제로 그려지는 것을 확인했다.

---

**머지 후 fe-cd가 돌아 배포되면 프로덕션에서도 해결된다.** 지금은 여전히 깨져 있다.
