### PR TITLE
feat : S-04 숙소 배지 · 숙소 상세 시트 · 숙소 이동 행

### DIFF
--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/stay/StayControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/stay/StayControllerTest.java
@@ -195,6 +195,27 @@ class StayControllerTest extends ApiTestSupport {
         }
 
         @Test
+        @DisplayName("숙소를 지워도 `일정으로 추가`로 만든 일정은 남는다")
+        void keepsActivitiesMadeFromStay() throws Exception {
+            long stayId = stayId(createStay("도톤보리 호텔", "2026-10-24", "2026-10-27"));
+            // 시트의 `일정으로 추가`가 만드는 것 — 만들고 나면 숙소와 아무 관계가 없는
+            // 보통 일정이다. 숙소를 지웠다고 사라지면 사용자가 옮겨 둔 순서·메모까지 날아간다.
+            createActivityWithoutPlace("도톤보리 호텔 체크인", "2026-10-24");
+
+            mockMvc.perform(delete("/api/travel/stays/" + stayId)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk());
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/board")
+                            .param("date", "2026-10-24")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.activities", hasSize(1)))
+                    .andExpect(jsonPath("$.data.activities[0].title")
+                            .value("도톤보리 호텔 체크인"));
+        }
+
+        @Test
         @DisplayName("남의 숙소는 404 — 존재 여부가 새어나가지 않는다")
         void deleteScopedByMember() throws Exception {
             long stayId = stayId(createStay("도톤보리 호텔", "2026-10-24", "2026-10-27"));
@@ -351,6 +372,16 @@ class StayControllerTest extends ApiTestSupport {
                         .content("""
                                 {"title": "%s", "activityDate": "%s", "placeId": %d}
                                 """.formatted(title, date, placeId)))
+                .andExpect(status().isOk());
+    }
+
+    private void createActivityWithoutPlace(String title, String date) throws Exception {
+        mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "%s", "activityDate": "%s"}
+                                """.formatted(title, date)))
                 .andExpect(status().isOk());
     }
 

--- a/fe/e2e/travel-board-drag.spec.ts
+++ b/fe/e2e/travel-board-drag.spec.ts
@@ -103,6 +103,10 @@ async function mockBoard(page: Page): Promise<Captured> {
   await page.route("**/api/travel/summary", (route) =>
     route.fulfill(ok({ ongoing: null, next: null, recentCompleted: null })),
   );
+  // 보드는 숙소 목록을 함께 읽는다(#1143). 이 화면에서 확인할 것은 아니라 비워 둔다.
+  await page.route("**/api/travel/trips/*/stays", (route) =>
+    route.fulfill(ok([])),
+  );
 
   await page.route(
     `**/api/travel/trips/${TRIP_ID}/activities/order`,

--- a/fe/e2e/travel-board-swipe.spec.ts
+++ b/fe/e2e/travel-board-swipe.spec.ts
@@ -70,6 +70,10 @@ async function mockBoard(page: Page): Promise<Captured> {
   await page.route("**/api/travel/summary", (route) =>
     route.fulfill(ok({ ongoing: null, next: null, recentCompleted: null })),
   );
+  // 보드는 숙소 목록을 함께 읽는다(#1143). 이 화면에서 확인할 것은 아니라 비워 둔다.
+  await page.route("**/api/travel/trips/*/stays", (route) =>
+    route.fulfill(ok([])),
+  );
   await page.route("**/api/travel/activities/*", (route) => {
     const method = route.request().method();
     const id = route.request().url().split("/").pop() ?? "";

--- a/fe/e2e/travel-city-move.spec.ts
+++ b/fe/e2e/travel-city-move.spec.ts
@@ -78,6 +78,10 @@ async function mockBoard(page: Page) {
   await page.route("**/api/travel/summary", (route) =>
     route.fulfill(ok({ ongoing: null, next: null, recentCompleted: null })),
   );
+  // 보드는 숙소 목록을 함께 읽는다(#1143). 이 화면에서 확인할 것은 아니라 비워 둔다.
+  await page.route("**/api/travel/trips/*/stays", (route) =>
+    route.fulfill(ok([])),
+  );
   await page.route(`**/api/travel/trips/${TRIP_ID}/board*`, (route) =>
     route.fulfill(
       ok({

--- a/fe/e2e/travel-day-city.spec.ts
+++ b/fe/e2e/travel-day-city.spec.ts
@@ -77,6 +77,10 @@ async function mockBoard(page: Page): Promise<Captured> {
   await page.route("**/api/travel/summary", (route) =>
     route.fulfill(ok({ ongoing: null, next: null, recentCompleted: null })),
   );
+  // 보드는 숙소 목록을 함께 읽는다(#1143). 이 화면에서 확인할 것은 아니라 비워 둔다.
+  await page.route("**/api/travel/trips/*/stays", (route) =>
+    route.fulfill(ok([])),
+  );
   await page.route("**/api/travel/days/*", (route) => {
     const dayId = route.request().url().split("/").pop() ?? "";
     captured.dayUpdates.push({

--- a/fe/e2e/travel-leg-editor.spec.ts
+++ b/fe/e2e/travel-leg-editor.spec.ts
@@ -45,6 +45,10 @@ async function mockForm(page: Page): Promise<Record<string, unknown>[]> {
     const q = new URL(route.request().url()).searchParams.get("q") ?? "";
     return route.fulfill(ok(CITIES.filter((city) => city.name.includes(q))));
   });
+  // 보드는 숙소 목록을 함께 읽는다(#1143). 이 화면에서 확인할 것은 아니라 비워 둔다.
+  await page.route("**/api/travel/trips/*/stays", (route) =>
+    route.fulfill(ok([])),
+  );
   await page.route("**/api/travel/trips", (route) => {
     if (route.request().method() !== "POST") return route.continue();
     created.push(route.request().postDataJSON() as Record<string, unknown>);

--- a/fe/e2e/travel-stay.spec.ts
+++ b/fe/e2e/travel-stay.spec.ts
@@ -1,0 +1,190 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 숙소 배지·시트(S-04, #1143).
+ *
+ * <p>여기서 확인하는 것은 <b>등록한 것이 곧바로 배지에 보이는가</b>다. 숙소는 어느 날짜에
+ * 붙는지를 저장하지 않고 기간에서 파생하므로, 저장 → 보드 무효화 → 배지까지가 한 흐름으로
+ * 이어져야 한다. 한 군데만 끊겨도 "저장했는데 아무 일도 안 일어난" 화면이 된다.
+ */
+
+const TRIP_ID = 1;
+const D1 = "2026-10-24";
+const D2 = "2026-10-25";
+
+const TOKYO = {
+  placeId: 21,
+  name: "도쿄",
+  timezone: "Asia/Tokyo",
+  currency: "JPY",
+  countryCode: "JP",
+  cityPlaceRef: null,
+  lat: null,
+  lng: null,
+};
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+interface Stay {
+  stayId: number;
+  name: string;
+  placeId: number | null;
+  checkInDate: string;
+  checkOutDate: string;
+  checkInTime: string | null;
+  checkOutTime: string | null;
+  bookingUrl: string | null;
+  memo: string | null;
+  nights: number;
+}
+
+/**
+ * 서버를 흉내내되 <b>상태를 들고 있는다</b> — 등록한 숙소가 다음 보드 조회에 반영되어야
+ * 이 흐름이 성립한다. 날짜 판정(`checkIn <= day < checkOut`)도 서버와 같은 규칙으로 한다.
+ */
+async function mockTrip(page: Page) {
+  const stays: Stay[] = [];
+  let nextId = 76;
+
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/planner/reviews/summary", (route) =>
+    route.fulfill(
+      ok({
+        today: D1,
+        counts: { now: 0, overdue: 0, upcoming: 0, doneToday: 0 },
+        estimatedMinutes: 0,
+        materials: [],
+      }),
+    ),
+  );
+  await page.route("**/api/travel/summary", (route) =>
+    route.fulfill(ok({ ongoing: null, next: null, recentCompleted: null })),
+  );
+
+  await page.route(`**/api/travel/trips/${TRIP_ID}/stays`, async (route) => {
+    if (route.request().method() === "POST") {
+      const body = route.request().postDataJSON() as Omit<
+        Stay,
+        "stayId" | "nights"
+      >;
+      const stay: Stay = { ...body, stayId: nextId++, nights: 1 };
+      stays.push(stay);
+      return route.fulfill(ok(stay));
+    }
+    return route.fulfill(ok(stays));
+  });
+
+  await page.route("**/api/travel/stays/*", (route) => {
+    if (route.request().method() === "DELETE") {
+      const id = Number(route.request().url().split("/").pop());
+      stays.splice(
+        stays.findIndex((s) => s.stayId === id),
+        1,
+      );
+      return route.fulfill(ok(null));
+    }
+    return route.fulfill(ok(stays[0]));
+  });
+
+  await page.route(`**/api/travel/trips/${TRIP_ID}/board*`, (route) => {
+    const url = new URL(route.request().url());
+    const date = url.searchParams.get("date") ?? D1;
+    const tonightOn = (day: string) =>
+      stays.find((s) => s.checkInDate <= day && day < s.checkOutDate) ?? null;
+    const checkoutOn = (day: string) =>
+      stays.find((s) => s.checkOutDate === day) ?? null;
+
+    return route.fulfill(
+      ok({
+        trip: {
+          id: TRIP_ID,
+          title: "도쿄",
+          startDate: D1,
+          endDate: D2,
+          status: "UPCOMING",
+          recordMode: false,
+          cityCount: 1,
+          countryCount: 1,
+          singleCity: true,
+        },
+        days: [D1, D2].map((day, index) => {
+          const tonight = tonightOn(day);
+          const checkout = checkoutOn(day);
+          return {
+            dayId: 501 + index,
+            dayIndex: index + 1,
+            date: day,
+            weekday: index === 0 ? "토" : "일",
+            activityCount: 0,
+            baseCity: TOKYO,
+            cityChanged: false,
+            legIndex: 1,
+            cityMemo: null,
+            weather: null,
+            stayTonight: tonight && {
+              stayId: tonight.stayId,
+              name: tonight.name,
+              sameCity: true,
+              checkInTime: tonight.checkInTime,
+              isCheckInDay: tonight.checkInDate === day,
+            },
+            stayCheckout: checkout && {
+              stayId: checkout.stayId,
+              name: checkout.name,
+              checkOutTime: checkout.checkOutTime,
+            },
+          };
+        }),
+        selectedDate: date,
+        archiveCount: 0,
+        activities: [],
+        travelTimes: [],
+        stayMove: null,
+      }),
+    );
+  });
+}
+
+test.describe("숙소", () => {
+  test("등록하면 배지에 뜨고, 삭제하면 `숙소 추가`로 돌아간다", async ({
+    page,
+  }) => {
+    await mockTrip(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/board`);
+
+    // 아직 아무것도 없다.
+    const addButton = page.getByRole("button", { name: "숙소 추가" });
+    await expect(addButton).toBeVisible();
+
+    await addButton.click();
+    await page.getByLabel("이름").fill("도톤보리 호텔");
+    await page.getByLabel("체크인", { exact: true }).fill(D1);
+    await page.getByLabel("체크아웃", { exact: true }).fill(D2);
+    await page.getByLabel("체크인 시각").fill("15:00");
+    await page.getByRole("button", { name: "저장" }).click();
+
+    // 저장 → 보드 무효화 → 배지. 체크인하는 날이라 시각이 함께 붙는다.
+    const badge = page.getByRole("button", {
+      name: "숙소 도톤보리 호텔 · 오늘 체크인 15:00",
+    });
+    await expect(badge).toBeVisible();
+
+    await badge.click();
+    const sheet = page.getByRole("dialog");
+    await expect(sheet.getByText("도톤보리 호텔")).toBeVisible();
+
+    await sheet.getByRole("button", { name: "삭제" }).click();
+    await expect(
+      page.getByText("이 숙소가 붙어 있던 날짜에서 모두 사라집니다."),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "삭제" }).click();
+
+    await expect(page.getByRole("button", { name: "숙소 추가" })).toBeVisible();
+  });
+});

--- a/fe/src/features/travel/api/stays.ts
+++ b/fe/src/features/travel/api/stays.ts
@@ -1,0 +1,103 @@
+import axios from "axios";
+
+import { client } from "@/shared/api";
+
+interface ApiEnvelope<T> {
+  code: string;
+  data: T;
+}
+
+/**
+ * 숙소 1건. **기준 도시와 무관하다** — 닛코 당일치기 날의 기준 도시는 닛코지만 자는 곳은
+ * 도쿄일 수 있다.
+ *
+ * <p>어느 날짜에 붙는지는 저장하지 않고 기간에서 파생한다. `checkIn <= 날짜 < checkOut`이
+ * 그날 밤 자는 곳이고, `checkOut === 날짜`가 그날 체크아웃하는 곳이다.
+ */
+export interface Stay {
+  stayId: number;
+  name: string;
+  /** 좌표·도시 판정에 쓴다. 붙이지 않은 숙소는 null. */
+  placeId: number | null;
+  checkInDate: string;
+  checkOutDate: string;
+  /** 벽시계 시각(`15:00`). 없으면 null. */
+  checkInTime: string | null;
+  checkOutTime: string | null;
+  bookingUrl: string | null;
+  memo: string | null;
+  /** 묵는 밤 수. 반열린 구간이라 날짜 차이 그대로다. */
+  nights: number;
+}
+
+export interface StayWriteRequest {
+  name: string;
+  placeId?: number | null;
+  checkInDate: string;
+  checkOutDate: string;
+  checkInTime?: string | null;
+  checkOutTime?: string | null;
+  bookingUrl?: string | null;
+  memo?: string | null;
+}
+
+/** 겹침 409가 함께 주는 **어느 숙소와 겹쳤는지**. 이 값이 있어야 안내가 안내가 된다. */
+export interface StayOverlap {
+  stayId: number;
+  name: string;
+  checkInDate: string;
+  checkOutDate: string;
+}
+
+/** 기간 겹침. 서버가 이 코드와 함께 겹치는 숙소를 내려준다. */
+const OVERLAP_CODE = "TRAVEL-ERR-017";
+
+/**
+ * 겹침 거절이면 **어느 숙소와 겹쳤는지**를 꺼낸다. 아니면 null.
+ *
+ * <p>"이미 숙소가 잡힌 기간입니다"만으로는 사용자가 무엇을 고쳐야 할지 모른다 — 겹친 숙소의
+ * 이름과 기간을 그대로 보여줘야 "그 숙소를 먼저 줄이자"가 된다.
+ */
+export function stayOverlapOf(error: unknown): StayOverlap | null {
+  if (!axios.isAxiosError(error)) return null;
+  const body = error.response?.data as
+    | { code?: string; data?: StayOverlap }
+    | undefined;
+  if (body?.code !== OVERLAP_CODE) return null;
+  return body.data ?? null;
+}
+
+/** 여행의 숙소 전체. `checkInDate` 오름차순. */
+export async function fetchStays(tripId: number): Promise<Stay[]> {
+  const { data } = await client.get<ApiEnvelope<Stay[]>>(
+    `/travel/trips/${tripId}/stays`,
+  );
+  return data.data;
+}
+
+export async function createStay(
+  tripId: number,
+  body: StayWriteRequest,
+): Promise<Stay> {
+  const { data } = await client.post<ApiEnvelope<Stay>>(
+    `/travel/trips/${tripId}/stays`,
+    body,
+  );
+  return data.data;
+}
+
+/** 수정은 **전체 교체**다 — 생략한 필드는 비워진다. */
+export async function updateStay(
+  stayId: number,
+  body: StayWriteRequest,
+): Promise<Stay> {
+  const { data } = await client.put<ApiEnvelope<Stay>>(
+    `/travel/stays/${stayId}`,
+    body,
+  );
+  return data.data;
+}
+
+export async function deleteStay(stayId: number): Promise<void> {
+  await client.delete(`/travel/stays/${stayId}`);
+}

--- a/fe/src/features/travel/board/StayMoveRow.tsx
+++ b/fe/src/features/travel/board/StayMoveRow.tsx
@@ -1,0 +1,39 @@
+import { Car, Footprints, Hotel, TrainFront } from "lucide-react";
+
+import type { StayMove } from "@/features/travel/api/activities";
+
+interface StayMoveRowProps {
+  stayMove: StayMove;
+}
+
+/**
+ * 리스트 맨 아래 붙는 숙소 이동(§2.5) — 그날 마지막 일정에서 오늘 밤 자는 곳까지.
+ *
+ * <p>도시를 넘으면 서버가 계산하지 않는다(§3.4) — 시간 없이 `숙소로 이동`만 말한다.
+ * 좌표를 모르는 숙소도 마찬가지다. 이동이 성립하지 않는 것을 `0분`으로 답하면 화면이
+ * "바로 옆"이라고 읽는다.
+ *
+ * <p>탭할 것이 없다 — 목적지는 배지가 열어 주고, 길찾기는 그 안에 있다. 여기서 또 시트를
+ * 열면 같은 숙소로 가는 문이 두 개가 된다.
+ */
+export function StayMoveRow({ stayMove }: StayMoveRowProps) {
+  const { sameCity, mode, durationMinutes } = stayMove;
+  const computed = durationMinutes !== null;
+  const Icon = computed
+    ? mode === "WALK"
+      ? Footprints
+      : Car
+    : sameCity
+      ? Hotel
+      : TrainFront;
+  const label = computed ? `숙소까지 ${durationMinutes}분` : "숙소로 이동";
+
+  return (
+    <li className="border-t pt-2.5">
+      <p className="text-muted-foreground ml-[52px] flex items-center gap-1.5 px-2 text-xs">
+        <Icon className="size-[13px] shrink-0" />
+        {label}
+      </p>
+    </li>
+  );
+}

--- a/fe/src/features/travel/hooks/useStays.ts
+++ b/fe/src/features/travel/hooks/useStays.ts
@@ -1,0 +1,69 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  createStay,
+  deleteStay,
+  fetchStays,
+  type StayWriteRequest,
+  updateStay,
+} from "../api/stays";
+import { travelKeys } from "../queryKeys";
+
+/**
+ * 여행의 숙소 전체를 한 번에 읽는다.
+ *
+ * <p>날짜별로 나누지 않는 이유는 <b>어느 날짜에 어떤 숙소가 붙는지를 저장하지 않기</b>
+ * 때문이다(기간에서 파생한다). 날짜별로 캐시하면 숙소 하나를 고쳤을 때 무효화할 날짜를
+ * 다시 계산해야 하고, 그 계산이 곧 파생 규칙의 두 번째 사본이 된다.
+ */
+export function useStays(tripId: number, options: { enabled?: boolean } = {}) {
+  return useQuery({
+    queryKey: travelKeys.stays(tripId),
+    queryFn: () => fetchStays(tripId),
+    staleTime: 10_000,
+    enabled: options.enabled ?? true,
+  });
+}
+
+/**
+ * 숙소가 바뀌면 <b>보드를 통째로</b> 무효화한다. 숙소 하나가 여러 날짜에 걸쳐 있어
+ * `days[].stayTonight`·`stayCheckout`과 `stayMove`가 동시에 달라지기 때문이다 —
+ * 보고 있던 날짜만 갱신하면 다른 탭이 옛 숙소를 계속 말한다.
+ */
+function useInvalidateStays(tripId: number) {
+  const queryClient = useQueryClient();
+  return () => {
+    void queryClient.invalidateQueries({ queryKey: travelKeys.stays(tripId) });
+    void queryClient.invalidateQueries({ queryKey: travelKeys.boards(tripId) });
+  };
+}
+
+export function useCreateStay(tripId: number) {
+  const invalidate = useInvalidateStays(tripId);
+  return useMutation({
+    mutationFn: (body: StayWriteRequest) => createStay(tripId, body),
+    onSuccess: invalidate,
+  });
+}
+
+export function useUpdateStay(tripId: number) {
+  const invalidate = useInvalidateStays(tripId);
+  return useMutation({
+    mutationFn: ({
+      stayId,
+      body,
+    }: {
+      stayId: number;
+      body: StayWriteRequest;
+    }) => updateStay(stayId, body),
+    onSuccess: invalidate,
+  });
+}
+
+export function useDeleteStay(tripId: number) {
+  const invalidate = useInvalidateStays(tripId);
+  return useMutation({
+    mutationFn: (stayId: number) => deleteStay(stayId),
+    onSuccess: invalidate,
+  });
+}

--- a/fe/src/features/travel/lib/stayBadge.test.ts
+++ b/fe/src/features/travel/lib/stayBadge.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import type { BoardDay } from "@/features/travel/api/activities";
+
+import { badgeAboveList, badgeBelowList } from "./stayBadge";
+
+function day(overrides: Partial<BoardDay> = {}): BoardDay {
+  return {
+    dayId: 1,
+    dayIndex: 1,
+    date: "2026-10-27",
+    weekday: "화",
+    activityCount: 0,
+    baseCity: null,
+    cityChanged: false,
+    legIndex: 1,
+    cityMemo: null,
+    weather: null,
+    stayTonight: null,
+    stayCheckout: null,
+    ...overrides,
+  };
+}
+
+const DOTONBORI = {
+  stayId: 76,
+  name: "도톤보리 호텔",
+  checkOutTime: "11:00",
+};
+
+const KYOTO = {
+  stayId: 77,
+  name: "교토 게스트하우스",
+  sameCity: true,
+  checkInTime: "15:00",
+  isCheckInDay: true,
+};
+
+describe("리스트 위 배지", () => {
+  it("체크아웃이 먼저다 — 아침에 급한 정보는 몇 시에 나가야 하나다", () => {
+    const item = badgeAboveList(
+      day({ stayCheckout: DOTONBORI, stayTonight: KYOTO }),
+    );
+
+    expect(item).toEqual({
+      stayId: 76,
+      name: "도톤보리 호텔",
+      note: "오늘 체크아웃 11:00",
+    });
+  });
+
+  it("체크아웃 시각을 모르면 시각 없이 말한다 — 지어내지 않는다", () => {
+    const item = badgeAboveList(
+      day({ stayCheckout: { ...DOTONBORI, checkOutTime: null } }),
+    );
+
+    expect(item?.note).toBe("오늘 체크아웃");
+  });
+
+  it("체크아웃이 없으면 오늘 밤 숙소를 보여준다", () => {
+    const item = badgeAboveList(day({ stayTonight: KYOTO }));
+
+    expect(item).toEqual({
+      stayId: 77,
+      name: "교토 게스트하우스",
+      note: "오늘 체크인 15:00",
+    });
+  });
+
+  it("이어서 묵는 날에는 체크인 시각을 붙이지 않는다 — 지난 정보다", () => {
+    const item = badgeAboveList(
+      day({ stayTonight: { ...KYOTO, isCheckInDay: false } }),
+    );
+
+    expect(item?.note).toBeNull();
+  });
+
+  it("둘 다 없으면 null — 화면은 그 자리에 `숙소 추가`를 세운다", () => {
+    expect(badgeAboveList(day())).toBeNull();
+    expect(badgeAboveList(null)).toBeNull();
+  });
+});
+
+describe("리스트 아래 배지", () => {
+  it("숙소를 옮기는 날에만 나온다 — 위는 체크아웃, 아래는 오늘 밤", () => {
+    const target = day({ stayCheckout: DOTONBORI, stayTonight: KYOTO });
+
+    expect(badgeAboveList(target)?.stayId).toBe(76);
+    expect(badgeBelowList(target)?.stayId).toBe(77);
+  });
+
+  it("위 배지와 같은 숙소면 그리지 않는다 — 같은 것을 두 번 쓰면 소음이다", () => {
+    expect(badgeBelowList(day({ stayTonight: KYOTO }))).toBeNull();
+  });
+
+  it("오늘 밤 숙소가 없으면 없다 — 체크아웃만 하는 마지막 날", () => {
+    expect(badgeBelowList(day({ stayCheckout: DOTONBORI }))).toBeNull();
+  });
+});

--- a/fe/src/features/travel/lib/stayBadge.ts
+++ b/fe/src/features/travel/lib/stayBadge.ts
@@ -1,0 +1,51 @@
+import type { BoardDay } from "@/features/travel/api/activities";
+
+/** 배지 한 줄. 어느 숙소를 어떤 꼬리표로 보여줄지는 여기서 정해진다. */
+export interface StayBadgeItem {
+  stayId: number;
+  name: string;
+  /** `오늘 체크아웃 11:00`처럼 붙는 꼬리표. 붙일 게 없으면 null. */
+  note: string | null;
+}
+
+/**
+ * 리스트 **위** 배지 — <b>체크아웃이 먼저다</b>(§3.5).
+ *
+ * <p>아침에 이 화면을 열었을 때 급한 정보는 "오늘 어디서 자나"가 아니라 "몇 시에 나가야
+ * 하나"다. 체크아웃하는 날에 오늘 밤 숙소를 위에 띄우면, 정작 시간에 쫓기는 정보가 아래로
+ * 밀린다.
+ */
+export function badgeAboveList(day: BoardDay | null): StayBadgeItem | null {
+  if (day?.stayCheckout) {
+    const { stayId, name, checkOutTime } = day.stayCheckout;
+    return {
+      stayId,
+      name,
+      note: checkOutTime ? `오늘 체크아웃 ${checkOutTime}` : "오늘 체크아웃",
+    };
+  }
+  return tonightItem(day);
+}
+
+/**
+ * 리스트 **아래** 배지 — 위 배지와 <b>다를 때만</b>(= 숙소를 옮기는 날).
+ *
+ * <p>같으면 같은 숙소를 한 화면에 두 번 쓰는 것이라 정보가 아니라 소음이다. 다를 때만
+ * 그리면 그 자리에 배지가 있다는 것 자체가 "오늘 숙소를 옮긴다"는 뜻이 된다.
+ */
+export function badgeBelowList(day: BoardDay | null): StayBadgeItem | null {
+  const tonight = tonightItem(day);
+  if (tonight === null) return null;
+  return badgeAboveList(day)?.stayId === tonight.stayId ? null : tonight;
+}
+
+function tonightItem(day: BoardDay | null): StayBadgeItem | null {
+  if (!day?.stayTonight) return null;
+  const { stayId, name, checkInTime, isCheckInDay } = day.stayTonight;
+  return {
+    stayId,
+    name,
+    // 체크인하는 날에만 시각을 붙인다 — 이어서 묵는 날에 체크인 시각은 지난 정보다.
+    note: isCheckInDay && checkInTime ? `오늘 체크인 ${checkInTime}` : null,
+  };
+}

--- a/fe/src/features/travel/lib/stayForDay.ts
+++ b/fe/src/features/travel/lib/stayForDay.ts
@@ -14,6 +14,8 @@
  * 따로 있는 이유는 등록 폼의 겹침 미리보기처럼 **서버에 묻기 전에 답해야 하는 자리**가 있어서다.
  */
 
+import { formatShortDate } from "./tripStatus";
+
 /** 판정에 필요한 최소한. 날짜는 `"YYYY-MM-DD"` — 사전순 비교가 곧 날짜 비교다. */
 export interface StayPeriod {
   checkInDate: string;
@@ -36,6 +38,20 @@ export function isCheckOutOn(stay: StayPeriod, date: string): boolean {
  */
 export function overlaps(a: StayPeriod, b: StayPeriod): boolean {
   return a.checkInDate < b.checkOutDate && b.checkInDate < a.checkOutDate;
+}
+
+/**
+ * 겹침 안내 문구. **겹친 숙소의 이름과 기간을 그대로** 보여준다 — 무엇을 줄여야 하는지가
+ * 곧 답이다. "이미 숙소가 잡힌 기간입니다"만으로는 사용자가 어느 숙소를 손봐야 할지 모른다.
+ *
+ * <p>클라이언트가 미리 잡은 겹침과 서버가 409로 돌려준 겹침이 같은 문장을 쓴다 — 같은
+ * 사실을 두 가지로 말하면 사용자는 다른 문제라고 읽는다.
+ */
+export function overlapMessage(
+  conflict: StayPeriod & { name: string },
+): string {
+  const period = `${formatShortDate(conflict.checkInDate)}–${formatShortDate(conflict.checkOutDate)}`;
+  return `${conflict.name}(${period})와 기간이 겹쳐요. 기존 숙소 기간을 먼저 줄여주세요.`;
 }
 
 /** 그날 밤 자는 곳. 겹치는 숙소는 저장되지 않으므로 답은 하나뿐이다. */

--- a/fe/src/features/travel/queryKeys.ts
+++ b/fe/src/features/travel/queryKeys.ts
@@ -10,6 +10,8 @@ export const travelKeys = {
     ["travel", "board", tripId, day ?? "default"] as const,
   boards: (tripId: number) => ["travel", "board", tripId] as const,
   activity: (activityId: number) => ["travel", "activity", activityId] as const,
+  /** 여행의 숙소 전체. 날짜별로 나누지 않는다 — 어느 날짜에 붙는지는 기간에서 파생한다. */
+  stays: (tripId: number) => ["travel", "stays", tripId] as const,
   /** 장소 검색. 서버가 이미 캐시하지만, 뒤로 갔다 오면 결과가 그대로 있어야 한다. */
   placeSearch: (q: string, tripId?: number) =>
     ["travel", "places", "search", tripId ?? "none", q] as const,

--- a/fe/src/features/travel/stay/StayBadge.tsx
+++ b/fe/src/features/travel/stay/StayBadge.tsx
@@ -1,0 +1,57 @@
+import { Hotel, Plus } from "lucide-react";
+
+import type { StayBadgeItem } from "@/features/travel/lib/stayBadge";
+
+interface StayBadgeProps {
+  /** 보여줄 숙소. null이면 `＋ 숙소 추가`가 대신 선다. */
+  item: StayBadgeItem | null;
+  onOpen: (stayId: number) => void;
+  onAdd: () => void;
+  /** 오프라인이면 추가는 막고 조회는 남긴다(§4.6). */
+  offline: boolean;
+  /** 숙소가 없을 때 추가 버튼을 아예 그리지 않는다 — 리스트 아래 배지가 그렇다. */
+  hideAdd?: boolean;
+}
+
+/**
+ * 숙소 배지(§2.5) — 리스트 위아래에 같은 모양으로 선다.
+ *
+ * <p>무엇을 보여줄지는 여기서 정하지 않는다. 위는 체크아웃이 먼저이고 아래는 위와 다를
+ * 때만 나오는데, 그 우선순위는 날짜를 아는 쪽의 판단이라 `lib/stayBadge.ts`가 갖는다.
+ */
+export function StayBadge({
+  item,
+  onOpen,
+  onAdd,
+  offline,
+  hideAdd = false,
+}: StayBadgeProps) {
+  if (item === null) {
+    if (hideAdd || offline) return null;
+    return (
+      <button
+        type="button"
+        onClick={onAdd}
+        className="text-muted-foreground hover:bg-muted flex items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-[13px]"
+      >
+        <Plus className="size-3.5 shrink-0" />
+        숙소 추가
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(item.stayId)}
+      aria-label={`숙소 ${item.name}${item.note ? ` · ${item.note}` : ""}`}
+      className="bg-muted hover:bg-accent flex items-center gap-2 rounded-lg px-3 py-2 text-left text-[13px]"
+    >
+      <Hotel className="size-3.5 shrink-0" />
+      <span className="truncate font-medium">{item.name}</span>
+      {item.note && (
+        <span className="text-muted-foreground shrink-0">· {item.note}</span>
+      )}
+    </button>
+  );
+}

--- a/fe/src/features/travel/stay/StayFormSheet.tsx
+++ b/fe/src/features/travel/stay/StayFormSheet.tsx
@@ -1,0 +1,249 @@
+import { type FormEvent, useEffect, useState } from "react";
+
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { Button } from "@/components/ui/button";
+import { FieldError } from "@/components/ui/field-error";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { Stay, StayWriteRequest } from "@/features/travel/api/stays";
+import { overlapMessage, overlaps } from "@/features/travel/lib/stayForDay";
+import { formatShortDate } from "@/features/travel/lib/tripStatus";
+
+interface StayFormSheetProps {
+  open: boolean;
+  /** 수정 대상. null이면 새로 등록한다. */
+  stay: Stay | null;
+  tripStartDate: string;
+  tripEndDate: string;
+  /** 이미 있는 숙소들 — 겹침을 <b>서버에 묻기 전에</b> 답하는 데 쓴다. */
+  stays: Stay[];
+  onOpenChange: (open: boolean) => void;
+  /** 저장. 실패하면 던져야 한다 — 시트가 열린 채 사유를 보여준다. */
+  onSubmit: (body: StayWriteRequest) => Promise<void>;
+  pending: boolean;
+  /** 서버가 돌려준 겹침 안내. 클라이언트가 놓친 경우에만 채워진다. */
+  serverError: string | null;
+}
+
+interface Draft {
+  name: string;
+  checkInDate: string;
+  checkOutDate: string;
+  checkInTime: string;
+  checkOutTime: string;
+  bookingUrl: string;
+  memo: string;
+}
+
+const EMPTY: Draft = {
+  name: "",
+  checkInDate: "",
+  checkOutDate: "",
+  checkInTime: "",
+  checkOutTime: "",
+  bookingUrl: "",
+  memo: "",
+};
+
+/**
+ * 숙소 등록·수정 폼(§9.6).
+ *
+ * <p><b>겹침을 서버에 묻기 전에 답한다.</b> 저장을 눌러야 "안 된다"를 알게 되면 사용자는
+ * 이미 입력을 다 마친 뒤다. 같은 규칙(반열린 구간 `[in, out)`)이 FE에도 있는 이유는 중복이
+ * 아니라 <b>답하는 시점이 다르기</b> 때문이고, 최종 판단은 여전히 서버가 한다.
+ */
+export function StayFormSheet({
+  open,
+  stay,
+  tripStartDate,
+  tripEndDate,
+  stays,
+  onOpenChange,
+  onSubmit,
+  pending,
+  serverError,
+}: StayFormSheetProps) {
+  const [draft, setDraft] = useState<Draft>(EMPTY);
+  const [error, setError] = useState<string | null>(null);
+
+  // 다른 숙소를 열면 이전 입력이 남아 있으면 안 된다.
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    setDraft(
+      stay === null
+        ? EMPTY
+        : {
+            name: stay.name,
+            checkInDate: stay.checkInDate,
+            checkOutDate: stay.checkOutDate,
+            checkInTime: stay.checkInTime ?? "",
+            checkOutTime: stay.checkOutTime ?? "",
+            bookingUrl: stay.bookingUrl ?? "",
+            memo: stay.memo ?? "",
+          },
+    );
+  }, [open, stay]);
+
+  const set = <K extends keyof Draft>(key: K, value: Draft[K]) =>
+    setDraft((prev) => ({ ...prev, [key]: value }));
+
+  const validate = (): string | null => {
+    if (!draft.name.trim()) return "숙소 이름을 입력해 주세요.";
+    if (!draft.checkInDate || !draft.checkOutDate)
+      return "체크인·체크아웃 날짜를 입력해 주세요.";
+    if (draft.checkOutDate <= draft.checkInDate)
+      return "체크아웃은 체크인 다음 날부터예요.";
+    if (draft.checkInDate < tripStartDate)
+      return "체크인은 여행 시작일부터예요.";
+    if (draft.checkOutDate > tripEndDate)
+      // 마지막 밤에 묵으려면 여행이 하루 더 길어야 한다 — 막기만 하면 왜 안 되는지 모른다.
+      return "체크아웃일도 여행 기간 안이어야 해요. 마지막 밤에 묵으려면 여행 기간을 하루 늘려주세요.";
+
+    const conflict = stays.find(
+      (other) =>
+        other.stayId !== stay?.stayId &&
+        overlaps(other, {
+          checkInDate: draft.checkInDate,
+          checkOutDate: draft.checkOutDate,
+        }),
+    );
+    return conflict ? overlapMessage(conflict) : null;
+  };
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    const message = validate();
+    if (message !== null) {
+      setError(message);
+      return;
+    }
+    setError(null);
+    // 빈 문자열은 "지움"이다 — 선택 항목을 비워 저장하면 실제로 비워져야 한다.
+    await onSubmit({
+      name: draft.name.trim(),
+      // 수정은 전체 교체라 붙어 있던 장소를 그대로 실어 보낸다. 빼면 좌표가 사라져
+      // 숙소 이동 시간이 계산되지 않는다.
+      placeId: stay?.placeId ?? null,
+      checkInDate: draft.checkInDate,
+      checkOutDate: draft.checkOutDate,
+      checkInTime: draft.checkInTime || null,
+      checkOutTime: draft.checkOutTime || null,
+      bookingUrl: draft.bookingUrl.trim() || null,
+      memo: draft.memo.trim() || null,
+    });
+  };
+
+  return (
+    <BottomSheet
+      open={open}
+      onOpenChange={onOpenChange}
+      title={stay === null ? "숙소 추가" : "숙소 수정"}
+      description={`${formatShortDate(tripStartDate)} – ${formatShortDate(tripEndDate)} 안에서 고를 수 있어요`}
+    >
+      <form
+        onSubmit={(e) => void submit(e)}
+        noValidate
+        className="flex flex-col gap-3"
+      >
+        <FormField label="이름" htmlFor="stay-name">
+          <Input
+            id="stay-name"
+            value={draft.name}
+            onChange={(e) => set("name", e.target.value)}
+            placeholder="도톤보리 호텔"
+          />
+        </FormField>
+
+        <div className="flex gap-2">
+          <FormField label="체크인" htmlFor="stay-in" className="flex-1">
+            <Input
+              id="stay-in"
+              type="date"
+              value={draft.checkInDate}
+              min={tripStartDate}
+              max={tripEndDate}
+              onChange={(e) => set("checkInDate", e.target.value)}
+            />
+          </FormField>
+          <FormField label="체크아웃" htmlFor="stay-out" className="flex-1">
+            <Input
+              id="stay-out"
+              type="date"
+              value={draft.checkOutDate}
+              min={tripStartDate}
+              max={tripEndDate}
+              onChange={(e) => set("checkOutDate", e.target.value)}
+            />
+          </FormField>
+        </div>
+
+        <div className="flex gap-2">
+          <FormField
+            label="체크인 시각"
+            htmlFor="stay-in-time"
+            className="flex-1"
+          >
+            <Input
+              id="stay-in-time"
+              type="time"
+              value={draft.checkInTime}
+              onChange={(e) => set("checkInTime", e.target.value)}
+            />
+          </FormField>
+          <FormField
+            label="체크아웃 시각"
+            htmlFor="stay-out-time"
+            className="flex-1"
+          >
+            <Input
+              id="stay-out-time"
+              type="time"
+              value={draft.checkOutTime}
+              onChange={(e) => set("checkOutTime", e.target.value)}
+            />
+          </FormField>
+        </div>
+
+        <FormField label="예약 링크" htmlFor="stay-url">
+          <Input
+            id="stay-url"
+            type="url"
+            value={draft.bookingUrl}
+            onChange={(e) => set("bookingUrl", e.target.value)}
+            placeholder="https://"
+          />
+        </FormField>
+
+        <FormField label="메모" htmlFor="stay-memo">
+          <Textarea
+            id="stay-memo"
+            rows={2}
+            value={draft.memo}
+            onChange={(e) => set("memo", e.target.value)}
+          />
+        </FormField>
+
+        {(error ?? serverError) && (
+          <FieldError>{error ?? serverError}</FieldError>
+        )}
+
+        <div className="flex gap-2 pt-1">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="flex-1"
+            onClick={() => onOpenChange(false)}
+          >
+            취소
+          </Button>
+          <Button type="submit" size="sm" className="flex-1" disabled={pending}>
+            저장
+          </Button>
+        </div>
+      </form>
+    </BottomSheet>
+  );
+}

--- a/fe/src/features/travel/stay/StaySheet.tsx
+++ b/fe/src/features/travel/stay/StaySheet.tsx
@@ -1,0 +1,156 @@
+import {
+  CalendarPlus,
+  Hotel,
+  Link as LinkIcon,
+  StickyNote,
+} from "lucide-react";
+
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { Button } from "@/components/ui/button";
+import type { Stay } from "@/features/travel/api/stays";
+import { formatShortDate } from "@/features/travel/lib/tripStatus";
+
+interface StaySheetProps {
+  /** 열려 있는 숙소. null이면 닫혀 있다. */
+  stay: Stay | null;
+  onOpenChange: (open: boolean) => void;
+  onEdit: (stay: Stay) => void;
+  onDelete: (stay: Stay) => void;
+  /** `일정으로 추가` — **누를 때만** 일정을 만든다. */
+  onAddActivity: (stay: Stay) => void;
+  offline: boolean;
+  /** 일정 생성 중. 두 번 눌러 일정이 두 벌 생기면 안 된다. */
+  addingActivity: boolean;
+}
+
+/**
+ * 숙소 상세 시트(§9.6). 보드의 숙소 배지 탭으로 연다.
+ *
+ * <p>체크인·체크아웃 일정을 <b>자동으로 만들지 않는다.</b> 자동 생성하면 지워도 다음 조회에
+ * 되살아나는 일정이 된다 — 사용자가 지운 것을 앱이 되돌리면 안 된다. `일정으로 추가`를
+ * 눌렀을 때만 만들고, 그 뒤로는 숙소와 무관한 보통 일정이다(숙소를 지워도 남는다).
+ */
+export function StaySheet({
+  stay,
+  onOpenChange,
+  onEdit,
+  onDelete,
+  onAddActivity,
+  offline,
+  addingActivity,
+}: StaySheetProps) {
+  return (
+    <BottomSheet
+      open={stay !== null}
+      onOpenChange={onOpenChange}
+      title="숙소"
+      description={stay ? `${stay.nights}박` : undefined}
+    >
+      {stay && (
+        <div className="flex flex-col gap-3">
+          <p className="flex items-center gap-2 text-[15px] font-semibold">
+            <Hotel className="size-[17px] shrink-0" />
+            {stay.name}
+          </p>
+
+          <div className="flex gap-2">
+            <TimeBox
+              label="체크인"
+              date={stay.checkInDate}
+              time={stay.checkInTime}
+            />
+            <TimeBox
+              label="체크아웃"
+              date={stay.checkOutDate}
+              time={stay.checkOutTime}
+            />
+          </div>
+
+          {stay.memo && (
+            <p className="bg-muted flex items-start gap-2 rounded-lg px-3 py-2 text-[13px]">
+              <StickyNote className="mt-px size-3.5 shrink-0" />
+              {stay.memo}
+            </p>
+          )}
+
+          {stay.bookingUrl && (
+            <a
+              href={stay.bookingUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-primary flex items-center gap-1.5 text-[13px] underline underline-offset-2"
+            >
+              <LinkIcon className="size-3.5 shrink-0" />
+              예약 확인
+            </a>
+          )}
+
+          {!offline && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full"
+              disabled={addingActivity}
+              onClick={() => onAddActivity(stay)}
+            >
+              <CalendarPlus className="size-3.5" />
+              일정으로 추가
+            </Button>
+          )}
+
+          <div className="flex gap-2 pt-1">
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex-1"
+              onClick={() => onOpenChange(false)}
+            >
+              닫기
+            </Button>
+            {!offline && (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="flex-1"
+                  onClick={() => onEdit(stay)}
+                >
+                  수정
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-destructive flex-1"
+                  onClick={() => onDelete(stay)}
+                >
+                  삭제
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </BottomSheet>
+  );
+}
+
+/** 시각이 없으면 날짜만 — 없는 시각을 `00:00`으로 채우면 그 시각에 맞춰 움직이게 된다. */
+function TimeBox({
+  label,
+  date,
+  time,
+}: {
+  label: string;
+  date: string;
+  time: string | null;
+}) {
+  return (
+    <div className="flex-1 rounded-lg border px-3 py-2.5">
+      <p className="text-muted-foreground text-[11px]">{label}</p>
+      <p className="text-sm tabular-nums">
+        {formatShortDate(date)}
+        {time && ` ${time}`}
+      </p>
+    </div>
+  );
+}

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -108,6 +108,9 @@ function mockBoard(options: {
   trip?: Record<string, unknown>;
   travelTimes?: unknown[];
   days?: unknown[];
+  stayMove?: unknown;
+  /** `GET /trips/{id}/stays` 응답. 상세 시트·겹침 미리보기가 이 목록을 읽는다. */
+  stays?: unknown[];
 }) {
   const byDate = options.byDate ?? {};
   const archive = options.archive ?? [];
@@ -125,10 +128,13 @@ function mockBoard(options: {
           archiveCount: archive.length,
           activities: isArchive ? archive : (byDate[date] ?? []),
           travelTimes: isArchive ? [] : (options.travelTimes ?? []),
-          stayMove: null,
+          stayMove: isArchive ? null : (options.stayMove ?? null),
         },
       });
     }),
+    http.get(`${API_BASE}/travel/trips/:tripId/stays`, () =>
+      HttpResponse.json({ code: "OK", data: options.stays ?? [] }),
+    ),
   );
 }
 
@@ -1493,6 +1499,396 @@ describe("TripBoardPage", () => {
       expect(
         screen.getByRole("button", { name: "일정 추가" }),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("숙소 (§2.5 · §9.6)", () => {
+    const DOTONBORI = {
+      stayId: 76,
+      name: "도톤보리 호텔",
+      placeId: null,
+      checkInDate: "2026-10-24",
+      checkOutDate: "2026-10-26",
+      checkInTime: "15:00",
+      checkOutTime: "11:00",
+      bookingUrl: "https://booking.example/76",
+      memo: "1층 편의점",
+      nights: 2,
+    };
+
+    const KYOTO = {
+      ...DOTONBORI,
+      stayId: 77,
+      name: "교토 게스트하우스",
+      checkInDate: "2026-10-26",
+      checkOutDate: "2026-10-27",
+      bookingUrl: null,
+      memo: null,
+      nights: 1,
+    };
+
+    /** 보드가 내려주는 배지 값 — 서버가 기간에서 파생해 채운다. */
+    const tonight = (stayId: number, name: string, isCheckInDay = false) => ({
+      stayId,
+      name,
+      sameCity: true,
+      checkInTime: "15:00",
+      isCheckInDay,
+    });
+    const checkout = (stayId: number, name: string) => ({
+      stayId,
+      name,
+      checkOutTime: "11:00",
+    });
+
+    it("체크아웃하는 날 아침에는 체크아웃 시각이 배지에 뜬다", async () => {
+      mockBoard({
+        days: [
+          day(1, "2026-10-24", "토", 0, {
+            stayCheckout: checkout(76, "도톤보리 호텔"),
+            stayTonight: tonight(77, "교토 게스트하우스", true),
+          }),
+          ...DAYS.slice(1),
+        ],
+      });
+
+      renderBoard();
+
+      // 위는 체크아웃 — 급한 정보가 먼저다.
+      expect(
+        await screen.findByRole("button", {
+          name: "숙소 도톤보리 호텔 · 오늘 체크아웃 11:00",
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("이동일에는 위(체크아웃)와 아래(오늘 밤)에 서로 다른 숙소가 뜬다", async () => {
+      mockBoard({
+        byDate: { "2026-10-24": [activity()] },
+        days: [
+          day(1, "2026-10-24", "토", 1, {
+            stayCheckout: checkout(76, "도톤보리 호텔"),
+            stayTonight: tonight(77, "교토 게스트하우스", true),
+          }),
+          ...DAYS.slice(1),
+        ],
+      });
+
+      renderBoard();
+      await screen.findByText("센소지");
+
+      expect(
+        screen.getByRole("button", {
+          name: "숙소 도톤보리 호텔 · 오늘 체크아웃 11:00",
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", {
+          name: "숙소 교토 게스트하우스 · 오늘 체크인 15:00",
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("옮기지 않는 날에는 배지가 하나뿐이다 — 같은 숙소를 두 번 쓰지 않는다", async () => {
+      mockBoard({
+        byDate: { "2026-10-24": [activity()] },
+        days: [
+          day(1, "2026-10-24", "토", 1, {
+            stayTonight: tonight(76, "도톤보리 호텔"),
+          }),
+          ...DAYS.slice(1),
+        ],
+      });
+
+      renderBoard();
+      await screen.findByText("센소지");
+
+      expect(
+        screen.getAllByRole("button", { name: /^숙소 도톤보리 호텔/ }),
+      ).toHaveLength(1);
+    });
+
+    it("숙소가 없으면 `숙소 추가`가 선다", async () => {
+      mockBoard({});
+
+      renderBoard();
+
+      expect(
+        await screen.findByRole("button", { name: "숙소 추가" }),
+      ).toBeInTheDocument();
+    });
+
+    it("마지막 일정에서 숙소까지 이동이 리스트 아래에 붙는다", async () => {
+      mockBoard({
+        byDate: { "2026-10-24": [activity()] },
+        stayMove: {
+          stayId: 76,
+          sameCity: true,
+          mode: "WALK",
+          durationMinutes: 8,
+        },
+      });
+
+      renderBoard();
+
+      expect(await screen.findByText("숙소까지 8분")).toBeInTheDocument();
+    });
+
+    it("도시가 다르면 시간 없이 `숙소로 이동`만 — 계산하지 않는다(§3.4)", async () => {
+      mockBoard({
+        byDate: { "2026-10-24": [activity()] },
+        stayMove: {
+          stayId: 76,
+          sameCity: false,
+          mode: null,
+          durationMinutes: null,
+        },
+      });
+
+      renderBoard();
+
+      expect(await screen.findByText("숙소로 이동")).toBeInTheDocument();
+      expect(screen.queryByText(/분$/)).not.toBeInTheDocument();
+    });
+
+    it("배지를 탭하면 상세가 열린다 — 기간·메모·예약 링크", async () => {
+      mockBoard({
+        days: [
+          day(1, "2026-10-24", "토", 0, {
+            stayTonight: tonight(76, "도톤보리 호텔", true),
+          }),
+          ...DAYS.slice(1),
+        ],
+        stays: [DOTONBORI],
+      });
+
+      const user = userEvent.setup();
+      renderBoard();
+      await user.click(
+        await screen.findByRole("button", { name: /^숙소 도톤보리 호텔/ }),
+      );
+
+      const sheet = await screen.findByRole("dialog");
+      expect(within(sheet).getByText("2박")).toBeInTheDocument();
+      expect(within(sheet).getByText("1층 편의점")).toBeInTheDocument();
+      expect(
+        within(sheet).getByRole("link", { name: "예약 확인" }),
+      ).toHaveAttribute("href", "https://booking.example/76");
+    });
+
+    it("`일정으로 추가`는 누를 때만 요청한다 — 자동 생성하면 지워도 되살아난다", async () => {
+      const created: Record<string, unknown>[] = [];
+      server.use(
+        http.post(
+          `${API_BASE}/travel/trips/:tripId/activities`,
+          async ({ request }) => {
+            created.push((await request.json()) as Record<string, unknown>);
+            return HttpResponse.json({ code: "OK", data: activity() });
+          },
+        ),
+      );
+      mockBoard({
+        days: [
+          day(1, "2026-10-24", "토", 0, {
+            stayTonight: tonight(76, "도톤보리 호텔", true),
+          }),
+          ...DAYS.slice(1),
+        ],
+        stays: [DOTONBORI],
+      });
+
+      const user = userEvent.setup();
+      renderBoard();
+      await user.click(
+        await screen.findByRole("button", { name: /^숙소 도톤보리 호텔/ }),
+      );
+
+      // 시트를 여는 것만으로는 아무것도 만들지 않는다.
+      const sheet = await screen.findByRole("dialog");
+      expect(created).toHaveLength(0);
+
+      await user.click(
+        within(sheet).getByRole("button", { name: /일정으로 추가/ }),
+      );
+
+      await waitFor(() => expect(created).toHaveLength(2));
+      expect(created.map((body) => body.title)).toEqual([
+        "도톤보리 호텔 체크인",
+        "도톤보리 호텔 체크아웃",
+      ]);
+      expect(created[0].activityDate).toBe("2026-10-24");
+      expect(created[1].activityDate).toBe("2026-10-26");
+    });
+
+    it("겹치는 기간은 저장을 누르기 전에 막고 어느 숙소와 겹치는지 말한다", async () => {
+      const posted: unknown[] = [];
+      server.use(
+        http.post(`${API_BASE}/travel/trips/:tripId/stays`, async () => {
+          posted.push(1);
+          return HttpResponse.json({ code: "OK", data: KYOTO });
+        }),
+      );
+      mockBoard({ stays: [DOTONBORI] });
+
+      const user = userEvent.setup();
+      renderBoard();
+      await user.click(
+        await screen.findByRole("button", { name: "숙소 추가" }),
+      );
+
+      const sheet = await screen.findByRole("dialog");
+      await user.type(within(sheet).getByLabelText("이름"), "겹치는 호텔");
+      fireEvent.change(within(sheet).getByLabelText("체크인"), {
+        target: { value: "2026-10-25" },
+      });
+      fireEvent.change(within(sheet).getByLabelText("체크아웃"), {
+        target: { value: "2026-10-26" },
+      });
+      await user.click(within(sheet).getByRole("button", { name: "저장" }));
+
+      expect(
+        await within(sheet).findByText(
+          "도톤보리 호텔(10.24–10.26)와 기간이 겹쳐요. 기존 숙소 기간을 먼저 줄여주세요.",
+        ),
+      ).toBeInTheDocument();
+      // 서버에 묻기 전에 답한다 — 요청 자체가 나가지 않는다.
+      expect(posted).toHaveLength(0);
+    });
+
+    it("서버가 겹침을 돌려주면 시트를 닫지 않고 그대로 보여준다", async () => {
+      server.use(
+        http.post(`${API_BASE}/travel/trips/:tripId/stays`, () =>
+          HttpResponse.json(
+            {
+              code: "TRAVEL-ERR-017",
+              message: "이미 숙소가 잡힌 기간입니다.",
+              data: {
+                stayId: 76,
+                name: "도톤보리 호텔",
+                checkInDate: "2026-10-24",
+                checkOutDate: "2026-10-26",
+              },
+            },
+            { status: 409 },
+          ),
+        ),
+      );
+      // 클라이언트는 겹칠 것을 모른다(목록이 비어 있다) — 서버 안내가 유일한 답이다.
+      mockBoard({ stays: [] });
+
+      const user = userEvent.setup();
+      renderBoard();
+      await user.click(
+        await screen.findByRole("button", { name: "숙소 추가" }),
+      );
+
+      const sheet = await screen.findByRole("dialog");
+      await user.type(
+        within(sheet).getByLabelText("이름"),
+        "교토 게스트하우스",
+      );
+      fireEvent.change(within(sheet).getByLabelText("체크인"), {
+        target: { value: "2026-10-24" },
+      });
+      fireEvent.change(within(sheet).getByLabelText("체크아웃"), {
+        target: { value: "2026-10-26" },
+      });
+      await user.click(within(sheet).getByRole("button", { name: "저장" }));
+
+      expect(
+        await within(sheet).findByText(
+          "도톤보리 호텔(10.24–10.26)와 기간이 겹쳐요. 기존 숙소 기간을 먼저 줄여주세요.",
+        ),
+      ).toBeInTheDocument();
+      // 입력이 살아 있어야 한다 — 닫아 버리면 방금 친 것을 다시 쳐야 한다.
+      expect(within(sheet).getByLabelText("이름")).toHaveValue(
+        "교토 게스트하우스",
+      );
+    });
+
+    it("여행 마지막 날 밤은 담을 수 없고, 왜인지 말해 준다", async () => {
+      mockBoard({ stays: [] });
+
+      const user = userEvent.setup();
+      renderBoard();
+      await user.click(
+        await screen.findByRole("button", { name: "숙소 추가" }),
+      );
+
+      const sheet = await screen.findByRole("dialog");
+      await user.type(within(sheet).getByLabelText("이름"), "마지막 밤");
+      fireEvent.change(within(sheet).getByLabelText("체크인"), {
+        target: { value: "2026-10-26" },
+      });
+      fireEvent.change(within(sheet).getByLabelText("체크아웃"), {
+        target: { value: "2026-10-27" },
+      });
+      await user.click(within(sheet).getByRole("button", { name: "저장" }));
+
+      expect(
+        await within(sheet).findByText(/여행 기간을 하루 늘려주세요/),
+      ).toBeInTheDocument();
+    });
+
+    it("삭제는 무엇이 사라지는지 말하고 확인을 받는다", async () => {
+      const deleted: string[] = [];
+      server.use(
+        http.delete(`${API_BASE}/travel/stays/:stayId`, ({ params }) => {
+          deleted.push(String(params.stayId));
+          return HttpResponse.json({ code: "OK", data: null });
+        }),
+      );
+      mockBoard({
+        days: [
+          day(1, "2026-10-24", "토", 0, {
+            stayTonight: tonight(76, "도톤보리 호텔", true),
+          }),
+          ...DAYS.slice(1),
+        ],
+        stays: [DOTONBORI],
+      });
+
+      const user = userEvent.setup();
+      renderBoard();
+      await user.click(
+        await screen.findByRole("button", { name: /^숙소 도톤보리 호텔/ }),
+      );
+      await user.click(
+        within(await screen.findByRole("dialog")).getByRole("button", {
+          name: "삭제",
+        }),
+      );
+
+      expect(
+        await screen.findByText(
+          "이 숙소가 붙어 있던 날짜에서 모두 사라집니다.",
+        ),
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "삭제" }));
+      await waitFor(() => expect(deleted).toEqual(["76"]));
+    });
+
+    it("보관함에는 그날 밤이 없다 — 배지도 숙소 이동도 없다", async () => {
+      mockBoard({
+        archive: [activity()],
+        days: [
+          day(1, "2026-10-24", "토", 0, {
+            stayTonight: tonight(76, "도톤보리 호텔", true),
+          }),
+          ...DAYS.slice(1),
+        ],
+      });
+
+      renderBoard("/travel/trips/3/board?day=archive");
+      await screen.findByText("센소지");
+
+      expect(
+        screen.queryByRole("button", { name: /^숙소 / }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/숙소까지|숙소로 이동/),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -40,6 +40,8 @@ import type {
 // 삭제는 뮤테이션 훅이 아니라 raw 요청을 쓴다 — 화면을 떠난 뒤에 보낼 수도 있어서다.
 import { deleteActivity as deleteActivityRequest } from "@/features/travel/api/activities";
 import type { DayUpdateRequest } from "@/features/travel/api/days";
+import type { Stay, StayWriteRequest } from "@/features/travel/api/stays";
+import { stayOverlapOf } from "@/features/travel/api/stays";
 import { deleteTrip } from "@/features/travel/api/travel";
 import { ActivityRow } from "@/features/travel/board/ActivityRow";
 import { AddSheet } from "@/features/travel/board/AddSheet";
@@ -49,6 +51,7 @@ import { DragModeBar } from "@/features/travel/board/DragModeBar";
 import { LocalClockLine } from "@/features/travel/board/LocalClockLine";
 import { OfflineBanner } from "@/features/travel/board/OfflineBanner";
 import { usePendingActions } from "@/features/travel/board/pendingActions";
+import { StayMoveRow } from "@/features/travel/board/StayMoveRow";
 import { TransportSheet } from "@/features/travel/board/TransportSheet";
 import { TravelTimeRow } from "@/features/travel/board/TravelTimeRow";
 import { useUndoableAction } from "@/features/travel/board/useUndoableAction";
@@ -58,13 +61,27 @@ import {
   useUpdateActivity,
 } from "@/features/travel/hooks/useActivityMutations";
 import { useBoard } from "@/features/travel/hooks/useBoard";
+import {
+  useCreateStay,
+  useDeleteStay,
+  useStays,
+  useUpdateStay,
+} from "@/features/travel/hooks/useStays";
 import { useUpdateDay } from "@/features/travel/hooks/useUpdateDay";
 import {
   daysForPlace,
   groupArchiveByCity,
 } from "@/features/travel/lib/archiveGroups";
 import { directionsUrl } from "@/features/travel/lib/mapsLink";
+import {
+  badgeAboveList,
+  badgeBelowList,
+} from "@/features/travel/lib/stayBadge";
+import { overlapMessage } from "@/features/travel/lib/stayForDay";
 import { PickDaySheet } from "@/features/travel/places/PickDaySheet";
+import { StayBadge } from "@/features/travel/stay/StayBadge";
+import { StayFormSheet } from "@/features/travel/stay/StayFormSheet";
+import { StaySheet } from "@/features/travel/stay/StaySheet";
 import { toast } from "@/shared/lib/toast";
 import { useOnline } from "@/shared/lib/useOnline";
 
@@ -127,8 +144,22 @@ export function TripBoardPage() {
   const [pickingDayFor, setPickingDayFor] = useState<Activity | null>(null);
   const [dragMode, setDragMode] = useState(false);
   const [openTravelTime, setOpenTravelTime] = useState<TravelTime | null>(null);
+  /** 상세 시트를 연 숙소 id. null이면 닫혀 있다. */
+  const [openStayId, setOpenStayId] = useState<number | null>(null);
+  /** 등록·수정 폼. `editingStay`가 null이면 등록이다. */
+  const [stayFormOpen, setStayFormOpen] = useState(false);
+  const [editingStay, setEditingStay] = useState<Stay | null>(null);
+  const [deletingStay, setDeletingStay] = useState<Stay | null>(null);
+  /** 서버가 돌려준 겹침 안내. 폼이 열려 있는 동안만 유효하다. */
+  const [stayError, setStayError] = useState<string | null>(null);
   // 오프라인은 조회 전용이다(§4.6). 편집을 막는 게 아니라 진입 자체를 없앤다.
   const online = useOnline();
+
+  // 숙소는 여행 전체를 한 번에 읽는다 — 어느 날짜에 붙는지는 기간에서 파생한다.
+  const { data: stays } = useStays(tripId);
+  const createStay = useCreateStay(tripId);
+  const updateStay = useUpdateStay(tripId);
+  const removeStay = useDeleteStay(tripId);
 
   const createActivity = useCreateActivity(tripId);
   const updateActivity = useUpdateActivity(tripId);
@@ -372,6 +403,92 @@ export function TripBoardPage() {
     navigate("/travel/trips", { replace: true });
   };
 
+  /**
+   * 배지가 아는 것은 숙소 id뿐이다(보드 응답이 이름·시각만 싣는다) — 상세는 숙소 목록에서
+   * 찾는다. 오프라인이면 그 목록이 없어 열 수 없고, 왜 안 열리는지 말해 준다.
+   */
+  const openStay = (stayId: number) => {
+    if (!stays?.some((stay) => stay.stayId === stayId)) {
+      toast("숙소 정보를 불러오지 못했어요.", "error");
+      return;
+    }
+    setOpenStayId(stayId);
+  };
+
+  const startAddStay = () => {
+    setEditingStay(null);
+    setStayError(null);
+    setStayFormOpen(true);
+  };
+
+  const startEditStay = (stay: Stay) => {
+    setOpenStayId(null);
+    setEditingStay(stay);
+    setStayError(null);
+    setStayFormOpen(true);
+  };
+
+  /**
+   * 겹침(409)은 <b>실패가 아니라 안내</b>다 — 시트를 닫지 않고 어느 숙소와 겹쳤는지 그 자리에
+   * 보여준다. 닫아 버리면 사용자가 방금 친 것을 다시 쳐야 한다.
+   */
+  const saveStay = async (body: StayWriteRequest) => {
+    try {
+      if (editingStay) {
+        await updateStay.mutateAsync({ stayId: editingStay.stayId, body });
+      } else {
+        await createStay.mutateAsync(body);
+      }
+      setStayFormOpen(false);
+      setStayError(null);
+      toast(
+        editingStay ? "숙소를 수정했어요." : "숙소를 추가했어요.",
+        "success",
+      );
+    } catch (error) {
+      const conflict = stayOverlapOf(error);
+      setStayError(
+        conflict
+          ? overlapMessage(conflict)
+          : "저장하지 못했어요. 잠시 후 다시 시도해 주세요.",
+      );
+    }
+  };
+
+  const removeStayNow = async (stay: Stay) => {
+    await removeStay.mutateAsync(stay.stayId);
+    setDeletingStay(null);
+    setOpenStayId(null);
+    toast("숙소를 삭제했어요.", "success");
+  };
+
+  /**
+   * 체크인·체크아웃을 일정으로 만든다 — <b>누를 때만</b>. 자동 생성하면 지워도 다음 조회에
+   * 되살아나는 일정이 되고, 그 뒤로는 사용자가 지운 것을 앱이 되돌리는 셈이다.
+   *
+   * <p>만든 뒤로는 숙소와 아무 관계가 없는 보통 일정이다 — 숙소를 지워도 남는다.
+   */
+  const addStayActivities = async (stay: Stay) => {
+    await Promise.all(
+      [
+        {
+          title: `${stay.name} 체크인`,
+          activityDate: stay.checkInDate,
+          startTime: stay.checkInTime,
+        },
+        {
+          title: `${stay.name} 체크아웃`,
+          activityDate: stay.checkOutDate,
+          startTime: stay.checkOutTime,
+        },
+      ].map((input) =>
+        createActivity.mutateAsync({ ...input, placeId: stay.placeId }),
+      ),
+    );
+    setOpenStayId(null);
+    toast("체크인·체크아웃을 일정으로 추가했어요.", "success");
+  };
+
   return (
     <div className="mx-auto flex max-w-[720px] flex-col gap-3">
       <header className="flex items-center justify-between gap-2">
@@ -487,6 +604,16 @@ export function TripBoardPage() {
           </p>
         )}
 
+        {/* 숙소 배지 — 체크아웃이 먼저다(§3.5). 보관함에는 "그날 밤"이 없다. */}
+        {!isArchive && (
+          <StayBadge
+            item={badgeAboveList(selectedDay)}
+            onOpen={openStay}
+            onAdd={startAddStay}
+            offline={!online}
+          />
+        )}
+
         {/* 보관함은 도시별로 묶는다 — 그 도시 날짜를 짜는 동안 볼 것이 한 덩어리가 된다.
             순서가 없는 목록이라 드래그 정렬도 없다. */}
         {isArchive &&
@@ -549,8 +676,23 @@ export function TripBoardPage() {
                   />
                 </Fragment>
               ))}
+              {/* 마지막 일정 → 오늘 밤 숙소. 드래그 중에는 순서가 바뀌는 중이라 감춘다. */}
+              {!dragMode && board.stayMove && (
+                <StayMoveRow stayMove={board.stayMove} />
+              )}
             </ul>
           </SortableContext>
+        )}
+
+        {/* 숙소를 옮기는 날에만 — 위 배지(체크아웃)와 다른 숙소일 때다. 같으면 소음이다. */}
+        {!isArchive && badgeBelowList(selectedDay) && (
+          <StayBadge
+            item={badgeBelowList(selectedDay)}
+            onOpen={openStay}
+            onAdd={startAddStay}
+            offline={!online}
+            hideAdd
+          />
         )}
       </DndContext>
 
@@ -624,6 +766,42 @@ export function TripBoardPage() {
         onOpenChange={(open) => !open && setCityDay(null)}
         onSubmit={(body) => void saveDay(body)}
         pending={updateDay.isPending}
+      />
+
+      <StaySheet
+        stay={stays?.find((stay) => stay.stayId === openStayId) ?? null}
+        onOpenChange={(open) => !open && setOpenStayId(null)}
+        onEdit={startEditStay}
+        onDelete={(stay) => {
+          setOpenStayId(null);
+          setDeletingStay(stay);
+        }}
+        onAddActivity={(stay) => void addStayActivities(stay)}
+        offline={!online}
+        addingActivity={createActivity.isPending}
+      />
+
+      <StayFormSheet
+        open={stayFormOpen}
+        stay={editingStay}
+        tripStartDate={board.trip.startDate}
+        tripEndDate={board.trip.endDate}
+        stays={stays ?? []}
+        onOpenChange={(open) => !open && setStayFormOpen(false)}
+        onSubmit={saveStay}
+        pending={createStay.isPending || updateStay.isPending}
+        serverError={stayError}
+      />
+
+      <ConfirmDialog
+        open={deletingStay !== null}
+        onOpenChange={(open) => !open && setDeletingStay(null)}
+        title="숙소를 삭제할까요?"
+        description="이 숙소가 붙어 있던 날짜에서 모두 사라집니다."
+        confirmLabel="삭제"
+        destructive
+        onConfirm={() => deletingStay && void removeStayNow(deletingStay)}
+        pending={removeStay.isPending}
       />
 
       <ConfirmDialog

--- a/fe/src/test/mocks/handlers.ts
+++ b/fe/src/test/mocks/handlers.ts
@@ -147,6 +147,11 @@ export const handlers = [
     });
   }),
 
+  // 기본값: 숙소 없음. 보드는 숙소 목록을 항상 함께 읽는다(상세 시트·겹침 미리보기).
+  http.get(`${API_BASE}/travel/trips/:tripId/stays`, () => {
+    return HttpResponse.json({ code: "OK", data: [] });
+  }),
+
   // 기본값: 빈 캘린더 피드. `/select`의 "오늘 루틴" 메타가 항상 해소되도록.
   http.get(`${API_BASE}/planner/calendar`, () => {
     return HttpResponse.json({


### PR DESCRIPTION
## 이슈
closes #1143

## 작업 내용

**보드에서 오늘 자는 곳이 보인다.** #1141이 채워 둔 `stayTonight`·`stayCheckout`·`stayMove`를 처음으로 화면이 읽는다.

### 배지

- 우선순위는 **체크아웃이 먼저** → 오늘 밤 → `＋ 숙소 추가`. 아침에 이 화면을 열었을 때 급한 정보는 "오늘 어디서 자나"가 아니라 "몇 시에 나가야 하나"다
- 리스트 아래 배지는 **위와 다를 때만** = 숙소를 옮기는 날. 같으면 같은 숙소를 한 화면에 두 번 쓰는 것이라 소음이다
- 이어서 묵는 날에는 체크인 시각을 붙이지 않는다 — 지난 정보다

우선순위 판단은 컴포넌트가 아니라 `lib/stayBadge.ts`가 갖는다. "무엇을 보여줄까"는 날짜를 아는 쪽의 판단이고, 여기가 이 이슈에서 유일하게 규칙다운 규칙이라 단위 테스트를 붙였다.

### 숙소 이동 행

- 계산된 값이 있으면 `숙소까지 8분`, 없으면 시간 없이 `숙소로 이동`
- **도시를 넘거나 좌표를 모르면 시간이 없다**(#1142). 이동이 성립하지 않는 것을 `0분`으로 답하면 화면이 "바로 옆"이라고 읽는다
- 탭할 것이 없다 — 목적지는 배지가 열어 준다. 여기서 또 시트를 열면 같은 숙소로 가는 문이 두 개가 된다

### 상세 시트 · 폼

- 기간·시각·메모·예약 링크 / `일정으로 추가` / 닫기·수정·삭제(ConfirmDialog destructive)
- **`일정으로 추가`는 누를 때만** 만든다. 자동 생성하면 지워도 다음 조회에 되살아나는 일정이 된다
- **겹침을 서버에 묻기 전에 답한다.** 저장을 눌러야 "안 된다"를 알게 되면 사용자는 이미 입력을 다 마친 뒤다. 클라이언트가 놓친 경우 서버 409를 **같은 문장**으로 보여준다 — 같은 사실을 두 가지로 말하면 다른 문제라고 읽는다
- 겹침이 뜨면 시트를 닫지 않는다. 닫으면 방금 친 것을 다시 쳐야 한다

## 판단이 갈릴 수 있는 곳 (리뷰 요청)

**1. 시트에서 주소·도시 Badge·`구글 지도에서 길찾기`를 뺐다(설계 §9.6에는 있다).** 셋 다 숙소에 붙은 장소가 있어야 나오는데 **숙소에 장소를 붙일 방법이 지금 없다** — `StayRequest`는 내부 `placeId`만 받고, 일정(`ActivityWriteRequest.googlePlaceId`)처럼 검색 결과를 넘겨 서버가 upsert하는 길이 없다. 이 이슈는 FE 범위라 BE 계약을 늘리지 않고, 대신 아래 후속을 제안한다. 같은 이유로 `stayMove`의 **소요 시간도 아직 계산되지 않는다**(좌표가 없어 행은 `숙소로 이동`으로만 뜬다).

**2. `overlapMessage`를 `lib/stayForDay.ts`에 뒀다.** 클라이언트 미리보기와 서버 409가 같은 문장을 써야 해서 컴포넌트 밖에 있어야 했고, 겹침 규칙(`overlaps`)이 이미 거기 있다.

**3. 보드가 열릴 때 `GET /stays`를 함께 부른다.** 배지는 보드 응답만으로 되지만 상세 시트와 겹침 미리보기가 목록을 필요로 한다. 날짜별로 캐시하지 않은 이유는 어느 날짜에 붙는지를 저장하지 않기 때문이다 — 날짜별로 나누면 무효화할 날짜를 다시 계산해야 하고 그 계산이 곧 파생 규칙의 두 번째 사본이 된다. 오프라인이면 목록이 없어 시트를 열 수 없고, 그때는 왜 안 열리는지 말해 준다.

## 후속 제안

`StayRequest`에 `googlePlaceId`를 더하고 폼에 장소 검색을 붙이는 이슈. 그래야 §9.6의 주소·도시·길찾기와 `stayMove` 소요 시간이 살아난다. (도시 식별자까지 채워지려면 #1145의 `cityPlaceRef` 저장이 함께 필요하다.)

## 테스트

- 단위 — 배지 우선순위 8종(체크아웃 우선 · 시각 없음 · 이어 묵는 날 · 이동일 이중 배지 · 같으면 안 그림)
- 통합 — 배지 3종 · 숙소 이동 행(계산됨/도시 다름) · 상세 시트 · `일정으로 추가`는 **누를 때만**(시트를 여는 것만으로는 0건) · 클라이언트 겹침(요청이 안 나감) · 서버 409(시트 유지·입력 보존) · 마지막 날 밤 안내 · 삭제 확인 · 보관함엔 없음
- BE — **숙소를 지워도 `일정으로 추가`로 만든 일정은 남는다**(검증 항목이라 테스트로 고정)
- E2E — **실제 브라우저에서** 등록 → 배지 확인 → 상세 → 삭제 → `숙소 추가`로 복귀. 목이 상태를 들고 있어 저장 → 보드 무효화 → 배지까지 한 흐름으로 확인한다

기존 보드 E2E 5개에도 `/stays` 스텁을 넣었다(보드가 이제 이 요청을 함께 낸다).

## 게이트

- `cd be && ./gradlew check` ✅
- `cd fe && npm run format:check && npm run lint && npm test && npm run build` ✅ (974 tests)
- `npx playwright test` ✅ (89 passed)

## 위키

[Travel-UI-Design §9.6 · 컴포넌트 표](https://github.com/wcorn/orino/wiki/Travel-UI-Design) · [Travel-API-Spec 숙소 CRUD](https://github.com/wcorn/orino/wiki/Travel-API-Spec) — 장소를 붙일 수 없다는 제약을 근거와 함께 적어 두었다
