### PR TITLE
chore : Terraform CI에 Budgets · Cost Anomaly 권한 추가

### DIFF
--- a/infra/terraform/cicd.tf
+++ b/infra/terraform/cicd.tf
@@ -4,6 +4,11 @@
 #   main 머지(trusted)  → terraform-apply role (쓰기 가능)  → terraform apply
 # 미신뢰 PR(포크 포함)은 plan(미리보기)만 가능, 어떤 AWS 리소스도 변경 불가.
 
+# Budgets 는 리전 없는 계정 단위 리소스라 ARN(arn:aws:budgets::<account>:budget/*)에
+# 계정 ID 가 필요하다. sts:GetCallerIdentity 는 IAM 권한 없이 누구나 호출할 수 있어
+# plan/apply 양쪽 role 에 추가 권한이 들지 않는다.
+data "aws_caller_identity" "current" {}
+
 resource "aws_iam_openid_connect_provider" "github" {
   url             = "https://token.actions.githubusercontent.com"
   client_id_list  = ["sts.amazonaws.com"]
@@ -94,6 +99,35 @@ resource "aws_iam_role_policy" "terraform_apply" {
         ]
         Resource = "*"
       },
+      # --- 비용 관리 체계(#1148) — 예산 리소스를 만들기 전에 만들 권한을 먼저 연다 ---
+      # 태깅 액션까지 넣는 이유: aws_budgets_budget 은 tags 를 지원하므로 provider 가
+      # Read 마다 ListTagsForResource 를 부른다. 빼면 apply 가 아니라 refresh 에서 깨진다.
+      {
+        Sid    = "Budgets"
+        Effect = "Allow"
+        Action = [
+          "budgets:ViewBudget", "budgets:ModifyBudget",
+          "budgets:TagResource", "budgets:UntagResource", "budgets:ListTagsForResource",
+        ]
+        Resource = "arn:aws:budgets::${data.aws_caller_identity.current.account_id}:budget/*"
+      },
+      # Cost Anomaly Detection — 모니터·구독 라이프사이클과 태그만 부여한다.
+      # ce:GetCostAndUsage 같은 유료 조회 API(건당 $0.01)는 주지 않는다: CI 가
+      # 실수로 유료 조회를 돌 수 있게 만들 이유가 없다.
+      # 와일드카드(ce:*AnomalyMonitor)를 쓰지 않는 건 기존 IAM 블록의 원칙이기도 하지만,
+      # 조회 액션이 복수형(GetAnomalyMonitors)이라 그 패턴에 아예 걸리지도 않는다.
+      {
+        Sid    = "CostAnomalyDetection"
+        Effect = "Allow"
+        Action = [
+          "ce:CreateAnomalyMonitor", "ce:GetAnomalyMonitors",
+          "ce:UpdateAnomalyMonitor", "ce:DeleteAnomalyMonitor",
+          "ce:CreateAnomalySubscription", "ce:GetAnomalySubscriptions",
+          "ce:UpdateAnomalySubscription", "ce:DeleteAnomalySubscription",
+          "ce:TagResource", "ce:UntagResource", "ce:ListTagsForResource",
+        ]
+        Resource = "*"
+      },
     ]
   })
 }
@@ -153,6 +187,25 @@ resource "aws_iam_role_policy" "terraform_plan" {
         Sid      = "IamRead"
         Effect   = "Allow"
         Action   = ["iam:Get*", "iam:List*", "iam:GenerateServiceLastAccessedDetails"]
+        Resource = "*"
+      },
+      # --- 비용 관리 체계(#1148) refresh 용 읽기 ---
+      {
+        Sid      = "BudgetsRead"
+        Effect   = "Allow"
+        Action   = ["budgets:ViewBudget", "budgets:ListTagsForResource"]
+        Resource = "arn:aws:budgets::${data.aws_caller_identity.current.account_id}:budget/*"
+      },
+      # 다른 읽기 블록과 달리 ce 는 접두사 와일드카드(ce:Get*)를 쓰지 않는다.
+      # ce:Get* 는 GetCostAndUsage(호출당 $0.01)를 포함하고, 이 role 은 포크 PR 도
+      # assume 할 수 있다 — 미신뢰 PR 이 유료 API 를 부를 수 있는 경로를 만들지 않는다.
+      # refresh 가 실제로 부르는 것만 넣는다.
+      {
+        Sid    = "CostAnomalyDetectionRead"
+        Effect = "Allow"
+        Action = [
+          "ce:GetAnomalyMonitors", "ce:GetAnomalySubscriptions", "ce:ListTagsForResource",
+        ]
         Resource = "*"
       },
     ]


### PR DESCRIPTION
## 이슈
closes #1149
## 작업 내용
- `cicd.tf` apply role — `budgets:ViewBudget`·`ModifyBudget` + 태깅 액션을 `arn:aws:budgets::<account>:budget/*`로 한정해 추가
- `cicd.tf` apply role — Cost Anomaly Detection 모니터·구독 라이프사이클(`Create`/`Get`/`Update`/`Delete`) + `TagResource`·`UntagResource`·`ListTagsForResource`
- `cicd.tf` plan role — refresh에 필요한 읽기 액션만 추가
- 계정 ID는 `data.aws_caller_identity`로 조회 — `sts:GetCallerIdentity`는 IAM 권한이 필요 없어 양쪽 role에 추가 권한이 들지 않는다

### 이슈 본문과 다르게 간 곳 (2개)

이슈 표는 plan role에 `ce:Get*`·`ce:List*`를 주도록 되어 있지만, 같은 이슈가 **"`ce:*`·`budgets:*` 같은 와일드카드를 쓰지 않고 Terraform이 실제로 부르는 액션만 넣는다"**를 원칙으로 명시하고 있어 좁은 쪽을 택했다.

1. **`ce:Get*` 대신 `GetAnomalyMonitors`·`GetAnomalySubscriptions`·`ListTagsForResource` 3개만** — `ce:Get*`는 `GetCostAndUsage`(호출당 $0.01)를 포함한다. plan role은 **포크 PR도 assume할 수 있는 미신뢰 경로**라, 비용 관측 체계를 만들면서 미신뢰 PR이 유료 API를 부를 수 있는 경로를 여는 건 Epic #1148의 "관측이 과금을 만들지 않는다"와 정면으로 어긋난다.
2. **태깅 액션을 추가로 포함** — `aws_budgets_budget`이 `tags`를 지원하므로 provider가 Read마다 `ListTagsForResource`를 호출한다. 빠지면 apply가 아니라 **refresh 단계**에서 AccessDenied가 난다. 이슈 표에는 없지만 넣지 않으면 #1150이 깨진다.

> 참고: 이슈 표기 `ce:*AnomalyMonitor`는 와일드카드로 써도 조회 액션을 못 잡는다 — 실제 액션명이 복수형(`GetAnomalyMonitors`)이라 패턴에 걸리지 않는다. 명시 나열이 필요한 또 하나의 이유.

## 확인
- [x] `terraform fmt -check -recursive` 통과
- [x] `terraform validate` 통과 (`init -backend=false`)
- [ ] PR에서 plan이 깨지지 않는지 확인
- [ ] **머지 후 Actions에서 apply 성공을 눈으로 확인** — 이게 되어야 #1150을 연다

## 다음
이 PR은 #1150(AWS 예산 알림)의 **순수 선행**이다. 권한 추가와 예산 생성을 한 PR에 넣으면 apply 순서가 보장되지 않으므로, **머지 → apply 성공 확인 → 그 다음 #1150** 순서를 지킨다.