### PR TITLE
chore : 장소 사진 필드·컬럼 제거

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceDetail.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceDetail.java
@@ -21,14 +21,13 @@ public record PlaceDetail(
         String phone,
         BigDecimal rating,
         String openingHours,
-        String photoUrl,
         boolean manualEntry
 ) {
 
-    public static PlaceDetail from(TravelPlace place, String photoUrl) {
+    public static PlaceDetail from(TravelPlace place) {
         return new PlaceDetail(place.getId(), place.getGooglePlaceId(), place.getName(),
                 place.getAddress(), place.getLat(), place.getLng(), place.getCategory(),
-                place.getPhone(), place.getRating(), place.getOpeningHours(), photoUrl,
+                place.getPhone(), place.getRating(), place.getOpeningHours(),
                 place.isManualEntry());
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceSearchResult.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceSearchResult.java
@@ -6,7 +6,6 @@ import java.math.BigDecimal;
  * S-06 장소 검색 결과 한 건.
  *
  * @param id       이미 담아 둔 장소면 내부 id, 아니면 null
- * @param photoUrl MinIO에 캐시한 대표 사진. 장소 사진은 미도입이라 지금은 항상 null(결정 기록 D-16)
  */
 public record PlaceSearchResult(
         Long id,
@@ -15,7 +14,6 @@ public record PlaceSearchResult(
         String category,
         String address,
         BigDecimal rating,
-        String photoUrl,
         BigDecimal lat,
         BigDecimal lng
 ) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
@@ -100,8 +100,6 @@ public class PlaceService {
                 .map(r -> new PlaceSearchResult(
                         savedIds.get(r.googlePlaceId()), r.googlePlaceId(), r.name(),
                         r.category(), r.address(), r.rating(),
-                        // 사진 MinIO 캐시는 별도 이슈.
-                        null,
                         r.lat(), r.lng()))
                 .toList();
     }
@@ -118,11 +116,10 @@ public class PlaceService {
             placesClient.fetchDetails(place.getGooglePlaceId()).ifPresent(fresh -> {
                 place.updateBasics(fresh.address(), fresh.lat(), fresh.lng(),
                         fresh.category(), fresh.rating());
-                place.updateDetails(fresh.phone(), fresh.openingHours(),
-                        place.getPhotoObjectKey(), place.getPhotoAttribution(), clock.instant());
+                place.updateDetails(fresh.phone(), fresh.openingHours(), clock.instant());
             });
         }
-        return PlaceDetail.from(place, null);
+        return PlaceDetail.from(place);
     }
 
     /**
@@ -142,7 +139,7 @@ public class PlaceService {
         TravelPlace place = TravelPlace.fromGoogle(memberId, googlePlaceId, fresh.name());
         place.updateBasics(fresh.address(), fresh.lat(), fresh.lng(),
                 fresh.category(), fresh.rating());
-        place.updateDetails(fresh.phone(), fresh.openingHours(), null, null, clock.instant());
+        place.updateDetails(fresh.phone(), fresh.openingHours(), clock.instant());
         return placeRepository.save(place);
     }
 
@@ -151,7 +148,7 @@ public class PlaceService {
     public PlaceDetail createManual(Long memberId, PlaceCreateRequest request) {
         TravelPlace place = TravelPlace.manual(memberId, request.name().trim());
         place.updateBasics(request.address(), request.lat(), request.lng(), null, null);
-        return PlaceDetail.from(placeRepository.save(place), null);
+        return PlaceDetail.from(placeRepository.save(place));
     }
 
     // ---------------- helpers ----------------

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/052-drop-travel-place-photo-columns.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/052-drop-travel-place-photo-columns.yaml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  # 장소 사진 컬럼 제거 (#1101 후속, 결정 기록 D-16).
+  #
+  # 구글 장소 사진은 약관상 캐시할 수 없어 넣지 않기로 했다. 이 두 컬럼은 그 기능을
+  # 위해 047에서 미리 만들어 뒀던 자리인데, 채우는 코드가 머지된 적이 없다
+  # (PR #1100은 닫혔다) — 어느 행에도 값이 없다.
+  #
+  # 빈 컬럼을 남겨두면 "사진이 있는데 안 보이는 건가"로 읽힌다. 나중에 사진을 다시
+  # 들이게 되면 그때 컬럼을 새로 만드는 편이 낫다.
+
+  - changeSet:
+      id: 052-drop-travel-place-photo-columns
+      author: wcorn
+      comment: 미도입 결정된 장소 사진 컬럼 제거. 값이 들어간 적 없다.
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: travel_place
+            columnName: photo_object_key
+      changes:
+        - dropColumn:
+            tableName: travel_place
+            columnName: photo_object_key
+        - dropColumn:
+            tableName: travel_place
+            columnName: photo_attribution

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -101,3 +101,5 @@ databaseChangeLog:
       file: db/changelog/changes/050-create-trip-activity-log.yaml
   - include:
       file: db/changelog/changes/051-create-trip-activity-photo.yaml
+  - include:
+      file: db/changelog/changes/052-drop-travel-place-photo-columns.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
@@ -163,8 +163,7 @@ class PlaceControllerTest extends ApiTestSupport {
                     .andExpect(jsonPath("$.data[0].name").value("센소지"))
                     .andExpect(jsonPath("$.data[0].category").value("사찰"))
                     .andExpect(jsonPath("$.data[0].rating").value(4.5))
-                    .andExpect(jsonPath("$.data[0].id").doesNotExist())
-                    .andExpect(jsonPath("$.data[0].photoUrl").doesNotExist());
+                    .andExpect(jsonPath("$.data[0].id").doesNotExist());
         }
 
         @Test
@@ -276,7 +275,7 @@ class PlaceControllerTest extends ApiTestSupport {
             Long memberId = memberRepository.findAll().get(0).getId();
             TravelPlace saved = placeRepository.save(
                     TravelPlace.fromGoogle(memberId, "ChIJ_senso", "센소지"));
-            saved.updateDetails("+81", "{}", null, null, java.time.Instant.now());
+            saved.updateDetails("+81", "{}", java.time.Instant.now());
             placeRepository.saveAndFlush(saved);
 
             mockMvc.perform(get("/api/travel/places/" + saved.getId())

--- a/be/orino-app-api/src/test/java/ds/project/orino/schema/TravelPlacePhotoColumnsTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/schema/TravelPlacePhotoColumnsTest.java
@@ -1,0 +1,39 @@
+package ds.project.orino.schema;
+
+import ds.project.orino.support.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 장소 사진 컬럼이 실제로 사라졌는지 본다(052).
+ *
+ * <p>Hibernate {@code validate}는 <b>남는 컬럼을 잡지 않는다</b> — 엔티티에서 필드만 지우고
+ * 마이그레이션을 빠뜨려도 통과한다. 그래서 스키마를 직접 확인한다.
+ */
+@IntegrationTest
+class TravelPlacePhotoColumnsTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("장소 사진 컬럼은 스키마에 없다 — 미도입 결정(D-16)")
+    void photoColumnsAreGone() {
+        List<String> columns = jdbcTemplate.queryForList("""
+                SELECT column_name FROM information_schema.columns
+                WHERE table_schema = DATABASE() AND table_name = 'travel_place'
+                """, String.class);
+
+        assertThat(columns)
+                .doesNotContain("photo_object_key")
+                .doesNotContain("photo_attribution")
+                // 같이 지워지면 안 되는 것들.
+                .contains("opening_hours", "details_refreshed_at");
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TravelPlace.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TravelPlace.java
@@ -70,15 +70,7 @@ public class TravelPlace {
     @Column(name = "opening_hours", columnDefinition = "JSON")
     private String openingHours;
 
-    /** MinIO에 캐시한 대표 사진 key. 공개 URL은 base + key로 조립한다. */
-    @Column(name = "photo_object_key", length = 512)
-    private String photoObjectKey;
-
-    /** Google 사진 저작자 표기. 사진을 쓰면 함께 노출해야 한다. */
-    @Column(name = "photo_attribution", length = 500)
-    private String photoAttribution;
-
-    /** 영업시간·사진을 마지막으로 갱신한 시각. null이면 아직 상세를 받은 적 없다. */
+    /** 영업시간을 마지막으로 갱신한 시각. null이면 아직 상세를 받은 적 없다. */
     @Column(name = "details_refreshed_at")
     private Instant detailsRefreshedAt;
 
@@ -128,12 +120,9 @@ public class TravelPlace {
     }
 
     /** 상세 조회(영업시간·전화·사진) 결과를 채우고 갱신 시각을 찍는다. */
-    public void updateDetails(String phone, String openingHours, String photoObjectKey,
-                              String photoAttribution, Instant refreshedAt) {
+    public void updateDetails(String phone, String openingHours, Instant refreshedAt) {
         this.phone = phone;
         this.openingHours = openingHours;
-        this.photoObjectKey = photoObjectKey;
-        this.photoAttribution = photoAttribution;
         this.detailsRefreshedAt = refreshedAt;
     }
 
@@ -184,14 +173,6 @@ public class TravelPlace {
 
     public String getOpeningHours() {
         return openingHours;
-    }
-
-    public String getPhotoObjectKey() {
-        return photoObjectKey;
-    }
-
-    public String getPhotoAttribution() {
-        return photoAttribution;
     }
 
     public Instant getDetailsRefreshedAt() {

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TravelPlaceRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TravelPlaceRepositoryTest.java
@@ -44,7 +44,6 @@ class TravelPlaceRepositoryTest {
         place.updateBasics("도쿄도 다이토구 아사쿠사 2-3-1", new BigDecimal("35.7147651"),
                 new BigDecimal("139.7966553"), "buddhist_temple", new BigDecimal("4.5"));
         place.updateDetails("+81 3-3842-0181", "{\"weekdayText\":[\"월: 06:00~17:00\"]}",
-                "travel/places/senso-ji.jpg", "Google 사용자 제공",
                 Instant.parse("2026-08-07T00:00:00Z"));
         placeRepository.flush();
 
@@ -58,8 +57,6 @@ class TravelPlaceRepositoryTest {
         assertThat(found.getRating()).isEqualByComparingTo("4.5");
         assertThat(found.getPhone()).isEqualTo("+81 3-3842-0181");
         assertThat(found.getOpeningHours()).contains("06:00~17:00");
-        assertThat(found.getPhotoObjectKey()).isEqualTo("travel/places/senso-ji.jpg");
-        assertThat(found.getPhotoAttribution()).isEqualTo("Google 사용자 제공");
         assertThat(found.isManualEntry()).isFalse();
     }
 
@@ -133,7 +130,7 @@ class TravelPlaceRepositoryTest {
         // 아직 상세를 받은 적 없다.
         assertThat(place.needsDetailsRefresh(now)).isTrue();
 
-        place.updateDetails(null, "{}", null, null, Instant.parse("2026-08-07T00:00:00Z"));
+        place.updateDetails(null, "{}", Instant.parse("2026-08-07T00:00:00Z"));
         // 30일 딱 지나기 전에는 캐시를 그대로 쓴다.
         assertThat(place.needsDetailsRefresh(now)).isFalse();
         assertThat(place.needsDetailsRefresh(Instant.parse("2026-09-06T00:00:01Z"))).isTrue();

--- a/fe/src/features/travel/api/places.ts
+++ b/fe/src/features/travel/api/places.ts
@@ -25,7 +25,6 @@ export interface PlaceSearchResult {
   address: string | null;
   rating: number | null;
   /** 사진은 후속 작업(#1058)이라 지금은 항상 null. */
-  photoUrl: string | null;
   lat: number | null;
   lng: number | null;
 }
@@ -42,7 +41,6 @@ export interface PlaceDetail {
   rating: number | null;
   /** Google 원본 JSON 문자열. 상세 화면에서만 쓴다. */
   openingHours: string | null;
-  photoUrl: string | null;
   manualEntry: boolean;
 }
 

--- a/fe/src/features/travel/places/PlaceCard.tsx
+++ b/fe/src/features/travel/places/PlaceCard.tsx
@@ -1,5 +1,3 @@
-import { Image as ImageIcon } from "lucide-react";
-
 import { Button } from "@/components/ui/button";
 import type { PlaceSearchResult } from "@/features/travel/api/places";
 
@@ -23,26 +21,14 @@ function metaLine(place: PlaceSearchResult): string {
 /**
  * 검색 결과 카드(§S-06).
  *
- * <p>사진은 응답 필드만 있고 서버가 채우지 않는다 — 구글 장소 사진은 약관상 캐시할 수 없어
- * 넣지 않기로 했다(결정 기록 D-16). 자리 표시 아이콘이 그 자리를 대신한다.
+ * <p>썸네일 자리가 없다 — 구글 장소 사진은 약관상 캐시할 수 없어 넣지 않기로 했고(D-16),
+ * 영영 빈 자리 표시만 뜰 슬롯을 남겨두지 않는다.
  */
 export function PlaceCard({ place, onAdd, pending = false }: PlaceCardProps) {
   const meta = metaLine(place);
 
   return (
     <li className="border-border bg-card flex items-center gap-3 rounded-xl border p-2.5">
-      {place.photoUrl ? (
-        <img
-          src={place.photoUrl}
-          alt=""
-          className="size-16 shrink-0 rounded-lg object-cover"
-        />
-      ) : (
-        <div className="bg-muted flex size-16 shrink-0 items-center justify-center rounded-lg">
-          <ImageIcon className="text-muted-foreground size-[18px]" />
-        </div>
-      )}
-
       <div className="min-w-0 flex-1">
         <p className="truncate text-[15px] font-medium">{place.name}</p>
         {meta && (

--- a/fe/src/pages/travel/PlaceSearchPage.test.tsx
+++ b/fe/src/pages/travel/PlaceSearchPage.test.tsx
@@ -37,7 +37,6 @@ function place(overrides: Record<string, unknown> = {}) {
     category: "불교사찰",
     address: "도쿄도 다이토구",
     rating: 4.6,
-    photoUrl: null,
     lat: 35.7147,
     lng: 139.7966,
     ...overrides,


### PR DESCRIPTION
## 이슈
#1101 후속 (결정 기록 D-16)
## 작업 내용

`loved`와 같은 처지였던 `photoUrl`을 걷어낸다. 장소 사진은 약관상 캐시할 수 없어 미도입으로 정했는데(D-16), 필드는 응답에 남아 **늘 null**이었고 카드에는 **영영 채워지지 않을 자리 표시 아이콘**이 떠 있었다.

### 지운 것
- `PlaceSearchResult.photoUrl` · `PlaceDetail.photoUrl`
- `TravelPlace.photoObjectKey` · `photoAttribution` (필드·게터)
- `updateDetails(...)`의 죽은 파라미터 둘 — 호출부가 전부 `null, null`을 넘기고 있었다
- `PlaceCard`의 썸네일 슬롯(+ 안 쓰게 된 `ImageIcon` import)
- FE 타입·픽스처

### DB 컬럼도 지웠다 (`052`)

`photo_object_key` · `photo_attribution`을 드롭한다. **어느 행에도 값이 없다** — 채우는 코드는 PR #1100뿐이었고 그건 머지하지 않고 닫았다. 병합된 코드의 호출부는 전부 `null`을 넘긴다(확인함).

빈 컬럼을 남겨두면 "사진이 있는데 안 보이는 건가"로 읽힌다. 다시 들이게 되면 그때 컬럼을 새로 만드는 편이 낫다.

### 스키마 테스트를 추가한 이유

**Hibernate `validate`는 남는 컬럼을 잡지 않는다.** 엔티티에서 필드만 지우고 마이그레이션을 빠뜨려도 통과한다 — 그러면 컬럼이 조용히 남는다. 그래서 `information_schema`를 직접 보는 테스트를 넣었다. 같이 지워지면 안 되는 `opening_hours` · `details_refreshed_at`이 남아 있는지도 함께 본다.

### 검증
- BE `./gradlew check` 통과
- **마이그레이션이 실제로 도는지** `--rerun-tasks`로 캐시 없이 확인(`TravelSchemaTest`·`PlaceControllerTest`)
- 새 스키마 테스트로 컬럼이 실제로 사라진 것 확인
- FE `format:check` · `lint` · `test`(871 passed) · `build` 통과
