### PR TITLE
feat : 여행 고르는 자리들이 다구간을 말한다

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TravelSummaryResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TravelSummaryResponse.java
@@ -17,11 +17,21 @@ public record TravelSummaryResponse(
         CompletedTrip recentCompleted
 ) {
 
-    /** 진행 중 여행 — 탭하면 곧장 보드로 간다. */
-    public record OngoingTrip(Long id, String title, String boardPath) {
+    /**
+     * 진행 중 여행 — 탭하면 곧장 보드로 간다.
+     *
+     * <p>(v2.1) <b>오늘의 도시</b>가 함께 온다. `/select` 카드가 `오늘 오사카 → 교토`를
+     * 쓰고 S-01이 `오늘 · 교토`와 그날 타임존·통화를 쓴다 — 둘 다 이 응답 하나로 끝난다.
+     */
+    public record OngoingTrip(Long id, String title, String boardPath,
+                              LocalDate startDate, LocalDate endDate,
+                              long activityCount, TripCitySummary cities) {
 
-        public static OngoingTrip of(Long id, String title) {
-            return new OngoingTrip(id, title, "/travel/trips/%d/board".formatted(id));
+        public static OngoingTrip of(Long id, String title, LocalDate startDate,
+                                     LocalDate endDate, long activityCount,
+                                     TripCitySummary cities) {
+            return new OngoingTrip(id, title, "/travel/trips/%d/board".formatted(id),
+                    startDate, endDate, activityCount, cities);
         }
     }
 
@@ -33,7 +43,8 @@ public record TravelSummaryResponse(
             LocalDate startDate,
             LocalDate endDate,
             long dDay,
-            long activityCount
+            long activityCount,
+            TripCitySummary cities
     ) {
     }
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripCitySummary.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripCitySummary.java
@@ -1,0 +1,94 @@
+package ds.project.orino.planner.travel.trip.dto;
+
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 여행을 <b>고르는 자리</b>가 쓰는 도시 요약 — `/select` 카드 · S-01 홈 · S-02 목록.
+ *
+ * <p>세 화면이 같은 값을 다르게 줄여 쓴다(도시 나열과 오늘의 도시). 줄이는 규칙은 화면이
+ * 갖고, 서버는 <b>줄이기 전의 사실</b>만 준다.
+ *
+ * <p>이 값들은 목록이 <b>이미 읽어 둔 날짜 지도</b>에서 나온다. 여행마다
+ * {@code /city-legs}를 부르면 N+1이 되지만, 목록은 처음부터 모든 여행의 날짜별 기준 도시를
+ * 한 번에 받아 상태·D-day를 판정하고 있어 <b>추가 조회가 0이다.</b>
+ *
+ * @param names        구간 순서의 도시 이름. 연속으로 같은 도시는 이미 한 번으로 접혀 있다
+ *                     (도쿄 → 닛코 → 도쿄는 세 개다 — 사이가 끊기면 다른 구간이다)
+ * @param count        서로 다른 도시 수. 같은 도시를 다시 방문해도 하나로 센다
+ * @param today        오늘의 기준 도시 이름. 진행 중이 아니면 null
+ * @param movedFrom    오늘 도시가 바뀌었다면 <b>어제의</b> 도시. 아니면 null
+ * @param todayDayIndex 오늘이 며칠째인지(1부터). 진행 중이 아니면 null
+ * @param todayTimezone 오늘 도시의 타임존. 진행 중이 아니면 null
+ * @param todayCurrency 오늘 도시의 통화. 진행 중이 아니면 null
+ */
+public record TripCitySummary(
+        List<String> names,
+        int count,
+        String today,
+        String movedFrom,
+        Integer todayDayIndex,
+        String todayTimezone,
+        String todayCurrency
+) {
+
+    private static final TripCitySummary EMPTY =
+            new TripCitySummary(List.of(), 0, null, null, null, null, null);
+
+    public static TripCitySummary empty() {
+        return EMPTY;
+    }
+
+    /**
+     * 날짜별 기준 도시를 도시 나열로 접는다.
+     *
+     * @param today 오늘 날짜. 진행 중이 아니면 null을 주면 오늘 관련 값이 전부 비워진다
+     */
+    public static TripCitySummary of(LocalDate startDate, LocalDate endDate,
+                                     Map<LocalDate, TravelPlace> byDate, LocalDate today) {
+        List<String> names = new ArrayList<>();
+        LinkedHashSet<Long> distinct = new LinkedHashSet<>();
+        Long previousId = null;
+        String previousName = null;
+        String todayName = null;
+        String movedFrom = null;
+        Integer dayIndex = null;
+        String timezone = null;
+        String currency = null;
+
+        int index = 0;
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            index++;
+            TravelPlace city = byDate.get(date);
+            if (city == null) {
+                continue;
+            }
+            String name = nameOf(city);
+            if (!city.getId().equals(previousId)) {
+                names.add(name);
+                distinct.add(city.getId());
+            }
+            if (date.equals(today)) {
+                todayName = name;
+                // 어제와 다르면 오늘이 옮기는 날이다 — 화면이 `오사카 → 교토`로 쓴다.
+                movedFrom = city.getId().equals(previousId) ? null : previousName;
+                dayIndex = index;
+                timezone = city.getTimezone();
+                currency = city.getCurrency();
+            }
+            previousId = city.getId();
+            previousName = name;
+        }
+        return new TripCitySummary(List.copyOf(names), distinct.size(),
+                todayName, movedFrom, dayIndex, timezone, currency);
+    }
+
+    private static String nameOf(TravelPlace city) {
+        return city.getCityName() != null ? city.getCityName() : city.getName();
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripSummary.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/dto/TripSummary.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
  * @param status        저장된 값이 아니라 여행 타임존의 오늘로 파생한 상태
  * @param dDay          시작일까지 남은 일수. 시작 당일 0, 이미 시작했으면 음수
  * @param activityCount 보관함을 포함한 전체 일정 수
+ * @param cities        (v2.1) 구간 순서의 도시와 오늘의 도시. 카드가 이걸 줄여 쓴다
  */
 public record TripSummary(
         Long id,
@@ -19,6 +20,7 @@ public record TripSummary(
         LocalDate endDate,
         TripStatus status,
         long dDay,
-        long activityCount
+        long activityCount,
+        TripCitySummary cities
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/service/TripService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/trip/service/TripService.java
@@ -16,6 +16,7 @@ import ds.project.orino.planner.travel.day.service.TripDayService;
 import ds.project.orino.planner.travel.day.service.TripStayShrinkService;
 import ds.project.orino.planner.travel.trip.dto.ShrinkPreviewResponse;
 import ds.project.orino.planner.travel.trip.dto.TravelSummaryResponse;
+import ds.project.orino.planner.travel.trip.dto.TripCitySummary;
 import ds.project.orino.planner.travel.trip.dto.TripDetail;
 import ds.project.orino.planner.travel.trip.dto.TripListResponse;
 import ds.project.orino.planner.travel.trip.dto.TripSummary;
@@ -190,16 +191,21 @@ public class TripService {
                 .orElse(null);
 
         Map<Long, Long> counts = activityCountsOf(
-                Stream.of(next, completed).filter(Objects::nonNull).toList());
+                Stream.of(ongoing, next, completed).filter(Objects::nonNull).toList());
 
         return new TravelSummaryResponse(
                 ongoing == null ? null
-                        : TravelSummaryResponse.OngoingTrip.of(ongoing.getId(), ongoing.getTitle()),
+                        : TravelSummaryResponse.OngoingTrip.of(ongoing.getId(),
+                                ongoing.getTitle(), ongoing.getStartDate(),
+                                ongoing.getEndDate(),
+                                counts.getOrDefault(ongoing.getId(), 0L),
+                                citySummaryOf(ongoing, cities)),
                 next == null ? null : new TravelSummaryResponse.NextTrip(
                         next.getId(), next.getTitle(), cityNameOf(next, cities),
                         next.getStartDate(), next.getEndDate(),
                         daysUntilStart(next, cities),
-                        counts.getOrDefault(next.getId(), 0L)),
+                        counts.getOrDefault(next.getId(), 0L),
+                        citySummaryOf(next, cities)),
                 completed == null ? null : new TravelSummaryResponse.CompletedTrip(
                         completed.getId(), completed.getTitle(), completed.getEndDate(),
                         counts.getOrDefault(completed.getId(), 0L)));
@@ -315,7 +321,25 @@ public class TripService {
     private TripSummary summaryOf(Trip trip, TripCities cities, long activityCount) {
         return new TripSummary(trip.getId(), trip.getTitle(), cityNameOf(trip, cities),
                 trip.getStartDate(), trip.getEndDate(), statusOf(trip, cities),
-                daysUntilStart(trip, cities), activityCount);
+                daysUntilStart(trip, cities), activityCount, citySummaryOf(trip, cities));
+    }
+
+    /**
+     * 도시 나열과 오늘의 도시. <b>추가 조회가 없다</b> — 목록·요약은 상태 판정을 위해 이미
+     * 모든 여행의 날짜별 기준 도시를 한 번에 받아 두었고, 여기서는 그 지도를 접기만 한다.
+     * 여행마다 {@code /city-legs}를 부르면 그때부터 N+1이다.
+     *
+     * <p>오늘 관련 값은 <b>진행 중일 때만</b> 채운다. 예정 여행에 "오늘의 도시"를 주면 첫날
+     * 도시가 오늘인 것처럼 보인다.
+     */
+    private TripCitySummary citySummaryOf(Trip trip, TripCities cities) {
+        Map<LocalDate, TravelPlace> byDate = cities.of(trip);
+        if (byDate.isEmpty()) {
+            return TripCitySummary.empty();
+        }
+        LocalDate today = statusOf(trip, cities) == TripStatus.ONGOING
+                ? TripClock.today(trip, byDate, clock) : null;
+        return TripCitySummary.of(trip.getStartDate(), trip.getEndDate(), byDate, today);
     }
 
     /**

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/trip/controller/TripControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/trip/controller/TripControllerTest.java
@@ -23,6 +23,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -223,6 +224,91 @@ class TripControllerTest extends ApiTestSupport {
                     .andExpect(jsonPath("$.data.trips[1].title").value("나중예정"))
                     .andExpect(jsonPath("$.data.trips[2].title").value("최근완료"))
                     .andExpect(jsonPath("$.data.trips[3].title").value("오래된완료"));
+        }
+    }
+
+    @Nested
+    @DisplayName("도시 요약 (v2.1)")
+    class Cities {
+
+        /**
+         * 목록이 <b>여행마다 city-legs를 부르지 않는다.</b> 상태 판정을 위해 이미 모든 여행의
+         * 날짜별 기준 도시를 한 번에 받아 두었고, 도시 나열은 그 지도를 접기만 한 값이다.
+         */
+        @Test
+        @DisplayName("목록 카드에 구간 순서의 도시가 실려 온다")
+        void listCarriesCityPath() throws Exception {
+            long osaka = city("오사카");
+            long kyoto = city("교토");
+            createTripWithLegs("일본", "2026-10-24", "2026-10-27",
+                    leg(osaka, 2), leg(kyoto, 2));
+
+            mockMvc.perform(get("/api/travel/trips")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.trips[0].cities.names",
+                            contains("오사카", "교토")))
+                    .andExpect(jsonPath("$.data.trips[0].cities.count").value(2));
+        }
+
+        @Test
+        @DisplayName("도쿄 → 닛코 → 도쿄는 셋으로 남고 도시 수는 둘이다")
+        void keepsRevisitButCountsDistinct() throws Exception {
+            long tokyo = city("도쿄");
+            long nikko = city("닛코");
+            createTripWithLegs("일본", "2026-10-24", "2026-10-27",
+                    leg(tokyo, 1), leg(nikko, 1), leg(tokyo, 2));
+
+            mockMvc.perform(get("/api/travel/trips")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.trips[0].cities.names",
+                            contains("도쿄", "닛코", "도쿄")))
+                    .andExpect(jsonPath("$.data.trips[0].cities.count").value(2));
+        }
+
+        /** 고정 시각은 2026-01-15T02:00Z — 도쿄는 1/15 11:00이라 둘째 날을 지나는 중이다. */
+        @Test
+        @DisplayName("진행 중이면 오늘의 도시와 그날 타임존·통화가 함께 온다")
+        void ongoingCarriesTodayCity() throws Exception {
+            long osaka = city("오사카");
+            long kyoto = city("교토");
+            createTripWithLegs("일본", "2026-01-14", "2026-01-17",
+                    leg(osaka, 1), leg(kyoto, 3));
+
+            mockMvc.perform(get("/api/travel/summary")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.ongoing.cities.today").value("교토"))
+                    // 어제(오사카)와 다르니 오늘이 옮기는 날이다.
+                    .andExpect(jsonPath("$.data.ongoing.cities.movedFrom").value("오사카"))
+                    .andExpect(jsonPath("$.data.ongoing.cities.todayDayIndex").value(2))
+                    .andExpect(jsonPath("$.data.ongoing.cities.todayTimezone")
+                            .value("Asia/Tokyo"))
+                    .andExpect(jsonPath("$.data.ongoing.cities.todayCurrency").value("JPY"));
+        }
+
+        @Test
+        @DisplayName("같은 도시에 머무는 날이면 movedFrom이 없다")
+        void staysInSameCity() throws Exception {
+            long osaka = city("오사카");
+            createTripWithLegs("일본", "2026-01-14", "2026-01-17", leg(osaka, 4));
+
+            mockMvc.perform(get("/api/travel/summary")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.ongoing.cities.today").value("오사카"))
+                    .andExpect(jsonPath("$.data.ongoing.cities.movedFrom").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("예정 여행에는 오늘의 도시가 없다 — 첫날 도시가 오늘인 것처럼 보이면 안 된다")
+        void upcomingHasNoToday() throws Exception {
+            long tokyo = city("도쿄");
+            createTripWithLegs("도쿄", "2026-10-24", "2026-10-27", leg(tokyo, 4));
+
+            mockMvc.perform(get("/api/travel/summary")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(jsonPath("$.data.next.cities.names", contains("도쿄")))
+                    .andExpect(jsonPath("$.data.next.cities.today").doesNotExist());
         }
     }
 
@@ -537,6 +623,28 @@ class TripControllerTest extends ApiTestSupport {
         return """
                 {"title": "%s", "startDate": "%s", "endDate": "%s", %s}
                 """.formatted(title, start, end, TravelCityFixture.singleLeg(cityId, 1));
+    }
+
+    private long city(String name) throws Exception {
+        return TravelCityFixture.createCity(mockMvc, authHeader, name, "Asia/Tokyo", "JPY");
+    }
+
+    private static String leg(long cityPlaceId, int days) {
+        return "{\"cityPlaceId\": %d, \"days\": %d}".formatted(cityPlaceId, days);
+    }
+
+    private long createTripWithLegs(String title, String start, String end, String... legs)
+            throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "%s", "startDate": "%s", "endDate": "%s",
+                                 "legs": [%s]}
+                                """.formatted(title, start, end, String.join(", ", legs))))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
     }
 
     private long createTrip(String title, String destination, String start, String end)

--- a/fe/src/features/travel/api/travel.ts
+++ b/fe/src/features/travel/api/travel.ts
@@ -7,12 +7,36 @@ interface ApiEnvelope<T> {
   data: T;
 }
 
+/**
+ * 여행이 거쳐 가는 도시. **줄이는 규칙은 화면이 갖고, 서버는 줄이기 전의 사실만 준다.**
+ *
+ * <p>목록·요약이 이미 읽어 둔 날짜별 기준 도시에서 나오므로 추가 조회가 없다 — 여행마다
+ * `/city-legs`를 부르면 그때부터 N+1이다.
+ */
+export interface TripCitySummary {
+  /** 구간 순서의 도시 이름. 연속으로 같은 도시는 이미 한 번으로 접혀 있다. */
+  names: string[];
+  /** 서로 다른 도시 수. 같은 도시를 다시 방문해도 하나로 센다. */
+  count: number;
+  /** 오늘의 기준 도시. 진행 중이 아니면 null. */
+  today: string | null;
+  /** 오늘 도시가 바뀌었다면 어제의 도시. 아니면 null. */
+  movedFrom: string | null;
+  todayDayIndex: number | null;
+  todayTimezone: string | null;
+  todayCurrency: string | null;
+}
+
 /** 진행 중 여행 — 탭하면 곧바로 보드로 간다. */
 export interface OngoingTripSummary {
   id: number;
   title: string;
   /** 서버가 조립해 주는 보드 경로. 프론트가 경로를 다시 만들지 않는다. */
   boardPath: string;
+  startDate: string;
+  endDate: string;
+  activityCount: number;
+  cities: TripCitySummary;
 }
 
 /** 다음 예정 여행 — D-day 카운트다운 카드. */
@@ -25,6 +49,7 @@ export interface NextTripSummary {
   /** 시작일까지 남은 일수. 여행 타임존 기준이라 프론트에서 다시 계산하지 않는다. */
   dDay: number;
   activityCount: number;
+  cities: TripCitySummary;
 }
 
 /** 가장 최근에 끝난 여행. */
@@ -61,6 +86,7 @@ export interface TripSummary {
   status: TripStatus;
   dDay: number;
   activityCount: number;
+  cities: TripCitySummary;
 }
 
 export interface TripCounts {

--- a/fe/src/features/travel/lib/cityPath.test.ts
+++ b/fe/src/features/travel/lib/cityPath.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import type { TripCitySummary } from "@/features/travel/api/travel";
+
+import {
+  formatCities,
+  formatCityCount,
+  formatCityPath,
+  formatTodayCity,
+} from "./cityPath";
+
+function cities(
+  names: string[],
+  overrides: Partial<TripCitySummary> = {},
+): TripCitySummary {
+  return {
+    names,
+    count: new Set(names).size,
+    today: null,
+    movedFrom: null,
+    todayDayIndex: null,
+    todayTimezone: null,
+    todayCurrency: null,
+    ...overrides,
+  };
+}
+
+describe("formatCityPath", () => {
+  it("도시가 하나면 이름만", () => {
+    expect(formatCityPath(["오사카"])).toBe("오사카");
+  });
+
+  it("4개까지는 다 보여준다", () => {
+    expect(formatCityPath(["오사카", "교토", "나라", "고베"])).toBe(
+      "오사카 → 교토 → 나라 → 고베",
+    );
+  });
+
+  it("4개를 넘으면 처음 둘과 마지막만 — 출발지와 도착지가 여행의 모양을 말한다", () => {
+    expect(
+      formatCityPath(["오사카", "교토", "나라", "고베", "나고야", "도쿄"]),
+    ).toBe("오사카 → 교토 → … → 도쿄");
+  });
+
+  it("연속 중복은 접는다", () => {
+    expect(formatCityPath(["도쿄", "도쿄", "닛코"])).toBe("도쿄 → 닛코");
+  });
+
+  it("떨어져 있는 중복은 남긴다 — 돌아온 것이라 지우면 닛코에서 끝난 것처럼 보인다", () => {
+    expect(formatCityPath(["도쿄", "닛코", "도쿄"])).toBe("도쿄 → 닛코 → 도쿄");
+  });
+
+  it("도시가 없으면 빈 문자열", () => {
+    expect(formatCityPath([])).toBe("");
+  });
+});
+
+describe("formatCityCount", () => {
+  it("하나면 셀 것이 없다", () => {
+    expect(formatCityCount(1)).toBe("");
+  });
+
+  it("둘 이상이면 개수를 말한다", () => {
+    expect(formatCityCount(6)).toBe("6개 도시");
+  });
+});
+
+describe("formatCities", () => {
+  it("나열과 개수를 한 줄로", () => {
+    expect(
+      formatCities(
+        cities(["오사카", "교토", "나라", "고베", "나고야", "도쿄"]),
+      ),
+    ).toBe("오사카 → 교토 → … → 도쿄 (6개 도시)");
+  });
+
+  it("단일 도시 여행은 이름만 — v2.0과 같은 모양이다", () => {
+    expect(formatCities(cities(["도쿄"]))).toBe("도쿄");
+  });
+
+  it("같은 도시를 다시 방문해도 개수는 하나가 아니라 서로 다른 도시 수다", () => {
+    expect(formatCities(cities(["도쿄", "닛코", "도쿄"]))).toBe(
+      "도쿄 → 닛코 → 도쿄 (2개 도시)",
+    );
+  });
+
+  it("값이 없으면 빈 문자열 — 더미를 넣지 않는다", () => {
+    expect(formatCities(undefined)).toBe("");
+    expect(formatCities(cities([]))).toBe("");
+  });
+});
+
+describe("formatTodayCity", () => {
+  it("오늘의 도시를 말한다", () => {
+    expect(formatTodayCity(cities(["교토"], { today: "교토" }))).toBe("교토");
+  });
+
+  it("옮기는 날이면 어디서 어디로인지 말한다", () => {
+    expect(
+      formatTodayCity(
+        cities(["오사카", "교토"], { today: "교토", movedFrom: "오사카" }),
+      ),
+    ).toBe("오사카 → 교토");
+  });
+
+  it("진행 중이 아니면 빈 문자열", () => {
+    expect(formatTodayCity(cities(["교토"]))).toBe("");
+    expect(formatTodayCity(undefined)).toBe("");
+  });
+});

--- a/fe/src/features/travel/lib/cityPath.ts
+++ b/fe/src/features/travel/lib/cityPath.ts
@@ -1,0 +1,66 @@
+import type { TripCitySummary } from "@/features/travel/api/travel";
+
+/** 이 개수를 넘으면 가운데를 줄인다. 카드 한 줄에 들어가는 한계이기도 하다. */
+const MAX_SHOWN = 4;
+const ELLIPSIS = "…";
+
+/**
+ * 여행이 거쳐 가는 도시를 한 줄로 — `오사카 → 교토 → … → 도쿄`.
+ *
+ * <p>줄이는 규칙이 <b>한 곳에만</b> 있어야 한다. `/select` 카드 · S-01 홈 · S-02 목록이 같은
+ * 값을 조금씩 다르게 줄여 쓰는데, 화면마다 따로 만들면 규칙이 세 벌이 되고 그중 하나만 고치는
+ * 일이 반드시 생긴다.
+ *
+ * <ul>
+ *   <li><b>연속 중복은 접는다</b> — 서버가 이미 구간으로 접어 주지만, 여기서도 한 번 더 본다.
+ *       "도쿄 → 도쿄"는 어떤 경로로 들어와도 읽을 것이 없는 표기다</li>
+ *   <li><b>떨어져 있는 중복은 남긴다</b> — 도쿄 → 닛코 → 도쿄에서 마지막 도쿄는 돌아온
+ *       것이라, 지우면 여행이 닛코에서 끝난 것처럼 보인다</li>
+ *   <li>{@link MAX_SHOWN}개를 넘으면 <b>처음 둘과 마지막</b>만 두고 가운데를 줄인다 — 출발지와
+ *       도착지가 여행의 모양을 가장 많이 말한다</li>
+ * </ul>
+ */
+export function formatCityPath(names: string[]): string {
+  const path = collapseRepeats(names);
+  if (path.length === 0) return "";
+  if (path.length <= MAX_SHOWN) return path.join(" → ");
+  return [path[0], path[1], ELLIPSIS, path[path.length - 1]].join(" → ");
+}
+
+/** `6개 도시`. 도시가 하나뿐이면 셀 것이 없어 빈 문자열이다. */
+export function formatCityCount(count: number): string {
+  return count > 1 ? `${count}개 도시` : "";
+}
+
+/**
+ * 카드 한 줄 — `오사카 → 교토 → … → 도쿄 (6개 도시)`.
+ *
+ * <p>도시가 하나면 이름만 남는다. <b>단일 도시 여행에서 나열은 소음이다</b> — v2.0과 같은
+ * 모양으로 보여야 한다.
+ */
+export function formatCities(cities: TripCitySummary | undefined): string {
+  if (!cities || cities.names.length === 0) return "";
+  const path = formatCityPath(cities.names);
+  const count = formatCityCount(cities.count);
+  return count ? `${path} (${count})` : path;
+}
+
+/**
+ * 오늘 어디에 있는지 — `교토`, 옮기는 날이면 `오사카 → 교토`.
+ *
+ * <p>진행 중이 아니면 빈 문자열이다. 예정 여행에 "오늘의 도시"를 쓰면 첫날 도시가 오늘인
+ * 것처럼 보인다.
+ */
+export function formatTodayCity(cities: TripCitySummary | undefined): string {
+  if (!cities?.today) return "";
+  return cities.movedFrom
+    ? `${cities.movedFrom} → ${cities.today}`
+    : cities.today;
+}
+
+/** 붙어 있는 같은 이름을 하나로. 떨어져 있는 중복은 그대로 둔다. */
+function collapseRepeats(names: string[]): string[] {
+  return names.filter(
+    (name, index) => index === 0 || name !== names[index - 1],
+  );
+}

--- a/fe/src/pages/WorkspaceSelectPage.test.tsx
+++ b/fe/src/pages/WorkspaceSelectPage.test.tsx
@@ -11,6 +11,33 @@ import { renderWithRouter } from "@/test/render";
 
 const API_BASE = "https://api.orino.dev/api";
 
+/** 여행이 거쳐 가는 도시. 오늘 값은 진행 중일 때만 채운다. */
+function cities(names: string[], overrides: Record<string, unknown> = {}) {
+  return {
+    names,
+    count: new Set(names).size,
+    today: null,
+    movedFrom: null,
+    todayDayIndex: null,
+    todayTimezone: null,
+    todayCurrency: null,
+    ...overrides,
+  };
+}
+
+function ongoingTrip(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 3,
+    title: "일본 9박 10일",
+    boardPath: "/travel/trips/3/board",
+    startDate: "2026-10-24",
+    endDate: "2026-11-02",
+    activityCount: 27,
+    cities: cities(["오사카", "교토"]),
+    ...overrides,
+  };
+}
+
 function mockTravelSummary(data: unknown) {
   server.use(
     http.get(`${API_BASE}/travel/summary`, () =>
@@ -65,17 +92,18 @@ describe("WorkspaceSelectPage", () => {
     expect(travelCard).not.toHaveTextContent(/D-/);
   });
 
-  it("다음 여행이 있으면 D-day 배지와 기간 메타를 보여준다", async () => {
+  it("다음 여행이 있으면 D-day 배지와 기간·도시 메타를 보여준다", async () => {
     mockTravelSummary({
       ongoing: null,
       next: {
         id: 3,
-        title: "도쿄 3박 4일",
-        destinationName: "도쿄",
+        title: "일본 9박 10일",
+        destinationName: "오사카",
         startDate: "2026-10-24",
-        endDate: "2026-10-27",
+        endDate: "2026-11-02",
         dDay: 78,
         activityCount: 13,
+        cities: cities(["오사카", "교토", "나라", "고베", "나고야", "도쿄"]),
       },
       recentCompleted: null,
     });
@@ -86,16 +114,39 @@ describe("WorkspaceSelectPage", () => {
     await waitFor(() => {
       expect(travelCard).toHaveTextContent("D-78");
     });
-    expect(travelCard).toHaveTextContent("도쿄 3박 4일 · 10.24 – 10.27");
+    expect(travelCard).toHaveTextContent(
+      "일본 9박 10일 · 10.24 – 11.02 · 오사카 → 교토 → … → 도쿄 (6개 도시)",
+    );
+  });
+
+  it("진행 중 여행은 오늘 어디인지 말한다 — 옮기는 날이면 어디서 어디로", async () => {
+    mockTravelSummary({
+      ongoing: ongoingTrip({
+        cities: cities(["오사카", "교토"], {
+          today: "교토",
+          movedFrom: "오사카",
+          todayDayIndex: 4,
+          todayTimezone: "Asia/Tokyo",
+          todayCurrency: "JPY",
+        }),
+      }),
+      next: null,
+      recentCompleted: null,
+    });
+
+    renderApp(["/select"]);
+
+    const travelCard = await screen.findByRole("button", { name: /여행/ });
+    await waitFor(() => {
+      expect(travelCard).toHaveTextContent(
+        "일본 9박 10일 · 오늘 오사카 → 교토",
+      );
+    });
   });
 
   it("진행 중 여행이 있으면 '진행 중' 배지를 보여주고 눌렀을 때 보드로 간다", async () => {
     mockTravelSummary({
-      ongoing: {
-        id: 3,
-        title: "도쿄 3박 4일",
-        boardPath: "/travel/trips/3/board",
-      },
+      ongoing: ongoingTrip({ title: "도쿄 3박 4일" }),
       next: null,
       recentCompleted: null,
     });

--- a/fe/src/pages/WorkspaceSelectPage.tsx
+++ b/fe/src/pages/WorkspaceSelectPage.tsx
@@ -1,4 +1,4 @@
-import { CalendarDays, CheckSquare, LayoutGrid, Plane } from "lucide-react";
+import { CheckSquare, LayoutGrid, MapPin, Plane } from "lucide-react";
 import type { ComponentType } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -9,6 +9,7 @@ import { usePlannerCalendar } from "@/features/planner/hooks/usePlannerCalendar"
 import { useReviewSummary } from "@/features/review/hooks/useReviewSummary";
 import type { TravelSummary } from "@/features/travel/api/travel";
 import { useTravelSummary } from "@/features/travel/hooks/useTravelSummary";
+import { formatCities, formatTodayCity } from "@/features/travel/lib/cityPath";
 import { cn } from "@/lib/utils";
 
 /** "2026-10-24" → "10.24" */
@@ -23,25 +24,44 @@ function shortDate(isoDate: string): string {
  */
 function travelCardContent(summary: TravelSummary | undefined) {
   if (summary?.ongoing) {
+    // 진행 중 여행에서 궁금한 것은 제목이 아니라 "오늘 어디"다. 옮기는 날이면 `오사카 → 교토`.
+    const today = formatTodayCity(summary.ongoing.cities);
     return {
       badge: "진행 중",
-      meta: summary.ongoing.title,
+      badgeVariant: "success" as const,
+      meta: today
+        ? `${summary.ongoing.title} · 오늘 ${today}`
+        : summary.ongoing.title,
       to: summary.ongoing.boardPath,
     };
   }
   if (summary?.next) {
-    const { title, startDate, endDate, dDay } = summary.next;
+    const { title, startDate, endDate, dDay, cities } = summary.next;
+    // 아직 떠나지 않은 여행은 "언제"와 "어디"가 같이 궁금하다.
+    const where = formatCities(cities);
+    const period = `${shortDate(startDate)} – ${shortDate(endDate)}`;
     return {
       badge: `D-${dDay}`,
-      meta: `${title} · ${shortDate(startDate)} – ${shortDate(endDate)}`,
+      badgeVariant: "secondary" as const,
+      meta: where ? `${title} · ${period} · ${where}` : `${title} · ${period}`,
       to: "/travel",
     };
   }
   if (summary?.recentCompleted) {
-    return { badge: null, meta: "여행 만들기", to: "/travel" };
+    return {
+      badge: null,
+      badgeVariant: "secondary" as const,
+      meta: "여행 만들기",
+      to: "/travel",
+    };
   }
   // 아직 못 받았거나 여행이 하나도 없는 상태 — 둘 다 메타를 비운다.
-  return { badge: null, meta: null, to: "/travel" };
+  return {
+    badge: null,
+    badgeVariant: "secondary" as const,
+    meta: null,
+    to: "/travel",
+  };
 }
 
 /** 기기 시간대 기준 오늘. 일상 워크스페이스는 여행 타임존과 무관하다. */
@@ -63,7 +83,7 @@ export function WorkspaceSelectPage() {
   const reviewCount = review?.counts.now ?? 0;
   const routineCount =
     feed?.events.filter((event) => event.routine).length ?? 0;
-  const { badge, meta, to } = travelCardContent(travel);
+  const { badge, badgeVariant, meta, to } = travelCardContent(travel);
 
   const dailyMeta = routineCount > 0 ? `오늘 루틴 ${routineCount}개` : null;
 
@@ -85,7 +105,9 @@ export function WorkspaceSelectPage() {
               icon={Plane}
               iconClassName="bg-accent text-accent-foreground"
               badge={badge}
-              metaIcon={CalendarDays}
+              badgeVariant={badgeVariant}
+              // 여행 카드가 말하는 것은 날짜가 아니라 장소다(v2.1).
+              metaIcon={MapPin}
               meta={meta}
               onClick={() => navigate(to)}
             />
@@ -113,6 +135,7 @@ interface WorkspaceCardProps {
   icon: ComponentType<{ className?: string }>;
   iconClassName: string;
   badge: string | null;
+  badgeVariant?: "secondary" | "success";
   metaIcon: ComponentType<{ className?: string }>;
   meta: string | null;
   onClick: () => void;
@@ -124,6 +147,7 @@ function WorkspaceCard({
   icon: Icon,
   iconClassName,
   badge,
+  badgeVariant = "secondary",
   metaIcon: MetaIcon,
   meta,
   onClick,
@@ -146,7 +170,7 @@ function WorkspaceCard({
         >
           <Icon className="size-5" />
         </span>
-        {badge && <Badge variant="secondary">{badge}</Badge>}
+        {badge && <Badge variant={badgeVariant}>{badge}</Badge>}
       </div>
       <div>
         <p className="text-heading font-medium">{title}</p>

--- a/fe/src/pages/travel/TravelHomePage.test.tsx
+++ b/fe/src/pages/travel/TravelHomePage.test.tsx
@@ -26,6 +26,20 @@ function mockTrip(trip: Record<string, unknown>) {
   );
 }
 
+/** 여행이 거쳐 가는 도시. 오늘 값은 진행 중일 때만 채운다. */
+function cities(names: string[], overrides: Record<string, unknown> = {}) {
+  return {
+    names,
+    count: new Set(names).size,
+    today: null,
+    movedFrom: null,
+    todayDayIndex: null,
+    todayTimezone: null,
+    todayCurrency: null,
+    ...overrides,
+  };
+}
+
 const TOKYO = {
   id: 3,
   title: "도쿄 3박 4일",
@@ -82,6 +96,7 @@ describe("TravelHomePage", () => {
         endDate: "2026-10-27",
         dDay: 78,
         activityCount: 13,
+        cities: cities(["도쿄"]),
       },
       recentCompleted: null,
     });
@@ -101,10 +116,101 @@ describe("TravelHomePage", () => {
     expect(screen.getByText("Asia/Tokyo · JPY")).toBeInTheDocument();
   });
 
+  it("도시가 여럿이면 요약에 도시 수를 넣는다", async () => {
+    mockSummary({
+      ongoing: null,
+      next: {
+        ...TOKYO,
+        title: "일본 9박 10일",
+        endDate: "2026-11-02",
+        dDay: 78,
+        activityCount: 27,
+        cities: cities(["오사카", "교토", "나라", "고베", "나고야", "도쿄"]),
+      },
+      recentCompleted: null,
+    });
+    mockTrip({
+      ...TOKYO,
+      title: "일본 9박 10일",
+      endDate: "2026-11-02",
+      activityCount: 27,
+    });
+
+    renderApp();
+
+    expect(
+      await screen.findByText("10월 24일 – 11월 2일 · 6개 도시 · 일정 27개"),
+    ).toBeInTheDocument();
+  });
+
+  it("진행 중이면 오늘 어디인지와 그날 타임존·통화를 말한다", async () => {
+    mockSummary({
+      ongoing: {
+        id: 3,
+        title: "일본 9박 10일",
+        boardPath: "/travel/trips/3/board",
+        startDate: "2026-10-24",
+        endDate: "2026-11-02",
+        activityCount: 27,
+        cities: cities(["오사카", "교토"], {
+          today: "교토",
+          movedFrom: "오사카",
+          todayDayIndex: 4,
+          // 첫날(오사카)이 아니라 오늘 도시의 값이다 — v2.1에서 타임존의 주인은 날짜다.
+          todayTimezone: "Asia/Tokyo",
+          todayCurrency: "JPY",
+        }),
+      },
+      next: null,
+      recentCompleted: null,
+    });
+    mockTrip({
+      ...TOKYO,
+      status: "ONGOING",
+      timezone: "Asia/Seoul",
+      currency: "KRW",
+    });
+
+    renderApp();
+
+    expect(await screen.findByText("오늘 · 오사카 → 교토")).toBeInTheDocument();
+    expect(screen.getByText("4일차")).toBeInTheDocument();
+    expect(screen.getByText("Asia/Tokyo · JPY")).toBeInTheDocument();
+  });
+
+  it("진행 중 여행에 가려진 다음 여행은 첫 구간 도시와 D-day로 남는다", async () => {
+    mockSummary({
+      ongoing: {
+        id: 3,
+        title: "도쿄 3박 4일",
+        boardPath: "/travel/trips/3/board",
+        startDate: "2026-10-24",
+        endDate: "2026-10-27",
+        activityCount: 13,
+        cities: cities(["도쿄"], { today: "도쿄", todayDayIndex: 1 }),
+      },
+      next: {
+        ...TOKYO,
+        id: 4,
+        title: "유럽 2주",
+        dDay: 120,
+        cities: cities(["파리", "로마"]),
+      },
+      recentCompleted: null,
+    });
+    mockTrip({ ...TOKYO, status: "ONGOING" });
+
+    renderApp();
+
+    expect(await screen.findByText("다음 여행")).toBeInTheDocument();
+    expect(screen.getByText("파리 → 로마 (2개 도시)")).toBeInTheDocument();
+    expect(screen.getByText("D-120")).toBeInTheDocument();
+  });
+
   it("일자 칩을 기간만큼 만든다(1단계는 일차·요일만)", async () => {
     mockSummary({
       ongoing: null,
-      next: { ...TOKYO, dDay: 78 },
+      next: { ...TOKYO, dDay: 78, cities: cities(["도쿄"]) },
       recentCompleted: null,
     });
     mockTrip(TOKYO);
@@ -125,6 +231,15 @@ describe("TravelHomePage", () => {
         id: 3,
         title: "도쿄 3박 4일",
         boardPath: "/travel/trips/3/board",
+        startDate: "2026-10-24",
+        endDate: "2026-10-27",
+        activityCount: 13,
+        cities: cities(["도쿄"], {
+          today: "도쿄",
+          todayDayIndex: 2,
+          todayTimezone: "Asia/Tokyo",
+          todayCurrency: "JPY",
+        }),
       },
       next: null,
       recentCompleted: null,
@@ -142,7 +257,7 @@ describe("TravelHomePage", () => {
   it("보드 열기 링크가 그 여행의 보드를 가리킨다", async () => {
     mockSummary({
       ongoing: null,
-      next: { ...TOKYO, dDay: 78 },
+      next: { ...TOKYO, dDay: 78, cities: cities(["도쿄"]) },
       recentCompleted: null,
     });
     mockTrip(TOKYO);

--- a/fe/src/pages/travel/TravelHomePage.tsx
+++ b/fe/src/pages/travel/TravelHomePage.tsx
@@ -1,4 +1,4 @@
-import { CalendarDays, ChevronRight, Plus } from "lucide-react";
+import { CalendarDays, ChevronRight, MapPin, Plus } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { PageHeader } from "@/components/PageHeader";
@@ -8,12 +8,19 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { LoadingText } from "@/components/ui/loading-text";
 import type {
   CompletedTripSummary,
+  NextTripSummary,
   TravelSummary,
+  TripCitySummary,
   TripDetail,
 } from "@/features/travel/api/travel";
 import { useTravelSummary } from "@/features/travel/hooks/useTravelSummary";
 import { useTrip } from "@/features/travel/hooks/useTrip";
 import { firstDayZone } from "@/features/travel/lib/baseCity";
+import {
+  formatCities,
+  formatCityCount,
+  formatTodayCity,
+} from "@/features/travel/lib/cityPath";
 import {
   dayChips,
   daysUntil,
@@ -62,7 +69,14 @@ export function TravelHomePage() {
   return (
     <div className="mx-auto flex max-w-[720px] flex-col gap-6">
       <PageHeader title="여행" description={describeState(summary, featured)} />
-      {featured && <FeaturedTripCard trip={featured} />}
+      {featured && (
+        <FeaturedTripCard
+          trip={featured}
+          cities={summary?.ongoing?.cities ?? summary?.next?.cities}
+        />
+      )}
+      {/* 진행 중 여행에 가려진 다음 여행. 첫 구간 도시와 D-day만 한 줄로 남긴다. */}
+      {summary?.ongoing && summary.next && <NextTripRow trip={summary.next} />}
       {summary?.recentCompleted && (
         <RecentCompleted trip={summary.recentCompleted} />
       )}
@@ -83,12 +97,23 @@ function describeState(
   return `진행 중인 여행이 없어요. 다음 여행까지 ${days}일.`;
 }
 
-function FeaturedTripCard({ trip }: { trip: TripDetail }) {
+function FeaturedTripCard({
+  trip,
+  cities,
+}: {
+  trip: TripDetail;
+  cities: TripCitySummary | undefined;
+}) {
   const ongoing = trip.status === "ONGOING";
   // 서버가 준 dDay를 그대로 쓰지 않고 다시 계산한다 — 오프라인 캐시(4단계)로 어제 응답이
   // 돌아와도 숫자가 맞아야 한다. 기준은 첫날 도시다(`trip.timezone`이 그 값이다).
   const days = daysUntil(trip.startDate, firstDayZone(trip.timezone));
   const chips = dayChips(trip.startDate, trip.endDate);
+  const cityCount = formatCityCount(cities?.count ?? 0);
+  const todayCity = formatTodayCity(cities);
+  // 진행 중이면 <b>오늘 도시의</b> 타임존·통화다 — 여행 하나에 값 하나이던 v2.0과 다르다.
+  const timezone = cities?.todayTimezone ?? trip.timezone;
+  const currency = cities?.todayCurrency ?? trip.currency;
 
   return (
     <section className="bg-card ring-foreground/10 flex flex-col gap-4 rounded-xl py-4 ring-1">
@@ -99,19 +124,30 @@ function FeaturedTripCard({ trip }: { trip: TripDetail }) {
           </Badge>
           <h2 className="text-heading mt-1 font-medium">{trip.title}</h2>
           <p className="text-muted-foreground text-sm">
-            {formatPeriod(trip.startDate, trip.endDate)} · 일정{" "}
-            {trip.activityCount}개
+            {formatPeriod(trip.startDate, trip.endDate)}
+            {cityCount && ` · ${cityCount}`} · 일정 {trip.activityCount}개
           </p>
         </div>
         <div className="col-start-2 text-right">
           <p className="text-display text-primary font-semibold tabular-nums">
-            {formatDDay(days)}
+            {ongoing && cities?.todayDayIndex
+              ? `${cities.todayDayIndex}일차`
+              : formatDDay(days)}
           </p>
           <p className="text-caption text-muted-foreground">
-            {trip.timezone} · {trip.currency}
+            {timezone} · {currency}
           </p>
         </div>
       </header>
+      {/* 오늘 어디에 있는지가 이 카드에서 가장 먼저 읽혀야 한다. 옮기는 날이면 `A → B`. */}
+      {todayCity && (
+        <div className="px-4">
+          <p className="bg-accent text-accent-foreground flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium">
+            <MapPin className="size-[15px] shrink-0" />
+            오늘 · {todayCity}
+          </p>
+        </div>
+      )}
       <div className="px-4">
         {/* 날씨(3행)는 4단계. 1단계는 일차·요일만 채운다. */}
         <ul className="flex gap-2 overflow-x-auto pb-1">
@@ -152,6 +188,34 @@ function formatDDay(days: number): string {
   if (days > 0) return `D-${days}`;
   if (days === 0) return "D-DAY";
   return `D+${-days}`;
+}
+
+/** 진행 중 여행 뒤에 오는 다음 여행 — 첫 구간 도시와 D-day만. */
+function NextTripRow({ trip }: { trip: NextTripSummary }) {
+  const where = formatCities(trip.cities) || trip.destinationName;
+  return (
+    <section className="flex flex-col gap-2">
+      <h2 className="text-caption text-muted-foreground font-semibold">
+        다음 여행
+      </h2>
+      <Link
+        to={`/travel/trips/${trip.id}/board`}
+        className="bg-card ring-foreground/10 hover:ring-primary flex items-center justify-between gap-3 rounded-xl p-4 ring-1 transition-all"
+      >
+        <span className="min-w-0">
+          <span className="block truncate text-[15px] font-medium">
+            {trip.title}
+          </span>
+          <span className="text-muted-foreground block truncate text-[13px]">
+            {where}
+          </span>
+        </span>
+        <span className="text-primary shrink-0 text-sm font-semibold tabular-nums">
+          {formatDDay(trip.dDay)}
+        </span>
+      </Link>
+    </section>
+  );
 }
 
 function RecentCompleted({ trip }: { trip: CompletedTripSummary }) {

--- a/fe/src/pages/travel/TripListPage.test.tsx
+++ b/fe/src/pages/travel/TripListPage.test.tsx
@@ -23,6 +23,21 @@ function trip(overrides: Record<string, unknown> = {}) {
     status: "UPCOMING",
     dDay: 78,
     activityCount: 13,
+    cities: cities(["도쿄"]),
+    ...overrides,
+  };
+}
+
+/** 여행이 거쳐 가는 도시. 오늘 값은 진행 중일 때만 채운다. */
+function cities(names: string[], overrides: Record<string, unknown> = {}) {
+  return {
+    names,
+    count: new Set(names).size,
+    today: null,
+    movedFrom: null,
+    todayDayIndex: null,
+    todayTimezone: null,
+    todayCurrency: null,
     ...overrides,
   };
 }
@@ -77,10 +92,65 @@ describe("TripListPage", () => {
 
     renderApp();
 
-    // "도쿄 · 10.24 – 10.27 · 일정 6개"가 통째로 한 노드여야 한다.
+    // "10.24 – 10.27 · 일정 6개"가 통째로 한 노드여야 한다.
     expect(
-      await screen.findByText("도쿄 · 10.24 – 10.27 · 일정 6개"),
+      await screen.findByText("10.24 – 10.27 · 일정 6개"),
     ).toBeInTheDocument();
+  });
+
+  it("구간 순서대로 도시를 나열하고 4개를 넘으면 줄인다", async () => {
+    mockTripsByStatus({
+      UPCOMING: [
+        trip({
+          cities: cities(["오사카", "교토", "나라", "고베", "나고야", "도쿄"]),
+        }),
+      ],
+    });
+
+    renderApp();
+
+    expect(
+      await screen.findByText("오사카 → 교토 → … → 도쿄 (6개 도시)"),
+    ).toBeInTheDocument();
+  });
+
+  it("도쿄 → 닛코 → 도쿄에서 마지막 도쿄가 남는다 — 연속 중복만 접는다", async () => {
+    mockTripsByStatus({
+      UPCOMING: [trip({ cities: cities(["도쿄", "닛코", "도쿄"]) })],
+    });
+
+    renderApp();
+
+    expect(
+      await screen.findByText("도쿄 → 닛코 → 도쿄 (2개 도시)"),
+    ).toBeInTheDocument();
+  });
+
+  it("단일 도시 여행은 이름만 — 나열이 소음이 되지 않는다", async () => {
+    mockTripsByStatus({ UPCOMING: [trip()] });
+
+    renderApp();
+
+    expect(await screen.findByText("도쿄")).toBeInTheDocument();
+  });
+
+  it("진행 중 여행은 오늘의 도시를 앞세워 강조한다", async () => {
+    mockTripsByStatus({
+      ONGOING: [
+        trip({
+          status: "ONGOING",
+          cities: cities(["오사카", "교토"], {
+            today: "교토",
+            movedFrom: "오사카",
+          }),
+        }),
+      ],
+    });
+
+    renderApp();
+    await userEvent.click(await screen.findByRole("tab", { name: /진행 중/ }));
+
+    expect(await screen.findByText("오늘 오사카 → 교토")).toBeInTheDocument();
   });
 
   it("카드를 누르면 그 여행의 보드로 간다", async () => {

--- a/fe/src/pages/travel/TripListPage.tsx
+++ b/fe/src/pages/travel/TripListPage.tsx
@@ -9,6 +9,7 @@ import { LoadingText } from "@/components/ui/loading-text";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { TripCounts, TripSummary } from "@/features/travel/api/travel";
 import { useTrips } from "@/features/travel/hooks/useTrips";
+import { formatCities, formatTodayCity } from "@/features/travel/lib/cityPath";
 import type { TripStatus } from "@/features/travel/lib/tripStatus";
 import { formatShortDate } from "@/features/travel/lib/tripStatus";
 
@@ -110,6 +111,8 @@ function TripRow({ trip }: { trip: TripSummary }) {
         <span className="block truncate text-[15px] font-medium">
           {trip.title}
         </span>
+        {/* 도시 나열은 별도 줄이다 — 6개 도시가 기간·일정과 한 줄에 들어가지 않는다. */}
+        <span className="block truncate text-[13px]">{cityLine(trip)}</span>
         {/* 메타는 한 문자열이다 — 조각으로 나누면 "일정 6" / "개"처럼 숫자와 단위가 갈라진다. */}
         <span className="text-muted-foreground block text-[13px]">
           {metaLine(trip)}
@@ -122,5 +125,23 @@ function TripRow({ trip }: { trip: TripSummary }) {
 
 function metaLine(trip: TripSummary): string {
   const period = `${formatShortDate(trip.startDate)} – ${formatShortDate(trip.endDate)}`;
-  return `${trip.destinationName} · ${period} · 일정 ${trip.activityCount}개`;
+  return `${period} · 일정 ${trip.activityCount}개`;
+}
+
+/**
+ * 구간 순서대로 도시를 나열한다 — `오사카 → 교토 → … → 도쿄 (6개 도시)`.
+ *
+ * <p>진행 중 여행은 <b>오늘의 도시를 강조한다.</b> 그 카드에서 가장 급한 정보는 전체 경로가
+ * 아니라 "지금 어디"라서, 나열 앞에 오늘 도시를 세우고 굵게 남긴다.
+ */
+function cityLine(trip: TripSummary) {
+  const path = formatCities(trip.cities) || trip.destinationName;
+  const today = formatTodayCity(trip.cities);
+  if (!today) return path;
+  return (
+    <>
+      <span className="text-foreground font-medium">오늘 {today}</span>
+      <span className="text-muted-foreground"> · {path}</span>
+    </>
+  );
 }


### PR DESCRIPTION
## 이슈
closes #1135
## 작업 내용

### 도시 정보를 어떻게 받았나 (N+1 결정)
**목록·요약 응답에 얹었다.** 여행마다 `/city-legs`를 부르는 쪽은 N+1이지만, 그보다 중요한 사실이 있다 — `GET /trips`와 `GET /summary`는 **이미 모든 여행의 날짜별 기준 도시를 한 번에 읽고 있다.** 상태(예정/진행 중/완료)와 D-day를 여행마다 자기 도시의 오늘로 판정해야 해서다(`baseCitiesByTrip(ids)`). 도시 나열은 그 지도를 접기만 한 값이라 **추가 조회가 0**이고, 카드가 열릴 때 부르는 방식보다 단순하다. 별도 이슈로 뺄 이유가 없었다.

`TripCitySummary`(신규)를 `TripSummary` · `summary.ongoing` · `summary.next`에 붙였다.

| 필드 | 뜻 |
|---|---|
| `names` | 구간 순서의 도시. 연속 중복은 이미 접혀 있다 |
| `count` | 서로 다른 도시 수 |
| `today` · `movedFrom` | 오늘의 도시, 오늘 바뀌었다면 어제의 도시. **진행 중이 아니면 null** |
| `todayDayIndex` · `todayTimezone` · `todayCurrency` | 오늘이 며칠째이고 그 도시의 타임존·통화 |

### 포맷터 하나 (`cityPath.ts`)
세 화면이 같은 값을 조금씩 다르게 줄여 쓴다. 화면마다 만들면 규칙이 세 벌이 되고 그중 하나만 고치는 일이 반드시 생긴다.
- 4개까지는 전부, 넘으면 **처음 둘과 마지막** — `오사카 → 교토 → … → 도쿄`
- **연속 중복은 접고, 떨어져 있는 중복은 남긴다** — 도쿄 → 닛코 → 도쿄에서 마지막 도쿄를 지우면 여행이 닛코에서 끝난 것처럼 보인다
- 도시가 하나면 이름만 — **단일 도시 여행은 v2.0과 같은 모양이다**

### 화면
- **`/select`** — 진행 중이면 `일본 9박 10일 · 오늘 오사카 → 교토`(배지 `진행 중`, success), 예정이면 `제목 · 기간 · 도시 나열`(배지 `D-78`, secondary). 메타 아이콘을 `CalendarDays` → `MapPin`으로 바꿨다. **실데이터가 없으면 줄을 그리지 않는 규칙은 그대로다.**
- **S-01 홈** — 요약에 `· 6개 도시`, 우측이 진행 중이면 `4일차`(아니면 D-day), 그 아래가 **오늘 도시의** 타임존·통화. 카드 안에 `오늘 · 교토`(옮기는 날이면 `오사카 → 교토`) 강조 줄. 진행 중 여행에 가려진 다음 여행은 첫 구간 도시 + D-day 한 줄로 남겼다.
- **S-02 목록** — 도시 나열을 별도 줄로(6개 도시가 기간·일정과 한 줄에 안 들어간다). 진행 중 여행은 `오늘 오사카 → 교토`를 앞세워 강조한다.

### 범위에서 뺀 것
설계 §9.2의 홈 Content 2·3행(다음 일정 / 오늘 밤 숙소)은 넣지 않았다. 숙소는 3단계고, 다음 일정은 이슈 Todo에 없으며 요약 응답에 없는 값이라 새 조회가 필요하다.

## 테스트
- `cityPath.test.ts` (신규 15개) — 1·4·5개 경계, 연속 중복 접기, 떨어진 중복 유지, 단일 도시, 오늘 도시 3형태
- `TripListPage.test.tsx` +4 · `TravelHomePage.test.tsx` +3 · `WorkspaceSelectPage.test.tsx` +1
- `TripControllerTest` +5 — 목록 도시 나열, 재방문 유지·개수 구분, 진행 중 오늘 도시·타임존·통화, 머무는 날 `movedFrom` 없음, 예정 여행에 오늘 없음

## 확인
- BE `./gradlew check` 통과
- FE `format:check` · `lint` · `test`(950개) · `build` · `test:e2e`(96개) 통과