### PR TITLE
feat : 아침 요약 — 도시명 접두 · 도시 변경일은 전날 도시 08:00

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/BaseCityChangeService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/BaseCityChangeService.java
@@ -91,8 +91,11 @@ public class BaseCityChangeService {
 
         if (cityChanged) {
             // 벽시계 시각은 그대로다. 그 시각이 어느 순간인지가 바뀌었을 뿐이라 발송 시각만
-            // 다시 잡는다(§4.2). 그 날짜의 일정만 영향을 받는다.
+            // 다시 잡는다(§4.2). 일정 알림은 그 날짜만 영향을 받는다.
             notificationService.rescheduleDate(trip.getId(), day.getDayDate());
+            // 아침 요약은 다르다 — 일정이 아니라 날짜에 걸려 있고, "도시가 바뀌는 날인가"가
+            // 다음 날짜의 발송 시각까지 뒤집는다(v2.1 §3.6). 위 호출은 요약을 건드리지 않는다.
+            notificationService.rescheduleMorningSummary(trip.getId(), day.getDayDate());
         }
         return queryService.days(memberId, trip.getId());
     }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/MorningCity.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/MorningCity.java
@@ -1,0 +1,41 @@
+package ds.project.orino.planner.travel.push.service;
+
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+/**
+ * 아침 요약이 기준으로 삼는 도시(v2.1 §3.6).
+ *
+ * <p>예약(발송 시각)과 발송(본문 문구)이 <b>같은 판정</b>을 써야 한다 — 두 벌이면 오사카 시각에
+ * 보내면서 본문은 교토라고 말하는 날이 생긴다. 그래서 규칙을 여기 한 곳에 둔다.
+ */
+public final class MorningCity {
+
+    private MorningCity() {
+    }
+
+    /**
+     * 그날 아침에 <b>눈을 뜨는 도시</b>. 도시가 바뀌는 날은 아직 <b>전날 도시</b>에 있다.
+     *
+     * <p>첫날은 "바뀐 것"이 아니다 — 비교할 앞 날짜가 없다.
+     */
+    public static TravelPlace wakeUpIn(LocalDate date, Map<LocalDate, TravelPlace> cities) {
+        TravelPlace yesterday = cities.get(date.minusDays(1));
+        return changesOn(date, cities) ? yesterday : cities.get(date);
+    }
+
+    /**
+     * 그날 도시가 바뀌는가. 판정은 <b>장소 id</b>로 한다 — 같은 도시를 다시 지정해도 행이
+     * 같으면 바뀐 것이 아니고, 이름 비교는 표기 흔들림에 깨진다.
+     */
+    public static boolean changesOn(LocalDate date, Map<LocalDate, TravelPlace> cities) {
+        TravelPlace today = cities.get(date);
+        TravelPlace yesterday = cities.get(date.minusDays(1));
+        if (today == null || yesterday == null) {
+            return false;
+        }
+        return !today.getId().equals(yesterday.getId());
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/NotificationDispatchService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/NotificationDispatchService.java
@@ -6,8 +6,10 @@ import ds.project.orino.domain.planner.push.entity.PushNotification;
 import ds.project.orino.domain.planner.push.entity.PushSubscription;
 import ds.project.orino.domain.planner.push.repository.PushNotificationRepository;
 import ds.project.orino.domain.planner.push.repository.PushSubscriptionRepository;
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.entity.TripActivity;
 import ds.project.orino.domain.planner.travel.repository.TripActivityRepository;
+import ds.project.orino.planner.travel.day.service.TripDayService;
 import ds.project.orino.planner.travel.push.send.WebPushSender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +19,7 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,6 +38,7 @@ public class NotificationDispatchService {
     private final PushNotificationRepository notificationRepository;
     private final PushSubscriptionRepository subscriptionRepository;
     private final TripActivityRepository activityRepository;
+    private final TripDayService tripDayService;
     private final WebPushSender sender;
     private final ObjectMapper objectMapper;
     private final Clock clock;
@@ -42,12 +46,14 @@ public class NotificationDispatchService {
     public NotificationDispatchService(PushNotificationRepository notificationRepository,
                                        PushSubscriptionRepository subscriptionRepository,
                                        TripActivityRepository activityRepository,
+                                       TripDayService tripDayService,
                                        WebPushSender sender,
                                        ObjectMapper objectMapper,
                                        Clock clock) {
         this.notificationRepository = notificationRepository;
         this.subscriptionRepository = subscriptionRepository;
         this.activityRepository = activityRepository;
+        this.tripDayService = tripDayService;
         this.sender = sender;
         this.objectMapper = objectMapper;
         this.clock = clock;
@@ -133,22 +139,46 @@ public class NotificationDispatchService {
      * <p>0건이면 빈 값이라 호출부가 예약을 접는다.
      */
     private Optional<String> morningSummaryPayload(PushNotification notification) {
+        LocalDate date = notification.getTargetDate();
         List<TripActivity> ordered = activityRepository
                 .findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(
-                        notification.getTripId(), notification.getTargetDate());
+                        notification.getTripId(), date);
         if (ordered.isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(json("오늘 일정", summaryBody(ordered),
-                boardPath(notification), "morning-" + notification.getTargetDate()));
+        Map<LocalDate, TravelPlace> cities =
+                tripDayService.baseCitiesOf(notification.getTripId());
+        return Optional.of(json("오늘 일정", summaryBody(ordered, date, cities),
+                boardPath(notification), "morning-" + date));
     }
 
-    /** {@code 오늘 일정 4개 · 첫 일정 09:00 숙소 체크아웃} — 시각이 없으면 제목만 붙인다. */
-    private static String summaryBody(List<TripActivity> ordered) {
+    /**
+     * {@code 교토 · 오늘 일정 4개 · 첫 일정 09:00 숙소 체크아웃} — 시각이 없으면 제목만 붙인다.
+     *
+     * <p><b>도시가 바뀌는 날은 {@code 오사카 → 교토 · 오늘 일정 3개}</b>(v2.1 §3.6). 그날 가장
+     * 중요한 사실이 "어디로 옮긴다"라서 앞자리를 그것에 내주고, 첫 일정은 접는다 — 알림 본문은
+     * 한 줄이고 도시 두 개가 이미 그 줄을 채운다.
+     */
+    private static String summaryBody(List<TripActivity> ordered, LocalDate date,
+                                      Map<LocalDate, TravelPlace> cities) {
+        String count = "오늘 일정 %d개".formatted(ordered.size());
+        if (MorningCity.changesOn(date, cities)) {
+            return "%s → %s · %s".formatted(cityName(cities.get(date.minusDays(1))),
+                    cityName(cities.get(date)), count);
+        }
         TripActivity first = ordered.get(0);
         String when = first.getStartTime() == null ? "" : first.getStartTime() + " ";
-        return "오늘 일정 %d개 · 첫 일정 %s%s"
-                .formatted(ordered.size(), when, first.getTitle());
+        String body = "%s · 첫 일정 %s%s".formatted(count, when, first.getTitle());
+        TravelPlace today = cities.get(date);
+        // 도시를 모르면 접두를 붙이지 않는다 — `도시 없음 · …`은 알려주는 게 아니라 거슬린다.
+        return today == null ? body : "%s · %s".formatted(cityName(today), body);
+    }
+
+    private static String cityName(TravelPlace city) {
+        if (city == null) {
+            return "";
+        }
+        return city.getCityName() != null ? city.getCityName() : city.getName();
     }
 
     /** 특정 일정이 아니라 <b>그날 보드</b>로 보낸다 — 요약이 가리키는 것은 하루 전체다. */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/NotificationScheduleService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/push/service/NotificationScheduleService.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * 알림 예약과 재계산(§4.2).
@@ -108,18 +109,61 @@ public class NotificationScheduleService {
 
             if (trip.isMorningSummaryEnabled()) {
                 notificationRepository.save(PushNotification.morningSummary(
-                        trip.getMemberId(), trip.getId(), date, morningAt(date, zone)));
+                        trip.getMemberId(), trip.getId(), date, morningAt(date, cities)));
             }
         }
     }
 
     /**
-     * 아침 요약 시각 — 그 날짜의 <b>현지</b> 08:00(§4.3).
+     * 기준 도시가 바뀐 날짜 주변의 <b>아침 요약</b>만 다시 잡는다.
+     *
+     * <p>일정 알림과 따로 도는 이유는 아침 요약이 <b>일정이 아니라 날짜에 걸려 있어서</b>다 —
+     * {@link #rescheduleDate}는 일정 id로 취소하고 다시 만들기 때문에 요약은 손도 대지 못하고
+     * 옛 도시의 08:00에 그대로 남는다.
+     *
+     * <p><b>그 날짜만으로는 부족하다.</b> 도시가 바뀌면 그날이 "도시 변경일"이 되거나 아니게
+     * 되는데, 같은 변경이 <b>다음 날짜의 판정</b>도 뒤집는다 — N일차를 교토로 바꾸면 N일차는
+     * 변경일이 되고 N+1일차는 변경일이 아니게 된다. 두 날짜를 함께 다시 잡는다.
+     */
+    @Transactional
+    public void rescheduleMorningSummary(Long tripId, LocalDate date) {
+        if (date == null) {
+            return;
+        }
+        Trip trip = tripRepository.findById(tripId).orElse(null);
+        if (trip == null) {
+            return;
+        }
+        Map<LocalDate, TravelPlace> cities = tripDayService.baseCitiesOf(tripId);
+        List<LocalDate> affected = Stream.of(date, date.plusDays(1))
+                .filter(trip::covers)
+                .toList();
+
+        cancelAll(notificationRepository.findAllByTripIdAndTypeAndTargetDateInAndStatus(
+                tripId, NotificationType.MORNING_SUMMARY, affected, NotificationStatus.PENDING));
+        if (!trip.isMorningSummaryEnabled()) {
+            return;
+        }
+        notificationRepository.saveAll(affected.stream()
+                .map(affectedDate -> PushNotification.morningSummary(trip.getMemberId(),
+                        tripId, affectedDate, morningAt(affectedDate, cities)))
+                .toList());
+    }
+
+    /**
+     * 아침 요약 시각 — 그 날짜의 <b>현지</b> 08:00(§4.3). 단 <b>도시가 바뀌는 날은 전날 도시의
+     * 08:00</b>이다(v2.1 §3.6).
+     *
+     * <p>교토로 넘어가는 날 교토 시각 08:00에 알림이 오면 이미 늦다 — 그 시각에 사용자는 아직
+     * 오사카에서 짐을 싸고 있다. 아침에 보는 시계는 <b>떠나는 도시의 시계</b>다.
      *
      * <p>그날 일정이 0건이어도 지금은 만든다. 판정은 <b>보내기 직전</b>에 한다 — 예약 때만 보면
      * 나중에 일정을 채운 날은 영영 요약이 안 오고, 다 지운 날엔 "일정 0개"가 간다.
      */
-    private static Instant morningAt(LocalDate date, ZoneId zone) {
+    private static Instant morningAt(LocalDate date, Map<LocalDate, TravelPlace> cities) {
+        TravelPlace wakeUpIn = MorningCity.wakeUpIn(date, cities);
+        ZoneId zone = wakeUpIn == null ? ZoneId.systemDefault()
+                : TripDayService.zoneOf(wakeUpIn);
         return date.atTime(MORNING_SUMMARY_HOUR, 0).atZone(zone).toInstant();
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/MorningSummaryTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/push/MorningSummaryTest.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -186,6 +187,62 @@ class MorningSummaryTest extends ApiTestSupport {
     }
 
     @Nested
+    @DisplayName("도시가 바뀌는 날 (v2.1 §3.6)")
+    class CityChange {
+
+        @Test
+        @DisplayName("도시가 바뀌는 날은 전날 도시의 08:00에 보낸다 — 그 시각엔 아직 거기 있다")
+        void sendsAtPreviousCityMorning() throws Exception {
+            createTwoCityTrip();
+
+            // 1/3이 방콕 첫날이다. 방콕 08:00(01:00Z)이 아니라 도쿄 08:00이어야 한다.
+            assertThat(morningAt("2020-01-03")).isEqualTo(Instant.parse("2020-01-02T23:00:00Z"));
+        }
+
+        @Test
+        @DisplayName("도시가 그대로인 날은 그날 도시의 08:00이다")
+        void sendsAtOwnCityMorning() throws Exception {
+            createTwoCityTrip();
+
+            assertThat(morningAt("2020-01-02")).isEqualTo(Instant.parse("2020-01-01T23:00:00Z"));
+        }
+
+        @Test
+        @DisplayName("첫날은 바뀐 것이 아니다 — 비교할 앞 날짜가 없다")
+        void firstDayIsNotAChange() throws Exception {
+            createTwoCityTrip();
+
+            assertThat(morningAt("2020-01-01")).isEqualTo(Instant.parse("2019-12-31T23:00:00Z"));
+        }
+
+        @Test
+        @DisplayName("기준 도시를 바꾸면 다음 날짜 요약까지 다시 잡힌다")
+        void reschedulesFollowingDay() throws Exception {
+            long tripId = createTwoCityTrip();
+            // 1/3은 도쿄 → 방콕 이동일이라 도쿄 08:00에 잡혀 있다.
+            assertThat(morningAt("2020-01-03")).isEqualTo(Instant.parse("2020-01-02T23:00:00Z"));
+
+            // 1/2도 방콕으로 바꾸면 1/3은 더 이상 이동일이 아니다.
+            changeBaseCity(dayIdOf(tripId, "2020-01-02"), bangkokCityId());
+
+            // 바꾼 날짜가 아니라 그 다음 날짜의 발송 시각이 달라진다 — 방콕 08:00(01:00Z).
+            assertThat(morningAt("2020-01-03")).isEqualTo(Instant.parse("2020-01-03T01:00:00Z"));
+        }
+
+        @Test
+        @DisplayName("기준 도시를 바꿔도 요약이 두 벌 남지 않는다")
+        void doesNotLeaveDuplicates() throws Exception {
+            long tripId = createTwoCityTrip();
+
+            changeBaseCity(dayIdOf(tripId, "2020-01-02"), bangkokCityId());
+
+            assertThat(morningNotifications().stream()
+                    .filter(n -> n.getStatus() == NotificationStatus.PENDING).toList())
+                    .hasSize(3);
+        }
+    }
+
+    @Nested
     @DisplayName("발송")
     class Dispatch {
 
@@ -200,6 +257,30 @@ class MorningSummaryTest extends ApiTestSupport {
 
             assertThat(stub.sent).anySatisfy(s -> assertThat(s.payload())
                     .contains("오늘 일정 2개 · 첫 일정 09:00 숙소 체크아웃"));
+        }
+
+        @Test
+        @DisplayName("도시명을 앞에 붙인다 — 어느 도시의 하루인지가 첫 정보다")
+        void prefixesCityName() throws Exception {
+            long tripId = createTrip(true);
+            addActivity(tripId, "숙소 체크아웃", "2020-01-01", "09:00");
+
+            dispatchService.dispatchDue();
+
+            assertThat(stub.sent).anySatisfy(s -> assertThat(s.payload())
+                    .contains("도쿄 · 오늘 일정 1개 · 첫 일정 09:00 숙소 체크아웃"));
+        }
+
+        @Test
+        @DisplayName("도시가 바뀌는 날은 `도쿄 → 방콕` 꼴로 말한다 — 그날 가장 큰 사건이다")
+        void tellsCityMoveOnChangeDay() throws Exception {
+            long tripId = createTwoCityTrip();
+            addActivity(tripId, "공항 이동", "2020-01-03", "10:00");
+
+            dispatchService.dispatchDue();
+
+            assertThat(stub.sent).anySatisfy(s -> assertThat(s.payload())
+                    .contains("도쿄 → 방콕 · 오늘 일정 1개"));
         }
 
         @Test
@@ -255,6 +336,63 @@ class MorningSummaryTest extends ApiTestSupport {
 
     private long tokyoCityId() throws Exception {
         return TravelCityFixture.createCity(mockMvc, authHeader, "도쿄", "Asia/Tokyo", "JPY");
+    }
+
+    /**
+     * 도쿄(+9) 2일 → 방콕(+7) 1일.
+     *
+     * <p><b>타임존이 실제로 다른 두 도시</b>라야 "전날 도시 08:00"이 관찰된다 — 오사카·교토는
+     * 둘 다 {@code Asia/Tokyo}여서 규칙이 맞든 틀리든 같은 순간이 나온다.
+     */
+    private long createTwoCityTrip() throws Exception {
+        long tokyo = tokyoCityId();
+        long bangkok = TravelCityFixture.createCity(
+                mockMvc, authHeader, "방콕", "Asia/Bangkok", "THB");
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "동남아",
+                                 "startDate": "2020-01-01", "endDate": "2020-01-03",
+                                 "legs": [{"cityPlaceId": %d, "days": 2},
+                                          {"cityPlaceId": %d, "days": 1}],
+                                 "morningSummaryEnabled": true}
+                                """.formatted(tokyo, bangkok)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private long bangkokCityId() throws Exception {
+        return TravelCityFixture.createCity(mockMvc, authHeader, "방콕2", "Asia/Bangkok", "THB");
+    }
+
+    /** 그 날짜의 대기 중 아침 요약 예약 시각. */
+    private Instant morningAt(String date) {
+        return morningNotifications().stream()
+                .filter(n -> n.getStatus() == NotificationStatus.PENDING)
+                .filter(n -> n.getTargetDate().toString().equals(date))
+                .findFirst()
+                .orElseThrow()
+                .getScheduledAt();
+    }
+
+    private long dayIdOf(long tripId, String date) throws Exception {
+        String body = mockMvc.perform(get("/api/travel/trips/" + tripId + "/days")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        List<Integer> ids = com.jayway.jsonpath.JsonPath.read(
+                body, "$.data[?(@.date=='" + date + "')].dayId");
+        return ids.get(0).longValue();
+    }
+
+    private void changeBaseCity(long dayId, long cityPlaceId) throws Exception {
+        mockMvc.perform(put("/api/travel/days/" + dayId)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"baseCityPlaceId\": %d}".formatted(cityPlaceId)))
+                .andExpect(status().isOk());
     }
 
 }

--- a/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/push/repository/PushNotificationRepository.java
+++ b/be/orino-domain-rdb/src/main/java/ds/project/orino/domain/planner/push/repository/PushNotificationRepository.java
@@ -1,10 +1,13 @@
 package ds.project.orino.domain.planner.push.repository;
 
 import ds.project.orino.domain.planner.push.entity.NotificationStatus;
+import ds.project.orino.domain.planner.push.entity.NotificationType;
 import ds.project.orino.domain.planner.push.entity.PushNotification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 
 public interface PushNotificationRepository extends JpaRepository<PushNotification, Long> {
@@ -18,6 +21,16 @@ public interface PushNotificationRepository extends JpaRepository<PushNotificati
 
     /** 여행 단위 재계산(타임존 변경 등). */
     List<PushNotification> findAllByTripIdAndStatus(Long tripId, NotificationStatus status);
+
+    /**
+     * 날짜에 걸린 알림(아침 요약)의 재계산.
+     *
+     * <p>일정 id로는 찾을 수 없다 — 아침 요약은 하루 전체를 가리키므로 특정 일정에 붙어 있지
+     * 않다. 기준 도시가 바뀌면 이 경로로 찾아 다시 잡는다.
+     */
+    List<PushNotification> findAllByTripIdAndTypeAndTargetDateInAndStatus(
+            Long tripId, NotificationType type, Collection<LocalDate> targetDates,
+            NotificationStatus status);
 
     List<PushNotification> findAllByMemberIdOrderByScheduledAtAsc(Long memberId);
 }


### PR DESCRIPTION
## 이슈
closes #1167

## 작업 내용

**교토로 넘어가는 날, 교토 시각 08:00에 요약이 오면 이미 늦다.** 그 시각 사용자는 아직 오사카에서 짐을 싸고 있다. 아침에 보는 시계는 떠나는 도시의 시계다.

- 도시가 바뀌는 날의 아침 요약을 **그날 08:00이되 전날 도시의 시계로** 예약한다
- 본문에 도시 접두 — 같은 도시 `도쿄 · 오늘 일정 2개 · 첫 일정 09:00 …`, 이동일 `도쿄 → 방콕 · 오늘 일정 1개`
- 기준 도시를 바꾸면 아침 요약도 다시 잡는다 — **그 날짜와 다음 날짜 둘 다**
- 예약(발송 시각)과 발송(본문)이 **같은 판정**(`MorningCity`)을 쓴다. 두 벌이면 오사카 시각에 보내면서 본문은 교토라고 말하는 날이 생긴다

## 고친 버그 — 아침 요약은 재계산 그물에 걸리지 않았다

`rescheduleDate`는 **일정 id로** 대기 알림을 접고 다시 만든다. 아침 요약은 하루 전체를 가리켜 어느 일정에도 붙어 있지 않으므로 **취소되지도 새로 만들어지지도 않았다** — 기준 도시를 바꿔도 옛 도시의 08:00에 그대로 남았다. 요약을 만드는 곳은 `rescheduleTrip`(여행 생성·기간 변경) 하나뿐이었다.

**그리고 그 날짜만 다시 잡으면 여전히 틀린다.** 발송 시각이 "도시가 바뀌는 날인가"에 걸려 있고 그 판정은 앞 날짜와의 비교라, N일차를 바꾸면 **N+1일차의 판정까지 뒤집힌다.** 테스트가 이 경우를 직접 잡는다 — 1/2를 방콕으로 바꾸면 **1/3의 발송 시각**이 도쿄 08:00에서 방콕 08:00으로 옮겨간다.

## 위키에서 고친 모순 1건

[Travel-Architecture §4](https://github.com/wcorn/orino/wiki/Travel-Architecture)에 이렇게 적혀 있었다:

> 도시가 바뀌는 날의 요약은 **전날 날짜의 타임존으로 전날 08:00**에 나간다. 그날 도시 기준으로 계산하면 이미 이동 중일 때 도착한다.

**하루 앞당겨 보내라는 뜻이 되는데, 같은 문장의 근거와 어긋난다.** "이미 이동 중일 때 도착한다"가 가리키는 것은 *날짜*가 아니라 *시계*다. 하루 앞당기면 본문 `오늘 일정 3개`가 내일 이야기가 된다. [확정 명세 §3.6](https://github.com/wcorn/orino/wiki/Travel-Spec-v2-1)과 [설정 문구 §9.5](https://github.com/wcorn/orino/wiki/Travel-UI-Design)는 둘 다 "전날 **도시** 08:00"이라 2:1이기도 하다. 명세 쪽을 정본으로 보고 구현했고, 아키텍처 문서를 정정하며 왜 그렇게 읽었는지 남겼다.

**다르게 읽으셨다면 알려주세요** — 구현이 뒤집히는 지점입니다.

## 판단이 갈릴 수 있는 곳

**이동일 본문에서 `첫 일정`을 뺐다.** 명세 예시(`오사카 → 교토 · 오늘 일정 3개`)와 설정 미리보기가 둘 다 그 형태다. 알림 본문은 한 줄이고 도시 두 개가 이미 그 줄을 채운다.

**같은 타임존 안에서는 관찰되지 않는다.** 오사카·교토는 둘 다 `Asia/Tokyo`라 규칙이 맞든 틀리든 같은 순간이다. 실제로 값이 갈리는 것은 국가를 넘을 때뿐이라, 테스트도 **도쿄(+9) → 방콕(+7)** 으로 짰다. 10/24 일본 여행에서는 이 변경이 눈에 보이지 않는다.

## 테스트

- 예약 — 이동일은 전날 도시 08:00 · 그대로인 날은 그날 도시 08:00 · **첫날은 변경일이 아니다** · 기준 도시 변경이 **다음 날짜** 발송 시각을 옮긴다 · 요약이 두 벌 남지 않는다
- 발송 — 도시 접두 · 이동일 `도쿄 → 방콕` 꼴
- 기존 아침 요약 테스트 9종 그대로 통과(접두가 붙어도 `contains` 단언이 살아 있다)

> 통합 테스트가 **예약 → DB → 발송 → payload**까지 실제 경로로 돈다(TestContainers MySQL·Redis). 대역은 웹푸시 전송 하나뿐이다.

## 게이트

- `cd be && ./gradlew check` ✅
- FE 변경 없음

## 위키

[Travel-Architecture §4 · §6](https://github.com/wcorn/orino/wiki/Travel-Architecture) — 모순 정정 + 아침 요약 재계산 경로가 일정 알림과 다른 이유
