### PR TITLE
feat : 날짜 탭이 도시를 말한다

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/dto/DayUpdateRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/dto/DayUpdateRequest.java
@@ -1,19 +1,45 @@
 package ds.project.orino.planner.travel.day.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
 
 /**
  * 날짜 탭 롱프레스 시트가 보내는 것 — 기준 도시 변경과 도시 메모.
  *
  * <p><b>보낸 필드만 바꾼다.</b> 메모만 고치려는 요청이 기준 도시를 건드리면 안 되고, 그 반대도
- * 마찬가지다. 그래서 둘 다 선택이고 {@code null}은 "안 보냄"으로 읽는다.
+ * 마찬가지다. 그래서 전부 선택이고 {@code null}은 "안 보냄"으로 읽는다.
+ *
+ * <p>도시는 구간 입력과 <b>같은 두 가지 방식</b>으로 지정한다({@code TripLegRequest}) — 이미
+ * 담아 둔 도시({@code baseCityPlaceId})거나 검색 결과 그대로({@code baseCityGooglePlaceId})다.
+ * 뒤쪽이 없으면 여행에 아직 없는 도시로 하루를 옮길 때 화면이 먼저 장소를 만들어야 하는데,
+ * 그렇게 만든 도시에는 <b>도시 식별자가 없어</b> 그날 일정이 전부 "다른 도시"로 표시된다.
  *
  * @param cityMemo 빈 문자열을 보내면 메모를 지운다({@code null}은 "안 보냄"과 구분된다)
  */
 public record DayUpdateRequest(
         Long baseCityPlaceId,
 
+        String baseCityGooglePlaceId,
+
         @Size(max = 200, message = "도시 메모는 200자를 넘을 수 없습니다.")
         String cityMemo
 ) {
+
+    /** 둘 다 오면 어느 쪽이 맞는지 서버가 정할 수 없다. 둘 다 없는 것은 "도시 안 바꿈"이다. */
+    @JsonIgnore
+    @AssertTrue(message = "기준 도시는 baseCityPlaceId 또는 baseCityGooglePlaceId 중 하나로 지정해 주세요.")
+    public boolean isCityGivenAtMostOnce() {
+        return !(baseCityPlaceId != null && hasGoogleId());
+    }
+
+    @JsonIgnore
+    public boolean hasGoogleId() {
+        return baseCityGooglePlaceId != null && !baseCityGooglePlaceId.isBlank();
+    }
+
+    @JsonIgnore
+    public boolean hasCity() {
+        return baseCityPlaceId != null || hasGoogleId();
+    }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/BaseCityChangeService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/BaseCityChangeService.java
@@ -10,6 +10,7 @@ import ds.project.orino.domain.planner.travel.repository.TripDayRepository;
 import ds.project.orino.domain.planner.travel.repository.TripRepository;
 import ds.project.orino.planner.travel.day.dto.DayUpdateRequest;
 import ds.project.orino.planner.travel.day.dto.TripDayResponse;
+import ds.project.orino.planner.travel.place.service.PlaceService;
 import ds.project.orino.planner.travel.push.service.NotificationScheduleService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,17 +43,20 @@ public class BaseCityChangeService {
     private final TripRepository tripRepository;
     private final TripDayRepository dayRepository;
     private final TravelPlaceRepository placeRepository;
+    private final PlaceService placeService;
     private final NotificationScheduleService notificationService;
     private final TripDayQueryService queryService;
 
     public BaseCityChangeService(TripRepository tripRepository,
                                  TripDayRepository dayRepository,
                                  TravelPlaceRepository placeRepository,
+                                 PlaceService placeService,
                                  NotificationScheduleService notificationService,
                                  TripDayQueryService queryService) {
         this.tripRepository = tripRepository;
         this.dayRepository = dayRepository;
         this.placeRepository = placeRepository;
+        this.placeService = placeService;
         this.notificationService = notificationService;
         this.queryService = queryService;
     }
@@ -73,10 +77,12 @@ public class BaseCityChangeService {
                 // 남의 여행 날짜도 404 — 존재 여부가 새어나가지 않는다.
                 .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_DAY_NOT_FOUND));
 
-        boolean cityChanged = request.baseCityPlaceId() != null
-                && !request.baseCityPlaceId().equals(day.getBasePlaceId());
+        // 검색 결과로 바꾸는 경우, 담긴 도시의 id는 해석한 뒤에야 안다 — 이미 이 여행이 쓰던
+        // 도시를 다시 고른 것일 수도 있어 "바뀌었나"는 그다음에 묻는다.
+        Long newCityId = request.hasCity() ? resolveCity(memberId, request) : null;
+        boolean cityChanged = newCityId != null && !newCityId.equals(day.getBasePlaceId());
         if (cityChanged) {
-            day.changeBaseCity(requireCity(memberId, request.baseCityPlaceId()).getId());
+            day.changeBaseCity(newCityId);
         }
         if (request.cityMemo() != null) {
             day.updateCityMemo(request.cityMemo());
@@ -92,12 +98,29 @@ public class BaseCityChangeService {
     }
 
     /**
+     * 고른 방식 그대로 도시를 해석한다 — 담아 둔 도시면 id로, 검색 결과면 담으면서.
+     *
+     * <p>검색 결과를 그대로 받는 이유는 구간 입력과 같다: 고르기 전에 저장부터 하라고 하면
+     * 저장했다가 취소한 도시가 쌓이고, 화면이 만든 도시에는 <b>도시 식별자가 없어</b> 그날
+     * 일정이 전부 "다른 도시"로 표시된다.
+     */
+    private Long resolveCity(Long memberId, DayUpdateRequest request) {
+        if (request.hasGoogleId()) {
+            return requireCity(placeService
+                    .upsertCityFromGoogle(memberId, request.baseCityGooglePlaceId().trim()))
+                    .getId();
+        }
+        return requireCity(placeRepository
+                .findByIdAndMemberId(request.baseCityPlaceId(), memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PLACE_NOT_FOUND)))
+                .getId();
+    }
+
+    /**
      * 도시가 아닌 장소는 기준 도시가 될 수 없다. 타임존은 우연히 맞더라도 도시 일치 판정이
      * 그날 일정을 전부 "다른 도시"로 만든다.
      */
-    private TravelPlace requireCity(Long memberId, Long placeId) {
-        TravelPlace place = placeRepository.findByIdAndMemberId(placeId, memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PLACE_NOT_FOUND));
+    private TravelPlace requireCity(TravelPlace place) {
         if (!place.isCity() || place.getTimezone() == null) {
             throw new CustomException(ErrorCode.TRAVEL_NOT_A_CITY);
         }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardV21Test.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardV21Test.java
@@ -4,6 +4,9 @@ import com.jayway.jsonpath.JsonPath;
 import ds.project.orino.domain.member.repository.MemberRepository;
 import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.planner.travel.place.StubPlacesClient;
+import ds.project.orino.planner.travel.place.client.PlaceResult;
+import ds.project.orino.planner.travel.place.client.PlacesClient;
 import ds.project.orino.planner.travel.tools.StubWeatherClient;
 import ds.project.orino.planner.travel.tools.client.WeatherClient;
 import ds.project.orino.planner.travel.tools.dto.WeatherIcon;
@@ -26,6 +29,7 @@ import org.springframework.http.MediaType;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,6 +60,8 @@ class BoardV21Test extends ApiTestSupport {
     private DbCleaner dbCleaner;
     @Autowired
     private WeatherClient weatherClient;
+    @Autowired
+    private PlacesClient placesClient;
 
     private StubWeatherClient weatherStub;
     private String authHeader;
@@ -79,6 +85,8 @@ class BoardV21Test extends ApiTestSupport {
         dbCleaner.clean();
         weatherStub = (StubWeatherClient) weatherClient;
         weatherStub.reset();
+        placesStub().reset();
+        placesStub().detailResult = Optional.empty();
 
         memberRepository.save(MemberFixture.create());
         authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
@@ -256,9 +264,101 @@ class BoardV21Test extends ApiTestSupport {
         }
     }
 
+    @Nested
+    @DisplayName("기준 도시 변경 — 검색 결과 그대로")
+    class ChangeBaseCityFromSearch {
+
+        @Test
+        @DisplayName("담아 두지 않은 도시로도 하루를 옮긴다 — 서버가 담고 도시로 승격한다")
+        void upsertsCityFromGoogle() throws Exception {
+            long tripId = createTrip(leg(tokyo, 3));
+            placesStub().detailResult = Optional.of(googleCity("ChIJ_kyoto", "교토", "JP"));
+
+            changeCityByGoogleId(dayIdOf(tripId, 1), "ChIJ_kyoto")
+                    .andExpect(jsonPath("$.data[1].baseCity.name").value("교토"))
+                    .andExpect(jsonPath("$.data[1].baseCity.timezone").value("Asia/Tokyo"))
+                    .andExpect(jsonPath("$.data[1].baseCity.currency").value("JPY"))
+                    // 하루만 바꾸면 구간이 셋으로 쪼개진다. 정상이며 확인을 받지 않는다.
+                    .andExpect(jsonPath("$.data[2].legIndex").value(3));
+        }
+
+        /**
+         * 검색으로 고른 도시라야 <b>도시 식별자</b>가 생긴다. 화면이 먼저 장소를 만들어 보내면
+         * 식별자가 없어 그날 일정이 전부 "다른 도시"로 표시된다 — 이 경로가 있는 이유다.
+         */
+        @Test
+        @DisplayName("담긴 도시에 식별자가 붙어 도시 이탈 판정이 성립한다")
+        void keepsCityIdentifier() throws Exception {
+            long tripId = createTrip(leg(tokyo, 3));
+            placesStub().detailResult = Optional.of(googleCity("ChIJ_kyoto", "교토", "JP"));
+            changeCityByGoogleId(dayIdOf(tripId, 1), "ChIJ_kyoto");
+
+            long placeId = poiInCity("오사카성", "ChIJ_osaka");
+            createActivity(tripId, "오사카성", START.plusDays(1).toString(), placeId);
+
+            board(tripId, START.plusDays(1).toString())
+                    .andExpect(jsonPath("$.data.activities[0].outOfBaseCity").value(true));
+        }
+
+        @Test
+        @DisplayName("이미 이 여행이 쓰던 도시를 다시 고르면 아무것도 바뀌지 않는다")
+        void reusesSavedCity() throws Exception {
+            long tripId = createTrip(leg(tokyo, 3));
+            placesStub().reset();
+
+            mockMvc.perform(put("/api/travel/days/" + dayIdOf(tripId, 1))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"baseCityPlaceId\": %d}".formatted(tokyo)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data[1].baseCity.name").value("도쿄"))
+                    .andExpect(jsonPath("$.data[1].cityChanged").value(false));
+            assertThat(placesStub().detailFetches).isEmpty();
+        }
+
+        @Test
+        @DisplayName("도시를 두 방식으로 동시에 지정하면 400 — 어느 쪽이 맞는지 정할 수 없다")
+        void rejectsBothCityInputs() throws Exception {
+            long tripId = createTrip(leg(tokyo, 3));
+
+            mockMvc.perform(put("/api/travel/days/" + dayIdOf(tripId, 1))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"baseCityPlaceId": %d, "baseCityGooglePlaceId": "ChIJ_kyoto"}
+                                    """.formatted(tokyo)))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
     // ---------------- helpers ----------------
 
     private static final LocalDate START = LocalDate.of(2026, 10, 24);
+
+    private StubPlacesClient placesStub() {
+        return (StubPlacesClient) placesClient;
+    }
+
+    private static PlaceResult googleCity(String googlePlaceId, String name, String countryCode) {
+        return new PlaceResult(googlePlaceId, name, name, new BigDecimal("35.0116"),
+                new BigDecimal("135.7681"), null, null, null, null,
+                "Asia/Tokyo", name, countryCode, List.of());
+    }
+
+    /** 날짜 목록에서 {@code index}번째 날짜의 id. */
+    private long dayIdOf(long tripId, int index) throws Exception {
+        return ((Number) JsonPath.read(boardBody(tripId),
+                "$.data.days[%d].dayId".formatted(index))).longValue();
+    }
+
+    private org.springframework.test.web.servlet.ResultActions changeCityByGoogleId(
+            long dayId, String googlePlaceId) throws Exception {
+        return mockMvc.perform(put("/api/travel/days/" + dayId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"baseCityGooglePlaceId\": \"%s\"}".formatted(googlePlaceId)))
+                .andExpect(status().isOk());
+    }
 
     private static String startDate() {
         return START.toString();

--- a/fe/e2e/travel-day-city.spec.ts
+++ b/fe/e2e/travel-day-city.spec.ts
@@ -1,0 +1,217 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 날짜 탭의 기준 도시(S-04, #1133).
+ *
+ * <p>여기서 확인하는 것은 <b>두 롱프레스가 서로를 먹지 않는가</b>다. 일정 행은 400ms에
+ * 드래그 모드로 들어가고 날짜 탭은 450ms에 시트를 여는데, 둘 다 "누르고 기다린다"는 같은
+ * 손짓이라 실제 포인터로만 갈리는지 알 수 있다.
+ */
+
+const TRIP_ID = 1;
+const D1 = "2026-10-24";
+const D2 = "2026-10-25";
+
+const TOKYO = {
+  placeId: 21,
+  name: "도쿄",
+  timezone: "Asia/Tokyo",
+  currency: "JPY",
+  countryCode: "JP",
+  lat: null,
+  lng: null,
+};
+const NIKKO = { ...TOKYO, placeId: 22, name: "닛코" };
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+function day(
+  dayId: number,
+  dayIndex: number,
+  date: string,
+  weekday: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    dayId,
+    dayIndex,
+    date,
+    weekday,
+    activityCount: 0,
+    baseCity: TOKYO,
+    cityChanged: false,
+    legIndex: 1,
+    cityMemo: null,
+    weather: null,
+    stayTonight: null,
+    stayCheckout: null,
+    ...overrides,
+  };
+}
+
+interface Captured {
+  dayUpdates: { dayId: string; body: Record<string, unknown> }[];
+}
+
+async function mockBoard(page: Page): Promise<Captured> {
+  const captured: Captured = { dayUpdates: [] };
+
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/planner/reviews/summary", (route) =>
+    route.fulfill(
+      ok({
+        today: D1,
+        counts: { now: 0, overdue: 0, upcoming: 0, doneToday: 0 },
+        estimatedMinutes: 0,
+        materials: [],
+      }),
+    ),
+  );
+  await page.route("**/api/travel/summary", (route) =>
+    route.fulfill(ok({ ongoing: null, next: null, recentCompleted: null })),
+  );
+  await page.route("**/api/travel/days/*", (route) => {
+    const dayId = route.request().url().split("/").pop() ?? "";
+    captured.dayUpdates.push({
+      dayId,
+      body: route.request().postDataJSON() as Record<string, unknown>,
+    });
+    return route.fulfill(ok([]));
+  });
+  await page.route(`**/api/travel/trips/${TRIP_ID}/board*`, (route) => {
+    const url = new URL(route.request().url());
+    const isArchive = url.searchParams.get("archive") === "true";
+    const date = url.searchParams.get("date") ?? D1;
+    return route.fulfill(
+      ok({
+        trip: {
+          id: TRIP_ID,
+          title: "일본",
+          startDate: D1,
+          endDate: D2,
+          status: "UPCOMING",
+          recordMode: false,
+          cityCount: 2,
+          countryCount: 1,
+          singleCity: false,
+        },
+        days: [
+          day(501, 1, D1, "토"),
+          day(502, 2, D2, "일", {
+            baseCity: NIKKO,
+            cityChanged: true,
+            legIndex: 2,
+            cityMemo: "코인로커에 짐 보관",
+          }),
+        ],
+        selectedDate: isArchive ? null : date,
+        archiveCount: 0,
+        activities:
+          date !== D1 || isArchive
+            ? []
+            : [
+                {
+                  id: 1,
+                  tripId: TRIP_ID,
+                  title: "센소지",
+                  activityDate: D1,
+                  startTime: "09:00",
+                  place: null,
+                  memo: null,
+                  url: null,
+                  notifyEnabled: false,
+                  notifyMinutes: null,
+                  departureNotifyEnabled: false,
+                  sortOrder: 0,
+                  log: null,
+                  hasLog: false,
+                  outOfBaseCity: false,
+                  canDepartureNotify: true,
+                },
+              ],
+        travelTimes: [],
+        stayMove: null,
+      }),
+    );
+  });
+
+  return captured;
+}
+
+/** 손가락으로 누르고 기다린다. 움직이지 않는 것이 이 제스처의 전부다. */
+async function press(page: Page, locator: string, ms: number) {
+  const box = await page.locator(locator).first().boundingBox();
+  if (!box) throw new Error("대상을 찾지 못했다");
+  const x = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  await page.waitForTimeout(ms);
+  await page.mouse.up();
+}
+
+test.describe("날짜 탭 · 기준 도시", () => {
+  test("탭이 도시를 말하고 도시가 바뀌는 날짜에 메모가 붙는다", async ({
+    page,
+  }) => {
+    await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+
+    await expect(page.getByRole("tab").nth(0)).toContainText("1 도쿄");
+    await expect(page.getByRole("tab").nth(1)).toContainText("2 닛코");
+    // 부제는 보고 있는 날짜의 도시를 따른다.
+    await expect(page.getByText(/도쿄 · Asia\/Tokyo · JPY/)).toBeVisible();
+
+    await page.getByRole("tab").nth(1).click();
+    await expect(page.getByText("코인로커에 짐 보관")).toBeVisible();
+  });
+
+  test("450ms 누르면 기준 도시 시트가 열린다", async ({ page }) => {
+    await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByRole("tab").nth(0)).toBeVisible();
+
+    await press(page, '[role="tab"]', 600);
+
+    const sheet = page.getByRole("dialog");
+    await expect(sheet).toBeVisible();
+    await expect(sheet).toContainText("지금은 도쿄");
+  });
+
+  test("일정 행을 누르면 드래그 모드일 뿐 도시 시트는 열리지 않는다", async ({
+    page,
+  }) => {
+    await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByText("센소지")).toBeVisible();
+
+    await press(page, 'text="센소지"', 600);
+
+    await expect(page.getByRole("button", { name: "완료" })).toBeVisible();
+    await expect(page.getByRole("dialog")).toBeHidden();
+  });
+
+  test("시트에서 도시를 고르면 그 날짜만 바꾸는 요청이 나간다", async ({
+    page,
+  }) => {
+    const captured = await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+    await expect(page.getByRole("tab").nth(0)).toBeVisible();
+
+    await press(page, '[role="tab"]', 600);
+    const sheet = page.getByRole("dialog");
+    await sheet.getByRole("button", { name: "닛코" }).click();
+    await sheet.getByRole("button", { name: "저장" }).click();
+
+    await expect(page.getByRole("dialog")).toBeHidden();
+    expect(captured.dayUpdates).toEqual([
+      { dayId: "501", body: { baseCityPlaceId: 22 } },
+    ]);
+  });
+});

--- a/fe/src/components/ui/bottom-sheet.tsx
+++ b/fe/src/components/ui/bottom-sheet.tsx
@@ -18,7 +18,11 @@ const POPUP_CLASS = [
 
 interface BottomSheetProps {
   open: boolean;
-  onOpenChange: (open: boolean) => void;
+  /**
+   * 열림 상태 변경. `reason`은 무엇이 닫았는지다(`outside-press`·`escape-key`…) — 롱프레스로
+   * 연 시트처럼 <b>여는 손짓의 끝이 곧바로 바깥 클릭이 되는</b> 경우를 호출부가 가려낸다.
+   */
+  onOpenChange: (open: boolean, reason?: string) => void;
   /** 제목 — Dialog.Title로 렌더(접근성 필수). */
   title: ReactNode;
   /** 제목 아래 보조 설명(선택). */
@@ -44,7 +48,10 @@ export function BottomSheet({
   children,
 }: BottomSheetProps) {
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+    <Dialog.Root
+      open={open}
+      onOpenChange={(next, details) => onOpenChange(next, details.reason)}
+    >
       <Dialog.Portal>
         <Dialog.Backdrop className={BACKDROP_CLASS} />
         <Dialog.Popup className={cn(POPUP_CLASS, className)}>

--- a/fe/src/features/travel/api/days.ts
+++ b/fe/src/features/travel/api/days.ts
@@ -1,0 +1,49 @@
+import { client } from "@/shared/api";
+
+import type { BaseCity } from "./activities";
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+/**
+ * 날짜 하나. 보드 응답의 `days[]`와 같은 내용이되 일정·날씨가 없다 — 날짜만 필요한 화면과
+ * 기준 도시 변경 응답이 쓴다.
+ */
+export interface TripDay {
+  dayId: number;
+  dayIndex: number;
+  date: string;
+  weekday: string;
+  legIndex: number;
+  cityChanged: boolean;
+  cityMemo: string | null;
+  baseCity: BaseCity | null;
+}
+
+/**
+ * 기준 도시 변경 · 도시 메모. <b>보낸 필드만 바뀐다.</b>
+ *
+ * <p>도시는 구간 입력과 같은 두 방식이다 — 이미 담아 둔 도시(`baseCityPlaceId`)거나 검색 결과
+ * 그대로(`baseCityGooglePlaceId`)다. 뒤쪽을 쓰면 서버가 담으면서 도시 식별자를 붙여 주므로,
+ * 바꾼 도시에서도 도시 이탈 표시(`outOfBaseCity`)가 계속 성립한다.
+ */
+export interface DayUpdateRequest {
+  baseCityPlaceId?: number;
+  baseCityGooglePlaceId?: string;
+  /** 빈 문자열이면 메모를 지운다. 생략은 "안 바꿈"이다. */
+  cityMemo?: string;
+}
+
+/** 응답은 바꾼 날짜 하나가 아니라 기간 전체다 — 하루를 바꾸면 구간이 다시 나뉜다. */
+export async function updateDay(
+  dayId: number,
+  body: DayUpdateRequest,
+): Promise<TripDay[]> {
+  const { data } = await client.put<ApiEnvelope<TripDay[]>>(
+    `/travel/days/${dayId}`,
+    body,
+  );
+  return data.data;
+}

--- a/fe/src/features/travel/board/ActivityRow.tsx
+++ b/fe/src/features/travel/board/ActivityRow.tsx
@@ -154,6 +154,13 @@ export function ActivityRow({
               <span className="text-muted-foreground flex items-center gap-1 text-xs">
                 <MapPin className="size-3 shrink-0" />
                 <span className="truncate">{activity.place.name}</span>
+                {/* 그날 기준 도시와 다른 도시의 장소다. 막지 않고 알려만 준다 —
+                    오사카 가게를 교토 날짜에 두는 건 사용자의 선택이다. */}
+                {activity.outOfBaseCity && activity.place.cityName && (
+                  <span className="text-warning shrink-0">
+                    · {activity.place.cityName}
+                  </span>
+                )}
               </span>
             )}
           </Link>

--- a/fe/src/features/travel/board/BaseCitySheet.tsx
+++ b/fe/src/features/travel/board/BaseCitySheet.tsx
@@ -1,0 +1,267 @@
+import { Check, MapPin, Search, StickyNote } from "lucide-react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
+
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { LoadingText } from "@/components/ui/loading-text";
+import type { BoardDay } from "@/features/travel/api/activities";
+import type { DayUpdateRequest } from "@/features/travel/api/days";
+import { type City, searchCities } from "@/features/travel/api/places";
+import { formatShortDate } from "@/features/travel/lib/tripStatus";
+import { GoogleAttribution } from "@/features/travel/places/GoogleAttribution";
+import { cn } from "@/lib/utils";
+
+const MEMO_MAX = 200;
+
+/**
+ * 시트가 열린 직후 이 시간 안에 들어온 바깥 클릭은 무시한다.
+ *
+ * <p>이 시트를 여는 손짓은 <b>탭을 누른 채 기다리는 것</b>이다. 450ms에 시트가 올라오고 그
+ * 다음에 손가락이 떨어지는데, 그 순간 손끝은 이미 시트 <b>바깥</b>(스크림 위)에 있다 — 여는
+ * 동작의 마지막 절반이 곧바로 닫는 동작이 된다. 실제 브라우저에서만 드러나는 문제라 E2E가
+ * 먼저 잡았다.
+ */
+const OPEN_GUARD_MS = 400;
+
+interface BaseCitySheetProps {
+  /** 편집할 날짜. null이면 시트가 닫혀 있다. */
+  day: BoardDay | null;
+  /** 이 여행에 이미 등장하는 도시들 — 가장 자주 고르는 후보다. */
+  tripCities: { placeId: number; name: string }[];
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (body: DayUpdateRequest) => void;
+  pending: boolean;
+}
+
+/** 아직 저장하지 않은 선택. 고른 방식 그대로 들고 있다가 저장할 때 서버에 넘긴다. */
+type Picked =
+  | { kind: "saved"; placeId: number; name: string }
+  | { kind: "google"; googlePlaceId: string; name: string };
+
+/**
+ * 날짜 탭을 450ms 길게 눌러 여는 시트(§S-04) — 그날의 <b>기준 도시</b>와 도시 메모를 고친다.
+ *
+ * <p>후보를 두 층으로 나눈다. 위는 <b>이 여행에 이미 있는 도시</b>다 — 도쿄에서 하루 닛코에
+ * 다녀오고 다시 도쿄로 돌아오는 식의 변경이 대부분이라, 그때마다 검색을 시키면 손이 는다.
+ * 아래는 검색이다. 검색으로 고른 도시는 <b>고른 그대로</b> 보내고 서버가 담으면서 도시
+ * 식별자를 붙인다 — 화면이 먼저 장소를 만들면 그 식별자가 없어 그날 일정이 전부 "다른 도시"로
+ * 표시된다.
+ *
+ * <p>도시를 바꿔도 <b>이미 담긴 일정의 장소는 그대로 두고 경고하지 않는다.</b> 오사카 가게를
+ * 교토 날짜에 두는 건 사용자의 선택이다.
+ */
+export function BaseCitySheet({
+  day,
+  tripCities,
+  onOpenChange,
+  onSubmit,
+  pending,
+}: BaseCitySheetProps) {
+  const [picked, setPicked] = useState<Picked | null>(null);
+  const [memo, setMemo] = useState("");
+  const [draft, setDraft] = useState("");
+  const [results, setResults] = useState<City[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const openedAt = useRef(0);
+
+  // 다른 날짜를 열면 그 날짜의 값에서 다시 시작한다. 앞 날짜에서 고르다 만 도시가 남아
+  // 있으면, 저장 버튼 하나로 엉뚱한 날짜의 도시가 바뀐다.
+  useEffect(() => {
+    setPicked(null);
+    setMemo(day?.cityMemo ?? "");
+    setDraft("");
+    setResults(null);
+    setFailed(false);
+    if (day) openedAt.current = performance.now();
+  }, [day?.dayId, day?.cityMemo, day]);
+
+  const handleOpenChange = (open: boolean, reason?: string) => {
+    if (
+      !open &&
+      reason === "outside-press" &&
+      performance.now() - openedAt.current < OPEN_GUARD_MS
+    ) {
+      return;
+    }
+    onOpenChange(open);
+  };
+
+  const search = async (event: FormEvent) => {
+    event.preventDefault();
+    const q = draft.trim();
+    if (!q) return;
+    setSearching(true);
+    setFailed(false);
+    try {
+      setResults(await searchCities(q));
+    } catch {
+      setResults(null);
+      setFailed(true);
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const submit = () => {
+    const body: DayUpdateRequest = {};
+    if (picked?.kind === "saved") body.baseCityPlaceId = picked.placeId;
+    if (picked?.kind === "google")
+      body.baseCityGooglePlaceId = picked.googlePlaceId;
+    // 메모는 바뀌었을 때만 보낸다 — 생략은 "안 바꿈", 빈 문자열은 "지움"이다.
+    if (memo.trim() !== (day?.cityMemo ?? "")) body.cityMemo = memo.trim();
+    onSubmit(body);
+  };
+
+  const currentName = picked?.name ?? day?.baseCity?.name ?? "도시 없음";
+  const isCurrent = (placeId: number) =>
+    picked === null
+      ? day?.baseCity?.placeId === placeId
+      : picked.kind === "saved" && picked.placeId === placeId;
+
+  return (
+    <BottomSheet
+      open={day !== null}
+      onOpenChange={handleOpenChange}
+      title="기준 도시"
+      description={
+        day
+          ? `${day.dayIndex}일차 ${formatShortDate(day.date)} · 지금은 ${currentName}`
+          : undefined
+      }
+    >
+      <div className="mt-3 flex flex-col gap-4">
+        {tripCities.length > 0 && (
+          <section className="flex flex-col gap-1.5">
+            <h3 className="text-muted-foreground text-[13px]">
+              이 여행의 도시
+            </h3>
+            <div className="flex flex-wrap gap-1.5">
+              {tripCities.map((city) => (
+                <Button
+                  key={city.placeId}
+                  type="button"
+                  variant={isCurrent(city.placeId) ? "default" : "outline"}
+                  size="sm"
+                  onClick={() =>
+                    setPicked({
+                      kind: "saved",
+                      placeId: city.placeId,
+                      name: city.name,
+                    })
+                  }
+                >
+                  {isCurrent(city.placeId) && <Check className="size-3.5" />}
+                  {city.name}
+                </Button>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <FormField label="도시 검색" htmlFor="baseCitySearch">
+          <div className="flex items-center gap-2">
+            <Search className="text-muted-foreground size-4 shrink-0" />
+            <Input
+              id="baseCitySearch"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void search(e);
+              }}
+              placeholder="닛코"
+              maxLength={100}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={(e) => void search(e)}
+              disabled={searching || !draft.trim()}
+            >
+              검색
+            </Button>
+          </div>
+        </FormField>
+
+        {searching && <LoadingText />}
+        {failed && (
+          <p className="text-muted-foreground text-sm">
+            도시를 검색하지 못했어요.
+          </p>
+        )}
+
+        {results !== null && !searching && (
+          <ul className="bg-popover border-border overflow-hidden rounded-lg border">
+            {results.length === 0 ? (
+              <li className="text-muted-foreground p-3 text-sm">
+                검색 결과가 없어요.
+              </li>
+            ) : (
+              results.map((city) => (
+                <li key={city.googlePlaceId}>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setPicked({
+                        kind: "google",
+                        googlePlaceId: city.googlePlaceId,
+                        name: city.name,
+                      })
+                    }
+                    className={cn(
+                      "hover:bg-accent flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm",
+                      picked?.kind === "google" &&
+                        picked.googlePlaceId === city.googlePlaceId &&
+                        "bg-accent",
+                    )}
+                  >
+                    <MapPin className="text-muted-foreground size-3.5 shrink-0" />
+                    <span className="flex-1 truncate">{city.name}</span>
+                    <span className="text-muted-foreground shrink-0 text-xs">
+                      {city.timezone} · {city.currency}
+                    </span>
+                  </button>
+                </li>
+              ))
+            )}
+            {results.length > 0 && (
+              <li>
+                <GoogleAttribution />
+              </li>
+            )}
+          </ul>
+        )}
+
+        <FormField label="도시 메모" htmlFor="cityMemo">
+          <div className="flex items-center gap-2">
+            <StickyNote className="text-muted-foreground size-3.5 shrink-0" />
+            <Input
+              id="cityMemo"
+              value={memo}
+              onChange={(e) => setMemo(e.target.value)}
+              placeholder="체크아웃 후 코인로커에 짐 보관"
+              maxLength={MEMO_MAX}
+            />
+          </div>
+        </FormField>
+
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+          >
+            취소
+          </Button>
+          <Button type="button" onClick={submit} disabled={pending}>
+            저장
+          </Button>
+        </div>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/fe/src/features/travel/board/DayTabs.tsx
+++ b/fe/src/features/travel/board/DayTabs.tsx
@@ -1,5 +1,6 @@
 import { useDroppable } from "@dnd-kit/core";
 import { Archive } from "lucide-react";
+import { Fragment } from "react";
 
 import type { BoardDay } from "@/features/travel/api/activities";
 import type { DailyWeather } from "@/features/travel/api/tools";
@@ -7,13 +8,19 @@ import { formatShortDate } from "@/features/travel/lib/tripStatus";
 import { iconFor, needsUmbrella } from "@/features/travel/tools/weatherIcon";
 import { cn } from "@/lib/utils";
 
+import { TAB_HOLD_MS, useLongPress } from "./useLongPress";
+
 interface DayTabsProps {
   days: BoardDay[];
   archiveCount: number;
   /** 선택된 날짜. null이면 보관함 칩이 활성이다. */
   selectedDate: string | null;
+  /** 전 기간이 한 도시면 도시명을 감추고 `N일차`로 그린다. */
+  singleCity: boolean;
   onSelectDate: (date: string) => void;
   onSelectArchive: () => void;
+  /** 450ms 길게 눌러 그 날짜의 기준 도시 시트를 연다. */
+  onLongPressDay: (day: BoardDay) => void;
   /** 드래그 중이면 칩이 드롭 대상이 된다 — 여기로 떨어뜨리면 그 날짜로 옮긴다. */
   droppable?: boolean;
 }
@@ -23,13 +30,19 @@ interface DayTabsProps {
  *
  * <p>보관함이 마지막인 이유는 날짜가 시간 순서를 갖는 반면 보관함은 "아직 날짜를 못 정한 것"
  * 이라서다 — 중간에 끼우면 순서가 깨진 것처럼 보인다.
+ *
+ * <p><b>v2.1 — 탭이 도시를 말한다.</b> 어느 날 어느 도시에 있는지가 여기서 바로 읽혀야
+ * 다구간 일정에서 길을 잃지 않는다. 다만 <b>도시가 하나뿐인 여행에서는 감춘다</b> — 같은
+ * 이름을 열 번 반복하면 정보가 아니라 소음이다.
  */
 export function DayTabs({
   days,
   archiveCount,
   selectedDate,
+  singleCity,
   onSelectDate,
   onSelectArchive,
+  onLongPressDay,
   droppable = false,
 }: DayTabsProps) {
   return (
@@ -39,15 +52,27 @@ export function DayTabs({
       className="flex gap-1.5 overflow-x-auto pb-1"
     >
       {days.map((day) => (
-        <Chip
-          key={day.date}
-          dropId={droppable ? `day:${day.date}` : undefined}
-          active={selectedDate === day.date}
-          label={`${day.dayIndex}일차`}
-          sub={`${formatShortDate(day.date)} ${day.weekday}`}
-          weather={day.weather}
-          onClick={() => onSelectDate(day.date)}
-        />
+        <Fragment key={day.date}>
+          {/* 도시가 바뀌는 자리에 선을 하나 세운다 — 며칠째인지보다 "여기서 옮긴다"가 먼저
+              읽혀야 한다. 첫날은 비교할 앞 날짜가 없어 서지 않는다. */}
+          {day.cityChanged && (
+            <div aria-hidden="true" className="bg-border my-1 w-px shrink-0" />
+          )}
+          <Chip
+            dropId={droppable ? `day:${day.date}` : undefined}
+            active={selectedDate === day.date}
+            label={
+              singleCity || !day.baseCity
+                ? `${day.dayIndex}일차`
+                : `${day.dayIndex} ${day.baseCity.name}`
+            }
+            wide={!singleCity && day.baseCity !== null}
+            sub={`${formatShortDate(day.date)} ${day.weekday}`}
+            weather={day.weather}
+            onClick={() => onSelectDate(day.date)}
+            onLongPress={() => onLongPressDay(day)}
+          />
+        </Fragment>
       ))}
       <Chip
         dropId={droppable ? "day:archive" : undefined}
@@ -65,10 +90,14 @@ interface ChipProps {
   active: boolean;
   label: string;
   sub: string;
+  /** 도시명이 붙는 칩은 조금 넓다. 짧은 도시명에서 칸이 들쭉날쭉해지지 않게. */
+  wide?: boolean;
   /** 예보 범위(16일) 밖이면 없다 — 그 자리를 비운다. */
   weather?: DailyWeather | null;
   icon?: React.ReactNode;
   onClick: () => void;
+  /** 없으면 롱프레스를 받지 않는다(보관함 칩에는 기준 도시가 없다). */
+  onLongPress?: () => void;
   /** 있으면 드롭 대상으로 등록한다. */
   dropId?: string;
 }
@@ -77,9 +106,11 @@ function Chip({
   active,
   label,
   sub,
+  wide = false,
   weather,
   icon,
   onClick,
+  onLongPress,
   dropId,
 }: ChipProps) {
   const WeatherGlyph = weather
@@ -90,6 +121,13 @@ function Chip({
     id: dropId ?? "",
     disabled: !dropId,
   });
+  // 일정 행의 드래그 진입(400ms)과 같은 훅을 쓰되 임계값만 다르다. 탭과 행은 서로 다른
+  // 제스처 대상이라 두 판정이 동시에 돌 일이 없다.
+  const longPress = useLongPress(
+    onLongPress ?? (() => {}),
+    onLongPress !== undefined,
+    TAB_HOLD_MS,
+  );
 
   return (
     <button
@@ -98,8 +136,10 @@ function Chip({
       role="tab"
       aria-selected={active}
       onClick={onClick}
+      {...longPress}
       className={cn(
-        "flex min-w-[78px] shrink-0 flex-col items-start gap-0.5 rounded-lg border px-2.5 py-2 transition-colors",
+        "flex shrink-0 flex-col items-start gap-0.5 rounded-lg border px-2.5 py-2 transition-colors",
+        wide ? "min-w-[92px]" : "min-w-[78px]",
         active
           ? "bg-accent text-accent-foreground border-primary"
           : "bg-card border-border hover:bg-muted",
@@ -107,7 +147,7 @@ function Chip({
         isOver && "border-primary ring-primary bg-accent ring-2",
       )}
     >
-      <span className="flex items-center gap-1 text-[13px] font-semibold">
+      <span className="flex max-w-[110px] items-center gap-1 truncate text-[13px] font-semibold">
         {icon}
         {label}
       </span>

--- a/fe/src/features/travel/board/LocalClockLine.tsx
+++ b/fe/src/features/travel/board/LocalClockLine.tsx
@@ -3,18 +3,27 @@ import { useEffect, useState } from "react";
 import { localTime, sameOffset } from "@/features/travel/lib/localClock";
 
 interface LocalClockLineProps {
+  /** 보고 있는 날짜의 기준 도시. 도시를 옮겨 다니면 탭을 넘길 때마다 이 줄이 바뀐다. */
+  cityName: string;
   timezone: string;
+  currency: string;
   /** 완료된 여행은 시계가 아니라 기록 모드임을 알린다. */
   recordMode: boolean;
 }
 
 /**
- * 제목 아래 현지 시각 줄(§S-04).
+ * 제목 아래 부제(§S-04) — `현지 09:42 · 교토 · Asia/Tokyo · JPY`.
  *
- * <p>기기와 여행의 <b>오프셋이 같으면 숨긴다</b> — 서울에서 도쿄 여행을 보면 시계가 똑같아
- * 줄만 차지한다. 이 줄이 필요한 건 "지금 현지가 몇 시지"가 실제로 헷갈릴 때뿐이다.
+ * <p>기기와 <b>오프셋이 같으면 시각만 감춘다</b>. 서울에서 도쿄 여행을 보면 시계가 똑같아
+ * 알려 줄 것이 없지만, 도시와 타임존은 v2.1에서 <b>날짜마다 달라지는 값</b>이라 계속 필요하다
+ * (v2.0에서는 줄 전체를 감췄다 — 그때는 여행 하나에 타임존도 하나였다).
  */
-export function LocalClockLine({ timezone, recordMode }: LocalClockLineProps) {
+export function LocalClockLine({
+  cityName,
+  timezone,
+  currency,
+  recordMode,
+}: LocalClockLineProps) {
   const [now, setNow] = useState(() => new Date());
 
   useEffect(() => {
@@ -26,16 +35,14 @@ export function LocalClockLine({ timezone, recordMode }: LocalClockLineProps) {
   if (recordMode) {
     return (
       <p className="text-caption text-muted-foreground">
-        기록 모드 · {timezone}
+        기록 모드 · {cityName} · {timezone}
       </p>
     );
   }
-  if (sameOffset(timezone, now)) {
-    return null;
-  }
+  const parts = sameOffset(timezone, now)
+    ? [cityName, timezone, currency]
+    : [`현지 ${localTime(timezone, now)}`, cityName, timezone, currency];
   return (
-    <p className="text-caption text-muted-foreground">
-      현지 {localTime(timezone, now)} · {timezone}
-    </p>
+    <p className="text-caption text-muted-foreground">{parts.join(" · ")}</p>
   );
 }

--- a/fe/src/features/travel/board/useLongPress.ts
+++ b/fe/src/features/travel/board/useLongPress.ts
@@ -2,6 +2,11 @@ import { type PointerEvent, useCallback, useEffect, useRef } from "react";
 
 /** 설계가 정한 진입 시간. 스크롤하려던 손짓과 구분되는 최소한의 길이다. */
 const HOLD_MS = 400;
+/**
+ * 날짜 탭의 기준 도시 시트는 450ms다. 일정 행(400ms)과 <b>대상이 달라</b> 충돌하지 않지만,
+ * 탭은 가로 스크롤도 겸하는 자리라 반 박자 길게 잡는다.
+ */
+export const TAB_HOLD_MS = 450;
 /** 이만큼 움직이면 누른 게 아니라 스크롤·스와이프다. */
 const TOLERANCE_PX = 8;
 
@@ -15,7 +20,11 @@ const TOLERANCE_PX = 8;
  *
  * <p>그래서 진입은 이 훅이 맡고, 실제 드래그는 모드에 들어온 뒤에만 활성화한다.
  */
-export function useLongPress(onLongPress: () => void, enabled = true) {
+export function useLongPress(
+  onLongPress: () => void,
+  enabled = true,
+  holdMs: number = HOLD_MS,
+) {
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const origin = useRef<{ x: number; y: number } | null>(null);
 
@@ -33,7 +42,7 @@ export function useLongPress(onLongPress: () => void, enabled = true) {
     timer.current = setTimeout(() => {
       onLongPress();
       clear();
-    }, HOLD_MS);
+    }, holdMs);
   };
 
   const onPointerMove = (event: PointerEvent<HTMLElement>) => {

--- a/fe/src/features/travel/hooks/useUpdateDay.ts
+++ b/fe/src/features/travel/hooks/useUpdateDay.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { type DayUpdateRequest, updateDay } from "../api/days";
+import { travelKeys } from "../queryKeys";
+
+/**
+ * 기준 도시 변경 · 도시 메모.
+ *
+ * <p>성공하면 <b>그 여행의 보드를 통째로</b> 무효화한다. 하루를 바꾸면 구간이 다시 나뉘어
+ * 앞뒤 날짜의 `legIndex`·`cityChanged`까지 달라지고, 타임존이 바뀐 날짜는 시각 표시와 날씨도
+ * 달라진다 — 바꾼 날짜만 갱신하면 탭이 서로 어긋난 채 남는다.
+ */
+export function useUpdateDay(tripId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ dayId, body }: { dayId: number; body: DayUpdateRequest }) =>
+      updateDay(dayId, body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: travelKeys.boards(tripId),
+      });
+    },
+  });
+}

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -131,6 +131,14 @@ function mockBoard(options: {
   );
 }
 
+/** 날짜 탭을 450ms 길게 눌러 기준 도시 시트를 연다. 손가락이 하는 일 그대로다. */
+async function openCitySheet(tabIndex: number) {
+  const tab = screen.getAllByRole("tab")[tabIndex];
+  fireEvent.pointerDown(tab, { clientX: 10, clientY: 10 });
+  await screen.findByRole("dialog", undefined, { timeout: 2000 });
+  fireEvent.pointerUp(tab);
+}
+
 function renderBoard(path = "/travel/trips/3/board") {
   return renderWithRouter(
     <Providers>
@@ -237,7 +245,282 @@ describe("TripBoardPage", () => {
     });
   });
 
+  describe("탭이 도시를 말한다 (v2.1)", () => {
+    /** 도쿄 → 닛코 → 도쿄. 하루만 다른 도시라 구간이 셋으로 쪼개진 여행이다. */
+    const NIKKO = baseCity(22, "닛코", "Asia/Tokyo");
+    const MULTI_DAYS = [
+      day(1, "2026-10-24", "토", 0),
+      day(2, "2026-10-25", "일", 0, {
+        baseCity: NIKKO,
+        cityChanged: true,
+        legIndex: 2,
+      }),
+      day(3, "2026-10-26", "월", 0, { cityChanged: true, legIndex: 3 }),
+    ];
+
+    function mockMultiCity(overrides: Record<string, unknown> = {}) {
+      mockBoard({
+        byDate: { "2026-10-24": [], "2026-10-25": [], "2026-10-26": [] },
+        trip: { singleCity: false, cityCount: 2, ...overrides },
+        days: MULTI_DAYS,
+      });
+    }
+
+    it("도시가 여럿이면 탭이 `N 도시명`을 쓴다", async () => {
+      mockMultiCity();
+
+      renderBoard();
+
+      const tabs = await screen.findAllByRole("tab");
+      expect(tabs[0]).toHaveTextContent("1 도쿄");
+      expect(tabs[1]).toHaveTextContent("2 닛코");
+      expect(tabs[2]).toHaveTextContent("3 도쿄");
+    });
+
+    it("전 기간 한 도시면 도시명을 감추고 `N일차`로 쓴다 — 반복은 정보가 아니다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [] } });
+
+      renderBoard();
+
+      const tabs = await screen.findAllByRole("tab");
+      expect(tabs[0]).toHaveTextContent("1일차");
+      expect(tabs[0]).not.toHaveTextContent("도쿄");
+    });
+
+    it("도시가 바뀌는 탭 앞에만 구분선이 선다 — 첫날은 비교할 앞 날짜가 없다", async () => {
+      mockMultiCity();
+
+      renderBoard();
+      await screen.findAllByRole("tab");
+
+      // 탭 줄의 자식 순서로 확인한다: 칩 · 선 · 칩 · 선 · 칩 · 보관함 칩.
+      const strip = screen.getByRole("tablist");
+      const roles = [...strip.children].map((el) => el.getAttribute("role"));
+      expect(roles).toEqual(["tab", null, "tab", null, "tab", "tab"]);
+    });
+
+    it("450ms 눌러야 기준 도시 시트가 열린다 — 400ms는 아직 아니다", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      mockMultiCity();
+
+      renderBoard();
+      const tab = (await screen.findAllByRole("tab"))[1];
+
+      // 일정 행의 드래그 진입(400ms)과 같은 길이로는 열리지 않는다.
+      await act(async () => {
+        fireEvent.pointerDown(tab, { clientX: 10, clientY: 10 });
+        vi.advanceTimersByTime(420);
+      });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(60);
+      });
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByText(/2일차 10.25 · 지금은 닛코/)).toBeInTheDocument();
+      vi.useRealTimers();
+    });
+
+    it("이 여행의 도시를 고르면 그 날짜만 바꾸는 요청이 나간다", async () => {
+      const seen: { dayId: string; body: Record<string, unknown> }[] = [];
+      mockMultiCity();
+      server.use(
+        http.put(
+          `${API_BASE}/travel/days/:dayId`,
+          async ({ params, request }) => {
+            seen.push({
+              dayId: String(params.dayId),
+              body: (await request.json()) as Record<string, unknown>,
+            });
+            return HttpResponse.json({ code: "OK", data: [] });
+          },
+        ),
+      );
+
+      renderBoard();
+      await screen.findAllByRole("tab");
+      await openCitySheet(1);
+
+      const sheet = screen.getByRole("dialog");
+      await userEvent.click(
+        within(sheet).getByRole("button", { name: "도쿄" }),
+      );
+      await userEvent.click(
+        within(sheet).getByRole("button", { name: "저장" }),
+      );
+
+      await waitFor(() => expect(seen).toHaveLength(1));
+      // 2일차의 dayId. 보고 있던 날짜가 아니라 길게 누른 날짜다.
+      expect(seen[0].dayId).toBe("502");
+      expect(seen[0].body).toEqual({ baseCityPlaceId: 21 });
+    });
+
+    it("검색으로 고른 도시는 고른 그대로 보낸다 — 서버가 담으며 식별자를 붙인다", async () => {
+      const seen: Record<string, unknown>[] = [];
+      mockMultiCity();
+      server.use(
+        http.get(`${API_BASE}/travel/places/cities`, () =>
+          HttpResponse.json({
+            code: "OK",
+            data: [
+              {
+                googlePlaceId: "ChIJ_kyoto",
+                name: "교토",
+                address: "일본 교토부",
+                lat: 35.0116,
+                lng: 135.7681,
+                timezone: "Asia/Tokyo",
+                currency: "JPY",
+              },
+            ],
+          }),
+        ),
+        http.put(`${API_BASE}/travel/days/:dayId`, async ({ request }) => {
+          seen.push((await request.json()) as Record<string, unknown>);
+          return HttpResponse.json({ code: "OK", data: [] });
+        }),
+      );
+
+      renderBoard();
+      await screen.findAllByRole("tab");
+      await openCitySheet(1);
+
+      const sheet = screen.getByRole("dialog");
+      await userEvent.type(within(sheet).getByLabelText("도시 검색"), "교토");
+      await userEvent.click(
+        within(sheet).getByRole("button", { name: "검색" }),
+      );
+      await userEvent.click(
+        await within(sheet).findByRole("button", { name: /교토/ }),
+      );
+      await userEvent.click(
+        within(sheet).getByRole("button", { name: "저장" }),
+      );
+
+      await waitFor(() => expect(seen).toHaveLength(1));
+      expect(seen[0]).toEqual({ baseCityGooglePlaceId: "ChIJ_kyoto" });
+    });
+
+    it("도시 메모는 있을 때만 탭 아래 한 줄로 보인다", async () => {
+      mockBoard({
+        byDate: { "2026-10-24": [], "2026-10-25": [] },
+        days: [
+          day(1, "2026-10-24", "토", 0, { cityMemo: "코인로커에 짐 보관" }),
+          day(2, "2026-10-25", "일", 0),
+        ],
+      });
+
+      renderBoard();
+
+      expect(await screen.findByText("코인로커에 짐 보관")).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole("tab", { name: /2일차/ }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("코인로커에 짐 보관"),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("메모만 고치면 도시는 건드리지 않는다", async () => {
+      const seen: Record<string, unknown>[] = [];
+      mockBoard({ byDate: { "2026-10-24": [] } });
+      server.use(
+        http.put(`${API_BASE}/travel/days/:dayId`, async ({ request }) => {
+          seen.push((await request.json()) as Record<string, unknown>);
+          return HttpResponse.json({ code: "OK", data: [] });
+        }),
+      );
+
+      renderBoard();
+      await screen.findAllByRole("tab");
+      await openCitySheet(0);
+
+      const sheet = screen.getByRole("dialog");
+      await userEvent.type(
+        within(sheet).getByLabelText("도시 메모"),
+        "코인로커",
+      );
+      await userEvent.click(
+        within(sheet).getByRole("button", { name: "저장" }),
+      );
+
+      await waitFor(() => expect(seen).toHaveLength(1));
+      expect(seen[0]).toEqual({ cityMemo: "코인로커" });
+    });
+
+    it("메뉴로도 같은 시트를 연다 — 롱프레스는 손가락의 길일 뿐이다", async () => {
+      mockMultiCity();
+
+      renderBoard();
+      await screen.findAllByRole("tab");
+
+      await userEvent.click(screen.getByRole("button", { name: "여행 메뉴" }));
+      await userEvent.click(
+        await screen.findByRole("menuitem", { name: "기준 도시 변경" }),
+      );
+
+      expect(await screen.findByRole("dialog")).toHaveTextContent(
+        "1일차 10.24 · 지금은 도쿄",
+      );
+    });
+  });
+
   describe("일정 행", () => {
+    it("그날 도시가 아닌 장소면 도시명을 덧붙인다 — 막지는 않는다", async () => {
+      mockBoard({
+        byDate: {
+          "2026-10-24": [
+            activity({
+              title: "구로몬 시장",
+              outOfBaseCity: true,
+              place: {
+                id: 7,
+                name: "구로몬 시장",
+                address: null,
+                lat: null,
+                lng: null,
+                cityName: "오사카",
+                cityPlaceRef: "ChIJ_osaka",
+              },
+            }),
+          ],
+        },
+      });
+
+      renderBoard();
+
+      expect(await screen.findByText("· 오사카")).toBeInTheDocument();
+      // 경고일 뿐 일정은 그대로 있다(제목 + 장소명).
+      expect(screen.getAllByText("구로몬 시장")).toHaveLength(2);
+    });
+
+    it("같은 도시의 장소에는 아무것도 붙이지 않는다", async () => {
+      mockBoard({
+        byDate: {
+          "2026-10-24": [
+            activity({
+              place: {
+                id: 8,
+                name: "센소지",
+                address: null,
+                lat: null,
+                lng: null,
+                cityName: "도쿄",
+                cityPlaceRef: "ChIJ_tokyo",
+              },
+            }),
+          ],
+        },
+      });
+
+      renderBoard();
+
+      await screen.findAllByText("센소지");
+      expect(screen.queryByText("· 도쿄")).not.toBeInTheDocument();
+    });
+
     it("시각을 tabular-nums로 보여주고, 없으면 ── 로 자리를 지킨다", async () => {
       mockBoard({
         byDate: {
@@ -590,13 +873,59 @@ describe("TripBoardPage", () => {
 
       expect(await screen.findByText(/Europe\/Paris/)).toBeInTheDocument();
 
-      await userEvent.click(screen.getByRole("tab", { name: /2일차/ }));
+      // 도시가 둘이면 탭이 도시명을 쓴다 — `2일차`가 아니라 `2 호놀룰루`다.
+      await userEvent.click(screen.getByRole("tab", { name: /호놀룰루/ }));
 
       expect(await screen.findByText(/Pacific\/Honolulu/)).toBeInTheDocument();
       expect(screen.queryByText(/Europe\/Paris/)).not.toBeInTheDocument();
     });
 
-    it("메뉴에서 여행 수정으로 간다", async () => {
+    it("부제가 도시·타임존·통화를 함께 말한다 — v2.1에서 이 값들의 주인은 날짜다", async () => {
+      const paris = baseCity(23, "파리", "Europe/Paris", "EUR");
+      mockBoard({
+        byDate: { "2026-10-24": [] },
+        trip: { singleCity: false, cityCount: 2 },
+        days: [day(1, "2026-10-24", "토", 0, { baseCity: paris })],
+      });
+
+      renderBoard();
+
+      expect(
+        await screen.findByText(
+          /현지 \d{2}:\d{2} · 파리 · Europe\/Paris · EUR/,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("기기와 오프셋이 같으면 시각만 감추고 도시·타임존은 남긴다", async () => {
+      // 기기 타임존을 그대로 쓴다 — 어느 환경에서 돌려도 오프셋이 0이다.
+      const here = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      mockBoard({
+        byDate: { "2026-10-24": [] },
+        days: [
+          day(1, "2026-10-24", "토", 0, {
+            baseCity: baseCity(24, "여기", here, "KRW"),
+          }),
+        ],
+      });
+
+      renderBoard();
+
+      expect(
+        await screen.findByText(`여기 · ${here} · KRW`),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/현지 /)).not.toBeInTheDocument();
+    });
+
+    it("보관함에는 기준 도시가 없다 — 부제도 그렇게 말한다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [] }, archive: [] });
+
+      renderBoard("/travel/trips/3/board?day=archive");
+
+      expect(await screen.findByText("미배정 보관함")).toBeInTheDocument();
+    });
+
+    it("메뉴에서 구간 수정으로 간다", async () => {
       mockBoard({ byDate: { "2026-10-24": [] } });
       server.use(
         http.get(`${API_BASE}/travel/trips/:tripId`, () =>
@@ -623,7 +952,7 @@ describe("TripBoardPage", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "여행 메뉴" }));
       await userEvent.click(
-        await screen.findByRole("menuitem", { name: "여행 수정" }),
+        await screen.findByRole("menuitem", { name: "구간 수정" }),
       );
 
       await waitFor(() => {

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -20,6 +20,7 @@ import {
   MoreVertical,
   Plus,
   Search,
+  StickyNote,
   Wrench,
 } from "lucide-react";
 import { Fragment, useState } from "react";
@@ -30,12 +31,18 @@ import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { LoadingText } from "@/components/ui/loading-text";
 import { Menu, MenuItem } from "@/components/ui/menu";
-import type { Activity, TravelTime } from "@/features/travel/api/activities";
+import type {
+  Activity,
+  BoardDay,
+  TravelTime,
+} from "@/features/travel/api/activities";
 // 삭제는 뮤테이션 훅이 아니라 raw 요청을 쓴다 — 화면을 떠난 뒤에 보낼 수도 있어서다.
 import { deleteActivity as deleteActivityRequest } from "@/features/travel/api/activities";
+import type { DayUpdateRequest } from "@/features/travel/api/days";
 import { deleteTrip } from "@/features/travel/api/travel";
 import { ActivityRow } from "@/features/travel/board/ActivityRow";
 import { AddSheet } from "@/features/travel/board/AddSheet";
+import { BaseCitySheet } from "@/features/travel/board/BaseCitySheet";
 import { DayTabs } from "@/features/travel/board/DayTabs";
 import { DragModeBar } from "@/features/travel/board/DragModeBar";
 import { LocalClockLine } from "@/features/travel/board/LocalClockLine";
@@ -50,6 +57,7 @@ import {
   useUpdateActivity,
 } from "@/features/travel/hooks/useActivityMutations";
 import { useBoard } from "@/features/travel/hooks/useBoard";
+import { useUpdateDay } from "@/features/travel/hooks/useUpdateDay";
 import { toast } from "@/shared/lib/toast";
 import { useOnline } from "@/shared/lib/useOnline";
 
@@ -106,6 +114,8 @@ export function TripBoardPage() {
 
   const [sheetOpen, setSheetOpen] = useState(false);
   const [deletingTrip, setDeletingTrip] = useState(false);
+  /** 기준 도시 시트를 연 날짜. null이면 닫혀 있다. */
+  const [cityDay, setCityDay] = useState<BoardDay | null>(null);
   const [dragMode, setDragMode] = useState(false);
   const [openTravelTime, setOpenTravelTime] = useState<TravelTime | null>(null);
   // 오프라인은 조회 전용이다(§4.6). 편집을 막는 게 아니라 진입 자체를 없앤다.
@@ -113,6 +123,7 @@ export function TripBoardPage() {
 
   const createActivity = useCreateActivity(tripId);
   const updateActivity = useUpdateActivity(tripId);
+  const updateDay = useUpdateDay(tripId);
   const reorder = useReorderActivities(tripId);
   const undoable = useUndoableAction(tripId);
   const pendingIds = usePendingActions((state) => state.pendingIds);
@@ -152,11 +163,23 @@ export function TripBoardPage() {
     ]),
   );
 
+  /** 보고 있는 날짜. 보관함을 보고 있으면 없다. */
+  const selectedDay =
+    board.days.find((day) => day.date === board.selectedDate) ?? null;
   /** 보고 있는 날짜의 기준 도시. 보관함에는 날짜가 없어 첫날로 떨어진다. */
-  const selectedCity =
-    (board.selectedDate
-      ? board.days.find((day) => day.date === board.selectedDate)?.baseCity
-      : board.days[0]?.baseCity) ?? null;
+  const selectedCity = (selectedDay ?? board.days[0])?.baseCity ?? null;
+
+  /**
+   * 이 여행에 등장하는 도시들. 기준 도시를 바꿀 때 가장 자주 고르는 후보라 시트 위쪽에
+   * 그대로 올린다 — 도쿄↔닛코를 오가는 변경에 매번 검색을 시킬 이유가 없다.
+   */
+  const tripCities = [
+    ...new Map(
+      board.days
+        .flatMap((day) => (day.baseCity ? [day.baseCity] : []))
+        .map((city) => [city.placeId, city]),
+    ).values(),
+  ];
 
   const selectDay = (date: string) => {
     const index = board.days.findIndex((d) => d.date === date);
@@ -242,6 +265,30 @@ export function TripBoardPage() {
     );
   };
 
+  /**
+   * 기준 도시·도시 메모 저장. 도시가 바뀌면 구간이 다시 나뉘므로 탭 전체가 다시 그려진다
+   * (응답이 기간 전체라 훅이 보드를 통째로 무효화한다).
+   */
+  const saveDay = async (body: DayUpdateRequest) => {
+    if (!cityDay) return;
+    if (Object.keys(body).length === 0) {
+      setCityDay(null);
+      return;
+    }
+    try {
+      await updateDay.mutateAsync({ dayId: cityDay.dayId, body });
+      setCityDay(null);
+      toast(
+        body.baseCityPlaceId || body.baseCityGooglePlaceId
+          ? "기준 도시를 바꿨어요."
+          : "도시 메모를 저장했어요.",
+        "success",
+      );
+    } catch {
+      toast("저장하지 못했어요.", "error");
+    }
+  };
+
   /** 행을 길게 눌렀다 — 드래그 모드로 들어간다. */
   const enterDragMode = () => {
     if (dragMode) return;
@@ -295,13 +342,21 @@ export function TripBoardPage() {
             <h1 className="text-heading truncate font-semibold">
               {board.trip.title}
             </h1>
-            {/* 시계는 <b>보고 있는 날짜</b>의 기준 도시를 따른다 — 도시를 옮겨 다니면
-                날짜 탭을 넘길 때마다 현지 시각이 바뀐다. */}
-            {selectedCity && (
-              <LocalClockLine
-                timezone={selectedCity.timezone}
-                recordMode={board.trip.recordMode}
-              />
+            {/* 부제는 <b>보고 있는 날짜</b>의 기준 도시를 따른다 — 도시를 옮겨 다니면
+                날짜 탭을 넘길 때마다 도시도 현지 시각도 바뀐다. */}
+            {isArchive ? (
+              <p className="text-caption text-muted-foreground">
+                미배정 보관함
+              </p>
+            ) : (
+              selectedCity && (
+                <LocalClockLine
+                  cityName={selectedCity.name}
+                  timezone={selectedCity.timezone}
+                  currency={selectedCity.currency}
+                  recordMode={board.trip.recordMode}
+                />
+              )
             )}
           </div>
         </div>
@@ -337,8 +392,15 @@ export function TripBoardPage() {
               </Button>
             }
           >
+            {/* 롱프레스는 손가락의 길이다. 마우스·키보드로도 같은 곳에 닿아야 한다. */}
+            <MenuItem
+              disabled={selectedDay === null || !online}
+              onClick={() => setCityDay(selectedDay)}
+            >
+              기준 도시 변경
+            </MenuItem>
             <MenuItem onClick={() => navigate(`/travel/trips/${tripId}/edit`)}>
-              여행 수정
+              구간 수정
             </MenuItem>
             <MenuItem disabled>알림 설정</MenuItem>
             <MenuItem
@@ -362,12 +424,22 @@ export function TripBoardPage() {
           days={board.days}
           archiveCount={board.archiveCount}
           selectedDate={selectedDate}
+          singleCity={board.trip.singleCity}
           onSelectDate={selectDay}
           onSelectArchive={selectArchive}
+          onLongPressDay={setCityDay}
           // 드래그가 시작된 뒤에 등록하면 그 드래그의 충돌 판정 대상에 들어가지 못한다.
           // 드래그 중이 아닐 때는 아무 영향도 없으므로 항상 켜 둔다.
           droppable
         />
+
+        {/* 도시 메모는 있을 때만 한 줄. 없는 날짜에 빈 자리를 남기지 않는다. */}
+        {selectedDay?.cityMemo && (
+          <p className="bg-muted flex items-center gap-2 rounded-lg px-3 py-2 text-[13px]">
+            <StickyNote className="size-3.5 shrink-0" />
+            {selectedDay.cityMemo}
+          </p>
+        )}
 
         {activities.length > 0 && (
           <SortableContext
@@ -456,6 +528,14 @@ export function TripBoardPage() {
         onPickFromArchive={(a) => void pickFromArchive(a)}
         onSearchPlaces={() => navigate(`/travel/trips/${tripId}/places`)}
         pending={createActivity.isPending || updateActivity.isPending}
+      />
+
+      <BaseCitySheet
+        day={cityDay}
+        tripCities={tripCities}
+        onOpenChange={(open) => !open && setCityDay(null)}
+        onSubmit={(body) => void saveDay(body)}
+        pending={updateDay.isPending}
       />
 
       <ConfirmDialog


### PR DESCRIPTION
## 이슈
closes #1133
## 작업 내용
- **탭 표기** — 1행이 `N 도시명`. 전 기간 한 도시(`trip.singleCity`)면 도시명을 감추고 `N일차`로 돌아간다. 같은 이름을 열 번 반복하면 정보가 아니라 소음이라서다.
- **도시 경계 구분선** — `cityChanged`인 탭 왼쪽에 세로선. 첫날은 비교할 앞 날짜가 없어 서지 않는다.
- **450ms 롱프레스 → 기준 도시 시트** — 일정 행의 드래그 진입(400ms)과 같은 `useLongPress`를 쓰고 임계값만 다르게 준다. 시트는 `이 여행의 도시`(가장 자주 고르는 후보) + 도시 검색 + 도시 메모.
- **도시 메모** — 있을 때만 탭 아래 한 줄. 같은 시트에서 고치고 `PUT /days/{dayId}`의 `cityMemo`로 저장한다.
- **헤더 부제** — `현지 09:42 · 교토 · Asia/Tokyo · JPY`. 기기와 오프셋이 0이면 **시각만** 감추고 도시·타임존·통화는 남긴다(v2.0은 줄 전체를 감췄다 — 그때는 여행 하나에 타임존도 하나였다). 보관함은 `미배정 보관함`.
- **도시 이탈 표시** — `outOfBaseCity`인 일정의 장소명 뒤에 `· 오사카`를 경고색으로. 막지 않는다.
- **메뉴** — `기준 도시 변경` 추가(롱프레스는 손가락의 길이라 마우스·키보드에도 같은 입구가 필요하다), `여행 수정` → `구간 수정`으로 이름 변경.

### BE — `PUT /days/{dayId}`에 `baseCityGooglePlaceId` 추가
기존에는 **담아 둔 도시의 id만** 받았다. 그러면 여행에 아직 없는 도시로 하루를 옮길 때 화면이 먼저 `POST /travel/places`로 장소를 만들어야 하는데, 그렇게 만든 도시에는 **도시 식별자(`cityPlaceRef`)가 없어** 그날 일정이 전부 `outOfBaseCity`로 표시된다. 구간 입력(`legs[]`)과 같은 방식으로 검색 결과를 그대로 받아 서버가 담으면서 승격시킨다. 둘 다 보내면 400.

## 테스트
- `TripBoardPage.test.tsx` +16 — 탭 표기 두 형태, 구분선 위치(탭 줄 자식 순서), 450ms는 열리고 400ms는 안 열림, 저장 요청 본문(담아 둔 도시 / 검색 결과 / 메모만), 메모 줄 표시·전환, 메뉴 경로, 부제 3형태, 도시 이탈 표기
- `BoardV21Test` +4 — 검색 결과로 기준 도시 변경, 담긴 도시에 식별자가 붙어 이탈 판정이 성립, 이미 쓰던 도시 재선택 시 외부 호출 없음, 두 방식 동시 지정 400
- `e2e/travel-day-city.spec.ts` (신규 4개) — 실제 브라우저에서 롱프레스. **탭 450ms와 행 400ms가 서로를 먹지 않는지**를 여기서만 확인할 수 있다

### E2E가 잡은 버그
롱프레스로 연 시트가 **손가락을 떼는 순간 닫혔다.** 450ms에 시트가 올라오고 그다음 손이 떨어지는데, 그 시점 손끝은 이미 스크림 위(시트 바깥)라 여는 동작의 끝이 곧바로 바깥 클릭이 된다. jsdom에서는 재현되지 않는다. `BottomSheet`가 base-ui의 변경 사유(`outside-press`)를 호출부에 넘기게 하고, 시트가 연 직후 400ms 안의 바깥 클릭은 무시하도록 고쳤다.

## 확인
- BE `./gradlew check` 통과
- FE `format:check` · `lint` · `test`(915개) · `build` · `test:e2e`(96개) 통과
  - 전체 E2E 1회차에서 `note-block-selection.spec.ts > 표에서 탈출한 뒤 Backspace가 본문에 먹는다` 가 한 번 실패했다. 단독 재실행은 통과하고 이번 변경은 노트 에디터를 건드리지 않는다 — 기존 flaky로 본다.