### PR TITLE
feat : 날짜 기준 도시 변경 API + 구간(Leg) 파생 조회

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/controller/TripDayController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/controller/TripDayController.java
@@ -1,0 +1,61 @@
+package ds.project.orino.planner.travel.day.controller;
+
+import ds.project.orino.common.response.ApiResponse;
+import ds.project.orino.planner.travel.day.dto.CityLegResponse;
+import ds.project.orino.planner.travel.day.dto.DayUpdateRequest;
+import ds.project.orino.planner.travel.day.dto.TripDayResponse;
+import ds.project.orino.planner.travel.day.service.BaseCityChangeService;
+import ds.project.orino.planner.travel.day.service.TripDayQueryService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 날짜와 구간(§4.5). 보드 응답에도 같은 내용이 들어가지만, 구간 편집기(S-03)와 담기 시트처럼
+ * <b>일정 없이 날짜만</b> 필요한 화면이 따로 부른다.
+ */
+@RestController
+@RequestMapping("/api/travel")
+public class TripDayController {
+
+    private final TripDayQueryService queryService;
+    private final BaseCityChangeService baseCityChangeService;
+
+    public TripDayController(TripDayQueryService queryService,
+                             BaseCityChangeService baseCityChangeService) {
+        this.queryService = queryService;
+        this.baseCityChangeService = baseCityChangeService;
+    }
+
+    @GetMapping("/trips/{tripId}/days")
+    public ApiResponse<List<TripDayResponse>> days(@AuthenticationPrincipal Long memberId,
+                                                   @PathVariable Long tripId) {
+        return ApiResponse.success(queryService.days(memberId, tripId));
+    }
+
+    /**
+     * 기준 도시 변경 · 도시 메모. 응답은 기간 전체의 날짜다 — 하루를 바꾸면 구간이 다시
+     * 나뉘어 앞뒤 날짜의 표시까지 달라진다.
+     */
+    @PutMapping("/days/{dayId}")
+    public ApiResponse<List<TripDayResponse>> updateDay(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long dayId,
+            @Valid @RequestBody DayUpdateRequest request) {
+        return ApiResponse.success(baseCityChangeService.update(memberId, dayId, request));
+    }
+
+    /** 파생 구간. 저장된 것이 아니라 날짜에서 매번 계산한다. */
+    @GetMapping("/trips/{tripId}/city-legs")
+    public ApiResponse<List<CityLegResponse>> cityLegs(@AuthenticationPrincipal Long memberId,
+                                                       @PathVariable Long tripId) {
+        return ApiResponse.success(queryService.cityLegs(memberId, tripId));
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/dto/BaseCityResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/dto/BaseCityResponse.java
@@ -1,0 +1,27 @@
+package ds.project.orino.planner.travel.day.dto;
+
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+
+import java.math.BigDecimal;
+
+/**
+ * 날짜의 기준 도시. <b>그 날짜의 모든 파생값이 여기서 나온다</b> — 타임존·통화·날씨 좌표·
+ * 검색 편향까지. 화면이 이 하나만 들고 있으면 그날의 시각 표시를 스스로 맞출 수 있다.
+ */
+public record BaseCityResponse(
+        Long placeId,
+        String name,
+        String timezone,
+        String currency,
+        String countryCode,
+        BigDecimal lat,
+        BigDecimal lng
+) {
+
+    public static BaseCityResponse from(TravelPlace city) {
+        return new BaseCityResponse(city.getId(),
+                city.getCityName() != null ? city.getCityName() : city.getName(),
+                city.getTimezone(), city.getCurrency(), city.getCountryCode(),
+                city.getLat(), city.getLng());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/dto/CityLegResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/dto/CityLegResponse.java
@@ -1,0 +1,26 @@
+package ds.project.orino.planner.travel.day.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 파생된 구간 하나. 구간 편집기(S-03)의 초기값과 지도의 {@code 전체} 모드가 쓴다.
+ *
+ * <p><b>저장된 것이 아니라 매번 계산한다</b>(D-21). 그래서 날짜를 바꾸면 다음 조회에서
+ * 곧바로 반영되고, 구간과 날짜가 어긋나는 상태가 존재하지 않는다.
+ *
+ * @param legIndex 1부터. 같은 도시를 다시 방문하면 다른 번호다
+ * @param days     머무는 일수(당일 포함)
+ */
+public record CityLegResponse(
+        int legIndex,
+        Long cityPlaceId,
+        String cityName,
+        int days,
+        LocalDate startDate,
+        LocalDate endDate,
+        String timezone,
+        BigDecimal lat,
+        BigDecimal lng
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/dto/DayUpdateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/dto/DayUpdateRequest.java
@@ -1,0 +1,19 @@
+package ds.project.orino.planner.travel.day.dto;
+
+import jakarta.validation.constraints.Size;
+
+/**
+ * 날짜 탭 롱프레스 시트가 보내는 것 — 기준 도시 변경과 도시 메모.
+ *
+ * <p><b>보낸 필드만 바꾼다.</b> 메모만 고치려는 요청이 기준 도시를 건드리면 안 되고, 그 반대도
+ * 마찬가지다. 그래서 둘 다 선택이고 {@code null}은 "안 보냄"으로 읽는다.
+ *
+ * @param cityMemo 빈 문자열을 보내면 메모를 지운다({@code null}은 "안 보냄"과 구분된다)
+ */
+public record DayUpdateRequest(
+        Long baseCityPlaceId,
+
+        @Size(max = 200, message = "도시 메모는 200자를 넘을 수 없습니다.")
+        String cityMemo
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/dto/TripDayResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/dto/TripDayResponse.java
@@ -1,0 +1,24 @@
+package ds.project.orino.planner.travel.day.dto;
+
+import java.time.LocalDate;
+
+/**
+ * 날짜 하나. 보드 응답에도 같은 내용이 들어가지만, 구간 편집기(S-03)와 담기 시트처럼
+ * <b>일정 없이 날짜만</b> 필요한 화면이 따로 쓴다.
+ *
+ * @param dayIndex     1부터 시작하는 일차
+ * @param weekday      한국어 요일 한 글자("화")
+ * @param legIndex     이 날짜가 속한 구간 번호(1부터). 저장된 값이 아니라 파생이다
+ * @param cityChanged  직전 날짜와 기준 도시가 다르다 — 날짜 탭 왼쪽에 구분선이 붙는다
+ */
+public record TripDayResponse(
+        Long dayId,
+        int dayIndex,
+        LocalDate date,
+        String weekday,
+        int legIndex,
+        boolean cityChanged,
+        String cityMemo,
+        BaseCityResponse baseCity
+) {
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/BaseCityChangeService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/BaseCityChangeService.java
@@ -1,0 +1,106 @@
+package ds.project.orino.planner.travel.day.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import ds.project.orino.domain.planner.travel.entity.TripDay;
+import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.domain.planner.travel.repository.TripDayRepository;
+import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.day.dto.DayUpdateRequest;
+import ds.project.orino.planner.travel.day.dto.TripDayResponse;
+import ds.project.orino.planner.travel.push.service.NotificationScheduleService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 날짜의 기준 도시를 바꾸고, 그 변경이 부르는 <b>연쇄를 한 곳에서</b> 처리한다.
+ *
+ * <pre>
+ * 기준 도시 변경
+ *   → 타임존(벽시계 값은 그대로, 발송 시각만 재계산)
+ *   → 통화 · 날씨 · 검색 편향 좌표
+ * </pre>
+ *
+ * <p><b>연쇄를 흩어 두면 하나가 빠졌을 때 화면은 새 도시를 보여주는데 알림은 옛 시각에 온다</b> —
+ * 사용자가 알아차릴 방법이 없는 오류다. 그래서 도시를 바꾸는 입구를 여기 하나로 둔다.
+ *
+ * <p>통화·날씨·검색 좌표는 <b>따로 갱신할 것이 없다.</b> 셋 다 저장하지 않고 조회할 때 기준
+ * 도시에서 파생하므로, 도시가 바뀐 다음 조회부터 새 값이 나온다. 이동시간 캐시도 마찬가지로
+ * 좌표 쌍이 키라(§4.4) 도시가 바뀌어도 두 장소 사이 거리는 그대로다 — 도시 경계를 넘는
+ * 구간을 계산 대상에서 빼는 규칙은 3단계에서 붙는다.
+ *
+ * <p><b>이미 담긴 일정의 장소는 건드리지 않고 경고도 띄우지 않는다.</b> 오사카 가게를 교토
+ * 날짜에 두는 건 사용자의 선택이다.
+ */
+@Service
+public class BaseCityChangeService {
+
+    private final TripRepository tripRepository;
+    private final TripDayRepository dayRepository;
+    private final TravelPlaceRepository placeRepository;
+    private final NotificationScheduleService notificationService;
+    private final TripDayQueryService queryService;
+
+    public BaseCityChangeService(TripRepository tripRepository,
+                                 TripDayRepository dayRepository,
+                                 TravelPlaceRepository placeRepository,
+                                 NotificationScheduleService notificationService,
+                                 TripDayQueryService queryService) {
+        this.tripRepository = tripRepository;
+        this.dayRepository = dayRepository;
+        this.placeRepository = placeRepository;
+        this.notificationService = notificationService;
+        this.queryService = queryService;
+    }
+
+    /**
+     * 보낸 필드만 반영한다. 메모만 고치려는 요청이 기준 도시를 건드리면 안 되고, 그 반대도
+     * 마찬가지다.
+     *
+     * <p>응답은 바꾼 날짜 하나가 아니라 <b>기간 전체의 날짜</b>다. 하루를 바꾸면 구간이 다시
+     * 나뉘어({@code legIndex}·{@code cityChanged}) 앞뒤 날짜의 표시까지 달라지므로, 한 건만
+     * 돌려주면 화면이 곧바로 목록을 다시 받아야 한다.
+     */
+    @Transactional
+    public List<TripDayResponse> update(Long memberId, Long dayId, DayUpdateRequest request) {
+        TripDay day = dayRepository.findById(dayId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_DAY_NOT_FOUND));
+        Trip trip = tripRepository.findByIdAndMemberId(day.getTripId(), memberId)
+                // 남의 여행 날짜도 404 — 존재 여부가 새어나가지 않는다.
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_DAY_NOT_FOUND));
+
+        boolean cityChanged = request.baseCityPlaceId() != null
+                && !request.baseCityPlaceId().equals(day.getBasePlaceId());
+        if (cityChanged) {
+            day.changeBaseCity(requireCity(memberId, request.baseCityPlaceId()).getId());
+        }
+        if (request.cityMemo() != null) {
+            day.updateCityMemo(request.cityMemo());
+        }
+        dayRepository.saveAndFlush(day);
+
+        if (cityChanged) {
+            // 벽시계 시각은 그대로다. 그 시각이 어느 순간인지가 바뀌었을 뿐이라 발송 시각만
+            // 다시 잡는다(§4.2). 그 날짜의 일정만 영향을 받는다.
+            notificationService.rescheduleDate(trip.getId(), day.getDayDate());
+        }
+        return queryService.days(memberId, trip.getId());
+    }
+
+    /**
+     * 도시가 아닌 장소는 기준 도시가 될 수 없다. 타임존은 우연히 맞더라도 도시 일치 판정이
+     * 그날 일정을 전부 "다른 도시"로 만든다.
+     */
+    private TravelPlace requireCity(Long memberId, Long placeId) {
+        TravelPlace place = placeRepository.findByIdAndMemberId(placeId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PLACE_NOT_FOUND));
+        if (!place.isCity() || place.getTimezone() == null) {
+            throw new CustomException(ErrorCode.TRAVEL_NOT_A_CITY);
+        }
+        return place;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/LegDeriver.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/LegDeriver.java
@@ -1,0 +1,59 @@
+package ds.project.orino.planner.travel.day.service;
+
+import ds.project.orino.domain.planner.travel.entity.TripDay;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 날짜에서 구간을 <b>파생</b>한다 — 연속된 같은 기준 도시 날짜를 하나로 묶는다.
+ * {@link LegExpander}(구간 → 날짜)의 반대 방향이다.
+ *
+ * <p><b>구간을 저장하지 않는 이유</b>(D-21): 저장하면 날짜와 구간이 어긋날 수 있는 상태가 두 개
+ * 생긴다. 하루의 기준 도시를 바꿨는데 구간 테이블이 그대로면, 화면 두 곳이 서로 다른 답을
+ * 보여준다.
+ *
+ * <p>하루만 바꿔서 구간이 셋으로 쪼개지는 것(도쿄/닛코/도쿄)은 <b>정상</b>이다. 같은 도시라도
+ * 사이에 다른 도시가 끼면 다른 구간이다 — "언제 어디에 있었나"가 구간의 뜻이기 때문이다.
+ */
+public final class LegDeriver {
+
+    private LegDeriver() {
+    }
+
+    /**
+     * @param days <b>날짜 오름차순</b>으로 정렬된 여행 날짜. 순서가 어긋나면 구간도 어긋난다
+     */
+    public static List<DerivedLeg> derive(List<TripDay> days) {
+        List<DerivedLeg> legs = new ArrayList<>();
+        for (TripDay day : days) {
+            DerivedLeg last = legs.isEmpty() ? null : legs.getLast();
+            if (last != null && last.basePlaceId().equals(day.getBasePlaceId())) {
+                legs.set(legs.size() - 1, last.extendedTo(day.getDayDate()));
+            } else {
+                legs.add(new DerivedLeg(legs.size() + 1, day.getBasePlaceId(),
+                        day.getDayDate(), day.getDayDate()));
+            }
+        }
+        return legs;
+    }
+
+    /**
+     * 파생된 구간 하나.
+     *
+     * @param legIndex 1부터. 같은 도시를 다시 방문하면 번호가 다르다(구간이 다르다)
+     */
+    public record DerivedLeg(int legIndex, Long basePlaceId,
+                             LocalDate startDate, LocalDate endDate) {
+
+        private DerivedLeg extendedTo(LocalDate date) {
+            return new DerivedLeg(legIndex, basePlaceId, startDate, date);
+        }
+
+        /** 머무는 일수(당일 포함). 구간 편집기가 이 값을 스테퍼 초기값으로 쓴다. */
+        public int days() {
+            return (int) java.time.temporal.ChronoUnit.DAYS.between(startDate, endDate) + 1;
+        }
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/TripDayQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/TripDayQueryService.java
@@ -1,0 +1,127 @@
+package ds.project.orino.planner.travel.day.service;
+
+import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.entity.Trip;
+import ds.project.orino.domain.planner.travel.entity.TripDay;
+import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.domain.planner.travel.repository.TripDayRepository;
+import ds.project.orino.domain.planner.travel.repository.TripRepository;
+import ds.project.orino.planner.travel.day.dto.BaseCityResponse;
+import ds.project.orino.planner.travel.day.dto.CityLegResponse;
+import ds.project.orino.planner.travel.day.dto.TripDayResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 날짜와 구간 조회. 구간은 {@link LegDeriver}로 <b>매번 파생</b>하므로 날짜를 바꾸면 다음
+ * 조회에서 곧바로 반영되고, 구간과 날짜가 어긋나는 상태가 아예 존재하지 않는다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class TripDayQueryService {
+
+    private final TripRepository tripRepository;
+    private final TripDayRepository dayRepository;
+    private final TravelPlaceRepository placeRepository;
+
+    public TripDayQueryService(TripRepository tripRepository,
+                               TripDayRepository dayRepository,
+                               TravelPlaceRepository placeRepository) {
+        this.tripRepository = tripRepository;
+        this.dayRepository = dayRepository;
+        this.placeRepository = placeRepository;
+    }
+
+    public List<TripDayResponse> days(Long memberId, Long tripId) {
+        Trip trip = getOwned(memberId, tripId);
+        List<TripDay> days = dayRepository.findAllByTripIdOrderByDayDateAsc(tripId);
+        Map<Long, TravelPlace> cities = citiesOf(days);
+        Map<LocalDate, Integer> legIndexes = legIndexByDate(days);
+
+        List<TripDayResponse> responses = new ArrayList<>();
+        Long previousCity = null;
+        for (TripDay day : days) {
+            TravelPlace city = cities.get(day.getBasePlaceId());
+            responses.add(new TripDayResponse(
+                    day.getId(),
+                    trip.dayNumberOf(day.getDayDate()),
+                    day.getDayDate(),
+                    weekdayOf(day.getDayDate()),
+                    legIndexes.getOrDefault(day.getDayDate(), 1),
+                    // 첫날은 "바뀐 것"이 아니다 — 비교할 앞 날짜가 없다.
+                    previousCity != null && !previousCity.equals(day.getBasePlaceId()),
+                    day.getCityMemo(),
+                    city == null ? null : BaseCityResponse.from(city)));
+            previousCity = day.getBasePlaceId();
+        }
+        return responses;
+    }
+
+    public List<CityLegResponse> cityLegs(Long memberId, Long tripId) {
+        getOwned(memberId, tripId);
+        List<TripDay> days = dayRepository.findAllByTripIdOrderByDayDateAsc(tripId);
+        Map<Long, TravelPlace> cities = citiesOf(days);
+
+        return LegDeriver.derive(days).stream()
+                .map(leg -> toResponse(leg, cities.get(leg.basePlaceId())))
+                .toList();
+    }
+
+    private static CityLegResponse toResponse(LegDeriver.DerivedLeg leg, TravelPlace city) {
+        return new CityLegResponse(leg.legIndex(), leg.basePlaceId(),
+                city == null ? null : cityName(city), leg.days(),
+                leg.startDate(), leg.endDate(),
+                city == null ? null : city.getTimezone(),
+                city == null ? null : city.getLat(),
+                city == null ? null : city.getLng());
+    }
+
+    private static String weekdayOf(LocalDate date) {
+        return date.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN);
+    }
+
+    private static String cityName(TravelPlace city) {
+        return city.getCityName() != null ? city.getCityName() : city.getName();
+    }
+
+    /** 도시는 여러 날짜가 공유하므로 장소는 한 번씩만 읽는다. */
+    private Map<Long, TravelPlace> citiesOf(List<TripDay> days) {
+        if (days.isEmpty()) {
+            return Map.of();
+        }
+        return placeRepository
+                .findAllById(days.stream().map(TripDay::getBasePlaceId).distinct().toList())
+                .stream()
+                .collect(Collectors.toMap(TravelPlace::getId, Function.identity()));
+    }
+
+    /** 날짜가 몇 번째 구간에 속하는지 — 구간 파생 결과를 날짜로 되풀어 둔다. */
+    private static Map<LocalDate, Integer> legIndexByDate(List<TripDay> days) {
+        Map<LocalDate, Integer> byDate = new HashMap<>();
+        for (LegDeriver.DerivedLeg leg : LegDeriver.derive(days)) {
+            for (LocalDate date = leg.startDate();
+                    !date.isAfter(leg.endDate()); date = date.plusDays(1)) {
+                byDate.put(date, leg.legIndex());
+            }
+        }
+        return byDate;
+    }
+
+    private Trip getOwned(Long memberId, Long tripId) {
+        // 소유권 실패도 404 — 403이면 "그 id의 여행은 존재한다"가 새어나간다.
+        return tripRepository.findByIdAndMemberId(tripId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_TRIP_NOT_FOUND));
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/day/LegDeriverTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/day/LegDeriverTest.java
@@ -1,0 +1,88 @@
+package ds.project.orino.planner.travel.day;
+
+import ds.project.orino.domain.planner.travel.entity.TripDay;
+import ds.project.orino.planner.travel.day.service.LegDeriver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 날짜 → 구간 파생 규칙을 고정한다. 구간은 저장하지 않으므로(D-21) <b>이 계산이 곧 구간의
+ * 정의</b>다 — 틀리면 DB를 봐도 알 수 없다.
+ */
+class LegDeriverTest {
+
+    private static final LocalDate OCT24 = LocalDate.of(2026, 10, 24);
+    private static final Long TOKYO = 1L;
+    private static final Long NIKKO = 2L;
+    private static final Long OSAKA = 3L;
+
+    @Test
+    @DisplayName("전 기간 같은 도시면 구간은 하나다")
+    void singleCityIsOneLeg() {
+        List<LegDeriver.DerivedLeg> legs = LegDeriver.derive(
+                days(TOKYO, TOKYO, TOKYO, TOKYO));
+
+        assertThat(legs).singleElement().satisfies(leg -> {
+            assertThat(leg.legIndex()).isEqualTo(1);
+            assertThat(leg.basePlaceId()).isEqualTo(TOKYO);
+            assertThat(leg.days()).isEqualTo(4);
+            assertThat(leg.startDate()).isEqualTo(OCT24);
+            assertThat(leg.endDate()).isEqualTo(OCT24.plusDays(3));
+        });
+    }
+
+    @Test
+    @DisplayName("[도쿄, 닛코, 도쿄] → 구간 3개로 쪼개진다 — 같은 도시라도 사이가 끊기면 다른 구간이다")
+    void sameCityAfterAnotherIsNewLeg() {
+        List<LegDeriver.DerivedLeg> legs = LegDeriver.derive(days(TOKYO, NIKKO, TOKYO));
+
+        assertThat(legs).hasSize(3);
+        assertThat(legs).extracting(LegDeriver.DerivedLeg::basePlaceId)
+                .containsExactly(TOKYO, NIKKO, TOKYO);
+        assertThat(legs).extracting(LegDeriver.DerivedLeg::legIndex)
+                .containsExactly(1, 2, 3);
+        assertThat(legs).extracting(LegDeriver.DerivedLeg::days)
+                .containsExactly(1, 1, 1);
+    }
+
+    @Test
+    @DisplayName("연속된 같은 도시는 한 구간으로 묶이고 일수가 합쳐진다")
+    void consecutiveDaysMerge() {
+        List<LegDeriver.DerivedLeg> legs = LegDeriver.derive(
+                days(OSAKA, OSAKA, OSAKA, NIKKO, TOKYO, TOKYO));
+
+        assertThat(legs).extracting(LegDeriver.DerivedLeg::days).containsExactly(3, 1, 2);
+        assertThat(legs.get(0).endDate()).isEqualTo(OCT24.plusDays(2));
+        assertThat(legs.get(1).startDate()).isEqualTo(OCT24.plusDays(3));
+        assertThat(legs.getLast().endDate()).isEqualTo(OCT24.plusDays(5));
+    }
+
+    @Test
+    @DisplayName("날짜가 하나면 구간도 하나, 하루짜리다")
+    void singleDay() {
+        List<LegDeriver.DerivedLeg> legs = LegDeriver.derive(days(TOKYO));
+
+        assertThat(legs).singleElement()
+                .satisfies(leg -> assertThat(leg.days()).isEqualTo(1));
+    }
+
+    @Test
+    @DisplayName("날짜가 없으면 구간도 없다")
+    void emptyDays() {
+        assertThat(LegDeriver.derive(List.of())).isEmpty();
+    }
+
+    /** 10.24부터 하루씩, 주어진 순서대로 기준 도시를 붙인 날짜들. */
+    private static List<TripDay> days(Long... basePlaceIds) {
+        List<TripDay> days = new java.util.ArrayList<>();
+        for (int i = 0; i < basePlaceIds.length; i++) {
+            days.add(new TripDay(1L, OCT24.plusDays(i), basePlaceIds[i]));
+        }
+        return days;
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/day/TripDayControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/day/TripDayControllerTest.java
@@ -1,0 +1,319 @@
+package ds.project.orino.planner.travel.day;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.push.entity.NotificationStatus;
+import ds.project.orino.domain.planner.push.entity.PushNotification;
+import ds.project.orino.domain.planner.push.repository.PushNotificationRepository;
+import ds.project.orino.domain.planner.travel.entity.TripActivity;
+import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.FixedClockConfig;
+import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.TravelCityFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 날짜 조회 · 기준 도시 변경 · 구간 파생(§4.5).
+ *
+ * <p>기준 도시 변경이 <b>연쇄를 부르는지</b>가 이 테스트의 핵심이다 — 화면만 바뀌고 알림이
+ * 옛 시각에 남으면 사용자가 알아차릴 방법이 없다. 그래서 알림의 {@code scheduled_at}을
+ * 직접 확인한다.
+ */
+@Import(FixedClockConfig.class)
+class TripDayControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TripActivityRepository activityRepository;
+    @Autowired
+    private PushNotificationRepository notificationRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    private String authHeader;
+    private String otherAuthHeader;
+    private long tokyo;
+    private long nikko;
+    private long tripId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        memberRepository.save(MemberFixture.create());
+        memberRepository.save(MemberFixture.create("other", "password"));
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        otherAuthHeader = "Bearer "
+                + AuthFixture.loginAndGetAccessToken(mockMvc, "other", "password");
+
+        tokyo = TravelCityFixture.createCity(mockMvc, authHeader, "도쿄", "Asia/Tokyo", "JPY");
+        nikko = TravelCityFixture.createCity(mockMvc, authHeader, "닛코", "Asia/Tokyo", "JPY");
+        tripId = createTrip();
+    }
+
+    @Nested
+    @DisplayName("GET /trips/{tripId}/days")
+    class Days {
+
+        @Test
+        @DisplayName("기간 전체의 날짜에 기준 도시가 붙어 온다")
+        void listsDaysWithBaseCity() throws Exception {
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/days")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data", hasSize(4)))
+                    .andExpect(jsonPath("$.data[0].dayIndex").value(1))
+                    .andExpect(jsonPath("$.data[0].date").value("2026-10-24"))
+                    .andExpect(jsonPath("$.data[0].weekday").value("토"))
+                    .andExpect(jsonPath("$.data[0].baseCity.name").value("도쿄"))
+                    .andExpect(jsonPath("$.data[0].baseCity.timezone").value("Asia/Tokyo"))
+                    .andExpect(jsonPath("$.data[0].baseCity.currency").value("JPY"))
+                    .andExpect(jsonPath("$.data[0].legIndex").value(1))
+                    // 첫날은 "바뀐 것"이 아니다 — 비교할 앞 날짜가 없다.
+                    .andExpect(jsonPath("$.data[0].cityChanged").value(false))
+                    .andExpect(jsonPath("$.data[3].dayIndex").value(4));
+        }
+
+        @Test
+        @DisplayName("남의 여행 날짜는 404")
+        void scopedByMember() throws Exception {
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/days")
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-001"));
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /days/{dayId}")
+    class ChangeBaseCity {
+
+        @Test
+        @DisplayName("기준 도시를 바꾸면 그 날짜만 바뀌고 구간이 쪼개진다")
+        void changesOneDayAndSplitsLegs() throws Exception {
+            changeBaseCity(dayIdAt(1), nikko);
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/days")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data[0].baseCity.name").value("도쿄"))
+                    .andExpect(jsonPath("$.data[1].baseCity.name").value("닛코"))
+                    .andExpect(jsonPath("$.data[2].baseCity.name").value("도쿄"))
+                    // 도시가 바뀌는 날짜마다 탭에 구분선이 붙는다.
+                    .andExpect(jsonPath("$.data[1].cityChanged").value(true))
+                    .andExpect(jsonPath("$.data[2].cityChanged").value(true))
+                    .andExpect(jsonPath("$.data[3].cityChanged").value(false))
+                    .andExpect(jsonPath("$.data[1].legIndex").value(2))
+                    .andExpect(jsonPath("$.data[2].legIndex").value(3));
+        }
+
+        @Test
+        @DisplayName("응답은 기간 전체의 날짜다 — 하루를 바꾸면 앞뒤 표시까지 달라진다")
+        void returnsWholePeriod() throws Exception {
+            mockMvc.perform(put("/api/travel/days/" + dayIdAt(1))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"baseCityPlaceId\": %d}".formatted(nikko)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data", hasSize(4)))
+                    .andExpect(jsonPath("$.data[1].baseCity.name").value("닛코"));
+        }
+
+        @Test
+        @DisplayName("도시를 바꾸면 그 날짜 일정의 PENDING 알림 발송시각이 실제로 바뀐다")
+        void reschedulesNotifications() throws Exception {
+            // 방콕(UTC+7)은 도쿄(UTC+9)보다 2시간 늦다 — 09:00은 그대로고 그 순간만 바뀐다.
+            long bangkok = TravelCityFixture.createCity(mockMvc, authHeader, "방콕",
+                    "Asia/Bangkok", "THB");
+            createActivity("2026-10-25", "09:00");
+            Instant before = pendingScheduledAt();
+            assertThat(before).isEqualTo(Instant.parse("2026-10-24T23:45:00Z"));
+
+            changeBaseCity(dayIdAt(1), bangkok);
+
+            assertThat(pendingScheduledAt()).isEqualTo(Instant.parse("2026-10-25T01:45:00Z"));
+        }
+
+        @Test
+        @DisplayName("도시를 바꿔도 그 날짜 일정의 장소는 그대로다 — 경고도 띄우지 않는다")
+        void keepsActivityPlaces() throws Exception {
+            long placeId = createPoi("센소지");
+            long activityId = createActivityWithPlace("2026-10-25", placeId);
+
+            changeBaseCity(dayIdAt(1), nikko);
+
+            TripActivity activity = activityRepository.findById(activityId).orElseThrow();
+            assertThat(activity.getPlaceId()).isEqualTo(placeId);
+        }
+
+        @Test
+        @DisplayName("도시 메모만 보내면 기준 도시는 건드리지 않는다")
+        void updatesMemoOnly() throws Exception {
+            mockMvc.perform(put("/api/travel/days/" + dayIdAt(1))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"cityMemo": "체크아웃 후 코인로커에 짐 보관"}
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data[1].cityMemo")
+                            .value("체크아웃 후 코인로커에 짐 보관"))
+                    .andExpect(jsonPath("$.data[1].baseCity.name").value("도쿄"));
+        }
+
+        @Test
+        @DisplayName("도시가 아닌 장소를 기준 도시로 지정하면 400")
+        void rejectsNonCityPlace() throws Exception {
+            long poiId = createPoi("센소지");
+
+            mockMvc.perform(put("/api/travel/days/" + dayIdAt(1))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"baseCityPlaceId\": %d}".formatted(poiId)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-016"));
+        }
+
+        @Test
+        @DisplayName("남의 여행 날짜는 404")
+        void scopedByMember() throws Exception {
+            mockMvc.perform(put("/api/travel/days/" + dayIdAt(0))
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"cityMemo\": \"남의 메모\"}"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-019"));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /trips/{tripId}/city-legs")
+    class CityLegs {
+
+        @Test
+        @DisplayName("전 기간 같은 도시면 구간 1개")
+        void singleLeg() throws Exception {
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/city-legs")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data", hasSize(1)))
+                    .andExpect(jsonPath("$.data[0].legIndex").value(1))
+                    .andExpect(jsonPath("$.data[0].cityName").value("도쿄"))
+                    .andExpect(jsonPath("$.data[0].days").value(4))
+                    .andExpect(jsonPath("$.data[0].startDate").value("2026-10-24"))
+                    .andExpect(jsonPath("$.data[0].endDate").value("2026-10-27"))
+                    .andExpect(jsonPath("$.data[0].timezone").value("Asia/Tokyo"));
+        }
+
+        @Test
+        @DisplayName("[도쿄, 닛코, 도쿄] → 구간 3개. 저장된 것이 아니라 매번 파생한다")
+        void splitsIntoThree() throws Exception {
+            changeBaseCity(dayIdAt(1), nikko);
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/city-legs")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data", hasSize(3)))
+                    .andExpect(jsonPath("$.data[0].cityName").value("도쿄"))
+                    .andExpect(jsonPath("$.data[0].days").value(1))
+                    .andExpect(jsonPath("$.data[1].cityName").value("닛코"))
+                    .andExpect(jsonPath("$.data[2].cityName").value("도쿄"))
+                    .andExpect(jsonPath("$.data[2].days").value(2))
+                    .andExpect(jsonPath("$.data[2].legIndex").value(3));
+        }
+    }
+
+    // ---------------- helpers ----------------
+
+    private long createTrip() throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "도쿄", "startDate": "2026-10-24",
+                                 "endDate": "2026-10-27", %s}
+                                """.formatted(TravelCityFixture.singleLeg(tokyo, 4))))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    /** 날짜 목록에서 {@code index}번째 날짜의 id. */
+    private long dayIdAt(int index) throws Exception {
+        String body = mockMvc.perform(get("/api/travel/trips/" + tripId + "/days")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data[%d].dayId".formatted(index))).longValue();
+    }
+
+    /** 도시가 아닌 일반 장소. 기준 도시로는 쓸 수 없고 일정에는 붙는다. */
+    private long createPoi(String name) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/places")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"%s\"}".formatted(name)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private void changeBaseCity(long dayId, long cityPlaceId) throws Exception {
+        mockMvc.perform(put("/api/travel/days/" + dayId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"baseCityPlaceId\": %d}".formatted(cityPlaceId)))
+                .andExpect(status().isOk());
+    }
+
+    private void createActivity(String date, String startTime) throws Exception {
+        mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "센소지", "activityDate": "%s", "startTime": "%s",
+                                 "notifyEnabled": true}
+                                """.formatted(date, startTime)))
+                .andExpect(status().isOk());
+    }
+
+    private long createActivityWithPlace(String date, long placeId) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "센소지", "activityDate": "%s", "placeId": %d}
+                                """.formatted(date, placeId)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private Instant pendingScheduledAt() {
+        List<PushNotification> pending = notificationRepository.findAll().stream()
+                .filter(n -> n.getStatus() == NotificationStatus.PENDING)
+                .filter(n -> n.getActivityId() != null)
+                .toList();
+        assertThat(pending).singleElement();
+        return pending.getFirst().getScheduledAt();
+    }
+}

--- a/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
+++ b/be/orino-common/src/main/java/ds/project/orino/common/exception/ErrorCode.java
@@ -59,7 +59,9 @@ public enum ErrorCode {
     // 015는 도시 경계 이동시간(3단계) 자리다 — 번호를 당기지 않고 비워 둔다.
     // 도시가 아닌 장소를 기준 도시로 지정하면 타임존은 우연히 맞아도 도시 일치 판정이
     // 그날 일정을 전부 "다른 도시"로 만든다.
-    TRAVEL_NOT_A_CITY("TRAVEL-ERR-016", "도시로 등록된 장소만 기준 도시가 될 수 있습니다.", 400);
+    TRAVEL_NOT_A_CITY("TRAVEL-ERR-016", "도시로 등록된 장소만 기준 도시가 될 수 있습니다.", 400),
+    // 017(숙소 기간 겹침)·018(도시 간 이동의 출발 알림)은 3·4단계 자리다 — 비워 둔다.
+    TRAVEL_DAY_NOT_FOUND("TRAVEL-ERR-019", "존재하지 않는 여행 날짜입니다.", 404);
 
     private final String code;
     private final String message;


### PR DESCRIPTION
## 이슈
closes #1122

## 작업 내용

날짜의 **기준 도시를 바꾸는 API**와 구간(Leg) 파생 조회. 날짜 탭 롱프레스 시트(2단계)가 쓸 자리다.

```
GET /api/travel/trips/{tripId}/days
PUT /api/travel/days/{dayId}          { baseCityPlaceId, cityMemo }
GET /api/travel/trips/{tripId}/city-legs
```

### 연쇄를 한 곳에 모았다

`BaseCityChangeService`가 도시를 바꾸는 유일한 입구다. 흩어 두면 하나가 빠졌을 때 **화면은 새 도시를 보여주는데 알림은 옛 시각에 온다** — 사용자가 알아차릴 방법이 없는 오류다.

다만 연쇄의 실제 내용은 예상보다 짧았다.

| 연쇄 | 이번에 한 일 |
|---|---|
| 알림 발송시각 | 그 날짜 PENDING 알림 재계산 (`rescheduleDate`) |
| 통화 · 날씨 · 검색 편향 좌표 | **따로 갱신할 것이 없다.** 셋 다 저장하지 않고 조회할 때 기준 도시에서 파생하므로 다음 조회부터 새 값이 나온다 |
| 이동시간 캐시 | 아래 참고 |

> **이동시간 캐시는 무효화할 것이 없다.** 캐시 키가 `좌표 쌍 + 이동수단`이라(§4.4 — "순서를 바꿔도 같은 두 장소 사이 이동은 재사용") 기준 도시가 바뀌어도 두 장소 사이 거리는 그대로다. 도시 변경이 실제로 바꾸는 것은 **도시 경계를 넘는 구간을 계산 대상에서 빼는 판정**인데, 그 규칙은 3단계에서 붙는다. 이슈 Todo의 "그 날짜의 이동시간 캐시 무효화"는 지금 구조에서는 지울 대상이 없어 하지 않았고, 그 이유를 `BaseCityChangeService` 주석에 남겼다.

### 구간은 저장하지 않는다

`LegDeriver`가 연속된 같은 `base_place_id`를 매번 묶는다(D-21). 저장하면 날짜와 구간이 어긋날 수 있는 상태가 두 개 생기고, 하루를 바꿨을 때 화면 두 곳이 서로 다른 답을 보여준다.

하루만 바꿔 구간이 셋으로 쪼개지는 것(도쿄/닛코/도쿄)은 **정상**이며 확인을 받지 않는다. `LegExpander`(구간 → 날짜)의 반대 방향이라 같은 패키지에 나란히 뒀다.

### 이미 담긴 일정은 건드리지 않는다

도시를 바꿔도 그 날짜 일정의 `place_id`는 그대로고 경고도 내려보내지 않는다. 오사카 가게를 교토 날짜에 두는 건 사용자의 선택이다.

### PUT 응답은 기간 전체의 날짜다

한 건만 돌려주면 화면이 곧바로 목록을 다시 받아야 한다 — 하루를 바꾸면 `legIndex`·`cityChanged`가 앞뒤 날짜까지 다시 나뉘기 때문이다. 여행 하나는 길어야 한 달이라 통째로 주는 편이 왕복도 적고 정확하다.

### 새 에러 코드

`TRAVEL-ERR-019` (존재하지 않는 여행 날짜, 404). 리소스별 404 코드를 두는 기존 관례(001 여행 · 006 일정 · 008 장소 · 014 사진)를 따랐다. **017·018은 스펙이 3·4단계용으로 잡아 둔 자리라 비워 뒀다.**

## 테스트

- `LegDeriverTest` — 파생 규칙(단일 도시 1구간 · `[도쿄, 닛코, 도쿄]` 3구간 · 연속 병합 · 하루 · 빈 목록)
- `TripDayControllerTest` — 조회·변경·구간을 API로 훑는다. **도시를 바꾼 뒤 PENDING 알림의 `scheduled_at`이 실제로 바뀌는지 직접 확인**(도쿄 09:00 → 방콕 09:00 = 2시간 뒤), 일정의 `place_id`는 그대로인지, 메모만 보내면 도시를 건드리지 않는지, 남의 여행 날짜는 404인지

`./gradlew check` 통과.

## 로컬 확인

BE를 띄우고 실제 API로 확인했다.

```
2일차를 닛코로 바꾼 뒤
  2026-10-24 도쿄 leg=1 changed=False
  2026-10-25 닛코 leg=2 changed=True  코인로커에 짐 보관
  2026-10-26 도쿄 leg=3 changed=True
  2026-10-27 도쿄 leg=3 changed=False

구간: 1 도쿄 1일 / 2 닛코 1일 / 3 도쿄 2일
```

같은 날짜를 방콕(UTC+7)으로 다시 바꾸자 알림 테이블이 이렇게 남았다 — **취소는 삭제가 아니라 상태 전이**라 왜 그 시각이었는지가 그대로 추적된다.

```
ACTIVITY  CANCELED  2026-10-24 23:45:00   (도쿄 09:00)
ACTIVITY  CANCELED  2026-10-24 23:45:00   (닛코 09:00 — 같은 타임존)
ACTIVITY  PENDING   2026-10-25 01:45:00   (방콕 09:00 — 2시간 뒤)
```

FE는 손대지 않았다. 날짜 탭 롱프레스 시트(S-04)는 계획대로 2단계다.
