### PR TITLE
chore : Loki retention 활성화 + shipper 폴링 5m→30m

### DIFF
--- a/infra/helm/loki/values.yaml
+++ b/infra/helm/loki/values.yaml
@@ -25,11 +25,33 @@ loki:
         secretAccessKey: ${AWS_SECRET_ACCESS_KEY}
         accessKeyId: ${AWS_ACCESS_KEY_ID}
         s3ForcePathStyle: false
+
+    # tsdb shipper 가 오브젝트 스토리지의 인덱스 테이블을 폴링하는 주기.
+    # 기본 5m × 테이블 수만큼 LIST 가 나간다. 최근 3시간 데이터는 ingester 가
+    # 직접 서빙하므로(query_ingesters_within) 이 주기를 늘려도 조회 신선도에
+    # 영향이 없다. 차트 기본값의 index_gateway_client 와 딥머지된다 — #1114
+    storage_config:
+      tsdb_shipper:
+        resync_interval: 30m
+
     limits_config:
       retention_period: 2160h
       # structured metadata 허용 (Alloy가 logger/requestId/userId/traceId를 부착).
       # tsdb + schema v13 전제이며 Loki 3.x 기본값이 true지만 의도를 명시.
       allow_structured_metadata: true
+
+    # retention_period(90d)만으로는 아무것도 삭제되지 않는다. Loki는
+    # compactor.retention_enabled 가 true 여야 retention 을 실제로 집행하며
+    # 기본값이 false 다. 그래서 인덱스 테이블이 하루 1개씩 무한 증가했고
+    # (실측 135개 = 90일치를 초과), tsdb shipper 가 5분마다 전 테이블을
+    # LIST 하면서 S3 Tier1 39,744회/day 를 썼다 — AWS 청구 단일 최대 항목.
+    # retention_enabled 시 delete_request_store 가 필수다(미설정 시 기동 실패).
+    # apply_retention_interval 은 기본 0s(= compaction 주기 10m 마다)라
+    # 90일 정책엔 과하다. 하루 1회로 충분 — #1114
+    compactor:
+      retention_enabled: true
+      delete_request_store: s3
+      apply_retention_interval: 24h
 
     # 로그 기반 알림(Loki Ruler). 룰 파일은 loki-alerting-rules ConfigMap을
     # /rules/fake 로 마운트(auth_enabled=false → 테넌트 id "fake").


### PR DESCRIPTION
## 이슈
closes #1114

## 작업 내용

- `loki.compactor` 추가 — `retention_enabled: true` · `delete_request_store: s3` · `apply_retention_interval: 24h`
- `loki.storage_config.tsdb_shipper.resync_interval: 30m` 추가

Thanos Tier2를 -93%로 잡은 뒤(#1104 · #1107 · #1110) 남은 Tier1을 추적하니 **Loki `S3.List` 단독 39,744회/day = 월 $5.25**, AWS 청구 단일 최대 항목이었다. 근본 원인은 **Loki retention이 한 번도 작동한 적이 없다**는 것.

### 원인

`values.yaml`에 `retention_period: 2160h`(90일)가 선언돼 있지만 Loki는 `compactor.retention_enabled: true`가 있어야 retention을 집행한다. **기본값은 `false`**이고 설정된 적이 없다. 운영 중인 Loki `/config` 실측:

```
compactor.retention_enabled:                 false    ← 문제
compactor.apply_retention_interval:          0s
storage_config.tsdb_shipper.resync_interval: 5m
limits_config.retention_period:              90d      ← 선언만, 무의미
```

결과:

- 인덱스 테이블 **135개** (`index_20539` ~ `index_20673` = 2026-03-27 ~ 08-08). 90일 정책이면 90개여야 한다
- Loki 버킷 객체 수 15일간 118,886 → 128,880, **감소 구간 0** (~713/day 순증)
- shipper가 5분마다 전 테이블 LIST → **135 × 288회/day = 38,880** (실측 39,744와 일치)
- 테이블이 매일 1개씩 늘어 **비용이 매달 자동 상승**(약 +$0.04/월)하는 구조

### Tier1 재귀속 (실측)

| 항목 | /day |
|---|---|
| **Loki S3.List** | **39,744** |
| Loki PUT | 2,880 |
| Longhorn 블록 PUT | ~2,100 |
| Thanos compactor iter | 2,314 |
| Tempo PUT | 1,728 |
| 기타 (storegateway · sidecar) | 132 |
| 귀속 합계 | 48,898 |
| CE 실측 | 66,500 |
| 미귀속 | 17,602 (~$1.4/월) |

### 효과

| | 현재 | 조치 후 |
|---|---|---|
| 인덱스 테이블 | 135개 (무한 증가) | 90개 (상한) |
| shipper 폴링 | 288회/day | 48회/day |
| **Tier1 LIST** | **38,880/day** | **4,320/day** |
| **비용** | **$5.25/월 (상승 중)** | **$0.58/월 (고정)** |

90일 초과 청크가 삭제된 적이 없으므로 스토리지도 함께 정리된다.

`resync_interval`은 최근 3시간 데이터를 ingester가 직접 서빙하므로(`query_ingesters_within`) 늘려도 조회 신선도에 영향이 없다.

## ⚠️ 데이터 삭제

retention 활성화 시 **90일 초과 로그가 실제로 삭제된다.** 현재 135일치가 있어 **약 45일치가 삭제되며 되돌릴 수 없다.** `values.yaml`에 이미 선언된 90일 의도를 실제로 적용하는 것이다. **사용자 승인 완료.**

## 검증

- 운영 Loki `/config`에서 실제 동작값 확인 (`retention_enabled: false` 등 위 표)
- 인덱스 테이블 135개 · 버킷 객체 추이는 S3/CloudWatch 실측
- 상위 차트(grafana/loki 6.55.0)가 `loki.compactor` · `loki.storage_config` 키를 지원함을 확인
- `helm template` 렌더링 확인 — **차트 기본값과 딥머지되는지가 관건**이었고 정상 동작

```yaml
### compactor
apply_retention_interval: 24h
delete_request_store: s3
retention_enabled: true

### storage_config.tsdb_shipper
index_gateway_client:
  server_address: ''      # ← 차트 기본값 유지됨
resync_interval: 30m      # ← 추가분

### limits_config.retention_period
2160h
```

- `yamllint -c .yamllint.yml infra/` 통과
- `helm lint infra/helm/loki` 통과
- `helm template infra/helm/loki | kubeconform -strict -ignore-missing-schemas` → Valid 18 / Invalid 0 (Skipped 1)

## 배포 후 확인 항목

- [ ] Loki 기동 확인 — `delete_request_store` 누락 시 기동 실패하므로 우선 확인
- [ ] 인덱스 테이블 135 → 90 수렴
- [ ] `loki_s3_request_duration_seconds_count{operation="S3.List"}` 실측 → 4,320/day 수렴
- [ ] 1~2주 뒤 CE 일 비용 확인

## 관련

- #1104 / #1107 / #1110 (Thanos Tier2, 완료)
