### PR TITLE
feat : 도시 경계 이동시간 규칙 — 계산하지 않고 도시 이동으로 표시

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityResponse.java
@@ -1,6 +1,7 @@
 package ds.project.orino.planner.travel.activity.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.entity.TripActivity;
 
 import java.time.LocalDate;
@@ -16,8 +17,9 @@ import java.time.LocalTime;
  * @param hasLog       기록 존재 여부. 목록은 {@code log}를 다 펼치지 않고 이 표시만 쓴다
  * @param outOfBaseCity      (v2.1) 그날 기준 도시와 <b>다른 도시</b>의 장소다 → 화면이 경고색으로
  *                           도시명을 덧붙인다. 판정은 {@code place.cityPlaceRef}로만 한다
- * @param canDepartureNotify (v2.1) 출발 알림을 켤 수 있는가. 도시를 넘는 이동은 계산 대상이
- *                           아니라 켤 수 없다(3단계에서 판정이 붙는다)
+ * @param canDepartureNotify (v2.1) 출발 알림을 켤 수 있는가. <b>직전에 장소 있는 일정이 있고</b>
+ *                           그 사이가 <b>도시를 넘지 않아야</b> 한다 — 도시를 넘는 이동은 계산
+ *                           대상이 아니라 언제 나서야 하는지 정할 수 없다(§3.4)
  */
 public record ActivityResponse(
         Long id,
@@ -47,7 +49,7 @@ public record ActivityResponse(
                 activity.getActivityDate(), activity.getStartTime(), place,
                 activity.getMemo(), activity.getUrl(), activity.isNotifyEnabled(),
                 activity.getNotifyMinutes(), activity.isDepartureNotifyEnabled(),
-                activity.getSortOrder(), log, log != null, false, true);
+                activity.getSortOrder(), log, log != null, false, false);
     }
 
     /** 기록이 아직 없는(또는 필요 없는) 자리에서 쓴다. */
@@ -66,13 +68,21 @@ public record ActivityResponse(
     }
 
     /**
+     * 출발 알림을 켤 수 있는지를 덧씌운다. 판정에는 <b>같은 날 앞뒤 일정</b>이 필요해서(§3.4)
+     * 일정 하나만 봐서는 알 수 없다 — 목록을 아는 쪽이 계산해 넘긴다.
+     */
+    public ActivityResponse withCanDepartureNotify(boolean can) {
+        return new ActivityResponse(id, tripId, title, activityDate, startTime, place,
+                memo, url, notifyEnabled, notifyMinutes, departureNotifyEnabled,
+                sortOrder, log, hasLog, outOfBaseCity, can);
+    }
+
+    /**
      * <b>식별자가 둘 다 있고 서로 다를 때만</b> 다른 도시로 본다. 한쪽이라도 모르면 판정하지
      * 않는다 — 모르는 것을 "다르다"로 답하면 멀쩡한 일정에 경고가 붙는다.
      */
     private boolean isOutOf(String baseCityPlaceRef) {
-        if (place == null || place.cityPlaceRef() == null || baseCityPlaceRef == null) {
-            return false;
-        }
-        return !place.cityPlaceRef().equals(baseCityPlaceRef);
+        return TravelPlace.crossesCity(
+                place == null ? null : place.cityPlaceRef(), baseCityPlaceRef);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
@@ -347,10 +347,29 @@ public class ActivityService {
 
     private ActivityResponse toResponse(TripActivity activity) {
         return ActivityResponse.of(activity, placeOf(activity.getPlaceId()),
-                logRepository.findByActivityId(activity.getId())
-                        .map(log -> ActivityLogResponse.from(log,
-                                photoService.photosOf(log.getId())))
-                        .orElse(null));
+                        logRepository.findByActivityId(activity.getId())
+                                .map(log -> ActivityLogResponse.from(log,
+                                        photoService.photosOf(log.getId())))
+                                .orElse(null))
+                .withCanDepartureNotify(canDepartureNotify(activity));
+    }
+
+    /**
+     * 상세·저장 응답에도 출발 알림 가능 여부를 채운다 — <b>스위치가 있는 화면이 여기다</b>.
+     * 보드만 채우면 목록에선 못 켠다고 하고 상세에선 켤 수 있다고 하는, 화면마다 다른 답이 된다.
+     *
+     * <p>판정에 그날 목록이 필요해 조회가 한 번 더 나간다. 그래도 <b>외부 호출은 없다</b> —
+     * 도시 판정은 저장된 식별자만 본다.
+     */
+    private boolean canDepartureNotify(TripActivity activity) {
+        // 보관함 일정은 날짜가 없어 알림 시각 자체가 서지 않는다(§1.2).
+        if (activity.getActivityDate() == null) {
+            return false;
+        }
+        return travelTimeService.departureNotifiable(
+                activityRepository.findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(
+                        activity.getTripId(), activity.getActivityDate()))
+                .contains(activity.getId());
     }
 
     private ActivityPlace placeOf(Long placeId) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/dto/BoardResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/dto/BoardResponse.java
@@ -115,7 +115,8 @@ public record BoardResponse(
     /**
      * 리스트 맨 아래 붙는 숙소 이동. 오늘 밤 숙소가 없거나 그날 일정이 없으면 null이다.
      *
-     * <p>{@code sameCity = false}면 {@code mode}·{@code durationMinutes}가 null이다 —
+     * <p>{@code sameCity}는 <b>마지막 일정과 숙소가 같은 도시인가</b>다 — 기준 도시가 아니라
+     * 이 이동의 양 끝을 견준다. false면 {@code mode}·{@code durationMinutes}가 없다.
      * 도시를 넘는 이동은 계산하지 않는다(v2.1 §3.4).
      */
     public record StayMove(

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -104,13 +105,16 @@ public class BoardService {
                 buildDays(trip, cities, stays),
                 selectedDate,
                 activityRepository.countUnscheduled(tripId),
-                withBaseCity(activityService.toResponses(activities), selectedCity),
+                withCityRules(activityService.toResponses(activities), selectedCity,
+                        // 보관함 일정은 날짜가 없어 출발 알림 시각 자체가 서지 않는다.
+                        selectedDate == null ? Set.of()
+                                : travelTimeService.departureNotifiable(activities)),
                 // 보관함은 날짜에 배정되지 않은 목록이라 순서에 이동 의미가 없다.
                 // 계산해 봐야 화면에 쓰지 않고, 호출당 과금이라 그냥 낭비다.
                 selectedDate == null ? List.of() : travelTimeService.travelTimes(activities),
                 // 보관함에는 "그날 밤"이 없다 — 숙소 이동도 없다.
                 selectedDate == null ? null
-                        : stayAssembler.moveToStay(stays, selectedDate, activities, selectedCity));
+                        : stayAssembler.moveToStay(stays, selectedDate, activities));
     }
 
     /**
@@ -135,11 +139,20 @@ public class BoardService {
                 (int) cityCount, (int) countryCount, cityCount <= 1);
     }
 
-    /** 선택한 날짜의 기준 도시와 견줘 일정마다 도시 이탈 여부를 붙인다. */
-    private static List<ActivityResponse> withBaseCity(List<ActivityResponse> activities,
-                                                       TravelPlace baseCity) {
+    /**
+     * 일정마다 도시 관련 판정을 붙인다 — 기준 도시 이탈, 그리고 출발 알림 가능 여부.
+     *
+     * <p>둘 다 <b>그날 전체를 봐야</b> 나오는 값이라 일정 하나를 조립할 때는 알 수 없다.
+     * 조립을 마친 뒤 덧씌운다.
+     */
+    private static List<ActivityResponse> withCityRules(List<ActivityResponse> activities,
+                                                        TravelPlace baseCity,
+                                                        Set<Long> departureNotifiable) {
         String ref = baseCity == null ? null : baseCity.getCityPlaceRef();
-        return activities.stream().map(activity -> activity.withBaseCity(ref)).toList();
+        return activities.stream()
+                .map(activity -> activity.withBaseCity(ref)
+                        .withCanDepartureNotify(departureNotifiable.contains(activity.id())))
+                .toList();
     }
 
     /**

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/dto/TravelTimeResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/dto/TravelTimeResponse.java
@@ -7,9 +7,14 @@ import ds.project.orino.planner.travel.route.client.TravelMode;
  *
  * @param fromActivityId  출발 일정
  * @param toActivityId    도착 일정. 사이에 장소 없는 일정이 끼면 건너뛴 결과다
- * @param durationMinutes 소요 시간(분). {@code fallback}이면 null — 거리만 안다
- * @param distanceM       거리(m). 경로 거리이고, {@code fallback}이면 직선거리다
+ * @param mode            앱이 정한 이동수단. {@code crossCity}면 null — 수단을 판정하지 않는다
+ * @param durationMinutes 소요 시간(분). {@code fallback}·{@code crossCity}면 null
+ * @param distanceM       거리(m). 경로 거리이고, {@code fallback}·{@code crossCity}면 직선거리다
  * @param fallback        Routes를 못 얻어 직선거리로 대체했다. FE는 {@code 약 N.Nkm}로 보여준다
+ * @param crossCity       도시 경계를 넘어 <b>계산하지 않았다</b>(§3.4). FE는 {@code 도시 이동}으로
+ *                        그리고, 탭하면 이동수단 시트 없이 곧바로 대중교통 딥링크로 나간다 —
+ *                        도시를 넘는 이동에 도보/자동차를 물어볼 이유가 없다.
+ *                        <b>거리는 참고값일 뿐 화면에 쓰지 않는다</b>
  */
 public record TravelTimeResponse(
         Long fromActivityId,
@@ -17,6 +22,17 @@ public record TravelTimeResponse(
         TravelMode mode,
         Integer durationMinutes,
         int distanceM,
-        boolean fallback
+        boolean fallback,
+        boolean crossCity
 ) {
+
+    /**
+     * 도시 경계를 넘는 이동. 외부 호출 없이 만든다 — 오사카에서 도쿄까지 "자동차 6시간"은
+     * 틀린 값이고, 틀린 값을 사느니 안 사는 게 낫다.
+     */
+    public static TravelTimeResponse crossCity(Long fromActivityId, Long toActivityId,
+                                               int straightM) {
+        return new TravelTimeResponse(fromActivityId, toActivityId, null, null,
+                straightM, false, true);
+    }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/service/TravelTimeService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/service/TravelTimeService.java
@@ -15,9 +15,11 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -53,6 +55,9 @@ public class TravelTimeService {
      *
      * <p><b>장소 없는 일정은 건너뛴다</b>(§4.4) — "점심"처럼 장소를 안 정한 일정이 사이에 끼어도
      * 앞뒤 장소 사이 이동은 여전히 알고 싶다. 그걸 끊으면 정작 필요한 이동시간이 사라진다.
+     *
+     * <p><b>도시 경계를 넘는 구간은 계산하지 않는다</b>(§3.4) — 표시용 값만 만들고 외부 호출도
+     * 하지 않는다.
      */
     public List<TravelTimeResponse> travelTimes(List<TripActivity> ordered) {
         List<Located> located = locate(ordered);
@@ -87,7 +92,8 @@ public class TravelTimeService {
      * 그날 <b>마지막 일정에서 어떤 장소까지</b>의 이동. 숙소 이동 행(§3.5)이 쓴다.
      *
      * <p>일정 사이 이동과 같은 규칙·같은 캐시를 탄다 — 좌표 쌍이 키라 숙소든 일정이든 두 지점
-     * 사이 거리는 같은 값이다.
+     * 사이 거리는 같은 값이다. <b>도시 경계 규칙도 같다</b> — 마지막 일정과 목적지가 다른
+     * 도시면 계산하지 않는다(§3.4).
      *
      * <p>마지막 일정에 좌표가 없거나 목적지에 좌표가 없으면 <b>비어 있는 값</b>을 준다. 이동이
      * 성립하지 않는 것을 0분으로 답하면 화면이 "바로 옆"이라고 읽는다.
@@ -101,16 +107,50 @@ public class TravelTimeService {
             return Optional.empty();
         }
         Located from = located.get(located.size() - 1);
-        Located to = new Located(null, destination.getLat(), destination.getLng());
+        Located to = new Located(null, destination.getLat(), destination.getLng(),
+                destination.getCityPlaceRef());
+        if (crossesCity(from, to)) {
+            return Optional.of(Move.crossingCity());
+        }
         TravelMode mode = autoMode(from, to);
         return Optional.of(route(from, to, mode)
-                .map(r -> new Move(mode, Math.round(r.durationSeconds() / 60f)))
+                .map(r -> new Move(mode, Math.round(r.durationSeconds() / 60f), false))
                 // 실패해도 수단은 남긴다 — 거리만 아는 상태와 아무것도 모르는 상태는 다르다.
-                .orElseGet(() -> new Move(mode, null)));
+                .orElseGet(() -> new Move(mode, null, false)));
+    }
+
+    /**
+     * 출발 알림을 켤 수 있는 일정 id.
+     *
+     * <p>두 조건을 다 넘어야 한다 — <b>직전에 장소 있는 일정이 있고</b>(어디서 출발하는지 모르면
+     * 언제 나서야 하는지도 모른다), <b>그 사이가 도시를 넘지 않는다</b>(도시를 넘는 이동은
+     * 계산하지 않으므로 알림 시각을 정할 수 없다, §3.4).
+     *
+     * <p><b>외부 호출이 없다</b> — 도시 판정은 저장된 식별자만 보고, 소요 시간은 여기서 묻지
+     * 않는다. 일정을 열 때마다 유료 호출이 나가면 안 된다.
+     *
+     * <p>계산이 일시적으로 실패한 구간({@code fallback})은 <b>켤 수 있다고 본다</b>. 스위치는
+     * 저장되는 설정이라, 잠깐의 외부 장애로 끄면 복구된 뒤에도 사용자가 꺼 둔 것과 구분되지
+     * 않는다.
+     */
+    public Set<Long> departureNotifiable(List<TripActivity> ordered) {
+        List<Located> located = locate(ordered);
+        Set<Long> ids = new HashSet<>();
+        for (int i = 0; i + 1 < located.size(); i++) {
+            if (!crossesCity(located.get(i), located.get(i + 1))) {
+                ids.add(located.get(i + 1).activityId());
+            }
+        }
+        return ids;
     }
 
     /** 이동 한 건의 표시값. 도착지가 일정이 아니라 장소라 일정 id가 없다. */
-    public record Move(TravelMode mode, Integer durationMinutes) {
+    public record Move(TravelMode mode, Integer durationMinutes, boolean crossCity) {
+
+        /** 도시를 넘는 이동 — 수단도 소요 시간도 없다. */
+        static Move crossingCity() {
+            return new Move(null, null, true);
+        }
     }
 
     /** 좌표를 가진 일정만 순서대로 남긴다. 장소가 있어도 좌표가 없으면(직접 입력) 뺀다. */
@@ -135,9 +175,15 @@ public class TravelTimeService {
             if (place == null || place.getLat() == null || place.getLng() == null) {
                 continue;
             }
-            located.add(new Located(activity.getId(), place.getLat(), place.getLng()));
+            located.add(new Located(activity.getId(), place.getLat(), place.getLng(),
+                    place.getCityPlaceRef()));
         }
         return located;
+    }
+
+    /** 도시 판정은 장소에 저장된 식별자로만 한다(D-23) — 좌표 거리로 추측하지 않는다. */
+    private static boolean crossesCity(Located from, Located to) {
+        return TravelPlace.crossesCity(from.cityPlaceRef(), to.cityPlaceRef());
     }
 
     private TravelTimeResponse travelTime(Located from, Located to) {
@@ -154,12 +200,18 @@ public class TravelTimeService {
     private TravelTimeResponse travelTime(Located from, Located to, TravelMode mode) {
         int straightM = Haversine.distanceM(from.lat(), from.lng(), to.lat(), to.lng());
 
+        // 도시를 넘으면 여기서 끝낸다(§3.4). 이동수단 시트가 수단을 지정해 물어와도 마찬가지다 —
+        // 판정이 갈리면 시트가 보드에 없는 값을 보여주게 된다.
+        if (crossesCity(from, to)) {
+            return TravelTimeResponse.crossCity(from.activityId(), to.activityId(), straightM);
+        }
+
         return route(from, to, mode)
                 .map(r -> new TravelTimeResponse(from.activityId(), to.activityId(), mode,
-                        Math.round(r.durationSeconds() / 60f), r.distanceM(), false))
+                        Math.round(r.durationSeconds() / 60f), r.distanceM(), false, false))
                 // 실패해도 이동시간 행 자체는 남긴다 — 거리만이라도 알면 계획을 세울 수 있다.
                 .orElseGet(() -> new TravelTimeResponse(from.activityId(), to.activityId(), mode,
-                        null, straightM, true));
+                        null, straightM, true, false));
     }
 
     /**
@@ -196,6 +248,6 @@ public class TravelTimeService {
         return value.setScale(5, java.math.RoundingMode.HALF_UP).stripTrailingZeros();
     }
 
-    private record Located(Long activityId, BigDecimal lat, BigDecimal lng) {
+    private record Located(Long activityId, BigDecimal lat, BigDecimal lng, String cityPlaceRef) {
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/stay/service/StayBoardAssembler.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/stay/service/StayBoardAssembler.java
@@ -63,24 +63,29 @@ public class StayBoardAssembler {
      * <p>도시가 다르면 계산하지 않고 표시만 한다(§3.4). 오사카 가게에서 도쿄 숙소까지 "자동차
      * 6시간"이 뜨면 그 화면은 신뢰를 잃는다.
      *
+     * <p><b>견주는 대상은 기준 도시가 아니라 출발지인 마지막 일정의 도시다.</b> 이 행이 답하는
+     * 것은 "이 이동을 계산해도 되는가"이고, 경계는 그 이동의 양 끝에 있다 — 닛코 당일치기 날
+     * (기준 도시 도쿄) 닛코에서 도쿄 숙소로 돌아가는 이동은 기준 도시와는 같지만 실제로는
+     * 도시를 넘는다. 판정은 {@link TravelTimeService}가 한다. 출발지가 좌표 없는 일정이면 그
+     * 앞 일정으로 밀리는데, 그 결정을 두 곳에서 따로 하면 어긋난다.
+     *
      * <p><b>모르면 다르다고 하지 않는다</b>(D-23) — 도시 식별자가 한쪽이라도 없으면 같은 도시로
      * 보고 계산한다. 모르는 것을 근거로 기능을 끄면 사용자는 왜 시간이 안 나오는지 알 수 없다.
      */
     public BoardResponse.StayMove moveToStay(Stays stays, LocalDate date,
-                                             List<TripActivity> ordered,
-                                             TravelPlace baseCity) {
+                                             List<TripActivity> ordered) {
         Optional<TripStay> tonight = stays.tonight(date);
         if (tonight.isEmpty() || ordered.isEmpty()) {
             return null;
         }
         TripStay stay = tonight.get();
         TravelPlace stayPlace = stays.placeOf(stay);
-        boolean sameCity = isSameCity(stayPlace, baseCity);
-        if (!sameCity || stayPlace == null) {
-            return new BoardResponse.StayMove(stay.getId(), sameCity, null, null);
+        if (stayPlace == null) {
+            // 숙소에 장소가 안 붙어 있으면 좌표도 도시도 없다 — 행만 남긴다.
+            return new BoardResponse.StayMove(stay.getId(), true, null, null);
         }
         return travelTimeService.moveToPlace(ordered, stayPlace)
-                .map(move -> new BoardResponse.StayMove(stay.getId(), true,
+                .map(move -> new BoardResponse.StayMove(stay.getId(), !move.crossCity(),
                         move.mode(), move.durationMinutes()))
                 // 마지막 일정에 좌표가 없으면 이동 자체가 성립하지 않는다 — 행만 남긴다.
                 .orElseGet(() -> new BoardResponse.StayMove(stay.getId(), true, null, null));
@@ -107,9 +112,7 @@ public class StayBoardAssembler {
         if (stayPlace == null || baseCity == null) {
             return true;
         }
-        String stayRef = stayPlace.getCityPlaceRef();
-        String cityRef = baseCity.getCityPlaceRef();
-        return stayRef == null || cityRef == null || stayRef.equals(cityRef);
+        return !TravelPlace.crossesCity(stayPlace.getCityPlaceRef(), baseCity.getCityPlaceRef());
     }
 
     /** 여행 한 건의 숙소 전체와 그 장소들. 날짜 판정은 여기서 한다. */

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/NotificationScheduleTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/NotificationScheduleTest.java
@@ -109,6 +109,13 @@ class NotificationScheduleTest extends ApiTestSupport {
         return placeRepository.saveAndFlush(place).getId();
     }
 
+    /** 도시 식별자를 가진 장소. 도시 경계 판정은 좌표가 아니라 이 값으로만 한다(D-23). */
+    private Long placeIn(String name, String cityPlaceRef, BigDecimal lat, BigDecimal lng) {
+        TravelPlace place = placeRepository.findById(placeAt(name, lat, lng)).orElseThrow();
+        place.updateCityInfo(cityPlaceRef, cityPlaceRef, "JP");
+        return placeRepository.saveAndFlush(place).getId();
+    }
+
     private long addActivity(String json) throws Exception {
         String body = mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
@@ -229,6 +236,21 @@ class NotificationScheduleTest extends ApiTestSupport {
                     {"title": "스카이트리", "activityDate": "2026-10-24", "startTime": "11:00",
                      "placeId": %d, "departureNotifyEnabled": true}
                     """.formatted(placeAt("스카이트리", SKYTREE_LAT, SKYTREE_LNG)));
+
+            assertThat(pending()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("도시를 넘는 이동에는 만들지 않는다 — 이동시간을 모르는데 언제 나서라고 할 수 없다")
+        void skipsAcrossCityBoundary() throws Exception {
+            addActivity("""
+                    {"title": "오사카 가게", "activityDate": "2026-10-24", "startTime": "09:00",
+                     "placeId": %d}
+                    """.formatted(placeIn("오사카 가게", "ChIJ_osaka", SENSOJI_LAT, SENSOJI_LNG)));
+            addActivity("""
+                    {"title": "교토 가게", "activityDate": "2026-10-24", "startTime": "11:00",
+                     "placeId": %d, "departureNotifyEnabled": true}
+                    """.formatted(placeIn("교토 가게", "ChIJ_kyoto", SKYTREE_LAT, SKYTREE_LNG)));
 
             assertThat(pending()).isEmpty();
         }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/TravelTimeIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/TravelTimeIntegrationTest.java
@@ -92,6 +92,16 @@ class TravelTimeIntegrationTest extends ApiTestSupport {
         return placeRepository.saveAndFlush(place).getId();
     }
 
+    /**
+     * 도시 식별자를 가진 장소. 도시 경계 판정은 <b>이 값으로만</b> 하고 좌표 거리는 보지
+     * 않는다(D-23) — 그래서 아래 테스트들은 좌표를 바꾸지 않고 식별자만 바꿔 경계를 만든다.
+     */
+    private Long placeIn(String name, String cityPlaceRef, BigDecimal lat, BigDecimal lng) {
+        TravelPlace place = placeRepository.findById(placeAt(name, lat, lng)).orElseThrow();
+        place.updateCityInfo(cityPlaceRef, cityPlaceRef, "JP");
+        return placeRepository.saveAndFlush(place).getId();
+    }
+
     private long createTrip() throws Exception {
         String body = mockMvc.perform(post("/api/travel/trips")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
@@ -375,6 +385,158 @@ class TravelTimeIntegrationTest extends ApiTestSupport {
                     .andExpect(jsonPath("$.data.travelTimes", hasSize(0)));
 
             assertThat(stub.calls).isEmpty();
+        }
+    }
+
+    /**
+     * 목적은 비용이 아니라 <b>오답 제거</b>다 — 오사카에서 도쿄에 "자동차 6시간"이 뜨면 그
+     * 화면은 신뢰를 잃는다. 호출이 주는 것은 부수 효과다.
+     */
+    @Nested
+    @DisplayName("도시 경계(§3.4)")
+    class CityBoundary {
+
+        @Test
+        @DisplayName("같은 도시 안 두 장소는 v2.0 그대로 계산한다")
+        void computesWithinSameCity() throws Exception {
+            addActivity("센소지", placeIn("센소지", "ChIJ_tokyo",
+                    jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("스카이트리", placeIn("스카이트리", "ChIJ_tokyo",
+                    jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+
+            board()
+                    .andExpect(jsonPath("$.data.travelTimes", hasSize(1)))
+                    .andExpect(jsonPath("$.data.travelTimes[0].crossCity").value(false))
+                    .andExpect(jsonPath("$.data.travelTimes[0].mode").value("WALK"))
+                    .andExpect(jsonPath("$.data.travelTimes[0].durationMinutes").value(12));
+            assertThat(stub.calls).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("도시를 넘으면 계산하지 않는다 — 외부 호출이 0회다")
+        void skipsAcrossCities() throws Exception {
+            // 좌표는 둘 다 도쿄 안이다. 그래도 도시 식별자가 다르면 경계다 —
+            // 판정이 좌표 거리로 새면 이 테스트가 통과하지 않는다.
+            addActivity("오사카 가게", placeIn("오사카 가게", "ChIJ_osaka",
+                    jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("교토 가게", placeIn("교토 가게", "ChIJ_kyoto",
+                    jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+
+            board()
+                    // 행 자체는 남는다 — 사라지면 "이동이 없다"로 읽힌다.
+                    .andExpect(jsonPath("$.data.travelTimes", hasSize(1)))
+                    .andExpect(jsonPath("$.data.travelTimes[0].crossCity").value(true))
+                    .andExpect(jsonPath("$.data.travelTimes[0].mode").doesNotExist())
+                    .andExpect(jsonPath("$.data.travelTimes[0].durationMinutes").doesNotExist())
+                    .andExpect(jsonPath("$.data.travelTimes[0].fallback").value(false));
+
+            assertThat(stub.calls).isEmpty();
+        }
+
+        @Test
+        @DisplayName("도시 식별자를 모르는 장소는 경계로 판정하지 않는다 — 모르는 것을 경고로 바꾸지 않는다")
+        void unknownCityIsNotABoundary() throws Exception {
+            addActivity("교토 가게", placeIn("교토 가게", "ChIJ_kyoto",
+                    jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            // 직접 입력한 장소처럼 도시를 모르는 경우.
+            addActivity("골목 카페", placeAt("골목 카페",
+                    jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+
+            board()
+                    .andExpect(jsonPath("$.data.travelTimes[0].crossCity").value(false))
+                    .andExpect(jsonPath("$.data.travelTimes[0].durationMinutes").value(12));
+            assertThat(stub.calls).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("이동수단 시트도 도시를 넘으면 계산하지 않는다 — 보드와 답이 갈리면 안 된다")
+        void sheetAlsoRefusesAcrossCities() throws Exception {
+            addActivity("오사카 가게", placeIn("오사카 가게", "ChIJ_osaka",
+                    jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("교토 가게", placeIn("교토 가게", "ChIJ_kyoto",
+                    jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+            List<Integer> ids = activityIds();
+
+            travelTimeBetween(ids.get(0), ids.get(1), "WALK")
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.crossCity").value(true))
+                    .andExpect(jsonPath("$.data.durationMinutes").doesNotExist());
+
+            assertThat(stub.calls).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("출발 알림을 켤 수 있는가")
+    class DepartureNotifiable {
+
+        @Test
+        @DisplayName("도시를 넘어 들어오는 일정은 켤 수 없다 — 언제 나서야 할지 모른다")
+        void blockedWhenIncomingCrossesCity() throws Exception {
+            addActivity("오사카 가게", placeIn("오사카 가게", "ChIJ_osaka",
+                    jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("교토 가게", placeIn("교토 가게", "ChIJ_kyoto",
+                    jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+
+            board()
+                    .andExpect(jsonPath("$.data.activities[1].canDepartureNotify").value(false));
+        }
+
+        @Test
+        @DisplayName("같은 도시 안이면 켤 수 있다")
+        void allowedWithinSameCity() throws Exception {
+            addActivity("센소지", placeIn("센소지", "ChIJ_tokyo",
+                    jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("스카이트리", placeIn("스카이트리", "ChIJ_tokyo",
+                    jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+
+            board()
+                    .andExpect(jsonPath("$.data.activities[1].canDepartureNotify").value(true));
+        }
+
+        @Test
+        @DisplayName("그날 첫 일정은 켤 수 없다 — 어디서 출발하는지가 없다")
+        void blockedForFirstActivity() throws Exception {
+            addActivity("센소지", placeIn("센소지", "ChIJ_tokyo",
+                    jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("스카이트리", placeIn("스카이트리", "ChIJ_tokyo",
+                    jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+
+            board()
+                    .andExpect(jsonPath("$.data.activities[0].canDepartureNotify").value(false));
+        }
+
+        @Test
+        @DisplayName("상세 응답도 보드와 같은 답을 준다 — 스위치가 있는 화면이 상세다")
+        void detailAgreesWithBoard() throws Exception {
+            addActivity("오사카 가게", placeIn("오사카 가게", "ChIJ_osaka",
+                    jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addActivity("교토 가게", placeIn("교토 가게", "ChIJ_kyoto",
+                    jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+            List<Integer> ids = activityIds();
+
+            mockMvc.perform(get("/api/travel/activities/" + ids.get(1))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.canDepartureNotify").value(false));
+
+            // 판정에 외부 호출이 끼면 일정을 열 때마다 과금된다.
+            assertThat(stub.calls).isEmpty();
+        }
+
+        @Test
+        @DisplayName("보관함 일정은 켤 수 없다 — 날짜가 없어 알림 시각 자체가 서지 않는다")
+        void blockedInArchive() throws Exception {
+            addUnscheduled("센소지", placeIn("센소지", "ChIJ_tokyo",
+                    jitter(SENSOJI_LAT), jitter(SENSOJI_LNG)));
+            addUnscheduled("스카이트리", placeIn("스카이트리", "ChIJ_tokyo",
+                    jitter(SKYTREE_LAT), jitter(SKYTREE_LNG)));
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                            .param("archive", "true")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.activities[1].canDepartureNotify").value(false));
         }
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/stay/StayControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/stay/StayControllerTest.java
@@ -256,6 +256,22 @@ class StayControllerTest extends ApiTestSupport {
         }
 
         @Test
+        @DisplayName("견주는 대상은 기준 도시가 아니라 마지막 일정이다 — 닛코에서 도쿄 숙소로 가는 날")
+        void comparesAgainstLastActivityNotBaseCity() throws Exception {
+            // 기준 도시는 오사카인데 그날 마지막 일정만 교토에 있고 숙소는 오사카다.
+            // 기준 도시로 견주면 "같은 도시"라 교토→오사카를 자동차로 계산해 버린다.
+            withCityRef(osaka, "ChIJ_osaka");
+            long stayPlace = poiInCity("난바 호텔", "ChIJ_osaka");
+            createActivity("기요미즈데라", "2026-10-24", poiInCity("기요미즈데라", "ChIJ_kyoto"));
+            createStayWithPlace("난바 호텔", "2026-10-24", "2026-10-26", stayPlace);
+
+            board("2026-10-24")
+                    .andExpect(jsonPath("$.data.stayMove.sameCity").value(false))
+                    .andExpect(jsonPath("$.data.stayMove.mode").doesNotExist())
+                    .andExpect(jsonPath("$.data.stayMove.durationMinutes").doesNotExist());
+        }
+
+        @Test
         @DisplayName("보관함에는 그날 밤이 없다 — 숙소 이동도 없다")
         void noStayMoveInArchive() throws Exception {
             createStay("도톤보리 호텔", "2026-10-24", "2026-10-26");

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TravelPlace.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/travel/entity/TravelPlace.java
@@ -179,6 +179,20 @@ public class TravelPlace {
         return placeKind == PlaceKind.CITY;
     }
 
+    /**
+     * 두 지점이 <b>도시 경계를 넘는가</b>(D-23). 이동시간·도시 이탈·숙소 이동이 모두 이 판정
+     * 하나를 쓴다 — 규칙이 여러 벌이면 한 화면만 조용히 다르게 답한다.
+     *
+     * <p><b>식별자가 둘 다 있고 서로 다를 때만</b> 넘는다고 본다. 한쪽이라도 모르면 넘지 않는
+     * 것으로 둔다 — 모르는 것을 "다르다"로 답하면 멀쩡한 이동에서 시간이 사라지고, 사용자는
+     * 왜 안 나오는지 알 수 없다. 좌표 거리로 추측하지 않는 이유는 오사카-교토(43km)와
+     * 도쿄-요코하마(30km)가 같은 임계에서 다른 답이 되기 때문이다.
+     */
+    public static boolean crossesCity(String cityPlaceRef, String otherCityPlaceRef) {
+        return cityPlaceRef != null && otherCityPlaceRef != null
+                && !cityPlaceRef.equals(otherCityPlaceRef);
+    }
+
     /** 위치·주소·분류 등 검색 응답으로 채워지는 기본 정보. */
     public void updateBasics(String address, BigDecimal lat, BigDecimal lng,
                              String category, BigDecimal rating) {

--- a/fe/e2e/travel-city-move.spec.ts
+++ b/fe/e2e/travel-city-move.spec.ts
@@ -1,0 +1,168 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 도시 경계 이동시간(§3.4, #1142).
+ *
+ * <p>여기서 확인하는 것은 <b>탭 한 번에 지도로 나가는가</b>다. 도시를 넘는 이동에는 도보/자동차를
+ * 물어볼 이유가 없어 이동수단 시트를 건너뛰는데, "시트가 열리지 않는다"는 실제 클릭으로만
+ * 확인된다 — 핸들러를 갈아끼운 검사는 시트가 열렸다 닫혔는지 구분하지 못한다.
+ */
+
+const TRIP_ID = 1;
+const D1 = "2026-10-24";
+
+const OSAKA = {
+  placeId: 21,
+  name: "오사카",
+  timezone: "Asia/Tokyo",
+  currency: "JPY",
+  countryCode: "JP",
+  cityPlaceRef: "ChIJ_osaka",
+  lat: null,
+  lng: null,
+};
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+function activity(
+  id: number,
+  title: string,
+  place: { name: string; lat: number; lng: number; cityPlaceRef: string },
+) {
+  return {
+    id,
+    tripId: TRIP_ID,
+    title,
+    activityDate: D1,
+    startTime: null,
+    place: {
+      id: id + 100,
+      name: place.name,
+      address: `${place.name} 주소`,
+      lat: place.lat,
+      lng: place.lng,
+      cityName: place.cityPlaceRef === "ChIJ_osaka" ? "오사카" : "교토",
+      cityPlaceRef: place.cityPlaceRef,
+    },
+    memo: null,
+    url: null,
+    notifyEnabled: false,
+    notifyMinutes: null,
+    departureNotifyEnabled: false,
+    sortOrder: id - 1,
+    log: null,
+    hasLog: false,
+    outOfBaseCity: place.cityPlaceRef !== "ChIJ_osaka",
+    canDepartureNotify: false,
+  };
+}
+
+async function mockBoard(page: Page) {
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/planner/reviews/summary", (route) =>
+    route.fulfill(
+      ok({
+        today: D1,
+        counts: { now: 0, overdue: 0, upcoming: 0, doneToday: 0 },
+        estimatedMinutes: 0,
+        materials: [],
+      }),
+    ),
+  );
+  await page.route("**/api/travel/summary", (route) =>
+    route.fulfill(ok({ ongoing: null, next: null, recentCompleted: null })),
+  );
+  await page.route(`**/api/travel/trips/${TRIP_ID}/board*`, (route) =>
+    route.fulfill(
+      ok({
+        trip: {
+          id: TRIP_ID,
+          title: "일본",
+          startDate: D1,
+          endDate: D1,
+          status: "UPCOMING",
+          recordMode: false,
+          cityCount: 2,
+          countryCount: 1,
+          singleCity: false,
+        },
+        days: [
+          {
+            dayId: 501,
+            dayIndex: 1,
+            date: D1,
+            weekday: "토",
+            activityCount: 2,
+            baseCity: OSAKA,
+            cityChanged: false,
+            legIndex: 1,
+            cityMemo: null,
+            weather: null,
+            stayTonight: null,
+            stayCheckout: null,
+          },
+        ],
+        selectedDate: D1,
+        archiveCount: 0,
+        activities: [
+          activity(1, "구로몬 시장", {
+            name: "구로몬 시장",
+            lat: 34.6656,
+            lng: 135.5061,
+            cityPlaceRef: "ChIJ_osaka",
+          }),
+          activity(2, "기요미즈데라", {
+            name: "기요미즈데라",
+            lat: 34.9949,
+            lng: 135.785,
+            cityPlaceRef: "ChIJ_kyoto",
+          }),
+        ],
+        // 서버가 계산하지 않은 구간 — 수단도 소요 시간도 없이 온다.
+        travelTimes: [
+          {
+            fromActivityId: 1,
+            toActivityId: 2,
+            mode: null,
+            durationMinutes: null,
+            distanceM: 42800,
+            fallback: false,
+            crossCity: true,
+          },
+        ],
+        stayMove: null,
+      }),
+    ),
+  );
+}
+
+test.describe("도시 경계 이동", () => {
+  test("시간 대신 `도시 이동`만 뜨고, 탭하면 시트 없이 곧바로 지도로 나간다", async ({
+    page,
+    context,
+  }) => {
+    await mockBoard(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+
+    const row = page.getByRole("button", { name: "이동시간 도시 이동" });
+    await expect(row).toBeVisible();
+    // "약 42.8km"는 계획에 쓸 수 없는 숫자다 — 거리도 말하지 않는다.
+    await expect(page.getByText(/km/)).toHaveCount(0);
+
+    // 딥링크는 새 탭으로 열린다. 그 탭이 열리는 것 자체가 확인 대상이다.
+    const opened = context.waitForEvent("page");
+    await row.click();
+    const mapTab = await opened;
+
+    expect(mapTab.url()).toContain("google.com/maps/dir/");
+    expect(mapTab.url()).toContain("travelmode=transit");
+    // 도보/자동차를 물어볼 이유가 없다 — 이동수단 시트는 열리지 않는다.
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+  });
+});

--- a/fe/src/features/travel/api/activities.ts
+++ b/fe/src/features/travel/api/activities.ts
@@ -138,13 +138,21 @@ export type TravelMode = "WALK" | "DRIVE";
 export interface TravelTime {
   fromActivityId: number;
   toActivityId: number;
-  mode: TravelMode;
-  /** `fallback`이면 null — 거리만 안다. */
+  /** `crossCity`면 null — 도시를 넘는 이동에 수단을 판정하지 않는다. */
+  mode: TravelMode | null;
+  /** `fallback`·`crossCity`면 null — 거리만 안다. */
   durationMinutes: number | null;
-  /** 경로 거리. `fallback`이면 직선거리다. */
+  /** 경로 거리. `fallback`·`crossCity`면 직선거리다. */
   distanceM: number;
   /** Routes를 못 얻어 직선거리로 대체했다. 화면은 `약 N.Nkm`로 보여준다. */
   fallback: boolean;
+  /**
+   * 도시 경계를 넘어 서버가 계산하지 않았다(§3.4). `도시 이동`으로 그리고, 탭하면 이동수단
+   * 시트 없이 곧바로 대중교통 딥링크로 나간다 — 도보/자동차를 물어볼 이유가 없다.
+   *
+   * <p>**거리도 보여주지 않는다.** 오사카→도쿄에 "약 400km"는 계획에 쓸 수 없는 숫자다.
+   */
+  crossCity: boolean;
 }
 
 export interface Board {
@@ -159,7 +167,8 @@ export interface Board {
   /**
    * 그날 마지막 일정 → 오늘 밤 숙소 이동. 숙소가 없거나 보관함을 보고 있으면 null.
    *
-   * <p>`sameCity`가 false면 `mode`·`durationMinutes`가 없다 — 도시를 넘는 이동은 계산하지
+   * <p>`sameCity`는 **마지막 일정과 숙소가** 같은 도시인가다 — 기준 도시가 아니라 이 이동의
+   * 양 끝을 견준다. false면 `mode`·`durationMinutes`가 없다. 도시를 넘는 이동은 계산하지
    * 않는다(§3.4).
    */
   stayMove: StayMove | null;

--- a/fe/src/features/travel/board/TransportSheet.tsx
+++ b/fe/src/features/travel/board/TransportSheet.tsx
@@ -51,8 +51,11 @@ export function TransportSheet({
   // 다른 구간을 탭하면 이전 구간의 값이 남아 있으면 안 된다.
   useEffect(() => {
     if (!travelTime) return;
-    setByMode({ [travelTime.mode]: travelTime });
-    setSelected(travelTime.mode);
+    // 도시를 넘는 이동은 수단이 없다(§3.4). 보드가 이 시트 대신 지도로 보내므로 여기까지
+    // 오지 않지만, 오더라도 없는 수단을 골라 둔 것처럼 보이면 안 된다.
+    const mode = travelTime.mode;
+    setByMode(mode === null ? {} : { [mode]: travelTime });
+    setSelected(mode);
   }, [travelTime]);
 
   if (!travelTime) return null;

--- a/fe/src/features/travel/board/TravelTimeRow.tsx
+++ b/fe/src/features/travel/board/TravelTimeRow.tsx
@@ -1,22 +1,47 @@
-import { Car, ChevronRight, Footprints } from "lucide-react";
+import {
+  Car,
+  ChevronRight,
+  Footprints,
+  Navigation,
+  TrainFront,
+} from "lucide-react";
 
 import type { TravelTime } from "@/features/travel/api/activities";
 import { travelTimeLabel } from "@/features/travel/lib/travelTimeLabel";
 
 interface TravelTimeRowProps {
   travelTime: TravelTime;
+  /**
+   * 탭했을 때. 도시를 넘는 이동이면 이동수단 시트가 아니라 곧바로 지도로 나가야 하므로,
+   * 무엇을 열지는 이 행이 아니라 좌표를 아는 쪽(보드)이 정한다.
+   */
   onOpen: (travelTime: TravelTime) => void;
   /** 오프라인이면 캐시에서 온 값이고, 다른 수단은 물어볼 수 없다(§4.6). */
   offline: boolean;
 }
 
-/** 일정 사이의 이동시간 행(§S-04). 탭하면 이동수단 시트가 열린다. */
+/**
+ * 일정 사이의 이동시간 행(§S-04). 탭하면 이동수단 시트가 열린다.
+ *
+ * <p>도시를 넘는 이동은 시간 대신 `도시 이동`만 말하고, 탭하면 시트 없이 곧바로 대중교통
+ * 길찾기로 나간다(§3.4) — 도시를 넘는 이동에 도보/자동차를 물어볼 이유가 없다.
+ */
 export function TravelTimeRow({
   travelTime,
   onOpen,
   offline,
 }: TravelTimeRowProps) {
-  const Icon = travelTime.mode === "WALK" ? Footprints : Car;
+  const Icon = travelTime.crossCity
+    ? TrainFront
+    : travelTime.mode === "WALK"
+      ? Footprints
+      : Car;
+  // 시트가 아니라 밖으로 나간다는 뜻이라 꼬리표도 다르다.
+  const Trailing = travelTime.crossCity ? Navigation : ChevronRight;
+  // 도시가 바뀌는 지점은 그날 일정에서 가장 큰 사건이라 다른 이동시간 줄보다 조금 세게 읽힌다.
+  const tone = travelTime.crossCity
+    ? "text-foreground/75 font-medium"
+    : "text-muted-foreground";
 
   return (
     <li>
@@ -25,13 +50,13 @@ export function TravelTimeRow({
         onClick={() => onOpen(travelTime)}
         disabled={offline}
         aria-label={`이동시간 ${travelTimeLabel(travelTime)}`}
-        className={`text-muted-foreground ml-[52px] flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs ${
+        className={`${tone} ml-[52px] flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs ${
           offline ? "opacity-60" : "hover:bg-muted"
         }`}
       >
         <Icon className="size-[13px] shrink-0" />
         {travelTimeLabel(travelTime)}
-        <ChevronRight className="size-3 shrink-0" />
+        <Trailing className="size-3 shrink-0" />
       </button>
     </li>
   );

--- a/fe/src/features/travel/lib/travelTimeLabel.ts
+++ b/fe/src/features/travel/lib/travelTimeLabel.ts
@@ -3,10 +3,16 @@ import type { TravelTime } from "@/features/travel/api/activities";
 /**
  * 이동시간을 사람이 읽는 값으로.
  *
+ * <p>도시를 넘는 이동은 서버가 계산하지 않는다(§3.4) — 분도 거리도 말하지 않고 **무슨 이동인지만**
+ * 말한다. 오사카에서 도쿄에 "자동차 6시간"이 뜨면 그 화면은 신뢰를 잃는다.
+ *
  * <p>계산이 실패하면(`fallback`) 시간을 지어내지 않고 <b>거리만</b> 보여준다 — 거리만 알아도
  * "걸어갈 만한가"는 판단이 서지만, 틀린 분 수는 계획을 망친다.
  */
 export function travelTimeLabel(travelTime: TravelTime): string {
+  if (travelTime.crossCity) {
+    return "도시 이동";
+  }
   if (travelTime.fallback || travelTime.durationMinutes === null) {
     return `약 ${(travelTime.distanceM / 1000).toFixed(1)}km`;
   }

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -1100,6 +1100,7 @@ describe("TripBoardPage", () => {
         durationMinutes: 12,
         distanceM: 900,
         fallback: false,
+        crossCity: false,
         ...overrides,
       };
     }
@@ -1310,6 +1311,71 @@ describe("TripBoardPage", () => {
         screen.queryByRole("button", { name: /이동시간/ }),
       ).not.toBeInTheDocument();
     });
+
+    describe("도시 경계 (§3.4)", () => {
+      /** 서버가 계산하지 않은 구간 — 수단도 소요 시간도 없이 온다. */
+      function crossCityTime() {
+        return travelTime({
+          mode: null,
+          durationMinutes: null,
+          distanceM: 402_000,
+          crossCity: true,
+        });
+      }
+
+      it("시간 대신 `도시 이동`만 보여준다 — 거리도 말하지 않는다", async () => {
+        mockBoard({
+          byDate: { "2026-10-24": twoActivities() },
+          travelTimes: [crossCityTime()],
+        });
+
+        renderBoard();
+
+        expect(
+          await screen.findByRole("button", { name: "이동시간 도시 이동" }),
+        ).toBeInTheDocument();
+        // "약 402.0km"는 계획에 쓸 수 없는 숫자다.
+        expect(screen.queryByText(/km/)).not.toBeInTheDocument();
+      });
+
+      it("탭하면 이동수단 시트 없이 곧바로 대중교통 길찾기로 나간다", async () => {
+        const open = vi.spyOn(window, "open").mockImplementation(() => null);
+        mockBoard({
+          byDate: { "2026-10-24": twoActivities() },
+          travelTimes: [crossCityTime()],
+        });
+
+        const user = userEvent.setup();
+        renderBoard();
+        await user.click(
+          await screen.findByRole("button", { name: "이동시간 도시 이동" }),
+        );
+
+        expect(open).toHaveBeenCalledWith(
+          expect.stringContaining("travelmode=transit"),
+          "_blank",
+          "noopener",
+        );
+        // 도보/자동차를 물어볼 이유가 없다 — 시트가 열리면 안 된다.
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        open.mockRestore();
+      });
+
+      it("같은 도시 구간은 그대로 시트가 열린다", async () => {
+        mockBoard({
+          byDate: { "2026-10-24": twoActivities() },
+          travelTimes: [travelTime()],
+        });
+
+        const user = userEvent.setup();
+        renderBoard();
+        await user.click(
+          await screen.findByRole("button", { name: "이동시간 12분" }),
+        );
+
+        expect(await screen.findByRole("dialog")).toBeInTheDocument();
+      });
+    });
   });
 
   describe("오프라인 (§4.6)", () => {
@@ -1403,6 +1469,7 @@ describe("TripBoardPage", () => {
             durationMinutes: 12,
             distanceM: 900,
             fallback: false,
+            crossCity: false,
           },
         ],
       });

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -63,6 +63,7 @@ import {
   daysForPlace,
   groupArchiveByCity,
 } from "@/features/travel/lib/archiveGroups";
+import { directionsUrl } from "@/features/travel/lib/mapsLink";
 import { PickDaySheet } from "@/features/travel/places/PickDaySheet";
 import { toast } from "@/shared/lib/toast";
 import { useOnline } from "@/shared/lib/useOnline";
@@ -170,6 +171,31 @@ export function TripBoardPage() {
       travelTime,
     ]),
   );
+
+  /**
+   * 이동시간 행을 탭했다.
+   *
+   * <p>도시를 넘는 이동이면 <b>이동수단 시트를 열지 않고</b> 곧바로 대중교통 길찾기로 나간다
+   * (§3.4) — 서버가 계산하지 않은 구간이라 시트에 보여줄 도보/자동차가 애초에 없고, 물어볼
+   * 이유도 없다. 실제로 타는 건 신칸센이고 그건 구글 지도가 답한다.
+   */
+  const openTravelTimeRow = (travelTime: TravelTime) => {
+    if (!travelTime.crossCity) {
+      setOpenTravelTime(travelTime);
+      return;
+    }
+    const from = activities.find((a) => a.id === travelTime.fromActivityId);
+    const to = activities.find((a) => a.id === travelTime.toActivityId);
+    const url =
+      from?.place && to?.place ? directionsUrl(from.place, to.place) : null;
+    if (url === null) {
+      // 좌표가 없으면 이동시간 행 자체가 없다. 그래도 열리면 아무 일도 안 일어난 것처럼
+      // 두지 않는다 — 눌렀는데 반응이 없으면 고장으로 읽힌다.
+      toast("길찾기를 열 수 없어요", "error");
+      return;
+    }
+    window.open(url, "_blank", "noopener");
+  };
 
   /** 보고 있는 날짜. 보관함을 보고 있으면 없다. */
   const selectedDay =
@@ -504,7 +530,7 @@ export function TripBoardPage() {
                   {!dragMode && travelTimesByTo.get(activity.id) && (
                     <TravelTimeRow
                       travelTime={travelTimesByTo.get(activity.id)!}
-                      onOpen={setOpenTravelTime}
+                      onOpen={openTravelTimeRow}
                       offline={!online}
                     />
                   )}


### PR DESCRIPTION
## 이슈
closes #1142

## 작업 내용

**오사카 가게 → 교토 가게 사이에 이제 시간이 뜨지 않는다.** 도시 경계를 넘는 구간은 계산하지 않고 `도시 이동`으로만 표시한다. 목적은 비용이 아니라 오답 제거다.

### BE

- **이동시간 조립에 도시 경계 판정을 넣었다** — 경계를 넘으면 Routes 호출·캐시 조회 자체를 건너뛴다. 판정은 응답 조립 단계에 있어 **기존 캐시는 그대로 유효하다**(도시가 바뀌어도 두 좌표 사이 거리는 그대로고, 바뀌는 건 판정뿐)
- `travelTimes[].crossCity` 표시값 추가 — FE가 좌표로 다시 판정하지 않는다
- **판정을 `TravelPlace.crossesCity(a, b)` 하나로 모았다.** 같은 D-23 규칙을 이동시간·숙소 이동·도시 이탈 세 곳이 각자 구현하고 있었다. 규칙이 여러 벌이면 한 화면만 조용히 다르게 답한다
- `canDepartureNotify` 실제 판정 — 직전에 장소 있는 일정이 있고 그 사이가 도시를 넘지 않을 때만 `true`
- 이동수단 시트(`GET /travel-time`)도 같은 판정을 탄다 — 시트가 보드에 없는 값을 보여주면 안 된다

### FE

- `도시 이동` 행 — `TrainFront` + `도시 이동`, 탭하면 **이동수단 시트를 열지 않고** 곧바로 대중교통 딥링크
- 거리도 보여주지 않는다. "약 42.8km"는 계획에 쓸 수 없는 숫자다

## 판단이 갈릴 수 있는 곳 (리뷰 요청)

**1. 숙소 이동은 기준 도시가 아니라 마지막 일정과 견준다.** #1141은 `stayMove.sameCity`를 *기준 도시 ↔ 숙소*로 판정했다. 그러면 닛코 당일치기 날(기준 도시 도쿄) 닛코 → 도쿄 숙소 이동이 "같은 도시"가 되어 계산된다 — 실제로는 특급열차를 타는데 "자동차 2시간"이 붙는다. 이 행이 답하는 것은 "이 이동을 계산해도 되는가"이고 경계는 그 이동의 양 끝에 있어서, *마지막 일정 ↔ 숙소*로 바꿨다. 배지용 `stayTonight.sameCity`는 기준 도시 비교 그대로 두었다.

**2. `mode: "CITY_MOVE"` 대신 `crossCity` 필드를 썼다.** 위키 API 스펙 초안은 `mode`에 `CITY_MOVE` 센티넬을 넣는 안이었다. `TravelMode`는 `GET /travel-time?mode=`의 입력이자 Routes 요청 값이라, 계산하지 않는 상태를 그 enum에 넣으면 "대중교통 경로를 계산해 달라"는 뜻 없는 요청이 타입상 유효해진다. "무슨 수단인가"와 "계산했는가"는 다른 축이라 필드를 나눴다(`fallback`도 같은 이유로 별도 필드다). 위키에 근거와 함께 반영했다.

**3. `canDepartureNotify`를 상세 응답에도 채웠다.** 이슈 Todo는 판정만 요구했지만, 스위치가 있는 화면은 상세다. 보드만 채우면 목록은 "못 켠다", 상세는 "켤 수 있다"가 되어 못 켜는 스위치를 켤 수 있는 것처럼 보여준다. 판정에 외부 호출이 없어(저장된 식별자만 본다) 상세에서도 부담 없이 계산된다. **UI 차단 문구는 4단계(S-07)라 화면은 아직 이 값을 읽지 않는다.**

**4. `distanceM`은 경계 구간에서도 직선거리가 들어 있다.** 위키 초안은 `null`이었으나, Haversine은 로컬 계산이라 "계산하지 않는다"의 대상이 아니고 필드를 `Integer`로 바꾸면 FE에 도달 불가능한 분기가 생긴다. 화면에 쓰지 않는다는 것을 테스트로 못박았다(`km` 텍스트가 렌더링되지 않는지 확인).

## 하지 않은 것

- **`숙소로 이동`(다른 도시) 행 표시.** 이슈 Todo에 있지만 `stayMove`를 그리는 FE 컴포넌트가 아직 없다(#1141은 BE 필드만 채웠다). BE는 이미 도시를 넘으면 `mode`·`durationMinutes`를 비워 내려주고 테스트로 고정했으니, 행을 만드는 #1143에서 그대로 쓰면 된다.

## 테스트

- BE — 같은 도시 계산 유지 · 경계는 **외부 호출 0회** · 식별자를 모르면 경계로 판정하지 않음 · 시트도 같은 판정 · `canDepartureNotify` 4종 · 도시 넘는 이동에 출발 알림 미생성 · 숙소 이동은 마지막 일정과 견줌
- FE — `도시 이동` 라벨(거리 미표시) · 탭 시 시트 없이 딥링크 · 같은 도시는 시트 그대로
- E2E — **실제 브라우저에서 진짜 클릭으로** 새 탭이 `travelmode=transit`으로 열리고 시트가 열리지 않는 것을 확인 (`travel-city-move.spec.ts`)

## 게이트

- `cd be && ./gradlew check` ✅
- `cd fe && npm run format:check && npm run lint && npm test && npm run build` ✅ (953 tests)
- `npx playwright test travel-city-move` ✅

## 위키

[Travel-Spec-v2-1 §3.4](https://github.com/wcorn/orino/wiki/Travel-Spec-v2-1) · [Travel-API-Spec](https://github.com/wcorn/orino/wiki/Travel-API-Spec) · [Travel-Architecture §5.2](https://github.com/wcorn/orino/wiki/Travel-Architecture) · [Travel-UI-Design](https://github.com/wcorn/orino/wiki/Travel-UI-Design) 업데이트
