### PR TITLE
feat : 여행 날짜·숙소 테이블 + 목적지 컬럼 제거 (Liquibase 053)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
@@ -17,6 +17,7 @@ import ds.project.orino.planner.travel.activity.dto.ActivityPlace;
 import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
 import ds.project.orino.planner.travel.activity.dto.ActivityWriteRequest;
 import ds.project.orino.planner.travel.activity.dto.ReorderRequest;
+import ds.project.orino.planner.travel.day.service.TripDayService;
 import ds.project.orino.planner.travel.photo.dto.PhotoResponse;
 import ds.project.orino.planner.travel.photo.service.TravelPhotoService;
 import ds.project.orino.planner.travel.push.service.NotificationScheduleService;
@@ -64,6 +65,7 @@ public class ActivityService {
     private final PlaceService placeService;
     private final LegService legService;
     private final NotificationScheduleService notificationService;
+    private final TripDayService tripDayService;
     private final Clock clock;
 
     public ActivityService(TripActivityRepository activityRepository,
@@ -75,6 +77,7 @@ public class ActivityService {
                            PlaceService placeService,
                            LegService legService,
                            NotificationScheduleService notificationService,
+                           TripDayService tripDayService,
                            Clock clock) {
         this.activityRepository = activityRepository;
         this.logRepository = logRepository;
@@ -85,6 +88,7 @@ public class ActivityService {
         this.placeService = placeService;
         this.legService = legService;
         this.notificationService = notificationService;
+        this.tripDayService = tripDayService;
         this.clock = clock;
     }
 
@@ -255,9 +259,13 @@ public class ActivityService {
 
     // ---------------- helpers ----------------
 
-    /** 기록은 여행 시작일부터다. 기준은 기기 시간대가 아니라 여행 타임존의 오늘이다. */
+    /**
+     * 기록은 여행 시작일부터다. 기준은 기기 시간대가 아니라 <b>첫날 기준 도시</b>의 오늘이다 —
+     * 여행이 시작되는 곳의 날짜가 넘어가야 시작된 것이다.
+     */
     private void requireTripStarted(Trip trip) {
-        if (trip.todayAtDestination(clock).isBefore(trip.getStartDate())) {
+        if (trip.todayIn(clock, tripDayService.primaryZone(trip.getId()))
+                .isBefore(trip.getStartDate())) {
             throw new CustomException(ErrorCode.TRAVEL_LOG_BEFORE_TRIP);
         }
     }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
@@ -2,6 +2,7 @@ package ds.project.orino.planner.travel.board.service;
 
 import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.entity.Trip;
 import ds.project.orino.domain.planner.travel.entity.TripActivity;
 import ds.project.orino.domain.planner.travel.entity.TripStatus;
@@ -10,6 +11,7 @@ import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
 import ds.project.orino.domain.planner.travel.repository.TripRepository;
 import ds.project.orino.planner.travel.activity.service.ActivityService;
 import ds.project.orino.planner.travel.board.dto.BoardResponse;
+import ds.project.orino.planner.travel.day.service.TripDayService;
 import ds.project.orino.planner.travel.route.service.LegService;
 import ds.project.orino.planner.travel.tools.dto.WeatherResponse;
 import ds.project.orino.planner.travel.tools.service.WeatherService;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.TextStyle;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +42,7 @@ public class BoardService {
     private final TripRepository tripRepository;
     private final TripActivityRepository activityRepository;
     private final ActivityService activityService;
+    private final TripDayService tripDayService;
     private final LegService legService;
     private final WeatherService weatherService;
     private final Clock clock;
@@ -46,12 +50,14 @@ public class BoardService {
     public BoardService(TripRepository tripRepository,
                         TripActivityRepository activityRepository,
                         ActivityService activityService,
+                        TripDayService tripDayService,
                         LegService legService,
                         WeatherService weatherService,
                         Clock clock) {
         this.tripRepository = tripRepository;
         this.activityRepository = activityRepository;
         this.activityService = activityService;
+        this.tripDayService = tripDayService;
         this.legService = legService;
         this.weatherService = weatherService;
         this.clock = clock;
@@ -64,17 +70,21 @@ public class BoardService {
     public BoardResponse board(Long memberId, Long tripId, LocalDate date, boolean archive) {
         Trip trip = tripRepository.findByIdAndMemberId(tripId, memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_TRIP_NOT_FOUND));
-        TripStatus status = trip.status(clock);
+        // 헤더의 타임존·통화는 아직 첫날 기준 도시에서 온다. 선택한 날짜의 도시로 갈라내는 건
+        // 파생 재작성(#1123)·보드 응답 v2.1(#1124)의 몫이다.
+        TravelPlace city = tripDayService.primaryCity(tripId);
+        TripStatus status = trip.status(clock, TripDayService.zoneOf(city));
 
-        LocalDate selectedDate = archive ? null : resolveSelectedDate(trip, status, date);
+        LocalDate selectedDate = archive ? null
+                : resolveSelectedDate(trip, status, date, TripDayService.zoneOf(city));
         List<TripActivity> activities = selectedDate == null
                 ? activityRepository.findUnscheduled(tripId)
                 : activityRepository.findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(
                         tripId, selectedDate);
 
         return new BoardResponse(
-                new BoardResponse.BoardTrip(trip.getId(), trip.getTitle(), trip.getTimezone(),
-                        trip.getCurrency(), trip.getStartDate(), trip.getEndDate(), status,
+                new BoardResponse.BoardTrip(trip.getId(), trip.getTitle(), city.getTimezone(),
+                        city.getCurrency(), trip.getStartDate(), trip.getEndDate(), status,
                         status == TripStatus.COMPLETED),
                 buildDays(trip),
                 selectedDate,
@@ -86,17 +96,18 @@ public class BoardService {
     }
 
     /**
-     * 날짜를 안 주면 — 여행 중이면 <b>여행 타임존의 오늘</b>, 아니면 1일차를 연다.
+     * 날짜를 안 주면 — 여행 중이면 <b>기준 도시 타임존의 오늘</b>, 아니면 1일차를 연다.
      * 현지에서 앱을 열자마자 오늘 일정이 보여야 하고, 그 "오늘"은 기기 시간대가 아니다.
      */
-    private LocalDate resolveSelectedDate(Trip trip, TripStatus status, LocalDate requested) {
+    private LocalDate resolveSelectedDate(Trip trip, TripStatus status, LocalDate requested,
+                                          ZoneId zone) {
         if (requested != null) {
             if (!trip.covers(requested)) {
                 throw new CustomException(ErrorCode.TRAVEL_DATE_OUT_OF_RANGE);
             }
             return requested;
         }
-        return status == TripStatus.ONGOING ? trip.todayAtDestination(clock) : trip.getStartDate();
+        return status == TripStatus.ONGOING ? trip.todayIn(clock, zone) : trip.getStartDate();
     }
 
     /** 기간에서 날짜 탭을 만든다. 일정이 하나도 없는 날짜도 탭은 나와야 한다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/BaseCityResolver.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/BaseCityResolver.java
@@ -1,0 +1,76 @@
+package ds.project.orino.planner.travel.day.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.travel.entity.PlaceKind;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+/**
+ * 이름·타임존·통화로 들어온 목적지를 <b>도시 장소</b>로 바꾼다.
+ *
+ * <p>v2.1에서 타임존·통화의 주인은 여행이 아니라 도시다. 그런데 화면은 아직 목적지 하나를
+ * 보내고(구간 입력은 #1121), 그 목적지가 검색으로 고른 장소일 수도 직접 친 이름일 수도 있다.
+ * 두 경우 모두 기준 도시로 쓸 행이 있어야 하므로 여기서 승격하거나 만들어 준다.
+ *
+ * <p>같은 멤버가 같은 도시를 다시 쓰면 <b>행을 새로 만들지 않는다.</b> 이름만 같은 도시 행이
+ * 여럿이면 도시 일치 판정({@code cityPlaceRef})이 여행마다 갈려, 같은 오사카인데 어떤 여행에서만
+ * "다른 도시"로 표시된다.
+ */
+@Component
+public class BaseCityResolver {
+
+    private final TravelPlaceRepository placeRepository;
+
+    public BaseCityResolver(TravelPlaceRepository placeRepository) {
+        this.placeRepository = placeRepository;
+    }
+
+    /**
+     * 기준 도시로 쓸 장소를 찾아 반환한다. 필요하면 만들고, 검색으로 고른 장소면 도시로
+     * 승격한다.
+     *
+     * @param placeId 검색으로 고른 장소. {@code null}이면 이름으로 도시를 만든다
+     */
+    @Transactional
+    public TravelPlace resolve(Long memberId, Long placeId, String name,
+                               String timezone, String currency,
+                               BigDecimal lat, BigDecimal lng) {
+        TravelPlace city = placeId != null
+                ? promote(memberId, placeId, name, timezone, currency)
+                : findOrCreateManualCity(memberId, name, timezone, currency);
+
+        // 좌표는 날씨 조회의 기준점이다. 검색으로 고른 도시는 이미 갖고 있으므로 덮지 않는다.
+        if (city.getLat() == null && lat != null && lng != null) {
+            city.updateCoordinates(lat, lng);
+        }
+        return placeRepository.save(city);
+    }
+
+    private TravelPlace promote(Long memberId, Long placeId, String name,
+                                String timezone, String currency) {
+        TravelPlace place = placeRepository.findByIdAndMemberId(placeId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PLACE_NOT_FOUND));
+        // 목적지로 고른 장소는 곧 그 여행의 도시다 — v2.0의 destination_place_id가
+        // 그런 의미였고, 마이그레이션도 같은 판단으로 CITY 표시를 달았다.
+        place.promoteToCity(name, timezone, currency);
+        return place;
+    }
+
+    private TravelPlace findOrCreateManualCity(Long memberId, String name,
+                                               String timezone, String currency) {
+        return placeRepository
+                .findFirstByMemberIdAndNameAndPlaceKindAndGooglePlaceIdIsNull(
+                        memberId, name, PlaceKind.CITY)
+                .map(existing -> {
+                    // 같은 이름의 도시라도 타임존·통화는 이번 입력이 최신이다.
+                    existing.promoteToCity(name, timezone, currency);
+                    return existing;
+                })
+                .orElseGet(() -> TravelPlace.manualCity(memberId, name, timezone, currency));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/TripDayService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/TripDayService.java
@@ -1,0 +1,212 @@
+package ds.project.orino.planner.travel.day.service;
+
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.entity.TripDay;
+import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.domain.planner.travel.repository.TripDayRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 여행 날짜와 기준 도시를 다루는 한 곳. <b>여행에는 타임존이 없다</b>는 v2.1의 전제를 지키려면
+ * 타임존·통화·좌표를 찾는 경로가 하나여야 한다 — 흩어 두면 어떤 화면은 새 도시를 보여주는데
+ * 알림은 옛 시각에 가는, 사용자가 알아차릴 방법이 없는 오류가 난다.
+ *
+ * <p><b>날짜 집합은 항상 기간과 일치한다.</b> 비어 있는 날짜는 타임존이 없는 날이고, 그 순간
+ * 알림·날씨·상태 판정이 전부 죽는다. 그래서 기간을 바꾸는 쪽은 반드시
+ * {@link #syncPeriod(Trip, Long)}을 같은 트랜잭션에서 부른다.
+ *
+ * <p>지금은 조회 대부분이 {@link #primaryCity(Long)}(첫날의 기준 도시)을 쓴다 — 마이그레이션
+ * 직후의 모든 여행이 단일 도시라 v2.0과 결과가 같다. 값마다 어느 날짜의 도시를 봐야 하는지
+ * (상태는 오늘, D-day는 첫날, 보드 헤더는 선택한 날짜)는 #1123에서 갈라낸다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class TripDayService {
+
+    private final TripDayRepository dayRepository;
+    private final TravelPlaceRepository placeRepository;
+
+    public TripDayService(TripDayRepository dayRepository, TravelPlaceRepository placeRepository) {
+        this.dayRepository = dayRepository;
+        this.placeRepository = placeRepository;
+    }
+
+    /**
+     * 여행 기간의 날짜 행을 만들거나 지워 기간과 일치시킨다.
+     *
+     * <ul>
+     *   <li>늘어난 날짜는 <b>직전(마지막) 날짜의 기준 도시를 상속</b>한다</li>
+     *   <li>잘린 날짜는 행을 지운다 — 그 날짜 일정의 보관함 이동은 호출부가 따로 처리한다</li>
+     *   <li>날짜가 하나도 없으면(신규 생성) 전 날짜에 {@code fallbackBaseCityId}를 채운다</li>
+     * </ul>
+     *
+     * <p>{@code cityMemo}는 날짜 기준으로 살아남는다. 기간 안에 남아 있는 날짜의 행을 지우지
+     * 않기 때문에, 도시가 바뀌어도 그 날짜에 적어 둔 메모는 그대로다.
+     */
+    @Transactional
+    public void syncPeriod(Trip trip, Long fallbackBaseCityId) {
+        Map<LocalDate, TripDay> existing = dayRepository
+                .findAllByTripIdOrderByDayDateAsc(trip.getId()).stream()
+                .collect(Collectors.toMap(TripDay::getDayDate, Function.identity(),
+                        (first, second) -> first, LinkedHashMap::new));
+
+        List<TripDay> outside = existing.entrySet().stream()
+                .filter(entry -> !trip.covers(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .toList();
+        dayRepository.deleteAll(outside);
+        outside.forEach(day -> existing.remove(day.getDayDate()));
+
+        // 새 날짜는 "바로 앞 날짜"의 도시를 물려받는다. 시작일이 앞으로 당겨져 앞에 붙는
+        // 날짜에는 앞 날짜가 없으므로 첫날의 도시를 쓴다 — 도쿄에서 시작하는 여행에 하루를
+        // 더 붙이면 그 하루도 도쿄다.
+        Long inherited = existing.isEmpty() ? fallbackBaseCityId
+                : existing.values().iterator().next().getBasePlaceId();
+
+        List<TripDay> created = new ArrayList<>();
+        for (LocalDate date = trip.getStartDate(); !date.isAfter(trip.getEndDate());
+                date = date.plusDays(1)) {
+            TripDay day = existing.get(date);
+            if (day == null) {
+                created.add(new TripDay(trip.getId(), date, inherited));
+            } else {
+                inherited = day.getBasePlaceId();
+            }
+        }
+        dayRepository.saveAll(created);
+    }
+
+    /**
+     * 전 날짜의 기준 도시를 하나로 맞춘다. 여행 전체의 목적지를 한 번에 바꾸는 화면(v2.0 폼)만
+     * 쓴다 — 날짜별로 다르게 두는 길은 기준 도시 변경 API(#1122)다.
+     */
+    @Transactional
+    public void rebaseAll(Long tripId, Long basePlaceId) {
+        List<TripDay> days = dayRepository.findAllByTripIdOrderByDayDateAsc(tripId);
+        days.forEach(day -> day.changeBaseCity(basePlaceId));
+        dayRepository.saveAll(days);
+    }
+
+    /** 여행 전체의 날짜 → 기준 도시. 도시는 여러 날짜가 공유하므로 장소는 한 번씩만 읽는다. */
+    public Map<LocalDate, TravelPlace> baseCitiesOf(Long tripId) {
+        List<TripDay> days = dayRepository.findAllByTripIdOrderByDayDateAsc(tripId);
+        if (days.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, TravelPlace> places = placeRepository
+                .findAllById(days.stream().map(TripDay::getBasePlaceId).distinct().toList())
+                .stream()
+                .collect(Collectors.toMap(TravelPlace::getId, Function.identity()));
+
+        Map<LocalDate, TravelPlace> byDate = new LinkedHashMap<>();
+        for (TripDay day : days) {
+            TravelPlace city = places.get(day.getBasePlaceId());
+            if (city != null) {
+                byDate.put(day.getDayDate(), city);
+            }
+        }
+        return byDate;
+    }
+
+    /**
+     * 여행 여럿의 첫날 기준 도시를 한 번에. 목록·요약 화면이 여행 수만큼 조회하지 않게 한다.
+     *
+     * <p>날짜 행이 없는 여행은 지도에서 빠진다 — 목록 전체를 죽이는 대신 호출부가 그 한 건만
+     * 기기 타임존으로 판정하게 둔다. 만들어질 수 없는 상태라 정상 경로에서는 비지 않는다.
+     */
+    public Map<Long, TravelPlace> primaryCitiesOf(Collection<Long> tripIds) {
+        if (tripIds.isEmpty()) {
+            return Map.of();
+        }
+        List<TripDay> days = dayRepository.findAllByTripIdInOrderByTripIdAscDayDateAsc(tripIds);
+        Map<Long, TravelPlace> places = placeRepository
+                .findAllById(days.stream().map(TripDay::getBasePlaceId).distinct().toList())
+                .stream()
+                .collect(Collectors.toMap(TravelPlace::getId, Function.identity()));
+
+        Map<Long, TripDay> firstDays = new LinkedHashMap<>();
+        for (TripDay day : days) {
+            firstDays.merge(day.getTripId(), day,
+                    (kept, next) -> next.getDayDate().isBefore(kept.getDayDate()) ? next : kept);
+        }
+        Map<Long, TravelPlace> byTrip = new LinkedHashMap<>();
+        firstDays.forEach((tripId, day) -> {
+            TravelPlace city = places.get(day.getBasePlaceId());
+            if (city != null) {
+                byTrip.put(tripId, city);
+            }
+        });
+        return byTrip;
+    }
+
+    /**
+     * 그 날짜의 기준 도시. 기간 밖 날짜를 물으면 가장 가까운 끝(첫날/마지막 날)의 도시를 준다 —
+     * 상태 판정처럼 "오늘"이 기간 밖일 수 있는 호출부가 있고, 거기서 도시가 비면 판정 자체를
+     * 못 한다.
+     */
+    public TravelPlace baseCityOn(Long tripId, LocalDate date) {
+        Map<LocalDate, TravelPlace> cities = baseCitiesOf(tripId);
+        requireDays(tripId, cities);
+
+        TravelPlace exact = cities.get(date);
+        if (exact != null) {
+            return exact;
+        }
+        List<LocalDate> dates = List.copyOf(cities.keySet());
+        LocalDate first = dates.getFirst();
+        return date.isBefore(first) ? cities.get(first) : cities.get(dates.getLast());
+    }
+
+    /**
+     * 첫날의 기준 도시. v2.0에서 {@code trip}이 들고 있던 목적지가 이 자리로 내려왔다 —
+     * D-day처럼 "여행이 시작되는 곳"을 기준으로 하는 값이 쓴다.
+     */
+    public TravelPlace primaryCity(Long tripId) {
+        Map<LocalDate, TravelPlace> cities = baseCitiesOf(tripId);
+        requireDays(tripId, cities);
+        return cities.values().iterator().next();
+    }
+
+    /** 첫날 기준 도시의 타임존. */
+    public ZoneId primaryZone(Long tripId) {
+        return zoneOf(primaryCity(tripId));
+    }
+
+    /** 그 날짜 기준 도시의 타임존. */
+    public ZoneId zoneOn(Long tripId, LocalDate date) {
+        return zoneOf(baseCityOn(tripId, date));
+    }
+
+    /**
+     * 도시의 타임존. 도시 장소에는 타임존이 반드시 있어야 하지만, 값이 비어 있다고 화면 전체를
+     * 죽이지는 않는다 — 그런 도시는 애초에 기준 도시로 지정될 수 없으므로 여기 오면 데이터
+     * 문제이고, 시스템 기본값으로 버티면서 로그가 아니라 화면의 시각으로 드러나게 둔다.
+     */
+    public static ZoneId zoneOf(TravelPlace city) {
+        return city.getTimezone() == null ? ZoneId.systemDefault()
+                : ZoneId.of(city.getTimezone());
+    }
+
+    /**
+     * 날짜 행이 하나도 없는 여행은 v2.1에서 존재할 수 없다. 조용히 기본값으로 때우면 그
+     * 화면만 틀린 시각을 보여주므로, 만들어질 수 없는 상태라는 걸 드러낸다.
+     */
+    private void requireDays(Long tripId, Map<LocalDate, TravelPlace> cities) {
+        if (cities.isEmpty()) {
+            throw new IllegalStateException(
+                    "여행 %d에 기준 도시가 붙은 날짜가 없습니다.".formatted(tripId));
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/service/TravelPhotoService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/photo/service/TravelPhotoService.java
@@ -10,6 +10,7 @@ import ds.project.orino.domain.planner.travel.repository.TripActivityLogReposito
 import ds.project.orino.domain.planner.travel.repository.TripActivityPhotoRepository;
 import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
 import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.day.service.TripDayService;
 import ds.project.orino.planner.travel.photo.dto.PhotoRegisterRequest;
 import ds.project.orino.planner.travel.photo.dto.PhotoResponse;
 import org.springframework.stereotype.Service;
@@ -40,6 +41,7 @@ public class TravelPhotoService {
     private final TripActivityPhotoRepository photoRepository;
     private final TripRepository tripRepository;
     private final TravelPhotoStorageService storageService;
+    private final TripDayService tripDayService;
     private final Clock clock;
 
     public TravelPhotoService(TripActivityRepository activityRepository,
@@ -47,12 +49,14 @@ public class TravelPhotoService {
                               TripActivityPhotoRepository photoRepository,
                               TripRepository tripRepository,
                               TravelPhotoStorageService storageService,
+                              TripDayService tripDayService,
                               Clock clock) {
         this.activityRepository = activityRepository;
         this.logRepository = logRepository;
         this.photoRepository = photoRepository;
         this.tripRepository = tripRepository;
         this.storageService = storageService;
+        this.tripDayService = tripDayService;
         this.clock = clock;
     }
 
@@ -140,11 +144,12 @@ public class TravelPhotoService {
      */
     /**
      * 기록은 여행 시작일부터다(§S-07) — 사진도 기록의 일부라 같은 규칙을 따른다.
-     * 기준은 기기 시간대가 아니라 여행 타임존의 오늘이다.
+     * 기준은 기기 시간대가 아니라 첫날 기준 도시의 오늘이다.
      */
     private void requireTripStarted(TripActivity activity) {
         Trip trip = tripRepository.findById(activity.getTripId()).orElseThrow();
-        if (trip.todayAtDestination(clock).isBefore(trip.getStartDate())) {
+        if (trip.todayIn(clock, tripDayService.primaryZone(trip.getId()))
+                .isBefore(trip.getStartDate())) {
             throw new CustomException(ErrorCode.TRAVEL_LOG_BEFORE_TRIP);
         }
     }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
@@ -6,6 +6,7 @@ import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.entity.Trip;
 import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
 import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.day.service.TripDayService;
 import ds.project.orino.planner.travel.place.client.PlaceResult;
 import ds.project.orino.planner.travel.place.client.PlacesClient;
 import ds.project.orino.planner.travel.place.config.PlacesProperties;
@@ -44,6 +45,7 @@ public class PlaceService {
     private final PlaceSearchCacheRepository cache;
     private final TravelPlaceRepository placeRepository;
     private final TripRepository tripRepository;
+    private final TripDayService tripDayService;
     private final PlacesProperties props;
     private final ObjectMapper objectMapper;
     private final Clock clock;
@@ -52,6 +54,7 @@ public class PlaceService {
                         PlaceSearchCacheRepository cache,
                         TravelPlaceRepository placeRepository,
                         TripRepository tripRepository,
+                        TripDayService tripDayService,
                         PlacesProperties props,
                         ObjectMapper objectMapper,
                         Clock clock) {
@@ -59,6 +62,7 @@ public class PlaceService {
         this.cache = cache;
         this.placeRepository = placeRepository;
         this.tripRepository = tripRepository;
+        this.tripDayService = tripDayService;
         this.props = props;
         this.objectMapper = objectMapper;
         this.clock = clock;
@@ -191,15 +195,23 @@ public class PlaceService {
         }
     }
 
+    /**
+     * 검색 편향 좌표. 지금은 <b>첫날 기준 도시</b>를 쓴다 — 날짜를 골라 그 도시로 검색하는
+     * 기준 도시 칩({@code ?city=})은 3단계(S-06)에서 붙는다.
+     */
     private PlacesClient.Coordinates biasOf(Long memberId, Long tripId) {
         if (tripId == null) {
             return null;
         }
         Trip trip = tripRepository.findByIdAndMemberId(tripId, memberId).orElse(null);
-        if (trip == null || trip.getLat() == null || trip.getLng() == null) {
+        if (trip == null) {
             return null;
         }
-        return new PlacesClient.Coordinates(trip.getLat(), trip.getLng());
+        TravelPlace city = tripDayService.primaryCity(trip.getId());
+        if (city.getLat() == null || city.getLng() == null) {
+            return null;
+        }
+        return new PlacesClient.Coordinates(city.getLat(), city.getLng());
     }
 
     private Map<String, Long> savedIdsOf(Long memberId, List<PlaceResult> results) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/NotificationScheduleService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/NotificationScheduleService.java
@@ -4,10 +4,12 @@ import ds.project.orino.domain.planner.push.entity.NotificationStatus;
 import ds.project.orino.domain.planner.push.entity.NotificationType;
 import ds.project.orino.domain.planner.push.entity.PushNotification;
 import ds.project.orino.domain.planner.push.repository.PushNotificationRepository;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.entity.Trip;
 import ds.project.orino.domain.planner.travel.entity.TripActivity;
 import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
 import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.day.service.TripDayService;
 import ds.project.orino.planner.travel.route.dto.LegResponse;
 import ds.project.orino.planner.travel.route.service.LegService;
 import org.springframework.stereotype.Service;
@@ -43,15 +45,18 @@ public class NotificationScheduleService {
     private final PushNotificationRepository notificationRepository;
     private final TripActivityRepository activityRepository;
     private final TripRepository tripRepository;
+    private final TripDayService tripDayService;
     private final LegService legService;
 
     public NotificationScheduleService(PushNotificationRepository notificationRepository,
                                        TripActivityRepository activityRepository,
                                        TripRepository tripRepository,
+                                       TripDayService tripDayService,
                                        LegService legService) {
         this.notificationRepository = notificationRepository;
         this.activityRepository = activityRepository;
         this.tripRepository = tripRepository;
+        this.tripDayService = tripDayService;
         this.legService = legService;
     }
 
@@ -74,10 +79,15 @@ public class NotificationScheduleService {
                 .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(tripId, date);
 
         ordered.forEach(activity -> cancelPending(activity.getId()));
-        notificationRepository.saveAll(build(trip, ordered));
+        notificationRepository.saveAll(build(trip, ordered, tripDayService.zoneOn(tripId, date)));
     }
 
-    /** 여행 전체를 다시 짠다 — 타임존이 바뀌면 모든 날짜의 환산 결과가 달라진다. */
+    /**
+     * 여행 전체를 다시 짠다 — 기준 도시가 바뀌면 그 날짜부터의 환산 결과가 달라진다.
+     *
+     * <p><b>날짜마다 자기 기준 도시의 타임존으로 환산한다.</b> 여행 하나에 타임존 하나라고
+     * 보면, 오사카에서 나고야로 넘어간 날의 09:00 알림이 오사카 시각으로 예약된다.
+     */
     @Transactional
     public void rescheduleTrip(Long tripId) {
         Trip trip = tripRepository.findById(tripId).orElse(null);
@@ -87,11 +97,14 @@ public class NotificationScheduleService {
         cancelAll(notificationRepository.findAllByTripIdAndStatus(
                 tripId, NotificationStatus.PENDING));
 
-        ZoneId zone = ZoneId.of(trip.getTimezone());
+        // 날짜를 하나씩 조회하지 않고 기준 도시를 한 번에 받아 둔다.
+        Map<LocalDate, TravelPlace> cities = tripDayService.baseCitiesOf(tripId);
         for (int dayIndex = 0; dayIndex < trip.totalDays(); dayIndex++) {
             LocalDate date = trip.getStartDate().plusDays(dayIndex);
+            ZoneId zone = zoneOn(cities, date);
             notificationRepository.saveAll(build(trip, activityRepository
-                    .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(trip.getId(), date)));
+                    .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(trip.getId(), date),
+                    zone));
 
             if (trip.isMorningSummaryEnabled()) {
                 notificationRepository.save(PushNotification.morningSummary(
@@ -126,9 +139,17 @@ public class NotificationScheduleService {
         notificationRepository.saveAll(notifications);
     }
 
-    /** 그 날짜의 일정들에서 만들 알림을 전부 계산한다. */
-    private List<PushNotification> build(Trip trip, List<TripActivity> ordered) {
-        ZoneId zone = ZoneId.of(trip.getTimezone());
+    /**
+     * 그 날짜의 기준 도시 타임존. 날짜 행이 없으면(있을 수 없는 상태) 기기 타임존으로 버틴다 —
+     * 여기서 터뜨리면 알림 재계산을 부르는 저장 요청이 통째로 실패한다.
+     */
+    private static ZoneId zoneOn(Map<LocalDate, TravelPlace> cities, LocalDate date) {
+        TravelPlace city = cities.get(date);
+        return city == null ? ZoneId.systemDefault() : TripDayService.zoneOf(city);
+    }
+
+    /** 그 날짜의 일정들에서 만들 알림을 전부 계산한다. 시각 환산은 그 날짜의 타임존으로 한다. */
+    private List<PushNotification> build(Trip trip, List<TripActivity> ordered, ZoneId zone) {
         // 이동시간은 출발 알림에만 쓴다. 아무도 켜지 않았으면 조회할 이유가 없다 —
         // 일정을 저장할 때마다 유료 API를 부르게 되고, 저장이 그만큼 느려진다.
         Map<Long, LegResponse> legsByTo = ordered.stream()

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/WeatherService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/WeatherService.java
@@ -2,8 +2,10 @@ package ds.project.orino.planner.travel.tools.service;
 
 import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.entity.Trip;
 import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.day.service.TripDayService;
 import ds.project.orino.planner.travel.tools.client.WeatherClient;
 import ds.project.orino.planner.travel.tools.config.ToolsProperties;
 import ds.project.orino.planner.travel.tools.dto.WeatherResponse;
@@ -31,6 +33,7 @@ import java.util.stream.Collectors;
 public class WeatherService {
 
     private final TripRepository tripRepository;
+    private final TripDayService tripDayService;
     private final WeatherClient weatherClient;
     private final ToolsCacheRepository cacheRepository;
     private final ToolsProperties props;
@@ -38,12 +41,14 @@ public class WeatherService {
     private final Clock clock;
 
     public WeatherService(TripRepository tripRepository,
+                          TripDayService tripDayService,
                           WeatherClient weatherClient,
                           ToolsCacheRepository cacheRepository,
                           ToolsProperties props,
                           ObjectMapper objectMapper,
                           Clock clock) {
         this.tripRepository = tripRepository;
+        this.tripDayService = tripDayService;
         this.weatherClient = weatherClient;
         this.cacheRepository = cacheRepository;
         this.props = props;
@@ -58,18 +63,24 @@ public class WeatherService {
     }
 
     /**
-     * 보드가 날짜 탭에 붙일 요약. 여행 좌표가 없으면(직접 입력한 목적지) 날씨도 없다.
+     * 보드가 날짜 탭에 붙일 요약. 기준 도시 좌표가 없으면(직접 입력한 목적지) 날씨도 없다.
      */
     public Map<LocalDate, WeatherResponse.DailyWeather> dailyByDate(Trip trip) {
         return forecastOf(trip).daily().stream()
                 .collect(Collectors.toMap(WeatherResponse.DailyWeather::date, day -> day));
     }
 
+    /**
+     * 지금은 <b>첫날 기준 도시</b> 하나로 조회한다. 도시별로 나눠 조회해 날짜에 펼치는 것은
+     * 보드 응답 v2.1(#1124)에서 다룬다 — 캐시 키가 도시라 도시 수만큼만 호출되는 구조는
+     * 이미 여기(좌표+타임존 키)에 있다.
+     */
     private WeatherResponse forecastOf(Trip trip) {
-        if (trip.getLat() == null || trip.getLng() == null) {
+        TravelPlace city = tripDayService.primaryCity(trip.getId());
+        if (city.getLat() == null || city.getLng() == null) {
             return WeatherResponse.empty(clock.instant());
         }
-        WeatherResponse forecast = cached(trip);
+        WeatherResponse forecast = cached(city);
         return clampToTrip(forecast, trip);
     }
 
@@ -91,16 +102,17 @@ public class WeatherService {
 
     /**
      * 좌표·타임존이 키다. 기간은 넣지 않는다 — 어차피 오늘 기준 16일을 받아 오므로
-     * 기간이 달라도 같은 응답이고, 넣으면 여행마다 캐시가 갈린다.
+     * 기간이 달라도 같은 응답이고, 넣으면 여행마다 캐시가 갈린다. <b>키가 도시에서 나오므로
+     * 같은 도시를 오가는 여행(도쿄 → 닛코 → 도쿄)은 캐시를 공유한다.</b>
      */
-    private WeatherResponse cached(Trip trip) {
-        String key = "%s,%s:%s".formatted(trip.getLat(), trip.getLng(), trip.getTimezone());
+    private WeatherResponse cached(TravelPlace city) {
+        String key = "%s,%s:%s".formatted(city.getLat(), city.getLng(), city.getTimezone());
         Optional<String> hit = cacheRepository.findWeather(key);
         if (hit.isPresent()) {
             return objectMapper.readValue(hit.get(), new TypeReference<WeatherResponse>() { });
         }
         Optional<WeatherResponse> fresh =
-                weatherClient.forecast(trip.getLat(), trip.getLng(), trip.getTimezone());
+                weatherClient.forecast(city.getLat(), city.getLng(), city.getTimezone());
         // 실패는 캐시하지 않는다 — 6시간 동안 날씨가 통째로 비어 보인다.
         fresh.ifPresent(response -> cacheRepository.saveWeather(
                 key, objectMapper.writeValueAsString(response), props.weatherTtl()));

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/service/TripService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/service/TripService.java
@@ -2,12 +2,15 @@ package ds.project.orino.planner.travel.trip.service;
 
 import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.entity.Trip;
 import ds.project.orino.domain.planner.travel.entity.TripActivity;
 import ds.project.orino.domain.planner.travel.entity.TripStatus;
 import ds.project.orino.domain.planner.travel.repository.TripActivityCount;
 import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
 import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.day.service.BaseCityResolver;
+import ds.project.orino.planner.travel.day.service.TripDayService;
 import ds.project.orino.planner.travel.trip.dto.ShrinkPreviewResponse;
 import ds.project.orino.planner.travel.trip.dto.TravelSummaryResponse;
 import ds.project.orino.planner.travel.trip.dto.TripDetail;
@@ -34,7 +37,7 @@ import java.util.stream.Stream;
  * 여행 CRUD와 기간 단축 처리.
  *
  * <p>상태(예정/진행 중/완료)와 D-day는 <b>저장하지 않고 매 조회 시 파생한다</b>. 기준은 기기
- * 시간대가 아니라 각 여행의 타임존이라, 목록에서도 여행마다 자기 타임존으로 따로 판정한다
+ * 시간대가 아니라 <b>첫날 기준 도시</b>의 타임존이라, 목록에서도 여행마다 따로 판정한다
  * (도쿄 여행과 하와이 여행이 같은 순간에 서로 다른 "오늘"을 갖는다).
  *
  * <p>기간을 줄이면 잘려나간 일정을 <b>지우지 않고 보관함으로 옮긴다</b>. 사용자가 모르고 일정을
@@ -47,27 +50,34 @@ public class TripService {
     private final TripRepository tripRepository;
     private final TripActivityRepository activityRepository;
     private final NotificationScheduleService notificationService;
+    private final TripDayService tripDayService;
+    private final BaseCityResolver baseCityResolver;
     private final Clock clock;
 
     public TripService(TripRepository tripRepository,
                        TripActivityRepository activityRepository,
                        NotificationScheduleService notificationService,
+                       TripDayService tripDayService,
+                       BaseCityResolver baseCityResolver,
                        Clock clock) {
         this.tripRepository = tripRepository;
         this.activityRepository = activityRepository;
         this.notificationService = notificationService;
+        this.tripDayService = tripDayService;
+        this.baseCityResolver = baseCityResolver;
         this.clock = clock;
     }
 
     @Transactional
     public TripDetail create(Long memberId, TripWriteRequest request) {
         validate(request);
-        Trip trip = new Trip(memberId, request.resolvedTitle(), request.destinationName().trim(),
-                request.startDate(), request.endDate(), request.timezone(),
-                normalizedCurrency(request.currency()));
+        Trip trip = new Trip(memberId, request.resolvedTitle(),
+                request.startDate(), request.endDate());
         applyOptionalSettings(trip, request);
         Trip saved = tripRepository.save(trip);
         tripRepository.flush();
+        // 날짜 행이 없으면 타임존이 없는 여행이 된다 — 같은 트랜잭션에서 반드시 채운다.
+        tripDayService.syncPeriod(saved, resolveBaseCity(memberId, request).getId());
         // 아침 요약은 일정이 아니라 날짜에 매달려 있어, 일정이 하나도 없어도 지금 잡힌다(§4.3).
         notificationService.rescheduleTrip(saved.getId());
         return detailOf(saved);
@@ -75,16 +85,20 @@ public class TripService {
 
     public TripListResponse list(Long memberId, TripStatus status) {
         List<Trip> all = tripRepository.findAllByMemberIdOrderByStartDateDescIdDesc(memberId);
+        // 여행마다 자기 기준 도시의 오늘로 판정한다 — 도쿄 여행과 하와이 여행이 같은 순간에
+        // 서로 다른 "오늘"을 갖는다. 도시는 여행 수만큼 조회하지 않고 한 번에 받아 둔다.
+        Map<Long, TravelPlace> cities = primaryCitiesOf(all);
         // 건수는 필터와 무관하게 전체 기준으로 센다 — 탭을 옮길 때마다 다른 탭 숫자가 0이 되면 안 된다.
-        TripListResponse.TripCounts counts = countByStatus(all);
+        TripListResponse.TripCounts counts = countByStatus(all, cities);
 
         List<Trip> filtered = status == null ? all
-                : all.stream().filter(trip -> statusOf(trip) == status).toList();
-        List<Trip> sorted = sortForDisplay(filtered);
+                : all.stream().filter(trip -> statusOf(trip, cities) == status).toList();
+        List<Trip> sorted = sortForDisplay(filtered, cities);
 
         Map<Long, Long> activityCounts = activityCountsOf(sorted);
         List<TripSummary> summaries = sorted.stream()
-                .map(trip -> summaryOf(trip, activityCounts.getOrDefault(trip.getId(), 0L)))
+                .map(trip -> summaryOf(trip, cities,
+                        activityCounts.getOrDefault(trip.getId(), 0L)))
                 .toList();
         return new TripListResponse(counts, summaries);
     }
@@ -110,13 +124,21 @@ public class TripService {
         }
 
         // 타임존이 바뀌어도 일정의 벽시계 시각은 건드리지 않는다 — 09:00은 어디서든 09:00이다.
-        trip.update(request.resolvedTitle(), request.destinationName().trim(),
-                request.startDate(), request.endDate(), request.timezone(),
-                normalizedCurrency(request.currency()));
+        trip.update(request.resolvedTitle(), request.startDate(), request.endDate());
         applyOptionalSettings(trip, request);
 
         if (movedCount > 0) {
             archiveActivitiesOutsidePeriod(trip);
+        }
+        // 기간이 바뀌었으면 날짜 집합도 같이 움직여야 한다. 새로 생긴 날짜는 앞 날짜의
+        // 도시를 물려받고, 남아 있는 날짜의 도시 메모는 그대로다.
+        TravelPlace city = resolveBaseCity(memberId, request);
+        tripDayService.syncPeriod(trip, city.getId());
+        // 이 화면은 여행 전체의 목적지 <b>하나</b>를 보낸다(v2.0 폼). 목적지를 바꿨다면 전
+        // 날짜가 따라 바뀌는 게 그 화면의 뜻이다. 날짜마다 다른 도시를 두는 길은 구간 입력
+        // (#1121)과 기준 도시 변경 API(#1122)로 따로 열린다.
+        if (!city.getId().equals(tripDayService.primaryCity(trip.getId()).getId())) {
+            tripDayService.rebaseAll(trip.getId(), city.getId());
         }
         tripRepository.flush();
         // §4.2 — 타임존이 바뀌면 벽시계 시각은 그대로고 알림 시각만 전부 다시 계산된다.
@@ -145,17 +167,18 @@ public class TripService {
     /** `/select` 카드와 여행 홈(S-01)이 함께 쓰는 요약. 셋 다 없으면 전부 null이다. */
     public TravelSummaryResponse summary(Long memberId) {
         List<Trip> all = tripRepository.findAllByMemberIdOrderByStartDateDescIdDesc(memberId);
+        Map<Long, TravelPlace> cities = primaryCitiesOf(all);
 
         Trip ongoing = all.stream()
-                .filter(trip -> statusOf(trip) == TripStatus.ONGOING)
+                .filter(trip -> statusOf(trip, cities) == TripStatus.ONGOING)
                 .min(Comparator.comparing(Trip::getStartDate).thenComparing(Trip::getId))
                 .orElse(null);
         Trip next = all.stream()
-                .filter(trip -> statusOf(trip) == TripStatus.UPCOMING)
+                .filter(trip -> statusOf(trip, cities) == TripStatus.UPCOMING)
                 .min(Comparator.comparing(Trip::getStartDate).thenComparing(Trip::getId))
                 .orElse(null);
         Trip completed = all.stream()
-                .filter(trip -> statusOf(trip) == TripStatus.COMPLETED)
+                .filter(trip -> statusOf(trip, cities) == TripStatus.COMPLETED)
                 .max(Comparator.comparing(Trip::getEndDate).thenComparing(Trip::getId))
                 .orElse(null);
 
@@ -166,8 +189,9 @@ public class TripService {
                 ongoing == null ? null
                         : TravelSummaryResponse.OngoingTrip.of(ongoing.getId(), ongoing.getTitle()),
                 next == null ? null : new TravelSummaryResponse.NextTrip(
-                        next.getId(), next.getTitle(), next.getDestinationName(),
-                        next.getStartDate(), next.getEndDate(), next.daysUntilStart(clock),
+                        next.getId(), next.getTitle(), cityNameOf(next, cities),
+                        next.getStartDate(), next.getEndDate(),
+                        next.daysUntilStart(clock, zoneOf(next, cities)),
                         counts.getOrDefault(next.getId(), 0L)),
                 completed == null ? null : new TravelSummaryResponse.CompletedTrip(
                         completed.getId(), completed.getTitle(), completed.getEndDate(),
@@ -195,10 +219,17 @@ public class TripService {
         }
     }
 
+    /**
+     * 요청의 목적지를 기준 도시로 바꾼다. 이름·타임존·통화가 여행이 아니라 도시에 붙는
+     * 것이 v2.1이라, 저장 전에 도시 행을 확보해야 한다.
+     */
+    private TravelPlace resolveBaseCity(Long memberId, TripWriteRequest request) {
+        return baseCityResolver.resolve(memberId, request.destinationPlaceId(),
+                request.destinationName().trim(), request.timezone(),
+                normalizedCurrency(request.currency()), request.lat(), request.lng());
+    }
+
     private void applyOptionalSettings(Trip trip, TripWriteRequest request) {
-        if (request.destinationPlaceId() != null || request.lat() != null || request.lng() != null) {
-            trip.updateDestinationPlace(request.destinationPlaceId(), request.lat(), request.lng());
-        }
         // 생략된 값은 기존 설정을 유지한다(수정 화면이 알림 설정을 안 보낼 수 있다).
         int notifyMinutes = request.defaultNotifyMinutes() != null
                 ? request.defaultNotifyMinutes() : trip.getDefaultNotifyMinutes();
@@ -241,8 +272,28 @@ public class TripService {
         return currency.trim().toUpperCase(Locale.ROOT);
     }
 
-    private TripStatus statusOf(Trip trip) {
-        return trip.status(clock);
+    /** 여행별 첫날 기준 도시. 상태·D-day·목적지 표시가 전부 여기서 나온다. */
+    private Map<Long, TravelPlace> primaryCitiesOf(List<Trip> trips) {
+        return tripDayService.primaryCitiesOf(trips.stream().map(Trip::getId).toList());
+    }
+
+    /**
+     * 판정에 쓸 타임존. 날짜 행이 없는 여행은 v2.1에서 만들어질 수 없지만, 목록 한복판에서
+     * 터뜨리는 대신 기기 타임존으로 넘긴다 — 한 건의 데이터 문제로 목록 전체가 사라지면
+     * 사용자는 원인을 볼 방법이 없다.
+     */
+    private ZoneId zoneOf(Trip trip, Map<Long, TravelPlace> cities) {
+        TravelPlace city = cities.get(trip.getId());
+        return city == null ? ZoneId.systemDefault() : TripDayService.zoneOf(city);
+    }
+
+    private String cityNameOf(Trip trip, Map<Long, TravelPlace> cities) {
+        TravelPlace city = cities.get(trip.getId());
+        return city == null ? null : city.getName();
+    }
+
+    private TripStatus statusOf(Trip trip, Map<Long, TravelPlace> cities) {
+        return trip.status(clock, zoneOf(trip, cities));
     }
 
     /**
@@ -250,12 +301,12 @@ public class TripService {
      * 방향이 반대라 하나의 Comparator로 묶지 않고 두 덩어리로 나눠 이어 붙인다.
      * 필터 없이 전체를 볼 때는 앞으로 갈 여행이 먼저, 지나간 여행이 뒤로 온다.
      */
-    private List<Trip> sortForDisplay(List<Trip> trips) {
+    private List<Trip> sortForDisplay(List<Trip> trips, Map<Long, TravelPlace> cities) {
         Stream<Trip> upcoming = trips.stream()
-                .filter(trip -> statusOf(trip) != TripStatus.COMPLETED)
+                .filter(trip -> statusOf(trip, cities) != TripStatus.COMPLETED)
                 .sorted(Comparator.comparing(Trip::getStartDate).thenComparing(Trip::getId));
         Stream<Trip> completed = trips.stream()
-                .filter(trip -> statusOf(trip) == TripStatus.COMPLETED)
+                .filter(trip -> statusOf(trip, cities) == TripStatus.COMPLETED)
                 .sorted(Comparator.comparing(Trip::getEndDate).reversed()
                         .thenComparing(Trip::getId));
         return Stream.concat(upcoming, completed).toList();
@@ -270,24 +321,33 @@ public class TripService {
                 .collect(Collectors.toMap(TripActivityCount::tripId, TripActivityCount::count));
     }
 
-    private TripSummary summaryOf(Trip trip, long activityCount) {
-        return new TripSummary(trip.getId(), trip.getTitle(), trip.getDestinationName(),
-                trip.getStartDate(), trip.getEndDate(), statusOf(trip),
-                trip.daysUntilStart(clock), activityCount);
+    private TripSummary summaryOf(Trip trip, Map<Long, TravelPlace> cities, long activityCount) {
+        return new TripSummary(trip.getId(), trip.getTitle(), cityNameOf(trip, cities),
+                trip.getStartDate(), trip.getEndDate(), statusOf(trip, cities),
+                trip.daysUntilStart(clock, zoneOf(trip, cities)), activityCount);
     }
 
+    /**
+     * 상세는 여행 하나라 첫날 기준 도시를 바로 읽는다. 목적지 자리에 그 도시의 이름·타임존·
+     * 통화·좌표가 그대로 들어간다 — v2.0의 목적지가 첫날의 기준 도시로 내려온 것이라,
+     * 단일 도시 여행에서는 응답이 전과 같다.
+     */
     private TripDetail detailOf(Trip trip) {
-        return new TripDetail(trip.getId(), trip.getTitle(), trip.getDestinationName(),
-                trip.getDestinationPlaceId(), trip.getStartDate(), trip.getEndDate(),
-                trip.getTimezone(), trip.getCurrency(), trip.getLat(), trip.getLng(),
+        TravelPlace city = tripDayService.primaryCity(trip.getId());
+        ZoneId zone = TripDayService.zoneOf(city);
+        return new TripDetail(trip.getId(), trip.getTitle(), city.getName(),
+                city.getId(), trip.getStartDate(), trip.getEndDate(),
+                city.getTimezone(), city.getCurrency(), city.getLat(), city.getLng(),
                 trip.getDefaultNotifyMinutes(), trip.isMorningSummaryEnabled(),
-                statusOf(trip), trip.daysUntilStart(clock), trip.totalDays(),
+                trip.status(clock, zone), trip.daysUntilStart(clock, zone), trip.totalDays(),
                 activityRepository.countByTripId(trip.getId()));
     }
 
-    private TripListResponse.TripCounts countByStatus(List<Trip> trips) {
+    private TripListResponse.TripCounts countByStatus(List<Trip> trips,
+                                                      Map<Long, TravelPlace> cities) {
         Map<TripStatus, Long> byStatus = trips.stream()
-                .collect(Collectors.groupingBy(this::statusOf, Collectors.counting()));
+                .collect(Collectors.groupingBy(trip -> statusOf(trip, cities),
+                        Collectors.counting()));
         return new TripListResponse.TripCounts(
                 byStatus.getOrDefault(TripStatus.UPCOMING, 0L),
                 byStatus.getOrDefault(TripStatus.ONGOING, 0L),

--- a/be/orino-app-api/src/main/resources/db/changelog/changes/053-travel-multi-city.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/changes/053-travel-multi-city.yaml
@@ -1,0 +1,441 @@
+databaseChangeLog:
+  # 여행 v2.1 — 다구간 · 날짜별 기준 도시 · 숙소 (#1119, Epic #1118).
+  #
+  # v2.1의 핵심은 하나다 — 목적지를 여행이 아니라 "날짜"가 갖는다.
+  # 여행은 도시·타임존·통화를 갖지 않고, 날짜마다 기준 도시(trip_day.base_place_id)가
+  # 붙어 타임존·통화·검색 좌표·날씨가 거기서 파생된다.
+  #
+  # 컬럼을 NULL 허용으로 남기지 않고 지운다. 남겨두면 trip.timezone을 읽는 코드가 컴파일도
+  # 테스트도 통과한 채 살아남고, 그 화면만 조용히 틀린다. 지워야 컴파일이 깨지고,
+  # 깨지는 곳이 곧 고쳐야 할 목록이 된다.
+  #
+  # 한 파일에 아래 순서를 담는다. 컬럼 삭제를 백필과 다른 파일로 나누면 중간 상태에서
+  # 배포가 물린다.
+  #   1) travel_place에 v2.1 컬럼 추가
+  #   2) 기존 목적지 장소를 CITY로 승격 + trip의 타임존·통화를 장소로 복사
+  #   3) trip_day · trip_stay 생성
+  #   4) 백필 — 여행 1건당 전 날짜에 trip_day INSERT (기존 여행 = 단일 도시)
+  #   5) trip에서 목적지 6개 컬럼 DROP
+  #
+  # rollback을 반드시 적는다. 5번 이후에는 목적지 정보가 trip_day에만 남으므로,
+  # 롤백은 trip_day에서 되돌려 채우는 방향이어야 한다.
+
+  # 되돌릴 지점. 이 뒤로는 목적지가 여행에서 날짜로 내려가 trip 컬럼이 사라지므로,
+  # 한 changeSet씩 세지 않고 이름으로 되돌릴 수 있어야 한다
+  # (`liquibase rollback pre-travel-multi-city`).
+  - changeSet:
+      id: 053-tag-before-multi-city
+      author: wcorn
+      comment: v2.1 다구간 전환 직전 지점에 이름을 붙인다.
+      changes:
+        - tagDatabase:
+            tag: pre-travel-multi-city
+
+  - changeSet:
+      id: 053-add-travel-place-city-columns
+      author: wcorn
+      comment: 장소에 도시 식별·타임존·통화를 붙인다. 기준 도시로 쓸 수 있는 건 place_kind=CITY 뿐이다.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: travel_place
+                columnName: place_kind
+      changes:
+        - addColumn:
+            tableName: travel_place
+            columns:
+              # 이 장소가 속한 도시 표시명.
+              - column:
+                  name: city_name
+                  type: VARCHAR(100)
+              # 도시 식별자(구글 장소 id). 도시 일치 판정은 좌표 거리가 아니라 이 값으로만 한다 —
+              # 거리 임계로 하면 오사카-교토(43km)와 도쿄-요코하마(30km)에서 답이 갈린다(D-23).
+              - column:
+                  name: city_place_ref
+                  type: VARCHAR(255)
+              # ISO 3166-1 alpha-2. 통화·번역 목적 언어 파생에 쓴다.
+              - column:
+                  name: country_code
+                  type: CHAR(2)
+              # IANA ID. 기준 도시로 쓰일 때 필수(애플리케이션 검증).
+              - column:
+                  name: timezone
+                  type: VARCHAR(64)
+              # ISO 4217.
+              - column:
+                  name: currency
+                  type: CHAR(3)
+              # CITY · POI. 기존 행은 전부 POI에서 출발한다.
+              - column:
+                  name: place_kind
+                  type: VARCHAR(20)
+                  defaultValue: POI
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 053-promote-destination-places
+      author: wcorn
+      comment: trip.destination_place_id가 가리키던 장소를 CITY로 승격하고 여행의 타임존·통화를 옮긴다.
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: trip
+            columnName: destination_place_id
+      changes:
+        - sql:
+            comment: 목적지 장소 = 도시. 타임존·통화의 진짜 주인이 trip에서 장소로 넘어간다.
+            sql: >-
+              UPDATE travel_place p
+                JOIN trip t ON t.destination_place_id = p.id
+                 SET p.place_kind = 'CITY',
+                     p.timezone = t.timezone,
+                     p.currency = t.currency,
+                     p.city_name = COALESCE(p.city_name, t.destination_name),
+                     p.city_place_ref = COALESCE(p.city_place_ref, p.google_place_id)
+      rollback:
+        - sql:
+            sql: >-
+              UPDATE travel_place
+                 SET place_kind = 'POI',
+                     timezone = NULL,
+                     currency = NULL,
+                     city_name = NULL,
+                     city_place_ref = NULL
+               WHERE place_kind = 'CITY'
+
+  - changeSet:
+      id: 053-create-trip-day
+      author: wcorn
+      comment: 여행 기간의 날짜 1건. 기간 내 모든 날짜에 반드시 존재한다 — 빈 날짜는 타임존 없는 날이다.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: trip_day
+      changes:
+        - createTable:
+            tableName: trip_day
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: trip_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_trip_day_trip
+                    references: trip(id)
+                    deleteCascade: true
+              # date는 MySQL 함수명과 혼동되므로 쓰지 않는다.
+              - column:
+                  name: day_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              # 기준 도시. place_kind = CITY 인 행만 허용한다(애플리케이션 검증).
+              # 기준 도시가 사라지면 그 날짜는 타임존을 잃으므로 SET NULL도 CASCADE도 아닌
+              # RESTRICT다 — 도시로 쓰이는 장소는 지워지지 않아야 한다.
+              - column:
+                  name: base_place_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_trip_day_base_place
+                    references: travel_place(id)
+              # "체크아웃 후 교토역 코인로커에 짐 보관"
+              - column:
+                  name: city_memo
+                  type: VARCHAR(200)
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        # 하루에 기준 도시는 하나다.
+        - createIndex:
+            tableName: trip_day
+            indexName: uk_day_trip_date
+            unique: true
+            columns:
+              - column:
+                  name: trip_id
+              - column:
+                  name: day_date
+      # 자동 롤백은 인덱스를 먼저 지우려 드는데, (trip_id, ...) 인덱스는 FK가 쓰고 있어
+      # MySQL이 거부한다. 테이블을 지우면 인덱스·FK가 함께 사라진다.
+      rollback:
+        - dropTable:
+            tableName: trip_day
+
+  - changeSet:
+      id: 053-create-trip-stay
+      author: wcorn
+      comment: 숙소 1건. 기준 도시와 무관하다 — 닛코 당일치기 날의 기준 도시는 닛코지만 자는 곳은 도쿄일 수 있다.
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: trip_stay
+      changes:
+        - createTable:
+            tableName: trip_stay
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: trip_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_trip_stay_trip
+                    references: trip(id)
+                    deleteCascade: true
+              - column:
+                  name: name
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              # 좌표·도시 판정에 쓴다. FK는 아래에서 따로 건다 —
+              # ON DELETE SET NULL은 인라인 제약으로 표현할 수 없다.
+              - column:
+                  name: place_id
+                  type: BIGINT
+              - column:
+                  name: check_in_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              # > check_in_date 는 애플리케이션 검증. 겹침 검증도 애플리케이션에서 한다.
+              - column:
+                  name: check_out_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              # 벽시계 시각. UTC로 변환하지 않는다.
+              - column:
+                  name: check_in_time
+                  type: TIME
+              - column:
+                  name: check_out_time
+                  type: TIME
+              - column:
+                  name: booking_url
+                  type: VARCHAR(500)
+              - column:
+                  name: memo
+                  type: VARCHAR(500)
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: trip_stay
+            baseColumnNames: place_id
+            constraintName: fk_trip_stay_place
+            referencedTableName: travel_place
+            referencedColumnNames: id
+            onDelete: SET NULL
+        - createIndex:
+            tableName: trip_stay
+            indexName: idx_stay_trip_checkin
+            columns:
+              - column:
+                  name: trip_id
+              - column:
+                  name: check_in_date
+      rollback:
+        - dropTable:
+            tableName: trip_stay
+
+  - changeSet:
+      id: 053-backfill-manual-destination-places
+      author: wcorn
+      comment: 목적지를 수동 입력한 여행(1단계 분)에는 붙일 장소가 없다 — 도시 장소를 만들어 잇는다.
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: trip
+            columnName: destination_name
+      changes:
+        # 같은 멤버가 같은 목적지로 여러 번 갔다면 장소 한 행을 공유한다(장소는 여행에 종속되지 않는다).
+        - sql:
+            sql: >-
+              INSERT INTO travel_place
+                (member_id, name, lat, lng, manual_entry,
+                 city_name, timezone, currency, place_kind, created_at, updated_at)
+              SELECT DISTINCT t.member_id, t.destination_name, t.lat, t.lng, b'1',
+                     t.destination_name, t.timezone, t.currency, 'CITY', NOW(6), NOW(6)
+                FROM trip t
+               WHERE t.destination_place_id IS NULL
+        # NULL 안전 비교(<=>)를 쓴다 — lat/lng가 NULL인 수동 입력 여행이 대부분이라
+        # = 로 비교하면 한 건도 매칭되지 않는다.
+        - sql:
+            sql: >-
+              UPDATE trip t
+                 SET t.destination_place_id = (
+                       SELECT MAX(p.id) FROM travel_place p
+                        WHERE p.member_id = t.member_id
+                          AND p.place_kind = 'CITY'
+                          AND p.manual_entry = b'1'
+                          AND p.google_place_id IS NULL
+                          AND p.name = t.destination_name
+                          AND p.timezone <=> t.timezone
+                          AND p.currency <=> t.currency
+                          AND p.lat <=> t.lat
+                          AND p.lng <=> t.lng)
+               WHERE t.destination_place_id IS NULL
+      rollback:
+        - sql:
+            sql: >-
+              UPDATE trip t
+                JOIN travel_place p ON p.id = t.destination_place_id
+                 SET t.destination_place_id = NULL
+               WHERE p.place_kind = 'CITY'
+                 AND p.manual_entry = b'1'
+                 AND p.google_place_id IS NULL
+        - sql:
+            sql: >-
+              DELETE FROM travel_place
+               WHERE place_kind = 'CITY'
+                 AND manual_entry = b'1'
+                 AND google_place_id IS NULL
+
+  - changeSet:
+      id: 053-backfill-trip-day
+      author: wcorn
+      comment: 여행 1건당 start_date~end_date 전 날짜에 행을 만든다. 기존 여행은 단일 도시라 전 날짜가 같은 도시다.
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: trip
+            columnName: destination_place_id
+      changes:
+        # 재귀 CTE로 기간을 날짜로 편다. 여행 기간은 길어야 한 달이라
+        # cte_max_recursion_depth(기본 1000)에 닿지 않는다.
+        - sql:
+            sql: >-
+              INSERT INTO trip_day (trip_id, day_date, base_place_id, created_at, updated_at)
+              WITH RECURSIVE expanded (trip_id, day_date, end_date, base_place_id) AS (
+                  SELECT t.id, t.start_date, t.end_date, t.destination_place_id
+                    FROM trip t
+                   WHERE t.destination_place_id IS NOT NULL
+                  UNION ALL
+                  SELECT e.trip_id, e.day_date + INTERVAL 1 DAY, e.end_date, e.base_place_id
+                    FROM expanded e
+                   WHERE e.day_date < e.end_date
+              )
+              SELECT trip_id, day_date, base_place_id, NOW(6), NOW(6) FROM expanded
+      rollback:
+        - delete:
+            tableName: trip_day
+
+  - changeSet:
+      id: 053-drop-trip-destination-columns
+      author: wcorn
+      comment: 여행에서 목적지를 걷어낸다. 여기서부터 목적지의 진실은 trip_day 하나뿐이다.
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: trip
+            columnName: timezone
+      changes:
+        # FK가 걸린 컬럼은 그대로 못 지운다.
+        - dropForeignKeyConstraint:
+            baseTableName: trip
+            constraintName: fk_trip_destination_place
+        - dropColumn:
+            tableName: trip
+            columns:
+              - column:
+                  name: destination_name
+              - column:
+                  name: destination_place_id
+              - column:
+                  name: timezone
+              - column:
+                  name: currency
+              - column:
+                  name: lat
+              - column:
+                  name: lng
+      rollback:
+        # 되돌릴 때는 NULL 허용으로 먼저 만든다 — 채우기 전에는 NOT NULL을 걸 수 없다.
+        - addColumn:
+            tableName: trip
+            columns:
+              - column:
+                  name: destination_name
+                  type: VARCHAR(100)
+              - column:
+                  name: destination_place_id
+                  type: BIGINT
+              - column:
+                  name: timezone
+                  type: VARCHAR(64)
+              - column:
+                  name: currency
+                  type: CHAR(3)
+              - column:
+                  name: lat
+                  type: DECIMAL(10, 7)
+              - column:
+                  name: lng
+                  type: DECIMAL(10, 7)
+        # 목적지 정보는 trip_day에만 남아 있다. 첫날의 기준 도시가 v2.0의 목적지였다.
+        - sql:
+            sql: >-
+              UPDATE trip t
+                JOIN (SELECT d.trip_id, d.base_place_id
+                        FROM trip_day d
+                        JOIN (SELECT trip_id, MIN(day_date) AS first_date
+                                FROM trip_day GROUP BY trip_id) f
+                          ON f.trip_id = d.trip_id AND f.first_date = d.day_date) first_day
+                  ON first_day.trip_id = t.id
+                JOIN travel_place p ON p.id = first_day.base_place_id
+                 SET t.destination_place_id = p.id,
+                     t.destination_name = COALESCE(p.city_name, p.name),
+                     t.timezone = p.timezone,
+                     t.currency = p.currency,
+                     t.lat = p.lat,
+                     t.lng = p.lng
+        - addNotNullConstraint:
+            tableName: trip
+            columnName: destination_name
+            columnDataType: VARCHAR(100)
+        - addNotNullConstraint:
+            tableName: trip
+            columnName: timezone
+            columnDataType: VARCHAR(64)
+        - addNotNullConstraint:
+            tableName: trip
+            columnName: currency
+            columnDataType: CHAR(3)
+        - addForeignKeyConstraint:
+            baseTableName: trip
+            baseColumnNames: destination_place_id
+            constraintName: fk_trip_destination_place
+            referencedTableName: travel_place
+            referencedColumnNames: id

--- a/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/be/orino-app-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -103,3 +103,5 @@ databaseChangeLog:
       file: db/changelog/changes/051-create-trip-activity-photo.yaml
   - include:
       file: db/changelog/changes/052-drop-travel-place-photo-columns.yaml
+  - include:
+      file: db/changelog/changes/053-travel-multi-city.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/migration/TravelMultiCityMigrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/migration/TravelMultiCityMigrationTest.java
@@ -1,0 +1,208 @@
+package ds.project.orino.planner.travel.migration;
+
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * v2.1 마이그레이션(053)이 <b>이미 데이터가 있는 DB</b>에서 무엇을 하는지 고정한다.
+ *
+ * <p>보통의 테스트는 빈 DB에 changelog를 처음부터 적용하므로 백필 구문이 한 행도 건드리지 않아
+ * "돌긴 했다"는 것 말고는 아무것도 증명하지 못한다. 여기서는 태그 지점까지 <b>되돌린 뒤</b>
+ * v2.0 형태의 여행을 심고 다시 적용한다 — 롤백문과 백필문이 둘 다 실제로 검증된다.
+ *
+ * <p>백필 없이 컬럼만 지우면 기존 여행이 전부 타임존을 잃고 상태 판정이 죽는다. 실사용 데이터가
+ * 아직 없어 손실 위험은 낮지만, 그 순서를 지켰는지는 코드가 아니라 DB에 물어봐야 안다.
+ *
+ * <p>공용 TestContainer를 쓰지 않고 <b>이 클래스 전용 컨테이너</b>를 띄운다 — 스키마를 통째로
+ * 되감았다 다시 감는 시험이라, 같은 DB를 쓰는 다른 테스트와 섞이면 안 된다.
+ */
+class TravelMultiCityMigrationTest {
+
+    private static final String CHANGELOG = "db/changelog/db.changelog-master.yaml";
+    private static final String TAG = "pre-travel-multi-city";
+
+    @SuppressWarnings("resource")
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.4.4");
+
+    private static Connection connection;
+
+    @BeforeAll
+    static void startDatabase() throws Exception {
+        MYSQL.start();
+        connection = DriverManager.getConnection(
+                MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword());
+    }
+
+    @AfterAll
+    static void stopDatabase() throws Exception {
+        if (connection != null) {
+            connection.close();
+        }
+        MYSQL.stop();
+    }
+
+    @Test
+    @DisplayName("v2.0 여행이 담긴 DB에 적용하면 날짜마다 기준 도시가 붙고 목적지 컬럼이 사라진다")
+    void backfillsDaysAndDropsDestinationColumns() throws Exception {
+        runLiquibase(liquibase -> liquibase.update(new Contexts(), new LabelExpression()));
+
+        // 태그 지점까지 되돌리면 v2.0 스키마다 — 되돌리기가 정말 되는지부터 확인한다.
+        runLiquibase(liquibase -> liquibase.rollback(TAG, new Contexts(), new LabelExpression()));
+        assertThat(columnExists("trip", "timezone")).isTrue();
+        assertThat(tableExists("trip_day")).isFalse();
+
+        seedV20Trips();
+
+        runLiquibase(liquibase -> liquibase.update(new Contexts(), new LabelExpression()));
+
+        // 1) 목적지 컬럼은 사라졌다. 남겨두면 trip.timezone을 읽는 코드가 살아남는다.
+        assertThat(columnExists("trip", "destination_name")).isFalse();
+        assertThat(columnExists("trip", "destination_place_id")).isFalse();
+        assertThat(columnExists("trip", "timezone")).isFalse();
+        assertThat(columnExists("trip", "currency")).isFalse();
+        assertThat(columnExists("trip", "lat")).isFalse();
+        assertThat(columnExists("trip", "lng")).isFalse();
+
+        // 2) 검색으로 고른 목적지 장소는 CITY로 승격되고 타임존·통화를 넘겨받았다.
+        assertThat(queryOne("SELECT place_kind FROM travel_place WHERE id = 1")).isEqualTo("CITY");
+        assertThat(queryOne("SELECT timezone FROM travel_place WHERE id = 1"))
+                .isEqualTo("Asia/Tokyo");
+        assertThat(queryOne("SELECT currency FROM travel_place WHERE id = 1")).isEqualTo("JPY");
+        assertThat(queryOne("SELECT city_name FROM travel_place WHERE id = 1")).isEqualTo("오사카");
+        // 도시 식별자는 자기 구글 id다 — 일정 장소의 city_place_ref와 같은 축에서 비교된다.
+        assertThat(queryOne("SELECT city_place_ref FROM travel_place WHERE id = 1"))
+                .isEqualTo("ChIJ_osaka");
+
+        // 3) 하루도 비지 않는다. 빈 날짜는 타임존이 없는 날이고 그 순간 판정이 전부 죽는다.
+        assertThat(queryOne("SELECT COUNT(*) FROM trip_day WHERE trip_id = 1")).isEqualTo("4");
+        assertThat(queryList("SELECT day_date FROM trip_day WHERE trip_id = 1 ORDER BY day_date"))
+                .containsExactly("2026-10-24", "2026-10-25", "2026-10-26", "2026-10-27");
+        // 기존 여행은 단일 도시라 전 날짜가 같은 도시를 가리킨다.
+        assertThat(queryList(
+                "SELECT DISTINCT base_place_id FROM trip_day WHERE trip_id = 1"))
+                .containsExactly("1");
+
+        // 4) 목적지를 직접 입력한 여행(장소 참조 없음)도 도시 장소를 새로 만들어 붙였다.
+        assertThat(queryOne("SELECT COUNT(*) FROM trip_day WHERE trip_id = 2")).isEqualTo("2");
+        assertThat(queryOne("""
+                SELECT p.name FROM trip_day d JOIN travel_place p ON p.id = d.base_place_id
+                 WHERE d.trip_id = 2 LIMIT 1""")).isEqualTo("교토");
+        assertThat(queryOne("""
+                SELECT p.timezone FROM trip_day d JOIN travel_place p ON p.id = d.base_place_id
+                 WHERE d.trip_id = 2 LIMIT 1""")).isEqualTo("Asia/Tokyo");
+        assertThat(queryOne("""
+                SELECT p.place_kind FROM trip_day d JOIN travel_place p ON p.id = d.base_place_id
+                 WHERE d.trip_id = 2 LIMIT 1""")).isEqualTo("CITY");
+        // 좌표까지 옮겨야 그 도시 날씨가 나온다.
+        assertThat(queryOne("""
+                SELECT p.lat FROM trip_day d JOIN travel_place p ON p.id = d.base_place_id
+                 WHERE d.trip_id = 2 LIMIT 1""")).isEqualTo("35.0116000");
+
+        // 5) 숙소 테이블은 비어 있지만 자리는 마련돼 있다(3단계에서 채운다).
+        assertThat(tableExists("trip_stay")).isTrue();
+    }
+
+    /** v2.0 형태의 여행 두 건 — 하나는 검색으로 고른 목적지, 하나는 직접 입력. */
+    private void seedV20Trips() throws SQLException {
+        execute("""
+                INSERT INTO travel_place
+                    (id, member_id, google_place_id, name, lat, lng, manual_entry,
+                     created_at, updated_at)
+                VALUES (1, 1, 'ChIJ_osaka', '오사카', 34.6937249, 135.5022535, b'0',
+                        NOW(6), NOW(6))""");
+        execute("""
+                INSERT INTO trip
+                    (id, member_id, title, destination_name, destination_place_id,
+                     start_date, end_date, timezone, currency, lat, lng,
+                     default_notify_minutes, morning_summary_enabled, created_at, updated_at)
+                VALUES (1, 1, '오사카 3박4일', '오사카', 1,
+                        '2026-10-24', '2026-10-27', 'Asia/Tokyo', 'JPY',
+                        34.6937249, 135.5022535, 15, b'0', NOW(6), NOW(6))""");
+        execute("""
+                INSERT INTO trip
+                    (id, member_id, title, destination_name, destination_place_id,
+                     start_date, end_date, timezone, currency, lat, lng,
+                     default_notify_minutes, morning_summary_enabled, created_at, updated_at)
+                VALUES (2, 1, '교토 1박2일', '교토', NULL,
+                        '2026-11-01', '2026-11-02', 'Asia/Tokyo', 'JPY',
+                        35.0116, 135.7681, 15, b'0', NOW(6), NOW(6))""");
+    }
+
+    // ---------------- helpers ----------------
+
+    private interface LiquibaseAction {
+        void run(Liquibase liquibase) throws Exception;
+    }
+
+    /**
+     * {@code Liquibase#close()}가 넘겨받은 커넥션까지 닫으므로 실행마다 따로 연다 —
+     * 조회용 커넥션을 물려주면 두 번째 호출이 닫힌 커넥션을 쓴다.
+     */
+    private void runLiquibase(LiquibaseAction action) throws Exception {
+        try (Connection own = DriverManager.getConnection(
+                MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword())) {
+            Database database = DatabaseFactory.getInstance()
+                    .findCorrectDatabaseImplementation(new JdbcConnection(own));
+            try (Liquibase liquibase =
+                         new Liquibase(CHANGELOG, new ClassLoaderResourceAccessor(), database)) {
+                action.run(liquibase);
+            }
+        }
+    }
+
+    private boolean tableExists(String table) throws SQLException {
+        return queryOne("""
+                SELECT COUNT(*) FROM information_schema.tables
+                 WHERE table_schema = DATABASE() AND table_name = '%s'"""
+                .formatted(table)).equals("1");
+    }
+
+    private boolean columnExists(String table, String column) throws SQLException {
+        return queryOne("""
+                SELECT COUNT(*) FROM information_schema.columns
+                 WHERE table_schema = DATABASE() AND table_name = '%s' AND column_name = '%s'"""
+                .formatted(table, column)).equals("1");
+    }
+
+    private String queryOne(String sql) throws SQLException {
+        List<String> rows = queryList(sql);
+        return rows.isEmpty() ? null : rows.getFirst();
+    }
+
+    private List<String> queryList(String sql) throws SQLException {
+        try (Statement statement = connection.createStatement();
+             ResultSet rs = statement.executeQuery(sql)) {
+            List<String> values = new ArrayList<>();
+            while (rs.next()) {
+                values.add(rs.getString(1));
+            }
+            return values;
+        }
+    }
+
+    private void execute(String sql) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
@@ -338,7 +338,10 @@ class PlaceControllerTest extends ApiTestSupport {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.place.name").value("센소지"));
 
-            assertThat(placeRepository.findAll()).hasSize(1);
+            // 여행의 기준 도시도 travel_place 행이라, 검색으로 담은 장소만 센다.
+            assertThat(placeRepository.findAll())
+                    .filteredOn(place -> place.getGooglePlaceId() != null)
+                    .hasSize(1);
         }
 
         @Test
@@ -359,7 +362,9 @@ class PlaceControllerTest extends ApiTestSupport {
             }
 
             // 같은 장소를 두 번 저장하지 않는다(uk_place_member_google).
-            assertThat(placeRepository.findAll()).hasSize(1);
+            assertThat(placeRepository.findAll())
+                    .filteredOn(place -> place.getGooglePlaceId() != null)
+                    .hasSize(1);
             assertThat(stub.detailFetches).containsExactly("ChIJ_senso");
         }
     }

--- a/be/orino-app-api/src/test/java/ds/project/orino/schema/TravelSchemaTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/schema/TravelSchemaTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * 여행 스키마(047)에서 Hibernate {@code validate}가 봐주지 않는 것들을 고정한다 —
+ * 여행 스키마(047·053)에서 Hibernate {@code validate}가 봐주지 않는 것들을 고정한다 —
  * <b>FK 삭제 규칙 · 인덱스 · 컬럼 타입</b>. validate는 컬럼의 존재와 타입 호환만 보므로
  * cascade가 빠져도, 인덱스가 없어도 통과한다.
  *
@@ -73,9 +73,56 @@ class TravelSchemaTest {
     void foreignKeyDeleteRules() {
         assertThat(deleteRuleOf("fk_trip_activity_trip")).isEqualTo("CASCADE");
         assertThat(deleteRuleOf("fk_trip_activity_place")).isEqualTo("SET NULL");
-        // 목적지 장소는 여행이 참조 중이면 지워지면 안 된다. 삭제 규칙을 안 주면 InnoDB가
-        // RESTRICT로 동작하지만 information_schema에는 NO ACTION으로 적힌다(같은 뜻).
-        assertThat(deleteRuleOf("fk_trip_destination_place")).isEqualTo("NO ACTION");
+        assertThat(deleteRuleOf("fk_trip_day_trip")).isEqualTo("CASCADE");
+        assertThat(deleteRuleOf("fk_trip_stay_trip")).isEqualTo("CASCADE");
+        // 숙소 장소는 지워져도 숙소는 남는다(참조만 끊는다).
+        assertThat(deleteRuleOf("fk_trip_stay_place")).isEqualTo("SET NULL");
+        // 기준 도시는 그 날짜의 타임존이라 SET NULL도 CASCADE도 아니다. 삭제 규칙을 안 주면
+        // InnoDB가 RESTRICT로 동작하지만 information_schema에는 NO ACTION으로 적힌다(같은 뜻).
+        assertThat(deleteRuleOf("fk_trip_day_base_place")).isEqualTo("NO ACTION");
+    }
+
+    @Test
+    @DisplayName("여행에는 목적지 컬럼이 없다 — 남아 있으면 그걸 읽는 코드가 조용히 살아남는다")
+    void tripHasNoDestinationColumns() {
+        assertThat(columnNamesOf("trip"))
+                .doesNotContain("destination_name", "destination_place_id",
+                        "timezone", "currency", "lat", "lng");
+    }
+
+    @Test
+    @DisplayName("날짜를 지우면 여행이 아니라 그 반대다 — 여행을 지우면 날짜·숙소가 함께 지워진다")
+    @Transactional
+    void deletingTripCascadesToDaysAndStays() {
+        long memberId = insertMember("day-cascade-member");
+        long tripId = insertTrip(memberId, "간사이");
+        long cityId = insertCity(memberId, "오사카");
+        insertDay(tripId, cityId, "2026-10-24");
+        jdbcTemplate.update("""
+                INSERT INTO trip_stay (trip_id, name, check_in_date, check_out_date,
+                                       created_at, updated_at)
+                VALUES (?, '오사카 호텔', '2026-10-24', '2026-10-27', NOW(6), NOW(6))
+                """, tripId);
+
+        jdbcTemplate.update("DELETE FROM trip WHERE id = ?", tripId);
+
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM trip_day WHERE trip_id = ?", Integer.class, tripId)).isZero();
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM trip_stay WHERE trip_id = ?", Integer.class, tripId)).isZero();
+    }
+
+    @Test
+    @DisplayName("같은 여행·같은 날짜는 두 번 들어가지 않는다(하루에 기준 도시는 하나)")
+    @Transactional
+    void dayIsUniquePerDate() {
+        long memberId = insertMember("day-unique-member");
+        long tripId = insertTrip(memberId, "간사이");
+        long cityId = insertCity(memberId, "오사카");
+        insertDay(tripId, cityId, "2026-10-24");
+
+        assertThatThrownBy(() -> insertDay(tripId, cityId, "2026-10-24"))
+                .isInstanceOf(DuplicateKeyException.class);
     }
 
     @Test
@@ -92,6 +139,11 @@ class TravelSchemaTest {
                 .containsExactly("member_id", "google_place_id");
         assertThat(indexColumnsOf("travel_place", "idx_place_member_name"))
                 .containsExactly("member_id", "name");
+        // 하루에 기준 도시는 하나다.
+        assertThat(indexColumnsOf("trip_day", "uk_day_trip_date"))
+                .containsExactly("trip_id", "day_date");
+        assertThat(indexColumnsOf("trip_stay", "idx_stay_trip_checkin"))
+                .containsExactly("trip_id", "check_in_date");
     }
 
     @Test
@@ -116,8 +168,13 @@ class TravelSchemaTest {
         assertThat(columnTypeOf("trip_activity", "start_time")).isEqualTo("time");
         assertThat(columnTypeOf("trip", "start_date")).isEqualTo("date");
         assertThat(columnTypeOf("trip", "end_date")).isEqualTo("date");
-        // 여행 타임존은 IANA ID 문자열. 여기서 파생 계산의 기준이 나온다.
-        assertThat(columnTypeOf("trip", "timezone")).isEqualTo("varchar");
+        // 날짜도 숙소 시각도 벽시계 값이다.
+        assertThat(columnTypeOf("trip_day", "day_date")).isEqualTo("date");
+        assertThat(columnTypeOf("trip_stay", "check_in_date")).isEqualTo("date");
+        assertThat(columnTypeOf("trip_stay", "check_in_time")).isEqualTo("time");
+        // 타임존은 IANA ID 문자열. v2.1에서는 여행이 아니라 도시가 갖는다.
+        assertThat(columnTypeOf("travel_place", "timezone")).isEqualTo("varchar");
+        assertThat(columnTypeOf("travel_place", "place_kind")).isEqualTo("varchar");
     }
 
     @Test
@@ -211,14 +268,31 @@ class TravelSchemaTest {
         return jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
     }
 
-    private long insertTrip(long memberId, String destination) {
+    private long insertTrip(long memberId, String title) {
         jdbcTemplate.update("""
-                INSERT INTO trip (member_id, title, destination_name, start_date, end_date,
-                                  timezone, currency, default_notify_minutes,
-                                  morning_summary_enabled, created_at, updated_at)
-                VALUES (?, ?, ?, '2026-10-24', '2026-10-27', 'Asia/Tokyo', 'JPY', 15, b'0',
-                        NOW(6), NOW(6))
-                """, memberId, destination, destination);
+                INSERT INTO trip (member_id, title, start_date, end_date,
+                                  default_notify_minutes, morning_summary_enabled,
+                                  created_at, updated_at)
+                VALUES (?, ?, '2026-10-24', '2026-10-27', 15, b'0', NOW(6), NOW(6))
+                """, memberId, title);
+        return jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+    }
+
+    /** 기준 도시로 쓸 도시 장소. v2.1에서 타임존·통화의 주인이다. */
+    private long insertCity(long memberId, String name) {
+        jdbcTemplate.update("""
+                INSERT INTO travel_place (member_id, name, manual_entry, city_name,
+                                          timezone, currency, place_kind, created_at, updated_at)
+                VALUES (?, ?, b'1', ?, 'Asia/Tokyo', 'JPY', 'CITY', NOW(6), NOW(6))
+                """, memberId, name, name);
+        return jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+    }
+
+    private long insertDay(long tripId, long basePlaceId, String date) {
+        jdbcTemplate.update("""
+                INSERT INTO trip_day (trip_id, day_date, base_place_id, created_at, updated_at)
+                VALUES (?, ?, ?, NOW(6), NOW(6))
+                """, tripId, date, basePlaceId);
         return jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
     }
 
@@ -249,6 +323,13 @@ class TravelSchemaTest {
                 WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?
                 ORDER BY seq_in_index
                 """, String.class, table, indexName);
+    }
+
+    private List<String> columnNamesOf(String table) {
+        return jdbcTemplate.queryForList("""
+                SELECT column_name FROM information_schema.columns
+                WHERE table_schema = DATABASE() AND table_name = ?
+                """, String.class, table);
     }
 
     private String columnTypeOf(String table, String column) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/DbCleaner.java
@@ -12,6 +12,8 @@ public class DbCleaner {
             "trip_activity_photo",
             "trip_activity_log",
             "trip_activity",
+            "trip_stay",
+            "trip_day",
             "trip",
             "travel_place",
             "push_subscription",

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/PlaceKind.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/PlaceKind.java
@@ -1,0 +1,17 @@
+package ds.project.orino.domain.planner.travel.entity;
+
+/**
+ * 장소의 종류. <b>{@link #CITY}만 날짜의 기준 도시로 지정할 수 있다.</b>
+ *
+ * <p>구분을 두는 이유는 오지정을 막는 것이다 — "오사카성"을 기준 도시로 넣으면 타임존·통화는
+ * 우연히 맞지만, 도시 일치 판정({@code city_place_ref})이 그 날짜의 모든 일정을
+ * "다른 도시"로 만든다.
+ */
+public enum PlaceKind {
+
+    /** 도시. 타임존·통화·검색 좌표·날씨의 기준점이 된다. */
+    CITY,
+
+    /** 일반 장소(가게·명소·숙소). */
+    POI
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TravelPlace.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TravelPlace.java
@@ -3,6 +3,8 @@ package ds.project.orino.domain.planner.travel.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -18,12 +20,13 @@ import java.time.Instant;
 /**
  * 장소 캐시 하나. 구글에서 가져온 장소 또는 직접 입력한 장소를 담는다.
  *
- * <p><b>여행에 종속되지 않는다.</b> 이전 여행에서 평점 4 이상을 준 장소에 {@code ⭐ 좋았던 곳}
- * 배지를 다는 요구가 있어, 장소는 여행을 가로질러 멤버 단위로 재사용돼야 한다.
+ * <p><b>여행에 종속되지 않는다.</b> 같은 장소를 일정마다 새 행으로 만들면 영업시간·좌표 캐시가
+ * 장소 수만큼 중복되고, 한 행만 갱신돼 나머지가 옛 값으로 남는다. {@code uk_place_member_google}이
+ * 멤버당 한 행을 강제한다.
  *
- * <p>1단계에서는 아무것도 쓰지 않는다. {@link Trip#getDestinationPlaceId()}·
- * {@link TripActivity#getPlaceId()} FK를 나중에 붙이면 ALTER가 필요해 테이블만 미리 두고,
- * 2단계(장소 검색)부터 채우기 시작한다.
+ * <p><b>v2.1 — 도시도 장소다.</b> {@link PlaceKind#CITY}로 표시된 행은 날짜의 기준 도시
+ * ({@link TripDay#getBasePlaceId()})가 되어 타임존·통화·날씨 좌표의 주인이 된다. v2.0에서
+ * {@code trip}이 들고 있던 값들이 이 자리로 내려왔다.
  */
 @Entity
 @EntityListeners(AuditingEntityListener.class)
@@ -70,6 +73,34 @@ public class TravelPlace {
     @Column(name = "opening_hours", columnDefinition = "JSON")
     private String openingHours;
 
+    /** 이 장소가 속한 도시 표시명. 도시 장소 자신이면 자기 이름이 들어간다. */
+    @Column(name = "city_name", length = 100)
+    private String cityName;
+
+    /**
+     * 도시 식별자(구글 장소 id). <b>도시 일치 판정은 이 값으로만 한다</b> — 좌표 거리 임계로
+     * 하면 오사카-교토(43km)와 도쿄-요코하마(30km)에서 서로 다른 답이 나온다(D-23).
+     */
+    @Column(name = "city_place_ref", length = 255)
+    private String cityPlaceRef;
+
+    /** ISO 3166-1 alpha-2. 통화·번역 목적 언어를 파생한다. */
+    @Column(name = "country_code", length = 2)
+    private String countryCode;
+
+    /** IANA 타임존 ID. 기준 도시로 쓰이는 장소에는 반드시 있어야 한다. */
+    @Column(length = 64)
+    private String timezone;
+
+    /** ISO 4217 통화 코드. */
+    @Column(length = 3)
+    private String currency;
+
+    /** 도시인지 일반 장소인지. {@link PlaceKind#CITY}만 기준 도시로 지정할 수 있다. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "place_kind", nullable = false, length = 20)
+    private PlaceKind placeKind = PlaceKind.POI;
+
     /** 영업시간을 마지막으로 갱신한 시각. null이면 아직 상세를 받은 적 없다. */
     @Column(name = "details_refreshed_at")
     private Instant detailsRefreshedAt;
@@ -109,6 +140,45 @@ public class TravelPlace {
         return new TravelPlace(memberId, null, name, true);
     }
 
+    /**
+     * 검색을 거치지 않고 이름만으로 만든 <b>도시</b> 장소. 목적지를 직접 입력한 여행이
+     * 기준 도시를 가지려면 도시 행이 있어야 한다.
+     */
+    public static TravelPlace manualCity(Long memberId, String name,
+                                         String timezone, String currency) {
+        TravelPlace place = new TravelPlace(memberId, null, name, true);
+        place.promoteToCity(name, timezone, currency);
+        return place;
+    }
+
+    /**
+     * 이 장소를 기준 도시로 쓸 수 있게 만든다. 타임존·통화의 주인이 여행에서 도시로 넘어왔으므로,
+     * 도시로 승격하는 순간 두 값을 함께 받는다.
+     *
+     * <p>{@code cityPlaceRef}는 도시 자신의 식별자다 — 도시 장소에서는 자기 구글 id가 곧
+     * 도시 식별자라, 일정 장소({@code POI})의 {@code cityPlaceRef}와 같은 축에서 비교된다.
+     */
+    public void promoteToCity(String cityName, String timezone, String currency) {
+        this.placeKind = PlaceKind.CITY;
+        this.cityName = cityName;
+        this.timezone = timezone;
+        this.currency = currency;
+        if (this.cityPlaceRef == null) {
+            this.cityPlaceRef = this.googlePlaceId;
+        }
+    }
+
+    /** 이 장소가 어느 도시에 속하는지. 일정 장소의 도시 이탈 판정(§1124)이 이 값을 본다. */
+    public void updateCityInfo(String cityName, String cityPlaceRef, String countryCode) {
+        this.cityName = cityName;
+        this.cityPlaceRef = cityPlaceRef;
+        this.countryCode = countryCode;
+    }
+
+    public boolean isCity() {
+        return placeKind == PlaceKind.CITY;
+    }
+
     /** 위치·주소·분류 등 검색 응답으로 채워지는 기본 정보. */
     public void updateBasics(String address, BigDecimal lat, BigDecimal lng,
                              String category, BigDecimal rating) {
@@ -117,6 +187,15 @@ public class TravelPlace {
         this.lng = lng;
         this.category = category;
         this.rating = rating;
+    }
+
+    /**
+     * 좌표만 채운다. 도시 장소는 검색을 거치지 않고 만들어질 수 있어 좌표가 비는데,
+     * 좌표가 없으면 그 도시 날짜의 날씨가 통째로 사라진다.
+     */
+    public void updateCoordinates(BigDecimal lat, BigDecimal lng) {
+        this.lat = lat;
+        this.lng = lng;
     }
 
     /** 상세 조회(영업시간·전화·사진) 결과를 채우고 갱신 시각을 찍는다. */
@@ -173,6 +252,30 @@ public class TravelPlace {
 
     public String getOpeningHours() {
         return openingHours;
+    }
+
+    public String getCityName() {
+        return cityName;
+    }
+
+    public String getCityPlaceRef() {
+        return cityPlaceRef;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public PlaceKind getPlaceKind() {
+        return placeKind;
     }
 
     public Instant getDetailsRefreshedAt() {

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/Trip.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/Trip.java
@@ -11,7 +11,6 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -19,11 +18,18 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 /**
- * 여행 1건. 일정({@link TripActivity})의 소유자이자 타임존·통화의 기준점이다.
+ * 여행 1건. 일정({@link TripActivity})의 소유자이자 기간의 주인이다.
+ *
+ * <p><b>v2.1 — 여행은 도시·타임존·통화를 갖지 않는다.</b> 목적지는 날짜가 갖는다
+ * ({@link TripDay#getBasePlaceId()}). 여행 하나에 타임존 하나라는 가정이 한 군데라도 남으면
+ * 오사카 → 교토 → 나고야를 옮겨 다닐 때 그 화면만 조용히 틀리기 때문에, 컬럼을 NULL 허용으로
+ * 남기지 않고 지웠다.
  *
  * <p><b>상태·D-day·일차 번호를 저장하지 않는다.</b> 셋 다 "오늘"에 의존하는 값이라 컬럼으로 두면
- * 날짜가 넘어가는 순간 어긋난다. 대신 {@link #status(Clock)}·{@link #daysUntilStart(Clock)}으로
- * 조회 시마다 파생하며, 기준은 기기 시간대가 아니라 {@link #timezone}의 오늘이다.
+ * 날짜가 넘어가는 순간 어긋난다. 대신 {@link #status(Clock, ZoneId)}·
+ * {@link #daysUntilStart(Clock, ZoneId)}으로 조회 시마다 파생한다. 기준 타임존은 기기 시간대도
+ * 여행의 것도 아니라 <b>날짜의 기준 도시</b>에서 오므로, 호출부가 어느 날짜의 타임존인지 정해
+ * 넘긴다(어느 날짜를 쓰는지는 값마다 다르다 — #1123).
  */
 @Entity
 @EntityListeners(AuditingEntityListener.class)
@@ -37,17 +43,9 @@ public class Trip {
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
-    /** 최대 50자. 미입력 시 목적지명으로 채워 저장한다(빈 제목을 만들지 않는다). */
+    /** 최대 50자. v2.1부터 필수다 — 목적지가 여행에 없으니 자동으로 채울 이름도 없다. */
     @Column(nullable = false, length = 50)
     private String title;
-
-    /** 목적지 표시명. 목록 카드 메타에 쓰려고 denormalize한다. */
-    @Column(name = "destination_name", nullable = false, length = 100)
-    private String destinationName;
-
-    /** 검색으로 고른 목적지 도시({@link TravelPlace}). 1단계는 항상 null(수동 입력). */
-    @Column(name = "destination_place_id")
-    private Long destinationPlaceId;
 
     @Column(name = "start_date", nullable = false)
     private LocalDate startDate;
@@ -55,21 +53,6 @@ public class Trip {
     /** 종료일(당일 포함). 항상 {@code >= startDate} — 애플리케이션에서 검증한다. */
     @Column(name = "end_date", nullable = false)
     private LocalDate endDate;
-
-    /** IANA 타임존 ID(예: {@code Asia/Tokyo}). 상태·D-day·알림 시각 환산의 유일한 기준. */
-    @Column(nullable = false, length = 64)
-    private String timezone;
-
-    /** ISO 4217 통화 코드(예: {@code JPY}). */
-    @Column(nullable = false, length = 3)
-    private String currency;
-
-    /** 목적지 좌표 — 날씨 조회 기준점. */
-    @Column(precision = 10, scale = 7)
-    private BigDecimal lat;
-
-    @Column(precision = 10, scale = 7)
-    private BigDecimal lng;
 
     /** 여행 단위 기본 알림 시점(분 전). 일정이 값을 따로 정하지 않으면 이걸 쓴다. */
     @Column(name = "default_notify_minutes", nullable = false)
@@ -89,33 +72,18 @@ public class Trip {
     protected Trip() {
     }
 
-    public Trip(Long memberId, String title, String destinationName, LocalDate startDate,
-                LocalDate endDate, String timezone, String currency) {
+    public Trip(Long memberId, String title, LocalDate startDate, LocalDate endDate) {
         this.memberId = memberId;
         this.title = title;
-        this.destinationName = destinationName;
         this.startDate = startDate;
         this.endDate = endDate;
-        this.timezone = timezone;
-        this.currency = currency;
     }
 
-    /** 제목·목적지·기간·타임존·통화 등 기본 정보를 갱신한다. */
-    public void update(String title, String destinationName, LocalDate startDate,
-                       LocalDate endDate, String timezone, String currency) {
+    /** 제목·기간을 갱신한다. 목적지는 여행이 아니라 날짜가 갖는다. */
+    public void update(String title, LocalDate startDate, LocalDate endDate) {
         this.title = title;
-        this.destinationName = destinationName;
         this.startDate = startDate;
         this.endDate = endDate;
-        this.timezone = timezone;
-        this.currency = currency;
-    }
-
-    /** 목적지 좌표(날씨 기준점)와 검색으로 고른 목적지 장소를 잇는다. 2단계부터 쓴다. */
-    public void updateDestinationPlace(Long destinationPlaceId, BigDecimal lat, BigDecimal lng) {
-        this.destinationPlaceId = destinationPlaceId;
-        this.lat = lat;
-        this.lng = lng;
     }
 
     public void updateNotificationSettings(int defaultNotifyMinutes, boolean morningSummaryEnabled) {
@@ -123,14 +91,19 @@ public class Trip {
         this.morningSummaryEnabled = morningSummaryEnabled;
     }
 
-    /** 여행 타임존 기준 오늘 날짜. 상태·D-day·일차 계산은 전부 이 값을 기준으로 한다. */
-    public LocalDate todayAtDestination(Clock clock) {
-        return LocalDate.now(clock.withZone(ZoneId.of(timezone)));
+    /**
+     * 주어진 타임존 기준 오늘 날짜. 상태·D-day·일차 계산이 전부 이 값을 쓴다.
+     *
+     * <p>타임존을 인자로 받는 이유 — 여행에는 타임존이 없다. 어느 날짜의 기준 도시를 쓸지는
+     * 값마다 달라서(상태는 오늘 날짜, D-day는 첫날) 호출부가 정한다.
+     */
+    public LocalDate todayIn(Clock clock, ZoneId zone) {
+        return LocalDate.now(clock.withZone(zone));
     }
 
-    /** 여행 타임존의 오늘로 판정한 상태. */
-    public TripStatus status(Clock clock) {
-        return statusOn(todayAtDestination(clock));
+    /** 주어진 타임존의 오늘로 판정한 상태. */
+    public TripStatus status(Clock clock, ZoneId zone) {
+        return statusOn(todayIn(clock, zone));
     }
 
     /** 주어진 날짜를 오늘로 보고 판정한 상태. 목록을 한 번에 훑을 때 오늘을 재사용한다. */
@@ -140,10 +113,10 @@ public class Trip {
 
     /**
      * 시작일까지 남은 일수(D-day). 시작 당일이면 0, 이미 시작했으면 음수다.
-     * 표시 여부(예정 여행에만 노출)는 호출부가 {@link #status(Clock)}로 판단한다.
+     * 표시 여부(예정 여행에만 노출)는 호출부가 {@link #status(Clock, ZoneId)}로 판단한다.
      */
-    public long daysUntilStart(Clock clock) {
-        return ChronoUnit.DAYS.between(todayAtDestination(clock), startDate);
+    public long daysUntilStart(Clock clock, ZoneId zone) {
+        return ChronoUnit.DAYS.between(todayIn(clock, zone), startDate);
     }
 
     /** 여행 총 일수(당일 포함). 하루짜리 여행이면 1. */
@@ -173,36 +146,12 @@ public class Trip {
         return title;
     }
 
-    public String getDestinationName() {
-        return destinationName;
-    }
-
-    public Long getDestinationPlaceId() {
-        return destinationPlaceId;
-    }
-
     public LocalDate getStartDate() {
         return startDate;
     }
 
     public LocalDate getEndDate() {
         return endDate;
-    }
-
-    public String getTimezone() {
-        return timezone;
-    }
-
-    public String getCurrency() {
-        return currency;
-    }
-
-    public BigDecimal getLat() {
-        return lat;
-    }
-
-    public BigDecimal getLng() {
-        return lng;
     }
 
     public int getDefaultNotifyMinutes() {

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TripDay.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TripDay.java
@@ -1,0 +1,112 @@
+package ds.project.orino.domain.planner.travel.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * 여행 기간의 날짜 1건. <b>v2.1에서 목적지는 여행이 아니라 이 날짜가 갖는다</b> —
+ * 타임존·통화·검색 좌표·날씨가 전부 {@link #basePlaceId}(기준 도시)에서 파생된다.
+ *
+ * <p><b>기간 내 모든 날짜에 행이 반드시 존재한다.</b> 비어 있는 날짜를 허용하면 타임존이 없는
+ * 날이 생기고, 그 순간 알림·날씨·상태 판정이 전부 NPE 아니면 조용한 오답이 된다. 여행 생성·기간
+ * 변경은 한 트랜잭션에서 날짜 집합을 기간과 일치시킨다.
+ *
+ * <p><b>구간(Leg) 테이블을 만들지 않는다.</b> 연속된 같은 {@code basePlaceId}를 묶어 파생한다.
+ * 구간을 저장하면 날짜와 구간이 어긋날 수 있는 상태가 두 개 생긴다(D-21).
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "trip_day", uniqueConstraints = @UniqueConstraint(
+        name = "uk_day_trip_date", columnNames = {"trip_id", "day_date"}))
+public class TripDay {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "trip_id", nullable = false)
+    private Long tripId;
+
+    /** 컬럼명이 {@code date}가 아닌 이유 — MySQL 함수명과 혼동돼 DDL·쿼리가 읽기 어려워진다. */
+    @Column(name = "day_date", nullable = false)
+    private LocalDate dayDate;
+
+    /** 기준 도시. {@link PlaceKind#CITY}인 장소만 허용한다(애플리케이션 검증). */
+    @Column(name = "base_place_id", nullable = false)
+    private Long basePlaceId;
+
+    /** "체크아웃 후 교토역 코인로커에 짐 보관" — 날짜에 붙는 메모라 도시가 바뀌어도 살린다. */
+    @Column(name = "city_memo", length = 200)
+    private String cityMemo;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected TripDay() {
+    }
+
+    public TripDay(Long tripId, LocalDate dayDate, Long basePlaceId) {
+        this.tripId = tripId;
+        this.dayDate = dayDate;
+        this.basePlaceId = basePlaceId;
+    }
+
+    /**
+     * 기준 도시를 바꾼다. <b>이미 담긴 일정의 장소는 건드리지 않는다</b> — 오사카 가게를 교토
+     * 날짜에 두는 건 사용자의 선택이다. 타임존·통화·날씨·알림 발송시각의 재계산은 호출부가
+     * 한 곳에 모아 처리한다.
+     */
+    public void changeBaseCity(Long basePlaceId) {
+        this.basePlaceId = basePlaceId;
+    }
+
+    /** 공백만 남으면 비운다 — 빈 문자열을 저장하면 화면에 메모 자리가 남는다. */
+    public void updateCityMemo(String cityMemo) {
+        this.cityMemo = cityMemo == null || cityMemo.isBlank() ? null : cityMemo.trim();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getTripId() {
+        return tripId;
+    }
+
+    public LocalDate getDayDate() {
+        return dayDate;
+    }
+
+    public Long getBasePlaceId() {
+        return basePlaceId;
+    }
+
+    public String getCityMemo() {
+        return cityMemo;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TripStay.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TripStay.java
@@ -1,0 +1,185 @@
+package ds.project.orino.domain.planner.travel.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * 숙소 1건. <b>기준 도시와 분리된 별도 엔티티다</b> — "오늘 있는 도시"와 "오늘 자는 곳"이
+ * 다를 수 있다. 닛코 당일치기 날의 기준 도시는 닛코지만 자는 곳은 도쿄다.
+ *
+ * <p>날짜 판정은 반열린 구간 {@code [checkIn, checkOut)}으로 한다 —
+ * 체크아웃일 밤은 이미 다른 곳에서 잔다.
+ *
+ * <pre>
+ * stayTonight(day)  = checkInDate &lt;= day &lt;  checkOutDate   오늘 밤 자는 곳
+ * stayCheckout(day) = checkOutDate == day                    오늘 체크아웃하는 곳
+ * </pre>
+ *
+ * <p>겹치는 기간의 숙소는 저장하지 않는다. 겹침을 허용하면 "오늘 밤 어디서 자는가"에 답이
+ * 둘이 되고, 화면은 그중 하나를 임의로 고를 수밖에 없다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "trip_stay")
+public class TripStay {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "trip_id", nullable = false)
+    private Long tripId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    /** 좌표·도시 판정에 쓴다. 직접 입력한 숙소면 null. */
+    @Column(name = "place_id")
+    private Long placeId;
+
+    @Column(name = "check_in_date", nullable = false)
+    private LocalDate checkInDate;
+
+    /** 항상 {@code > checkInDate} — 애플리케이션에서 검증한다. */
+    @Column(name = "check_out_date", nullable = false)
+    private LocalDate checkOutDate;
+
+    /** 벽시계 시각. UTC로 변환하지 않는다 — 15:00 체크인은 어느 도시에서든 15:00이다. */
+    @Column(name = "check_in_time")
+    private LocalTime checkInTime;
+
+    @Column(name = "check_out_time")
+    private LocalTime checkOutTime;
+
+    @Column(name = "booking_url", length = 500)
+    private String bookingUrl;
+
+    @Column(length = 500)
+    private String memo;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected TripStay() {
+    }
+
+    public TripStay(Long tripId, String name, LocalDate checkInDate, LocalDate checkOutDate) {
+        this.tripId = tripId;
+        this.name = name;
+        this.checkInDate = checkInDate;
+        this.checkOutDate = checkOutDate;
+    }
+
+    public void updateBasics(String name, Long placeId, LocalDate checkInDate,
+                             LocalDate checkOutDate) {
+        this.name = name;
+        this.placeId = placeId;
+        this.checkInDate = checkInDate;
+        this.checkOutDate = checkOutDate;
+    }
+
+    public void updateDetails(LocalTime checkInTime, LocalTime checkOutTime,
+                              String bookingUrl, String memo) {
+        this.checkInTime = checkInTime;
+        this.checkOutTime = checkOutTime;
+        this.bookingUrl = bookingUrl;
+        this.memo = memo;
+    }
+
+    /**
+     * 여행 기간이 줄어 체크아웃일이 기간 밖으로 밀렸을 때 종료일까지 당긴다.
+     * 그 결과 하루도 남지 않으면({@code in >= out}) 숙소 자체를 지워야 한다 —
+     * 판단은 호출부가 {@link #isEmptyPeriod()}로 한다.
+     */
+    public void shrinkCheckOutTo(LocalDate newCheckOutDate) {
+        this.checkOutDate = newCheckOutDate;
+    }
+
+    /** 체크인이 체크아웃과 같거나 뒤면 묵는 밤이 없다. */
+    public boolean isEmptyPeriod() {
+        return !checkInDate.isBefore(checkOutDate);
+    }
+
+    /** 그날 밤 여기서 자는가. 체크아웃일은 포함하지 않는다. */
+    public boolean coversNight(LocalDate date) {
+        return !date.isBefore(checkInDate) && date.isBefore(checkOutDate);
+    }
+
+    /** 그날 여기서 체크아웃하는가. */
+    public boolean isCheckOutOn(LocalDate date) {
+        return checkOutDate.equals(date);
+    }
+
+    /**
+     * 다른 숙소와 묵는 밤이 겹치는가. {@code [in, out)} 반열린 구간이라
+     * {@code 10.24–10.27} 다음의 {@code 10.27–10.29}는 겹침이 아니다(이동일).
+     */
+    public boolean overlaps(LocalDate otherCheckIn, LocalDate otherCheckOut) {
+        return checkInDate.isBefore(otherCheckOut) && otherCheckIn.isBefore(checkOutDate);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getTripId() {
+        return tripId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getPlaceId() {
+        return placeId;
+    }
+
+    public LocalDate getCheckInDate() {
+        return checkInDate;
+    }
+
+    public LocalDate getCheckOutDate() {
+        return checkOutDate;
+    }
+
+    public LocalTime getCheckInTime() {
+        return checkInTime;
+    }
+
+    public LocalTime getCheckOutTime() {
+        return checkOutTime;
+    }
+
+    public String getBookingUrl() {
+        return bookingUrl;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TravelPlaceRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TravelPlaceRepository.java
@@ -1,5 +1,6 @@
 package ds.project.orino.domain.planner.travel.repository;
 
+import ds.project.orino.domain.planner.travel.entity.PlaceKind;
 import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -27,4 +28,12 @@ public interface TravelPlaceRepository extends JpaRepository<TravelPlace, Long> 
 
     /** 이름 부분일치 — 직접 입력한 장소를 다시 고를 때. */
     List<TravelPlace> findAllByMemberIdAndNameContainingOrderByNameAsc(Long memberId, String name);
+
+    /**
+     * 검색을 거치지 않고 만든 도시. 목적지를 직접 입력한 여행이 같은 도시를 다시 쓸 때
+     * 장소를 새로 만들지 않기 위해 찾는다(같은 도시가 이름만 같은 행으로 늘어나면
+     * 도시 일치 판정이 여행마다 갈린다).
+     */
+    Optional<TravelPlace> findFirstByMemberIdAndNameAndPlaceKindAndGooglePlaceIdIsNull(
+            Long memberId, String name, PlaceKind placeKind);
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripDayRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripDayRepository.java
@@ -1,0 +1,31 @@
+package ds.project.orino.domain.planner.travel.repository;
+
+import ds.project.orino.domain.planner.travel.entity.TripDay;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 여행 날짜 조회. 보드는 <b>기간 전체를 한 번에</b> 읽는다 — 길어야 한 달이라 날짜별로 끊어
+ * 읽을 이유가 없고, 구간(Leg) 파생은 어차피 연속된 날짜를 전부 봐야 한다.
+ */
+public interface TripDayRepository extends JpaRepository<TripDay, Long> {
+
+    /** 날짜 오름차순 — 구간 파생이 연속성을 보려면 순서가 보장돼야 한다. */
+    List<TripDay> findAllByTripIdOrderByDayDateAsc(Long tripId);
+
+    /** 목록 화면용 배치 조회 — 여행 수만큼 날짜를 따로 읽지 않는다(N+1 회피). */
+    List<TripDay> findAllByTripIdInOrderByTripIdAscDayDateAsc(Collection<Long> tripIds);
+
+    Optional<TripDay> findByTripIdAndDayDate(Long tripId, LocalDate dayDate);
+
+    /** 기간이 줄었을 때 잘린 날짜만 지운다. */
+    void deleteAllByTripIdAndDayDateBefore(Long tripId, LocalDate dayDate);
+
+    void deleteAllByTripIdAndDayDateAfter(Long tripId, LocalDate dayDate);
+
+    long countByTripId(Long tripId);
+}

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripStayRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/repository/TripStayRepository.java
@@ -1,0 +1,19 @@
+package ds.project.orino.domain.planner.travel.repository;
+
+import ds.project.orino.domain.planner.travel.entity.TripStay;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 숙소 조회. 겹침 검증도 목록 조회도 <b>여행 전체</b>를 읽어 애플리케이션에서 판정한다 —
+ * 여행 하나에 숙소는 많아야 예닐곱 건이고, 겹침 규칙({@code [in, out)} 반열린 구간)을
+ * SQL로 표현하면 체크아웃일 경계에서 틀리기 쉽다.
+ */
+public interface TripStayRepository extends JpaRepository<TripStay, Long> {
+
+    List<TripStay> findAllByTripIdOrderByCheckInDateAscIdAsc(Long tripId);
+
+    Optional<TripStay> findByIdAndTripId(Long id, Long tripId);
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/entity/TripTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/entity/TripTest.java
@@ -14,15 +14,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * 저장하지 않고 파생하는 값들(상태·D-day·일차)을 고정한다. 이 계산이 틀리면 컬럼이 없으니
  * DB를 봐도 알 수 없다 — 여기가 유일한 안전망이다.
+ *
+ * <p>v2.1부터 판정 타임존은 여행이 아니라 <b>날짜의 기준 도시</b>에서 온다. 여행은 타임존을
+ * 갖지 않으므로 여기서는 호출부가 하듯 존을 인자로 넣어 준다.
  */
 class TripTest {
 
     private static final ZoneId TOKYO = ZoneId.of("Asia/Tokyo");
+    private static final ZoneId HONOLULU = ZoneId.of("Pacific/Honolulu");
 
     /** 도쿄 여행 10/24~10/27. 에픽의 실사용 일정 그대로다. */
     private static Trip tokyoTrip() {
-        return new Trip(1L, "도쿄", "도쿄", LocalDate.of(2026, 10, 24),
-                LocalDate.of(2026, 10, 27), "Asia/Tokyo", "JPY");
+        return new Trip(1L, "도쿄", LocalDate.of(2026, 10, 24), LocalDate.of(2026, 10, 27));
     }
 
     /** 기기 시간대와 무관하게 판정돼야 하므로, 시스템 존을 일부러 여행지와 다르게 준다. */
@@ -37,49 +40,50 @@ class TripTest {
         @Test
         @DisplayName("오늘이 시작일 전이면 예정")
         void upcomingBeforeStart() {
-            assertThat(tokyoTrip().status(utcClockAt("2026-10-20T03:00:00Z")))
+            assertThat(tokyoTrip().status(utcClockAt("2026-10-20T03:00:00Z"), TOKYO))
                     .isEqualTo(TripStatus.UPCOMING);
         }
 
         @Test
         @DisplayName("시작일·종료일 당일도 진행 중이다(경계 포함)")
         void ongoingIncludesBothEnds() {
-            assertThat(tokyoTrip().status(utcClockAt("2026-10-24T03:00:00Z")))
+            assertThat(tokyoTrip().status(utcClockAt("2026-10-24T03:00:00Z"), TOKYO))
                     .isEqualTo(TripStatus.ONGOING);
-            assertThat(tokyoTrip().status(utcClockAt("2026-10-27T03:00:00Z")))
+            assertThat(tokyoTrip().status(utcClockAt("2026-10-27T03:00:00Z"), TOKYO))
                     .isEqualTo(TripStatus.ONGOING);
         }
 
         @Test
         @DisplayName("종료일 다음날부터 완료")
         void completedAfterEnd() {
-            assertThat(tokyoTrip().status(utcClockAt("2026-10-28T03:00:00Z")))
+            assertThat(tokyoTrip().status(utcClockAt("2026-10-28T03:00:00Z"), TOKYO))
                     .isEqualTo(TripStatus.COMPLETED);
         }
 
         @Test
-        @DisplayName("기기 시간대가 아니라 여행 타임존의 오늘로 판정한다")
-        void derivedFromTripTimezoneNotDeviceZone() {
+        @DisplayName("기기 시간대가 아니라 기준 도시 타임존의 오늘로 판정한다")
+        void derivedFromBaseCityTimezoneNotDeviceZone() {
             // 2026-10-23 16:00 UTC — 서울/UTC로는 아직 10/23이지만 도쿄는 이미 10/24 01:00이다.
             Clock justBeforeMidnightUtc = utcClockAt("2026-10-23T16:00:00Z");
 
             assertThat(LocalDate.now(justBeforeMidnightUtc)).isEqualTo(LocalDate.of(2026, 10, 23));
-            assertThat(tokyoTrip().todayAtDestination(justBeforeMidnightUtc))
+            assertThat(tokyoTrip().todayIn(justBeforeMidnightUtc, TOKYO))
                     .isEqualTo(LocalDate.of(2026, 10, 24));
             // 도쿄 기준으로는 여행이 이미 시작됐다. UTC로 판정했다면 예정으로 잘못 나온다.
-            assertThat(tokyoTrip().status(justBeforeMidnightUtc)).isEqualTo(TripStatus.ONGOING);
+            assertThat(tokyoTrip().status(justBeforeMidnightUtc, TOKYO))
+                    .isEqualTo(TripStatus.ONGOING);
         }
 
         @Test
         @DisplayName("날짜변경선 반대편(하와이) 여행도 그 지역 오늘로 판정한다")
         void worksForZonesBehindUtc() {
-            Trip honolulu = new Trip(1L, "하와이", "호놀룰루", LocalDate.of(2026, 10, 24),
-                    LocalDate.of(2026, 10, 27), "Pacific/Honolulu", "USD");
+            Trip honolulu = new Trip(1L, "하와이", LocalDate.of(2026, 10, 24),
+                    LocalDate.of(2026, 10, 27));
             // 10/24 05:00 UTC — 호놀룰루(UTC-10)는 아직 10/23 19:00이라 출발 전이다.
             Clock clock = utcClockAt("2026-10-24T05:00:00Z");
 
-            assertThat(honolulu.todayAtDestination(clock)).isEqualTo(LocalDate.of(2026, 10, 23));
-            assertThat(honolulu.status(clock)).isEqualTo(TripStatus.UPCOMING);
+            assertThat(honolulu.todayIn(clock, HONOLULU)).isEqualTo(LocalDate.of(2026, 10, 23));
+            assertThat(honolulu.status(clock, HONOLULU)).isEqualTo(TripStatus.UPCOMING);
         }
 
         @Test
@@ -97,16 +101,19 @@ class TripTest {
     class Derived {
 
         @Test
-        @DisplayName("D-day는 여행 타임존의 오늘에서 시작일까지 남은 일수")
+        @DisplayName("D-day는 기준 도시 타임존의 오늘에서 시작일까지 남은 일수")
         void daysUntilStart() {
-            assertThat(tokyoTrip().daysUntilStart(utcClockAt("2026-10-20T03:00:00Z"))).isEqualTo(4);
+            assertThat(tokyoTrip().daysUntilStart(utcClockAt("2026-10-20T03:00:00Z"), TOKYO))
+                    .isEqualTo(4);
         }
 
         @Test
         @DisplayName("시작 당일은 0, 시작 후에는 음수")
         void daysUntilStartOnAndAfterStart() {
-            assertThat(tokyoTrip().daysUntilStart(utcClockAt("2026-10-24T03:00:00Z"))).isZero();
-            assertThat(tokyoTrip().daysUntilStart(utcClockAt("2026-10-26T03:00:00Z"))).isEqualTo(-2);
+            assertThat(tokyoTrip().daysUntilStart(utcClockAt("2026-10-24T03:00:00Z"), TOKYO))
+                    .isZero();
+            assertThat(tokyoTrip().daysUntilStart(utcClockAt("2026-10-26T03:00:00Z"), TOKYO))
+                    .isEqualTo(-2);
         }
 
         @Test
@@ -114,8 +121,8 @@ class TripTest {
         void totalDaysIsInclusive() {
             assertThat(tokyoTrip().totalDays()).isEqualTo(4);
 
-            Trip oneDay = new Trip(1L, "당일치기", "부산", LocalDate.of(2026, 10, 24),
-                    LocalDate.of(2026, 10, 24), "Asia/Seoul", "KRW");
+            Trip oneDay = new Trip(1L, "당일치기", LocalDate.of(2026, 10, 24),
+                    LocalDate.of(2026, 10, 24));
             assertThat(oneDay.totalDays()).isEqualTo(1);
         }
 
@@ -139,17 +146,15 @@ class TripTest {
     }
 
     @Test
-    @DisplayName("타임존을 바꾸면 상태·D-day가 새 타임존 기준으로 다시 계산된다")
-    void statusFollowsUpdatedTimezone() {
+    @DisplayName("같은 순간이라도 기준 도시가 다르면 상태·D-day가 다르게 나온다")
+    void derivationFollowsBaseCityZone() {
         Trip trip = tokyoTrip();
         Clock clock = utcClockAt("2026-10-23T16:00:00Z");
-        assertThat(trip.status(clock)).isEqualTo(TripStatus.ONGOING);
 
-        // 같은 기간을 호놀룰루로 옮기면 그 지역은 아직 10/23이라 출발 전으로 돌아간다.
-        trip.update("하와이", "호놀룰루", trip.getStartDate(), trip.getEndDate(),
-                "Pacific/Honolulu", "USD");
-
-        assertThat(trip.status(clock)).isEqualTo(TripStatus.UPCOMING);
-        assertThat(trip.daysUntilStart(clock)).isEqualTo(1);
+        // 도쿄는 이미 10/24 — 여행이 시작됐다.
+        assertThat(trip.status(clock, TOKYO)).isEqualTo(TripStatus.ONGOING);
+        // 같은 기간을 호놀룰루 기준으로 보면 아직 10/23이라 출발 전이다.
+        assertThat(trip.status(clock, HONOLULU)).isEqualTo(TripStatus.UPCOMING);
+        assertThat(trip.daysUntilStart(clock, HONOLULU)).isEqualTo(1);
     }
 }

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TripActivityRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TripActivityRepositoryTest.java
@@ -43,8 +43,8 @@ class TripActivityRepositoryTest {
     @BeforeEach
     void setUp() {
         Long memberId = memberRepository.save(new Member("traveler", "pw")).getId();
-        tripId = tripRepository.save(new Trip(memberId, "도쿄", "도쿄", DAY1,
-                LocalDate.of(2026, 10, 27), "Asia/Tokyo", "JPY")).getId();
+        tripId = tripRepository.save(new Trip(memberId, "도쿄", DAY1,
+                LocalDate.of(2026, 10, 27))).getId();
     }
 
     @Test
@@ -161,8 +161,8 @@ class TripActivityRepositoryTest {
     @DisplayName("보드·보관함 조회는 다른 여행의 일정을 섞지 않는다")
     void scopedByTrip() {
         Long otherMember = memberRepository.save(new Member("other", "pw")).getId();
-        Long otherTrip = tripRepository.save(new Trip(otherMember, "오사카", "오사카", DAY1,
-                DAY2, "Asia/Tokyo", "JPY")).getId();
+        Long otherTrip = tripRepository.save(new Trip(otherMember, "오사카", DAY1,
+                DAY2)).getId();
         activityRepository.save(new TripActivity(otherTrip, "남의 일정", DAY1, 0, null));
         activityRepository.save(new TripActivity(otherTrip, "남의 후보", null, 0, null));
         Long mine = activityRepository.save(new TripActivity(tripId, "센소지", DAY1, 0, null)).getId();
@@ -178,8 +178,8 @@ class TripActivityRepositoryTest {
     @DisplayName("findByIdAndTripId는 다른 여행의 일정을 넘겨주지 않는다")
     void findByIdScopedByTrip() {
         Long otherMember = memberRepository.save(new Member("other", "pw")).getId();
-        Long otherTrip = tripRepository.save(new Trip(otherMember, "오사카", "오사카", DAY1,
-                DAY2, "Asia/Tokyo", "JPY")).getId();
+        Long otherTrip = tripRepository.save(new Trip(otherMember, "오사카", DAY1,
+                DAY2)).getId();
         Long id = activityRepository.save(new TripActivity(tripId, "센소지", DAY1, 0, null)).getId();
 
         assertThat(activityRepository.findByIdAndTripId(id, tripId)).isPresent();

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TripDayRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TripDayRepositoryTest.java
@@ -1,0 +1,163 @@
+package ds.project.orino.domain.planner.travel.repository;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.travel.entity.PlaceKind;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import ds.project.orino.domain.planner.travel.entity.TripDay;
+import ds.project.orino.domain.support.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 날짜 ↔ 기준 도시 매핑을 고정한다. v2.1에서 타임존·통화·날씨 좌표가 전부 여기서 파생되므로,
+ * <b>이 매핑이 틀리면 화면은 멀쩡한데 시각만 조용히 어긋난다.</b>
+ */
+@RepositoryTest
+@Transactional
+class TripDayRepositoryTest {
+
+    private static final LocalDate DAY1 = LocalDate.of(2026, 10, 24);
+    private static final LocalDate DAY2 = LocalDate.of(2026, 10, 25);
+
+    @Autowired
+    private TripDayRepository dayRepository;
+    @Autowired
+    private TripRepository tripRepository;
+    @Autowired
+    private TravelPlaceRepository placeRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Long memberId;
+    private Long tripId;
+    private Long osaka;
+
+    @BeforeEach
+    void setUp() {
+        memberId = memberRepository.save(new Member("traveler", "pw")).getId();
+        tripId = tripRepository.save(new Trip(memberId, "간사이", DAY1, DAY2)).getId();
+        osaka = city("오사카", "Asia/Tokyo", "JPY").getId();
+    }
+
+    @Test
+    @DisplayName("날짜와 기준 도시가 그대로 저장·조회된다")
+    void savesAndLoads() {
+        TripDay saved = dayRepository.save(new TripDay(tripId, DAY1, osaka));
+        saved.updateCityMemo("체크아웃 후 교토역 코인로커에 짐 보관");
+        dayRepository.flush();
+
+        TripDay found = dayRepository.findById(saved.getId()).orElseThrow();
+        assertThat(found.getTripId()).isEqualTo(tripId);
+        assertThat(found.getDayDate()).isEqualTo(DAY1);
+        assertThat(found.getBasePlaceId()).isEqualTo(osaka);
+        assertThat(found.getCityMemo()).isEqualTo("체크아웃 후 교토역 코인로커에 짐 보관");
+        assertThat(found.getCreatedAt()).isNotNull();
+        assertThat(found.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("같은 여행·같은 날짜로 두 번 저장하면 UNIQUE 위반이다")
+    void rejectsDuplicateDate() {
+        dayRepository.save(new TripDay(tripId, DAY1, osaka));
+        dayRepository.flush();
+
+        // 하루에 기준 도시는 하나다 — 둘이면 그날의 타임존에 답이 두 개가 된다.
+        // id가 IDENTITY라 save 시점에 INSERT가 나가고 거기서 막힌다.
+        assertThatThrownBy(() -> dayRepository.save(new TripDay(tripId, DAY1, osaka)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("다른 여행이면 같은 날짜를 각자 가질 수 있다")
+    void allowsSameDateAcrossTrips() {
+        Long other = tripRepository.save(new Trip(memberId, "제주", DAY1, DAY2)).getId();
+        dayRepository.save(new TripDay(tripId, DAY1, osaka));
+        dayRepository.save(new TripDay(other, DAY1, osaka));
+
+        assertThat(dayRepository.countByTripId(tripId)).isEqualTo(1);
+        assertThat(dayRepository.countByTripId(other)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("여행 날짜는 날짜 오름차순으로 나온다(구간 파생이 연속성을 본다)")
+    void listsInDateOrder() {
+        dayRepository.save(new TripDay(tripId, DAY2, osaka));
+        dayRepository.save(new TripDay(tripId, DAY1, osaka));
+
+        assertThat(dayRepository.findAllByTripIdOrderByDayDateAsc(tripId))
+                .extracting(TripDay::getDayDate)
+                .containsExactly(DAY1, DAY2);
+    }
+
+    @Test
+    @DisplayName("여러 여행의 날짜를 한 번에 읽는다(목록 화면 N+1 회피)")
+    void listsAcrossTrips() {
+        Long other = tripRepository.save(new Trip(memberId, "제주", DAY1, DAY2)).getId();
+        dayRepository.save(new TripDay(tripId, DAY1, osaka));
+        dayRepository.save(new TripDay(other, DAY2, osaka));
+
+        assertThat(dayRepository
+                .findAllByTripIdInOrderByTripIdAscDayDateAsc(List.of(tripId, other)))
+                .extracting(TripDay::getTripId)
+                .containsExactly(tripId, other);
+    }
+
+    @Test
+    @DisplayName("기준 도시를 바꿔도 그 날짜의 도시 메모는 살아남는다")
+    void keepsCityMemoWhenBaseCityChanges() {
+        Long kyoto = city("교토", "Asia/Tokyo", "JPY").getId();
+        TripDay day = dayRepository.save(new TripDay(tripId, DAY1, osaka));
+        day.updateCityMemo("코인로커");
+        dayRepository.flush();
+
+        day.changeBaseCity(kyoto);
+        dayRepository.flush();
+
+        TripDay found = dayRepository.findByTripIdAndDayDate(tripId, DAY1).orElseThrow();
+        assertThat(found.getBasePlaceId()).isEqualTo(kyoto);
+        assertThat(found.getCityMemo()).isEqualTo("코인로커");
+    }
+
+    @Test
+    @DisplayName("공백만 남은 도시 메모는 비운 것으로 저장한다")
+    void blankMemoBecomesNull() {
+        TripDay day = dayRepository.save(new TripDay(tripId, DAY1, osaka));
+        day.updateCityMemo("   ");
+        dayRepository.flush();
+
+        assertThat(dayRepository.findById(day.getId()).orElseThrow().getCityMemo()).isNull();
+    }
+
+    @Test
+    @DisplayName("기준 도시에서 타임존·통화·좌표를 그대로 읽는다")
+    void baseCityCarriesTimezoneAndCurrency() {
+        dayRepository.save(new TripDay(tripId, DAY1, osaka));
+
+        TravelPlace city = placeRepository.findById(osaka).orElseThrow();
+        assertThat(city.getPlaceKind()).isEqualTo(PlaceKind.CITY);
+        assertThat(city.isCity()).isTrue();
+        assertThat(city.getTimezone()).isEqualTo("Asia/Tokyo");
+        assertThat(city.getCurrency()).isEqualTo("JPY");
+        assertThat(city.getLat()).isEqualByComparingTo("34.6937249");
+        assertThat(city.getLng()).isEqualByComparingTo("135.5022535");
+    }
+
+    private TravelPlace city(String name, String timezone, String currency) {
+        TravelPlace place = TravelPlace.manualCity(memberId, name, timezone, currency);
+        place.updateCoordinates(new BigDecimal("34.6937249"), new BigDecimal("135.5022535"));
+        return placeRepository.save(place);
+    }
+}

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TripRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TripRepositoryTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -18,8 +17,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * 여행 매핑과 목록 조회 규칙을 고정한다. 상태(예정/진행 중/완료)로 거르는 쿼리는 없다 —
- * 상태는 컬럼이 아니라 여행 타임존의 오늘로 파생하는 값이라 SQL에서 판정할 수 없고,
+ * 상태는 컬럼이 아니라 기준 도시 타임존의 오늘로 파생하는 값이라 SQL에서 판정할 수 없고,
  * 여기서는 그 대신 쓰는 기간 비교 조회만 검증한다(파생 판정은 {@code TripTest}).
+ *
+ * <p>v2.1부터 목적지·타임존·통화·좌표는 여행이 아니라 날짜의 기준 도시가 갖는다 —
+ * 그쪽 매핑은 {@code TripDayRepositoryTest}에서 본다.
  */
 @RepositoryTest
 @Transactional
@@ -40,35 +42,18 @@ class TripRepositoryTest {
     @Test
     @DisplayName("여행 필드가 그대로 저장·조회되고 알림 기본값이 붙는다")
     void savesAndLoadsTrip() {
-        Trip saved = tripRepository.save(new Trip(memberId, "도쿄 3박4일", "도쿄",
-                LocalDate.of(2026, 10, 24), LocalDate.of(2026, 10, 27), "Asia/Tokyo", "JPY"));
+        Trip saved = tripRepository.save(new Trip(memberId, "도쿄 3박4일",
+                LocalDate.of(2026, 10, 24), LocalDate.of(2026, 10, 27)));
 
         Trip found = tripRepository.findById(saved.getId()).orElseThrow();
         assertThat(found.getMemberId()).isEqualTo(memberId);
         assertThat(found.getTitle()).isEqualTo("도쿄 3박4일");
-        assertThat(found.getDestinationName()).isEqualTo("도쿄");
         assertThat(found.getStartDate()).isEqualTo(LocalDate.of(2026, 10, 24));
         assertThat(found.getEndDate()).isEqualTo(LocalDate.of(2026, 10, 27));
-        assertThat(found.getTimezone()).isEqualTo("Asia/Tokyo");
-        assertThat(found.getCurrency()).isEqualTo("JPY");
         assertThat(found.getDefaultNotifyMinutes()).isEqualTo(15);
         assertThat(found.isMorningSummaryEnabled()).isFalse();
-        // 1단계는 목적지를 수동 입력하므로 장소 참조가 비어 있다.
-        assertThat(found.getDestinationPlaceId()).isNull();
         assertThat(found.getCreatedAt()).isNotNull();
         assertThat(found.getUpdatedAt()).isNotNull();
-    }
-
-    @Test
-    @DisplayName("목적지 좌표(날씨 기준점)는 소수점 7자리까지 보존된다")
-    void keepsCoordinatePrecision() {
-        Trip trip = tripRepository.save(tokyoTrip());
-        trip.updateDestinationPlace(null, new BigDecimal("35.6812362"), new BigDecimal("139.7671248"));
-        tripRepository.flush();
-
-        Trip found = tripRepository.findById(trip.getId()).orElseThrow();
-        assertThat(found.getLat()).isEqualByComparingTo("35.6812362");
-        assertThat(found.getLng()).isEqualByComparingTo("139.7671248");
     }
 
     @Test
@@ -133,8 +118,8 @@ class TripRepositoryTest {
     void listsScopedByMember() {
         Long other = memberRepository.save(new Member("other", "pw")).getId();
         tripRepository.save(tokyoTrip());
-        tripRepository.save(new Trip(other, "남의 여행", "파리",
-                LocalDate.of(2026, 10, 24), LocalDate.of(2026, 10, 27), "Europe/Paris", "EUR"));
+        tripRepository.save(new Trip(other, "남의 여행",
+                LocalDate.of(2026, 10, 24), LocalDate.of(2026, 10, 27)));
 
         assertThat(tripRepository.findAllByMemberIdOrderByStartDateDescIdDesc(memberId))
                 .extracting(Trip::getTitle)
@@ -154,17 +139,15 @@ class TripRepositoryTest {
     }
 
     @Test
-    @DisplayName("update는 기간·타임존·통화를 함께 바꾼다")
+    @DisplayName("update는 제목과 기간을 함께 바꾼다")
     void updatesBasics() {
         Trip trip = tripRepository.save(tokyoTrip());
 
-        trip.update("오사카 2박3일", "오사카", LocalDate.of(2026, 11, 2),
-                LocalDate.of(2026, 11, 4), "Asia/Tokyo", "JPY");
+        trip.update("오사카 2박3일", LocalDate.of(2026, 11, 2), LocalDate.of(2026, 11, 4));
         tripRepository.flush();
 
         Trip found = tripRepository.findById(trip.getId()).orElseThrow();
         assertThat(found.getTitle()).isEqualTo("오사카 2박3일");
-        assertThat(found.getDestinationName()).isEqualTo("오사카");
         assertThat(found.getStartDate()).isEqualTo(LocalDate.of(2026, 11, 2));
         assertThat(found.getEndDate()).isEqualTo(LocalDate.of(2026, 11, 4));
         assertThat(found.totalDays()).isEqualTo(3);
@@ -188,7 +171,6 @@ class TripRepositoryTest {
     }
 
     private Trip trip(String title, String startDate, String endDate) {
-        return new Trip(memberId, title, title, LocalDate.parse(startDate),
-                LocalDate.parse(endDate), "Asia/Tokyo", "JPY");
+        return new Trip(memberId, title, LocalDate.parse(startDate), LocalDate.parse(endDate));
     }
 }

--- a/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TripStayRepositoryTest.java
+++ b/be/orino-domain-rdb/src/test/java/ds/project/orino/domain/planner/travel/repository/TripStayRepositoryTest.java
@@ -1,0 +1,132 @@
+package ds.project.orino.domain.planner.travel.repository;
+
+import ds.project.orino.domain.member.entity.Member;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import ds.project.orino.domain.planner.travel.entity.TripStay;
+import ds.project.orino.domain.support.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 숙소 매핑과 날짜 판정을 고정한다. 판정은 DB가 아니라 애플리케이션에서 하므로
+ * ({@code [in, out)} 반열린 구간) 경계 규칙을 여기서 못 박는다 —
+ * <b>체크아웃일 밤은 이미 다른 곳에서 잔다.</b>
+ */
+@RepositoryTest
+@Transactional
+class TripStayRepositoryTest {
+
+    private static final LocalDate OCT24 = LocalDate.of(2026, 10, 24);
+    private static final LocalDate OCT27 = LocalDate.of(2026, 10, 27);
+    private static final LocalDate OCT29 = LocalDate.of(2026, 10, 29);
+
+    @Autowired
+    private TripStayRepository stayRepository;
+    @Autowired
+    private TripRepository tripRepository;
+    @Autowired
+    private TravelPlaceRepository placeRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Long memberId;
+    private Long tripId;
+
+    @BeforeEach
+    void setUp() {
+        memberId = memberRepository.save(new Member("traveler", "pw")).getId();
+        tripId = tripRepository.save(new Trip(memberId, "간사이", OCT24, OCT29)).getId();
+    }
+
+    @Test
+    @DisplayName("숙소 필드가 그대로 저장·조회된다")
+    void savesAndLoads() {
+        Long placeId = placeRepository.save(
+                TravelPlace.manual(memberId, "호텔 한큐")).getId();
+        TripStay stay = stayRepository.save(new TripStay(tripId, "호텔 한큐", OCT24, OCT27));
+        stay.updateBasics("호텔 한큐 레스파이어", placeId, OCT24, OCT27);
+        stay.updateDetails(LocalTime.of(15, 0), LocalTime.of(11, 0),
+                "https://example.com/booking", "조식 포함");
+        stayRepository.flush();
+
+        TripStay found = stayRepository.findById(stay.getId()).orElseThrow();
+        assertThat(found.getTripId()).isEqualTo(tripId);
+        assertThat(found.getName()).isEqualTo("호텔 한큐 레스파이어");
+        assertThat(found.getPlaceId()).isEqualTo(placeId);
+        assertThat(found.getCheckInDate()).isEqualTo(OCT24);
+        assertThat(found.getCheckOutDate()).isEqualTo(OCT27);
+        // 벽시계 시각이다 — UTC로 환산하지 않는다.
+        assertThat(found.getCheckInTime()).isEqualTo(LocalTime.of(15, 0));
+        assertThat(found.getCheckOutTime()).isEqualTo(LocalTime.of(11, 0));
+        assertThat(found.getBookingUrl()).isEqualTo("https://example.com/booking");
+        assertThat(found.getMemo()).isEqualTo("조식 포함");
+        assertThat(found.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("체크인 날짜 오름차순으로 나온다")
+    void listsByCheckInDate() {
+        stayRepository.save(new TripStay(tripId, "교토 료칸", OCT27, OCT29));
+        stayRepository.save(new TripStay(tripId, "오사카 호텔", OCT24, OCT27));
+
+        assertThat(stayRepository.findAllByTripIdOrderByCheckInDateAscIdAsc(tripId))
+                .extracting(TripStay::getName)
+                .containsExactly("오사카 호텔", "교토 료칸");
+    }
+
+    @Test
+    @DisplayName("다른 여행의 숙소를 넘겨주지 않는다")
+    void scopedByTrip() {
+        Long other = tripRepository.save(new Trip(memberId, "제주", OCT24, OCT27)).getId();
+        Long id = stayRepository.save(new TripStay(tripId, "오사카 호텔", OCT24, OCT27)).getId();
+
+        assertThat(stayRepository.findByIdAndTripId(id, tripId)).isPresent();
+        assertThat(stayRepository.findByIdAndTripId(id, other)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("오늘 밤 자는 곳은 체크인 이상 체크아웃 미만인 날짜다")
+    void coversNightIsHalfOpen() {
+        TripStay stay = new TripStay(tripId, "오사카 호텔", OCT24, OCT27);
+
+        assertThat(stay.coversNight(LocalDate.of(2026, 10, 23))).isFalse();
+        assertThat(stay.coversNight(OCT24)).isTrue();
+        assertThat(stay.coversNight(LocalDate.of(2026, 10, 26))).isTrue();
+        // 체크아웃일 밤은 다른 곳에서 잔다.
+        assertThat(stay.coversNight(OCT27)).isFalse();
+        assertThat(stay.isCheckOutOn(OCT27)).isTrue();
+    }
+
+    @Test
+    @DisplayName("이동일(앞 숙소 체크아웃 = 뒤 숙소 체크인)은 겹침이 아니다")
+    void checkoutDayIsNotOverlap() {
+        TripStay osaka = new TripStay(tripId, "오사카 호텔", OCT24, OCT27);
+
+        assertThat(osaka.overlaps(OCT27, OCT29)).isFalse();
+        // 하루라도 밤이 겹치면 겹침이다.
+        assertThat(osaka.overlaps(LocalDate.of(2026, 10, 26), OCT29)).isTrue();
+        assertThat(osaka.overlaps(LocalDate.of(2026, 10, 20), LocalDate.of(2026, 10, 25))).isTrue();
+    }
+
+    @Test
+    @DisplayName("여행 기간이 줄면 체크아웃을 당기고, 묵는 밤이 없어지면 지울 대상이 된다")
+    void shrinkCheckOut() {
+        TripStay stay = stayRepository.save(new TripStay(tripId, "오사카 호텔", OCT24, OCT29));
+
+        stay.shrinkCheckOutTo(OCT27);
+        assertThat(stay.isEmptyPeriod()).isFalse();
+
+        stay.shrinkCheckOutTo(OCT24);
+        assertThat(stay.isEmptyPeriod()).isTrue();
+    }
+}


### PR DESCRIPTION
## 이슈
closes #1119

## 작업 내용

**v2.1 다구간 모델의 스키마를 세우고, `trip`에서 목적지 6개 컬럼을 걷어냈다.** 여기서부터 목적지의 진실은 `trip_day` 하나다.

### Liquibase `053-travel-multi-city.yaml`

한 파일에 순서대로 담았다 — 컬럼 삭제를 백필과 나누면 중간 상태에서 배포가 물린다.

1. `travel_place`에 v2.1 컬럼 (`city_name`·`city_place_ref`·`country_code`·`timezone`·`currency`·`place_kind`)
2. 기존 `trip.destination_place_id`가 가리키던 장소를 `CITY`로 승격 + 여행의 타임존·통화를 장소로 복사
3. `trip_day` · `trip_stay` 생성
4. 백필 — 여행 1건당 전 날짜에 `trip_day` INSERT (재귀 CTE). 목적지 장소가 NULL인 여행은 도시 장소를 만들어 붙인다
5. `trip`에서 `destination_name`·`destination_place_id`·`timezone`·`currency`·`lat`·`lng` DROP

`rollback`은 전부 작성했고, 5번 이후에는 목적지가 `trip_day`에만 남으므로 **첫날 기준 도시에서 되돌려 채우는** 방향이다. 되돌릴 지점에 `pre-travel-multi-city` 태그를 붙여 changeSet 수를 세지 않고 이름으로 되돌릴 수 있게 했다.

> `trip_day`·`trip_stay`는 자동 롤백을 쓰지 않는다. 자동 롤백은 인덱스를 먼저 지우려 드는데 `(trip_id, ...)` 인덱스를 FK가 쓰고 있어 MySQL이 거부한다 — 테이블을 지우는 명시 롤백으로 바꿨다. (마이그레이션 테스트가 잡았다)

### 엔티티 · 리포지토리

- `TripDay`(`day_date`·`base_place_id` NOT NULL·`city_memo`, `uk_day_trip_date`) · `TripStay`(반열린 구간 판정 메서드 포함) · `PlaceKind`
- `TravelPlace`에 v2.1 필드 + `promoteToCity`·`manualCity`
- `Trip`에서 목적지 6필드 제거. `status`·`daysUntilStart`·`todayIn`이 **판정 타임존을 인자로 받는다** — 어느 날짜의 도시를 쓸지는 값마다 달라서(상태는 오늘, D-day는 첫날) 호출부가 정한다
- `TripDayRepository` · `TripStayRepository`

### 컴파일이 깨진 자리 (= 옮긴 자리)

`trip.timezone`을 읽던 7개 서비스를 전부 기준 도시 기반으로 옮겼다. 목록은 이슈 코멘트에 남겼다.

- `TripDayService` — 날짜 집합을 기간과 일치시키고(`syncPeriod`) 기준 도시에서 타임존·통화·좌표를 파생하는 경로를 한 곳에 모았다. 흩어 두면 화면은 새 도시를 보여주는데 알림은 옛 시각에 가는, 사용자가 알아차릴 방법이 없는 오류가 난다
- `BaseCityResolver` — 화면이 아직 보내는 목적지 하나(이름 또는 장소)를 도시 장소로 승격·생성한다. 구간 입력은 #1121
- 알림 발송시각은 **그 날짜 기준 도시의 타임존**으로 환산한다(루프가 이미 날짜별이라 자연스럽게 갈렸다). 아침 요약의 전날 08:00 규칙은 4단계 몫

API 응답 형태는 그대로다 — 단일 도시 여행에서 첫날 기준 도시가 곧 v2.0의 목적지라, 응답이 전과 같다.

## 테스트

- `TripDayRepositoryTest` · `TripStayRepositoryTest` — 매핑 · UNIQUE · 반열린 구간 경계
- `TravelMultiCityMigrationTest` — **전용 컨테이너에서 태그까지 롤백 → v2.0 여행 2건 심기 → 다시 적용.** 빈 DB에 처음부터 적용하면 백필이 한 행도 건드리지 않아 아무것도 증명하지 못한다. 롤백문과 백필문이 둘 다 실제로 검증된다
- `TravelSchemaTest` — FK 규칙·인덱스·컬럼 타입에 `trip_day`·`trip_stay` 추가, `trip`에 목적지 컬럼이 없음을 직접 확인

`./gradlew check` 통과 (904 tests)

## 로컬 확인

`bootRun` + curl로 직접 확인했다.

- 마이그레이션 후 `trip`에 목적지 컬럼 없음, `trip_day`·`trip_stay` 생성됨
- 여행 생성 → 기간 4일에 `trip_day` 4행, 전부 오사카(`CITY`, Asia/Tokyo, JPY, 좌표)
- 기간 10/27 → 10/29로 늘림 → 6행, 새 날짜가 앞 날짜 도시를 상속
- 목적지를 호놀룰루로 바꾸고 기간 축소 → 4행으로 줄고 전 날짜가 새 도시로 바뀜, 도시 장소가 새로 생성됨
- 보드 조회가 기준 도시의 타임존·통화로 헤더를 그림