### PR TITLE
chore : 좋았던 곳 배지 제거

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
@@ -93,7 +93,7 @@ public class ActivityService {
      *
      * <p>화면은 구글 검색 결과를 그대로 "담기"로 보내므로(§5), 그때 장소를 upsert 해 id로 바꾼다.
      * 이미 담아 둔 장소면 새로 만들지 않고 기존 것을 재사용한다 — 여행을 가로질러 같은 장소를
-     * 가리켜야 "이전 여행에서 좋았던 곳" 판정이 성립한다.
+     * 가리켜야 영업시간·좌표 캐시가 한 곳에 모인다(행이 늘면 한 행만 갱신되는 일이 생긴다).
      */
     private Long resolvePlaceId(Long memberId, ActivityWriteRequest request) {
         if (request.googlePlaceId() != null && !request.googlePlaceId().isBlank()) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceSearchResult.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceSearchResult.java
@@ -6,9 +6,7 @@ import java.math.BigDecimal;
  * S-06 장소 검색 결과 한 건.
  *
  * @param id       이미 담아 둔 장소면 내부 id, 아니면 null
- * @param photoUrl MinIO에 캐시한 대표 사진. 사진 캐시는 별도 이슈라 지금은 항상 null
- * @param loved    이전 여행에서 평점 4 이상을 준 곳(⭐ 좋았던 곳).
- *                 기록 테이블이 4단계라 지금은 항상 false
+ * @param photoUrl MinIO에 캐시한 대표 사진. 장소 사진은 미도입이라 지금은 항상 null(결정 기록 D-16)
  */
 public record PlaceSearchResult(
         Long id,
@@ -19,7 +17,6 @@ public record PlaceSearchResult(
         BigDecimal rating,
         String photoUrl,
         BigDecimal lat,
-        BigDecimal lng,
-        boolean loved
+        BigDecimal lng
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
@@ -102,9 +102,7 @@ public class PlaceService {
                         r.category(), r.address(), r.rating(),
                         // 사진 MinIO 캐시는 별도 이슈.
                         null,
-                        r.lat(), r.lng(),
-                        // ⭐ 좋았던 곳은 기록(평점)이 있어야 판정된다 — 기록은 4단계다.
-                        false))
+                        r.lat(), r.lng()))
                 .toList();
     }
 
@@ -129,7 +127,7 @@ public class PlaceService {
 
     /**
      * 구글 장소를 담는다. 같은 장소를 두 번 저장하지 않는다 — 이미 있으면 그걸 돌려준다
-     * (일정마다 새 행을 만들면 "이전 여행에서 좋았던 곳" 판정이 불가능해진다).
+     * ({@code uk_place_member_google}이 멤버당 한 행을 강제한다).
      */
     @Transactional
     public TravelPlace upsertFromGoogle(Long memberId, String googlePlaceId) {

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/047-create-travel-tables.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/047-create-travel-tables.yaml
@@ -17,7 +17,7 @@ databaseChangeLog:
   - changeSet:
       id: 047-create-travel-place
       author: wcorn
-      comment: 장소 캐시. 여행에 종속되지 않고 멤버 단위로 재사용한다(⭐ 좋았던 곳 판정).
+      comment: 장소 캐시. 여행에 종속되지 않고 멤버 단위로 재사용한다(같은 장소를 두 번 저장하지 않는다).
       preConditions:
         - onFail: MARK_RAN
         - not:

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
@@ -153,7 +153,7 @@ class PlaceControllerTest extends ApiTestSupport {
     class Search {
 
         @Test
-        @DisplayName("검색 결과를 그대로 준다(사진·좋았던 곳은 후속 단계라 비어 있다)")
+        @DisplayName("검색 결과를 그대로 준다")
         void returnsResults() throws Exception {
             stub.placeResults = List.of(place("ChIJ_senso", "센소지"));
 
@@ -164,8 +164,7 @@ class PlaceControllerTest extends ApiTestSupport {
                     .andExpect(jsonPath("$.data[0].category").value("사찰"))
                     .andExpect(jsonPath("$.data[0].rating").value(4.5))
                     .andExpect(jsonPath("$.data[0].id").doesNotExist())
-                    .andExpect(jsonPath("$.data[0].photoUrl").doesNotExist())
-                    .andExpect(jsonPath("$.data[0].loved").value(false));
+                    .andExpect(jsonPath("$.data[0].photoUrl").doesNotExist());
         }
 
         @Test
@@ -360,7 +359,7 @@ class PlaceControllerTest extends ApiTestSupport {
                         .andExpect(status().isOk());
             }
 
-            // 여행을 가로질러 같은 장소를 가리켜야 "좋았던 곳" 판정이 성립한다.
+            // 같은 장소를 두 번 저장하지 않는다(uk_place_member_google).
             assertThat(placeRepository.findAll()).hasSize(1);
             assertThat(stub.detailFetches).containsExactly("ChIJ_senso");
         }

--- a/fe/src/features/travel/api/places.ts
+++ b/fe/src/features/travel/api/places.ts
@@ -28,8 +28,6 @@ export interface PlaceSearchResult {
   photoUrl: string | null;
   lat: number | null;
   lng: number | null;
-  /** 이전 여행에서 평점 4 이상을 준 곳. 기록은 4단계라 지금은 항상 false. */
-  loved: boolean;
 }
 
 export interface PlaceDetail {

--- a/fe/src/features/travel/places/PlaceCard.tsx
+++ b/fe/src/features/travel/places/PlaceCard.tsx
@@ -1,6 +1,5 @@
-import { Image as ImageIcon, Star } from "lucide-react";
+import { Image as ImageIcon } from "lucide-react";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { PlaceSearchResult } from "@/features/travel/api/places";
 
@@ -24,8 +23,8 @@ function metaLine(place: PlaceSearchResult): string {
 /**
  * 검색 결과 카드(§S-06).
  *
- * <p>사진과 `좋았던 곳` 배지는 응답 필드가 이미 있고 서버가 채우기 시작하면 그대로 뜬다
- * (사진 #1058, 평점 기록은 4단계). 그때 이 컴포넌트는 손대지 않는다.
+ * <p>사진은 응답 필드만 있고 서버가 채우지 않는다 — 구글 장소 사진은 약관상 캐시할 수 없어
+ * 넣지 않기로 했다(결정 기록 D-16). 자리 표시 아이콘이 그 자리를 대신한다.
  */
 export function PlaceCard({ place, onAdd, pending = false }: PlaceCardProps) {
   const meta = metaLine(place);
@@ -45,15 +44,7 @@ export function PlaceCard({ place, onAdd, pending = false }: PlaceCardProps) {
       )}
 
       <div className="min-w-0 flex-1">
-        <p className="flex items-center gap-1.5 text-[15px] font-medium">
-          <span className="truncate">{place.name}</span>
-          {place.loved && (
-            <Badge variant="warning" className="shrink-0 gap-0.5">
-              <Star className="size-[11px]" />
-              좋았던 곳
-            </Badge>
-          )}
-        </p>
+        <p className="truncate text-[15px] font-medium">{place.name}</p>
         {meta && (
           <p className="text-muted-foreground truncate text-xs">{meta}</p>
         )}

--- a/fe/src/pages/travel/PlaceSearchPage.test.tsx
+++ b/fe/src/pages/travel/PlaceSearchPage.test.tsx
@@ -40,7 +40,6 @@ function place(overrides: Record<string, unknown> = {}) {
     photoUrl: null,
     lat: 35.7147,
     lng: 139.7966,
-    loved: false,
     ...overrides,
   };
 }
@@ -341,23 +340,6 @@ describe("PlaceSearchPage", () => {
         placeId: 7,
         activityDate: "2026-10-24",
       });
-    });
-  });
-
-  describe("좋았던 곳 배지", () => {
-    it("loved가 true면 배지를 보여준다", async () => {
-      mockSearch([place({ loved: true })]);
-      renderSearch("/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80");
-
-      expect(await screen.findByText("좋았던 곳")).toBeInTheDocument();
-    });
-
-    it("기본값(false)에서는 배지가 없다 — 평점 기록은 4단계다", async () => {
-      mockSearch();
-      renderSearch("/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80");
-
-      await screen.findByText("센소지");
-      expect(screen.queryByText("좋았던 곳")).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## 이슈
closes #1101
## 작업 내용

`⭐ 좋았던 곳` 배지를 **판정을 붙이는 대신 기능째 제거**한다.

1인용 앱이고 여행이 아직 한 번도 안 끝났다. 판정을 구현해도 **한동안 아무 장소에도 배지가 안 뜬다** — 늘 `false`인 필드와 절대 안 보이는 UI를 들고 다니는 비용만 남는다. 필요해지면 그때 넣는 편이 싸다(기록 테이블은 #1090에서 이미 만들어져 있다).

### 지운 것
- `PlaceSearchResult.loved` (BE 응답 필드)
- `PlaceCard`의 배지 + 이제 안 쓰는 `Star`·`Badge` import
- FE 타입·픽스처, 관련 테스트 2건

### 주석을 고친 것 — 여기가 실제로 중요하다

`travel_place`를 **여행이 아니라 멤버 단위로 재사용**하는 설계의 근거로 이 배지가 세 군데(마이그레이션 주석, `PlaceService`, `ActivityService`)에 인용돼 있었다. 배지를 지우면 그 근거만 사라지고 설계는 남아, 나중에 읽는 사람이 "왜 이렇게 했지"를 알 수 없게 된다.

그래서 지우지 않고 **진짜 이유로 바꿔 적었다**:

> 같은 장소를 일정마다 새 행으로 만들면 영업시간·좌표 캐시가 장소 수만큼 중복되고, 한 행만 갱신돼 나머지가 옛 값으로 남는다. `uk_place_member_google`이 멤버당 한 행을 강제한다.

이 이유는 배지와 무관하게 그대로 성립한다. 설계는 바뀌지 않는다.

### 위키
- **D-18** 추가(배지 미도입 + 근거)
- 기존 D-6(장소를 여행에 종속시키지 않는다)의 근거를 위와 같이 교체
- Spec v2 §S-06 · Usecase · UI Design · API Spec · Data Model에서 배지 서술 정리

### 검증
- BE `./gradlew check` 통과
- FE `format:check` · `lint` · `test`(871 passed) · `build` 통과

---

**함께 볼 것**: `photoUrl`도 지금 같은 처지다 — 장소 사진 미도입(D-16)으로 **항상 null**이다. 다만 이 필드를 지우면 `PlaceCard`의 썸네일 자리(현재 자리 표시 아이콘)까지 없어져 카드 레이아웃이 눈에 띄게 바뀐다. 그건 판단이 필요해 이 PR에서는 손대지 않고 주석만 현재 결정에 맞게 고쳤다.
