### PR TITLE
feat : FE 모델 레이어 — 구간·기준 도시·숙소 판정

### DIFF
--- a/fe/src/features/travel/lib/baseCity.test.ts
+++ b/fe/src/features/travel/lib/baseCity.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import type { BoardDay } from "@/features/travel/api/activities";
+
+import { cityCount, cityOn, firstDayZone, zoneByDate } from "./baseCity";
+import { daysUntil, deriveStatus, todayOfTrip } from "./tripStatus";
+
+/**
+ * 날짜 → 기준 도시 조회. 파생 계산에 그대로 물려 쓰는 것이 목적이라, 조회 자체보다
+ * **물렸을 때 결과가 맞는지**를 함께 본다.
+ */
+
+function city(placeId: number, name: string, timezone: string) {
+  return {
+    placeId,
+    name,
+    timezone,
+    currency: "JPY",
+    countryCode: "JP",
+    lat: null,
+    lng: null,
+  };
+}
+
+const TOKYO = city(21, "도쿄", "Asia/Tokyo");
+const HONOLULU = city(22, "호놀룰루", "Pacific/Honolulu");
+
+function days(...cities: (ReturnType<typeof city> | null)[]): BoardDay[] {
+  return cities.map((baseCity, i) => ({
+    dayId: 500 + i,
+    dayIndex: i + 1,
+    date: `2026-10-${24 + i}`,
+    weekday: "토",
+    activityCount: 0,
+    baseCity,
+    cityChanged: false,
+    legIndex: 1,
+    cityMemo: null,
+    weather: null,
+    stayTonight: null,
+    stayCheckout: null,
+  }));
+}
+
+describe("cityOn", () => {
+  it("그 날짜의 기준 도시를 준다", () => {
+    expect(cityOn(days(TOKYO, HONOLULU), "2026-10-25")?.name).toBe("호놀룰루");
+  });
+
+  it("기간 밖 날짜는 null이다", () => {
+    expect(cityOn(days(TOKYO), "2026-11-01")).toBeNull();
+  });
+});
+
+describe("cityCount", () => {
+  it("같은 도시를 다시 방문해도 하나로 센다", () => {
+    expect(cityCount(days(TOKYO, HONOLULU, TOKYO))).toBe(2);
+    expect(cityCount(days(TOKYO, TOKYO))).toBe(1);
+    expect(cityCount([])).toBe(0);
+  });
+});
+
+describe("zoneByDate", () => {
+  it("날짜마다 그 도시의 타임존을 준다", () => {
+    const zones = zoneByDate(days(TOKYO, HONOLULU));
+
+    expect(zones("2026-10-24")).toBe("Asia/Tokyo");
+    expect(zones("2026-10-25")).toBe("Pacific/Honolulu");
+  });
+
+  it("모르는 날짜는 첫날 타임존으로 답한다 — 비면 판정 자체를 못 한다", () => {
+    const zones = zoneByDate(days(TOKYO, HONOLULU));
+
+    expect(zones("2026-12-31")).toBe("Asia/Tokyo");
+  });
+
+  it("파생 계산에 물리면 날짜별로 갈린다", () => {
+    // 10/25만 호놀룰루(UTC-10). 10/25 05:00 UTC —
+    // 도쿄로 10/24는 이미 지났고(10/25 14:00), 호놀룰루로 10/25는 아직이다(10/24 19:00).
+    const zones = zoneByDate(days(TOKYO, HONOLULU, TOKYO, TOKYO));
+    const now = new Date("2026-10-25T05:00:00Z");
+
+    expect(todayOfTrip("2026-10-24", "2026-10-27", zones, now)).toBe(
+      "2026-10-25",
+    );
+    expect(deriveStatus("2026-10-24", "2026-10-27", zones, now)).toBe(
+      "ONGOING",
+    );
+  });
+});
+
+describe("firstDayZone", () => {
+  it("D-day는 첫날 도시로 센다 — 뒷날 도시가 달라도 흔들리지 않는다", () => {
+    // 호놀룰루(UTC-10)에서 출발하는 여행. 10/24 05:00 UTC면 현지는 아직 10/23이다.
+    const zones = firstDayZone("Pacific/Honolulu");
+
+    expect(
+      daysUntil("2026-10-24", zones, new Date("2026-10-24T05:00:00Z")),
+    ).toBe(1);
+  });
+});

--- a/fe/src/features/travel/lib/baseCity.ts
+++ b/fe/src/features/travel/lib/baseCity.ts
@@ -1,0 +1,39 @@
+import type { BaseCity, BoardDay } from "@/features/travel/api/activities";
+
+import type { ZoneByDate } from "./tripStatus";
+
+/**
+ * 그 날짜의 기준 도시. 없는 날짜를 물으면 `null`이다 — v2.1에서 기간 내 모든 날짜에는
+ * 기준 도시가 있으므로, `null`이 나오면 기간 밖을 물었거나 데이터가 깨진 것이다.
+ */
+export function cityOn(days: BoardDay[], date: string): BaseCity | null {
+  return days.find((day) => day.date === date)?.baseCity ?? null;
+}
+
+/**
+ * 날짜 → 타임존 조회 함수. 파생 계산(`deriveStatus`·`daysUntil`·`todayOfTrip`)에 그대로 넘긴다.
+ *
+ * 모르는 날짜를 물으면 **첫날의 타임존**으로 답한다. 기간 밖 날짜를 묻는 쪽은 상태 판정처럼
+ * "오늘이 기간 밖일 수 있는" 계산인데, 거기서 타임존이 비면 판정 자체를 못 한다.
+ */
+export function zoneByDate(days: BoardDay[]): ZoneByDate {
+  const fallback = days[0]?.baseCity?.timezone;
+  return (date) => cityOn(days, date)?.timezone ?? fallback ?? "UTC";
+}
+
+/**
+ * D-day 전용 — **첫날** 기준 도시의 타임존. "언제 출발하나"는 출발하는 곳의 시계로 세는
+ * 값이라, 날짜별 조회가 필요 없다.
+ *
+ * 여행 상세·목록 응답의 `timezone`이 곧 첫날 기준 도시의 타임존이다(서버가 그렇게 채운다).
+ */
+export function firstDayZone(timezone: string): ZoneByDate {
+  return () => timezone;
+}
+
+/** 기간에 등장하는 **서로 다른** 도시 수. 같은 도시를 다시 방문해도 1이다. */
+export function cityCount(days: BoardDay[]): number {
+  return new Set(
+    days.map((day) => day.baseCity?.placeId).filter((id) => id != null),
+  ).size;
+}

--- a/fe/src/features/travel/lib/legs.test.ts
+++ b/fe/src/features/travel/lib/legs.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import type { BoardDay } from "@/features/travel/api/activities";
+
+import { deriveLegs } from "./legs";
+
+/**
+ * 구간 파생 규칙. **BE `LegDeriverTest`와 같은 케이스**를 쓴다 — 규칙이 두 벌 존재하는 것은
+ * 오프라인 때문에 피할 수 없으니, 어긋나지 않게 같은 질문을 양쪽에 던져 둔다.
+ */
+
+const TOKYO = city(21, "도쿄");
+const NIKKO = city(22, "닛코");
+const OSAKA = city(23, "오사카");
+
+function city(placeId: number, name: string) {
+  return {
+    placeId,
+    name,
+    timezone: "Asia/Tokyo",
+    currency: "JPY",
+    countryCode: "JP",
+    lat: null,
+    lng: null,
+  };
+}
+
+/** 10.24부터 하루씩, 주어진 순서대로 기준 도시를 붙인 날짜들. */
+function days(...cities: (ReturnType<typeof city> | null)[]): BoardDay[] {
+  return cities.map((baseCity, i) => ({
+    dayId: 500 + i,
+    dayIndex: i + 1,
+    date: `2026-10-${24 + i}`,
+    weekday: "토",
+    activityCount: 0,
+    baseCity,
+    cityChanged: false,
+    legIndex: 1,
+    cityMemo: null,
+    weather: null,
+    stayTonight: null,
+    stayCheckout: null,
+  }));
+}
+
+describe("deriveLegs", () => {
+  it("전 기간 같은 도시면 구간은 하나다", () => {
+    const legs = deriveLegs(days(TOKYO, TOKYO, TOKYO, TOKYO));
+
+    expect(legs).toHaveLength(1);
+    expect(legs[0]).toMatchObject({
+      legIndex: 1,
+      cityPlaceId: 21,
+      cityName: "도쿄",
+      days: 4,
+      startDate: "2026-10-24",
+      endDate: "2026-10-27",
+    });
+  });
+
+  it("[도쿄, 닛코, 도쿄] → 구간 3개. 같은 도시라도 사이가 끊기면 다른 구간이다", () => {
+    const legs = deriveLegs(days(TOKYO, NIKKO, TOKYO));
+
+    expect(legs.map((leg) => leg.cityName)).toEqual(["도쿄", "닛코", "도쿄"]);
+    expect(legs.map((leg) => leg.legIndex)).toEqual([1, 2, 3]);
+    expect(legs.map((leg) => leg.days)).toEqual([1, 1, 1]);
+  });
+
+  it("연속된 같은 도시는 한 구간으로 묶이고 일수가 합쳐진다", () => {
+    const legs = deriveLegs(days(OSAKA, OSAKA, OSAKA, NIKKO, TOKYO, TOKYO));
+
+    expect(legs.map((leg) => leg.days)).toEqual([3, 1, 2]);
+    expect(legs[0].endDate).toBe("2026-10-26");
+    expect(legs[1].startDate).toBe("2026-10-27");
+    expect(legs[legs.length - 1].endDate).toBe("2026-10-29");
+  });
+
+  it("날짜가 하나면 구간도 하나, 하루짜리다", () => {
+    expect(deriveLegs(days(TOKYO))).toEqual([
+      {
+        legIndex: 1,
+        cityPlaceId: 21,
+        cityName: "도쿄",
+        days: 1,
+        startDate: "2026-10-24",
+        endDate: "2026-10-24",
+      },
+    ]);
+  });
+
+  it("날짜가 없으면 구간도 없다", () => {
+    expect(deriveLegs([])).toEqual([]);
+  });
+
+  it("기준 도시를 모르는 날짜도 자리를 지킨다 — 빠지면 날짜가 건너뛴 것처럼 보인다", () => {
+    const legs = deriveLegs(days(TOKYO, null, TOKYO));
+
+    expect(legs).toHaveLength(3);
+    expect(legs[1].cityPlaceId).toBeNull();
+    expect(legs[1].startDate).toBe("2026-10-25");
+  });
+});

--- a/fe/src/features/travel/lib/legs.ts
+++ b/fe/src/features/travel/lib/legs.ts
@@ -1,0 +1,53 @@
+import type { BoardDay } from "@/features/travel/api/activities";
+
+/**
+ * 구간 하나 — 연속된 같은 기준 도시 날짜의 묶음.
+ *
+ * @param legIndex 1부터. 같은 도시를 다시 방문하면 다른 번호다
+ * @param days 머무는 일수(당일 포함)
+ */
+export interface Leg {
+  legIndex: number;
+  cityPlaceId: number | null;
+  cityName: string | null;
+  days: number;
+  startDate: string;
+  endDate: string;
+}
+
+/**
+ * 날짜에서 구간을 **파생**한다. 서버도 같은 규칙을 갖고 있고(`LegDeriver`), 여기서 다시
+ * 계산하는 이유는 **보드 응답 하나로 화면이 성립해야** 하기 때문이다 — 구간을 알기 위해
+ * 따로 조회하면 오프라인에서 탭 표기가 무너진다.
+ *
+ * **구간을 저장하지 않는 이유**(D-21): 저장하면 날짜와 구간이 어긋날 수 있는 상태가 두 개
+ * 생긴다. 하루의 기준 도시를 바꿨는데 구간이 그대로면 화면 두 곳이 서로 다른 답을 보여준다.
+ *
+ * 하루만 바꿔서 구간이 셋으로 쪼개지는 것(도쿄/닛코/도쿄)은 **정상**이다. 같은 도시라도
+ * 사이에 다른 도시가 끼면 다른 구간이다 — "언제 어디에 있었나"가 구간의 뜻이기 때문이다.
+ *
+ * @param days **날짜 오름차순**으로 정렬된 여행 날짜. 순서가 어긋나면 구간도 어긋난다
+ */
+export function deriveLegs(days: BoardDay[]): Leg[] {
+  const legs: Leg[] = [];
+
+  for (const day of days) {
+    const cityPlaceId = day.baseCity?.placeId ?? null;
+    const last = legs[legs.length - 1];
+
+    if (last && last.cityPlaceId === cityPlaceId) {
+      last.endDate = day.date;
+      last.days += 1;
+      continue;
+    }
+    legs.push({
+      legIndex: legs.length + 1,
+      cityPlaceId,
+      cityName: day.baseCity?.name ?? null,
+      days: 1,
+      startDate: day.date,
+      endDate: day.date,
+    });
+  }
+  return legs;
+}

--- a/fe/src/features/travel/lib/stayForDay.test.ts
+++ b/fe/src/features/travel/lib/stayForDay.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  coversNight,
+  isCheckOutOn,
+  overlaps,
+  stayCheckout,
+  stayTonight,
+} from "./stayForDay";
+
+/**
+ * 숙소 날짜 판정. **BE `TripStayRepositoryTest`와 같은 경계**를 쓴다 —
+ * 체크아웃일 밤은 이미 다른 곳에서 잔다.
+ */
+
+const OSAKA_HOTEL = {
+  name: "오사카 호텔",
+  checkInDate: "2026-10-24",
+  checkOutDate: "2026-10-27",
+};
+const KYOTO_RYOKAN = {
+  name: "교토 료칸",
+  checkInDate: "2026-10-27",
+  checkOutDate: "2026-10-29",
+};
+
+describe("coversNight · isCheckOutOn", () => {
+  it("체크인 이상 체크아웃 미만인 날짜에만 잔다", () => {
+    expect(coversNight(OSAKA_HOTEL, "2026-10-23")).toBe(false);
+    expect(coversNight(OSAKA_HOTEL, "2026-10-24")).toBe(true);
+    expect(coversNight(OSAKA_HOTEL, "2026-10-26")).toBe(true);
+    // 체크아웃일 밤은 다른 곳에서 잔다.
+    expect(coversNight(OSAKA_HOTEL, "2026-10-27")).toBe(false);
+  });
+
+  it("체크아웃일은 따로 판정한다", () => {
+    expect(isCheckOutOn(OSAKA_HOTEL, "2026-10-27")).toBe(true);
+    expect(isCheckOutOn(OSAKA_HOTEL, "2026-10-26")).toBe(false);
+  });
+});
+
+describe("overlaps", () => {
+  it("이동일(앞 체크아웃 = 뒤 체크인)은 겹침이 아니다", () => {
+    expect(overlaps(OSAKA_HOTEL, KYOTO_RYOKAN)).toBe(false);
+  });
+
+  it("하루라도 밤이 겹치면 겹침이다", () => {
+    expect(
+      overlaps(OSAKA_HOTEL, {
+        checkInDate: "2026-10-26",
+        checkOutDate: "2026-10-29",
+      }),
+    ).toBe(true);
+    expect(
+      overlaps(OSAKA_HOTEL, {
+        checkInDate: "2026-10-20",
+        checkOutDate: "2026-10-25",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("stayTonight · stayCheckout", () => {
+  const stays = [OSAKA_HOTEL, KYOTO_RYOKAN];
+
+  it("이동일에는 자는 곳과 체크아웃하는 곳이 다르다", () => {
+    // 10/27 — 오사카에서 체크아웃하고 교토에서 잔다.
+    expect(stayCheckout(stays, "2026-10-27")?.name).toBe("오사카 호텔");
+    expect(stayTonight(stays, "2026-10-27")?.name).toBe("교토 료칸");
+  });
+
+  it("해당 없는 날짜는 null이다", () => {
+    expect(stayTonight(stays, "2026-10-29")).toBeNull();
+    expect(stayCheckout(stays, "2026-10-28")).toBeNull();
+    expect(stayTonight([], "2026-10-24")).toBeNull();
+  });
+});

--- a/fe/src/features/travel/lib/stayForDay.ts
+++ b/fe/src/features/travel/lib/stayForDay.ts
@@ -1,0 +1,55 @@
+/**
+ * 숙소 날짜 판정. **기준 도시와 무관하다** — 닛코 당일치기 날의 기준 도시는 닛코지만
+ * 자는 곳은 도쿄일 수 있다.
+ *
+ * 판정은 반열린 구간 `[checkIn, checkOut)`으로 한다. **체크아웃일 밤은 이미 다른 곳에서
+ * 잔다** — 이 한 줄이 규칙의 전부이고, 화면마다 다시 쓰면 한 곳에서 경계가 어긋난다.
+ *
+ * ```
+ * stayTonight(day)  = checkInDate <= day <  checkOutDate   오늘 밤 자는 곳
+ * stayCheckout(day) = checkOutDate == day                  오늘 체크아웃하는 곳
+ * ```
+ *
+ * 숙소 API는 3단계다. 지금은 규칙만 두고, 보드 응답의 `stayTonight`·`stayCheckout`은
+ * 서버가 같은 규칙으로 채워 보낸다.
+ */
+
+/** 판정에 필요한 최소한. 날짜는 `"YYYY-MM-DD"` — 사전순 비교가 곧 날짜 비교다. */
+export interface StayPeriod {
+  checkInDate: string;
+  checkOutDate: string;
+}
+
+/** 그날 밤 여기서 자는가. 체크아웃일은 포함하지 않는다. */
+export function coversNight(stay: StayPeriod, date: string): boolean {
+  return stay.checkInDate <= date && date < stay.checkOutDate;
+}
+
+/** 그날 여기서 체크아웃하는가. */
+export function isCheckOutOn(stay: StayPeriod, date: string): boolean {
+  return stay.checkOutDate === date;
+}
+
+/**
+ * 두 숙소의 묵는 밤이 겹치는가. `10.24–10.27` 다음의 `10.27–10.29`는 **겹침이 아니다**
+ * (이동일).
+ */
+export function overlaps(a: StayPeriod, b: StayPeriod): boolean {
+  return a.checkInDate < b.checkOutDate && b.checkInDate < a.checkOutDate;
+}
+
+/** 그날 밤 자는 곳. 겹치는 숙소는 저장되지 않으므로 답은 하나뿐이다. */
+export function stayTonight<T extends StayPeriod>(
+  stays: T[],
+  date: string,
+): T | null {
+  return stays.find((stay) => coversNight(stay, date)) ?? null;
+}
+
+/** 그날 체크아웃하는 곳. */
+export function stayCheckout<T extends StayPeriod>(
+  stays: T[],
+  date: string,
+): T | null {
+  return stays.find((stay) => isCheckOutOn(stay, date)) ?? null;
+}

--- a/fe/src/features/travel/lib/tripStatus.test.ts
+++ b/fe/src/features/travel/lib/tripStatus.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  constantZone,
   dayChips,
   daysUntil,
   deriveStatus,
@@ -12,6 +11,12 @@ import {
   totalDays,
   type ZoneByDate,
 } from "./tripStatus";
+
+/** 전 기간이 한 도시인 여행 — 어느 날짜를 물어도 같은 타임존이다. */
+const zone =
+  (timezone: string): ZoneByDate =>
+  () =>
+    timezone;
 
 /** 2026-10-23 16:00 UTC — 도쿄는 이미 10/24 01:00, 호놀룰루는 아직 10/23 06:00. */
 const CROSSING = new Date("2026-10-23T16:00:00Z");
@@ -35,21 +40,21 @@ describe("deriveStatus", () => {
     expect(
       deriveStatus(
         ...period,
-        constantZone("Asia/Tokyo"),
+        zone("Asia/Tokyo"),
         new Date("2026-10-20T03:00:00Z"),
       ),
     ).toBe("UPCOMING");
     expect(
       deriveStatus(
         ...period,
-        constantZone("Asia/Tokyo"),
+        zone("Asia/Tokyo"),
         new Date("2026-10-25T03:00:00Z"),
       ),
     ).toBe("ONGOING");
     expect(
       deriveStatus(
         ...period,
-        constantZone("Asia/Tokyo"),
+        zone("Asia/Tokyo"),
         new Date("2026-10-28T03:00:00Z"),
       ),
     ).toBe("COMPLETED");
@@ -59,14 +64,14 @@ describe("deriveStatus", () => {
     expect(
       deriveStatus(
         ...period,
-        constantZone("Asia/Tokyo"),
+        zone("Asia/Tokyo"),
         new Date("2026-10-24T03:00:00Z"),
       ),
     ).toBe("ONGOING");
     expect(
       deriveStatus(
         ...period,
-        constantZone("Asia/Tokyo"),
+        zone("Asia/Tokyo"),
         new Date("2026-10-27T03:00:00Z"),
       ),
     ).toBe("ONGOING");
@@ -74,40 +79,36 @@ describe("deriveStatus", () => {
 
   it("기기 시간대가 아니라 기준 도시 타임존으로 판정한다", () => {
     // 같은 순간·같은 기간인데 목적지에 따라 갈린다.
-    expect(deriveStatus(...period, constantZone("Asia/Tokyo"), CROSSING)).toBe(
+    expect(deriveStatus(...period, zone("Asia/Tokyo"), CROSSING)).toBe(
       "ONGOING",
     );
-    expect(
-      deriveStatus(...period, constantZone("Pacific/Honolulu"), CROSSING),
-    ).toBe("UPCOMING");
+    expect(deriveStatus(...period, zone("Pacific/Honolulu"), CROSSING)).toBe(
+      "UPCOMING",
+    );
   });
 });
 
 describe("daysUntil", () => {
   it("남은 일수를 준다 — 당일 0, 시작 후 음수", () => {
-    expect(daysUntil("2026-10-24", constantZone("Asia/Tokyo"), CROSSING)).toBe(
-      0,
-    );
+    expect(daysUntil("2026-10-24", zone("Asia/Tokyo"), CROSSING)).toBe(0);
     expect(
       daysUntil(
         "2026-10-24",
-        constantZone("Asia/Tokyo"),
+        zone("Asia/Tokyo"),
         new Date("2026-10-20T03:00:00Z"),
       ),
     ).toBe(4);
     expect(
       daysUntil(
         "2026-10-24",
-        constantZone("Asia/Tokyo"),
+        zone("Asia/Tokyo"),
         new Date("2026-10-26T03:00:00Z"),
       ),
     ).toBe(-2);
   });
 
   it("호놀룰루는 같은 순간에도 하루가 더 남는다", () => {
-    expect(
-      daysUntil("2026-10-24", constantZone("Pacific/Honolulu"), CROSSING),
-    ).toBe(1);
+    expect(daysUntil("2026-10-24", zone("Pacific/Honolulu"), CROSSING)).toBe(1);
   });
 
   it("서머타임 경계를 넘어도 일수가 어긋나지 않는다", () => {
@@ -115,7 +116,7 @@ describe("daysUntil", () => {
     expect(
       daysUntil(
         "2026-11-05",
-        constantZone("America/New_York"),
+        zone("America/New_York"),
         new Date("2026-10-29T16:00:00Z"),
       ),
     ).toBe(7);
@@ -201,7 +202,7 @@ describe("다구간 — 날짜마다 타임존이 다를 때", () => {
     expect(
       deriveStatus(
         ...period,
-        constantZone("Asia/Tokyo"),
+        zone("Asia/Tokyo"),
         new Date("2026-10-28T03:00:00Z"),
       ),
     ).toBe("COMPLETED");

--- a/fe/src/features/travel/lib/tripStatus.ts
+++ b/fe/src/features/travel/lib/tripStatus.ts
@@ -5,13 +5,11 @@ export type TripStatus = "UPCOMING" | "ONGOING" | "COMPLETED";
  *
  * v2.1에서 **여행은 타임존을 갖지 않는다.** 날짜마다 기준 도시가 있고 타임존은 거기서
  * 나오므로, 파생 계산은 "여행의 타임존" 대신 이 조회 함수를 받는다.
+ *
+ * 만드는 쪽은 `lib/baseCity.ts`에 있다 — 날짜별 조회는 `zoneByDate(days)`,
+ * D-day처럼 첫날 하나면 되는 자리는 `firstDayZone(timezone)`.
  */
 export type ZoneByDate = (date: string) => string;
-
-/** 전 기간이 한 도시인 여행. 다구간 데이터가 오기 전(#1124)까지 대부분 이 모양이다. */
-export function constantZone(timezone: string): ZoneByDate {
-  return () => timezone;
-}
 
 /**
  * 주어진 타임존 기준 오늘 날짜("YYYY-MM-DD").

--- a/fe/src/pages/travel/TravelHomePage.tsx
+++ b/fe/src/pages/travel/TravelHomePage.tsx
@@ -13,8 +13,8 @@ import type {
 } from "@/features/travel/api/travel";
 import { useTravelSummary } from "@/features/travel/hooks/useTravelSummary";
 import { useTrip } from "@/features/travel/hooks/useTrip";
+import { firstDayZone } from "@/features/travel/lib/baseCity";
 import {
-  constantZone,
   dayChips,
   daysUntil,
   formatPeriod,
@@ -78,16 +78,16 @@ function describeState(
   if (summary?.ongoing) return `${summary.ongoing.title} 여행 중이에요.`;
   if (!featured) return undefined;
 
-  const days = daysUntil(featured.startDate, constantZone(featured.timezone));
+  const days = daysUntil(featured.startDate, firstDayZone(featured.timezone));
   if (days <= 0) return "오늘 출발이에요.";
   return `진행 중인 여행이 없어요. 다음 여행까지 ${days}일.`;
 }
 
 function FeaturedTripCard({ trip }: { trip: TripDetail }) {
   const ongoing = trip.status === "ONGOING";
-  // 서버가 준 dDay를 그대로 쓰지 않고 여행 타임존으로 다시 계산한다 —
-  // 오프라인 캐시(4단계)로 어제 응답이 돌아와도 숫자가 맞아야 한다.
-  const days = daysUntil(trip.startDate, constantZone(trip.timezone));
+  // 서버가 준 dDay를 그대로 쓰지 않고 다시 계산한다 — 오프라인 캐시(4단계)로 어제 응답이
+  // 돌아와도 숫자가 맞아야 한다. 기준은 첫날 도시다(`trip.timezone`이 그 값이다).
+  const days = daysUntil(trip.startDate, firstDayZone(trip.timezone));
   const chips = dayChips(trip.startDate, trip.endDate);
 
   return (


### PR DESCRIPTION
## 이슈
closes #1131

## 작업 내용

2단계 화면들이 공통으로 쓸 FE 모델 레이어를 먼저 만들었다. 네 화면이 전부 같은 질문을 한다 — **"이 날짜의 도시는 어디이고, 구간은 어떻게 나뉘는가."** 화면마다 각자 계산하면 규칙이 네 벌 생기고, 그중 하나만 고쳐졌을 때 **그 화면만 조용히 틀린다.**

| 모듈 | 하는 일 |
|---|---|
| `lib/legs.ts` | `days[]` → 구간 파생. 연속된 같은 기준 도시 날짜를 묶는다 |
| `lib/baseCity.ts` | `cityOn` · `zoneByDate` · `cityCount` · `firstDayZone` |
| `lib/stayForDay.ts` | `[in, out)` 반열린 구간 판정 — `coversNight` · `isCheckOutOn` · `overlaps` · `stayTonight` · `stayCheckout` |

### BE와 같은 케이스로 테스트를 맞췄다

규칙이 BE·FE 두 벌 존재하는 것은 오프라인 캐시 때문에 피할 수 없다. 대신 어긋나지 않게 **같은 질문을 양쪽에 던져 둔다** — `[도쿄, 닛코, 도쿄]` 3구간, 단일 도시 1구간, 체크아웃일 밤 제외, 이동일에 자는 곳과 체크아웃하는 곳이 다름.

`zoneByDate`를 파생 계산에 물렸을 때 날짜별로 갈리는지도 확인한다 — #1123에서 확정한 "지나갔나" 규칙이 FE에서도 같은 답을 낸다(10/25만 호놀룰루인 여행에서 오늘은 10/25).

### `constantZone`을 지웠다

#1123에서 다구간 데이터가 오기 전까지의 임시 감싸개로 뒀던 함수인데, 프로덕션 호출부가 하나뿐이었고 **그 자리는 원래 단일 존이 맞는 곳**이었다 — D-day는 첫날 기준 도시로 세는 값이고, 여행 상세 응답의 `timezone`이 곧 그 값이다.

그래서 "다구간 데이터가 없어서 임시로 상수를 쓴다"가 아니라 **"이 값은 첫날 기준이라 하나면 된다"** 로 이름을 바로잡았다(`firstDayZone`). 같은 몸통의 함수를 둘 두지 않으려고 `constantZone`은 제거했고, 테스트는 지역 헬퍼를 쓴다.

> 즉 **이 PR에서 바꿀 호출부는 없었다.** 이슈 Todo의 "`constantZone` 감싸기를 실제 날짜별 조회로 교체"는, 확인해 보니 교체가 아니라 **이름 정정**이 맞는 일이었다. 진짜 날짜별 조회가 필요한 자리(날짜 탭·보관함 그룹·목록 표기)는 #1133~#1135에서 `zoneByDate`·`deriveLegs`를 쓰기 시작한다.

### `stayForDay`는 규칙만 둔다

숙소 API는 3단계다. 판정에 필요한 최소 타입(`StayPeriod = { checkInDate, checkOutDate }`)만 두고 순수 함수로 규칙을 고정했다 — 이 형태는 [데이터 모델 §2.9](https://github.com/wcorn/orino/wiki/Travel-Data-Model)에 있는 것이지 지어낸 것이 아니다. 보드 응답의 `stayTonight`·`stayCheckout`은 서버가 같은 규칙으로 채워 보낸다.

## 테스트

`legs.test.ts`(6) · `baseCity.test.ts`(7) · `stayForDay.test.ts`(6) 신규.

`npm run format:check && npm run lint && npm test && npm run build` · `npm run test:e2e` 통과 (895 tests · E2E 89).

> 빌드에서 `Array.prototype.at`이 `lib` 타깃에 없어 걸렸다(`tsc --noEmit`은 통과하는데 `tsc -b`가 잡는다). 인덱스 접근으로 바꿨다.

## 다음

#1132(S-03) · #1133(S-04 탭) · #1134(보관함) · #1135(목록 표기)가 이 레이어를 쓴다.
