### PR TITLE
feat : 보드 응답 v2.1 (기준 도시·도시 이동·숙소 자리)

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityPlace.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityPlace.java
@@ -5,21 +5,27 @@ import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import java.math.BigDecimal;
 
 /**
- * 일정에 붙은 장소 요약. 좌표는 지도·이동시간(2단계)이 쓴다.
+ * 일정에 붙은 장소 요약. 좌표는 지도·이동시간이 쓴다.
  *
- * <p>1단계에는 장소를 만드는 경로가 없어 항상 {@code null}로 나가지만, 조립은 지금 해 둔다 —
- * 2단계에서 장소가 생기는 순간 보드·상세가 그대로 채워진다.
+ * <p><b>도시 정보를 함께 싣는다</b>(v2.1). 그날 기준 도시와 같은 도시인지 판정하려면 화면이
+ * 아니라 데이터가 답을 갖고 있어야 한다.
+ *
+ * @param cityName     이 장소가 속한 도시 표시명. 화면의 {@code · 오사카} 꼬리표
+ * @param cityPlaceRef 도시 식별자. <b>도시 일치 판정은 이 값으로만 한다</b> — 좌표 거리로
+ *                     추측하면 오사카-교토(43km)와 도쿄-요코하마(30km)에서 답이 갈린다(D-23)
  */
 public record ActivityPlace(
         Long id,
         String name,
         String address,
         BigDecimal lat,
-        BigDecimal lng
+        BigDecimal lng,
+        String cityName,
+        String cityPlaceRef
 ) {
 
     public static ActivityPlace from(TravelPlace place) {
         return new ActivityPlace(place.getId(), place.getName(), place.getAddress(),
-                place.getLat(), place.getLng());
+                place.getLat(), place.getLng(), place.getCityName(), place.getCityPlaceRef());
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityResponse.java
@@ -14,6 +14,10 @@ import java.time.LocalTime;
  * @param sortOrder    같은 날짜(또는 보관함) 안에서의 순서. 정렬의 유일한 기준이다
  * @param log          사후 기록(평점·메모). 아직 기록이 없으면 null
  * @param hasLog       기록 존재 여부. 목록은 {@code log}를 다 펼치지 않고 이 표시만 쓴다
+ * @param outOfBaseCity      (v2.1) 그날 기준 도시와 <b>다른 도시</b>의 장소다 → 화면이 경고색으로
+ *                           도시명을 덧붙인다. 판정은 {@code place.cityPlaceRef}로만 한다
+ * @param canDepartureNotify (v2.1) 출발 알림을 켤 수 있는가. 도시를 넘는 이동은 계산 대상이
+ *                           아니라 켤 수 없다(3단계에서 판정이 붙는다)
  */
 public record ActivityResponse(
         Long id,
@@ -32,7 +36,9 @@ public record ActivityResponse(
         boolean departureNotifyEnabled,
         int sortOrder,
         ActivityLogResponse log,
-        boolean hasLog
+        boolean hasLog,
+        boolean outOfBaseCity,
+        boolean canDepartureNotify
 ) {
 
     public static ActivityResponse of(TripActivity activity, ActivityPlace place,
@@ -41,11 +47,32 @@ public record ActivityResponse(
                 activity.getActivityDate(), activity.getStartTime(), place,
                 activity.getMemo(), activity.getUrl(), activity.isNotifyEnabled(),
                 activity.getNotifyMinutes(), activity.isDepartureNotifyEnabled(),
-                activity.getSortOrder(), log, log != null);
+                activity.getSortOrder(), log, log != null, false, true);
     }
 
     /** 기록이 아직 없는(또는 필요 없는) 자리에서 쓴다. */
     public static ActivityResponse of(TripActivity activity, ActivityPlace place) {
         return of(activity, place, null);
+    }
+
+    /**
+     * 그날 기준 도시와 견줘 도시 이탈 여부를 붙인다. 보드만 아는 값이라(상세 화면에는 "그날"이
+     * 없다) 조립을 마친 뒤 덧씌운다.
+     */
+    public ActivityResponse withBaseCity(String baseCityPlaceRef) {
+        return new ActivityResponse(id, tripId, title, activityDate, startTime, place,
+                memo, url, notifyEnabled, notifyMinutes, departureNotifyEnabled,
+                sortOrder, log, hasLog, isOutOf(baseCityPlaceRef), canDepartureNotify);
+    }
+
+    /**
+     * <b>식별자가 둘 다 있고 서로 다를 때만</b> 다른 도시로 본다. 한쪽이라도 모르면 판정하지
+     * 않는다 — 모르는 것을 "다르다"로 답하면 멀쩡한 일정에 경고가 붙는다.
+     */
+    private boolean isOutOf(String baseCityPlaceRef) {
+        if (place == null || place.cityPlaceRef() == null || baseCityPlaceRef == null) {
+            return false;
+        }
+        return !place.cityPlaceRef().equals(baseCityPlaceRef);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/dto/BoardResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/dto/BoardResponse.java
@@ -1,18 +1,26 @@
 package ds.project.orino.planner.travel.board.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import ds.project.orino.domain.planner.travel.entity.TripStatus;
 import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
+import ds.project.orino.planner.travel.day.dto.BaseCityResponse;
+import ds.project.orino.planner.travel.route.client.TravelMode;
 import ds.project.orino.planner.travel.route.dto.TravelTimeResponse;
 import ds.project.orino.planner.travel.tools.dto.WeatherResponse;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 /**
- * 보드(S-04)의 <b>단일 조회</b> 응답. 날짜 탭·보관함 건수·선택된 날짜의 일정을 한 번에 담는다.
+ * 보드(S-04)의 단일 조회.
  *
- * <p>화면이 N+1 호출을 하지 않게 하려는 것이고, 더 중요하게는 <b>오프라인 캐시가 응답 하나로
- * 성립해야</b> 하기 때문이다(4단계). 응답을 쪼개면 비행기 모드에서 탭 하나만 살아난다.
+ * <p>날짜 탭·보관함 건수·선택된 날짜의 일정을 한 응답에 담는다. 화면의 N+1 호출을 막는 것도
+ * 있지만, 진짜 이유는 <b>오프라인 캐시가 응답 하나로 성립해야</b> 한다는 것이다 —
+ * 응답을 쪼개면 비행기 모드에서 탭 하나만 살아난다.
+ *
+ * <p><b>v2.1 — 타임존·통화가 여행이 아니라 날짜에 붙는다.</b> 화면이 쓰던 {@code trip.timezone}
+ * 자리는 {@code days[i].baseCity}로 옮겼다.
  *
  * @param days          여행 기간에서 만든 날짜 탭 전체. 보관함 칩은 FE가 뒤에 붙인다
  * @param selectedDate  이번 응답의 {@code activities}가 속한 날짜. {@code null}이면 보관함을 보고 있다.
@@ -20,6 +28,7 @@ import java.util.List;
  * @param archiveCount  미배정 보관함 일정 수(보관함 칩의 "{n}개")
  * @param activities    선택된 날짜(또는 보관함)의 일정만. {@code sortOrder} 순
  * @param travelTimes   연속한 두 일정 사이 이동시간(§4.4). 장소 없는 일정은 건너뛴다
+ * @param stayMove      마지막 일정 → 숙소 이동. 숙소는 3단계라 지금은 항상 {@code null}
  */
 public record BoardResponse(
         BoardTrip trip,
@@ -27,22 +36,26 @@ public record BoardResponse(
         LocalDate selectedDate,
         long archiveCount,
         List<ActivityResponse> activities,
-        List<TravelTimeResponse> travelTimes
+        List<TravelTimeResponse> travelTimes,
+        StayMove stayMove
 ) {
 
     /**
-     * @param status     여행 타임존의 오늘로 파생한 상태
-     * @param recordMode 완료된 여행이면 true — 계획 편집 대신 기록 입력을 보여준다
+     * @param status      기준 도시 타임존의 오늘로 파생한 상태
+     * @param recordMode  완료된 여행이면 true — 계획 편집 대신 기록 입력을 보여준다
+     * @param cityCount   기간에 등장하는 <b>서로 다른 도시</b> 수(같은 도시를 다시 방문해도 1)
+     * @param singleCity  전 기간이 한 도시다 — 날짜 탭을 {@code N일차}로 그린다
      */
     public record BoardTrip(
             Long id,
             String title,
-            String timezone,
-            String currency,
             LocalDate startDate,
             LocalDate endDate,
             TripStatus status,
-            boolean recordMode
+            boolean recordMode,
+            int cityCount,
+            int countryCount,
+            boolean singleCity
     ) {
     }
 
@@ -52,14 +65,64 @@ public record BoardResponse(
      * @param dayIndex      1부터 시작하는 일차
      * @param weekday       한국어 요일 한 글자("금")
      * @param activityCount 그 날짜의 일정 수
+     * @param baseCity      그날의 기준 도시 — 타임존·통화·날씨 좌표가 전부 여기서 나온다
+     * @param cityChanged   직전 날짜와 도시가 다르다 → 탭 왼쪽에 구분선
+     * @param legIndex      이 날짜가 속한 구간 번호(1부터). 저장값이 아니라 파생이다
      * @param weather       날씨 요약. 예보 범위(16일) 밖이면 null이다
+     * @param stayTonight   오늘 밤 자는 곳. 숙소는 3단계라 지금은 항상 null
+     * @param stayCheckout  오늘 체크아웃하는 곳. 3단계까지 null
      */
     public record BoardDay(
+            Long dayId,
             int dayIndex,
             LocalDate date,
             String weekday,
             long activityCount,
-            WeatherResponse.DailyWeather weather
+            BaseCityResponse baseCity,
+            boolean cityChanged,
+            int legIndex,
+            String cityMemo,
+            WeatherResponse.DailyWeather weather,
+            StayTonight stayTonight,
+            StayCheckout stayCheckout
+    ) {
+    }
+
+    /**
+     * 오늘 밤 자는 곳. <b>3단계에 테이블이 채워지기 전까지 항상 null</b>이다 —
+     * 형태를 지금 확정해 두면 FE가 두 번 고치지 않는다.
+     *
+     * @param sameCity     그날 기준 도시와 같은 도시인가. 닛코 당일치기 날 도쿄에서 자면 false
+     * @param isCheckInDay 오늘 체크인하는 날인가 — 배지에 시각을 함께 보여줄지 가른다
+     */
+    public record StayTonight(
+            Long stayId,
+            String name,
+            boolean sameCity,
+            @JsonFormat(pattern = "HH:mm") LocalTime checkInTime,
+            boolean isCheckInDay
+    ) {
+    }
+
+    /** 오늘 체크아웃하는 곳. 3단계까지 null. */
+    public record StayCheckout(
+            Long stayId,
+            String name,
+            @JsonFormat(pattern = "HH:mm") LocalTime checkOutTime
+    ) {
+    }
+
+    /**
+     * 리스트 맨 아래 붙는 숙소 이동. 3단계까지 null.
+     *
+     * <p>{@code sameCity = false}면 {@code mode}·{@code durationMinutes}가 null이다 —
+     * 도시를 넘는 이동은 계산하지 않는다(v2.1 §3.4).
+     */
+    public record StayMove(
+            Long stayId,
+            boolean sameCity,
+            TravelMode mode,
+            Integer durationMinutes
     ) {
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
@@ -7,10 +7,15 @@ import ds.project.orino.domain.planner.travel.entity.Trip;
 import ds.project.orino.domain.planner.travel.entity.TripActivity;
 import ds.project.orino.domain.planner.travel.entity.TripStatus;
 import ds.project.orino.domain.planner.travel.repository.ActivityDateCount;
+import ds.project.orino.domain.planner.travel.entity.TripDay;
 import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
+import ds.project.orino.domain.planner.travel.repository.TripDayRepository;
 import ds.project.orino.domain.planner.travel.repository.TripRepository;
 import ds.project.orino.planner.travel.activity.service.ActivityService;
+import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
 import ds.project.orino.planner.travel.board.dto.BoardResponse;
+import ds.project.orino.planner.travel.day.dto.BaseCityResponse;
+import ds.project.orino.planner.travel.day.service.LegDeriver;
 import ds.project.orino.planner.travel.day.service.TripClock;
 import ds.project.orino.planner.travel.day.service.TripDayService;
 import ds.project.orino.planner.travel.route.service.TravelTimeService;
@@ -23,9 +28,11 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.format.TextStyle;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -41,6 +48,7 @@ public class BoardService {
 
     private final TripRepository tripRepository;
     private final TripActivityRepository activityRepository;
+    private final TripDayRepository dayRepository;
     private final ActivityService activityService;
     private final TripDayService tripDayService;
     private final TravelTimeService travelTimeService;
@@ -49,6 +57,7 @@ public class BoardService {
 
     public BoardService(TripRepository tripRepository,
                         TripActivityRepository activityRepository,
+                        TripDayRepository dayRepository,
                         ActivityService activityService,
                         TripDayService tripDayService,
                         TravelTimeService travelTimeService,
@@ -56,6 +65,7 @@ public class BoardService {
                         Clock clock) {
         this.tripRepository = tripRepository;
         this.activityRepository = activityRepository;
+        this.dayRepository = dayRepository;
         this.activityService = activityService;
         this.tripDayService = tripDayService;
         this.travelTimeService = travelTimeService;
@@ -80,24 +90,49 @@ public class BoardService {
                 : activityRepository.findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(
                         tripId, selectedDate);
 
-        // 헤더의 `현지 09:42`는 <b>보고 있는 날짜</b>의 시계다. 보관함에는 날짜가 없으므로
-        // 첫날로 떨어뜨린다 — 그 화면에는 시각이 걸린 것이 없다.
-        TravelPlace headerCity = cities.get(
-                selectedDate != null ? selectedDate : trip.getStartDate());
+        // 선택한 날짜의 기준 도시. 도시 이탈 판정이 이 도시와 견준다.
+        TravelPlace selectedCity = selectedDate == null ? null : cities.get(selectedDate);
 
         return new BoardResponse(
-                new BoardResponse.BoardTrip(trip.getId(), trip.getTitle(),
-                        headerCity == null ? null : headerCity.getTimezone(),
-                        headerCity == null ? null : headerCity.getCurrency(),
-                        trip.getStartDate(), trip.getEndDate(), status,
-                        status == TripStatus.COMPLETED),
-                buildDays(trip),
+                buildTrip(trip, cities, status),
+                buildDays(trip, cities),
                 selectedDate,
                 activityRepository.countUnscheduled(tripId),
-                activityService.toResponses(activities),
+                withBaseCity(activityService.toResponses(activities), selectedCity),
                 // 보관함은 날짜에 배정되지 않은 목록이라 순서에 이동 의미가 없다.
                 // 계산해 봐야 화면에 쓰지 않고, 호출당 과금이라 그냥 낭비다.
-                selectedDate == null ? List.of() : travelTimeService.travelTimes(activities));
+                selectedDate == null ? List.of() : travelTimeService.travelTimes(activities),
+                // 숙소는 3단계다. 형태만 확정해 두고 값은 아직 없다.
+                null);
+    }
+
+    /**
+     * 여행 헤더. <b>타임존·통화가 없다</b>(v2.1) — 화면이 쓰던 자리는 {@code days[i].baseCity}다.
+     *
+     * <p>{@code singleCity}는 전 기간이 한 도시라는 뜻이고, 그때 날짜 탭은 도시명 대신
+     * {@code N일차}로 그린다. 도시가 하나뿐인 여행에 도시명을 반복해 붙이면 정보가 아니라
+     * 소음이다.
+     */
+    private static BoardResponse.BoardTrip buildTrip(Trip trip,
+                                                     Map<LocalDate, TravelPlace> cities,
+                                                     TripStatus status) {
+        long cityCount = cities.values().stream().map(TravelPlace::getId).distinct().count();
+        long countryCount = cities.values().stream()
+                .map(TravelPlace::getCountryCode)
+                .filter(Objects::nonNull)
+                .distinct()
+                .count();
+        return new BoardResponse.BoardTrip(trip.getId(), trip.getTitle(),
+                trip.getStartDate(), trip.getEndDate(), status,
+                status == TripStatus.COMPLETED,
+                (int) cityCount, (int) countryCount, cityCount <= 1);
+    }
+
+    /** 선택한 날짜의 기준 도시와 견줘 일정마다 도시 이탈 여부를 붙인다. */
+    private static List<ActivityResponse> withBaseCity(List<ActivityResponse> activities,
+                                                       TravelPlace baseCity) {
+        String ref = baseCity == null ? null : baseCity.getCityPlaceRef();
+        return activities.stream().map(activity -> activity.withBaseCity(ref)).toList();
     }
 
     /**
@@ -117,22 +152,58 @@ public class BoardService {
                 ? TripClock.today(trip, cities, clock) : trip.getStartDate();
     }
 
-    /** 기간에서 날짜 탭을 만든다. 일정이 하나도 없는 날짜도 탭은 나와야 한다. */
-    private List<BoardResponse.BoardDay> buildDays(Trip trip) {
+    /**
+     * 기간에서 날짜 탭을 만든다. 일정이 하나도 없는 날짜도 탭은 나와야 한다.
+     *
+     * <p>날짜마다 기준 도시와 구간 번호가 붙는다. {@code cityChanged}는 <b>직전 날짜와 도시가
+     * 다른가</b>이고, 화면은 그 자리에 구분선을 긋는다 — 도시가 바뀌는 지점이 한눈에 보여야
+     * 며칠씩 이어지는 일정에서 길을 잃지 않는다.
+     */
+    private List<BoardResponse.BoardDay> buildDays(Trip trip,
+                                                   Map<LocalDate, TravelPlace> cities) {
         Map<LocalDate, Long> counts = activityRepository.countByDate(trip.getId()).stream()
                 .collect(Collectors.toMap(ActivityDateCount::activityDate, ActivityDateCount::count));
         // 날짜 탭이 전부 필요로 하므로 여행 기간을 한 번에 받는다(§S-08).
-        Map<LocalDate, WeatherResponse.DailyWeather> weather = weatherService.dailyByDate(trip);
+        // 도시별로 한 번씩만 조회한다 — 열흘짜리 여행이 열 번을 부르면 안 된다.
+        Map<LocalDate, WeatherResponse.DailyWeather> weather =
+                weatherService.dailyByDate(trip, cities);
+        List<TripDay> dayRows = dayRepository.findAllByTripIdOrderByDayDateAsc(trip.getId());
+        Map<LocalDate, Integer> legIndexes = legIndexByDate(dayRows);
 
         List<BoardResponse.BoardDay> days = new ArrayList<>();
-        for (int dayIndex = 1; dayIndex <= trip.totalDays(); dayIndex++) {
-            LocalDate date = trip.getStartDate().plusDays(dayIndex - 1L);
-            days.add(new BoardResponse.BoardDay(dayIndex, date,
+        Long previousCity = null;
+        for (TripDay row : dayRows) {
+            LocalDate date = row.getDayDate();
+            TravelPlace city = cities.get(date);
+            days.add(new BoardResponse.BoardDay(
+                    row.getId(),
+                    trip.dayNumberOf(date),
+                    date,
                     date.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN),
                     counts.getOrDefault(date, 0L),
+                    city == null ? null : BaseCityResponse.from(city),
+                    // 첫날은 "바뀐 것"이 아니다 — 비교할 앞 날짜가 없다.
+                    previousCity != null && !previousCity.equals(row.getBasePlaceId()),
+                    legIndexes.getOrDefault(date, 1),
+                    row.getCityMemo(),
                     // 예보 범위(오늘부터 16일) 밖이면 null이다 — 화면이 그 자리를 비운다.
-                    weather.get(date)));
+                    weather.get(date),
+                    // 숙소는 3단계다.
+                    null, null));
+            previousCity = row.getBasePlaceId();
         }
         return days;
+    }
+
+    /** 날짜가 몇 번째 구간에 속하는지 — 구간은 저장하지 않고 날짜에서 파생한다(D-21). */
+    private static Map<LocalDate, Integer> legIndexByDate(List<TripDay> days) {
+        Map<LocalDate, Integer> byDate = new HashMap<>();
+        for (LegDeriver.DerivedLeg leg : LegDeriver.derive(days)) {
+            for (LocalDate date = leg.startDate();
+                    !date.isAfter(leg.endDate()); date = date.plusDays(1)) {
+                byDate.put(date, leg.legIndex());
+            }
+        }
+        return byDate;
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/GooglePlacesClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/GooglePlacesClient.java
@@ -206,6 +206,7 @@ public class GooglePlacesClient implements PlacesClient {
                 text(node, "nationalPhoneNumber"),
                 rawJson(node.get("regularOpeningHours")),
                 nestedText(node, "timeZone", "id"),
+                cityName(node.get("addressComponents")),
                 countryCode(node.get("addressComponents")),
                 types(node.get("types")));
     }
@@ -222,6 +223,33 @@ public class GooglePlacesClient implements PlacesClient {
     }
 
     /** 주소 구성요소에서 국가 코드(alpha-2)를 뽑는다. 통화를 여기서 유도한다. */
+    /**
+     * 이 장소가 속한 도시 이름. {@code locality}가 없으면 한 단계 넓은 행정구역으로 떨어진다 —
+     * 도쿄 23구처럼 {@code locality}가 안 붙는 곳이 있다.
+     */
+    private String cityName(JsonNode components) {
+        String fallback = null;
+        if (components == null || !components.isArray()) {
+            return null;
+        }
+        for (JsonNode component : components) {
+            JsonNode types = component.get("types");
+            if (types == null) {
+                continue;
+            }
+            for (JsonNode type : types) {
+                String name = type.asString();
+                if ("locality".equals(name)) {
+                    return text(component, "longText");
+                }
+                if ("administrative_area_level_1".equals(name) && fallback == null) {
+                    fallback = text(component, "longText");
+                }
+            }
+        }
+        return fallback;
+    }
+
     private String countryCode(JsonNode components) {
         if (components == null || !components.isArray()) {
             return null;

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/PlaceResult.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/client/PlaceResult.java
@@ -11,6 +11,7 @@ import java.util.List;
  *
  * @param googlePlaceId 구글 장소 식별자
  * @param timezone      IANA 타임존. <b>Places가 직접 준다</b>(좌표→타임존 매핑이 필요 없다)
+ * @param cityName      이 장소가 속한 도시 이름. 도시 이탈 표시(§1124)가 쓴다
  * @param countryCode   ISO 3166-1 alpha-2. 통화를 여기서 유도한다
  * @param openingHours  영업시간 원본 JSON. 구조를 해석하지 않고 그대로 캐시해 FE에 넘긴다
  * @param types         Google place type 목록. 목적지 검색에서 행정구역만 골라내는 데 쓴다
@@ -26,6 +27,7 @@ public record PlaceResult(
         String phone,
         String openingHours,
         String timezone,
+        String cityName,
         String countryCode,
         List<String> types
 ) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
@@ -145,6 +145,8 @@ public class PlaceService {
         place.updateBasics(fresh.address(), fresh.lat(), fresh.lng(),
                 fresh.category(), fresh.rating());
         place.updateDetails(fresh.phone(), fresh.openingHours(), clock.instant());
+        // 어느 도시의 장소인지는 상세 응답에 이미 들어 있다 — 화면의 `· 오사카` 꼬리표가 쓴다.
+        place.updateCityInfo(fresh.cityName(), place.getCityPlaceRef(), fresh.countryCode());
         return placeRepository.save(place);
     }
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/WeatherService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/WeatherService.java
@@ -17,6 +17,7 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -63,25 +64,40 @@ public class WeatherService {
     }
 
     /**
-     * 보드가 날짜 탭에 붙일 요약. 기준 도시 좌표가 없으면(직접 입력한 목적지) 날씨도 없다.
+     * 보드가 날짜 탭에 붙일 요약. <b>도시별로 한 번씩 조회해 날짜에 펼친다.</b>
+     *
+     * <p>날짜마다 조회하면 열흘짜리 여행이 열 번을 부른다. 도시 단위로 묶으면 오사카 3일
+     * 여행은 1회, 도쿄 → 닛코 → 도쿄는 2회다(같은 도시는 캐시를 공유한다).
+     *
+     * <p>기준 도시 좌표가 없으면(직접 입력한 도시) 그 날짜만 날씨가 없다 — 다른 도시 날짜는
+     * 멀쩡히 나온다.
      */
-    public Map<LocalDate, WeatherResponse.DailyWeather> dailyByDate(Trip trip) {
-        return forecastOf(trip).daily().stream()
-                .collect(Collectors.toMap(WeatherResponse.DailyWeather::date, day -> day));
+    public Map<LocalDate, WeatherResponse.DailyWeather> dailyByDate(
+            Trip trip, Map<LocalDate, TravelPlace> cities) {
+        Map<Long, WeatherResponse> byCity = new HashMap<>();
+        Map<LocalDate, WeatherResponse.DailyWeather> byDate = new HashMap<>();
+
+        cities.forEach((date, city) -> {
+            WeatherResponse forecast = byCity.computeIfAbsent(city.getId(), id -> forecastOf(city));
+            forecast.daily().stream()
+                    .filter(day -> day.date().equals(date))
+                    .findFirst()
+                    .ifPresent(day -> byDate.put(date, day));
+        });
+        return byDate;
     }
 
-    /**
-     * 지금은 <b>첫날 기준 도시</b> 하나로 조회한다. 도시별로 나눠 조회해 날짜에 펼치는 것은
-     * 보드 응답 v2.1(#1124)에서 다룬다 — 캐시 키가 도시라 도시 수만큼만 호출되는 구조는
-     * 이미 여기(좌표+타임존 키)에 있다.
-     */
-    private WeatherResponse forecastOf(Trip trip) {
-        TravelPlace city = tripDayService.primaryCity(trip.getId());
+    /** 그 도시의 예보. 좌표가 없으면 조회 자체를 하지 않는다. */
+    private WeatherResponse forecastOf(TravelPlace city) {
         if (city.getLat() == null || city.getLng() == null) {
             return WeatherResponse.empty(clock.instant());
         }
-        WeatherResponse forecast = cached(city);
-        return clampToTrip(forecast, trip);
+        return cached(city);
+    }
+
+    /** 도구 화면(§S-08)이 쓰는 여행 단위 예보. 지금은 첫날 기준 도시로 본다. */
+    private WeatherResponse forecastOf(Trip trip) {
+        return clampToTrip(forecastOf(tripDayService.primaryCity(trip.getId())), trip);
     }
 
     /** 예보 전체에서 <b>여행 기간</b>만 남긴다. 그 밖의 날짜는 화면이 쓸 일이 없다. */

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardControllerTest.java
@@ -78,10 +78,15 @@ class BoardControllerTest extends ApiTestSupport {
         mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
                         .header(HttpHeaders.AUTHORIZATION, authHeader))
                 .andExpect(jsonPath("$.data.trip.title").value("도쿄"))
-                .andExpect(jsonPath("$.data.trip.timezone").value("Asia/Tokyo"))
-                .andExpect(jsonPath("$.data.trip.currency").value("JPY"))
                 .andExpect(jsonPath("$.data.trip.status").value("UPCOMING"))
-                .andExpect(jsonPath("$.data.trip.recordMode").value(false));
+                .andExpect(jsonPath("$.data.trip.recordMode").value(false))
+                // v2.1 — 타임존·통화는 여행이 아니라 날짜의 기준 도시가 갖는다.
+                .andExpect(jsonPath("$.data.trip.timezone").doesNotExist())
+                .andExpect(jsonPath("$.data.trip.currency").doesNotExist())
+                .andExpect(jsonPath("$.data.days[0].baseCity.timezone").value("Asia/Tokyo"))
+                .andExpect(jsonPath("$.data.days[0].baseCity.currency").value("JPY"))
+                .andExpect(jsonPath("$.data.trip.singleCity").value(true))
+                .andExpect(jsonPath("$.data.trip.cityCount").value(1));
     }
 
     @Test

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardV21Test.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardV21Test.java
@@ -1,0 +1,360 @@
+package ds.project.orino.planner.travel.board.controller;
+
+import com.jayway.jsonpath.JsonPath;
+import ds.project.orino.domain.member.repository.MemberRepository;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.planner.travel.tools.StubWeatherClient;
+import ds.project.orino.planner.travel.tools.client.WeatherClient;
+import ds.project.orino.planner.travel.tools.dto.WeatherIcon;
+import ds.project.orino.planner.travel.tools.dto.WeatherResponse;
+import ds.project.orino.support.ApiTestSupport;
+import ds.project.orino.support.AuthFixture;
+import ds.project.orino.support.DbCleaner;
+import ds.project.orino.support.MemberFixture;
+import ds.project.orino.support.StubExternalsConfig;
+import ds.project.orino.support.TravelCityFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 보드 응답 v2.1 — 날짜마다 기준 도시가 붙고, 날씨는 <b>도시별로 한 번씩</b> 조회한다.
+ *
+ * <p>날씨 호출 횟수를 세는 것이 이 테스트의 절반이다. 날짜마다 부르면 열흘짜리 여행이 열 번을
+ * 부르는데, 화면으로는 구별되지 않고 <b>요금 고지서로만 드러난다.</b>
+ */
+// 스텁 조합을 새로 만들지 않는다 — 조합이 늘 때마다 Spring 컨텍스트가 하나씩 더 뜨고,
+// 각각이 커넥션 풀을 물고 있어 전체 실행에서 OutOfMemoryError로 무너진다.
+// 고정 시계는 쓰지 않는다: 모든 조회가 ?date=를 명시하므로 "오늘"에 기대지 않는다.
+@Import(StubExternalsConfig.class)
+class BoardV21Test extends ApiTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TravelPlaceRepository placeRepository;
+    @Autowired
+    private DbCleaner dbCleaner;
+    @Autowired
+    private WeatherClient weatherClient;
+
+    private StubWeatherClient weatherStub;
+    private String authHeader;
+    private long tokyo;
+    private long nikko;
+    private String tokyoLat;
+
+    /**
+     * 날씨 캐시(Redis)는 테스트 사이에 살아 있다. 좌표가 같으면 앞 테스트가 캐시해 둔 예보가
+     * 새어 들어와 <b>호출 횟수 검증이 무너진다</b> — 이 테스트의 절반이 그 숫자다.
+     */
+    private static String jitter(String base) {
+        int nudge = Math.abs(UUID.randomUUID().hashCode() % 9000) + 1000;
+        return new BigDecimal(base)
+                .add(new BigDecimal("0.0000001").multiply(BigDecimal.valueOf(nudge)))
+                .toPlainString();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbCleaner.clean();
+        weatherStub = (StubWeatherClient) weatherClient;
+        weatherStub.reset();
+
+        memberRepository.save(MemberFixture.create());
+        authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
+        // 좌표가 있어야 날씨를 조회한다. 도시마다 다른 좌표를 줘야 캐시가 갈린다.
+        tokyoLat = jitter("35.6812");
+        tokyo = city("도쿄", tokyoLat, "139.7671");
+        nikko = city("닛코", jitter("36.7199"), "139.6982");
+    }
+
+    @Nested
+    @DisplayName("여행 헤더")
+    class Header {
+
+        @Test
+        @DisplayName("전 기간 한 도시면 singleCity — 날짜 탭을 N일차로 그린다")
+        void singleCityTrip() throws Exception {
+            long tripId = createTrip(leg(tokyo, 4));
+
+            board(tripId)
+                    .andExpect(jsonPath("$.data.trip.singleCity").value(true))
+                    .andExpect(jsonPath("$.data.trip.cityCount").value(1))
+                    .andExpect(jsonPath("$.data.trip.countryCount").value(0));
+        }
+
+        @Test
+        @DisplayName("도시가 둘이면 singleCity가 아니고 도시 수를 센다")
+        void multiCityTrip() throws Exception {
+            long tripId = createTrip(leg(tokyo, 2), leg(nikko, 2));
+
+            board(tripId)
+                    .andExpect(jsonPath("$.data.trip.singleCity").value(false))
+                    .andExpect(jsonPath("$.data.trip.cityCount").value(2));
+        }
+
+        @Test
+        @DisplayName("같은 도시를 다시 방문해도 도시 수는 하나다")
+        void sameCityCountedOnce() throws Exception {
+            long tripId = createTrip(leg(tokyo, 1), leg(nikko, 1), leg(tokyo, 2));
+
+            board(tripId).andExpect(jsonPath("$.data.trip.cityCount").value(2));
+        }
+    }
+
+    @Nested
+    @DisplayName("날짜")
+    class Days {
+
+        @Test
+        @DisplayName("날짜마다 기준 도시가 붙고 도시가 바뀌는 날짜에 cityChanged가 선다")
+        void marksCityChange() throws Exception {
+            long tripId = createTrip(leg(tokyo, 1), leg(nikko, 1), leg(tokyo, 2));
+
+            board(tripId)
+                    .andExpect(jsonPath("$.data.days", hasSize(4)))
+                    .andExpect(jsonPath("$.data.days[0].baseCity.name").value("도쿄"))
+                    // 첫날은 "바뀐 것"이 아니다 — 비교할 앞 날짜가 없다.
+                    .andExpect(jsonPath("$.data.days[0].cityChanged").value(false))
+                    .andExpect(jsonPath("$.data.days[1].baseCity.name").value("닛코"))
+                    .andExpect(jsonPath("$.data.days[1].cityChanged").value(true))
+                    .andExpect(jsonPath("$.data.days[2].cityChanged").value(true))
+                    .andExpect(jsonPath("$.data.days[3].cityChanged").value(false))
+                    // 도쿄 → 닛코 → 도쿄는 구간 3개다(같은 도시라도 사이가 끊기면 다른 구간).
+                    .andExpect(jsonPath("$.data.days[0].legIndex").value(1))
+                    .andExpect(jsonPath("$.data.days[1].legIndex").value(2))
+                    .andExpect(jsonPath("$.data.days[3].legIndex").value(3));
+        }
+
+        @Test
+        @DisplayName("날짜 id와 도시 메모가 함께 온다 — 롱프레스 시트가 그대로 쓴다")
+        void carriesDayIdAndMemo() throws Exception {
+            long tripId = createTrip(leg(tokyo, 4));
+            long dayId = ((Number) JsonPath.read(boardBody(tripId), "$.data.days[1].dayId"))
+                    .longValue();
+
+            mockMvc.perform(put("/api/travel/days/" + dayId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"cityMemo\": \"코인로커\"}"))
+                    .andExpect(status().isOk());
+
+            board(tripId)
+                    .andExpect(jsonPath("$.data.days[1].dayId").value(dayId))
+                    .andExpect(jsonPath("$.data.days[1].cityMemo").value("코인로커"));
+        }
+
+        @Test
+        @DisplayName("숙소 자리는 형태만 있고 값은 아직 없다 — FE가 두 번 고치지 않게")
+        void stayFieldsAreNullUntilStage3() throws Exception {
+            long tripId = createTrip(leg(tokyo, 4));
+
+            board(tripId)
+                    .andExpect(jsonPath("$.data.days[0].stayTonight").doesNotExist())
+                    .andExpect(jsonPath("$.data.days[0].stayCheckout").doesNotExist())
+                    .andExpect(jsonPath("$.data.stayMove").doesNotExist());
+        }
+    }
+
+    @Nested
+    @DisplayName("날씨 — 도시별로 한 번씩")
+    class Weather {
+
+        @Test
+        @DisplayName("오사카 3일 여행에서 Open-Meteo 호출이 1회")
+        void singleCityFetchesOnce() throws Exception {
+            long tripId = createTrip(leg(tokyo, 4));
+
+            board(tripId).andExpect(status().isOk());
+
+            assertThat(weatherStub.calls).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("도쿄 → 닛코 → 도쿄는 2회 — 같은 도시는 캐시를 공유한다")
+        void sameCitySharesCache() throws Exception {
+            long tripId = createTrip(leg(tokyo, 1), leg(nikko, 1), leg(tokyo, 2));
+
+            board(tripId).andExpect(status().isOk());
+
+            assertThat(weatherStub.calls).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("날짜마다 그 도시의 예보가 붙는다")
+        void spreadsForecastOverDates() throws Exception {
+            LocalDate today = LocalDate.now(java.time.ZoneId.of("Asia/Tokyo"));
+            weatherStub.byCoordinates = coords -> forecast(today,
+                    coords.startsWith(tokyoLat) ? 20 : 10);
+            long tripId = createTripFrom(today, leg(tokyo, 1), leg(nikko, 1));
+
+            board(tripId, today.toString())
+                    .andExpect(jsonPath("$.data.days[0].weather.tempMax").value(20))
+                    .andExpect(jsonPath("$.data.days[1].weather.tempMax").value(10));
+        }
+    }
+
+    @Nested
+    @DisplayName("도시 이탈 표시")
+    class OutOfBaseCity {
+
+        @Test
+        @DisplayName("다른 도시의 장소면 outOfBaseCity가 선다 — 식별자로만 판정한다")
+        void marksActivityInAnotherCity() throws Exception {
+            long tripId = createTrip(leg(tokyo, 4));
+            withCityRef(tokyo, "ChIJ_tokyo");
+            // 기준 도시(도쿄)의 식별자와 다른 도시에 속한 장소.
+            long placeId = poiInCity("오사카성", "ChIJ_osaka");
+            createActivity(tripId, "오사카성", startDate(), placeId);
+
+            board(tripId)
+                    .andExpect(jsonPath("$.data.activities[0].outOfBaseCity").value(true))
+                    .andExpect(jsonPath("$.data.activities[0].place.cityName").value("오사카"));
+        }
+
+        @Test
+        @DisplayName("같은 도시의 장소면 서지 않는다")
+        void sameCityIsNotFlagged() throws Exception {
+            long tripId = createTrip(leg(tokyo, 4));
+            withCityRef(tokyo, "ChIJ_tokyo");
+            long placeId = poiInCity("센소지", "ChIJ_tokyo");
+            createActivity(tripId, "센소지", startDate(), placeId);
+
+            board(tripId)
+                    .andExpect(jsonPath("$.data.activities[0].outOfBaseCity").value(false));
+        }
+
+        @Test
+        @DisplayName("도시를 모르는 장소는 판정하지 않는다 — 모르는 것을 경고로 바꾸지 않는다")
+        void unknownCityIsNotFlagged() throws Exception {
+            long tripId = createTrip(leg(tokyo, 4));
+            long placeId = poiInCity("이름만 아는 곳", null);
+            createActivity(tripId, "직접 입력", startDate(), placeId);
+
+            board(tripId)
+                    .andExpect(jsonPath("$.data.activities[0].outOfBaseCity").value(false));
+        }
+    }
+
+    // ---------------- helpers ----------------
+
+    private static final LocalDate START = LocalDate.of(2026, 10, 24);
+
+    private static String startDate() {
+        return START.toString();
+    }
+
+    private long city(String name, String lat, String lng) throws Exception {
+        return TravelCityFixture.createCity(mockMvc, authHeader, name, "Asia/Tokyo", "JPY",
+                lat, lng);
+    }
+
+    /** 도시 식별자를 가진 일반 장소. 도시 이탈 판정은 이 값만 본다. */
+    private long poiInCity(String name, String cityPlaceRef) {
+        Long memberId = memberRepository.findAll().get(0).getId();
+        TravelPlace place = placeRepository.save(
+                TravelPlace.fromGoogle(memberId, "g-" + UUID.randomUUID(), name));
+        place.updateBasics(null, new BigDecimal("35.71"), new BigDecimal("139.79"), null, null);
+        place.updateCityInfo(cityPlaceRef == null ? null : "오사카", cityPlaceRef, "JP");
+        return placeRepository.saveAndFlush(place).getId();
+    }
+
+    /**
+     * 도시에 식별자를 붙인다. <b>직접 입력한 도시는 구글 id가 없어 식별자도 없고</b>, 그때는
+     * 이탈 판정 자체가 성립하지 않는다 — 검색으로 고른 도시라야 비교할 값이 생긴다.
+     */
+    private void withCityRef(long cityPlaceId, String cityPlaceRef) {
+        TravelPlace city = placeRepository.findById(cityPlaceId).orElseThrow();
+        city.updateCityInfo(city.getName(), cityPlaceRef, "JP");
+        placeRepository.saveAndFlush(city);
+    }
+
+    private static String leg(long cityPlaceId, int days) {
+        return "{\"cityPlaceId\": %d, \"days\": %d}".formatted(cityPlaceId, days);
+    }
+
+    private long createTrip(String... legs) throws Exception {
+        return createTripFrom(START, legs);
+    }
+
+    private long createTripFrom(LocalDate start, String... legs) throws Exception {
+        int total = legs.length == 0 ? 1 : legs.length;
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "여행", "startDate": "%s", "endDate": "%s",
+                                 "legs": [%s]}
+                                """.formatted(start, start.plusDays(daysOf(legs) - 1L),
+                                        String.join(", ", legs))))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(total).isPositive();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private static int daysOf(String... legs) {
+        int sum = 0;
+        for (String leg : legs) {
+            sum += Integer.parseInt(leg.replaceAll(".*\"days\": (\\d+).*", "$1"));
+        }
+        return Math.max(1, sum);
+    }
+
+    private void createActivity(long tripId, String title, String date, long placeId)
+            throws Exception {
+        mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "%s", "activityDate": "%s", "placeId": %d}
+                                """.formatted(title, date, placeId)))
+                .andExpect(status().isOk());
+    }
+
+    private org.springframework.test.web.servlet.ResultActions board(long tripId)
+            throws Exception {
+        return board(tripId, startDate());
+    }
+
+    private org.springframework.test.web.servlet.ResultActions board(long tripId, String date)
+            throws Exception {
+        return mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                        .param("date", date)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk());
+    }
+
+    private String boardBody(long tripId) throws Exception {
+        return board(tripId).andReturn().getResponse().getContentAsString();
+    }
+
+    private static WeatherResponse forecast(LocalDate from, int tempMax) {
+        List<WeatherResponse.DailyWeather> daily = List.of(
+                new WeatherResponse.DailyWeather(from, WeatherIcon.CLEAR, tempMax, 5, 10),
+                new WeatherResponse.DailyWeather(from.plusDays(1), WeatherIcon.CLEAR,
+                        tempMax, 5, 10));
+        return new WeatherResponse(WeatherResponse.SOURCE, WeatherResponse.LICENSE,
+                java.time.Instant.now(), daily, java.util.Map.of());
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
@@ -77,7 +77,7 @@ class PlaceControllerTest extends ApiTestSupport {
 
     private static PlaceResult city(String id, String name, String tz, String country) {
         return new PlaceResult(id, name, "일본 도쿄도", new BigDecimal("35.6762"),
-                new BigDecimal("139.6503"), null, null, null, null, tz, country,
+                new BigDecimal("139.6503"), null, null, null, null, tz, name, country,
                 List.of("locality", "political"));
     }
 
@@ -85,7 +85,7 @@ class PlaceControllerTest extends ApiTestSupport {
         return new PlaceResult(id, name, "도쿄도 다이토구", new BigDecimal("35.7147"),
                 new BigDecimal("139.7966"), "사찰", new BigDecimal("4.5"),
                 "+81 3-3842-0181", "{\"weekdayDescriptions\":[\"월: 06:00~17:00\"]}",
-                "Asia/Tokyo", "JP", List.of("tourist_attraction"));
+                "Asia/Tokyo", "도쿄", "JP", List.of("tourist_attraction"));
     }
 
     @Nested

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/client/GooglePlacesClientTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/client/GooglePlacesClientTest.java
@@ -20,7 +20,7 @@ class GooglePlacesClientTest {
     private static PlaceResult candidate(String name, String... types) {
         return new PlaceResult("id-" + name, name, name + " 주소",
                 new BigDecimal("35.0"), new BigDecimal("139.0"),
-                null, null, null, null, "Asia/Seoul", "KR", List.of(types));
+                null, null, null, null, "Asia/Seoul", name, "KR", List.of(types));
     }
 
     @Nested

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/StubWeatherClient.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/StubWeatherClient.java
@@ -24,9 +24,19 @@ public class StubWeatherClient implements WeatherClient {
     public Optional<WeatherResponse> result = Optional.of(
             WeatherResponse.empty(Instant.parse("2026-08-08T00:00:00Z")));
 
+    /**
+     * 좌표마다 다른 예보를 주고 싶을 때. 도시별 조회가 정말 도시별인지 보려면 응답이 달라야
+     * 한다 — 같은 값이면 어느 도시 것이 붙었는지 구별되지 않는다.
+     */
+    public java.util.function.Function<String, WeatherResponse> byCoordinates;
+
     @Override
     public Optional<WeatherResponse> forecast(BigDecimal lat, BigDecimal lng, String timezone) {
-        calls.add("%s,%s:%s".formatted(lat, lng, timezone));
+        String key = "%s,%s".formatted(lat, lng);
+        calls.add("%s:%s".formatted(key, timezone));
+        if (byCoordinates != null) {
+            return Optional.of(byCoordinates.apply(key));
+        }
         return result;
     }
 
@@ -39,6 +49,7 @@ public class StubWeatherClient implements WeatherClient {
 
     public void reset() {
         calls.clear();
+        byCoordinates = null;
         result = Optional.of(WeatherResponse.empty(Instant.parse("2026-08-08T00:00:00Z")));
     }
 }

--- a/fe/e2e/travel-board-drag.spec.ts
+++ b/fe/e2e/travel-board-drag.spec.ts
@@ -11,20 +11,45 @@ import { expect, type Page, test } from "@playwright/test";
  */
 
 const TRIP_ID = 1;
+
+const TOKYO = {
+  placeId: 21,
+  name: "도쿄",
+  timezone: "Asia/Tokyo",
+  currency: "JPY",
+  countryCode: "JP",
+  lat: null,
+  lng: null,
+};
+
 const DAYS = [
   {
+    dayId: 501,
     dayIndex: 1,
     date: "2026-10-24",
     weekday: "토",
     activityCount: 3,
+    baseCity: TOKYO,
+    cityChanged: false,
+    legIndex: 1,
+    cityMemo: null,
     weather: null,
+    stayTonight: null,
+    stayCheckout: null,
   },
   {
+    dayId: 502,
     dayIndex: 2,
     date: "2026-10-25",
     weekday: "일",
     activityCount: 0,
+    baseCity: TOKYO,
+    cityChanged: false,
+    legIndex: 1,
+    cityMemo: null,
     weather: null,
+    stayTonight: null,
+    stayCheckout: null,
   },
 ];
 
@@ -109,12 +134,13 @@ async function mockBoard(page: Page): Promise<Captured> {
         trip: {
           id: TRIP_ID,
           title: "도쿄 3박 4일",
-          timezone: "Asia/Tokyo",
-          currency: "JPY",
           startDate: DAYS[0].date,
           endDate: DAYS[1].date,
           status: "UPCOMING",
           recordMode: false,
+          cityCount: 1,
+          countryCount: 1,
+          singleCity: true,
         },
         days: DAYS,
         selectedDate: isArchive ? null : date,
@@ -128,6 +154,7 @@ async function mockBoard(page: Page): Promise<Captured> {
                 activity(3, "디즈니씨", 2),
               ],
         travelTimes: [],
+        stayMove: null,
       }),
     );
   });

--- a/fe/e2e/travel-board-swipe.spec.ts
+++ b/fe/e2e/travel-board-swipe.spec.ts
@@ -11,6 +11,16 @@ import { expect, type Page, test } from "@playwright/test";
 const TRIP_ID = 1;
 const DAY = "2026-10-24";
 
+const TOKYO = {
+  placeId: 21,
+  name: "도쿄",
+  timezone: "Asia/Tokyo",
+  currency: "JPY",
+  countryCode: "JP",
+  lat: null,
+  lng: null,
+};
+
 const ok = (data: unknown) => ({
   status: 200,
   contentType: "application/json",
@@ -80,20 +90,28 @@ async function mockBoard(page: Page): Promise<Captured> {
         trip: {
           id: TRIP_ID,
           title: "도쿄",
-          timezone: "Asia/Tokyo",
-          currency: "JPY",
           startDate: DAY,
           endDate: DAY,
           status: "UPCOMING",
           recordMode: false,
+          cityCount: 1,
+          countryCount: 1,
+          singleCity: true,
         },
         days: [
           {
+            dayId: 501,
             dayIndex: 1,
             date: DAY,
             weekday: "토",
             activityCount: 2,
+            baseCity: TOKYO,
+            cityChanged: false,
+            legIndex: 1,
+            cityMemo: null,
             weather: null,
+            stayTonight: null,
+            stayCheckout: null,
           },
         ],
         selectedDate: isArchive === "true" ? null : DAY,
@@ -103,6 +121,7 @@ async function mockBoard(page: Page): Promise<Captured> {
             ? []
             : [activity(1, "센소지", 0), activity(2, "우에노", 1)],
         travelTimes: [],
+        stayMove: null,
       }),
     );
   });

--- a/fe/src/features/travel/api/activities.ts
+++ b/fe/src/features/travel/api/activities.ts
@@ -15,6 +15,10 @@ export interface ActivityPlace {
   address: string | null;
   lat: number | null;
   lng: number | null;
+  /** 이 장소가 속한 도시 표시명. 도시를 벗어난 일정의 `· 오사카` 꼬리표. */
+  cityName: string | null;
+  /** 도시 식별자. 도시 일치 판정은 이 값으로만 한다(좌표 거리로 추측하지 않는다). */
+  cityPlaceRef: string | null;
 }
 
 /**
@@ -45,31 +49,62 @@ export interface Activity {
   notifyEnabled: boolean;
   notifyMinutes: number | null;
   departureNotifyEnabled: boolean;
+  /** 그날 기준 도시와 다른 도시의 장소다 → 도시명을 경고색으로 덧붙인다. */
+  outOfBaseCity: boolean;
+  /** 도시를 넘는 이동은 계산 대상이 아니라 출발 알림을 켤 수 없다(3단계에서 판정이 붙는다). */
+  canDepartureNotify: boolean;
   sortOrder: number;
   /** 아직 기록이 없으면 null. */
   log: ActivityLog | null;
   hasLog: boolean;
 }
 
+/**
+ * 그 날짜의 기준 도시. **타임존·통화·날씨 좌표가 전부 여기서 나온다** — v2.1에서 여행은
+ * 타임존을 갖지 않는다.
+ */
+export interface BaseCity {
+  placeId: number;
+  name: string;
+  timezone: string;
+  currency: string;
+  countryCode: string | null;
+  lat: number | null;
+  lng: number | null;
+}
+
 export interface BoardDay {
+  dayId: number;
   dayIndex: number;
   date: string;
   weekday: string;
   activityCount: number;
+  baseCity: BaseCity | null;
+  /** 직전 날짜와 도시가 다르다 → 탭 왼쪽에 구분선. */
+  cityChanged: boolean;
+  /** 이 날짜가 속한 구간 번호(1부터). 저장값이 아니라 파생이다. */
+  legIndex: number;
+  cityMemo: string | null;
   /** 예보 범위(16일) 밖이면 null이다 — 오류가 아니라 "아직 모름"이다. */
   weather: DailyWeather | null;
+  /** 숙소는 3단계 — 형태만 확정돼 있고 값은 아직 없다. */
+  stayTonight: null;
+  stayCheckout: null;
 }
 
 export interface BoardTrip {
   id: number;
   title: string;
-  timezone: string;
-  currency: string;
   startDate: string;
   endDate: string;
   status: TripStatus;
   /** 완료된 여행이면 true — 계획 편집 대신 기록을 보여준다(4단계). */
   recordMode: boolean;
+  /** 기간에 등장하는 서로 다른 도시 수. 같은 도시를 다시 방문해도 1이다. */
+  cityCount: number;
+  countryCount: number;
+  /** 전 기간이 한 도시 — 날짜 탭을 `N일차`로 그린다. */
+  singleCity: boolean;
 }
 
 /** 앱이 계산하는 이동수단. 대중교통은 계산하지 않는다 — 구글 지도 딥링크가 맡는다. */
@@ -96,6 +131,8 @@ export interface Board {
   activities: Activity[];
   /** 연속한 두 일정 사이 이동. 장소 없는 일정은 건너뛴 결과다. */
   travelTimes: TravelTime[];
+  /** 마지막 일정 → 숙소 이동. 숙소는 3단계라 아직 null이다. */
+  stayMove: null;
 }
 
 /**

--- a/fe/src/features/travel/map/toMapped.test.ts
+++ b/fe/src/features/travel/map/toMapped.test.ts
@@ -20,6 +20,8 @@ function activity(id: number, place: Activity["place"] = null): Activity {
     sortOrder: id,
     log: null,
     hasLog: false,
+    outOfBaseCity: false,
+    canDepartureNotify: true,
   };
 }
 
@@ -29,6 +31,8 @@ const SENSOJI = {
   address: "다이토구",
   lat: 35.7147651,
   lng: 139.7966553,
+  cityName: "도쿄",
+  cityPlaceRef: "ChIJ_tokyo",
 };
 const SKYTREE = {
   id: 11,
@@ -36,6 +40,8 @@ const SKYTREE = {
   address: "스미다구",
   lat: 35.7100627,
   lng: 139.8107004,
+  cityName: "도쿄",
+  cityPlaceRef: "ChIJ_tokyo",
 };
 
 describe("지도에 올릴 일정 고르기", () => {
@@ -57,6 +63,8 @@ describe("지도에 올릴 일정 고르기", () => {
       address: null,
       lat: null,
       lng: null,
+      cityName: null,
+      cityPlaceRef: null,
     };
 
     expect(toMapped([activity(1, manual)])).toHaveLength(0);

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -14,39 +14,65 @@ import { renderWithRouter } from "@/test/render";
 
 const API_BASE = "https://api.orino.dev/api";
 
+function baseCity(
+  placeId: number,
+  name: string,
+  timezone: string,
+  currency = "JPY",
+) {
+  return {
+    placeId,
+    name,
+    timezone,
+    currency,
+    countryCode: "JP",
+    lat: null,
+    lng: null,
+  };
+}
+
+const TOKYO = baseCity(21, "도쿄", "Asia/Tokyo");
+
+function day(
+  dayIndex: number,
+  date: string,
+  weekday: string,
+  activityCount: number,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    dayId: 500 + dayIndex,
+    dayIndex,
+    date,
+    weekday,
+    activityCount,
+    baseCity: TOKYO,
+    cityChanged: false,
+    legIndex: 1,
+    cityMemo: null,
+    weather: null,
+    stayTonight: null,
+    stayCheckout: null,
+    ...overrides,
+  };
+}
+
 const DAYS = [
-  {
-    dayIndex: 1,
-    date: "2026-10-24",
-    weekday: "토",
-    activityCount: 2,
-    weather: null,
-  },
-  {
-    dayIndex: 2,
-    date: "2026-10-25",
-    weekday: "일",
-    activityCount: 0,
-    weather: null,
-  },
-  {
-    dayIndex: 3,
-    date: "2026-10-26",
-    weekday: "월",
-    activityCount: 1,
-    weather: null,
-  },
+  day(1, "2026-10-24", "토", 2),
+  day(2, "2026-10-25", "일", 0),
+  day(3, "2026-10-26", "월", 1),
 ];
 
 const TRIP = {
   id: 3,
   title: "도쿄 3박 4일",
-  timezone: "Asia/Tokyo",
-  currency: "JPY",
   startDate: "2026-10-24",
   endDate: "2026-10-26",
   status: "UPCOMING",
   recordMode: false,
+  cityCount: 1,
+  countryCount: 1,
+  singleCity: true,
 };
 
 function activity(overrides: Record<string, unknown> = {}) {
@@ -65,6 +91,8 @@ function activity(overrides: Record<string, unknown> = {}) {
     sortOrder: 0,
     log: null,
     hasLog: false,
+    outOfBaseCity: false,
+    canDepartureNotify: true,
     ...overrides,
   };
 }
@@ -78,6 +106,7 @@ function mockBoard(options: {
   archive?: unknown[];
   trip?: Record<string, unknown>;
   travelTimes?: unknown[];
+  days?: unknown[];
 }) {
   const byDate = options.byDate ?? {};
   const archive = options.archive ?? [];
@@ -90,11 +119,12 @@ function mockBoard(options: {
         code: "OK",
         data: {
           trip: { ...TRIP, ...options.trip },
-          days: DAYS,
+          days: options.days ?? DAYS,
           selectedDate: isArchive ? null : date,
           archiveCount: archive.length,
           activities: isArchive ? archive : (byDate[date] ?? []),
           travelTimes: isArchive ? [] : (options.travelTimes ?? []),
+          stayMove: null,
         },
       });
     }),
@@ -537,6 +567,35 @@ describe("TripBoardPage", () => {
   });
 
   describe("헤더", () => {
+    it("현지 시계가 보고 있는 날짜의 기준 도시를 따른다", async () => {
+      // 1일차는 파리, 2일차는 호놀룰루. 같은 여행인데 탭을 넘기면 시계가 바뀐다.
+      // 둘 다 기기와 오프셋이 다른 도시로 고른다 — 같으면 줄 자체를 숨기는 것이 규칙이다.
+      const paris = baseCity(23, "파리", "Europe/Paris", "EUR");
+      const honolulu = baseCity(22, "호놀룰루", "Pacific/Honolulu", "USD");
+      mockBoard({
+        byDate: { "2026-10-24": [], "2026-10-25": [] },
+        trip: { singleCity: false, cityCount: 2 },
+        days: [
+          day(1, "2026-10-24", "토", 0, { baseCity: paris }),
+          day(2, "2026-10-25", "일", 0, {
+            baseCity: honolulu,
+            cityChanged: true,
+            legIndex: 2,
+          }),
+          day(3, "2026-10-26", "월", 0, { baseCity: paris }),
+        ],
+      });
+
+      renderBoard();
+
+      expect(await screen.findByText(/Europe\/Paris/)).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole("tab", { name: /2일차/ }));
+
+      expect(await screen.findByText(/Pacific\/Honolulu/)).toBeInTheDocument();
+      expect(screen.queryByText(/Europe\/Paris/)).not.toBeInTheDocument();
+    });
+
     it("메뉴에서 여행 수정으로 간다", async () => {
       mockBoard({ byDate: { "2026-10-24": [] } });
       server.use(

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -152,6 +152,12 @@ export function TripBoardPage() {
     ]),
   );
 
+  /** 보고 있는 날짜의 기준 도시. 보관함에는 날짜가 없어 첫날로 떨어진다. */
+  const selectedCity =
+    (board.selectedDate
+      ? board.days.find((day) => day.date === board.selectedDate)?.baseCity
+      : board.days[0]?.baseCity) ?? null;
+
   const selectDay = (date: string) => {
     const index = board.days.findIndex((d) => d.date === date);
     setSearchParams({ day: String(index) }, { replace: true });
@@ -289,10 +295,14 @@ export function TripBoardPage() {
             <h1 className="text-heading truncate font-semibold">
               {board.trip.title}
             </h1>
-            <LocalClockLine
-              timezone={board.trip.timezone}
-              recordMode={board.trip.recordMode}
-            />
+            {/* 시계는 <b>보고 있는 날짜</b>의 기준 도시를 따른다 — 도시를 옮겨 다니면
+                날짜 탭을 넘길 때마다 현지 시각이 바뀐다. */}
+            {selectedCity && (
+              <LocalClockLine
+                timezone={selectedCity.timezone}
+                recordMode={board.trip.recordMode}
+              />
+            )}
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">


### PR DESCRIPTION
## 이슈
closes #1124

## 작업 내용

보드 단일 조회를 v2.1 형태로 바꿨다. 화면이 N+1 호출을 하지 않고 오프라인 캐시가 응답 하나로 성립해야 한다는 원칙은 그대로다.

### 응답

| 자리 | 바뀐 것 |
|---|---|
| `trip` | `timezone`·`currency` **제거**, `cityCount`·`countryCount`·`singleCity` 추가 |
| `days[]` | `dayId`·`baseCity`·`cityChanged`·`legIndex`·`cityMemo` 추가 |
| `activities[]` | `outOfBaseCity`·`canDepartureNotify`, `place.cityName`·`place.cityPlaceRef` |
| 숙소 | `days[].stayTonight`·`stayCheckout`·`stayMove` — **타입은 확정, 값은 항상 null**(3단계) |

숙소 필드를 `Object`가 아니라 실제 레코드로 선언했다. 형태가 정해져 있어야 FE가 두 번 고치지 않는다.

### 도시 이탈은 "모르면 판정하지 않는다"

`outOfBaseCity`는 **식별자가 둘 다 있고 서로 다를 때만** true다. 한쪽이라도 모르면 false다 — 모르는 것을 "다르다"로 답하면 멀쩡한 일정에 경고가 붙는다. 좌표 거리로 추측하지 않는 것은 D-23 그대로다.

> **그래서 직접 입력한 도시를 기준 도시로 쓰는 여행에서는 이 표시가 뜨지 않는다.** 그런 도시에는 구글 id가 없어 비교할 값 자체가 없다. 검색으로 고른 도시라야 판정이 성립한다. Wiki에 명시했고, 테스트로도 세 경우(다름/같음/모름)를 고정했다.

일정 장소의 `cityName`은 채웠다 — 구글 상세 응답의 `addressComponents`에 이미 들어 있던 값이라 추가 호출이 없다.

### 날씨는 도시별로 한 번씩

날짜마다 부르면 열흘짜리 여행이 열 번을 부른다. 도시로 묶어 조회하고 날짜에 펼친다.

- 도쿄 4일 → **1회**
- 도쿄 → 닛코 → 도쿄 → **2회** (같은 도시는 캐시를 공유한다)

호출 횟수는 화면으로 구별되지 않고 **요금 고지서로만 드러나서**, 스텁 호출 수를 세는 테스트로 못 박았다.

### FE

헤더 시계가 **보고 있는 날짜**의 기준 도시를 따른다. 날짜 탭을 넘기면 현지 시각과 타임존이 바뀐다. 테스트는 파리 ↔ 호놀룰루로 탭을 눌러 확인한다(둘 다 기기와 오프셋이 달라야 줄이 보인다 — 같으면 숨기는 것이 이 줄의 규칙이다).

## 테스트

- `BoardV21Test` — 헤더(`singleCity`·`cityCount`) · 날짜(`cityChanged`·`legIndex`·`dayId`·메모) · 날씨 호출 횟수 · 도시 이탈 3경우
- `BoardControllerTest` — `trip.timezone`이 **없어졌음**을 직접 확인하고 그 자리를 `days[0].baseCity`로 옮김
- FE 픽스처·E2E 스텁을 v2.1 형태로 갱신

`./gradlew check`(968) · FE 게이트 4종(876) · E2E(89) 통과.

> **테스트 컨텍스트 함정 하나를 밟았다.** 새 테스트에 `@Import({StubExternalsConfig, FixedClockConfig})`라는 **새 조합**을 썼더니 Spring 컨텍스트가 하나 더 뜨고 전체 실행이 `OutOfMemoryError`로 무너졌다(단독 실행은 통과해서 안 보였다). `StubExternalsConfig`의 javadoc이 정확히 경고하던 상황이라, 고정 시계를 빼고 기존 조합을 쓰도록 되돌렸다 — 모든 조회가 `?date=`를 명시해 "오늘"에 기대지 않으므로 고정 시계가 필요 없었다.

## 로컬 확인

도쿄 2일 + 호놀룰루 2일 여행으로 확인했다.

```
헤더 키: [cityCount, countryCount, endDate, id, recordMode, singleCity, startDate, status, title]
        cityCount=2  singleCity=false  timezone 필드 없음

2026-10-24 도쿄     Asia/Tokyo       JPY  leg=1 changed=false
2026-10-25 도쿄     Asia/Tokyo       JPY  leg=1 changed=false
2026-10-26 호놀룰루  Pacific/Honolulu USD  leg=2 changed=true
2026-10-27 호놀룰루  Pacific/Honolulu USD  leg=2 changed=false
```

브라우저에서 3일차 탭을 누르자 헤더가 `현지 02:33 · Pacific/Honolulu`로 바뀌었다. 1·2일차(도쿄)에서는 줄이 숨는데, 기기(서울)와 오프셋이 같기 때문이다 — 의도된 동작이다.

## 남은 것

`days[].baseCity`가 내려오므로 FE의 `constantZone` 감싸기를 실제 날짜별 조회로 바꿀 수 있다. 상태·D-day는 규칙상 오늘·첫날 기준이라 지금 값이 이미 맞고, 날짜별 조회가 의미를 갖는 자리(도시별 표시·담기 시트 정렬)는 2단계 화면 작업과 함께 온다.
