### PR TITLE
chore : Loki · Tempo Prometheus 스크랩 추가

### DIFF
--- a/infra/helm/loki/values.yaml
+++ b/infra/helm/loki/values.yaml
@@ -117,6 +117,41 @@ loki:
     allocatedCPU: 100m
     defaultValidity: 12h
 
+  # Prometheus 스크랩 (#1152). 지금까지 Loki 지표는 kubectl port-forward 로만 볼 수
+  # 있었다 — ELOG-027 의 S3 요청 수치를 손으로 포워딩해 얻은 이유다. 사람이 손으로
+  # 포워딩해야 보이는 지표는 감시 수단이 아니다.
+  #
+  # 이 ServiceMonitor 가 실제로 잡는 대상은 loki 만이 아니다. selector 가
+  # name+instance 라벨만 보므로 loki · loki-canary · loki-chunks-cache ·
+  # loki-results-cache 4종이 걸린다(loki-headless 는 차트가
+  # prometheus.io/service-monitor=false 를 붙여 스스로 제외 — 같은 파드 중복 스크랩 방지).
+  monitoring:
+    serviceMonitor:
+      enabled: true
+      # 차트 기본 15s 는 차트 내장 recording rule(1m rate)을 전제한 값인데 그 룰은
+      # 켜지 않는다(monitoring.rules.enabled 기본 false). 샘플 수는 그대로
+      # Prometheus TSDB → Thanos S3 업로드로 이어지므로 60s 로 낮춘다.
+      # 대신 이 지표를 쓰는 쿼리(#1153 대시보드)는 5m 이상 창을 쓴다.
+      interval: 60s
+      # 카디널리티 제한. 실측(2026-08-11, 현재 head series 56,813 기준):
+      #   loki-0            3,894 → 1,239  (_bucket 2,655 제거)
+      #   chunks/results-cache 각 1,318 → 103 (memcached_slab_* 1,215 = 92% 제거)
+      #   loki-canary ×2      각 133 → 92
+      #   합계              6,796 → 1,629  (+12.0% → +2.9%)
+      # 히스토그램 버킷: 비용·retention 감시에 필요한 건 _count/_sum 이고 분위수는
+      # 쓰지 않는다. 지금 이 지표를 쓰는 대시보드가 하나도 없으므로 깨질 것도 없다.
+      # memcached_slab_*: 슬랩 id 별로 시리즈가 갈리는데 캐시에서 볼 값은
+      # memcached_commands_total(hit/miss)뿐이다 — 그건 남는다.
+      # 나중에 특정 분위수가 필요해지면 이 규칙 앞에 keep 을 하나 넣는다.
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: (.*_bucket|memcached_slab_.*)
+          action: drop
+      metricsInstance:
+        # Grafana Agent Operator(deprecated)용 CR. 차트가 CRD 존재 여부로도 막지만
+        # CRD 가 생기면 조용히 켜지므로 의도를 명시해 둔다.
+        enabled: false
+
   gateway:
     enabled: false
 

--- a/infra/helm/tempo/values.yaml
+++ b/infra/helm/tempo/values.yaml
@@ -39,6 +39,22 @@ tempo:
         cpu: "1"
         memory: 1536Mi   # 512Mi→1.5Gi: WAL replay + 블록 완료 + blocklist 폴링 OOM(137) 방지
 
+  # Prometheus 스크랩 (#1152). S3 요청 수를 알려주는 건
+  # tempodb_backend_request_duration_seconds_count{operation} 이다.
+  #
+  # 이 차트의 ServiceMonitor 템플릿은 metricRelabelings 를 지원하지 않아 Loki 처럼
+  # 히스토그램 버킷을 버릴 수 없다. 실측 802 시리즈(그중 _bucket 506)로 현재
+  # head series 56,813 대비 +1.4% 라, 차트를 갈아엎고 자체 ServiceMonitor 를
+  # 유지하는 드리프트 비용이 이득보다 크다. 배포 후 TSDB 증가폭이 예상을 넘으면
+  # 그때 자체 템플릿으로 전환한다.
+  #
+  # 템플릿이 endpoint 를 2개(tempo-prom-metrics, jaeger-metrics) 만드는데 우리
+  # 서비스에는 jaeger-metrics 포트가 없다 → 해당 job 은 타깃 0개가 되어 up 시리즈
+  # 자체가 안 생긴다(TargetDown 노이즈 없음).
+  serviceMonitor:
+    enabled: true
+    interval: 60s  # Loki 와 동일 — 샘플 수가 Thanos S3 업로드로 이어진다
+
   persistence:
     enabled: true
     storageClassName: longhorn


### PR DESCRIPTION
## 이슈
closes #1152
## 작업 내용
- `infra/helm/loki/values.yaml` — `monitoring.serviceMonitor` 활성화, `interval: 60s`, `metricRelabelings`로 카디널리티 제한
- `infra/helm/tempo/values.yaml` — `serviceMonitor` 활성화, `interval: 60s`

### ⚠️ Epic #1148의 메트릭명 전제가 틀렸다 — 실측으로 확인

Epic과 이 이슈는 세 컴포넌트 모두 `*_objstore_bucket_operations_total`을 낸다고 전제하는데, **Thanos만 그렇다.** 클러스터에서 `/metrics`를 직접 확인한 결과:

| 컴포넌트 | 실제 메트릭 | 라벨 |
|---|---|---|
| Thanos | `thanos_objstore_bucket_operations_total` | `bucket`, `operation` (upload·iter·get·exists·delete) |
| **Loki** | **`loki_s3_request_duration_seconds_count`** | `operation` (`S3.PutObject`·`S3.List`·`S3.GetObject`·`S3.DeleteObject`), `status_code` |
| **Tempo** | **`tempodb_backend_request_duration_seconds_count`** | `operation` (PUT·GET·POST·DELETE), `status_code` |

Loki에도 `loki_objstore_bucket_last_successful_upload_time`이 있긴 한데 `{bucket=""} 0`으로 비어 있다 — thanos-objstore 클라이언트 경로(`use_thanos_objstore`)를 안 쓰기 때문이다. **#1153 대시보드와 #1156 차분식은 위 표의 이름으로 짜야 한다.**

차분식의 Tier1(PUT/LIST) 대응:
- Thanos: `operation=~"upload|iter"`
- Loki: `operation=~"S3.PutObject|S3.List"`
- Tempo: `operation=~"PUT|POST"`

### 카디널리티 — 실측 후 relabel (2026-08-11, 현재 head series 56,813)

Loki ServiceMonitor는 selector가 name+instance 라벨만 보므로 **loki 하나가 아니라 4종을 잡는다.**

| 타깃 | 원본 | 드롭 후 |
|---|---:|---:|
| loki-0 | 3,894 | 1,239 (`_bucket` 2,655 제거) |
| loki-chunks-cache | 1,318 | 103 (`memcached_slab_*` 1,215 = 92% 제거) |
| loki-results-cache | 1,318 | 103 |
| loki-canary ×2 | 266 | 184 |
| **Loki 합계** | **6,796** | **1,629** |
| Tempo | 802 | 802 (차트가 metricRelabelings 미지원) |
| **총 증가** | **+7,598 (+13.4%)** | **+2,431 (+4.3%)** |

- **`_bucket` 드롭**: 비용·retention 감시에 필요한 건 `_count`/`_sum`이고 분위수는 안 쓴다. 지금 이 지표를 쓰는 대시보드가 하나도 없어(스크랩 자체가 없었으므로) 깨질 것도 없다.
- **`memcached_slab_*` 드롭**: 슬랩 id별로 시리즈가 갈려 캐시 파드 시리즈의 92%를 차지한다. 실제로 볼 값인 `memcached_commands_total`(hit/miss — S3 GET 절감 지표)은 남는다.
- **Tempo는 그대로**: 차트 ServiceMonitor 템플릿이 `metricRelabelings`를 지원하지 않는다. +1.4%를 줄이려고 자체 템플릿을 들고 유지하는 드리프트 비용이 이득보다 크다. 배포 후 TSDB 증가폭이 예상을 넘으면 그때 전환한다.
- **`interval: 60s`**: 차트 기본 15s는 차트 내장 recording rule(1m rate) 전제인데 그 룰은 안 켠다. 샘플 수는 그대로 Prometheus TSDB → Thanos S3 업로드(=과금)로 이어진다. 대신 #1153 쿼리는 5m 이상 창을 쓴다.
- `metricsInstance`(Grafana Agent Operator, deprecated)는 명시적으로 `false`.

### 스크랩 자체는 과금을 만들지 않는다
클러스터 내부 스크랩이라 S3 요청도 AWS API 호출도 없다. 늘어나는 건 Prometheus TSDB → Thanos 업로드분뿐이고, 그래서 위처럼 relabel로 조였다.

## 확인
- [x] `yamllint -c .yamllint.yml infra/` 통과
- [x] `helm lint loki` · `helm lint tempo` 통과
- [x] `helm template --api-versions monitoring.coreos.com/v1/ServiceMonitor`로 렌더링 확인 (템플릿이 Capabilities 게이팅이라 이 플래그 없으면 안 나온다 — ArgoCD v3.3.3은 클러스터에서 apiVersions를 채워 넣으므로 실제 동기화에는 문제없음)
- [x] `kubectl apply --dry-run=server`로 **실제 Prometheus Operator CRD 스키마 검증** 통과 (kubeconform은 CRD 스키마가 없어 어차피 skip된다)
- [x] Loki selector 실측 대조 — `loki`·`loki-canary`·`loki-chunks-cache`·`loki-results-cache` 4종이 잡히고, `loki-headless`는 차트가 `prometheus.io/service-monitor=false`로 스스로 제외(같은 파드 중복 스크랩 방지), `loki-memberlist`는 `http-metrics` 포트가 없어 타깃 0
- [x] Tempo ServiceMonitor selector가 실제 svc 라벨과 일치하는지 대조. 템플릿이 만드는 `jaeger-metrics` endpoint는 해당 포트가 없어 타깃 0 → `up` 시리즈가 안 생기므로 TargetDown 노이즈 없음
- [ ] ArgoCD 동기화 후 Prometheus 타깃에 loki·tempo가 `UP`으로 뜨는지 확인
- [ ] 배포 전후 `prometheus_tsdb_head_series` 비교 — 예상(+2,431)보다 크면 relabel로 더 조인다

## 다음
#1153(비용 대시보드) · #1156(Tier1 차분 귀속)의 선행이 풀린다.
