### PR TITLE
feat : AWS 예산 알림 + 비용 이상탐지

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -26,6 +26,11 @@ jobs:
     defaults:
       run:
         working-directory: infra/terraform
+    # 예산 알림 수신 주소(#1150). 개인 이메일이라 공개 저장소의 variables.tf 기본값에
+    # 두지 않고 시크릿으로 주입한다. TF_VAR_ 는 list(string) 을 HCL 로 파싱하므로
+    # JSON 배열 형태로 넘긴다. 시크릿이 비면 variables.tf 의 validation 이 잡는다.
+    env:
+      TF_VAR_budget_alert_emails: '["${{ secrets.BUDGET_ALERT_EMAIL }}"]'
     steps:
       - uses: actions/checkout@v4
 

--- a/infra/terraform/budgets.tf
+++ b/infra/terraform/budgets.tf
@@ -1,0 +1,89 @@
+# AWS 비용 알림 (#1150 · Epic #1148).
+#
+# 지금까지 관측은 지출과 정확히 반대로 걸려 있었다 — GCP는 예산 알림이 있는데 실지출이
+# ~$0이고, 실제로 돈이 나가는 AWS($15.50/월)에는 알림이 없었다. AWS에서 무슨 일이 나면
+# 사람이 Cost Explorer를 CLI로 조회할 때까지(건당 $0.01) 아무도 모르는 상태였다.
+#
+# ── 온프레미스를 경유하지 않는다 ──────────────────────────────────────────────
+# Grafana는 note1/note2 위에 있다. 클러스터가 죽어서 백업 잡이 미쳐 도는 상황이 바로
+# 알림이 필요한 순간인데, 그때 Grafana 경유 알림은 같이 죽는다. 여기 알림은
+# AWS → 이메일 직결이어야 한다. 빠른 탐지(Prometheus 레이어)는 #1153이 담당한다.
+#
+# ── SNS를 두지 않는다 ────────────────────────────────────────────────────────
+# Budgets도 Anomaly Subscription도 이메일 구독자를 직접 받는다. SNS를 끼우면 토픽 정책·
+# 구독 확인·IAM이 늘어나는데 얻는 게 없다. IMMEDIATE 알림은 SNS가 필수지만 AWS 비용
+# 데이터 자체가 하루 가까이 지연되므로 실제 탐지시간은 달라지지 않는다 — 목표(G1-b)는
+# 2일이고 DAILY로 충분하다. 중간 구성요소가 하나 줄면 고장날 곳도 하나 준다.
+
+# 계정당 2개까지 무료. $25는 현재 $15.50에 여유를 둔 값 — 정상이면 닿지 않고,
+# 새 폴링 루프 하나가 붙었을 때는 걸린다(ELOG-027의 루프 하나가 연 환산 $36이었다).
+resource "aws_budgets_budget" "monthly" {
+  name         = "orino-monthly"
+  budget_type  = "COST"
+  limit_amount = tostring(var.aws_budget_usd)
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  # 실제 지출 80% — 아직 여유가 있을 때 먼저 안다.
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = var.budget_alert_emails
+  }
+
+  # 실제 지출 100% — 상한에 닿았다.
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = var.budget_alert_emails
+  }
+
+  # 예측 100% — 월말에 상한을 넘길 추세면 닿기 전에 알린다. 실제로 상한을 넘긴 뒤
+  # 알리는 것보다 이쪽이 먼저 울리는 게 정상이다(GCP 예산의 FORECASTED_SPEND와 같은 역할).
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = var.budget_alert_emails
+  }
+}
+
+# 비용 이상탐지 — 무료. 예산은 "총액이 선을 넘었나"만 보지만 이쪽은 서비스별 패턴에서
+# 벗어난 지출을 잡는다. 총액이 $25 안이어도 특정 서비스가 갑자기 튀면 걸린다.
+#
+# ⚠️ 베이스라인 학습에 열흘쯤 걸린다. 켠 다음 날 조용한 것은 고장이 아니다.
+resource "aws_ce_anomaly_monitor" "service" {
+  name              = "orino-service-monitor"
+  monitor_type      = "DIMENSIONAL"
+  monitor_dimension = "SERVICE"
+}
+
+resource "aws_ce_anomaly_subscription" "service" {
+  name      = "orino-anomaly-daily"
+  frequency = "DAILY"
+
+  monitor_arn_list = [aws_ce_anomaly_monitor.service.arn]
+
+  dynamic "subscriber" {
+    for_each = var.budget_alert_emails
+    content {
+      type    = "EMAIL"
+      address = subscriber.value
+    }
+  }
+
+  # 임계 미만의 이상은 알리지 않는다. 취미 클러스터 규모에서 몇 센트 흔들림까지
+  # 매일 메일이 오면 진짜 알림을 무시하게 된다.
+  threshold_expression {
+    dimension {
+      key           = "ANOMALY_TOTAL_IMPACT_ABSOLUTE"
+      match_options = ["GREATER_THAN_OR_EQUAL"]
+      values        = [tostring(var.anomaly_threshold_usd)]
+    }
+  }
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,7 +1,11 @@
 # 이 파일을 terraform.tfvars로 복사 후 실제 값으로 채우세요.
 # terraform.tfvars는 .gitignore로 추적 제외됩니다.
 
-operator_emails = ["you@example.com"]
+# 예산·이상탐지 알림 수신 주소(#1150). 기본값이 없는 유일한 변수다 —
+# 개인 이메일이라 공개 저장소에 두지 않는다.
+# CI는 이 파일을 쓰지 않고 BUDGET_ALERT_EMAIL 저장소 시크릿을
+# TF_VAR_budget_alert_emails로 주입한다(.github/workflows/terraform.yml).
+budget_alert_emails = ["you@example.com"]
 
-# GCP 관련 값(프로젝트·결제계정·예산액)은 variables.tf에 기본값이 있어 따로 채우지 않아도 된다.
-# 예산액만 바꾸려면: gcp_budget_krw = 50000
+# 나머지는 variables.tf에 기본값이 있어 따로 채우지 않아도 된다.
+# 예산액만 바꾸려면: aws_budget_usd = 40 / gcp_budget_krw = 50000

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -4,6 +4,39 @@ variable "aws_region" {
   default     = "ap-northeast-2"
 }
 
+# --- 비용 알림 (#1150, Epic #1148) ---
+
+# 기본값을 두지 않는다 — 개인 이메일이고 이 저장소는 공개다. CI 는 워크플로우에서
+# TF_VAR_budget_alert_emails 로 주입하고(BUDGET_ALERT_EMAIL 시크릿), 로컬에서는
+# terraform.tfvars 에 넣는다.
+variable "budget_alert_emails" {
+  description = "예산·이상탐지 알림 수신 주소. AWS Budgets 는 이메일 구독자를 직접 지원해 SNS 를 두지 않는다"
+  type        = list(string)
+
+  # 시크릿 미설정 시 TF_VAR 가 [""] 로 들어온다. 그대로 두면 AWS API 가 뱉는
+  # 알아보기 힘든 에러로 apply 가 깨지므로 원인을 이름으로 알려준다.
+  validation {
+    condition = length(var.budget_alert_emails) > 0 && alltrue([
+      for e in var.budget_alert_emails : can(regex("^[^@[:space:]]+@[^@[:space:]]+\\.[^@[:space:]]+$", e))
+    ])
+    error_message = "유효한 이메일이 최소 1개 필요하다. CI 라면 BUDGET_ALERT_EMAIL 저장소 시크릿이 설정되어 있는지 확인한다."
+  }
+}
+
+# 현재 청구는 월 $15.50. 정상이면 닿지 않고, 새 폴링 루프 하나가 붙었을 때는 걸리는 선.
+variable "aws_budget_usd" {
+  description = "AWS 월 예산(USD). 계정당 예산 2개까지 무료"
+  type        = number
+  default     = 25
+}
+
+# 몇 센트 흔들림까지 매일 메일이 오면 진짜 알림을 무시하게 된다.
+variable "anomaly_threshold_usd" {
+  description = "이상탐지 알림 최소 영향 금액(USD). 이 미만의 이상은 알리지 않는다"
+  type        = number
+  default     = 5
+}
+
 # --- Google Cloud (여행 모듈, #1050) ---
 
 variable "gcp_project_id" {


### PR DESCRIPTION
## 이슈
closes #1150
## 작업 내용
- `infra/terraform/budgets.tf` 신규 — `aws_budgets_budget` 월 $25, 임계 3종(실제 80% · 실제 100% · **예측 100%**)
- `budgets.tf` — `aws_ce_anomaly_monitor`(DIMENSIONAL/SERVICE) + `aws_ce_anomaly_subscription`(이메일, `DAILY`)
- `variables.tf` — `budget_alert_emails`(기본값 없음) · `aws_budget_usd`(25) · `anomaly_threshold_usd`(5)
- `.github/workflows/terraform.yml` — `TF_VAR_budget_alert_emails` 주입
- `terraform.tfvars.example` — 유령 변수 `operator_emails` 정리

## ⚠️ 머지 전에 저장소 시크릿을 먼저 설정해야 한다

**이 시크릿이 없으면 이 PR의 plan부터 실패한다.** 아래를 먼저 실행해 주세요:

```bash
gh secret set BUDGET_ALERT_EMAIL --repo wcorn/orino
# 프롬프트에 수신 이메일 주소 입력
```

설정 후 이 PR의 Terraform 체크를 re-run하면 통과합니다.

### 왜 시크릿인가
이 저장소는 **공개**다. CI는 `terraform.tfvars`(gitignore)도 안 쓰고 `TF_VAR`도 안 쓰던 상태라 지금까지 모든 변수가 `variables.tf` 기본값에 의존했는데, 개인 이메일을 기본값에 두면 공개 저장소 히스토리에 영구히 남는다(나중에 지워도 히스토리에 남는다). 그래서 이 변수만 기본값 없이 두고 워크플로우에서 주입한다.

시크릿이 비면 `TF_VAR`가 `[""]`로 들어와 AWS API가 알아보기 힘든 에러를 뱉는다. 그래서 변수에 validation을 걸어 **원인을 이름으로** 알려준다. 실제로 발화하는지 격리 환경에서 케이스별로 확인했다:

```
=== 거부되어야 하는 값 ===
  거부됨 ✅  빈 시크릿 (CI에서 secret 미설정)  ([""])
  거부됨 ✅  빈 리스트                        ([])
  거부됨 ✅  이메일 아님                      (["notanemail"])
  거부됨 ✅  공백 포함                        (["a b@c.com"])
=== 통과해야 하는 값 ===
  통과됨 ✅  일반 주소                        (["dsk08208@gmail.com"])
  통과됨 ✅  Gmail +태그                      (["dsk08208+aws@gmail.com"])
  통과됨 ✅  복수 주소                        (["a@b.com","c@d.co.kr"])
```

> plan 출력은 `GITHUB_STEP_SUMMARY`로 나가지만 GitHub이 시크릿을 마스킹하므로 이메일은 `***`로 표시된다.

## 설계 판단

**SNS를 두지 않는다.** Budgets도 Anomaly Subscription도 이메일 구독자를 직접 받는다. `IMMEDIATE` 알림은 SNS가 필수지만 **AWS 비용 데이터 자체가 하루 가까이 지연**되므로 `IMMEDIATE`로 만들어도 실제 탐지시간이 달라지지 않는다 — 목표 G1-b는 2일이고 `DAILY`로 충분하다. 빠른 탐지는 #1153(Grafana 레이어)이 담당한다. 중간 구성요소가 하나 줄면 고장날 곳도 하나 준다.

**온프레미스를 경유하지 않는다.** 클러스터가 죽어서 백업 잡이 미쳐 도는 상황이 바로 알림이 필요한 순간인데, 그때 Grafana 경유 알림은 같이 죽는다.

**이상탐지 임계 $5 (이슈에 미지정 → 추가한 값).** 임계가 없으면 몇 센트 흔들림에도 매일 메일이 온다. 진짜 알림을 무시하게 만드는 게 알림 없는 것 다음으로 나쁘다. 현재 월 $15.50 규모에서 $5는 "청구의 1/3이 흔들렸다" 수준이라 의미 있는 것만 잡는다. ELOG-027의 루프(월 $3)를 놓칠 수 있는 선이지만, 그 급은 #1153의 rate 알림(1시간 내)이 잡는 게 설계 의도다.

## 확인
- [x] `terraform fmt -check -recursive` 통과
- [x] `terraform validate` 통과
- [x] validation 규칙 실증 — 격리 config에서 `terraform plan`으로 7개 케이스 확인(위 출력)
- [x] `yamllint -c .yamllint.yml infra/` 통과 · 워크플로우 YAML 파싱 확인
- [ ] **`gh secret set BUDGET_ALERT_EMAIL` 설정** ← 이게 먼저다
- [ ] PR에서 plan 확인
- [ ] 머지 후 apply 성공 확인
- [ ] **실사 테스트** — 임계 일시 인하 PR → 하루 대기 → 휴대폰에서 알림 수신 확인 → 원복 PR (원복은 반드시 별도 PR)
- [ ] 수신한 알림의 발신 주소·본문 형태를 이슈 코멘트로 기록

> ⚠️ 실사 테스트는 즉시 안 울리는 게 정상이다. 비용 데이터가 하루 가까이 지연되고 예산 평가도 하루 몇 회다. Cost Anomaly Detection은 베이스라인 학습에 열흘쯤 걸리므로 켠 다음 날 조용한 것도 고장이 아니다.
