### PR TITLE
feat : 구간 입력으로 여행 생성·수정 API 교체 (날짜 전개)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/BaseCityResolver.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/BaseCityResolver.java
@@ -2,75 +2,61 @@ package ds.project.orino.planner.travel.day.service;
 
 import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
-import ds.project.orino.domain.planner.travel.entity.PlaceKind;
 import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.planner.travel.place.service.PlaceService;
+import ds.project.orino.planner.travel.trip.dto.TripLegRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
+import java.util.List;
 
 /**
- * 이름·타임존·통화로 들어온 목적지를 <b>도시 장소</b>로 바꾼다.
+ * 구간이 가리키는 도시를 <b>기준 도시로 쓸 수 있는 장소</b>로 바꾼다.
  *
- * <p>v2.1에서 타임존·통화의 주인은 여행이 아니라 도시다. 그런데 화면은 아직 목적지 하나를
- * 보내고(구간 입력은 #1121), 그 목적지가 검색으로 고른 장소일 수도 직접 친 이름일 수도 있다.
- * 두 경우 모두 기준 도시로 쓸 행이 있어야 하므로 여기서 승격하거나 만들어 준다.
+ * <p>입력은 두 가지다 — 이미 담아 둔 도시({@code cityPlaceId})거나, 검색 결과 그대로
+ * ({@code cityGooglePlaceId})다. 뒤쪽을 받는 이유는 일정 담기와 같다: 고르기 전에 저장부터
+ * 하라고 하면 저장했다가 취소한 도시가 쌓인다.
  *
- * <p>같은 멤버가 같은 도시를 다시 쓰면 <b>행을 새로 만들지 않는다.</b> 이름만 같은 도시 행이
- * 여럿이면 도시 일치 판정({@code cityPlaceRef})이 여행마다 갈려, 같은 오사카인데 어떤 여행에서만
- * "다른 도시"로 표시된다.
+ * <p><b>도시가 아닌 장소는 거절한다.</b> "오사카성"을 기준 도시로 받으면 타임존은 우연히
+ * 맞지만 도시 일치 판정({@code cityPlaceRef})이 그날 일정을 전부 "다른 도시"로 만든다.
  */
 @Component
 public class BaseCityResolver {
 
     private final TravelPlaceRepository placeRepository;
+    private final PlaceService placeService;
 
-    public BaseCityResolver(TravelPlaceRepository placeRepository) {
+    public BaseCityResolver(TravelPlaceRepository placeRepository, PlaceService placeService) {
         this.placeRepository = placeRepository;
+        this.placeService = placeService;
+    }
+
+    /** 구간 목록의 도시를 순서대로 해석한다. 같은 도시가 여러 번 나오면 같은 행을 가리킨다. */
+    @Transactional
+    public List<TravelPlace> resolveAll(Long memberId, List<TripLegRequest> legs) {
+        return legs.stream().map(leg -> resolve(memberId, leg)).toList();
+    }
+
+    @Transactional
+    public TravelPlace resolve(Long memberId, TripLegRequest leg) {
+        if (leg.cityPlaceId() != null) {
+            return requireCity(placeRepository
+                    .findByIdAndMemberId(leg.cityPlaceId(), memberId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PLACE_NOT_FOUND)));
+        }
+        return requireCity(
+                placeService.upsertCityFromGoogle(memberId, leg.cityGooglePlaceId().trim()));
     }
 
     /**
-     * 기준 도시로 쓸 장소를 찾아 반환한다. 필요하면 만들고, 검색으로 고른 장소면 도시로
-     * 승격한다.
-     *
-     * @param placeId 검색으로 고른 장소. {@code null}이면 이름으로 도시를 만든다
+     * 도시로 쓸 수 있는지 확인한다. 타임존이 없는 도시도 막는다 — 저장은 되지만 그 날짜의
+     * 시각 계산이 전부 기기 타임존으로 떨어져, 화면은 멀쩡한데 알림만 엉뚱한 시각에 간다.
      */
-    @Transactional
-    public TravelPlace resolve(Long memberId, Long placeId, String name,
-                               String timezone, String currency,
-                               BigDecimal lat, BigDecimal lng) {
-        TravelPlace city = placeId != null
-                ? promote(memberId, placeId, name, timezone, currency)
-                : findOrCreateManualCity(memberId, name, timezone, currency);
-
-        // 좌표는 날씨 조회의 기준점이다. 검색으로 고른 도시는 이미 갖고 있으므로 덮지 않는다.
-        if (city.getLat() == null && lat != null && lng != null) {
-            city.updateCoordinates(lat, lng);
+    private TravelPlace requireCity(TravelPlace place) {
+        if (!place.isCity() || place.getTimezone() == null) {
+            throw new CustomException(ErrorCode.TRAVEL_NOT_A_CITY);
         }
-        return placeRepository.save(city);
-    }
-
-    private TravelPlace promote(Long memberId, Long placeId, String name,
-                                String timezone, String currency) {
-        TravelPlace place = placeRepository.findByIdAndMemberId(placeId, memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PLACE_NOT_FOUND));
-        // 목적지로 고른 장소는 곧 그 여행의 도시다 — v2.0의 destination_place_id가
-        // 그런 의미였고, 마이그레이션도 같은 판단으로 CITY 표시를 달았다.
-        place.promoteToCity(name, timezone, currency);
         return place;
-    }
-
-    private TravelPlace findOrCreateManualCity(Long memberId, String name,
-                                               String timezone, String currency) {
-        return placeRepository
-                .findFirstByMemberIdAndNameAndPlaceKindAndGooglePlaceIdIsNull(
-                        memberId, name, PlaceKind.CITY)
-                .map(existing -> {
-                    // 같은 이름의 도시라도 타임존·통화는 이번 입력이 최신이다.
-                    existing.promoteToCity(name, timezone, currency);
-                    return existing;
-                })
-                .orElseGet(() -> TravelPlace.manualCity(memberId, name, timezone, currency));
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/LegExpander.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/LegExpander.java
@@ -1,0 +1,71 @@
+package ds.project.orino.planner.travel.day.service;
+
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 구간(도시 + 일수)을 <b>날짜별 기준 도시</b>로 편다. 입력은 구간이고 진실은 날짜다.
+ *
+ * <pre>
+ * [오사카 3일][교토 1일][나고야 1일] + 10.24–11.02
+ *   → 10.24·25·26 오사카 / 10.27 교토 / 10.28 나고야 / 10.29~11.02 나고야(상속)
+ * </pre>
+ *
+ * <p><b>합계와 기간이 달라도 막지 않는다.</b> 여행을 짜는 중간 상태가 대부분 불일치라,
+ * 400으로 거절하면 도시를 하나 추가할 때마다 기간을 먼저 늘려야 한다.
+ *
+ * <ul>
+ *   <li>합계가 <b>모자라면</b> 남은 날짜가 마지막 구간 도시를 이어 쓴다</li>
+ *   <li>합계가 <b>넘치면</b> 기간을 채운 시점에서 뒤 구간이 잘린다</li>
+ * </ul>
+ *
+ * <p>순수 계산이라 서비스에서 떼어 둔다 — 이 규칙이 v2.1 입력의 전부라 따로 검증할 수 있어야
+ * 한다.
+ */
+public final class LegExpander {
+
+    private LegExpander() {
+    }
+
+    /**
+     * @param legs 구간별 (기준 도시 장소 id, 일수). 순서가 곧 방문 순서다
+     * @return 날짜 → 기준 도시 장소 id. 기간의 <b>모든</b> 날짜가 들어 있다
+     */
+    public static Map<LocalDate, Long> expand(LocalDate startDate, LocalDate endDate,
+                                              List<Leg> legs) {
+        if (legs.isEmpty()) {
+            throw new IllegalArgumentException("구간이 하나도 없으면 날짜에 기준 도시를 줄 수 없습니다.");
+        }
+        Map<LocalDate, Long> byDate = new LinkedHashMap<>();
+        int legIndex = 0;
+        int usedInLeg = 0;
+
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            // 현재 구간의 일수를 다 쓰면 다음 구간으로. 마지막 구간에서는 더 갈 곳이 없어
+            // 그대로 머무는데, 그게 "남은 날짜가 마지막 도시를 상속한다"는 규칙이다.
+            while (usedInLeg >= legs.get(legIndex).days() && legIndex < legs.size() - 1) {
+                legIndex++;
+                usedInLeg = 0;
+            }
+            byDate.put(date, legs.get(legIndex).basePlaceId());
+            usedInLeg++;
+        }
+        return byDate;
+    }
+
+    /**
+     * 해석이 끝난 구간 하나.
+     *
+     * @param days 1 이상. 0을 허용하면 도시가 하루도 없는 구간이 생겨 순서만 차지한다
+     */
+    public record Leg(Long basePlaceId, int days) {
+
+        public Leg {
+            if (days < 1) {
+                throw new IllegalArgumentException("구간의 일수는 1일 이상이어야 합니다.");
+            }
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/TripDayService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/TripDayService.java
@@ -89,14 +89,35 @@ public class TripDayService {
     }
 
     /**
-     * 전 날짜의 기준 도시를 하나로 맞춘다. 여행 전체의 목적지를 한 번에 바꾸는 화면(v2.0 폼)만
-     * 쓴다 — 날짜별로 다르게 두는 길은 기준 도시 변경 API(#1122)다.
+     * 구간을 편 결과({@code 날짜 → 기준 도시})를 그대로 반영한다. 기간과 도시 배치를 한 번에
+     * 맞추므로 여행 생성·구간 재전개가 이걸 쓴다.
+     *
+     * <p><b>{@code cityMemo}는 날짜 기준으로 살아남는다.</b> 행을 지웠다 새로 만들지 않고
+     * 남아 있는 날짜의 기준 도시만 바꾼다 — 도시가 바뀌어도 그 날짜에 적어 둔 메모("체크아웃 후
+     * 코인로커에 짐 보관")는 여전히 그 날짜의 일이다.
      */
     @Transactional
-    public void rebaseAll(Long tripId, Long basePlaceId) {
-        List<TripDay> days = dayRepository.findAllByTripIdOrderByDayDateAsc(tripId);
-        days.forEach(day -> day.changeBaseCity(basePlaceId));
-        dayRepository.saveAll(days);
+    public void applyPlan(Trip trip, Map<LocalDate, Long> baseCityByDate) {
+        Map<LocalDate, TripDay> existing = dayRepository
+                .findAllByTripIdOrderByDayDateAsc(trip.getId()).stream()
+                .collect(Collectors.toMap(TripDay::getDayDate, Function.identity(),
+                        (first, second) -> first, LinkedHashMap::new));
+
+        dayRepository.deleteAll(existing.entrySet().stream()
+                .filter(entry -> !baseCityByDate.containsKey(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .toList());
+
+        List<TripDay> created = new ArrayList<>();
+        baseCityByDate.forEach((date, basePlaceId) -> {
+            TripDay day = existing.get(date);
+            if (day == null) {
+                created.add(new TripDay(trip.getId(), date, basePlaceId));
+            } else {
+                day.changeBaseCity(basePlaceId);
+            }
+        });
+        dayRepository.saveAll(created);
     }
 
     /** 여행 전체의 날짜 → 기준 도시. 도시는 여러 날짜가 공유하므로 장소는 한 번씩만 읽는다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/TripStayShrinkService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/TripStayShrinkService.java
@@ -1,0 +1,69 @@
+package ds.project.orino.planner.travel.day.service;
+
+import ds.project.orino.domain.planner.travel.entity.TripStay;
+import ds.project.orino.domain.planner.travel.repository.TripStayRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 여행 기간이 줄 때 걸쳐 있던 숙소를 정리한다.
+ *
+ * <p>기간 밖으로 밀려난 체크아웃일을 <b>새 종료일로 당긴다.</b> 그냥 두면 여행이 끝난 뒤까지
+ * 묵는 숙소가 남아 "오늘 밤 자는 곳"이 기간 밖 날짜에도 잡힌다.
+ *
+ * <p>당긴 결과 묵는 밤이 하나도 없어지면({@code in >= out}) 숙소를 지운다. 0박짜리 숙소를
+ * 남겨두면 목록에는 있는데 어느 날짜에도 안 붙는 유령이 된다.
+ */
+@Service
+public class TripStayShrinkService {
+
+    private final TripStayRepository stayRepository;
+
+    public TripStayShrinkService(TripStayRepository stayRepository) {
+        this.stayRepository = stayRepository;
+    }
+
+    /** 실제로 바꾸지 않고 몇 건이 줄고 몇 건이 사라지는지만 센다(확인 모달용). */
+    public Impact preview(Long tripId, LocalDate newEndDate) {
+        long shrunk = 0;
+        long removed = 0;
+        for (TripStay stay : affected(tripId, newEndDate)) {
+            if (!stay.getCheckInDate().isBefore(newEndDate)) {
+                removed++;
+            } else {
+                shrunk++;
+            }
+        }
+        return new Impact(shrunk, removed);
+    }
+
+    @Transactional
+    public Impact apply(Long tripId, LocalDate newEndDate) {
+        long shrunk = 0;
+        long removed = 0;
+        for (TripStay stay : affected(tripId, newEndDate)) {
+            stay.shrinkCheckOutTo(newEndDate);
+            if (stay.isEmptyPeriod()) {
+                stayRepository.delete(stay);
+                removed++;
+            } else {
+                shrunk++;
+            }
+        }
+        return new Impact(shrunk, removed);
+    }
+
+    /** 체크아웃일이 새 종료일보다 뒤인 숙소만 영향을 받는다. */
+    private List<TripStay> affected(Long tripId, LocalDate newEndDate) {
+        return stayRepository.findAllByTripIdOrderByCheckInDateAscIdAsc(tripId).stream()
+                .filter(stay -> stay.getCheckOutDate().isAfter(newEndDate))
+                .toList();
+    }
+
+    /** @param shrunkCount 기간만 줄어든 숙소 · @param removedCount 묵는 밤이 없어져 지워진 숙소 */
+    public record Impact(long shrunkCount, long removedCount) {
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceCreateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/dto/PlaceCreateRequest.java
@@ -1,5 +1,6 @@
 package ds.project.orino.planner.travel.place.dto;
 
+import ds.project.orino.domain.planner.travel.entity.PlaceKind;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -7,6 +8,12 @@ import java.math.BigDecimal;
 
 /**
  * 직접 입력한 장소(S-06 "검색 결과가 없어요"). 구글에 없는 곳도 일정에 넣을 수 있어야 한다.
+ *
+ * <p>{@code kind = CITY}면 <b>기준 도시로 쓸 수 있는 도시 장소</b>를 만든다. 도시 검색이 못
+ * 찾는 곳으로 가는 여행도 기준 도시가 없으면 타임존이 없어 시각 계산이 통째로 죽는다.
+ * 이때는 구글이 알려줄 수 없으므로 {@code timezone}·{@code currency}를 함께 받는다.
+ *
+ * @param kind 생략하면 {@link PlaceKind#POI}
  */
 public record PlaceCreateRequest(
         @NotBlank(message = "장소 이름을 입력해 주세요.")
@@ -17,6 +24,18 @@ public record PlaceCreateRequest(
         String address,
 
         BigDecimal lat,
-        BigDecimal lng
+        BigDecimal lng,
+
+        PlaceKind kind,
+
+        @Size(max = 64, message = "시간대가 너무 깁니다.")
+        String timezone,
+
+        @Size(max = 3, message = "통화 코드는 3자리입니다.")
+        String currency
 ) {
+
+    public boolean isCity() {
+        return kind == PlaceKind.CITY;
+    }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
@@ -23,6 +23,7 @@ import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 
 import java.time.Clock;
+import java.time.ZoneId;
 import java.util.Currency;
 import java.util.List;
 import java.util.Locale;
@@ -147,12 +148,67 @@ public class PlaceService {
         return placeRepository.save(place);
     }
 
-    /** 직접 입력. 검색에 안 나오는 곳도 일정에 넣을 수 있어야 한다. */
+    /**
+     * 구글 도시를 담고 <b>기준 도시로 쓸 수 있게 승격</b>한다. 구간 입력이 검색 결과를 그대로
+     * 보내면 여기서 id로 바뀐다.
+     *
+     * <p>타임존은 도시로 쓰이는 장소의 필수 조건이라, 이미 담아 둔 장소인데 타임존이 비어
+     * 있으면(일정 장소로 먼저 담긴 경우) 상세를 한 번 더 불러 채운다.
+     */
+    @Transactional
+    public TravelPlace upsertCityFromGoogle(Long memberId, String googlePlaceId) {
+        TravelPlace place = upsertFromGoogle(memberId, googlePlaceId);
+        if (place.getTimezone() != null) {
+            place.promoteToCity(place.getCityName() != null ? place.getCityName() : place.getName(),
+                    place.getTimezone(), place.getCurrency());
+            return place;
+        }
+        PlaceResult fresh = placesClient.fetchDetails(googlePlaceId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PLACE_NOT_FOUND));
+        place.promoteToCity(place.getName(), fresh.timezone(), currencyOf(fresh.countryCode()));
+        place.updateCityInfo(place.getName(), googlePlaceId, fresh.countryCode());
+        return place;
+    }
+
+    /**
+     * 직접 입력. 검색에 안 나오는 곳도 일정에 넣을 수 있어야 한다.
+     *
+     * <p>{@code kind = CITY}면 도시로 저장한다 — 도시 검색이 못 찾는 곳으로 여행을 갈 때도
+     * 기준 도시는 있어야 한다(그때는 타임존·통화를 사용자가 고른다).
+     */
     @Transactional
     public PlaceDetail createManual(Long memberId, PlaceCreateRequest request) {
         TravelPlace place = TravelPlace.manual(memberId, request.name().trim());
         place.updateBasics(request.address(), request.lat(), request.lng(), null, null);
+        if (request.isCity()) {
+            requireValidTimezone(request.timezone());
+            String currency = normalizedCurrency(request.currency());
+            requireValidCurrency(currency);
+            place.promoteToCity(request.name().trim(), request.timezone(), currency);
+        }
         return PlaceDetail.from(placeRepository.save(place));
+    }
+
+    /**
+     * IANA 지역 ID만 받는다. {@code ZoneId.of}는 {@code "UTC+09:00"} 같은 오프셋도 통과시키는데,
+     * 오프셋은 서머타임을 모르므로 알림 시각 환산이 계절에 따라 어긋난다.
+     */
+    private void requireValidTimezone(String timezone) {
+        if (timezone == null || !ZoneId.getAvailableZoneIds().contains(timezone)) {
+            throw new CustomException(ErrorCode.TRAVEL_INVALID_TIMEZONE);
+        }
+    }
+
+    private void requireValidCurrency(String currency) {
+        try {
+            Currency.getInstance(currency);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new CustomException(ErrorCode.TRAVEL_INVALID_CURRENCY);
+        }
+    }
+
+    private String normalizedCurrency(String currency) {
+        return currency == null ? null : currency.trim().toUpperCase(Locale.ROOT);
     }
 
     // ---------------- helpers ----------------

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/controller/TripController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/controller/TripController.java
@@ -9,6 +9,8 @@ import ds.project.orino.planner.travel.trip.dto.TripListResponse;
 import ds.project.orino.planner.travel.trip.dto.TripWriteRequest;
 import ds.project.orino.planner.travel.trip.service.TripService;
 import jakarta.validation.Valid;
+import jakarta.validation.groups.Default;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -46,9 +48,12 @@ public class TripController {
         return ApiResponse.success(tripService.list(memberId, status));
     }
 
+    /** 생성은 구간이 필수라 {@link TripWriteRequest.OnCreate} 그룹까지 함께 검증한다. */
     @PostMapping("/trips")
-    public ApiResponse<TripDetail> create(@AuthenticationPrincipal Long memberId,
-                                          @Valid @RequestBody TripWriteRequest request) {
+    public ApiResponse<TripDetail> create(
+            @AuthenticationPrincipal Long memberId,
+            @Validated({Default.class, TripWriteRequest.OnCreate.class})
+            @RequestBody TripWriteRequest request) {
         return ApiResponse.success(tripService.create(memberId, request));
     }
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/ShrinkPreviewResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/ShrinkPreviewResponse.java
@@ -1,11 +1,19 @@
 package ds.project.orino.planner.travel.trip.dto;
 
 /**
- * 기간을 줄였을 때 보관함으로 밀려날 일정 수. 확인 모달의 "일정 {n}개가 미배정 보관함으로
- * 이동합니다."에 그대로 들어간다.
+ * 기간을 줄였을 때 무엇이 밀려나는지. 확인 모달의 "잘리는 날짜의 일정 4개가 미배정 보관함으로
+ * 이동하고, 걸쳐 있던 숙소는 기간이 줄어듭니다."에 그대로 들어간다.
  *
  * <p>기간 단축을 확인 없이 시도했을 때의 409 응답에도 같은 형태로 실린다 — 클라이언트가
  * 미리보기를 건너뛰었더라도 같은 숫자를 보고 다시 물어볼 수 있어야 한다.
+ *
+ * @param movedActivityCount 보관함으로 옮겨질 일정 수
+ * @param shrunkStayCount    체크아웃일이 당겨질 숙소 수 (v2.1)
+ * @param removedStayCount   묵는 밤이 없어져 지워질 숙소 수 (v2.1)
  */
-public record ShrinkPreviewResponse(long movedActivityCount) {
+public record ShrinkPreviewResponse(
+        long movedActivityCount,
+        long shrunkStayCount,
+        long removedStayCount
+) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripLegRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripLegRequest.java
@@ -1,0 +1,41 @@
+package ds.project.orino.planner.travel.trip.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+/**
+ * 구간 하나 — <b>도시 + 머무는 일수</b>. 목록의 순서가 곧 방문 순서다.
+ *
+ * <p>날짜가 아니라 일수를 받는다. 여행을 짜는 동안 기간은 계속 움직이는데, 구간마다 날짜를
+ * 적어 두면 기간을 하루 늘릴 때마다 뒤 구간을 전부 고쳐야 한다.
+ *
+ * <p>도시는 <b>둘 중 하나</b>로 지정한다.
+ * <ul>
+ *   <li>{@code cityPlaceId} — 이미 담아 둔 도시 장소({@code place_kind = CITY})</li>
+ *   <li>{@code cityGooglePlaceId} — 검색 결과를 그대로. 서버가 담고 도시로 승격한다</li>
+ * </ul>
+ *
+ * <p>검색 결과를 그대로 받는 쪽이 있는 이유는 일정 담기와 같다 — 화면이 "고른 것"을 보내면
+ * 서버가 id로 바꾼다. 고르기 전에 저장부터 하라고 하면 저장했다가 취소한 도시가 쌓인다.
+ */
+public record TripLegRequest(
+        Long cityPlaceId,
+
+        String cityGooglePlaceId,
+
+        @NotNull(message = "구간의 일수를 입력해 주세요.")
+        @Positive(message = "구간의 일수는 1일 이상이어야 합니다.")
+        Integer days
+) {
+
+    /** 둘 다 없으면 도시를 알 수 없고, 둘 다 있으면 어느 쪽이 맞는지 서버가 정할 수 없다. */
+    @JsonIgnore
+    @AssertTrue(message = "구간의 도시는 cityPlaceId 또는 cityGooglePlaceId 중 하나로 지정해 주세요.")
+    public boolean isCityGivenExactlyOnce() {
+        boolean hasPlaceId = cityPlaceId != null;
+        boolean hasGoogleId = cityGooglePlaceId != null && !cityGooglePlaceId.isBlank();
+        return hasPlaceId ^ hasGoogleId;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripWriteRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripWriteRequest.java
@@ -1,38 +1,36 @@
 package ds.project.orino.planner.travel.trip.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 
 /**
  * 여행 생성·수정 요청. 생성과 수정이 같은 필드를 쓰므로(전체 수정) 한 타입으로 둔다.
  *
- * <p>날짜는 여행 타임존의 벽시계 값이다 — UTC 오프셋을 붙이지 않는다.
+ * <p>날짜는 벽시계 값이다 — UTC 오프셋을 붙이지 않는다. 기준 타임존은 여행이 아니라
+ * <b>그 날짜의 기준 도시</b>가 갖는다.
  *
- * @param title                  최대 50자. 비우면 {@code destinationName}으로 채워 저장한다
- * @param destinationName        목적지 표시명(필수)
- * @param destinationPlaceId     2단계~. 1단계는 생략한다
- * @param timezone               IANA 타임존 ID. 상태·D-day·알림 환산의 기준이라 값 검증을 한다
- * @param currency               ISO 4217 3자리
- * @param lat                    목적지 좌표(날씨 기준점)
- * @param defaultNotifyMinutes   여행 단위 기본 알림 시점(분 전). 생략 시 기존값 유지
- * @param morningSummaryEnabled  아침 요약 알림. 생략 시 기존값 유지
- * @param confirmArchive         기간 단축으로 잘리는 일정을 보관함으로 옮겨도 좋다는 확인.
- *                               없으면 서버가 409로 거부한다
+ * <p><b>v2.1 — 목적지 하나가 아니라 구간 목록을 받는다.</b> 타임존·통화·좌표는 받지 않는다.
+ * 도시가 그 값들의 주인이라, 여행이 따로 들고 있으면 도시를 옮겨 다닐 때 서로 어긋난다.
+ *
+ * @param title                 최대 50자, 필수. 목적지가 여행에 없으니 자동으로 채울 이름도 없다
+ * @param legs                  구간 목록(도시 + 일수). 생성에는 반드시 있어야 하고,
+ *                              수정에서 생략하면 날짜별 기준 도시를 건드리지 않는다
+ * @param defaultNotifyMinutes  여행 단위 기본 알림 시점(분 전). 생략 시 기존값 유지
+ * @param morningSummaryEnabled 아침 요약 알림. 생략 시 기존값 유지
+ * @param confirmArchive        기간 단축으로 잘리는 일정을 보관함으로 옮겨도 좋다는 확인.
+ *                              없으면 서버가 409로 거부한다
  */
 public record TripWriteRequest(
+        @NotBlank(message = "여행 제목을 입력해 주세요.")
         @Size(max = 50, message = "제목은 50자를 넘을 수 없습니다.")
         String title,
-
-        @NotBlank(message = "목적지를 입력해 주세요.")
-        @Size(max = 100, message = "목적지는 100자를 넘을 수 없습니다.")
-        String destinationName,
-
-        Long destinationPlaceId,
 
         @NotNull(message = "시작일을 입력해 주세요.")
         LocalDate startDate,
@@ -40,14 +38,9 @@ public record TripWriteRequest(
         @NotNull(message = "종료일을 입력해 주세요.")
         LocalDate endDate,
 
-        @NotBlank(message = "시간대를 입력해 주세요.")
-        String timezone,
-
-        @NotBlank(message = "통화를 입력해 주세요.")
-        String currency,
-
-        BigDecimal lat,
-        BigDecimal lng,
+        @Valid
+        @NotEmpty(groups = OnCreate.class, message = "구간을 하나 이상 입력해 주세요.")
+        List<TripLegRequest> legs,
 
         @Positive(message = "알림 시점은 0보다 커야 합니다.")
         Integer defaultNotifyMinutes,
@@ -56,19 +49,23 @@ public record TripWriteRequest(
         Boolean confirmArchive
 ) {
 
-    /** 제목 컬럼 길이. 목적지명(100자)으로 채울 때 넘칠 수 있어 여기서 자른다. */
-    private static final int TITLE_MAX = 50;
-
-    /** 제목 미입력 시 목적지명으로 채운다 — 제목 없는 여행 카드를 만들지 않는다. */
-    public String resolvedTitle() {
-        if (title != null && !title.isBlank()) {
-            return title.trim();
-        }
-        String fallback = destinationName.trim();
-        return fallback.length() <= TITLE_MAX ? fallback : fallback.substring(0, TITLE_MAX);
+    /**
+     * 생성에만 거는 검증 그룹. 구간은 <b>생성에서 필수</b>지만 수정에서는 생략할 수 있다 —
+     * 알림 설정만 바꾸려는 요청이 도시 배치를 되감지 않게 하려면 "안 보냄"과 "비움"을
+     * 구분해야 한다.
+     */
+    public interface OnCreate {
     }
 
     public boolean archiveConfirmed() {
         return Boolean.TRUE.equals(confirmArchive);
+    }
+
+    /**
+     * 구간을 보냈는가. 수정에서 생략하면 날짜별 기준 도시는 그대로 두고 기간만 맞춘다 —
+     * 알림 설정만 바꾸려는 요청이 도시 배치를 통째로 되감으면 안 된다.
+     */
+    public boolean hasLegs() {
+        return legs != null && !legs.isEmpty();
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/service/TripService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/service/TripService.java
@@ -10,7 +10,9 @@ import ds.project.orino.domain.planner.travel.repository.TripActivityCount;
 import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
 import ds.project.orino.domain.planner.travel.repository.TripRepository;
 import ds.project.orino.planner.travel.day.service.BaseCityResolver;
+import ds.project.orino.planner.travel.day.service.LegExpander;
 import ds.project.orino.planner.travel.day.service.TripDayService;
+import ds.project.orino.planner.travel.day.service.TripStayShrinkService;
 import ds.project.orino.planner.travel.trip.dto.ShrinkPreviewResponse;
 import ds.project.orino.planner.travel.trip.dto.TravelSummaryResponse;
 import ds.project.orino.planner.travel.trip.dto.TripDetail;
@@ -25,9 +27,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Comparator;
-import java.util.Currency;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -52,6 +52,7 @@ public class TripService {
     private final NotificationScheduleService notificationService;
     private final TripDayService tripDayService;
     private final BaseCityResolver baseCityResolver;
+    private final TripStayShrinkService stayShrinkService;
     private final Clock clock;
 
     public TripService(TripRepository tripRepository,
@@ -59,25 +60,27 @@ public class TripService {
                        NotificationScheduleService notificationService,
                        TripDayService tripDayService,
                        BaseCityResolver baseCityResolver,
+                       TripStayShrinkService stayShrinkService,
                        Clock clock) {
         this.tripRepository = tripRepository;
         this.activityRepository = activityRepository;
         this.notificationService = notificationService;
         this.tripDayService = tripDayService;
         this.baseCityResolver = baseCityResolver;
+        this.stayShrinkService = stayShrinkService;
         this.clock = clock;
     }
 
     @Transactional
     public TripDetail create(Long memberId, TripWriteRequest request) {
-        validate(request);
-        Trip trip = new Trip(memberId, request.resolvedTitle(),
+        requireValidPeriod(request.startDate(), request.endDate());
+        Trip trip = new Trip(memberId, request.title().trim(),
                 request.startDate(), request.endDate());
         applyOptionalSettings(trip, request);
         Trip saved = tripRepository.save(trip);
         tripRepository.flush();
         // 날짜 행이 없으면 타임존이 없는 여행이 된다 — 같은 트랜잭션에서 반드시 채운다.
-        tripDayService.syncPeriod(saved, resolveBaseCity(memberId, request).getId());
+        tripDayService.applyPlan(saved, expandLegs(memberId, saved, request));
         // 아침 요약은 일정이 아니라 날짜에 매달려 있어, 일정이 하나도 없어도 지금 잡힌다(§4.3).
         notificationService.rescheduleTrip(saved.getId());
         return detailOf(saved);
@@ -113,33 +116,35 @@ public class TripService {
      */
     @Transactional
     public TripDetail update(Long memberId, Long tripId, TripWriteRequest request) {
-        validate(request);
+        requireValidPeriod(request.startDate(), request.endDate());
         Trip trip = getOwned(memberId, tripId);
 
         long movedCount = activityRepository.countOutsidePeriod(
                 tripId, request.startDate(), request.endDate());
         if (movedCount > 0 && !request.archiveConfirmed()) {
+            TripStayShrinkService.Impact stays =
+                    stayShrinkService.preview(tripId, request.endDate());
             throw CustomException.withData(ErrorCode.TRAVEL_ARCHIVE_CONFIRM_REQUIRED,
-                    new ShrinkPreviewResponse(movedCount));
+                    new ShrinkPreviewResponse(movedCount,
+                            stays.shrunkCount(), stays.removedCount()));
         }
 
-        // 타임존이 바뀌어도 일정의 벽시계 시각은 건드리지 않는다 — 09:00은 어디서든 09:00이다.
-        trip.update(request.resolvedTitle(), request.startDate(), request.endDate());
+        // 기준 도시가 바뀌어도 일정의 벽시계 시각은 건드리지 않는다 — 09:00은 어디서든 09:00이다.
+        trip.update(request.title().trim(), request.startDate(), request.endDate());
         applyOptionalSettings(trip, request);
 
         if (movedCount > 0) {
             archiveActivitiesOutsidePeriod(trip);
         }
-        // 기간이 바뀌었으면 날짜 집합도 같이 움직여야 한다. 새로 생긴 날짜는 앞 날짜의
-        // 도시를 물려받고, 남아 있는 날짜의 도시 메모는 그대로다.
-        TravelPlace city = resolveBaseCity(memberId, request);
-        tripDayService.syncPeriod(trip, city.getId());
-        // 이 화면은 여행 전체의 목적지 <b>하나</b>를 보낸다(v2.0 폼). 목적지를 바꿨다면 전
-        // 날짜가 따라 바뀌는 게 그 화면의 뜻이다. 날짜마다 다른 도시를 두는 길은 구간 입력
-        // (#1121)과 기준 도시 변경 API(#1122)로 따로 열린다.
-        if (!city.getId().equals(tripDayService.primaryCity(trip.getId()).getId())) {
-            tripDayService.rebaseAll(trip.getId(), city.getId());
+        // 기간이 바뀌었으면 날짜 집합도 같이 움직여야 한다. 구간을 보냈으면 그대로 다시 펴고,
+        // 생략했으면 도시 배치는 두고 기간만 맞춘다(새 날짜는 앞 날짜 도시를 상속).
+        if (request.hasLegs()) {
+            tripDayService.applyPlan(trip, expandLegs(memberId, trip, request));
+        } else {
+            tripDayService.syncPeriod(trip, tripDayService.primaryCity(tripId).getId());
         }
+        // 걸쳐 있던 숙소는 체크아웃일을 새 종료일로 당기고, 묵는 밤이 없어지면 지운다.
+        stayShrinkService.apply(tripId, request.endDate());
         tripRepository.flush();
         // §4.2 — 타임존이 바뀌면 벽시계 시각은 그대로고 알림 시각만 전부 다시 계산된다.
         // 기본 알림 시점·기간 변경도 같은 재계산으로 흡수된다.
@@ -147,15 +152,17 @@ public class TripService {
         return detailOf(trip);
     }
 
-    /** 기간을 이렇게 바꾸면 몇 개가 보관함으로 가는지. 생략한 날짜는 현재 값을 쓴다. */
+    /** 기간을 이렇게 바꾸면 무엇이 밀려나는지. 생략한 날짜는 현재 값을 쓴다. */
     public ShrinkPreviewResponse shrinkPreview(Long memberId, Long tripId,
                                                LocalDate startDate, LocalDate endDate) {
         Trip trip = getOwned(memberId, tripId);
         LocalDate newStart = startDate != null ? startDate : trip.getStartDate();
         LocalDate newEnd = endDate != null ? endDate : trip.getEndDate();
         requireValidPeriod(newStart, newEnd);
+        TripStayShrinkService.Impact stays = stayShrinkService.preview(tripId, newEnd);
         return new ShrinkPreviewResponse(
-                activityRepository.countOutsidePeriod(tripId, newStart, newEnd));
+                activityRepository.countOutsidePeriod(tripId, newStart, newEnd),
+                stays.shrunkCount(), stays.removedCount());
     }
 
     /** 여행 삭제 — 일정은 FK CASCADE로 함께 정리된다. */
@@ -220,13 +227,16 @@ public class TripService {
     }
 
     /**
-     * 요청의 목적지를 기준 도시로 바꾼다. 이름·타임존·통화가 여행이 아니라 도시에 붙는
-     * 것이 v2.1이라, 저장 전에 도시 행을 확보해야 한다.
+     * 구간을 날짜로 편다. 도시 해석과 전개를 한 곳에 묶어 두는 이유는, 둘 사이에 다른 일이
+     * 끼면 "저장은 됐는데 어떤 날짜에는 도시가 없는" 중간 상태가 생기기 때문이다.
      */
-    private TravelPlace resolveBaseCity(Long memberId, TripWriteRequest request) {
-        return baseCityResolver.resolve(memberId, request.destinationPlaceId(),
-                request.destinationName().trim(), request.timezone(),
-                normalizedCurrency(request.currency()), request.lat(), request.lng());
+    private Map<LocalDate, Long> expandLegs(Long memberId, Trip trip, TripWriteRequest request) {
+        List<TravelPlace> cities = baseCityResolver.resolveAll(memberId, request.legs());
+        List<LegExpander.Leg> legs = new java.util.ArrayList<>();
+        for (int i = 0; i < cities.size(); i++) {
+            legs.add(new LegExpander.Leg(cities.get(i).getId(), request.legs().get(i).days()));
+        }
+        return LegExpander.expand(trip.getStartDate(), trip.getEndDate(), legs);
     }
 
     private void applyOptionalSettings(Trip trip, TripWriteRequest request) {
@@ -238,38 +248,10 @@ public class TripService {
         trip.updateNotificationSettings(notifyMinutes, morningSummary);
     }
 
-    private void validate(TripWriteRequest request) {
-        requireValidPeriod(request.startDate(), request.endDate());
-        requireValidTimezone(request.timezone());
-        requireValidCurrency(request.currency());
-    }
-
     private void requireValidPeriod(LocalDate startDate, LocalDate endDate) {
         if (endDate.isBefore(startDate)) {
             throw new CustomException(ErrorCode.TRAVEL_INVALID_PERIOD);
         }
-    }
-
-    /**
-     * IANA 지역 ID만 받는다. {@code ZoneId.of}는 {@code "UTC+09:00"} 같은 오프셋도 통과시키는데,
-     * 오프셋은 서머타임을 모르므로 알림 시각 환산이 계절에 따라 어긋난다.
-     */
-    private void requireValidTimezone(String timezone) {
-        if (!ZoneId.getAvailableZoneIds().contains(timezone)) {
-            throw new CustomException(ErrorCode.TRAVEL_INVALID_TIMEZONE);
-        }
-    }
-
-    private void requireValidCurrency(String currency) {
-        try {
-            Currency.getInstance(normalizedCurrency(currency));
-        } catch (IllegalArgumentException e) {
-            throw new CustomException(ErrorCode.TRAVEL_INVALID_CURRENCY);
-        }
-    }
-
-    private String normalizedCurrency(String currency) {
-        return currency.trim().toUpperCase(Locale.ROOT);
     }
 
     /** 여행별 첫날 기준 도시. 상태·D-day·목적지 표시가 전부 여기서 나온다. */

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/activity/controller/ActivityControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/activity/controller/ActivityControllerTest.java
@@ -9,6 +9,7 @@ import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.FixedClockConfig;
 import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.TravelCityFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -431,10 +432,11 @@ class ActivityControllerTest extends ApiTestSupport {
                         .header(HttpHeaders.AUTHORIZATION, header)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"title": "도쿄", "destinationName": "도쿄",
+                                {"title": "도쿄",
                                  "startDate": "2026-10-24", "endDate": "2026-10-27",
-                                 "timezone": "Asia/Tokyo", "currency": "JPY"}
-                                """))
+                                 %s}
+                                """.formatted(TravelCityFixture.singleLeg(
+                                        cityId(header), 4))))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         return ((Number) JsonPath.read(body, "$.data.id")).longValue();
@@ -482,4 +484,9 @@ class ActivityControllerTest extends ApiTestSupport {
         assertThat(ordered).extracting(TripActivity::getSortOrder)
                 .containsExactlyElementsOf(IntStream.range(0, expectedIds.size()).boxed().toList());
     }
+
+    private long cityId(String header) throws Exception {
+        return TravelCityFixture.createCity(mockMvc, header, "도쿄", "Asia/Tokyo", "JPY");
+    }
+
 }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/activity/controller/ActivityLogTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/activity/controller/ActivityLogTest.java
@@ -8,6 +8,7 @@ import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.FixedClockConfig;
 import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.TravelCityFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -223,10 +224,11 @@ class ActivityLogTest extends ApiTestSupport {
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"title": "도쿄", "destinationName": "도쿄",
+                                {"title": "도쿄",
                                  "startDate": "%s", "endDate": "%s",
-                                 "timezone": "Asia/Tokyo", "currency": "JPY"}
-                                """.formatted(startDate, endDate)))
+                                 %s}
+                                """.formatted(startDate, endDate,
+                                        TravelCityFixture.singleLeg(cityId(), 1))))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         return ((Number) JsonPath.read(body, "$.data.id")).longValue();
@@ -251,4 +253,9 @@ class ActivityLogTest extends ApiTestSupport {
                 .andReturn().getResponse().getContentAsString();
         return ((Number) JsonPath.read(body, "$.data.tripId")).longValue();
     }
+
+    private long cityId() throws Exception {
+        return TravelCityFixture.createCity(mockMvc, authHeader, "도쿄", "Asia/Tokyo", "JPY");
+    }
+
 }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardControllerTest.java
@@ -7,6 +7,7 @@ import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.FixedClockConfig;
 import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.TravelCityFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -209,13 +210,16 @@ class BoardControllerTest extends ApiTestSupport {
 
     private long createTrip(String title, String start, String end,
                             String timezone, String currency) throws Exception {
+        // 타임존·통화는 여행이 아니라 기준 도시가 갖는다(v2.1).
+        long cityId = TravelCityFixture.createCity(mockMvc, authHeader, title,
+                timezone, currency);
         String body = mockMvc.perform(post("/api/travel/trips")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"title": "%s", "destinationName": "%s", "startDate": "%s",
-                                 "endDate": "%s", "timezone": "%s", "currency": "%s"}
-                                """.formatted(title, title, start, end, timezone, currency)))
+                                {"title": "%s", "startDate": "%s", "endDate": "%s", %s}
+                                """.formatted(title, start, end,
+                                        TravelCityFixture.singleLeg(cityId, 1))))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         return ((Number) JsonPath.read(body, "$.data.id")).longValue();

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/day/LegExpanderTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/day/LegExpanderTest.java
@@ -1,0 +1,115 @@
+package ds.project.orino.planner.travel.day;
+
+import ds.project.orino.planner.travel.day.service.LegExpander;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 구간 → 날짜 전개 규칙을 고정한다. <b>입력은 구간, 진실은 날짜</b>라는 v2.1의 전제가 여기서
+ * 지켜지지 않으면 어떤 날짜는 도시가 없거나 두 도시를 갖는다.
+ *
+ * <p>합계와 기간이 어긋나도 저장을 막지 않는 것이 규칙이라, 어긋났을 때 무엇이 되는지가
+ * 곧 사양이다.
+ */
+class LegExpanderTest {
+
+    private static final LocalDate OCT24 = LocalDate.of(2026, 10, 24);
+    private static final Long TOKYO = 1L;
+    private static final Long NIKKO = 2L;
+    private static final Long OSAKA = 3L;
+
+    @Test
+    @DisplayName("[도쿄 3][닛코 1][도쿄 2] → 날짜 6개, 도시 구간 3개")
+    void expandsInOrder() {
+        Map<LocalDate, Long> byDate = LegExpander.expand(OCT24, OCT24.plusDays(5), List.of(
+                new LegExpander.Leg(TOKYO, 3),
+                new LegExpander.Leg(NIKKO, 1),
+                new LegExpander.Leg(TOKYO, 2)));
+
+        assertThat(byDate).hasSize(6);
+        assertThat(byDate.values()).containsExactly(TOKYO, TOKYO, TOKYO, NIKKO, TOKYO, TOKYO);
+        assertThat(byDate.keySet()).containsExactly(
+                OCT24, OCT24.plusDays(1), OCT24.plusDays(2),
+                OCT24.plusDays(3), OCT24.plusDays(4), OCT24.plusDays(5));
+    }
+
+    @Test
+    @DisplayName("합계가 기간보다 짧으면 남은 날짜가 마지막 도시를 이어 쓴다")
+    void shortageInheritsLastCity() {
+        // 합계 5일 / 기간 10일
+        Map<LocalDate, Long> byDate = LegExpander.expand(OCT24, OCT24.plusDays(9), List.of(
+                new LegExpander.Leg(TOKYO, 3),
+                new LegExpander.Leg(NIKKO, 1),
+                new LegExpander.Leg(OSAKA, 1)));
+
+        assertThat(byDate).hasSize(10);
+        assertThat(byDate.get(OCT24.plusDays(4))).isEqualTo(OSAKA);
+        assertThat(byDate.get(OCT24.plusDays(9))).isEqualTo(OSAKA);
+    }
+
+    @Test
+    @DisplayName("합계가 기간보다 길면 뒤 구간이 잘린다 — 저장을 막지 않는다")
+    void excessTruncatesTailLegs() {
+        // 합계 12일 / 기간 4일
+        Map<LocalDate, Long> byDate = LegExpander.expand(OCT24, OCT24.plusDays(3), List.of(
+                new LegExpander.Leg(TOKYO, 3),
+                new LegExpander.Leg(NIKKO, 4),
+                new LegExpander.Leg(OSAKA, 5)));
+
+        assertThat(byDate).hasSize(4);
+        assertThat(byDate.values()).containsExactly(TOKYO, TOKYO, TOKYO, NIKKO);
+        assertThat(byDate.values()).doesNotContain(OSAKA);
+    }
+
+    @Test
+    @DisplayName("구간이 하나면 전 날짜가 그 도시다")
+    void singleLegFillsPeriod() {
+        Map<LocalDate, Long> byDate = LegExpander.expand(OCT24, OCT24.plusDays(3),
+                List.of(new LegExpander.Leg(TOKYO, 1)));
+
+        assertThat(byDate.values()).containsOnly(TOKYO);
+        assertThat(byDate).hasSize(4);
+    }
+
+    @Test
+    @DisplayName("당일치기도 하루가 나온다")
+    void singleDayTrip() {
+        Map<LocalDate, Long> byDate = LegExpander.expand(OCT24, OCT24,
+                List.of(new LegExpander.Leg(TOKYO, 3)));
+
+        assertThat(byDate).containsExactly(Map.entry(OCT24, TOKYO));
+    }
+
+    @Test
+    @DisplayName("구간 순서를 바꾸면 날짜 배치가 다시 계산된다")
+    void reorderingLegsChangesDates() {
+        Map<LocalDate, Long> before = LegExpander.expand(OCT24, OCT24.plusDays(3), List.of(
+                new LegExpander.Leg(TOKYO, 2), new LegExpander.Leg(OSAKA, 2)));
+        Map<LocalDate, Long> after = LegExpander.expand(OCT24, OCT24.plusDays(3), List.of(
+                new LegExpander.Leg(OSAKA, 2), new LegExpander.Leg(TOKYO, 2)));
+
+        assertThat(before.values()).containsExactly(TOKYO, TOKYO, OSAKA, OSAKA);
+        assertThat(after.values()).containsExactly(OSAKA, OSAKA, TOKYO, TOKYO);
+    }
+
+    @Test
+    @DisplayName("구간이 없으면 전개할 수 없다 — 타임존 없는 날짜를 만들지 않는다")
+    void rejectsEmptyLegs() {
+        assertThatThrownBy(() -> LegExpander.expand(OCT24, OCT24.plusDays(1), List.of()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("0일짜리 구간은 만들 수 없다 — 순서만 차지하고 하루도 갖지 않는다")
+    void rejectsZeroDayLeg() {
+        assertThatThrownBy(() -> new LegExpander.Leg(TOKYO, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/photo/TravelPhotoIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/photo/TravelPhotoIntegrationTest.java
@@ -9,6 +9,7 @@ import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.FixedClockConfig;
 import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.TravelCityFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -274,14 +275,17 @@ class TravelPhotoIntegrationTest extends ApiTestSupport {
     }
 
     private long createTrip(String startDate, String endDate) throws Exception {
+        long cityId = TravelCityFixture.createCity(mockMvc, authHeader, "도쿄",
+                "Asia/Tokyo", "JPY");
         String body = mockMvc.perform(post("/api/travel/trips")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"title": "도쿄", "destinationName": "도쿄",
+                                {"title": "도쿄",
                                  "startDate": "%s", "endDate": "%s",
-                                 "timezone": "Asia/Tokyo", "currency": "JPY"}
-                                """.formatted(startDate, endDate)))
+                                 %s}
+                                """.formatted(startDate, endDate,
+                                        TravelCityFixture.singleLeg(cityId, 1))))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         return ((Number) JsonPath.read(body, "$.data.id")).longValue();

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
@@ -10,6 +10,7 @@ import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.MemberFixture;
 import ds.project.orino.support.StubExternalsConfig;
+import ds.project.orino.support.TravelCityFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -258,6 +259,51 @@ class PlaceControllerTest extends ApiTestSupport {
         }
 
         @Test
+        @DisplayName("kind=CITY면 기준 도시로 쓸 수 있는 도시 장소가 된다")
+        void createsManualCity() throws Exception {
+            // 도시 검색이 못 찾는 곳으로 가는 여행도 기준 도시는 있어야 한다.
+            mockMvc.perform(post("/api/travel/places")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "울란바토르", "kind": "CITY",
+                                     "timezone": "Asia/Ulaanbaatar", "currency": "mnt"}
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.name").value("울란바토르"))
+                    .andExpect(jsonPath("$.data.manualEntry").value(true));
+        }
+
+        @Test
+        @DisplayName("도시의 시간대는 IANA ID만 받는다 — 오프셋 표기는 400")
+        void rejectsNonIanaTimezoneForCity() throws Exception {
+            // 오프셋은 서머타임을 모르므로 알림 환산이 계절에 따라 어긋난다.
+            mockMvc.perform(post("/api/travel/places")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "도쿄", "kind": "CITY",
+                                     "timezone": "UTC+09:00", "currency": "JPY"}
+                                    """))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-003"));
+        }
+
+        @Test
+        @DisplayName("도시의 통화가 ISO 4217이 아니면 400")
+        void rejectsUnknownCurrencyForCity() throws Exception {
+            mockMvc.perform(post("/api/travel/places")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "도쿄", "kind": "CITY",
+                                     "timezone": "Asia/Tokyo", "currency": "ZZZ"}
+                                    """))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-004"));
+        }
+
+        @Test
         @DisplayName("이름이 없으면 400")
         void rejectsBlankName() throws Exception {
             mockMvc.perform(post("/api/travel/places")
@@ -371,15 +417,17 @@ class PlaceControllerTest extends ApiTestSupport {
 
     /** 편향 검증용 — 목적지 좌표가 있는 여행. */
     private long createTripWithCoordinates() throws Exception {
+        // 편향 좌표는 이제 기준 도시가 갖는다.
+        long cityId = TravelCityFixture.createCity(mockMvc, authHeader, "도쿄",
+                "Asia/Tokyo", "JPY", "35.6762", "139.6503");
         String body = mockMvc.perform(post("/api/travel/trips")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"title": "도쿄", "destinationName": "도쿄",
+                                {"title": "도쿄",
                                  "startDate": "2026-10-24", "endDate": "2026-10-27",
-                                 "timezone": "Asia/Tokyo", "currency": "JPY",
-                                 "lat": 35.6762, "lng": 139.6503}
-                                """))
+                                 %s}
+                                """.formatted(TravelCityFixture.singleLeg(cityId, 4))))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/MorningSummaryTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/MorningSummaryTest.java
@@ -14,6 +14,7 @@ import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.MemberFixture;
 import ds.project.orino.support.StubExternalsConfig;
+import ds.project.orino.support.TravelCityFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -75,15 +76,17 @@ class MorningSummaryTest extends ApiTestSupport {
 
     /** 과거 날짜로 만든다 — 08:00이 이미 지나 있어야 발송 대상이 된다. */
     private long createTrip(boolean morningSummary) throws Exception {
+        long cityId = tokyoCityId();
         String body = mockMvc.perform(post("/api/travel/trips")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"title": "도쿄", "destinationName": "도쿄",
+                                {"title": "도쿄",
                                  "startDate": "2020-01-01", "endDate": "2020-01-03",
-                                 "timezone": "Asia/Tokyo", "currency": "JPY",
+                                 %s,
                                  "morningSummaryEnabled": %s}
-                                """.formatted(morningSummary)))
+                                """.formatted(TravelCityFixture.singleLeg(cityId, 3),
+                                        morningSummary)))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
@@ -151,9 +154,8 @@ class MorningSummaryTest extends ApiTestSupport {
                             .header(HttpHeaders.AUTHORIZATION, authHeader)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
-                                    {"title": "도쿄", "destinationName": "도쿄",
+                                    {"title": "도쿄",
                                      "startDate": "2020-01-01", "endDate": "2020-01-03",
-                                     "timezone": "Asia/Tokyo", "currency": "JPY",
                                      "morningSummaryEnabled": true}
                                     """))
                     .andExpect(status().isOk());
@@ -171,9 +173,8 @@ class MorningSummaryTest extends ApiTestSupport {
                             .header(HttpHeaders.AUTHORIZATION, authHeader)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
-                                    {"title": "도쿄", "destinationName": "도쿄",
+                                    {"title": "도쿄",
                                      "startDate": "2020-01-01", "endDate": "2020-01-02",
-                                     "timezone": "Asia/Tokyo", "currency": "JPY",
                                      "morningSummaryEnabled": true, "confirmArchive": true}
                                     """))
                     .andExpect(status().isOk());
@@ -251,4 +252,9 @@ class MorningSummaryTest extends ApiTestSupport {
                     .contains("/travel/trips/" + tripId + "/board?date=2020-01-01"));
         }
     }
+
+    private long tokyoCityId() throws Exception {
+        return TravelCityFixture.createCity(mockMvc, authHeader, "도쿄", "Asia/Tokyo", "JPY");
+    }
+
 }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/NotificationDispatchTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/NotificationDispatchTest.java
@@ -12,6 +12,7 @@ import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.MemberFixture;
 import ds.project.orino.support.StubExternalsConfig;
+import ds.project.orino.support.TravelCityFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -70,14 +71,16 @@ class NotificationDispatchTest extends ApiTestSupport {
         subscriptionRepository.save(
                 new PushSubscription(memberId, ENDPOINT, "p256dh", "auth", "Android"));
 
+        long cityId = TravelCityFixture.createCity(mockMvc, authHeader, "도쿄",
+                "Asia/Tokyo", "JPY");
         String body = mockMvc.perform(post("/api/travel/trips")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"title": "도쿄", "destinationName": "도쿄",
+                                {"title": "도쿄",
                                  "startDate": "2020-01-01", "endDate": "2020-01-02",
-                                 "timezone": "Asia/Tokyo", "currency": "JPY"}
-                                """))
+                                 %s}
+                                """.formatted(TravelCityFixture.singleLeg(cityId, 2))))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         tripId = ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
@@ -151,14 +154,17 @@ class NotificationDispatchTest extends ApiTestSupport {
             addPastActivity("지금 갈 것");
 
             // 먼 미래 여행을 따로 만들어 예약만 잡아 둔다.
+            long futureCity = TravelCityFixture.createCity(mockMvc, authHeader, "도쿄",
+                    "Asia/Tokyo", "JPY");
             String future = mockMvc.perform(post("/api/travel/trips")
                             .header(HttpHeaders.AUTHORIZATION, authHeader)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
-                                    {"title": "먼 여행", "destinationName": "도쿄",
+                                    {"title": "먼 여행",
                                      "startDate": "2090-01-01", "endDate": "2090-01-02",
-                                     "timezone": "Asia/Tokyo", "currency": "JPY"}
-                                    """))
+                                     %s}
+                                    """.formatted(
+                                            TravelCityFixture.singleLeg(futureCity, 2))))
                     .andExpect(status().isOk())
                     .andReturn().getResponse().getContentAsString();
             long futureTripId =

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/NotificationScheduleTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/NotificationScheduleTest.java
@@ -13,6 +13,7 @@ import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.MemberFixture;
 import ds.project.orino.support.StubExternalsConfig;
+import ds.project.orino.support.TravelCityFixture;
 import ds.project.orino.planner.travel.route.StubRoutesClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -77,15 +78,16 @@ class NotificationScheduleTest extends ApiTestSupport {
     }
 
     private long createTrip(String timezone) throws Exception {
+        long cityId = TravelCityFixture.createCity(mockMvc, authHeader, "도쿄", timezone, "JPY");
         String body = mockMvc.perform(post("/api/travel/trips")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"title": "도쿄", "destinationName": "도쿄",
+                                {"title": "도쿄",
                                  "startDate": "2026-10-24", "endDate": "2026-10-27",
-                                 "timezone": "%s", "currency": "JPY",
+                                 %s,
                                  "defaultNotifyMinutes": 15}
-                                """.formatted(timezone)))
+                                """.formatted(TravelCityFixture.singleLeg(cityId, 4))))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
@@ -271,14 +273,17 @@ class NotificationScheduleTest extends ApiTestSupport {
             assertThat(pending()).singleElement().satisfies(n ->
                     assertThat(n.getScheduledAt()).isEqualTo(Instant.parse("2026-10-23T23:45:00Z")));
 
+            // v2.1에서 타임존을 바꾸는 길은 기준 도시를 바꾸는 것 하나뿐이다.
+            long bangkok = TravelCityFixture.createCity(mockMvc, authHeader, "방콕",
+                    "Asia/Bangkok", "THB");
             mockMvc.perform(put("/api/travel/trips/" + tripId)
                             .header(HttpHeaders.AUTHORIZATION, authHeader)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
-                                    {"title": "도쿄", "destinationName": "방콕",
+                                    {"title": "도쿄",
                                      "startDate": "2026-10-24", "endDate": "2026-10-27",
-                                     "timezone": "Asia/Bangkok", "currency": "THB"}
-                                    """))
+                                     %s}
+                                    """.formatted(TravelCityFixture.singleLeg(bangkok, 4))))
                     .andExpect(status().isOk());
 
             // 09:00은 어디서든 09:00이지만, 방콕(UTC+7) 09:00은 도쿄(UTC+9) 09:00보다 2시간 늦다.

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/TravelTimeIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/TravelTimeIntegrationTest.java
@@ -10,6 +10,7 @@ import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.MemberFixture;
 import ds.project.orino.support.StubExternalsConfig;
+import ds.project.orino.support.TravelCityFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -96,10 +97,11 @@ class TravelTimeIntegrationTest extends ApiTestSupport {
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"title": "도쿄", "destinationName": "도쿄",
+                                {"title": "도쿄",
                                  "startDate": "2026-10-24", "endDate": "2026-10-27",
-                                 "timezone": "Asia/Tokyo", "currency": "JPY"}
-                                """))
+                                 %s}
+                                """.formatted(TravelCityFixture.singleLeg(
+                                        cityId("도쿄"), 4))))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
@@ -490,6 +492,12 @@ class TravelTimeIntegrationTest extends ApiTestSupport {
                             .header(HttpHeaders.AUTHORIZATION, otherAuth))
                     .andExpect(status().isNotFound());
         }
+    }
+
+
+    /** 여행에는 기준 도시가 있어야 한다(v2.1). 같은 이름이어도 매번 새로 만든다. */
+    private long cityId(String name) throws Exception {
+        return TravelCityFixture.createCity(mockMvc, authHeader, name, "Asia/Tokyo", "JPY");
     }
 
 }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/ToolsControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/ToolsControllerTest.java
@@ -11,6 +11,7 @@ import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.MemberFixture;
 import ds.project.orino.support.StubExternalsConfig;
+import ds.project.orino.support.TravelCityFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -74,17 +75,19 @@ class ToolsControllerTest extends ApiTestSupport {
     }
 
     private long createTrip(boolean withCoordinates) throws Exception {
-        String coords = withCoordinates
-                ? ", \"lat\": %s, \"lng\": %s".formatted(jitter("35.6764"), jitter("139.6500"))
-                : "";
+        // 날씨 좌표는 여행이 아니라 기준 도시가 갖는다. 좌표가 없는 도시면 날씨도 없다.
+        long cityId = withCoordinates
+                ? TravelCityFixture.createCity(mockMvc, authHeader, "도쿄", "Asia/Tokyo", "JPY",
+                        jitter("35.6764").toPlainString(), jitter("139.6500").toPlainString())
+                : TravelCityFixture.createCity(mockMvc, authHeader, "도쿄", "Asia/Tokyo", "JPY");
         String body = mockMvc.perform(post("/api/travel/trips")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"title": "도쿄", "destinationName": "도쿄",
+                                {"title": "도쿄",
                                  "startDate": "2026-10-24", "endDate": "2026-10-26",
-                                 "timezone": "Asia/Tokyo", "currency": "JPY"%s}
-                                """.formatted(coords)))
+                                 %s}
+                                """.formatted(TravelCityFixture.singleLeg(cityId, 3))))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/trip/controller/TripControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/trip/controller/TripControllerTest.java
@@ -9,6 +9,7 @@ import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.FixedClockConfig;
 import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.TravelCityFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -82,33 +83,53 @@ class TripControllerTest extends ApiTestSupport {
         }
 
         @Test
-        @DisplayName("제목을 비우면 목적지명으로 채워 저장한다")
-        void fallsBackToDestinationName() throws Exception {
+        @DisplayName("제목은 필수다 — 목적지가 여행에 없으니 채울 이름도 없다")
+        void rejectsBlankTitle() throws Exception {
+            long cityId = TravelCityFixture.createCity(mockMvc, authHeader, "오사카",
+                    "Asia/Tokyo", "JPY");
             mockMvc.perform(post("/api/travel/trips")
                             .header(HttpHeaders.AUTHORIZATION, authHeader)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
-                                    {"title": "  ", "destinationName": "오사카",
-                                     "startDate": "2026-10-24", "endDate": "2026-10-27",
-                                     "timezone": "Asia/Tokyo", "currency": "JPY"}
-                                    """))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.title").value("오사카"));
+                                    {"title": "  ",
+                                     "startDate": "2026-10-24", "endDate": "2026-10-27", %s}
+                                    """.formatted(TravelCityFixture.singleLeg(cityId, 4))))
+                    .andExpect(status().isBadRequest());
         }
 
         @Test
-        @DisplayName("통화는 소문자로 보내도 대문자로 저장된다")
-        void normalizesCurrency() throws Exception {
+        @DisplayName("구간이 없으면 400 — 어느 날짜도 기준 도시를 갖지 못한다")
+        void rejectsMissingLegs() throws Exception {
             mockMvc.perform(post("/api/travel/trips")
                             .header(HttpHeaders.AUTHORIZATION, authHeader)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
-                                    {"destinationName": "도쿄", "startDate": "2026-10-24",
-                                     "endDate": "2026-10-27", "timezone": "Asia/Tokyo",
-                                     "currency": "jpy"}
+                                    {"title": "도쿄", "startDate": "2026-10-24",
+                                     "endDate": "2026-10-27"}
                                     """))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("도시가 아닌 장소를 구간에 넣으면 400")
+        void rejectsNonCityPlace() throws Exception {
+            String place = mockMvc.perform(post("/api/travel/places")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"name\": \"센소지\"}"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.currency").value("JPY"));
+                    .andReturn().getResponse().getContentAsString();
+            long poiId = ((Number) JsonPath.read(place, "$.data.id")).longValue();
+
+            mockMvc.perform(post("/api/travel/trips")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "도쿄", "startDate": "2026-10-24",
+                                     "endDate": "2026-10-27", %s}
+                                    """.formatted(TravelCityFixture.singleLeg(poiId, 4))))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-016"));
         }
 
         @Test
@@ -120,36 +141,6 @@ class TripControllerTest extends ApiTestSupport {
                             .content(tripBody("도쿄", "도쿄", "2026-10-27", "2026-10-24")))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value("TRAVEL-ERR-002"));
-        }
-
-        @Test
-        @DisplayName("IANA ID가 아닌 시간대는 400 — 오프셋 표기도 거부한다")
-        void rejectsNonIanaTimezone() throws Exception {
-            mockMvc.perform(post("/api/travel/trips")
-                            .header(HttpHeaders.AUTHORIZATION, authHeader)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("""
-                                    {"destinationName": "도쿄", "startDate": "2026-10-24",
-                                     "endDate": "2026-10-27", "timezone": "UTC+09:00",
-                                     "currency": "JPY"}
-                                    """))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-003"));
-        }
-
-        @Test
-        @DisplayName("ISO 4217이 아닌 통화는 400")
-        void rejectsUnknownCurrency() throws Exception {
-            mockMvc.perform(post("/api/travel/trips")
-                            .header(HttpHeaders.AUTHORIZATION, authHeader)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("""
-                                    {"destinationName": "도쿄", "startDate": "2026-10-24",
-                                     "endDate": "2026-10-27", "timezone": "Asia/Tokyo",
-                                     "currency": "ZZZ"}
-                                    """))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-004"));
         }
 
         @Test
@@ -288,9 +279,8 @@ class TripControllerTest extends ApiTestSupport {
                             .header(HttpHeaders.AUTHORIZATION, authHeader)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
-                                    {"title": "도쿄", "destinationName": "도쿄",
+                                    {"title": "도쿄",
                                      "startDate": "2026-10-24", "endDate": "2026-10-25",
-                                     "timezone": "Asia/Tokyo", "currency": "JPY",
                                      "confirmArchive": true}
                                     """))
                     .andExpect(status().isOk())
@@ -355,8 +345,8 @@ class TripControllerTest extends ApiTestSupport {
         }
 
         @Test
-        @DisplayName("타임존을 바꿔도 일정의 벽시계 시각은 그대로다")
-        void timezoneChangeKeepsWallClockTimes() throws Exception {
+        @DisplayName("기준 도시를 바꿔도 일정의 벽시계 시각은 그대로다")
+        void baseCityChangeKeepsWallClockTimes() throws Exception {
             long tripId = createTrip("도쿄", "도쿄", "2026-10-24", "2026-10-27");
             long activityId = addActivity(tripId, "09시 출발", LocalDate.of(2026, 10, 24),
                     LocalTime.of(9, 0));
@@ -364,11 +354,8 @@ class TripControllerTest extends ApiTestSupport {
             mockMvc.perform(put("/api/travel/trips/" + tripId)
                             .header(HttpHeaders.AUTHORIZATION, authHeader)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content("""
-                                    {"title": "하와이", "destinationName": "호놀룰루",
-                                     "startDate": "2026-10-24", "endDate": "2026-10-27",
-                                     "timezone": "Pacific/Honolulu", "currency": "USD"}
-                                    """))
+                            .content(tripBody("하와이", "호놀룰루", "2026-10-24", "2026-10-27",
+                                    "Pacific/Honolulu", "USD")))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.timezone").value("Pacific/Honolulu"));
 
@@ -537,11 +524,19 @@ class TripControllerTest extends ApiTestSupport {
 
     // ---------------- helpers ----------------
 
-    private static String tripBody(String title, String destination, String start, String end) {
+    /** 구간 하나짜리 요청 본문. 도시는 미리 만들어 둔 것을 쓴다. */
+    private String tripBody(String title, String destination, String start, String end)
+            throws Exception {
+        return tripBody(title, destination, start, end, "Asia/Tokyo", "JPY");
+    }
+
+    private String tripBody(String title, String destination, String start, String end,
+                            String timezone, String currency) throws Exception {
+        long cityId = TravelCityFixture.createCity(mockMvc, authHeader, destination,
+                timezone, currency);
         return """
-                {"title": "%s", "destinationName": "%s", "startDate": "%s", "endDate": "%s",
-                 "timezone": "Asia/Tokyo", "currency": "JPY"}
-                """.formatted(title, destination, start, end);
+                {"title": "%s", "startDate": "%s", "endDate": "%s", %s}
+                """.formatted(title, start, end, TravelCityFixture.singleLeg(cityId, 1));
     }
 
     private long createTrip(String title, String destination, String start, String end)
@@ -554,10 +549,7 @@ class TripControllerTest extends ApiTestSupport {
         String body = mockMvc.perform(post("/api/travel/trips")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"title": "%s", "destinationName": "%s", "startDate": "%s",
-                                 "endDate": "%s", "timezone": "%s", "currency": "%s"}
-                                """.formatted(title, destination, start, end, timezone, currency)))
+                        .content(tripBody(title, destination, start, end, timezone, currency)))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         return ((Number) JsonPath.read(body, "$.data.id")).longValue();
@@ -579,9 +571,8 @@ class TripControllerTest extends ApiTestSupport {
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"title": "도쿄", "destinationName": "도쿄",
+                                {"title": "도쿄",
                                  "startDate": "%s", "endDate": "%s",
-                                 "timezone": "Asia/Tokyo", "currency": "JPY",
                                  "confirmArchive": true}
                                 """.formatted(start, end)))
                 .andExpect(status().isOk());

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/trip/controller/TripLegInputTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/trip/controller/TripLegInputTest.java
@@ -1,0 +1,289 @@
+package ds.project.orino.planner.travel.trip.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.travel.entity.TripDay;
+import ds.project.orino.domain.planner.travel.entity.TripStay;
+import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
+import ds.project.orino.domain.planner.travel.repository.TripDayRepository;
+import ds.project.orino.domain.planner.travel.repository.TripStayRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.FixedClockConfig;
+import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.TravelCityFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 구간 입력으로 여행을 만들고 고치는 흐름(v2.1 §3.1·§3.2).
+ *
+ * <p>확인하는 것은 하나다 — <b>입력은 구간이지만 저장되는 진실은 날짜</b>다. 그래서 단언도
+ * 응답이 아니라 {@code trip_day} 행을 본다.
+ *
+ * <p>합계와 기간이 어긋나도 저장을 막지 않는 것이 규칙이라, 어긋난 채로 저장한 결과가 무엇인지가
+ * 곧 사양이다. 400을 기대하는 테스트가 여기 없는 이유다.
+ */
+@Import(FixedClockConfig.class)
+class TripLegInputTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TripDayRepository dayRepository;
+    @Autowired
+    private TripStayRepository stayRepository;
+    @Autowired
+    private TripActivityRepository activityRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private long osaka;
+    private long kyoto;
+    private long nagoya;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        osaka = city("오사카");
+        kyoto = city("교토");
+        nagoya = city("나고야");
+    }
+
+    @Nested
+    @DisplayName("구간 전개")
+    class Expansion {
+
+        @Test
+        @DisplayName("[오사카 3][교토 1][나고야 1] + 10.24~10.28 → 날짜 5개가 순서대로 붙는다")
+        void expandsLegsToDays() throws Exception {
+            long tripId = createTrip("2026-10-24", "2026-10-28",
+                    leg(osaka, 3), leg(kyoto, 1), leg(nagoya, 1));
+
+            assertThat(citiesOf(tripId)).containsExactly(
+                    Map.entry(LocalDate.of(2026, 10, 24), osaka),
+                    Map.entry(LocalDate.of(2026, 10, 25), osaka),
+                    Map.entry(LocalDate.of(2026, 10, 26), osaka),
+                    Map.entry(LocalDate.of(2026, 10, 27), kyoto),
+                    Map.entry(LocalDate.of(2026, 10, 28), nagoya));
+        }
+
+        @Test
+        @DisplayName("합계 5일 / 기간 10일 → 남은 날짜가 마지막 도시를 상속하고 저장된다")
+        void shortageIsSavedWithInheritedCity() throws Exception {
+            long tripId = createTrip("2026-10-24", "2026-11-02",
+                    leg(osaka, 3), leg(kyoto, 1), leg(nagoya, 1));
+
+            assertThat(dayRepository.countByTripId(tripId)).isEqualTo(10);
+            assertThat(citiesOf(tripId)).allSatisfy((date, cityId) -> {
+                if (date.isAfter(LocalDate.of(2026, 10, 27))) {
+                    assertThat(cityId).isEqualTo(nagoya);
+                }
+            });
+        }
+
+        @Test
+        @DisplayName("합계 12일 / 기간 4일 → 뒤 구간이 잘리고 저장된다")
+        void excessIsSavedTruncated() throws Exception {
+            long tripId = createTrip("2026-10-24", "2026-10-27",
+                    leg(osaka, 3), leg(kyoto, 4), leg(nagoya, 5));
+
+            assertThat(dayRepository.countByTripId(tripId)).isEqualTo(4);
+            assertThat(citiesOf(tripId).values())
+                    .containsExactly(osaka, osaka, osaka, kyoto)
+                    .doesNotContain(nagoya);
+        }
+
+        @Test
+        @DisplayName("[도쿄 3][닛코 1][도쿄 2]처럼 같은 도시가 다시 나와도 한 장소를 가리킨다")
+        void sameCityReusesPlace() throws Exception {
+            long tripId = createTrip("2026-10-24", "2026-10-29",
+                    leg(osaka, 3), leg(kyoto, 1), leg(osaka, 2));
+
+            assertThat(citiesOf(tripId).values())
+                    .containsExactly(osaka, osaka, osaka, kyoto, osaka, osaka);
+        }
+
+        @Test
+        @DisplayName("구간 순서를 바꾸면 날짜 범위가 다시 계산된다")
+        void reorderingLegsRecalculatesDates() throws Exception {
+            long tripId = createTrip("2026-10-24", "2026-10-27", leg(osaka, 2), leg(kyoto, 2));
+            assertThat(citiesOf(tripId).values()).containsExactly(osaka, osaka, kyoto, kyoto);
+
+            updateTrip(tripId, "2026-10-24", "2026-10-27", "", leg(kyoto, 2), leg(osaka, 2));
+
+            assertThat(citiesOf(tripId).values()).containsExactly(kyoto, kyoto, osaka, osaka);
+        }
+    }
+
+    @Nested
+    @DisplayName("기간 변경")
+    class PeriodChange {
+
+        @Test
+        @DisplayName("기간을 늘리면 새 날짜가 마지막 날 도시를 상속한다")
+        void extendingInheritsLastCity() throws Exception {
+            long tripId = createTrip("2026-10-24", "2026-10-27", leg(osaka, 2), leg(kyoto, 2));
+
+            // 구간을 보내지 않으면 도시 배치는 그대로 두고 기간만 맞춘다.
+            updateTrip(tripId, "2026-10-24", "2026-10-29", "");
+
+            assertThat(dayRepository.countByTripId(tripId)).isEqualTo(6);
+            assertThat(citiesOf(tripId).values())
+                    .containsExactly(osaka, osaka, kyoto, kyoto, kyoto, kyoto);
+        }
+
+        @Test
+        @DisplayName("기간을 줄이면 잘린 날짜가 사라지고 그 일정은 보관함으로 간다")
+        void shrinkingArchivesActivities() throws Exception {
+            long tripId = createTrip("2026-10-24", "2026-10-27", leg(osaka, 4));
+            createActivity(tripId, "잘리는 일정", "2026-10-27");
+
+            updateTrip(tripId, "2026-10-24", "2026-10-25", "\"confirmArchive\": true");
+
+            assertThat(dayRepository.countByTripId(tripId)).isEqualTo(2);
+            assertThat(activityRepository.findUnscheduled(tripId))
+                    .extracting(a -> a.getTitle())
+                    .containsExactly("잘리는 일정");
+        }
+
+        @Test
+        @DisplayName("도시 메모는 날짜 기준으로 보존된다 — 도시가 바뀌어도 그 날짜의 메모다")
+        void cityMemoSurvivesReexpansion() throws Exception {
+            long tripId = createTrip("2026-10-24", "2026-10-27", leg(osaka, 4));
+            TripDay day = dayRepository
+                    .findByTripIdAndDayDate(tripId, LocalDate.of(2026, 10, 26)).orElseThrow();
+            day.updateCityMemo("코인로커에 짐 보관");
+            dayRepository.saveAndFlush(day);
+
+            updateTrip(tripId, "2026-10-24", "2026-10-27", "", leg(kyoto, 4));
+
+            TripDay after = dayRepository
+                    .findByTripIdAndDayDate(tripId, LocalDate.of(2026, 10, 26)).orElseThrow();
+            assertThat(after.getBasePlaceId()).isEqualTo(kyoto);
+            assertThat(after.getCityMemo()).isEqualTo("코인로커에 짐 보관");
+        }
+
+        @Test
+        @DisplayName("기간을 줄이면 걸쳐 있던 숙소의 체크아웃일이 당겨진다")
+        void shrinkingPullsStayCheckOut() throws Exception {
+            long tripId = createTrip("2026-10-24", "2026-10-29", leg(osaka, 6));
+            stayRepository.saveAndFlush(new TripStay(tripId, "오사카 호텔",
+                    LocalDate.of(2026, 10, 24), LocalDate.of(2026, 10, 29)));
+
+            updateTrip(tripId, "2026-10-24", "2026-10-26", "\"confirmArchive\": true");
+
+            assertThat(stayRepository.findAllByTripIdOrderByCheckInDateAscIdAsc(tripId))
+                    .singleElement()
+                    .satisfies(stay -> assertThat(stay.getCheckOutDate())
+                            .isEqualTo(LocalDate.of(2026, 10, 26)));
+        }
+
+        @Test
+        @DisplayName("당긴 결과 묵는 밤이 없어진 숙소는 지운다")
+        void shrinkingRemovesEmptyStay() throws Exception {
+            long tripId = createTrip("2026-10-24", "2026-10-29", leg(osaka, 6));
+            stayRepository.saveAndFlush(new TripStay(tripId, "교토 료칸",
+                    LocalDate.of(2026, 10, 27), LocalDate.of(2026, 10, 29)));
+
+            updateTrip(tripId, "2026-10-24", "2026-10-26", "\"confirmArchive\": true");
+
+            assertThat(stayRepository.findAllByTripIdOrderByCheckInDateAscIdAsc(tripId)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("shrink-preview가 일정과 숙소 영향을 함께 알려준다")
+        void shrinkPreviewCountsStays() throws Exception {
+            long tripId = createTrip("2026-10-24", "2026-10-29", leg(osaka, 6));
+            createActivity(tripId, "잘리는 일정", "2026-10-28");
+            stayRepository.saveAndFlush(new TripStay(tripId, "오사카 호텔",
+                    LocalDate.of(2026, 10, 24), LocalDate.of(2026, 10, 29)));
+            stayRepository.saveAndFlush(new TripStay(tripId, "교토 료칸",
+                    LocalDate.of(2026, 10, 29), LocalDate.of(2026, 10, 30)));
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/shrink-preview")
+                            .param("endDate", "2026-10-26")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.movedActivityCount").value(1))
+                    .andExpect(jsonPath("$.data.shrunkStayCount").value(1))
+                    .andExpect(jsonPath("$.data.removedStayCount").value(1));
+        }
+    }
+
+    // ---------------- helpers ----------------
+
+    private long city(String name) throws Exception {
+        return TravelCityFixture.createCity(mockMvc, authHeader, name, "Asia/Tokyo", "JPY");
+    }
+
+    private static String leg(long cityPlaceId, int days) {
+        return "{\"cityPlaceId\": %d, \"days\": %d}".formatted(cityPlaceId, days);
+    }
+
+    private long createTrip(String start, String end, String... legs) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "간사이", "startDate": "%s", "endDate": "%s",
+                                 "legs": [%s]}
+                                """.formatted(start, end, String.join(", ", legs))))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    /** {@code legs}를 주지 않으면 구간을 생략한 요청이 된다(도시 배치를 건드리지 않는다). */
+    private void updateTrip(long tripId, String start, String end, String extra, String... legs)
+            throws Exception {
+        String legsField = legs.length == 0 ? ""
+                : ", \"legs\": [%s]".formatted(String.join(", ", legs));
+        String extraField = extra.isEmpty() ? "" : ", " + extra;
+        mockMvc.perform(put("/api/travel/trips/" + tripId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "간사이", "startDate": "%s", "endDate": "%s"%s%s}
+                                """.formatted(start, end, legsField, extraField)))
+                .andExpect(status().isOk());
+    }
+
+    private void createActivity(long tripId, String title, String date) throws Exception {
+        mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\": \"%s\", \"activityDate\": \"%s\"}"
+                                .formatted(title, date)))
+                .andExpect(status().isOk());
+    }
+
+    /** 날짜 → 기준 도시 장소 id. 저장된 진실을 그대로 본다. */
+    private Map<LocalDate, Long> citiesOf(long tripId) {
+        List<TripDay> days = dayRepository.findAllByTripIdOrderByDayDateAsc(tripId);
+        return days.stream().collect(java.util.stream.Collectors.toMap(
+                TripDay::getDayDate, TripDay::getBasePlaceId,
+                (first, second) -> first, java.util.LinkedHashMap::new));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/support/TravelCityFixture.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/support/TravelCityFixture.java
@@ -1,0 +1,49 @@
+package ds.project.orino.support;
+
+import com.jayway.jsonpath.JsonPath;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 여행을 만들려면 <b>기준 도시</b>가 먼저 있어야 한다(v2.1). 도시 검색은 구글을 타므로,
+ * 테스트는 직접 입력 경로로 도시를 만들어 그 id를 구간에 넣는다.
+ *
+ * <p>구간 입력을 쓰는 테스트가 여럿이라 여기 모아 둔다 — 도시 만드는 JSON이 파일마다
+ * 흩어지면 요청 형태가 또 바뀔 때 전부 다시 고쳐야 한다.
+ */
+public final class TravelCityFixture {
+
+    private TravelCityFixture() {
+    }
+
+    /** 좌표 없는 도시. 날씨를 안 보는 테스트는 이걸로 충분하다. */
+    public static long createCity(MockMvc mockMvc, String authHeader, String name,
+                                  String timezone, String currency) throws Exception {
+        return createCity(mockMvc, authHeader, name, timezone, currency, null, null);
+    }
+
+    public static long createCity(MockMvc mockMvc, String authHeader, String name,
+                                  String timezone, String currency,
+                                  String lat, String lng) throws Exception {
+        String coords = lat == null ? "" : ", \"lat\": %s, \"lng\": %s".formatted(lat, lng);
+        String body = mockMvc.perform(post("/api/travel/places")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name": "%s", "kind": "CITY",
+                                 "timezone": "%s", "currency": "%s"%s}
+                                """.formatted(name, timezone, currency, coords)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    /** 여행 생성·수정 요청에 넣을 구간 한 개짜리 조각. */
+    public static String singleLeg(long cityPlaceId, int days) {
+        return "\"legs\": [{\"cityPlaceId\": %d, \"days\": %d}]".formatted(cityPlaceId, days);
+    }
+}

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -55,7 +55,11 @@ public enum ErrorCode {
             "여행이 시작된 뒤에 기록할 수 있습니다.", 400),
     TRAVEL_PHOTO_LIMIT_EXCEEDED("TRAVEL-ERR-013",
             "사진은 일정당 10장까지 올릴 수 있습니다.", 400),
-    TRAVEL_PHOTO_NOT_FOUND("TRAVEL-ERR-014", "존재하지 않는 사진입니다.", 404);
+    TRAVEL_PHOTO_NOT_FOUND("TRAVEL-ERR-014", "존재하지 않는 사진입니다.", 404),
+    // 015는 도시 경계 이동시간(3단계) 자리다 — 번호를 당기지 않고 비워 둔다.
+    // 도시가 아닌 장소를 기준 도시로 지정하면 타임존은 우연히 맞아도 도시 일치 판정이
+    // 그날 일정을 전부 "다른 도시"로 만든다.
+    TRAVEL_NOT_A_CITY("TRAVEL-ERR-016", "도시로 등록된 장소만 기준 도시가 될 수 있습니다.", 400);
 
     private final String code;
     private final String message;

--- a/fe/src/features/travel/api/places.ts
+++ b/fe/src/features/travel/api/places.ts
@@ -74,6 +74,13 @@ export async function fetchPlaceDetail(placeId: number): Promise<PlaceDetail> {
 export interface ManualPlaceRequest {
   name: string;
   address?: string | null;
+  /** `CITY`면 기준 도시로 쓸 수 있는 도시 장소가 된다. 생략하면 일반 장소(POI). */
+  kind?: "CITY" | "POI";
+  /** 도시일 때만. 검색이 못 찾는 도시는 사용자가 시간대·통화를 고른다. */
+  timezone?: string;
+  currency?: string;
+  lat?: number | null;
+  lng?: number | null;
 }
 
 /** 검색으로 안 나오는 곳(골목 카페, 숙소)을 직접 만든다. */

--- a/fe/src/features/travel/api/travel.ts
+++ b/fe/src/features/travel/api/travel.ts
@@ -104,21 +104,30 @@ export async function fetchTrip(tripId: number): Promise<TripDetail> {
   return data.data;
 }
 
-/** 여행 생성·수정 요청. 전체 수정이라 두 경로가 같은 형태를 쓴다. */
+/**
+ * 구간 하나 — 도시 + 머무는 일수. 목록 순서가 곧 방문 순서다.
+ *
+ * 도시는 담아 둔 장소(`cityPlaceId`)나 검색 결과(`cityGooglePlaceId`) 중 하나로 지정한다.
+ */
+export interface TripLegRequest {
+  cityPlaceId?: number;
+  cityGooglePlaceId?: string;
+  days: number;
+}
+
+/**
+ * 여행 생성·수정 요청. 전체 수정이라 두 경로가 같은 형태를 쓴다.
+ *
+ * 타임존·통화·좌표는 보내지 않는다 — 도시가 그 값들의 주인이라(v2.1), 여행이 따로 들고
+ * 있으면 도시를 옮겨 다닐 때 서로 어긋난다.
+ */
 export interface TripWriteRequest {
-  /** 비우면 서버가 `destinationName`으로 채운다. */
-  title?: string;
-  destinationName: string;
+  /** v2.1부터 필수 — 목적지가 여행에 없으니 자동으로 채울 이름도 없다. */
+  title: string;
   startDate: string;
   endDate: string;
-  timezone: string;
-  currency: string;
-  /**
-   * 목적지 좌표. 장소 검색이 이 값으로 목적지 주변을 편향시킨다 —
-   * 없으면 현지 대신 사는 곳 근처 가게가 나온다.
-   */
-  lat?: number | null;
-  lng?: number | null;
+  /** 생성에는 필수. 수정에서 생략하면 날짜별 기준 도시를 건드리지 않는다. */
+  legs?: TripLegRequest[];
   defaultNotifyMinutes?: number;
   morningSummaryEnabled?: boolean;
   /** 기간 단축으로 잘리는 일정을 보관함으로 옮겨도 좋다는 확인. */
@@ -127,6 +136,10 @@ export interface TripWriteRequest {
 
 export interface ShrinkPreview {
   movedActivityCount: number;
+  /** 체크아웃일이 당겨질 숙소 수. */
+  shrunkStayCount: number;
+  /** 묵는 밤이 없어져 지워질 숙소 수. */
+  removedStayCount: number;
 }
 
 export async function createTrip(body: TripWriteRequest): Promise<TripDetail> {

--- a/fe/src/pages/travel/TravelSettingsPage.test.tsx
+++ b/fe/src/pages/travel/TravelSettingsPage.test.tsx
@@ -184,10 +184,12 @@ describe("TravelSettingsPage", () => {
       await waitFor(() => expect(bodies).toHaveLength(1));
       expect(bodies[0]).toMatchObject({
         morningSummaryEnabled: true,
-        // 다른 값을 덮어쓰지 않는다 — 전체 수정 API라 전부 실어 보내야 한다.
-        timezone: "Asia/Tokyo",
+        // 제목·기간은 덮어쓰지 않도록 그대로 실어 보낸다(전체 수정 API).
+        title: "도쿄 3박 4일",
         startDate: "2026-10-24",
       });
+      // 구간은 보내지 않는다 — 알림 스위치 하나가 날짜별 기준 도시를 되감으면 안 된다.
+      expect(bodies[0]).not.toHaveProperty("legs");
     });
 
     it("여행이 없으면 설정할 것이 없다고 알린다", async () => {

--- a/fe/src/pages/travel/TravelSettingsPage.tsx
+++ b/fe/src/pages/travel/TravelSettingsPage.tsx
@@ -52,15 +52,11 @@ export function TravelSettingsPage() {
   ) => {
     if (!trip) return;
     try {
+      // 구간을 보내지 않는다 — 알림 설정만 바꾸는 요청이 날짜별 기준 도시를 되감으면 안 된다.
       await updateTrip.mutateAsync({
         title: trip.title,
-        destinationName: trip.destinationName,
         startDate: trip.startDate,
         endDate: trip.endDate,
-        timezone: trip.timezone,
-        currency: trip.currency,
-        lat: trip.lat,
-        lng: trip.lng,
         defaultNotifyMinutes,
         morningSummaryEnabled,
       });

--- a/fe/src/pages/travel/TripFormPage.test.tsx
+++ b/fe/src/pages/travel/TripFormPage.test.tsx
@@ -15,7 +15,8 @@ const TOKYO = {
   id: 3,
   title: "도쿄 3박 4일",
   destinationName: "도쿄",
-  destinationPlaceId: null,
+  // v2.1부터 목적지는 첫날 기준 도시다 — 상세 응답에 그 장소 id가 늘 들어 있다.
+  destinationPlaceId: 21,
   startDate: "2026-10-24",
   endDate: "2026-10-27",
   timezone: "Asia/Tokyo",
@@ -72,6 +73,18 @@ const TOKYO_CITY = {
   timezone: "Asia/Tokyo",
   currency: "JPY",
 };
+
+/** 직접 입력한 도시 저장 요청을 잡아 둔다. 검색이 막혔을 때만 지나는 길이다. */
+function captureManualPlaces() {
+  const seen: Record<string, unknown>[] = [];
+  server.use(
+    http.post(`${API_BASE}/travel/places`, async ({ request }) => {
+      seen.push((await request.json()) as Record<string, unknown>);
+      return HttpResponse.json({ code: "OK", data: { id: 77, name: "도쿄" } });
+    }),
+  );
+  return seen;
+}
 
 /** 목적지 검색 응답. 호출된 검색어를 모아 둔다. */
 function mockCities(cities: unknown[] = [TOKYO_CITY]) {
@@ -142,7 +155,7 @@ describe("TripFormPage", () => {
       );
     });
 
-    it("제목을 비우면 요청에서 빼서 서버가 목적지명으로 채우게 한다", async () => {
+    it("제목을 비우면 목적지 이름으로 채워 보낸다 — 서버는 제목을 필수로 받는다", async () => {
       const seen = captureWrite("post");
       renderApp("/travel/trips/new");
       await screen.findByLabelText("목적지 도시");
@@ -151,13 +164,10 @@ describe("TripFormPage", () => {
       await userEvent.click(screen.getByRole("button", { name: "만들기" }));
 
       await waitFor(() => expect(seen).toHaveLength(1));
-      expect(seen[0].title).toBeUndefined();
       expect(seen[0]).toMatchObject({
-        destinationName: "도쿄",
+        title: "도쿄",
         startDate: "2026-10-24",
         endDate: "2026-10-27",
-        timezone: "Asia/Tokyo",
-        currency: "JPY",
         defaultNotifyMinutes: 15,
       });
     });
@@ -219,7 +229,7 @@ describe("TripFormPage", () => {
       expect(screen.getByText(/Asia\/Tokyo · JPY/)).toBeInTheDocument();
     });
 
-    it("고른 도시의 좌표를 함께 보낸다 — 장소 검색이 이걸로 목적지 주변을 편향시킨다", async () => {
+    it("고른 도시를 구간으로 보낸다 — 타임존·통화·좌표는 도시가 갖는다", async () => {
       const seen = captureWrite("post");
       renderApp("/travel/trips/new");
       await screen.findByLabelText("목적지 도시");
@@ -228,13 +238,13 @@ describe("TripFormPage", () => {
       await userEvent.click(screen.getByRole("button", { name: "만들기" }));
 
       await waitFor(() => expect(seen).toHaveLength(1));
-      expect(seen[0]).toMatchObject({
-        destinationName: "도쿄",
-        timezone: "Asia/Tokyo",
-        currency: "JPY",
-        lat: 35.6764225,
-        lng: 139.650027,
-      });
+      // 검색 결과를 그대로 보낸다 — 서버가 담아 도시로 승격한다.
+      expect(seen[0].legs).toEqual([
+        { cityGooglePlaceId: "ChIJ_tokyo", days: 4 },
+      ]);
+      expect(seen[0]).not.toHaveProperty("timezone");
+      expect(seen[0]).not.toHaveProperty("currency");
+      expect(seen[0]).not.toHaveProperty("lat");
     });
 
     it("검색어를 서버로 보낸다", async () => {
@@ -270,6 +280,7 @@ describe("TripFormPage", () => {
         ),
       );
       const seen = captureWrite("post");
+      const cities = captureManualPlaces();
       renderApp("/travel/trips/new");
       await screen.findByLabelText("목적지 도시");
 
@@ -286,7 +297,16 @@ describe("TripFormPage", () => {
       await userEvent.click(screen.getByRole("button", { name: "만들기" }));
 
       await waitFor(() => expect(seen).toHaveLength(1));
-      expect(seen[0]).toMatchObject({ destinationName: "도쿄" });
+      // 검색으로 고른 도시가 아니면 id가 없다 — 저장 직전에 도시로 만들어 붙인다.
+      expect(cities).toEqual([
+        expect.objectContaining({
+          name: "도쿄",
+          kind: "CITY",
+          timezone: "Asia/Tokyo",
+          currency: "JPY",
+        }),
+      ]);
+      expect(seen[0].legs).toEqual([{ cityPlaceId: 77, days: 4 }]);
     });
 
     it("직접 입력에서는 타임존·통화를 고를 수 있다 — 정해 줄 사람이 없다", async () => {

--- a/fe/src/pages/travel/TripFormPage.tsx
+++ b/fe/src/pages/travel/TripFormPage.tsx
@@ -9,10 +9,11 @@ import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { LoadingText } from "@/components/ui/loading-text";
 import { Select } from "@/components/ui/select";
-import type { City } from "@/features/travel/api/places";
+import { type City, createManualPlace } from "@/features/travel/api/places";
 import {
   fetchShrinkPreview,
   type TripDetail,
+  type TripLegRequest,
   type TripWriteRequest,
 } from "@/features/travel/api/travel";
 import { useTrip } from "@/features/travel/hooks/useTrip";
@@ -41,6 +42,10 @@ interface FormState {
   /** 목적지 검색으로만 채워진다. 직접 입력에는 좌표가 없다. */
   lat: number | null;
   lng: number | null;
+  /** 검색으로 고른 도시. 서버가 담아 도시로 승격한다. */
+  cityGooglePlaceId: string | null;
+  /** 수정 모드에서 이미 저장돼 있는 기준 도시. */
+  cityPlaceId: number | null;
   notifyMinutes: string;
 }
 
@@ -53,6 +58,8 @@ const EMPTY: FormState = {
   currency: "JPY",
   lat: null,
   lng: null,
+  cityGooglePlaceId: null,
+  cityPlaceId: null,
   notifyMinutes: String(DEFAULT_NOTIFY_MINUTES),
 };
 
@@ -115,6 +122,21 @@ export function TripFormPage() {
       currency: city.currency,
       lat: city.lat,
       lng: city.lng,
+      // 검색으로 고른 도시는 서버가 담아 승격한다 — 고르기 전에 저장하지 않는다.
+      cityGooglePlaceId: city.googlePlaceId,
+      cityPlaceId: null,
+    }));
+
+  /**
+   * 직접 입력으로 이름을 고쳤다 = 검색으로 고른 도시가 아니다. 구글 id를 그대로 두면
+   * 화면에는 새로 친 이름이 보이는데 저장은 전에 고른 도시로 된다.
+   */
+  const typeCityName = (name: string) =>
+    setForm((prev) => ({
+      ...prev,
+      destinationName: name,
+      cityGooglePlaceId: null,
+      cityPlaceId: null,
     }));
 
   /** 저장 직전 검증. 서버도 같은 규칙을 보지만 왕복 없이 바로 알려주는 편이 낫다. */
@@ -160,8 +182,8 @@ export function TripFormPage() {
   };
 
   const save = async (confirmArchive: boolean) => {
-    const body = toRequest(form, confirmArchive);
     try {
+      const body = await toRequest(form, editingId !== null, confirmArchive);
       const saved =
         editingId !== null
           ? await updateMutation.mutateAsync(body)
@@ -201,7 +223,7 @@ export function TripFormPage() {
               <Input
                 id="destinationName"
                 value={form.destinationName}
-                onChange={(e) => set("destinationName", e.target.value)}
+                onChange={(e) => typeCityName(e.target.value)}
                 placeholder="도쿄"
                 maxLength={100}
               />
@@ -345,6 +367,8 @@ function isShrinking(trip: TripDetail, form: FormState): boolean {
 function toFormState(trip: TripDetail): FormState {
   return {
     destinationName: trip.destinationName,
+    cityGooglePlaceId: null,
+    cityPlaceId: trip.destinationPlaceId,
     // 제목이 목적지명으로 자동 저장된 경우 폼을 비워 둔다 — 다시 저장해도 같은 값이 유지되고,
     // 사용자에겐 "안 정했다"는 원래 상태로 보인다.
     title: trip.title === trip.destinationName ? "" : trip.title,
@@ -358,17 +382,57 @@ function toFormState(trip: TripDetail): FormState {
   };
 }
 
-function toRequest(form: FormState, confirmArchive: boolean): TripWriteRequest {
+/**
+ * 화면은 목적지 하나를 받지만 서버는 구간 목록을 받는다 — 그 하나를 구간 1개로 보낸다.
+ * 다구간 편집기(S-03)는 2단계에서 이 자리를 대신한다.
+ *
+ * <p>직접 입력한 도시는 검색 결과가 아니라 id가 없다. 저장 직전에 도시로 만들어 id를 얻는다 —
+ * 도시가 없으면 그 여행의 어느 날짜도 타임존을 갖지 못한다.
+ */
+async function toRequest(
+  form: FormState,
+  editing: boolean,
+  confirmArchive: boolean,
+): Promise<TripWriteRequest> {
   return {
-    title: form.title.trim() || undefined,
-    destinationName: form.destinationName.trim(),
+    // 서버는 제목을 필수로 받는다. 비워 두면 목적지 이름으로 채우는 건 이 화면의 몫이다.
+    title: form.title.trim() || form.destinationName.trim(),
     startDate: form.startDate,
     endDate: form.endDate,
+    legs: await toLegs(form, editing),
+    defaultNotifyMinutes: Number(form.notifyMinutes),
+    ...(confirmArchive ? { confirmArchive: true } : {}),
+  };
+}
+
+async function toLegs(
+  form: FormState,
+  editing: boolean,
+): Promise<TripLegRequest[] | undefined> {
+  const days = periodDays(form.startDate, form.endDate);
+
+  if (form.cityGooglePlaceId) {
+    return [{ cityGooglePlaceId: form.cityGooglePlaceId, days }];
+  }
+  // 수정 중이고 목적지를 새로 고르지 않았으면 구간을 보내지 않는다 —
+  // 도시 배치를 건드리지 않고 기간·알림만 바뀐다.
+  if (editing && form.cityPlaceId !== null) {
+    return undefined;
+  }
+  const city = await createManualPlace({
+    name: form.destinationName.trim(),
+    kind: "CITY",
     timezone: form.timezone,
     currency: form.currency,
     lat: form.lat,
     lng: form.lng,
-    defaultNotifyMinutes: Number(form.notifyMinutes),
-    ...(confirmArchive ? { confirmArchive: true } : {}),
-  };
+  });
+  return [{ cityPlaceId: city.id, days }];
+}
+
+/** 기간의 일수(당일 포함). 구간이 하나라 합계가 기간과 늘 같다. */
+function periodDays(startDate: string, endDate: string): number {
+  const start = new Date(startDate).getTime();
+  const end = new Date(endDate).getTime();
+  return Math.max(1, Math.round((end - start) / 86_400_000) + 1);
 }


### PR DESCRIPTION
## 이슈
closes #1121

## 작업 내용

여행 생성·수정 입력을 **목적지 1개 → 구간(도시 + 일수) 목록**으로 바꾸고, 서버가 날짜로 전개한다.

```
[오사카 3일][교토 1일][나고야 1일] + 10.24–11.02
→ 10.24·25·26 오사카 / 10.27 교토 / 10.28 나고야 / 10.29~11.02 나고야(상속)
```

### 저장을 막지 않는다

합계와 기간이 달라도 400으로 거부하지 않는다. 부족하면 마지막 구간 도시를 이어 쓰고, 초과하면 뒤 구간이 잘린다. 여행을 짜는 중간 상태가 대부분 불일치이기 때문이다 — 막으면 도시를 하나 추가할 때마다 기간을 먼저 늘려야 한다.

전개 규칙은 순수 계산이라 `LegExpander`로 떼어 두고 단위 테스트로 고정했다. 이 규칙이 v2.1 입력의 전부다.

### 구간의 도시를 지정하는 두 가지

| 필드 | 언제 |
|---|---|
| `cityPlaceId` | 이미 담아 둔 도시(`place_kind = CITY`) |
| `cityGooglePlaceId` | 검색 결과 그대로 — 서버가 담고 도시로 승격 |

검색 결과를 그대로 받는 쪽이 있는 이유는 **일정 담기와 같다.** 고르기 전에 저장부터 하라고 하면 저장했다가 취소한 도시가 쌓인다. 둘 다 없거나 둘 다 있으면 400.

`POST /places`에 `kind=CITY`를 더했다 — 도시 검색이 못 찾는 곳으로 가는 여행도 기준 도시는 있어야 하고(없으면 그 여행의 어느 날짜도 타임존을 못 갖는다), 그때는 구글이 알려줄 수 없으므로 타임존·통화를 함께 받는다. **여행에서 없어진 타임존·통화 검증(`TRAVEL-ERR-003`·`004`)이 이 자리로 옮겨 왔다.**

### 기간 변경

| 변경 | 처리 |
|---|---|
| 늘림 | 새 날짜가 앞 날짜의 기준 도시를 상속 |
| 줄임 | 잘린 날짜의 일정 → 보관함, 걸친 숙소는 체크아웃일을 새 종료일로 당김(`in >= out`이면 삭제) |

`city_memo`는 **날짜 기준으로 보존**한다. 행을 지웠다 새로 만들지 않고 남아 있는 날짜의 기준 도시만 바꾼다 — 도시가 바뀌어도 "체크아웃 후 코인로커에 짐 보관"은 여전히 그 날짜의 일이다.

`PUT`에서 `legs`를 **생략하면 도시 배치를 건드리지 않고 기간만 맞춘다.** 알림 스위치 하나가 날짜별 기준 도시를 통째로 되감으면 안 되기 때문이다(설정 화면이 이 경로를 쓴다). 생성에서는 필수 — 검증 그룹으로 갈랐다.

`GET /shrink-preview` 응답에 `shrunkStayCount`·`removedStayCount`를 더했다.

## FE는 최소 연결만 했다

#1121의 Todo는 BE지만, 요청 형태를 바꾸면 지금 여행 폼이 400으로 죽는다. **화면은 그대로 두고 전송 형태만 구간 1개로 바꿨다.** 다구간 편집기(S-03)는 계획대로 2단계다.

- 검색으로 고른 도시 → `legs: [{ cityGooglePlaceId, days }]`
- 직접 입력(검색이 막혔을 때) → 저장 직전 `POST /places`로 도시를 만들고 `cityPlaceId`로 보낸다
- 제목은 서버가 필수로 받으므로, 비웠을 때 목적지 이름으로 채우는 일을 화면이 한다(사용자에게 보이는 동작은 전과 같다)
- 설정 화면의 알림 저장은 `legs`를 보내지 않는다

## 테스트

- `LegExpanderTest` — 전개 규칙(순서·부족·초과·단일 구간·당일치기·순서 변경·빈 구간·0일 구간)
- `TripLegInputTest` — 이슈의 검증 항목을 전부 케이스로. 단언은 응답이 아니라 **`trip_day` 행**을 본다(입력은 구간, 진실은 날짜)
- `PlaceControllerTest` — 도시 생성과 타임존·통화 검증(여행에서 옮겨 온 자리)
- `TripControllerTest` — 제목 필수·구간 필수·도시 아닌 장소 400으로 교체. 없어진 동작(제목 자동 채우기)의 테스트는 삭제
- 여행을 만드는 통합 테스트 11개를 `TravelCityFixture`로 정리 — 도시 만드는 JSON이 파일마다 흩어지면 요청 형태가 또 바뀔 때 전부 다시 고쳐야 한다

`./gradlew check` · FE 게이트 4종 · `npm run test:e2e` 모두 통과.

## 로컬 확인

BE·FE를 띄우고 직접 확인했다.

- `[오사카 3][교토 1][나고야 1]` + 10.24–11.02 → `trip_day` 10행, 10.29부터 나고야 상속 (에픽 예시 그대로)
- 합계 12일 / 기간 4일로 수정 → 4행으로 잘리고 **저장된다**
- `legs` 없이 기간만 10.27→10.29로 늘림 → 도시 배치 그대로, 새 날짜가 교토 상속
- 브라우저에서 여행 만들기 — 검색이 비어 직접 입력으로 넘어간 뒤 `POST /places`(`kind=CITY`) → `POST /trips {"legs":[{"cityPlaceId":4,"days":4}]}`가 나갔고 `trip_day` 4행이 CITY·Asia/Tokyo로 붙었다
