### PR TITLE
feat : S-05 지도 이 날짜/전체 토글 + 구간 리스트

### DIFF
--- a/fe/e2e/travel-map-mode.spec.ts
+++ b/fe/e2e/travel-map-mode.spec.ts
@@ -1,0 +1,203 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 지도 `이 날짜` / `전체` 토글(S-05, #1144).
+ *
+ * <p>여기서 확인하는 것은 <b>보던 모드가 새로고침에서 살아남는가</b>다. 상태를 URL이 소유해야
+ * 한다는 규칙(§9.7)은 진짜 주소창과 진짜 새로고침으로만 증명된다.
+ *
+ * <p>마커 자체는 확인하지 않는다 — 구글 지도 SDK는 여기서 뜨지 않는다. 도시당 하나·첫 방문
+ * 번호 규칙은 `lib/cityMarkers` 단위 테스트가, 핀을 실제로 찍는 일은 `TripMap` 테스트가 맡는다.
+ */
+
+const TRIP_ID = 1;
+const D1 = "2026-10-24";
+const D2 = "2026-10-25";
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+function city(placeId: number, name: string) {
+  return {
+    placeId,
+    name,
+    timezone: "Asia/Tokyo",
+    currency: "JPY",
+    countryCode: "JP",
+    cityPlaceRef: `ChIJ_${placeId}`,
+    lat: 35.68,
+    lng: 139.76,
+  };
+}
+
+/** 도쿄 → 닛코 → 도쿄. 구간 셋, 도시 둘. */
+const CITY_LEGS = [
+  {
+    legIndex: 1,
+    cityPlaceId: 21,
+    cityName: "도쿄",
+    days: 1,
+    startDate: D1,
+    endDate: D1,
+    timezone: "Asia/Tokyo",
+    lat: 35.68,
+    lng: 139.76,
+  },
+  {
+    legIndex: 2,
+    cityPlaceId: 22,
+    cityName: "닛코",
+    days: 1,
+    startDate: D2,
+    endDate: D2,
+    timezone: "Asia/Tokyo",
+    lat: 36.75,
+    lng: 139.6,
+  },
+];
+
+async function mockTrip(page: Page) {
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/planner/reviews/summary", (route) =>
+    route.fulfill(
+      ok({
+        today: D1,
+        counts: { now: 0, overdue: 0, upcoming: 0, doneToday: 0 },
+        estimatedMinutes: 0,
+        materials: [],
+      }),
+    ),
+  );
+  await page.route("**/api/travel/summary", (route) =>
+    route.fulfill(ok({ ongoing: null, next: null, recentCompleted: null })),
+  );
+  await page.route("**/api/travel/trips/*/stays", (route) =>
+    route.fulfill(ok([])),
+  );
+  await page.route("**/api/travel/trips/*/city-legs", (route) =>
+    route.fulfill(ok(CITY_LEGS)),
+  );
+
+  await page.route(`**/api/travel/trips/${TRIP_ID}/board*`, (route) => {
+    const date = new URL(route.request().url()).searchParams.get("date") ?? D1;
+    return route.fulfill(
+      ok({
+        trip: {
+          id: TRIP_ID,
+          title: "일본",
+          startDate: D1,
+          endDate: D2,
+          status: "UPCOMING",
+          recordMode: false,
+          cityCount: 2,
+          countryCount: 1,
+          singleCity: false,
+        },
+        days: [
+          {
+            dayId: 501,
+            dayIndex: 1,
+            date: D1,
+            weekday: "토",
+            activityCount: 1,
+            baseCity: city(21, "도쿄"),
+            cityChanged: false,
+            legIndex: 1,
+            cityMemo: null,
+            weather: null,
+            stayTonight: null,
+            stayCheckout: null,
+          },
+          {
+            dayId: 502,
+            dayIndex: 2,
+            date: D2,
+            weekday: "일",
+            activityCount: 0,
+            baseCity: city(22, "닛코"),
+            cityChanged: true,
+            legIndex: 2,
+            cityMemo: null,
+            weather: null,
+            stayTonight: null,
+            stayCheckout: null,
+          },
+        ],
+        selectedDate: date,
+        archiveCount: 0,
+        activities:
+          date === D1
+            ? [
+                {
+                  id: 1,
+                  tripId: TRIP_ID,
+                  title: "센소지",
+                  activityDate: D1,
+                  startTime: "09:00",
+                  place: {
+                    id: 10,
+                    name: "센소지",
+                    address: "다이토구",
+                    lat: 35.7147,
+                    lng: 139.7966,
+                    cityName: "도쿄",
+                    cityPlaceRef: "ChIJ_21",
+                  },
+                  memo: null,
+                  url: null,
+                  notifyEnabled: false,
+                  notifyMinutes: null,
+                  departureNotifyEnabled: false,
+                  sortOrder: 0,
+                  log: null,
+                  hasLog: false,
+                  outOfBaseCity: false,
+                  canDepartureNotify: false,
+                },
+              ]
+            : [],
+        travelTimes: [],
+        stayMove: null,
+      }),
+    );
+  });
+}
+
+test.describe("지도 범위 토글", () => {
+  test("전체로 바꾸면 새로고침해도 그대로고, 구간 행이 그 구간 첫날로 데려간다", async ({
+    page,
+  }) => {
+    await mockTrip(page);
+    await page.goto(`/travel/trips/${TRIP_ID}/map`);
+
+    // 기본은 하루다.
+    await expect(
+      page.getByRole("heading", { name: "1일차 동선" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "전체" }).click();
+    await expect(
+      page.getByRole("heading", { name: "여행 전체" }),
+    ).toBeVisible();
+    await expect(page.getByText("도시 2곳 · 구간 순서")).toBeVisible();
+
+    // 상태를 URL이 갖는다 — 주소에 남고 새로고침을 넘긴다(§9.7).
+    expect(page.url()).toContain("mode=all");
+    await page.reload();
+    await expect(
+      page.getByRole("heading", { name: "여행 전체" }),
+    ).toBeVisible();
+
+    // 구간 행을 누르면 그 구간 첫날 보드가 열린다.
+    await page.getByRole("button", { name: /닛코/ }).click();
+    await expect(page.getByRole("tab").nth(1)).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+});

--- a/fe/src/features/travel/hooks/useCityLegs.ts
+++ b/fe/src/features/travel/hooks/useCityLegs.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchCityLegs } from "../api/travel";
+import { travelKeys } from "../queryKeys";
+
+/**
+ * 파생 구간(§2.4). 연속으로 같은 기준 도시인 날짜의 묶음이다.
+ *
+ * <p><b>저장된 값이 아니라 날짜에서 매번 계산된다</b> — 하루의 기준 도시를 바꾸면 다음
+ * 조회에서 곧바로 반영된다. 그래서 앞뒤 구간의 번호까지 함께 달라질 수 있다.
+ *
+ * <p>지도의 `전체` 모드에서만 필요하다. `이 날짜`를 보는 동안 부르면 아무도 보지 않을 값을
+ * 받아 오는 것이라 `enabled`로 막는다.
+ */
+export function useCityLegs(
+  tripId: number,
+  options: { enabled?: boolean } = {},
+) {
+  return useQuery({
+    queryKey: travelKeys.cityLegs(tripId),
+    queryFn: () => fetchCityLegs(tripId),
+    staleTime: 10_000,
+    enabled: options.enabled ?? true,
+  });
+}

--- a/fe/src/features/travel/lib/cityMarkers.test.ts
+++ b/fe/src/features/travel/lib/cityMarkers.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import type { CityLeg } from "@/features/travel/api/travel";
+
+import { cityMarkers, legPath } from "./cityMarkers";
+
+function leg(
+  legIndex: number,
+  cityPlaceId: number,
+  cityName: string,
+  overrides: Partial<CityLeg> = {},
+): CityLeg {
+  return {
+    legIndex,
+    cityPlaceId,
+    cityName,
+    days: 2,
+    startDate: "2026-10-24",
+    endDate: "2026-10-25",
+    timezone: "Asia/Tokyo",
+    lat: 35.68 + legIndex,
+    lng: 139.76 + legIndex,
+    ...overrides,
+  };
+}
+
+/** 도쿄 → 닛코 → 도쿄. 구간은 셋, 도시는 둘이다. */
+const NIKKO_TRIP = [leg(1, 21, "도쿄"), leg(2, 22, "닛코"), leg(3, 21, "도쿄")];
+
+describe("도시 마커", () => {
+  it("같은 도시를 다시 방문해도 마커는 하나다", () => {
+    expect(cityMarkers(NIKKO_TRIP)).toHaveLength(2);
+  });
+
+  it("번호는 첫 방문 구간 것을 쓴다 — 도쿄는 3이 아니라 1이다", () => {
+    const markers = cityMarkers(NIKKO_TRIP);
+
+    expect(markers[0]).toMatchObject({ cityName: "도쿄", legIndex: 1 });
+    expect(markers[1]).toMatchObject({ cityName: "닛코", legIndex: 2 });
+  });
+
+  it("좌표를 모르는 도시는 찍지 않는다 — 지도에 놓을 자리가 없다", () => {
+    const markers = cityMarkers([
+      leg(1, 21, "도쿄"),
+      leg(2, 23, "하코네", { lat: null, lng: null }),
+    ]);
+
+    expect(markers.map((m) => m.cityName)).toEqual(["도쿄"]);
+  });
+
+  it("이름을 모르면 `도시 없음`으로 둔다 — 빈 칸을 남기지 않는다", () => {
+    expect(
+      cityMarkers([leg(1, 21, "도쿄", { cityName: null })])[0],
+    ).toMatchObject({ cityName: "도시 없음" });
+  });
+
+  it("구간이 없으면 마커도 없다", () => {
+    expect(cityMarkers([])).toEqual([]);
+  });
+});
+
+describe("연결선", () => {
+  it("구간 순서 그대로다 — 마커처럼 접지 않는다", () => {
+    // 접어 버리면 닛코에 갔다 온 사실이 선에서 사라진다.
+    expect(legPath(NIKKO_TRIP)).toHaveLength(3);
+  });
+
+  it("좌표를 모르는 구간은 건너뛴다", () => {
+    const path = legPath([
+      leg(1, 21, "도쿄"),
+      leg(2, 23, "하코네", { lat: null, lng: null }),
+      leg(3, 22, "닛코"),
+    ]);
+
+    expect(path).toHaveLength(2);
+  });
+});

--- a/fe/src/features/travel/lib/cityMarkers.ts
+++ b/fe/src/features/travel/lib/cityMarkers.ts
@@ -1,0 +1,53 @@
+import type { CityLeg } from "@/features/travel/api/travel";
+
+/** 지도에 찍히는 도시 하나. */
+export interface CityMarker {
+  cityPlaceId: number;
+  /** **첫 방문** 구간 번호. 같은 도시를 다시 들러도 처음 번호를 그대로 쓴다. */
+  legIndex: number;
+  cityName: string;
+  lat: number;
+  lng: number;
+}
+
+interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+/**
+ * 구간에서 도시 마커를 만든다 — **도시당 하나**.
+ *
+ * <p>도쿄 → 닛코 → 도쿄처럼 같은 도시를 다시 방문하면 구간은 셋이지만 지도 위의 점은 둘이다.
+ * 번호는 <b>첫 방문 구간</b> 것을 쓴다 — 같은 점에 2와 3을 겹쳐 쓸 수 없고, 둘 중 나중 것을
+ * 고르면 "도쿄가 3번째 도시"로 읽혀 여행의 시작이 어디였는지 흐려진다.
+ *
+ * <p>좌표가 없는 도시(직접 입력)는 뺀다. 지도에 찍을 자리가 없다.
+ */
+export function cityMarkers(legs: CityLeg[]): CityMarker[] {
+  const byCity = new Map<number, CityMarker>();
+  for (const leg of legs) {
+    if (leg.lat === null || leg.lng === null) continue;
+    if (byCity.has(leg.cityPlaceId)) continue;
+    byCity.set(leg.cityPlaceId, {
+      cityPlaceId: leg.cityPlaceId,
+      legIndex: leg.legIndex,
+      cityName: leg.cityName ?? "도시 없음",
+      lat: leg.lat,
+      lng: leg.lng,
+    });
+  }
+  return [...byCity.values()];
+}
+
+/**
+ * 연결선은 <b>구간 순서 그대로</b>다 — 마커처럼 접지 않는다.
+ *
+ * <p>도쿄 → 닛코 → 도쿄는 점 둘, 선은 갔다 오는 두 획이다. 마커를 따라 선을 그으면 닛코에
+ * 갔다 온 사실이 사라진다.
+ */
+export function legPath(legs: CityLeg[]): LatLng[] {
+  return legs
+    .filter((leg) => leg.lat !== null && leg.lng !== null)
+    .map((leg) => ({ lat: leg.lat as number, lng: leg.lng as number }));
+}

--- a/fe/src/features/travel/map/TripMap.test.tsx
+++ b/fe/src/features/travel/map/TripMap.test.tsx
@@ -2,8 +2,8 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { resetGoogleMapsLoader } from "./googleMaps";
-import type { MappedActivity } from "./toMapped";
-import { TripDayMap } from "./TripDayMap";
+import type { MapPoint } from "./TripMap";
+import { TripMap } from "./TripMap";
 
 /**
  * jsdom에는 구글 지도가 없다. <b>브라우저가 주는 것</b>이라 대역을 세운다 —
@@ -77,16 +77,17 @@ function stubGoogleMaps() {
   };
 }
 
-function activity(id: number, title: string, order: number): MappedActivity {
+function point(key: number, title: string, order: number): MapPoint {
   return {
+    key,
     order,
-    lat: 35.7 + id / 100,
-    lng: 139.7 + id / 100,
-    activity: { id, title } as MappedActivity["activity"],
+    title,
+    lat: 35.7 + key / 100,
+    lng: 139.7 + key / 100,
   };
 }
 
-describe("TripDayMap", () => {
+describe("TripMap", () => {
   beforeEach(() => {
     resetGoogleMapsLoader();
   });
@@ -101,10 +102,11 @@ describe("TripDayMap", () => {
     it("키가 없으면 안내를 대신 보여준다 — 빈 회색 상자로 두지 않는다", async () => {
       delete (window as { google?: unknown }).google;
       render(
-        <TripDayMap
-          mapped={[activity(1, "센소지", 1)]}
-          selectedId={null}
+        <TripMap
+          points={[point(1, "센소지", 1)]}
+          selectedKey={null}
           onSelect={() => {}}
+          label="하루 동선 지도"
         />,
       );
 
@@ -119,12 +121,13 @@ describe("TripDayMap", () => {
       stubGoogleMaps();
     });
 
-    it("일정마다 번호 핀을 찍는다", async () => {
+    it("점마다 번호 핀을 찍는다", async () => {
       render(
-        <TripDayMap
-          mapped={[activity(1, "센소지", 1), activity(2, "시부야", 2)]}
-          selectedId={null}
+        <TripMap
+          points={[point(1, "센소지", 1), point(2, "시부야", 2)]}
+          selectedKey={null}
           onSelect={() => {}}
+          label="하루 동선 지도"
         />,
       );
 
@@ -133,13 +136,14 @@ describe("TripDayMap", () => {
       expect(markers[0].title).toBe("1. 센소지");
     });
 
-    it("핀을 누르면 그 일정을 고른다", async () => {
+    it("핀을 누르면 그 점을 고른다", async () => {
       const onSelect = vi.fn();
       render(
-        <TripDayMap
-          mapped={[activity(7, "센소지", 1)]}
-          selectedId={null}
+        <TripMap
+          points={[point(7, "센소지", 1)]}
+          selectedKey={null}
           onSelect={onSelect}
+          label="하루 동선 지도"
         />,
       );
 
@@ -151,14 +155,11 @@ describe("TripDayMap", () => {
 
     it("두 곳 이상이면 순서대로 직선을 잇는다 — 실제 경로가 아니라 순서다", async () => {
       render(
-        <TripDayMap
-          mapped={[
-            activity(1, "a", 1),
-            activity(2, "b", 2),
-            activity(3, "c", 3),
-          ]}
-          selectedId={null}
+        <TripMap
+          points={[point(1, "a", 1), point(2, "b", 2), point(3, "c", 3)]}
+          selectedKey={null}
           onSelect={() => {}}
+          label="하루 동선 지도"
         />,
       );
 
@@ -166,12 +167,34 @@ describe("TripDayMap", () => {
       expect(polylines[0].path).toHaveLength(3);
     });
 
+    it("경로를 따로 주면 점이 아니라 그 경로로 잇는다 — 오간 자취가 선에 남는다", async () => {
+      // 도쿄 → 닛코 → 도쿄: 점은 둘, 획은 둘이다.
+      render(
+        <TripMap
+          points={[point(1, "도쿄", 1), point(2, "닛코", 2)]}
+          path={[
+            { lat: 35.68, lng: 139.76 },
+            { lat: 36.75, lng: 139.6 },
+            { lat: 35.68, lng: 139.76 },
+          ]}
+          selectedKey={null}
+          onSelect={() => {}}
+          label="여행 전체 지도"
+        />,
+      );
+
+      await waitFor(() => expect(polylines).toHaveLength(1));
+      expect(polylines[0].path).toHaveLength(3);
+      expect(markers).toHaveLength(2);
+    });
+
     it("한 곳뿐이면 선을 긋지 않는다", async () => {
       render(
-        <TripDayMap
-          mapped={[activity(1, "a", 1)]}
-          selectedId={null}
+        <TripMap
+          points={[point(1, "a", 1)]}
+          selectedKey={null}
           onSelect={() => {}}
+          label="하루 동선 지도"
         />,
       );
 
@@ -181,10 +204,11 @@ describe("TripDayMap", () => {
 
     it("핀이 전부 들어오게 범위를 맞춘다", async () => {
       render(
-        <TripDayMap
-          mapped={[activity(1, "a", 1), activity(2, "b", 2)]}
-          selectedId={null}
+        <TripMap
+          points={[point(1, "a", 1), point(2, "b", 2)]}
+          selectedKey={null}
           onSelect={() => {}}
+          label="하루 동선 지도"
         />,
       );
 
@@ -194,10 +218,11 @@ describe("TripDayMap", () => {
 
     it("고른 핀은 크게 그린다 — 어느 것을 보고 있는지 알아야 한다", async () => {
       render(
-        <TripDayMap
-          mapped={[activity(1, "a", 1), activity(2, "b", 2)]}
-          selectedId={2}
+        <TripMap
+          points={[point(1, "a", 1), point(2, "b", 2)]}
+          selectedKey={2}
           onSelect={() => {}}
+          label="하루 동선 지도"
         />,
       );
 

--- a/fe/src/features/travel/map/TripMap.tsx
+++ b/fe/src/features/travel/map/TripMap.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from "react";
 
 import { mapId, useGoogleMaps } from "./googleMaps";
-import type { MappedActivity } from "./toMapped";
 
 /** 핀 하나. leaflet divIcon으로 그리던 것과 같은 모양이라 화면은 그대로다. */
 function pinElement(order: number, selected: boolean): HTMLElement {
@@ -27,14 +26,42 @@ function pinElement(order: number, selected: boolean): HTMLElement {
   return el;
 }
 
-interface TripDayMapProps {
-  mapped: MappedActivity[];
-  selectedId: number | null;
-  onSelect: (activityId: number) => void;
+/** 지도 위의 점 하나. 하루 동선에서는 일정이고, 여행 전체에서는 도시다. */
+export interface MapPoint {
+  /** 선택·클릭이 가리키는 값 — 일정 id이거나 도시 placeId다. */
+  key: number;
+  /** 핀에 찍히는 번호. */
+  order: number;
+  lat: number;
+  lng: number;
+  title: string;
+}
+
+interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+interface TripMapProps {
+  points: MapPoint[];
+  /**
+   * 연결선 경로. 생략하면 점 순서 그대로 잇는다.
+   *
+   * <p>따로 받는 이유는 <b>점보다 획이 많을 수 있어서</b>다 — 도쿄 → 닛코 → 도쿄는 점이
+   * 둘이지만 선은 갔다 오는 두 획이다.
+   */
+  path?: LatLng[];
+  selectedKey: number | null;
+  onSelect: (key: number) => void;
+  /** 스크린리더용 이름. 무엇을 그린 지도인지는 모드마다 다르다. */
+  label: string;
 }
 
 /**
- * 하루 동선(§S-05).
+ * 여행 지도(§S-05) — 하루 동선과 여행 전체가 <b>같은 지도</b>를 쓴다.
+ *
+ * <p>다른 것은 무엇을 점으로 찍느냐뿐이고, SDK 수명주기·정리·불러오기 실패 처리는 같다.
+ * 모드마다 지도를 따로 만들면 그 까다로운 부분이 두 벌이 된다.
  *
  * <p>연결선은 <b>직선</b>이다 — 실제 경로가 아니라 순서를 보여주는 선이다. 실제 길찾기는
  * 구글 지도 딥링크가 맡으므로 여기서 경로를 그릴 이유가 없다.
@@ -42,7 +69,13 @@ interface TripDayMapProps {
  * <p>구글 지도를 쓴다. 이 화면은 이동시간(Routes 콘텐츠)을 지도 옆에 얹으므로 비구글
  * 지도를 쓸 수 없다(#1102).
  */
-export function TripDayMap({ mapped, selectedId, onSelect }: TripDayMapProps) {
+export function TripMap({
+  points,
+  path,
+  selectedKey,
+  onSelect,
+  label,
+}: TripMapProps) {
   const status = useGoogleMaps();
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<google.maps.Map | null>(null);
@@ -53,10 +86,11 @@ export function TripDayMap({ mapped, selectedId, onSelect }: TripDayMapProps) {
   selectRef.current = onSelect;
 
   useEffect(() => {
-    if (status !== "ready" || !containerRef.current || mapped.length === 0) {
+    if (status !== "ready" || !containerRef.current || points.length === 0) {
       return;
     }
     const maps = window.google.maps;
+    const line = path ?? points.map(({ lat, lng }) => ({ lat, lng }));
 
     mapRef.current ??= new maps.Map(containerRef.current, {
       mapId: mapId(),
@@ -64,43 +98,45 @@ export function TripDayMap({ mapped, selectedId, onSelect }: TripDayMapProps) {
       disableDefaultUI: true,
       gestureHandling: "greedy",
       zoom: 14,
-      center: { lat: mapped[0].lat, lng: mapped[0].lng },
+      center: { lat: points[0].lat, lng: points[0].lng },
     });
     const map = mapRef.current;
 
     markersRef.current.forEach((m) => (m.map = null));
-    markersRef.current = mapped.map((m) => {
+    markersRef.current = points.map((point) => {
       const marker = new maps.marker.AdvancedMarkerElement({
         map,
-        position: { lat: m.lat, lng: m.lng },
-        content: pinElement(m.order, m.activity.id === selectedId),
-        title: `${m.order}. ${m.activity.title}`,
+        position: { lat: point.lat, lng: point.lng },
+        content: pinElement(point.order, point.key === selectedKey),
+        title: `${point.order}. ${point.title}`,
       });
-      marker.addListener("click", () => selectRef.current(m.activity.id));
+      marker.addListener("click", () => selectRef.current(point.key));
       return marker;
     });
 
     lineRef.current?.setMap(null);
     lineRef.current =
-      mapped.length > 1
+      line.length > 1
         ? new maps.Polyline({
             map,
-            path: mapped.map((m) => ({ lat: m.lat, lng: m.lng })),
+            path: line,
             strokeColor: "#8b00ff",
             strokeWeight: 3,
           })
         : null;
 
     // 핀이 전부 들어오게 범위를 맞춘다.
-    if (mapped.length === 1) {
-      map.setCenter({ lat: mapped[0].lat, lng: mapped[0].lng });
+    if (points.length === 1) {
+      map.setCenter({ lat: points[0].lat, lng: points[0].lng });
       map.setZoom(15);
     } else {
       const bounds = new maps.LatLngBounds();
-      mapped.forEach((m) => bounds.extend({ lat: m.lat, lng: m.lng }));
+      points.forEach((point) =>
+        bounds.extend({ lat: point.lat, lng: point.lng }),
+      );
       map.fitBounds(bounds, 24);
     }
-  }, [status, mapped, selectedId]);
+  }, [status, points, path, selectedKey]);
 
   useEffect(() => {
     return () => {
@@ -124,7 +160,7 @@ export function TripDayMap({ mapped, selectedId, onSelect }: TripDayMapProps) {
     <div
       ref={containerRef}
       role="application"
-      aria-label="하루 동선 지도"
+      aria-label={label}
       className="bg-muted aspect-[8/5] w-full overflow-hidden rounded-lg border"
     />
   );

--- a/fe/src/features/travel/queryKeys.ts
+++ b/fe/src/features/travel/queryKeys.ts
@@ -12,6 +12,8 @@ export const travelKeys = {
   activity: (activityId: number) => ["travel", "activity", activityId] as const,
   /** 여행의 숙소 전체. 날짜별로 나누지 않는다 — 어느 날짜에 붙는지는 기간에서 파생한다. */
   stays: (tripId: number) => ["travel", "stays", tripId] as const,
+  /** 파생 구간. 저장값이 아니라 날짜에서 매번 계산되므로 날짜를 바꾸면 함께 무효화한다. */
+  cityLegs: (tripId: number) => ["travel", "cityLegs", tripId] as const,
   /**
    * 장소 검색. 서버가 이미 캐시하지만, 뒤로 갔다 오면 결과가 그대로 있어야 한다.
    *

--- a/fe/src/pages/travel/TripMapPage.test.tsx
+++ b/fe/src/pages/travel/TripMapPage.test.tsx
@@ -11,22 +11,97 @@ import { renderWithRouter } from "@/test/render";
 
 const API_BASE = "https://api.orino.dev/api";
 
+function city(placeId: number, name: string) {
+  return {
+    placeId,
+    name,
+    timezone: "Asia/Tokyo",
+    currency: "JPY",
+    countryCode: "JP",
+    cityPlaceRef: `ChIJ_${placeId}`,
+    lat: 35.68,
+    lng: 139.76,
+  };
+}
+
+const TOKYO = city(21, "도쿄");
+const NIKKO = city(22, "닛코");
+
 const DAYS = [
   {
+    dayId: 501,
     dayIndex: 1,
     date: "2026-10-24",
     weekday: "토",
     activityCount: 2,
+    baseCity: TOKYO,
+    cityChanged: false,
+    legIndex: 1,
+    cityMemo: null,
     weather: null,
+    stayTonight: null,
+    stayCheckout: null,
   },
   {
+    dayId: 502,
     dayIndex: 2,
     date: "2026-10-25",
     weekday: "일",
     activityCount: 1,
+    baseCity: NIKKO,
+    cityChanged: true,
+    legIndex: 2,
+    cityMemo: null,
     weather: null,
+    stayTonight: null,
+    stayCheckout: null,
   },
 ];
+
+/** 도쿄 → 닛코 → 도쿄. 구간은 셋인데 도시는 둘이다 — `전체` 모드의 핵심 사례다. */
+const CITY_LEGS = [
+  {
+    legIndex: 1,
+    cityPlaceId: 21,
+    cityName: "도쿄",
+    days: 3,
+    startDate: "2026-10-24",
+    endDate: "2026-10-26",
+    timezone: "Asia/Tokyo",
+    lat: 35.68,
+    lng: 139.76,
+  },
+  {
+    legIndex: 2,
+    cityPlaceId: 22,
+    cityName: "닛코",
+    days: 1,
+    startDate: "2026-10-25",
+    endDate: "2026-10-25",
+    timezone: "Asia/Tokyo",
+    lat: 36.75,
+    lng: 139.6,
+  },
+  {
+    legIndex: 3,
+    cityPlaceId: 21,
+    cityName: "도쿄",
+    days: 2,
+    startDate: "2026-10-26",
+    endDate: "2026-10-27",
+    timezone: "Asia/Tokyo",
+    lat: 35.68,
+    lng: 139.76,
+  },
+];
+
+function mockCityLegs(legs: unknown[] = CITY_LEGS) {
+  server.use(
+    http.get(`${API_BASE}/travel/trips/:tripId/city-legs`, () =>
+      HttpResponse.json({ code: "OK", data: legs }),
+    ),
+  );
+}
 
 function activity(overrides: Record<string, unknown> = {}) {
   return {
@@ -44,6 +119,8 @@ function activity(overrides: Record<string, unknown> = {}) {
     sortOrder: 0,
     log: null,
     hasLog: false,
+    outOfBaseCity: false,
+    canDepartureNotify: false,
     ...overrides,
   };
 }
@@ -54,6 +131,8 @@ const SENSOJI = {
   address: "다이토구",
   lat: 35.7147651,
   lng: 139.7966553,
+  cityName: "도쿄",
+  cityPlaceRef: "ChIJ_21",
 };
 
 function mockBoard(byDate: Record<string, unknown[]>) {
@@ -79,6 +158,7 @@ function mockBoard(byDate: Record<string, unknown[]>) {
           archiveCount: 0,
           activities: byDate[date] ?? [],
           travelTimes: [],
+          stayMove: null,
         },
       });
     }),
@@ -193,6 +273,111 @@ describe("TripMapPage", () => {
       expect(
         screen.getAllByRole("button", { name: /리스트로 전환/ }),
       ).toHaveLength(2);
+    });
+  });
+
+  describe("`전체` 모드 (§2.6)", () => {
+    it("도시를 다시 방문해도 마커는 하나이고 첫 방문 구간 번호를 쓴다", async () => {
+      mockBoard({ "2026-10-24": [activity({ id: 1, place: SENSOJI })] });
+      mockCityLegs();
+
+      renderMap("/travel/trips/3/map?mode=all");
+
+      // 구간은 셋인데 도시는 둘이다.
+      expect(
+        await screen.findByRole("heading", { name: "여행 전체" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("도시 2곳 · 구간 순서")).toBeInTheDocument();
+
+      // 구간 리스트는 접지 않는다 — 며칠씩 어디에 머무는지가 구간별 사실이다.
+      const legRows = screen.getAllByRole("button", { name: /일 · 10\./ });
+      expect(legRows).toHaveLength(3);
+      expect(legRows[0]).toHaveTextContent("도쿄");
+      expect(legRows[0]).toHaveTextContent("3일 · 10.24–10.26");
+    });
+
+    it("기본값은 `이 날짜`다 — 하루가 본체다", async () => {
+      mockBoard({ "2026-10-24": [activity({ id: 1, place: SENSOJI })] });
+
+      renderMap();
+
+      expect(
+        await screen.findByRole("heading", { name: "1일차 동선" }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "이 날짜" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    it("토글로 모드를 바꾸면 보던 날짜는 그대로 둔다", async () => {
+      mockBoard({ "2026-10-25": [activity({ id: 2, place: SENSOJI })] });
+      mockCityLegs();
+
+      const user = userEvent.setup();
+      renderMap("/travel/trips/3/map?day=1");
+      await screen.findByRole("heading", { name: "2일차 동선" });
+
+      await user.click(screen.getByRole("button", { name: "전체" }));
+      expect(
+        await screen.findByRole("heading", { name: "여행 전체" }),
+      ).toBeInTheDocument();
+
+      // 돌아오면 보던 날짜여야 한다 — 모드만 바꾼 것이지 날짜를 버린 게 아니다.
+      await user.click(screen.getByRole("button", { name: "이 날짜" }));
+      expect(
+        await screen.findByRole("heading", { name: "2일차 동선" }),
+      ).toBeInTheDocument();
+    });
+
+    it("구간 행을 누르면 그 구간 첫날 보드로 간다", async () => {
+      mockBoard({
+        "2026-10-24": [activity({ id: 1, place: SENSOJI })],
+        "2026-10-25": [
+          activity({ id: 2, activityDate: "2026-10-25", place: SENSOJI }),
+        ],
+      });
+      mockCityLegs();
+
+      const user = userEvent.setup();
+      renderMap("/travel/trips/3/map?mode=all");
+
+      const legRows = await screen.findAllByRole("button", {
+        name: /일 · 10\./,
+      });
+      // 2번째 구간(닛코)의 첫날은 2일차다.
+      await user.click(legRows[1]);
+
+      const tabs = await screen.findAllByRole("tab");
+      await waitFor(() =>
+        expect(tabs[1]).toHaveAttribute("aria-selected", "true"),
+      );
+    });
+
+    it("좌표를 아는 도시가 없으면 그렇게 말한다 — 장소 검색으로 보내지 않는다", async () => {
+      mockBoard({ "2026-10-24": [activity({ id: 1, place: SENSOJI })] });
+      mockCityLegs([
+        {
+          legIndex: 1,
+          cityPlaceId: 23,
+          cityName: "하코네",
+          days: 2,
+          startDate: "2026-10-24",
+          endDate: "2026-10-25",
+          timezone: "Asia/Tokyo",
+          lat: null,
+          lng: null,
+        },
+      ]);
+
+      renderMap("/travel/trips/3/map?mode=all");
+
+      expect(
+        await screen.findByText("좌표를 아는 도시가 없어요."),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /장소 검색/ }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/fe/src/pages/travel/TripMapPage.tsx
+++ b/fe/src/pages/travel/TripMapPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, List, WifiOff } from "lucide-react";
+import { ArrowLeft, List, MapPin, WifiOff } from "lucide-react";
 import { lazy, Suspense, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
@@ -6,31 +6,41 @@ import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { LoadingText } from "@/components/ui/loading-text";
 import { useBoard } from "@/features/travel/hooks/useBoard";
+import { useCityLegs } from "@/features/travel/hooks/useCityLegs";
+import { cityMarkers, legPath } from "@/features/travel/lib/cityMarkers";
+import { formatShortDate } from "@/features/travel/lib/tripStatus";
 import { toMapped } from "@/features/travel/map/toMapped";
+import type { MapPoint } from "@/features/travel/map/TripMap";
 import { useOnline } from "@/shared/lib/useOnline";
 
-// leaflet은 무겁고 이 화면에서만 쓴다 — 보드 진입 비용에 얹지 않는다.
-const TripDayMap = lazy(() =>
-  import("@/features/travel/map/TripDayMap").then((m) => ({
-    default: m.TripDayMap,
-  })),
+// 지도 SDK는 무겁고 이 화면에서만 쓴다 — 보드 진입 비용에 얹지 않는다.
+const TripMap = lazy(() =>
+  import("@/features/travel/map/TripMap").then((m) => ({ default: m.TripMap })),
 );
 
+/** `?mode=` 값. 기본은 하루다 — 이 화면이 늘 답하던 질문이 "오늘 이 순서가 말이 되나"다. */
+type Mode = "day" | "all";
+
 /**
- * S-05 지도 뷰. <b>선택한 날짜의 동선만</b> 그린다.
+ * S-05 지도 뷰.
  *
- * <p>여행 전체를 겹쳐 그리면 동선이 아니라 얼룩이 된다. 이 화면이 답하는 질문은
- * "오늘 이 순서가 말이 되나"이고, 그건 하루 단위로만 성립한다.
+ * <p>두 질문에 답한다 — `이 날짜`는 <b>오늘 동선이 말이 되는지</b>, `전체`는 <b>여행이 어떤
+ * 모양인지</b>. 하루가 본체이므로 기본값은 `이 날짜`다. 여행 전체를 일정 단위로 겹쳐 그리면
+ * 동선이 아니라 얼룩이 되므로, `전체`는 일정이 아니라 <b>도시</b>를 찍는다.
+ *
+ * <p><b>모드는 URL이 소유한다</b>(`?mode=day|all`, §9.7) — 새로고침·뒤로가기에서 살아남아야
+ * 한다.
  */
 export function TripMapPage() {
   const { tripId: tripIdParam } = useParams();
   const tripId = Number(tripIdParam);
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const online = useOnline();
 
   const day = searchParams.get("day");
   const dayIndex = day !== null ? Number(day) : null;
+  const mode: Mode = searchParams.get("mode") === "all" ? "all" : "day";
 
   const { data: base, isPending } = useBoard(tripId, {});
   const requestedDate =
@@ -43,12 +53,23 @@ export function TripMapPage() {
     { enabled: needsOwnQuery },
   );
   const board = needsOwnQuery ? dayBoard : base;
+  // `전체`를 보지 않는 동안에는 부르지 않는다 — 아무도 보지 않을 값이다.
+  const { data: legs } = useCityLegs(tripId, { enabled: mode === "all" });
 
-  const [selectedId, setSelectedId] = useState<number | null>(null);
+  /** 선택된 점. `이 날짜`에서는 일정 id, `전체`에서는 도시 placeId다. */
+  const [selectedKey, setSelectedKey] = useState<number | null>(null);
 
   const backToList = () => {
     const suffix = day === null ? "" : `?day=${day}`;
     navigate(`/travel/trips/${tripId}/board${suffix}`);
+  };
+
+  /** 모드만 바꾼다 — 보던 날짜는 그대로 둔다. 돌아왔을 때 그 날짜여야 한다. */
+  const switchMode = (next: Mode) => {
+    const merged = new URLSearchParams(searchParams);
+    merged.set("mode", next);
+    setSearchParams(merged, { replace: true });
+    setSelectedKey(null);
   };
 
   if (isPending || !board) {
@@ -60,9 +81,39 @@ export function TripMapPage() {
   }
 
   const mapped = toMapped(board.activities);
-  const selected = mapped.find((m) => m.activity.id === selectedId);
+  const markers = cityMarkers(legs ?? []);
   const dayNumber =
     board.days.findIndex((d) => d.date === board.selectedDate) + 1;
+
+  const points: MapPoint[] =
+    mode === "all"
+      ? markers.map((city) => ({
+          key: city.cityPlaceId,
+          order: city.legIndex,
+          lat: city.lat,
+          lng: city.lng,
+          title: city.cityName,
+        }))
+      : mapped.map((m) => ({
+          key: m.activity.id,
+          order: m.order,
+          lat: m.lat,
+          lng: m.lng,
+          title: m.activity.title,
+        }));
+
+  const selectedActivity = mapped.find((m) => m.activity.id === selectedKey);
+  const selectedCity = markers.find((city) => city.cityPlaceId === selectedKey);
+
+  /** 그 구간 첫날의 보드로 간다. 날짜 탭은 인덱스로 고르므로 날짜를 인덱스로 되돌린다. */
+  const openLegFirstDay = (startDate: string) => {
+    const index = board.days.findIndex((d) => d.date === startDate);
+    navigate(
+      `/travel/trips/${tripId}/board${index >= 0 ? `?day=${index}` : ""}`,
+    );
+  };
+
+  const empty = mode === "all" ? markers.length === 0 : mapped.length === 0;
 
   return (
     <div className="mx-auto flex w-full max-w-[520px] flex-col gap-3 px-4 pt-3">
@@ -76,10 +127,40 @@ export function TripMapPage() {
           <ArrowLeft className="size-4" />
         </Button>
         <div className="min-w-0 flex-1">
-          <h1 className="text-heading font-semibold">{dayNumber}일차 동선</h1>
+          <h1 className="text-heading font-semibold">
+            {mode === "all" ? "여행 전체" : `${dayNumber}일차 동선`}
+          </h1>
           <p className="text-muted-foreground text-xs">
-            장소가 있는 일정 {mapped.length}개 · 직선 연결
+            {mode === "all"
+              ? `도시 ${markers.length}곳 · 구간 순서`
+              : `장소가 있는 일정 ${mapped.length}개 · 직선 연결`}
           </p>
+        </div>
+        <div
+          role="group"
+          aria-label="지도 범위"
+          className="bg-muted flex gap-0.5 rounded-lg p-[3px]"
+        >
+          {(
+            [
+              { value: "day", label: "이 날짜" },
+              { value: "all", label: "전체" },
+            ] as const
+          ).map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              aria-pressed={mode === option.value}
+              onClick={() => switchMode(option.value)}
+              className={`h-7 rounded-md px-2.5 text-[13px] font-medium ${
+                mode === option.value
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground"
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
         </div>
         <Button
           variant="ghost"
@@ -102,17 +183,21 @@ export function TripMapPage() {
             리스트로 전환
           </Button>
         </EmptyState>
-      ) : mapped.length === 0 ? (
+      ) : empty ? (
         <EmptyState className="min-h-[40svh]">
           <p className="text-muted-foreground text-sm">
-            장소가 있는 일정이 없어요.
+            {mode === "all"
+              ? "좌표를 아는 도시가 없어요."
+              : "장소가 있는 일정이 없어요."}
           </p>
-          <Button
-            variant="outline"
-            onClick={() => navigate(`/travel/trips/${tripId}/places`)}
-          >
-            장소 검색
-          </Button>
+          {mode === "day" && (
+            <Button
+              variant="outline"
+              onClick={() => navigate(`/travel/trips/${tripId}/places`)}
+            >
+              장소 검색
+            </Button>
+          )}
         </EmptyState>
       ) : (
         <>
@@ -123,30 +208,36 @@ export function TripMapPage() {
               </div>
             }
           >
-            <TripDayMap
-              mapped={mapped}
-              selectedId={selectedId}
-              onSelect={setSelectedId}
+            <TripMap
+              points={points}
+              // 도시를 오가면 점보다 획이 많다 — 마커를 따라 이으면 다녀온 사실이 사라진다.
+              path={mode === "all" ? legPath(legs ?? []) : undefined}
+              selectedKey={selectedKey}
+              onSelect={setSelectedKey}
+              label={mode === "all" ? "여행 전체 지도" : "하루 동선 지도"}
             />
           </Suspense>
 
-          {selected && (
+          {mode === "day" && selectedActivity && (
             <div className="border-border bg-card flex items-center gap-3 rounded-xl border px-3.5 py-3">
               <span className="bg-primary text-primary-foreground grid size-[26px] shrink-0 place-items-center rounded-full text-xs font-semibold">
-                {selected.order}
+                {selectedActivity.order}
               </span>
               <div className="min-w-0 flex-1">
-                {selected.activity.startTime && (
-                  <p className="text-muted-foreground text-xs tabular-nums">
-                    {selected.activity.startTime}
-                  </p>
-                )}
-                <p className="truncate text-[15px] font-medium">
-                  {selected.activity.title}
+                <p className="text-muted-foreground text-xs tabular-nums">
+                  {[
+                    selectedActivity.activity.startTime,
+                    selectedActivity.activity.place?.cityName,
+                  ]
+                    .filter(Boolean)
+                    .join(" · ")}
                 </p>
-                {selected.activity.place?.address && (
+                <p className="truncate text-[15px] font-medium">
+                  {selectedActivity.activity.title}
+                </p>
+                {selectedActivity.activity.place?.address && (
                   <p className="text-muted-foreground truncate text-xs">
-                    {selected.activity.place.address}
+                    {selectedActivity.activity.place.address}
                   </p>
                 )}
               </div>
@@ -154,15 +245,92 @@ export function TripMapPage() {
                 variant="outline"
                 size="sm"
                 onClick={() =>
-                  navigate(`/travel/activities/${selected.activity.id}`)
+                  navigate(`/travel/activities/${selectedActivity.activity.id}`)
                 }
               >
                 일정 열기
               </Button>
             </div>
           )}
+
+          {mode === "all" && selectedCity && (
+            <LegCard
+              leg={legs?.find((l) => l.legIndex === selectedCity.legIndex)}
+              onOpen={openLegFirstDay}
+            />
+          )}
+
+          {/* 구간 리스트 — 지도가 못 하는 일을 한다. 어느 도시에 며칠 머무는지는 글자가 낫다. */}
+          {mode === "all" && (
+            <ul className="flex flex-col gap-1.5 pb-6">
+              {(legs ?? []).map((leg) => (
+                <li key={leg.legIndex}>
+                  <button
+                    type="button"
+                    onClick={() => openLegFirstDay(leg.startDate)}
+                    className="border-border bg-card hover:bg-accent flex w-full items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left"
+                  >
+                    <span className="bg-muted grid size-[22px] shrink-0 place-items-center rounded-full text-xs font-semibold tabular-nums">
+                      {leg.legIndex}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-[15px] font-medium">
+                      {leg.cityName ?? "도시 없음"}
+                    </span>
+                    <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+                      {leg.days}일 · {formatShortDate(leg.startDate)}–
+                      {formatShortDate(leg.endDate)}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
         </>
       )}
+    </div>
+  );
+}
+
+/** 마커를 탭했을 때 나오는 도시 카드. 지도 위에서 고른 것이 무엇인지 글자로 확인시킨다. */
+function LegCard({
+  leg,
+  onOpen,
+}: {
+  leg:
+    | {
+        legIndex: number;
+        cityName: string | null;
+        days: number;
+        startDate: string;
+        endDate: string;
+        timezone: string | null;
+      }
+    | undefined;
+  onOpen: (startDate: string) => void;
+}) {
+  if (!leg) return null;
+  return (
+    <div className="border-border bg-card flex items-center gap-3 rounded-xl border px-3.5 py-3">
+      <MapPin className="text-muted-foreground size-4 shrink-0" />
+      <div className="min-w-0 flex-1">
+        <p className="text-muted-foreground text-xs tabular-nums">
+          {leg.days}일 · 구간 {leg.legIndex}
+        </p>
+        <p className="truncate text-[15px] font-medium">
+          {leg.cityName ?? "도시 없음"}
+        </p>
+        <p className="text-muted-foreground truncate text-xs">
+          {[
+            `${formatShortDate(leg.startDate)} – ${formatShortDate(leg.endDate)}`,
+            leg.timezone,
+          ]
+            .filter(Boolean)
+            .join(" · ")}
+        </p>
+      </div>
+      <Button variant="outline" size="sm" onClick={() => onOpen(leg.startDate)}>
+        첫날 열기
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## 이슈
closes #1144

## 작업 내용

**지도가 하루와 여행 전체를 모두 답한다.** `이 날짜`는 오늘 동선이 말이 되는지, `전체`는 여행이 어떤 모양인지 묻는 화면이다. FE 전용 — 데이터(`GET /city-legs`)는 1단계에 이미 있었다.

- **`?mode=day|all`을 URL이 소유한다.** 기본은 `이 날짜` — 하루가 본체다
- **모드를 바꿔도 보던 날짜(`?day=`)는 그대로 둔다** — `이 날짜`로 돌아왔을 때 그 날짜여야 한다
- `전체`: 도시당 마커 하나, 번호는 **첫 방문 구간** 것. 지도 아래 구간 리스트 → 행을 누르면 그 구간 첫날 보드
- `이 날짜` 카드에 도시명 추가
- `전체`를 보지 않는 동안에는 `/city-legs`를 부르지 않는다

## 판단이 갈릴 수 있는 곳 (리뷰 요청)

**1. `TripDayMap`을 `TripMap`으로 일반화했다(리네임 포함).** 두 모드가 다른 것은 무엇을 점으로 찍느냐뿐이고, SDK 수명주기·마커 정리·불러오기 실패 처리는 같다. 지도를 두 벌 두면 그 까다로운 부분이 두 벌이 된다. 대신 props가 `mapped`(일정 전용) → `points`(중립)로 바뀌었다.

**2. 연결선과 마커의 접는 규칙이 다르다.** 마커는 도시당 하나로 접지만 **선과 구간 리스트는 접지 않는다.** 도쿄 → 닛코 → 도쿄면 점은 둘, 획은 둘, 리스트는 세 줄이다 — 마커를 따라 이으면 닛코에 갔다 온 자취가 사라지고, 리스트를 접으면 며칠씩 어디에 머무는지가 사라진다. `path`를 `points`와 따로 받는 이유가 이것뿐이다.

**3. `전체`의 빈 상태는 `장소 검색`으로 보내지 않는다.** 좌표를 아는 도시가 없다는 건 장소를 안 담아서가 아니라 **도시를 직접 입력해서**(구글 id 없음) 생기는 상태라, 장소 검색은 답이 아니다.

**4. 겹치는 마커는 손대지 않았다.** 이슈 Todo의 "줌·클러스터로 푼다"는 `fitBounds`(기존 동작)로 두었다 — 클러스터링 라이브러리를 넣을 만큼 도시 수가 많지 않고, **좌표를 흔들지 않는다**는 금지 조항만 지키면 남은 것은 줌이다. 실제 일정에서 뭉쳐 보이면 그때 다시 보는 편이 낫다고 판단했다.

## 위키에서 고친 오류 1건

§2.6 마지막 줄에 **"타일 attribution `© OpenStreetMap` 필수"** 가 남아 있었다. 같은 절 맨 위 D-17 주석(Google Maps 사용, leaflet·OSM 금지)과 정면으로 충돌하는 v2.0 초안 잔재로, 따르면 **쓰지도 않는 타일의 출처를 표기하게 된다.** 구글 SDK가 자기 표기를 직접 넣으므로 우리가 그릴 것이 없다고 고쳤다.

## 테스트

- 단위(`lib/cityMarkers`) — 재방문해도 마커 하나 · **도쿄가 3이 아니라 1** · 좌표 없는 도시 제외 · 이름 없으면 `도시 없음` · **연결선은 접지 않는다**
- 컴포넌트(`TripMap`) — 기존 6종 유지 + **경로를 따로 주면 점이 아니라 그 경로로 잇는다**(점 2 · 획 3)
- 통합(`TripMapPage`) — 기본값이 `이 날짜` · `전체` 헤더와 구간 리스트 3줄 · **모드를 바꿔도 날짜 유지** · 구간 행 → 그 구간 첫날 탭 선택 · 좌표 없는 도시뿐일 때 빈 상태
- E2E — **실제 브라우저에서** 토글 → `page.url()`에 `mode=all` → **새로고침** → 그대로 `전체` → 구간 행 → 2일차 탭 선택

> 마커를 실제로 찍는 일은 `TripMap` 테스트(SDK 대역)가, 규칙은 `cityMarkers` 단위 테스트가 맡는다. E2E에서는 구글 지도 SDK가 뜨지 않아 마커를 세지 않는다 — 그 사실을 스펙 파일 주석에 적어 두었다.

## 게이트

- `cd fe && npm run format:check && npm run lint && npm test && npm run build` ✅ (993 tests)
- `npx playwright test` ✅ (91 passed)
- BE 변경 없음

## 위키

[Travel-UI-Design §2.6](https://github.com/wcorn/orino/wiki/Travel-UI-Design) — 토글·리스트·attribution 정정 · [Travel-Open-Items D-17](https://github.com/wcorn/orino/wiki/Travel-Open-Items) — `TripMap` 일반화 기록
