### PR TITLE
feat : 보관함 도시별 그룹 + 담기 시트 도시 우선

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/dto/BaseCityResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/dto/BaseCityResponse.java
@@ -7,6 +7,10 @@ import java.math.BigDecimal;
 /**
  * 날짜의 기준 도시. <b>그 날짜의 모든 파생값이 여기서 나온다</b> — 타임존·통화·날씨 좌표·
  * 검색 편향까지. 화면이 이 하나만 들고 있으면 그날의 시각 표시를 스스로 맞출 수 있다.
+ *
+ * @param cityPlaceRef 도시 식별자. 장소의 같은 값과 맞춰 <b>도시 일치를 판정</b>한다 — 보관함
+ *                     도시별 그룹과 담기 시트 정렬이 이 값으로 묶는다(이름으로 묶지 않는다).
+ *                     직접 입력한 도시에는 없다
  */
 public record BaseCityResponse(
         Long placeId,
@@ -14,6 +18,7 @@ public record BaseCityResponse(
         String timezone,
         String currency,
         String countryCode,
+        String cityPlaceRef,
         BigDecimal lat,
         BigDecimal lng
 ) {
@@ -22,6 +27,6 @@ public record BaseCityResponse(
         return new BaseCityResponse(city.getId(),
                 city.getCityName() != null ? city.getCityName() : city.getName(),
                 city.getTimezone(), city.getCurrency(), city.getCountryCode(),
-                city.getLat(), city.getLng());
+                city.getCityPlaceRef(), city.getLat(), city.getLng());
     }
 }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardV21Test.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardV21Test.java
@@ -240,6 +240,31 @@ class BoardV21Test extends ApiTestSupport {
                     .andExpect(jsonPath("$.data.activities[0].place.cityName").value("오사카"));
         }
 
+        /**
+         * 화면이 보관함을 도시별로 묶고 담기 시트를 정렬하려면 <b>기준 도시 쪽 식별자</b>가
+         * 있어야 한다. 이름으로 묶으면 같은 글자를 쓰는 다른 도시가 한 덩어리가 된다.
+         */
+        @Test
+        @DisplayName("기준 도시에도 도시 식별자가 실려 온다 — 화면이 같은 값으로 묶는다")
+        void carriesBaseCityIdentifier() throws Exception {
+            long tripId = createTrip(leg(tokyo, 4));
+            withCityRef(tokyo, "ChIJ_tokyo");
+
+            board(tripId)
+                    .andExpect(jsonPath("$.data.days[0].baseCity.cityPlaceRef")
+                            .value("ChIJ_tokyo"));
+        }
+
+        @Test
+        @DisplayName("직접 입력한 도시에는 식별자가 없다 — 그런 장소는 묶지 않는다")
+        void manualCityHasNoIdentifier() throws Exception {
+            long tripId = createTrip(leg(tokyo, 4));
+
+            board(tripId)
+                    .andExpect(jsonPath("$.data.days[0].baseCity.cityPlaceRef")
+                            .doesNotExist());
+        }
+
         @Test
         @DisplayName("같은 도시의 장소면 서지 않는다")
         void sameCityIsNotFlagged() throws Exception {

--- a/fe/e2e/travel-board-drag.spec.ts
+++ b/fe/e2e/travel-board-drag.spec.ts
@@ -18,6 +18,7 @@ const TOKYO = {
   timezone: "Asia/Tokyo",
   currency: "JPY",
   countryCode: "JP",
+  cityPlaceRef: null,
   lat: null,
   lng: null,
 };

--- a/fe/e2e/travel-board-swipe.spec.ts
+++ b/fe/e2e/travel-board-swipe.spec.ts
@@ -17,6 +17,7 @@ const TOKYO = {
   timezone: "Asia/Tokyo",
   currency: "JPY",
   countryCode: "JP",
+  cityPlaceRef: null,
   lat: null,
   lng: null,
 };

--- a/fe/e2e/travel-day-city.spec.ts
+++ b/fe/e2e/travel-day-city.spec.ts
@@ -18,6 +18,7 @@ const TOKYO = {
   timezone: "Asia/Tokyo",
   currency: "JPY",
   countryCode: "JP",
+  cityPlaceRef: null,
   lat: null,
   lng: null,
 };

--- a/fe/src/features/travel/api/activities.ts
+++ b/fe/src/features/travel/api/activities.ts
@@ -69,6 +69,8 @@ export interface BaseCity {
   timezone: string;
   currency: string;
   countryCode: string | null;
+  /** 도시 식별자. 장소의 같은 값과 맞춰 도시 일치를 판정한다(이름으로 묶지 않는다). */
+  cityPlaceRef: string | null;
   lat: number | null;
   lng: number | null;
 }

--- a/fe/src/features/travel/board/ActivityRow.tsx
+++ b/fe/src/features/travel/board/ActivityRow.tsx
@@ -3,6 +3,7 @@ import { CSS } from "@dnd-kit/utilities";
 import {
   Archive,
   Bell,
+  CalendarPlus,
   ChevronDown,
   ChevronUp,
   GripVertical,
@@ -33,6 +34,8 @@ interface ActivityRowProps {
   canMoveUp: boolean;
   canMoveDown: boolean;
   onArchive: () => void;
+  /** 보관함에서만 — 담을 날짜를 고르는 시트를 연다. */
+  onPickDay?: () => void;
   onDelete: () => void;
   /** 400ms 길게 눌러 드래그 모드로 들어간다. */
   onEnterDragMode: () => void;
@@ -54,6 +57,7 @@ export function ActivityRow({
   canMoveUp,
   canMoveDown,
   onArchive,
+  onPickDay,
   onDelete,
   onEnterDragMode,
 }: ActivityRowProps) {
@@ -208,6 +212,18 @@ export function ActivityRow({
                   aria-label="기록 있음"
                   className="text-muted-foreground size-3.5"
                 />
+              )}
+              {/* 보관함 일정은 "언제 갈지"가 남은 유일한 질문이라 그 버튼을 준다. */}
+              {!offline && inArchive && onPickDay && (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={`${activity.title} 날짜에 담기`}
+                  onClick={onPickDay}
+                  {...stopDrag}
+                >
+                  <CalendarPlus className="size-4" />
+                </Button>
               )}
               {/* 오프라인이면 액션을 감춘다 — 눌러도 실패할 버튼을 두지 않는다. */}
               {!offline && !inArchive && (

--- a/fe/src/features/travel/lib/archiveGroups.test.ts
+++ b/fe/src/features/travel/lib/archiveGroups.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  Activity,
+  BaseCity,
+  BoardDay,
+} from "@/features/travel/api/activities";
+
+import { daysForPlace, groupArchiveByCity } from "./archiveGroups";
+
+function city(
+  placeId: number,
+  name: string,
+  cityPlaceRef: string | null,
+): BaseCity {
+  return {
+    placeId,
+    name,
+    timezone: "Asia/Tokyo",
+    currency: "JPY",
+    countryCode: "JP",
+    cityPlaceRef,
+    lat: null,
+    lng: null,
+  };
+}
+
+const OSAKA = city(21, "오사카", "ChIJ_osaka");
+const KYOTO = city(22, "교토", "ChIJ_kyoto");
+
+function day(dayIndex: number, date: string, baseCity: BaseCity): BoardDay {
+  return {
+    dayId: 500 + dayIndex,
+    dayIndex,
+    date,
+    weekday: "토",
+    activityCount: 0,
+    baseCity,
+    cityChanged: false,
+    legIndex: 1,
+    cityMemo: null,
+    weather: null,
+    stayTonight: null,
+    stayCheckout: null,
+  };
+}
+
+const DAYS = [
+  day(1, "2026-10-24", OSAKA),
+  day(2, "2026-10-25", OSAKA),
+  day(3, "2026-10-26", KYOTO),
+];
+
+function activity(
+  id: number,
+  title: string,
+  place: { cityName: string | null; cityPlaceRef: string | null } | null,
+): Activity {
+  return {
+    id,
+    tripId: 1,
+    title,
+    activityDate: null,
+    startTime: null,
+    place: place && {
+      id: 100 + id,
+      name: title,
+      address: null,
+      lat: null,
+      lng: null,
+      cityName: place.cityName,
+      cityPlaceRef: place.cityPlaceRef,
+    },
+    memo: null,
+    url: null,
+    notifyEnabled: false,
+    notifyMinutes: null,
+    departureNotifyEnabled: false,
+    outOfBaseCity: false,
+    canDepartureNotify: true,
+    sortOrder: id,
+    log: null,
+    hasLog: false,
+  };
+}
+
+describe("groupArchiveByCity", () => {
+  it("도시별로 묶고 구간 순서대로 배치한다", () => {
+    const groups = groupArchiveByCity(
+      [
+        activity(1, "니시키 시장", {
+          cityName: "교토",
+          cityPlaceRef: "ChIJ_kyoto",
+        }),
+        activity(2, "구로몬 시장", {
+          cityName: "오사카",
+          cityPlaceRef: "ChIJ_osaka",
+        }),
+      ],
+      DAYS,
+    );
+
+    // 목록에는 교토가 먼저 있었지만, 그룹 순서는 방문 순서(오사카 → 교토)다.
+    expect(groups.map((g) => g.label)).toEqual(["오사카", "교토"]);
+    expect(groups[0].activities.map((a) => a.title)).toEqual(["구로몬 시장"]);
+  });
+
+  it("여행의 어느 도시도 아니면 `기타`, 도시를 모르면 `도시 없음` — 둘 다 맨 뒤", () => {
+    const groups = groupArchiveByCity(
+      [
+        activity(1, "이름만 아는 곳", null),
+        activity(2, "나라 공원", {
+          cityName: "나라",
+          cityPlaceRef: "ChIJ_nara",
+        }),
+        activity(3, "구로몬 시장", {
+          cityName: "오사카",
+          cityPlaceRef: "ChIJ_osaka",
+        }),
+      ],
+      DAYS,
+    );
+
+    expect(groups.map((g) => g.label)).toEqual(["오사카", "기타", "도시 없음"]);
+  });
+
+  it("도시 이름이 같아도 식별자가 없으면 묶지 않는다 — 추측하지 않는다", () => {
+    const groups = groupArchiveByCity(
+      [
+        activity(1, "구로몬 시장", {
+          cityName: "오사카",
+          cityPlaceRef: "ChIJ_osaka",
+        }),
+        activity(2, "이름만 오사카", {
+          cityName: "오사카",
+          cityPlaceRef: null,
+        }),
+      ],
+      DAYS,
+    );
+
+    expect(groups.map((g) => g.label)).toEqual(["오사카", "도시 없음"]);
+  });
+
+  it("빈 보관함은 그룹도 없다 — 빈 헤더만 늘어선 목록은 읽을 것이 없다", () => {
+    expect(groupArchiveByCity([], DAYS)).toEqual([]);
+  });
+});
+
+describe("daysForPlace", () => {
+  it("그 장소의 도시가 기준 도시인 날짜를 위로 올린다", () => {
+    const sorted = daysForPlace(DAYS, "ChIJ_kyoto");
+
+    expect(sorted.map((d) => d.dayIndex)).toEqual([3, 1, 2]);
+  });
+
+  it("올린 것 말고는 원래 순서를 지킨다", () => {
+    const sorted = daysForPlace(DAYS, "ChIJ_osaka");
+
+    expect(sorted.map((d) => d.dayIndex)).toEqual([1, 2, 3]);
+  });
+
+  it("도시를 모르면 아무것도 올리지 않는다", () => {
+    expect(daysForPlace(DAYS, null).map((d) => d.dayIndex)).toEqual([1, 2, 3]);
+  });
+
+  it("여행에 없는 도시면 그대로 둔다", () => {
+    expect(daysForPlace(DAYS, "ChIJ_nara").map((d) => d.dayIndex)).toEqual([
+      1, 2, 3,
+    ]);
+  });
+});

--- a/fe/src/features/travel/lib/archiveGroups.ts
+++ b/fe/src/features/travel/lib/archiveGroups.ts
@@ -1,0 +1,100 @@
+import type {
+  Activity,
+  BaseCity,
+  BoardDay,
+} from "@/features/travel/api/activities";
+
+export interface ArchiveGroup {
+  /** 목록 key. 도시 식별자이거나 `other`·`none`이다. */
+  key: string;
+  label: string;
+  activities: Activity[];
+}
+
+/** 여행의 어느 기준 도시도 아닌 장소. */
+const OTHER = "other";
+/** 장소가 없거나 도시 식별자가 없는 장소. */
+const NONE = "none";
+
+/**
+ * 보관함을 <b>도시별로</b> 묶는다(§3.8).
+ *
+ * <p>다구간 여행에서 보관함이 평면 리스트면 "교토에서 갈 곳"과 "나고야에서 갈 곳"이 섞여,
+ * 정작 교토 날짜를 짜는 동안 목록을 위아래로 훑어야 한다. 도시로 묶으면 그 도시를 짜는 동안
+ * 볼 것이 한 덩어리가 된다.
+ *
+ * <p><b>묶는 기준은 도시 식별자(`cityPlaceRef`)뿐이다</b> — 좌표 거리로도, 도시 이름으로도
+ * 추측하지 않는다(D-23). 이름으로 묶으면 "교토"라는 같은 글자를 쓰는 다른 장소가 한 덩어리가
+ * 되고, 그렇게 묶인 목록은 틀렸다는 사실조차 드러나지 않는다.
+ *
+ * <p>그래서 <b>식별자가 없는 장소는 `도시 없음`으로 떨어진다.</b> 억지로 묶는 것보다 낫다 —
+ * 검색으로 담은 장소에 식별자를 채우는 일은 3단계에서 온다.
+ *
+ * <p>그룹 순서는 <b>구간 순서</b>다(날짜 순서 = 방문 순서). `기타`·`도시 없음`은 맨 뒤다.
+ */
+export function groupArchiveByCity(
+  activities: Activity[],
+  days: BoardDay[],
+): ArchiveGroup[] {
+  const cities = cityOrder(days);
+  const groups = new Map<string, ArchiveGroup>();
+
+  // 도시 그룹은 활동이 없어도 만들지 않는다 — 빈 헤더만 늘어선 목록은 읽을 것이 없다.
+  for (const activity of activities) {
+    const ref = activity.place?.cityPlaceRef ?? null;
+    const city = ref === null ? undefined : cities.get(ref);
+    const key = city ? ref! : ref === null ? NONE : OTHER;
+    const label = city ? city.name : ref === null ? "도시 없음" : "기타";
+    const group = groups.get(key) ?? { key, label, activities: [] };
+    group.activities.push(activity);
+    groups.set(key, group);
+  }
+
+  const order = [...cities.keys()];
+  return [...groups.values()].sort(
+    (a, b) => rank(a.key, order) - rank(b.key, order),
+  );
+}
+
+/** 여행에 등장하는 도시를 <b>처음 나오는 날짜 순서</b>로 — 그게 곧 구간 순서다. */
+function cityOrder(days: BoardDay[]): Map<string, BaseCity> {
+  const cities = new Map<string, BaseCity>();
+  for (const day of days) {
+    const ref = day.baseCity?.cityPlaceRef;
+    if (day.baseCity && ref && !cities.has(ref)) {
+      cities.set(ref, day.baseCity);
+    }
+  }
+  return cities;
+}
+
+/** `기타`와 `도시 없음`은 도시 뒤에, 그 둘 사이에서는 `기타`가 앞이다. */
+function rank(key: string, order: string[]): number {
+  if (key === NONE) return order.length + 1;
+  if (key === OTHER) return order.length;
+  return order.indexOf(key);
+}
+
+/**
+ * 담을 날짜를 고르는 목록을 정렬한다 — <b>그 장소의 도시가 기준 도시인 날짜를 위로</b>.
+ *
+ * <p>오사카 가게를 담을 때 오사카 날짜가 위에 있어야 한다. 나머지는 원래 순서(날짜 순)를
+ * 그대로 지킨다 — 위로 올린 것 말고는 아무것도 흔들지 않는다.
+ *
+ * <p>장소의 도시를 모르면(식별자가 없으면) 아무것도 올리지 않는다. 모르는 것을 근거로 순서를
+ * 바꾸면 사용자는 왜 그 날짜가 위에 있는지 알 수 없다.
+ */
+export function daysForPlace(
+  days: BoardDay[],
+  cityPlaceRef: string | null | undefined,
+): BoardDay[] {
+  if (!cityPlaceRef) return days;
+  const matches = days.filter(
+    (day) => day.baseCity?.cityPlaceRef === cityPlaceRef,
+  );
+  if (matches.length === 0) return days;
+  return [
+    ...matches,
+    ...days.filter((day) => day.baseCity?.cityPlaceRef !== cityPlaceRef),
+  ];
+}

--- a/fe/src/features/travel/lib/baseCity.test.ts
+++ b/fe/src/features/travel/lib/baseCity.test.ts
@@ -17,6 +17,7 @@ function city(placeId: number, name: string, timezone: string) {
     timezone,
     currency: "JPY",
     countryCode: "JP",
+    cityPlaceRef: null,
     lat: null,
     lng: null,
   };

--- a/fe/src/features/travel/lib/legs.test.ts
+++ b/fe/src/features/travel/lib/legs.test.ts
@@ -20,6 +20,7 @@ function city(placeId: number, name: string) {
     timezone: "Asia/Tokyo",
     currency: "JPY",
     countryCode: "JP",
+    cityPlaceRef: null,
     lat: null,
     lng: null,
   };

--- a/fe/src/features/travel/places/PickDaySheet.tsx
+++ b/fe/src/features/travel/places/PickDaySheet.tsx
@@ -15,10 +15,13 @@ interface PickDaySheetProps {
 }
 
 /**
- * 담을 날짜를 고르는 시트(§S-06). `1일차`~`N일차` 또는 `보관함`.
+ * 담을 날짜를 고르는 시트(§S-06). `3일차 · 교토` 또는 `보관함`.
  *
  * <p>보관함이 선택지에 있어야 하는 이유: 여행 계획은 "가고 싶다"가 "언제 갈지"보다 먼저 정해진다.
  * 날짜를 강제하면 정하지 못한 곳을 아예 담지 못하게 된다.
+ *
+ * <p><b>목록 순서는 호출부가 정한다</b>(`daysForPlace`) — 오사카 가게를 담을 때 오사카가 기준
+ * 도시인 날짜가 위에 온다. 시트는 받은 순서를 그대로 그린다.
  */
 export function PickDaySheet({
   open,
@@ -45,7 +48,12 @@ export function PickDaySheet({
             className="border-border hover:bg-accent flex items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left text-sm disabled:opacity-50"
           >
             <CalendarDays className="text-muted-foreground size-4 shrink-0" />
-            <span className="flex-1">{day.dayIndex}일차</span>
+            {/* 어느 도시의 날짜인지가 몇 일차인지만큼 중요하다 — 다구간 여행에서
+                "3일차"는 어디인지 말해 주지 않는다. */}
+            <span className="flex-1 truncate">
+              {day.dayIndex}일차
+              {day.baseCity && ` · ${day.baseCity.name}`}
+            </span>
             <span className="text-muted-foreground text-xs">
               {day.date.slice(5)} ({day.weekday})
             </span>

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -26,6 +26,7 @@ function baseCity(
     timezone,
     currency,
     countryCode: "JP",
+    cityPlaceRef: null,
     lat: null,
     lng: null,
   };
@@ -242,6 +243,114 @@ describe("TripBoardPage", () => {
       expect(await screen.findByText("가고 싶은 라멘집")).toBeInTheDocument();
       const tabs = await screen.findAllByRole("tab");
       expect(tabs[3]).toHaveAttribute("aria-selected", "true");
+    });
+  });
+
+  describe("보관함 — 도시별 그룹 (v2.1)", () => {
+    const OSAKA = baseCity(21, "오사카", "Asia/Tokyo");
+    const KYOTO = baseCity(22, "교토", "Asia/Tokyo");
+    const TWO_CITY_DAYS = [
+      day(1, "2026-10-24", "토", 0, {
+        baseCity: { ...OSAKA, cityPlaceRef: "ChIJ_osaka" },
+      }),
+      day(2, "2026-10-25", "일", 0, {
+        baseCity: { ...KYOTO, cityPlaceRef: "ChIJ_kyoto" },
+        cityChanged: true,
+        legIndex: 2,
+      }),
+    ];
+
+    /** 도시 식별자를 가진 장소가 붙은 보관함 일정. */
+    function archived(id: number, title: string, city: string | null) {
+      return activity({
+        id,
+        title,
+        activityDate: null,
+        place: {
+          id: 100 + id,
+          name: title,
+          address: null,
+          lat: null,
+          lng: null,
+          cityName: city === "ChIJ_kyoto" ? "교토" : "오사카",
+          cityPlaceRef: city,
+        },
+      });
+    }
+
+    function mockArchive(archive: unknown[]) {
+      mockBoard({
+        byDate: { "2026-10-24": [], "2026-10-25": [] },
+        trip: { singleCity: false, cityCount: 2 },
+        days: TWO_CITY_DAYS,
+        archive,
+      });
+    }
+
+    it("도시별로 묶어 구간 순서대로 보여주고, 모르는 도시는 맨 뒤로 보낸다", async () => {
+      mockArchive([
+        archived(9, "니시키 시장", "ChIJ_kyoto"),
+        archived(10, "이름만 아는 곳", null),
+        archived(11, "구로몬 시장", "ChIJ_osaka"),
+      ]);
+
+      renderBoard("/travel/trips/3/board?day=archive");
+
+      await screen.findAllByText("구로몬 시장");
+      const headings = screen.getAllByRole("heading", { level: 2 });
+      expect(headings.map((h) => h.textContent)).toEqual([
+        "오사카",
+        "교토",
+        "도시 없음",
+      ]);
+    });
+
+    it("담기 버튼을 누르면 그 장소의 도시 날짜가 목록 위에 온다", async () => {
+      mockArchive([archived(9, "니시키 시장", "ChIJ_kyoto")]);
+
+      renderBoard("/travel/trips/3/board?day=archive");
+      await userEvent.click(
+        await screen.findByRole("button", { name: "니시키 시장 날짜에 담기" }),
+      );
+
+      const sheet = await screen.findByRole("dialog");
+      const options = within(sheet).getAllByRole("button");
+      // 교토 장소라 교토 날짜(2일차)가 오사카 날짜보다 위에 있다.
+      expect(options[0]).toHaveTextContent("2일차 · 교토");
+      expect(options[1]).toHaveTextContent("1일차 · 오사카");
+    });
+
+    it("고른 날짜로 옮긴다", async () => {
+      const seen: Record<string, unknown>[] = [];
+      mockArchive([archived(9, "니시키 시장", "ChIJ_kyoto")]);
+      server.use(
+        http.put(`${API_BASE}/travel/activities/:id`, async ({ request }) => {
+          seen.push((await request.json()) as Record<string, unknown>);
+          return HttpResponse.json({ code: "OK", data: activity() });
+        }),
+      );
+
+      renderBoard("/travel/trips/3/board?day=archive");
+      await userEvent.click(
+        await screen.findByRole("button", { name: "니시키 시장 날짜에 담기" }),
+      );
+      const sheet = await screen.findByRole("dialog");
+      await userEvent.click(
+        within(sheet).getByRole("button", { name: /2일차 · 교토/ }),
+      );
+
+      await waitFor(() => expect(seen).toHaveLength(1));
+      expect(seen[0]).toMatchObject({ activityDate: "2026-10-25" });
+    });
+
+    it("빈 보관함 문구는 그대로다", async () => {
+      mockArchive([]);
+
+      renderBoard("/travel/trips/3/board?day=archive");
+
+      expect(
+        await screen.findByText("가고 싶은 곳을 미리 담아두세요"),
+      ).toBeInTheDocument();
     });
   });
 

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -17,6 +17,7 @@ import {
 import {
   ArrowLeft,
   Map as MapIcon,
+  MapPin,
   MoreVertical,
   Plus,
   Search,
@@ -58,6 +59,11 @@ import {
 } from "@/features/travel/hooks/useActivityMutations";
 import { useBoard } from "@/features/travel/hooks/useBoard";
 import { useUpdateDay } from "@/features/travel/hooks/useUpdateDay";
+import {
+  daysForPlace,
+  groupArchiveByCity,
+} from "@/features/travel/lib/archiveGroups";
+import { PickDaySheet } from "@/features/travel/places/PickDaySheet";
 import { toast } from "@/shared/lib/toast";
 import { useOnline } from "@/shared/lib/useOnline";
 
@@ -116,6 +122,8 @@ export function TripBoardPage() {
   const [deletingTrip, setDeletingTrip] = useState(false);
   /** 기준 도시 시트를 연 날짜. null이면 닫혀 있다. */
   const [cityDay, setCityDay] = useState<BoardDay | null>(null);
+  /** 날짜를 고르는 중인 보관함 일정. null이면 시트가 닫혀 있다. */
+  const [pickingDayFor, setPickingDayFor] = useState<Activity | null>(null);
   const [dragMode, setDragMode] = useState(false);
   const [openTravelTime, setOpenTravelTime] = useState<TravelTime | null>(null);
   // 오프라인은 조회 전용이다(§4.6). 편집을 막는 게 아니라 진입 자체를 없앤다.
@@ -180,6 +188,11 @@ export function TripBoardPage() {
         .map((city) => [city.placeId, city]),
     ).values(),
   ];
+
+  /** 보관함은 순서가 아니라 도시로 읽는다. 보고 있지 않으면 계산할 이유가 없다. */
+  const archiveGroups = isArchive
+    ? groupArchiveByCity(activities, board.days)
+    : [];
 
   const selectDay = (date: string) => {
     const index = board.days.findIndex((d) => d.date === date);
@@ -246,6 +259,13 @@ export function TripBoardPage() {
       date: selectedDate,
       activityIds: next.map((a) => a.id),
     });
+  };
+
+  /** 보관함 일정을 고른 날짜로 보낸다. 날짜를 고르지 않으면(보관함) 아무 일도 없다. */
+  const pickDayFor = async (activity: Activity, date: string | null) => {
+    setPickingDayFor(null);
+    if (date === null) return;
+    await moveToDay(activity, date);
   };
 
   /** 날짜 탭에 떨어뜨렸다 — 그 날짜의 맨 뒤로 보낸다. */
@@ -441,7 +461,38 @@ export function TripBoardPage() {
           </p>
         )}
 
-        {activities.length > 0 && (
+        {/* 보관함은 도시별로 묶는다 — 그 도시 날짜를 짜는 동안 볼 것이 한 덩어리가 된다.
+            순서가 없는 목록이라 드래그 정렬도 없다. */}
+        {isArchive &&
+          archiveGroups.map((group) => (
+            <section key={group.key} className="flex flex-col">
+              <h2 className="text-caption text-muted-foreground flex items-center gap-1.5 px-2 pt-2 font-semibold">
+                <MapPin className="size-3" />
+                {group.label}
+              </h2>
+              <ul className="flex flex-col">
+                {group.activities.map((activity) => (
+                  <ActivityRow
+                    key={activity.id}
+                    activity={activity}
+                    inArchive
+                    dragMode={false}
+                    offline={!online}
+                    canMoveUp={false}
+                    canMoveDown={false}
+                    onMoveUp={() => {}}
+                    onMoveDown={() => {}}
+                    onArchive={() => {}}
+                    onPickDay={() => setPickingDayFor(activity)}
+                    onDelete={() => removeActivityDeferred(activity)}
+                    onEnterDragMode={() => {}}
+                  />
+                ))}
+              </ul>
+            </section>
+          ))}
+
+        {!isArchive && activities.length > 0 && (
           <SortableContext
             items={activities.map((a) => a.id)}
             strategy={verticalListSortingStrategy}
@@ -528,6 +579,17 @@ export function TripBoardPage() {
         onPickFromArchive={(a) => void pickFromArchive(a)}
         onSearchPlaces={() => navigate(`/travel/trips/${tripId}/places`)}
         pending={createActivity.isPending || updateActivity.isPending}
+      />
+
+      {/* 담기 시트는 S-06 검색 결과와 같은 것을 쓴다 — 담는 자리마다 다르게 생기면
+          "어느 날에 담을까"라는 같은 질문을 두 번 배워야 한다. */}
+      <PickDaySheet
+        open={pickingDayFor !== null}
+        onOpenChange={(open) => !open && setPickingDayFor(null)}
+        placeName={pickingDayFor?.title ?? null}
+        days={daysForPlace(board.days, pickingDayFor?.place?.cityPlaceRef)}
+        onPick={(date) => pickingDayFor && void pickDayFor(pickingDayFor, date)}
+        pending={updateActivity.isPending}
       />
 
       <BaseCitySheet

--- a/fe/src/test/mocks/handlers.ts
+++ b/fe/src/test/mocks/handlers.ts
@@ -126,6 +126,7 @@ export const handlers = [
               timezone: "Asia/Tokyo",
               currency: "JPY",
               countryCode: "JP",
+              cityPlaceRef: null,
               lat: null,
               lng: null,
             },


### PR DESCRIPTION
## 이슈
closes #1134
## 작업 내용
- **보관함 도시별 그룹** — `MapPin` + 도시명 헤더로 묶고, 그룹 순서는 **구간 순서**(도시가 처음 나오는 날짜 순). 여행의 어느 기준 도시도 아니면 `기타`, 도시를 모르면 `도시 없음` — 둘 다 맨 뒤.
- **담기 버튼** — 보관함 행 우측에 `CalendarPlus`. 누르면 S-06과 **같은 담기 시트**가 열린다. 보관함은 순서가 아니라 도시로 읽는 목록이 되었으므로 그 안에서의 드래그 정렬은 없앴고, 날짜로 보내는 길을 명시적 버튼으로 바꿨다.
- **담기 시트** — 날짜마다 `3일차 · 교토`. 다구간 여행에서 "3일차"만으로는 어디인지 알 수 없다.
- **도시 우선 정렬** — 그 장소의 도시가 기준 도시인 날짜를 위로 올린다. **올린 것 말고는 원래 순서를 그대로 지킨다.**

### 판정은 식별자로만
묶는 기준은 `place.cityPlaceRef`뿐이다(D-23). 이름으로 묶으면 같은 글자를 쓰는 다른 도시가 한 덩어리가 되고, **그렇게 묶인 목록은 틀렸다는 사실조차 드러나지 않는다.** 그래서 식별자가 없는 장소는 `도시 없음`으로 떨어진다 — 억지로 묶는 것보다 낫다.

그 판정을 하려면 장소 쪽뿐 아니라 **기준 도시 쪽 식별자**도 필요해서, `baseCity`에 `cityPlaceRef`를 추가했다(BE `BaseCityResponse` + 위키 API 스펙). 직접 입력한 도시에는 없다(null).

> 검색으로 담은 장소의 `cityPlaceRef`를 채우는 일은 이슈에 적힌 대로 3단계(S-06 기준 도시 칩)다. 그때까지 실제 데이터는 상당수가 `도시 없음`으로 모인다 — 화면은 값이 오면 곧바로 묶는다.

## 테스트
- `archiveGroups.test.ts` (신규 8개) — 그룹 순서(구간 순), `기타`/`도시 없음` 위치, 이름이 같아도 식별자가 없으면 안 묶음, 빈 보관함, 담기 정렬 4종
- `TripBoardPage.test.tsx` +4 — 그룹 헤더 순서, 담기 시트가 그 도시 날짜를 위로, 고른 날짜로 이동, 빈 보관함 문구 유지
- `BoardV21Test` +2 — 기준 도시에 식별자가 실려 옴 / 직접 입력한 도시에는 없음

## 확인
- BE `./gradlew check` 통과
- FE `format:check` · `lint` · `test`(927개) · `build` · `test:e2e`(96개) 통과