### PR TITLE
feat : S-06 검색 기준 도시 칩 + 담은 장소에 도시 식별자

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityWriteRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityWriteRequest.java
@@ -36,6 +36,15 @@ public record ActivityWriteRequest(
          */
         String googlePlaceId,
 
+        /**
+         * (v2.1) 이 장소를 <b>어느 도시를 기준으로 찾았는지</b>(S-06 검색 기준 도시 칩).
+         * {@code googlePlaceId}로 새로 담기는 장소에만 쓰이며, 그 도시의 식별자를 장소에 함께
+         * 저장해 보관함 도시 그룹·도시 이탈 표시가 성립하게 한다.
+         *
+         * <p>없으면 장소는 도시 식별자 없이 저장된다 — 좌표로 도시를 추측하지 않는다(D-23).
+         */
+        Long cityPlaceId,
+
         @Size(max = 1000, message = "메모는 1000자를 넘을 수 없습니다.")
         String memo,
 

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/service/ActivityService.java
@@ -101,7 +101,10 @@ public class ActivityService {
      */
     private Long resolvePlaceId(Long memberId, ActivityWriteRequest request) {
         if (request.googlePlaceId() != null && !request.googlePlaceId().isBlank()) {
-            return placeService.upsertFromGoogle(memberId, request.googlePlaceId()).getId();
+            // 어느 도시를 기준으로 찾았는지(S-06 칩)를 함께 넘긴다 — 그래야 담은 장소가
+            // 보관함 도시 그룹과 도시 이탈 표시에서 `도시 없음`으로 떨어지지 않는다.
+            return placeService.upsertFromGoogle(memberId, request.googlePlaceId(),
+                    request.cityPlaceId()).getId();
         }
         return request.placeId();
     }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/controller/PlaceController.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/controller/PlaceController.java
@@ -35,13 +35,20 @@ public class PlaceController {
         return ApiResponse.success(placeService.searchCities(q));
     }
 
-    /** S-06 장소 검색. {@code tripId}를 주면 그 목적지 주변을 우선한다. */
+    /**
+     * S-06 장소 검색.
+     *
+     * @param tripId 주면 그 여행의 도시 주변을 우선한다
+     * @param city   (v2.1) 기준 도시 칩의 도시 {@code placeId}. 주면 <b>그 도시</b>로 편향하고,
+     *               없으면 첫날 도시로 떨어진다
+     */
     @GetMapping("/search")
     public ApiResponse<List<PlaceSearchResult>> search(
             @AuthenticationPrincipal Long memberId,
             @RequestParam String q,
-            @RequestParam(required = false) Long tripId) {
-        return ApiResponse.success(placeService.searchPlaces(memberId, q, tripId));
+            @RequestParam(required = false) Long tripId,
+            @RequestParam(required = false) Long city) {
+        return ApiResponse.success(placeService.searchPlaces(memberId, q, tripId, city));
     }
 
     @GetMapping("/{placeId}")

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
@@ -87,10 +87,14 @@ public class PlaceService {
     }
 
     /**
-     * S-06 장소 검색. `tripId`를 주면 그 여행의 목적지 좌표 주변을 우선한다(§1.5).
+     * S-06 장소 검색. `tripId`를 주면 그 여행의 도시 좌표 주변을 우선한다(§1.5).
+     *
+     * <p>{@code cityPlaceId}(기준 도시 칩)를 주면 <b>그 도시</b>로 편향한다. 안 주면 첫날 도시로
+     * 떨어지는데, 다구간 여행에서 그건 곧 "오사카 좌표로 교토 가게를 찾는" 상태다.
      */
-    public List<PlaceSearchResult> searchPlaces(Long memberId, String query, Long tripId) {
-        PlacesClient.Coordinates bias = biasOf(memberId, tripId);
+    public List<PlaceSearchResult> searchPlaces(Long memberId, String query, Long tripId,
+                                                Long cityPlaceId) {
+        PlacesClient.Coordinates bias = biasOf(memberId, tripId, cityPlaceId);
         String biasKey = bias == null ? "none" : bias.lat() + "," + bias.lng();
 
         List<PlaceResult> results = cached(
@@ -127,15 +131,28 @@ public class PlaceService {
         return PlaceDetail.from(place);
     }
 
+    /** 기준 도시를 모르는 자리(구간 입력 등)에서 담을 때. 장소는 도시 식별자 없이 저장된다. */
+    @Transactional
+    public TravelPlace upsertFromGoogle(Long memberId, String googlePlaceId) {
+        return upsertFromGoogle(memberId, googlePlaceId, null);
+    }
+
     /**
      * 구글 장소를 담는다. 같은 장소를 두 번 저장하지 않는다 — 이미 있으면 그걸 돌려준다
      * ({@code uk_place_member_google}이 멤버당 한 행을 강제한다).
+     *
+     * <p>{@code cityPlaceId}(기준 도시 칩, S-06)가 오면 <b>그 도시의 식별자를 함께 저장한다.</b>
+     * 이 값이 없으면 보관함 도시 그룹도 도시 이탈 표시도 성립하지 않는다 — 구글 상세 응답은
+     * 도시 <i>이름</i>만 주고 도시의 장소 id는 주지 않기 때문에, 어느 도시에서 찾았는지는
+     * 화면만 안다. 좌표 거리로 도시를 되짚지 않는 이유는 D-23에 있다.
      */
     @Transactional
-    public TravelPlace upsertFromGoogle(Long memberId, String googlePlaceId) {
+    public TravelPlace upsertFromGoogle(Long memberId, String googlePlaceId, Long cityPlaceId) {
         Optional<TravelPlace> existing =
                 placeRepository.findByMemberIdAndGooglePlaceId(memberId, googlePlaceId);
         if (existing.isPresent()) {
+            // 이미 담긴 장소의 도시는 덮지 않는다 — 나중에 다른 도시 칩으로 다시 담았다고
+            // 처음 알던 도시가 바뀌면, 그 장소가 붙은 다른 날짜의 판정까지 조용히 흔들린다.
             return existing.get();
         }
         PlaceResult fresh = placesClient.fetchDetails(googlePlaceId)
@@ -145,9 +162,15 @@ public class PlaceService {
         place.updateBasics(fresh.address(), fresh.lat(), fresh.lng(),
                 fresh.category(), fresh.rating());
         place.updateDetails(fresh.phone(), fresh.openingHours(), clock.instant());
-        // 어느 도시의 장소인지는 상세 응답에 이미 들어 있다 — 화면의 `· 오사카` 꼬리표가 쓴다.
-        place.updateCityInfo(fresh.cityName(), place.getCityPlaceRef(), fresh.countryCode());
+        // 도시 이름은 상세 응답 것을 쓴다(화면의 `· 오사카` 꼬리표). 식별자는 칩에서만 온다.
+        place.updateCityInfo(fresh.cityName(), cityRefOf(memberId, cityPlaceId),
+                fresh.countryCode());
         return placeRepository.save(place);
+    }
+
+    private String cityRefOf(Long memberId, Long cityPlaceId) {
+        return cityPlaceId == null ? null : requireOwnedCity(memberId, cityPlaceId)
+                .getCityPlaceRef();
     }
 
     /**
@@ -254,10 +277,16 @@ public class PlaceService {
     }
 
     /**
-     * 검색 편향 좌표. 지금은 <b>첫날 기준 도시</b>를 쓴다 — 날짜를 골라 그 도시로 검색하는
-     * 기준 도시 칩({@code ?city=})은 3단계(S-06)에서 붙는다.
+     * 검색 편향 좌표.
+     *
+     * <p>기준 도시 칩({@code ?city=})이 오면 그 도시를 쓰고, 없으면 <b>첫날 기준 도시</b>로
+     * 떨어진다. 칩이 있는데 조용히 첫날로 떨어뜨리지는 않는다 — 화면이 "교토"라고 말하면서
+     * 오사카 가게를 물어오는 것이 이 이슈가 없애려는 바로 그 상태다.
      */
-    private PlacesClient.Coordinates biasOf(Long memberId, Long tripId) {
+    private PlacesClient.Coordinates biasOf(Long memberId, Long tripId, Long cityPlaceId) {
+        if (cityPlaceId != null) {
+            return coordinatesOf(requireOwnedCity(memberId, cityPlaceId));
+        }
         if (tripId == null) {
             return null;
         }
@@ -265,11 +294,28 @@ public class PlaceService {
         if (trip == null) {
             return null;
         }
-        TravelPlace city = tripDayService.primaryCity(trip.getId());
+        return coordinatesOf(tripDayService.primaryCity(trip.getId()));
+    }
+
+    /** 좌표 없는 도시(직접 입력)는 편향할 수 없다 — 편향 없이 검색하는 편이 낫다. */
+    private static PlacesClient.Coordinates coordinatesOf(TravelPlace city) {
         if (city.getLat() == null || city.getLng() == null) {
             return null;
         }
         return new PlacesClient.Coordinates(city.getLat(), city.getLng());
+    }
+
+    /**
+     * 기준 도시로 쓸 수 있는 내 장소인지 확인한다. 남의 장소·없는 장소는 404, 도시가 아니면
+     * 400이다 — 가게를 기준 도시로 쓸 수는 없다(D-23).
+     */
+    private TravelPlace requireOwnedCity(Long memberId, Long cityPlaceId) {
+        TravelPlace city = placeRepository.findByIdAndMemberId(cityPlaceId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PLACE_NOT_FOUND));
+        if (!city.isCity()) {
+            throw new CustomException(ErrorCode.TRAVEL_NOT_A_CITY);
+        }
+        return city;
     }
 
     private Map<String, Long> savedIdsOf(Long memberId, List<PlaceResult> results) {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
@@ -221,6 +221,80 @@ class PlaceControllerTest extends ApiTestSupport {
         }
 
         @Test
+        @DisplayName("기준 도시 칩을 주면 그 도시로 편향한다 — 첫날 도시가 아니다")
+        void biasesTowardChosenCity() throws Exception {
+            long tripId = createTripWithCoordinates();
+            long kyoto = TravelCityFixture.createCity(mockMvc, authHeader, "교토",
+                    "Asia/Tokyo", "JPY", "35.0116", "135.7681");
+            stub.placeResults = List.of(place("ChIJ_senso", "센소지"));
+
+            mockMvc.perform(get("/api/travel/places/search")
+                            .param("q", uniqueQuery("라멘"))
+                            .param("tripId", String.valueOf(tripId))
+                            .param("city", String.valueOf(kyoto))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk());
+
+            assertThat(stub.biases).hasSize(1);
+            // 첫날 도시(도쿄 35.6762)가 아니라 고른 도시여야 한다.
+            assertThat(stub.biases.get(0).lat()).isEqualByComparingTo("35.0116");
+        }
+
+        @Test
+        @DisplayName("도시를 바꾸면 캐시를 재사용하지 않는다 — 편향이 다르면 다른 검색이다")
+        void differentCityIsADifferentSearch() throws Exception {
+            long tripId = createTripWithCoordinates();
+            long kyoto = TravelCityFixture.createCity(mockMvc, authHeader, "교토",
+                    "Asia/Tokyo", "JPY", "35.0116", "135.7681");
+            stub.placeResults = List.of(place("ChIJ_senso", "센소지"));
+            String query = uniqueQuery("라멘");
+
+            for (String city : List.of(String.valueOf(kyoto), "")) {
+                var request = get("/api/travel/places/search")
+                        .param("q", query).param("tripId", String.valueOf(tripId))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader);
+                if (!city.isEmpty()) {
+                    request = request.param("city", city);
+                }
+                mockMvc.perform(request).andExpect(status().isOk());
+            }
+
+            assertThat(stub.placeSearches).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("남의 도시로는 편향할 수 없다 — 404")
+        void rejectsOtherMembersCity() throws Exception {
+            long tripId = createTripWithCoordinates();
+            long kyoto = TravelCityFixture.createCity(mockMvc, authHeader, "교토",
+                    "Asia/Tokyo", "JPY", "35.0116", "135.7681");
+
+            mockMvc.perform(get("/api/travel/places/search")
+                            .param("q", uniqueQuery("라멘"))
+                            .param("tripId", String.valueOf(tripId))
+                            .param("city", String.valueOf(kyoto))
+                            .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-008"));
+        }
+
+        @Test
+        @DisplayName("가게를 기준 도시로 줄 수는 없다 — 400")
+        void rejectsNonCityAsBias() throws Exception {
+            long tripId = createTripWithCoordinates();
+            TravelPlace poi = placeRepository.save(TravelPlace.manual(
+                    memberRepository.findAll().get(0).getId(), "골목 카페"));
+
+            mockMvc.perform(get("/api/travel/places/search")
+                            .param("q", uniqueQuery("라멘"))
+                            .param("tripId", String.valueOf(tripId))
+                            .param("city", String.valueOf(poi.getId()))
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("TRAVEL-ERR-016"));
+        }
+
+        @Test
         @DisplayName("빈 결과는 캐시하지 않는다 — 일시적 실패를 한 시간 물고 있으면 안 된다")
         void doesNotCacheEmptyResults() throws Exception {
             String query = uniqueQuery("없는곳");
@@ -413,6 +487,88 @@ class PlaceControllerTest extends ApiTestSupport {
                     .hasSize(1);
             assertThat(stub.detailFetches).containsExactly("ChIJ_senso");
         }
+
+        @Test
+        @DisplayName("기준 도시를 함께 주면 담은 장소에 도시 식별자가 붙는다")
+        void savesCityIdentifierFromChip() throws Exception {
+            long tripId = createTripWithCoordinates();
+            long kyoto = cityWithRef("교토", "ChIJ_kyoto");
+            stub.detailResult = Optional.of(place("ChIJ_senso", "센소지"));
+
+            addPlaceToTrip(tripId, "ChIJ_senso", ", \"cityPlaceId\": " + kyoto);
+
+            assertThat(savedGooglePlace().getCityPlaceRef()).isEqualTo("ChIJ_kyoto");
+            // 도시 <b>이름</b>은 구글 상세 것을 쓴다 — 칩보다 그쪽이 정확하다.
+            assertThat(savedGooglePlace().getCityName()).isEqualTo("도쿄");
+        }
+
+        @Test
+        @DisplayName("기준 도시 없이 담으면 식별자도 없다 — 좌표로 도시를 추측하지 않는다(D-23)")
+        void leavesCityIdentifierEmptyWithoutChip() throws Exception {
+            long tripId = createTripWithCoordinates();
+            stub.detailResult = Optional.of(place("ChIJ_senso", "센소지"));
+
+            addPlaceToTrip(tripId, "ChIJ_senso", "");
+
+            assertThat(savedGooglePlace().getCityPlaceRef()).isNull();
+        }
+
+        @Test
+        @DisplayName("직접 입력한 도시는 식별자가 없어 붙일 것도 없다")
+        void manualCityHasNothingToAttach() throws Exception {
+            long tripId = createTripWithCoordinates();
+            // 검색을 거치지 않은 도시는 구글 id가 없어 `city_place_ref`가 비어 있다.
+            long manual = TravelCityFixture.createCity(mockMvc, authHeader, "하코네",
+                    "Asia/Tokyo", "JPY");
+            stub.detailResult = Optional.of(place("ChIJ_senso", "센소지"));
+
+            addPlaceToTrip(tripId, "ChIJ_senso", ", \"cityPlaceId\": " + manual);
+
+            assertThat(savedGooglePlace().getCityPlaceRef()).isNull();
+        }
+
+        @Test
+        @DisplayName("이미 담긴 장소의 도시는 덮지 않는다 — 다른 날짜의 판정까지 흔들린다")
+        void doesNotOverwriteCityOfExistingPlace() throws Exception {
+            long tripId = createTripWithCoordinates();
+            long kyoto = cityWithRef("교토", "ChIJ_kyoto");
+            long osaka = cityWithRef("오사카", "ChIJ_osaka");
+            stub.detailResult = Optional.of(place("ChIJ_senso", "센소지"));
+
+            addPlaceToTrip(tripId, "ChIJ_senso", ", \"cityPlaceId\": " + kyoto);
+            addPlaceToTrip(tripId, "ChIJ_senso", ", \"cityPlaceId\": " + osaka);
+
+            assertThat(savedGooglePlace().getCityPlaceRef()).isEqualTo("ChIJ_kyoto");
+        }
+    }
+
+    /** 검색으로 고른 도시처럼 <b>도시 식별자를 가진</b> 도시. 직접 입력한 도시에는 없다. */
+    private long cityWithRef(String name, String cityPlaceRef) throws Exception {
+        long cityId = TravelCityFixture.createCity(mockMvc, authHeader, name,
+                "Asia/Tokyo", "JPY", "35.0116", "135.7681");
+        TravelPlace city = placeRepository.findById(cityId).orElseThrow();
+        city.updateCityInfo(name, cityPlaceRef, "JP");
+        placeRepository.saveAndFlush(city);
+        return cityId;
+    }
+
+    private void addPlaceToTrip(long tripId, String googlePlaceId, String extra) throws Exception {
+        mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "담기", "activityDate": "2026-10-24",
+                                 "googlePlaceId": "%s"%s}
+                                """.formatted(googlePlaceId, extra)))
+                .andExpect(status().isOk());
+    }
+
+    /** 검색으로 담은 장소. 기준 도시 행도 travel_place라 구글 id로 가른다. */
+    private TravelPlace savedGooglePlace() {
+        return placeRepository.findAll().stream()
+                .filter(place -> place.getGooglePlaceId() != null)
+                .findFirst()
+                .orElseThrow();
     }
 
     /** 편향 검증용 — 목적지 좌표가 있는 여행. */

--- a/fe/e2e/travel-search-city.spec.ts
+++ b/fe/e2e/travel-search-city.spec.ts
@@ -1,0 +1,191 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 검색 기준 도시 칩(S-06, #1145).
+ *
+ * <p>여기서 확인하는 것은 <b>고른 도시가 새로고침에서 살아남는가</b>다. 상태를 URL이 소유해야
+ * 한다는 규칙(§9.7)은 진짜 주소창과 진짜 새로고침으로만 증명된다 — 메모리 라우터 위에서는
+ * 컴포넌트 state와 구분되지 않는다.
+ */
+
+const TRIP_ID = 1;
+const D1 = "2026-10-24";
+const D2 = "2026-10-25";
+
+function city(placeId: number, name: string, cityPlaceRef: string) {
+  return {
+    placeId,
+    name,
+    timezone: "Asia/Tokyo",
+    currency: "JPY",
+    countryCode: "JP",
+    cityPlaceRef,
+    lat: 34.6937,
+    lng: 135.5023,
+  };
+}
+
+const OSAKA = city(21, "오사카", "ChIJ_osaka");
+const KYOTO = city(22, "교토", "ChIJ_kyoto");
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+async function mockTrip(page: Page) {
+  const searches: URL[] = [];
+  const created: Record<string, unknown>[] = [];
+
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/planner/reviews/summary", (route) =>
+    route.fulfill(
+      ok({
+        today: D1,
+        counts: { now: 0, overdue: 0, upcoming: 0, doneToday: 0 },
+        estimatedMinutes: 0,
+        materials: [],
+      }),
+    ),
+  );
+  await page.route("**/api/travel/summary", (route) =>
+    route.fulfill(ok({ ongoing: null, next: null, recentCompleted: null })),
+  );
+  await page.route("**/api/travel/trips/*/stays", (route) =>
+    route.fulfill(ok([])),
+  );
+
+  await page.route("**/api/travel/places/search*", (route) => {
+    searches.push(new URL(route.request().url()));
+    return route.fulfill(
+      ok([
+        {
+          id: null,
+          googlePlaceId: "ChIJ_nishiki",
+          name: "니시키 시장",
+          category: "시장",
+          address: "교토부 교토시",
+          rating: 4.3,
+          lat: 35.0049,
+          lng: 135.7649,
+        },
+      ]),
+    );
+  });
+
+  await page.route(`**/api/travel/trips/${TRIP_ID}/activities`, (route) => {
+    created.push(route.request().postDataJSON() as Record<string, unknown>);
+    return route.fulfill(ok({ id: 1 }));
+  });
+
+  await page.route(`**/api/travel/trips/${TRIP_ID}/board*`, (route) =>
+    route.fulfill(
+      ok({
+        trip: {
+          id: TRIP_ID,
+          title: "일본",
+          startDate: D1,
+          endDate: D2,
+          status: "UPCOMING",
+          recordMode: false,
+          cityCount: 2,
+          countryCount: 1,
+          singleCity: false,
+        },
+        days: [
+          {
+            dayId: 501,
+            dayIndex: 1,
+            date: D1,
+            weekday: "토",
+            activityCount: 0,
+            baseCity: OSAKA,
+            cityChanged: false,
+            legIndex: 1,
+            cityMemo: null,
+            weather: null,
+            stayTonight: null,
+            stayCheckout: null,
+          },
+          {
+            dayId: 502,
+            dayIndex: 2,
+            date: D2,
+            weekday: "일",
+            activityCount: 0,
+            baseCity: KYOTO,
+            cityChanged: true,
+            legIndex: 2,
+            cityMemo: null,
+            weather: null,
+            stayTonight: null,
+            stayCheckout: null,
+          },
+        ],
+        selectedDate: D1,
+        archiveCount: 0,
+        activities: [],
+        travelTimes: [],
+        stayMove: null,
+      }),
+    ),
+  );
+
+  return { searches, created };
+}
+
+test.describe("검색 기준 도시", () => {
+  test("도시를 바꾸면 새로고침해도 그대로고, 담을 때 그 도시가 함께 간다", async ({
+    page,
+  }) => {
+    const { searches, created } = await mockTrip(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/places?q=시장`);
+
+    // 보던 날짜(1일차)가 오사카라 기준도 오사카다.
+    await expect(
+      page.getByRole("button", { name: "검색 기준 도시 오사카" }),
+    ).toBeVisible();
+    await expect
+      .poll(() => searches.at(-1)?.searchParams.get("city"))
+      .toBe("21");
+
+    await page.getByRole("button", { name: "검색 기준 도시 오사카" }).click();
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "교토" })
+      .click();
+
+    await expect(
+      page.getByRole("button", { name: "검색 기준 도시 교토" }),
+    ).toBeVisible();
+    await expect
+      .poll(() => searches.at(-1)?.searchParams.get("city"))
+      .toBe("22");
+
+    // 상태를 URL이 갖는다 — 주소에 남고 새로고침을 넘긴다(§9.7).
+    expect(page.url()).toContain("city=22");
+    expect(page.url()).toContain("q=");
+    await page.reload();
+    await expect(
+      page.getByRole("button", { name: "검색 기준 도시 교토" }),
+    ).toBeVisible();
+    await expect(page.getByLabel("장소 검색")).toHaveAttribute(
+      "placeholder",
+      "교토 주변 장소 검색",
+    );
+
+    // 담으면 그 도시 식별자가 함께 저장된다 — 보관함 도시 그룹이 여기서 살아난다.
+    await page.getByRole("button", { name: "담기" }).click();
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: /2일차/ })
+      .click();
+
+    await expect.poll(() => created.length).toBe(1);
+    expect(created[0].cityPlaceId).toBe(22);
+    expect(created[0].googlePlaceId).toBe("ChIJ_nishiki");
+  });
+});

--- a/fe/src/features/travel/api/activities.ts
+++ b/fe/src/features/travel/api/activities.ts
@@ -214,6 +214,12 @@ export interface ActivityWriteRequest {
    * 프론트가 장소를 먼저 만들 필요가 없다. `placeId`와 함께 보내지 않는다.
    */
   googlePlaceId?: string | null;
+  /**
+   * (v2.1) 이 장소를 **어느 도시를 기준으로 찾았는지**(S-06 검색 기준 도시 칩).
+   * `googlePlaceId`로 새로 담기는 장소에만 쓰이며, 그 도시의 식별자가 장소에 함께 저장돼
+   * 보관함 도시 그룹·도시 이탈 표시가 성립한다. 없으면 장소는 도시 없이 저장된다.
+   */
+  cityPlaceId?: number | null;
   memo?: string | null;
   url?: string | null;
   notifyEnabled?: boolean;

--- a/fe/src/features/travel/api/places.ts
+++ b/fe/src/features/travel/api/places.ts
@@ -52,14 +52,26 @@ export async function searchCities(q: string): Promise<City[]> {
   return data.data;
 }
 
-/** `tripId`를 주면 그 여행 목적지 주변을 우선한다(필터가 아니라 편향). */
+/**
+ * `tripId`를 주면 그 여행 도시 주변을 우선한다(필터가 아니라 **편향**).
+ *
+ * <p>`cityPlaceId`(기준 도시 칩)를 주면 그 도시로 편향한다. 안 주면 서버가 첫날 도시로
+ * 떨어뜨리는데, 다구간 여행에서 그건 "오사카 좌표로 교토 가게를 찾는" 상태다.
+ */
 export async function searchPlaces(
   q: string,
   tripId?: number,
+  cityPlaceId?: number | null,
 ): Promise<PlaceSearchResult[]> {
   const { data } = await client.get<ApiEnvelope<PlaceSearchResult[]>>(
     "/travel/places/search",
-    { params: tripId ? { q, tripId } : { q } },
+    {
+      params: {
+        q,
+        ...(tripId ? { tripId } : {}),
+        ...(cityPlaceId ? { city: cityPlaceId } : {}),
+      },
+    },
   );
   return data.data;
 }

--- a/fe/src/features/travel/hooks/usePlaceSearch.ts
+++ b/fe/src/features/travel/hooks/usePlaceSearch.ts
@@ -8,12 +8,22 @@ import { travelKeys } from "../queryKeys";
  *
  * <p>호출 하나가 곧 비용이라(Places는 호출당 과금) 타이핑마다 부르지 않는다.
  * 검색은 사용자가 <b>제출</b>했을 때만 일어난다 — `q`가 비면 아무것도 부르지 않는다.
+ *
+ * <p>`ready`는 <b>기준 도시가 정해졌는가</b>다. 도시를 모르는 채로 먼저 한 번 부르면 편향
+ * 없는 결과가 잠깐 보였다가 도시가 정해지며 다시 부르게 된다 — 틀린 결과를 보여주고
+ * 호출도 두 배로 낸다.
  */
-export function usePlaceSearch(q: string, tripId?: number) {
+export function usePlaceSearch(
+  q: string,
+  tripId?: number,
+  cityPlaceId?: number | null,
+  ready = true,
+) {
   return useQuery({
-    queryKey: travelKeys.placeSearch(q, tripId),
-    queryFn: () => searchPlaces(q, tripId),
-    enabled: q.trim().length > 0,
+    // 도시가 키에 들어간다 — 같은 검색어라도 도시가 다르면 다른 결과다.
+    queryKey: travelKeys.placeSearch(q, tripId, cityPlaceId),
+    queryFn: () => searchPlaces(q, tripId, cityPlaceId),
+    enabled: ready && q.trim().length > 0,
     // 서버가 1시간 캐시하지만, 뒤로 갔다 오는 동안 다시 부를 이유는 없다.
     staleTime: 5 * 60 * 1000,
   });

--- a/fe/src/features/travel/lib/baseCity.ts
+++ b/fe/src/features/travel/lib/baseCity.ts
@@ -37,3 +37,19 @@ export function cityCount(days: BoardDay[]): number {
     days.map((day) => day.baseCity?.placeId).filter((id) => id != null),
   ).size;
 }
+
+/**
+ * 이 여행에 등장하는 도시들. **구간 순서**로, 같은 도시를 다시 방문해도 한 번만 나온다.
+ *
+ * <p>기준 도시를 바꾸는 자리(날짜 탭 시트·검색 기준 칩)에서 가장 자주 고르는 후보라 그대로
+ * 올린다 — 도쿄↔닛코를 오가는 변경에 매번 검색을 시킬 이유가 없다.
+ */
+export function tripCities(days: BoardDay[]): BaseCity[] {
+  return [
+    ...new Map(
+      days
+        .flatMap((day) => (day.baseCity ? [day.baseCity] : []))
+        .map((city) => [city.placeId, city]),
+    ).values(),
+  ];
+}

--- a/fe/src/features/travel/places/SearchCityChip.tsx
+++ b/fe/src/features/travel/places/SearchCityChip.tsx
@@ -1,0 +1,79 @@
+import { ChevronDown, MapPin } from "lucide-react";
+
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import type { BaseCity } from "@/features/travel/api/activities";
+
+interface SearchCityChipProps {
+  /** 지금 검색이 기준으로 삼는 도시. 여행에 도시가 없으면 null. */
+  city: BaseCity | null;
+  /** 이 여행에 등장하는 도시들. 하나뿐이면 고를 것이 없어 시트를 열지 않는다. */
+  cities: BaseCity[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (city: BaseCity) => void;
+}
+
+/**
+ * 검색 기준 도시 칩(§2.7).
+ *
+ * <p><b>어느 도시를 기준으로 도는지 화면이 말한다.</b> 다구간 여행에서 검색은 조용히 첫날
+ * 도시로 편향되는데, 그 상태에서는 교토에서 검색해도 오사카 가게가 나온다. 무엇을 기준으로
+ * 찾고 있는지 보이지 않으면 사용자는 결과가 이상한 이유를 알 수 없다.
+ *
+ * <p>도시가 하나뿐인 여행에서는 고를 것이 없다 — 칩은 그대로 두되(무엇을 기준으로 찾는지는
+ * 여전히 정보다) 누를 수 없게 한다.
+ */
+export function SearchCityChip({
+  city,
+  cities,
+  open,
+  onOpenChange,
+  onSelect,
+}: SearchCityChipProps) {
+  if (city === null) return null;
+  const selectable = cities.length > 1;
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-muted-foreground shrink-0 text-xs">검색 기준</span>
+      <button
+        type="button"
+        disabled={!selectable}
+        onClick={() => onOpenChange(true)}
+        aria-label={`검색 기준 도시 ${city.name}`}
+        className="border-primary bg-accent flex items-center gap-1 rounded-full border px-2.5 py-1 text-[13px] font-medium disabled:opacity-100"
+      >
+        <MapPin className="size-[13px] shrink-0" />
+        {city.name}
+        {selectable && <ChevronDown className="size-[13px] shrink-0" />}
+      </button>
+
+      <BottomSheet
+        open={open}
+        onOpenChange={onOpenChange}
+        title="검색 기준 도시"
+        description="이 여행에서 지나는 도시 중에 고릅니다"
+      >
+        <ul className="flex flex-col gap-1.5">
+          {cities.map((candidate) => (
+            <li key={candidate.placeId}>
+              <button
+                type="button"
+                onClick={() => onSelect(candidate)}
+                aria-pressed={candidate.placeId === city.placeId}
+                className={`flex w-full items-center gap-2 rounded-lg border px-3 py-2.5 text-left text-sm ${
+                  candidate.placeId === city.placeId
+                    ? "border-primary bg-accent"
+                    : "border-border hover:bg-accent"
+                }`}
+              >
+                <MapPin className="text-muted-foreground size-4 shrink-0" />
+                <span className="flex-1">{candidate.name}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </BottomSheet>
+    </div>
+  );
+}

--- a/fe/src/features/travel/queryKeys.ts
+++ b/fe/src/features/travel/queryKeys.ts
@@ -12,9 +12,20 @@ export const travelKeys = {
   activity: (activityId: number) => ["travel", "activity", activityId] as const,
   /** 여행의 숙소 전체. 날짜별로 나누지 않는다 — 어느 날짜에 붙는지는 기간에서 파생한다. */
   stays: (tripId: number) => ["travel", "stays", tripId] as const,
-  /** 장소 검색. 서버가 이미 캐시하지만, 뒤로 갔다 오면 결과가 그대로 있어야 한다. */
-  placeSearch: (q: string, tripId?: number) =>
-    ["travel", "places", "search", tripId ?? "none", q] as const,
+  /**
+   * 장소 검색. 서버가 이미 캐시하지만, 뒤로 갔다 오면 결과가 그대로 있어야 한다.
+   *
+   * <p>기준 도시가 키에 들어간다 — 같은 검색어라도 편향 도시가 다르면 다른 결과다.
+   */
+  placeSearch: (q: string, tripId?: number, cityPlaceId?: number | null) =>
+    [
+      "travel",
+      "places",
+      "search",
+      tripId ?? "none",
+      cityPlaceId ?? "none",
+      q,
+    ] as const,
   citySearch: (q: string) => ["travel", "places", "cities", q] as const,
   place: (placeId: number) => ["travel", "place", placeId] as const,
   weather: (tripId: number) => ["travel", "weather", tripId] as const,

--- a/fe/src/pages/travel/PlaceSearchPage.test.tsx
+++ b/fe/src/pages/travel/PlaceSearchPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -12,20 +12,50 @@ import { renderWithRouter } from "@/test/render";
 
 const API_BASE = "https://api.orino.dev/api";
 
+function city(placeId: number, name: string, cityPlaceRef: string) {
+  return {
+    placeId,
+    name,
+    timezone: "Asia/Tokyo",
+    currency: "JPY",
+    countryCode: "JP",
+    cityPlaceRef,
+    lat: 35.6762,
+    lng: 139.6503,
+  };
+}
+
+const OSAKA = city(21, "오사카", "ChIJ_osaka");
+const KYOTO = city(22, "교토", "ChIJ_kyoto");
+
 const DAYS = [
   {
+    dayId: 501,
     dayIndex: 1,
     date: "2026-10-24",
     weekday: "토",
     activityCount: 0,
+    baseCity: OSAKA,
+    cityChanged: false,
+    legIndex: 1,
+    cityMemo: null,
     weather: null,
+    stayTonight: null,
+    stayCheckout: null,
   },
   {
+    dayId: 502,
     dayIndex: 2,
     date: "2026-10-25",
     weekday: "일",
     activityCount: 0,
+    baseCity: KYOTO,
+    cityChanged: true,
+    legIndex: 2,
+    cityMemo: null,
     weather: null,
+    stayTonight: null,
+    stayCheckout: null,
   },
 ];
 
@@ -45,8 +75,10 @@ function place(overrides: Record<string, unknown> = {}) {
 
 function mockBoard() {
   server.use(
-    http.get(`${API_BASE}/travel/trips/:tripId/board`, () =>
-      HttpResponse.json({
+    http.get(`${API_BASE}/travel/trips/:tripId/board`, ({ request }) => {
+      // 서버처럼 요청한 날짜를 그대로 돌려준다 — 날짜를 무시하면 탭을 옮겨도 같은 날이다.
+      const date = new URL(request.url).searchParams.get("date");
+      return HttpResponse.json({
         code: "OK",
         data: {
           trip: {
@@ -60,13 +92,14 @@ function mockBoard() {
             recordMode: false,
           },
           days: DAYS,
-          selectedDate: DAYS[0].date,
+          selectedDate: date ?? DAYS[0].date,
           archiveCount: 0,
           activities: [],
           travelTimes: [],
+          stayMove: null,
         },
-      }),
-    ),
+      });
+    }),
   );
 }
 
@@ -360,6 +393,118 @@ describe("PlaceSearchPage", () => {
       );
 
       expect(await screen.findByLabelText("장소 검색")).toBeInTheDocument();
+    });
+
+    it("보던 날짜의 도시를 들고 온다 — 이 화면의 기본 조회로는 알 수 없는 값이다", async () => {
+      mockSearch();
+      const user = userEvent.setup();
+      // 2일차(교토)를 보는 중. 검색 화면의 기본 보드 조회는 1일차(오사카)를 돌려주므로,
+      // 들고 오지 않으면 교토에서 검색했는데 오사카로 편향되는 그 상태가 된다.
+      renderWithRouter(
+        <Providers>
+          <AppRouter />
+        </Providers>,
+        { initialEntries: ["/travel/trips/3/board?day=1"] },
+      );
+
+      await user.click(
+        await screen.findByRole("button", { name: "장소 검색" }),
+      );
+
+      expect(
+        await screen.findByRole("button", { name: "검색 기준 도시 교토" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("검색 기준 도시 (§2.7)", () => {
+    it("보던 날짜의 도시가 기준이 되고, placeholder도 따라간다", async () => {
+      const calls = mockSearch();
+      const user = userEvent.setup();
+      // 서버가 고른 날짜(1일차)는 오사카다.
+      renderSearch();
+
+      expect(
+        await screen.findByRole("button", { name: "검색 기준 도시 오사카" }),
+      ).toBeInTheDocument();
+      const input = screen.getByLabelText("장소 검색");
+      expect(input).toHaveAttribute("placeholder", "오사카 주변 장소 검색");
+
+      await user.type(input, "라멘{Enter}");
+
+      await waitFor(() => expect(calls).toHaveLength(1));
+      expect(calls[0].searchParams.get("city")).toBe("21");
+    });
+
+    it("`?city=`가 있으면 그 도시로 연다 — 보드에서 들고 온 값이다", async () => {
+      mockSearch();
+      renderSearch("/travel/trips/3/places?city=22");
+
+      expect(
+        await screen.findByRole("button", { name: "검색 기준 도시 교토" }),
+      ).toBeInTheDocument();
+    });
+
+    it("칩으로 도시를 바꾸면 그 자리에서 다시 검색하고 검색어는 남는다", async () => {
+      const calls = mockSearch();
+      const user = userEvent.setup();
+      renderSearch("/travel/trips/3/places?q=라멘");
+
+      await waitFor(() => expect(calls).toHaveLength(1));
+      expect(calls[0].searchParams.get("city")).toBe("21");
+
+      await user.click(
+        screen.getByRole("button", { name: "검색 기준 도시 오사카" }),
+      );
+      const sheet = await screen.findByRole("dialog");
+      await user.click(within(sheet).getByRole("button", { name: "교토" }));
+
+      // 도시가 바뀌면 다시 부른다 — 편향이 다르면 다른 결과다.
+      await waitFor(() => expect(calls).toHaveLength(2));
+      expect(calls[1].searchParams.get("city")).toBe("22");
+      // 검색어를 지우지 않는다 — 한 URL에 같이 산다.
+      expect(calls[1].searchParams.get("q")).toBe("라멘");
+      expect(screen.getByLabelText("장소 검색")).toHaveValue("라멘");
+    });
+
+    it("담을 때 기준 도시를 함께 보낸다 — 그래야 보관함에서 그 도시로 묶인다", async () => {
+      const created: Record<string, unknown>[] = [];
+      server.use(
+        http.post(
+          `${API_BASE}/travel/trips/:tripId/activities`,
+          async ({ request }) => {
+            created.push((await request.json()) as Record<string, unknown>);
+            return HttpResponse.json({ code: "OK", data: { id: 1 } });
+          },
+        ),
+      );
+      mockSearch();
+      const user = userEvent.setup();
+      renderSearch("/travel/trips/3/places?q=센소지&city=22");
+
+      await user.click(await screen.findByRole("button", { name: "담기" }));
+      const sheet = await screen.findByRole("dialog");
+      await user.click(within(sheet).getByRole("button", { name: /1일차/ }));
+
+      await waitFor(() => expect(created).toHaveLength(1));
+      expect(created[0].googlePlaceId).toBe("ChIJ_senso");
+      expect(created[0].cityPlaceId).toBe(22);
+    });
+
+    it("담기 시트는 기준 도시인 날짜를 위로 올린다 (#1134)", async () => {
+      mockSearch();
+      const user = userEvent.setup();
+      // 교토 기준이면 교토 날짜(2일차)가 먼저 나와야 한다.
+      renderSearch("/travel/trips/3/places?q=센소지&city=22");
+
+      await user.click(await screen.findByRole("button", { name: "담기" }));
+      const sheet = await screen.findByRole("dialog");
+
+      const dayButtons = within(sheet)
+        .getAllByRole("button")
+        .map((button) => button.textContent ?? "")
+        .filter((text) => text.includes("일차"));
+      expect(dayButtons[0]).toContain("2일차");
     });
   });
 });

--- a/fe/src/pages/travel/PlaceSearchPage.tsx
+++ b/fe/src/pages/travel/PlaceSearchPage.tsx
@@ -8,11 +8,14 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { LoadingText } from "@/components/ui/loading-text";
+import type { BaseCity } from "@/features/travel/api/activities";
 import type { PlaceSearchResult } from "@/features/travel/api/places";
 import { createManualPlace } from "@/features/travel/api/places";
 import { useCreateActivity } from "@/features/travel/hooks/useActivityMutations";
 import { useBoard } from "@/features/travel/hooks/useBoard";
 import { usePlaceSearch } from "@/features/travel/hooks/usePlaceSearch";
+import { daysForPlace } from "@/features/travel/lib/archiveGroups";
+import { cityOn, tripCities } from "@/features/travel/lib/baseCity";
 import {
   addRecentSearch,
   clearRecentSearches,
@@ -21,6 +24,7 @@ import {
 import { GoogleAttribution } from "@/features/travel/places/GoogleAttribution";
 import { PickDaySheet } from "@/features/travel/places/PickDaySheet";
 import { PlaceCard } from "@/features/travel/places/PlaceCard";
+import { SearchCityChip } from "@/features/travel/places/SearchCityChip";
 import { toast } from "@/shared/lib/toast";
 
 /** 담기 대상 — 검색 결과이거나, 직접 입력해서 방금 만든 장소. */
@@ -45,6 +49,9 @@ export function PlaceSearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const query = searchParams.get("q") ?? "";
   const [draft, setDraft] = useState(query);
+  /** 기준 도시도 URL이 소유한다(§9.7) — 새로고침·뒤로가기에서 살아남아야 한다. */
+  const cityParam = Number(searchParams.get("city"));
+  const [citySheetOpen, setCitySheetOpen] = useState(false);
 
   const [recent, setRecent] = useState<string[]>(() =>
     Number.isFinite(tripId) ? getRecentSearches(tripId) : [],
@@ -57,21 +64,50 @@ export function PlaceSearchPage() {
   // 뒤로 가기로 검색어가 바뀌면 입력창도 따라가야 한다.
   useEffect(() => setDraft(query), [query]);
 
-  const { data: places, isPending, isError } = usePlaceSearch(query, tripId);
-  const { data: board } = useBoard(tripId, {});
+  const { data: board, isPending: boardPending } = useBoard(tripId, {});
+  const cities = tripCities(board?.days ?? []);
+  /**
+   * 검색이 기준으로 삼는 도시. `?city=`가 있으면 그 도시, 없으면 <b>보고 있던 날짜의</b>
+   * 도시다 — 교토 날짜를 보다가 검색으로 들어왔으면 교토가 기준이어야 한다.
+   */
+  const city =
+    cities.find((c) => c.placeId === cityParam) ??
+    cityOn(board?.days ?? [], board?.selectedDate ?? "") ??
+    cities[0] ??
+    null;
+
+  const {
+    data: places,
+    isPending,
+    isError,
+    // 보드가 오기 전에 부르면 편향 없는 결과를 한 번 사게 된다(호출당 과금).
+  } = usePlaceSearch(query, tripId, city?.placeId, !boardPending);
   const createActivity = useCreateActivity(tripId);
+
+  /** 검색어·도시가 한 URL에 같이 산다 — 한쪽을 바꿀 때 다른 쪽을 지우면 안 된다. */
+  const setParams = (next: { q?: string; city?: number }) => {
+    const merged = new URLSearchParams(searchParams);
+    if (next.q !== undefined) merged.set("q", next.q);
+    if (next.city !== undefined) merged.set("city", String(next.city));
+    setSearchParams(merged, { replace: true });
+  };
 
   const submit = (event: FormEvent) => {
     event.preventDefault();
     const trimmed = draft.trim();
     if (!trimmed) return;
     setRecent(addRecentSearch(tripId, trimmed));
-    setSearchParams({ q: trimmed });
+    setParams({ q: trimmed });
   };
 
   const searchFor = (q: string) => {
     setRecent(addRecentSearch(tripId, q));
-    setSearchParams({ q });
+    setParams({ q });
+  };
+
+  const selectCity = (next: BaseCity) => {
+    setCitySheetOpen(false);
+    setParams({ city: next.placeId });
   };
 
   const add = (date: string | null) => {
@@ -81,7 +117,9 @@ export function PlaceSearchPage() {
         title: target.name,
         activityDate: date,
         ...(target.kind === "google"
-          ? { googlePlaceId: target.googlePlaceId }
+          ? // 어느 도시를 기준으로 찾았는지 함께 보낸다 — 그래야 담은 장소가 보관함
+            // 도시 그룹과 도시 이탈 표시에서 `도시 없음`으로 떨어지지 않는다.
+            { googlePlaceId: target.googlePlaceId, cityPlaceId: city?.placeId }
           : { placeId: target.placeId }),
       },
       {
@@ -136,12 +174,20 @@ export function PlaceSearchPage() {
         <Input
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
-          placeholder="장소 검색"
+          placeholder={city ? `${city.name} 주변 장소 검색` : "장소 검색"}
           aria-label="장소 검색"
           maxLength={100}
           autoFocus
         />
       </form>
+
+      <SearchCityChip
+        city={city}
+        cities={cities}
+        open={citySheetOpen}
+        onOpenChange={setCitySheetOpen}
+        onSelect={selectCity}
+      />
 
       {query === "" ? (
         recent.length === 0 ? (
@@ -225,7 +271,8 @@ export function PlaceSearchPage() {
         open={target !== null}
         onOpenChange={(open) => !open && setTarget(null)}
         placeName={target?.name ?? null}
-        days={board?.days ?? []}
+        // 기준 도시가 곧 그 장소의 도시다 — 그 도시인 날짜를 위로 올린다(#1134).
+        days={daysForPlace(board?.days ?? [], city?.cityPlaceRef)}
         onPick={add}
         pending={createActivity.isPending}
       />

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -72,6 +72,7 @@ import {
   daysForPlace,
   groupArchiveByCity,
 } from "@/features/travel/lib/archiveGroups";
+import { tripCities } from "@/features/travel/lib/baseCity";
 import { directionsUrl } from "@/features/travel/lib/mapsLink";
 import {
   badgeAboveList,
@@ -238,13 +239,20 @@ export function TripBoardPage() {
    * 이 여행에 등장하는 도시들. 기준 도시를 바꿀 때 가장 자주 고르는 후보라 시트 위쪽에
    * 그대로 올린다 — 도쿄↔닛코를 오가는 변경에 매번 검색을 시킬 이유가 없다.
    */
-  const tripCities = [
-    ...new Map(
-      board.days
-        .flatMap((day) => (day.baseCity ? [day.baseCity] : []))
-        .map((city) => [city.placeId, city]),
-    ).values(),
-  ];
+  const cities = tripCities(board.days);
+
+  /**
+   * 장소 검색으로 넘어간다. <b>보고 있던 날짜의 도시를 들고 간다</b>(§2.7) — 교토 날짜를
+   * 보다가 검색으로 들어왔으면 교토 가게가 나와야 한다. 보관함에는 날짜가 없어 그냥 간다.
+   */
+  const searchPlaces = () => {
+    const city = selectedCity;
+    navigate(
+      city
+        ? `/travel/trips/${tripId}/places?city=${city.placeId}`
+        : `/travel/trips/${tripId}/places`,
+    );
+  };
 
   /** 보관함은 순서가 아니라 도시로 읽는다. 보고 있지 않으면 계산할 이유가 없다. */
   const archiveGroups = isArchive
@@ -705,11 +713,7 @@ export function TripBoardPage() {
               ? "가고 싶은 곳을 미리 담아두세요"
               : "일정이 없어요"}
           </p>
-          <Button
-            variant="outline"
-            disabled={!online}
-            onClick={() => navigate(`/travel/trips/${tripId}/places`)}
-          >
+          <Button variant="outline" disabled={!online} onClick={searchPlaces}>
             <Search className="size-4" />
             장소 검색
           </Button>
@@ -745,7 +749,7 @@ export function TripBoardPage() {
         targetDate={selectedDate}
         onCreate={(input) => void addActivity(input)}
         onPickFromArchive={(a) => void pickFromArchive(a)}
-        onSearchPlaces={() => navigate(`/travel/trips/${tripId}/places`)}
+        onSearchPlaces={searchPlaces}
         pending={createActivity.isPending || updateActivity.isPending}
       />
 
@@ -762,7 +766,7 @@ export function TripBoardPage() {
 
       <BaseCitySheet
         day={cityDay}
-        tripCities={tripCities}
+        tripCities={cities}
         onOpenChange={(open) => !open && setCityDay(null)}
         onSubmit={(body) => void saveDay(body)}
         pending={updateDay.isPending}


### PR DESCRIPTION
## 이슈
closes #1145

## 작업 내용

**교토에서 검색하면 교토 가게가 나온다.** 그리고 그렇게 담은 장소가 보관함에서 그 도시 그룹으로 묶인다 — #1134가 여기서 살아난다.

### BE

- `GET /places/search`에 **`city=`(도시 placeId)** 추가. 주면 그 도시로 편향하고, 없으면 지금처럼 첫날 도시
  - **조용히 첫날로 떨어뜨리지 않는다.** 남의 도시·없는 도시는 404, 가게를 도시로 주면 400 — 화면이 "교토"라고 말하면서 오사카 결과를 주는 것이 이 이슈가 없애려는 바로 그 상태다
  - 편향 좌표가 이미 캐시 키에 있어 도시를 바꾸면 자연히 다른 검색이다
- `POST/PUT /activities`에 **`cityPlaceId`** 추가 → `upsertFromGoogle`이 그 도시의 `city_place_ref`를 장소에 저장

### FE

- 기준 도시 칩 + 도시 선택 시트, placeholder도 `{도시} 주변 장소 검색`
- `?city=`를 URL이 소유하고, `?q=`와 **한 주소에 같이 산다** — 한쪽을 바꿀 때 다른 쪽을 지우지 않는다(기존 `setSearchParams({q})`가 통째로 덮고 있었다)
- **보드가 보던 날짜의 도시를 `?city=`로 들고 간다.** 검색 화면의 보드 조회는 날짜를 지정하지 않아 서버 기본값(1일차)이 오므로, 들고 오지 않으면 교토 날짜를 보다 들어와도 오사카로 편향된다
- 담기 시트가 기준 도시인 날짜를 위로 올린다 — 보드에는 있던 정렬(`daysForPlace`)이 이 화면에는 빠져 있었다

## 판단이 갈릴 수 있는 곳 (리뷰 요청)

**1. 도시 식별자는 "어느 도시에서 찾았는지"로만 채운다.** 구글 상세 응답은 도시 **이름**만 주고 도시의 장소 id는 주지 않아서, 칩 말고는 출처가 없다. 검색은 필터가 아니라 편향이라 교토 칩으로 오사카 가게가 나올 수도 있고, 그 경우 식별자가 실제와 어긋난다. 좌표로 되짚는 대안은 D-23이 막는다. 지금의 절충은 이슈 본문이 정한 방향이지만 한계는 분명하니 남겨 둔다.

**2. 도시 이름은 구글 것을, 식별자는 칩 것을 쓴다.** 이름은 상세 응답 쪽이 정확하고, 식별자는 거기 없다.

**3. 이미 담긴 장소의 도시는 덮지 않는다.** 나중에 다른 칩으로 같은 장소를 다시 담았다고 처음 알던 도시가 바뀌면, 그 장소가 붙은 **다른 날짜의 판정까지** 조용히 흔들린다. 대신 **이미 저장된 장소는 계속 식별자가 없다** — 과거 데이터 백필은 이 PR에 넣지 않았다.

**4. 보드 응답이 오기 전에는 검색하지 않게 했다(범위 밖 수정).** 테스트를 쓰다 발견했다. 기준 도시를 모르는 채로 먼저 부르면 편향 없는 결과가 잠깐 보였다가 도시가 정해지며 다시 부른다 — 틀린 결과를 보여주고 호출당 과금도 두 배다.

## 테스트

- BE — 칩 도시로 편향(첫날 도시가 아님) · 도시가 바뀌면 캐시 재사용 안 함 · 남의 도시 404 · 가게 400 · **담은 장소에 식별자가 붙는다** · 칩 없으면 식별자도 없다 · 직접 입력 도시는 붙일 게 없다 · 이미 담긴 장소는 안 덮는다
- FE — 보던 날짜의 도시가 기본값이고 placeholder도 따라간다 · `?city=`로 열기 · 칩으로 바꾸면 재검색하고 검색어는 남는다 · 담을 때 `cityPlaceId`가 실린다 · 담기 시트 정렬 · **보드에서 들고 온 도시**(이 화면의 기본 조회로는 알 수 없는 값이다)
- E2E — **실제 브라우저에서** 도시 변경 → `page.url()`에 `city=22` → **새로고침** → 그대로 교토. URL 소유는 메모리 라우터에서 컴포넌트 state와 구분되지 않아 여기서만 증명된다

## 게이트

- `cd be && ./gradlew check` ✅
- `cd fe && npm run format:check && npm run lint && npm test && npm run build` ✅ (980 tests)
- `npx playwright test` ✅ (90 passed)

## 위키

[Travel-API-Spec](https://github.com/wcorn/orino/wiki/Travel-API-Spec) — `city=` 파라미터와 `cityPlaceId` 저장 규칙 · [Travel-UI-Design §2.7](https://github.com/wcorn/orino/wiki/Travel-UI-Design) — 칩 동작과 URL 소유
