### PR TITLE
fix : S3 암호화 설정 영구 diff 제거

### DIFF
--- a/infra/terraform/modules/s3/main.tf
+++ b/infra/terraform/modules/s3/main.tf
@@ -5,7 +5,22 @@ resource "aws_s3_bucket" "this" {
 resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   bucket = aws_s3_bucket.this.id
 
+  # blocked_encryption_types · bucket_key_enabled 를 명시하는 이유는 설정을 바꾸려는
+  # 게 아니라 영구 diff 를 멈추기 위해서다. AWS 가 버킷에 blocked_encryption_types =
+  # ["SSE-C"] 를 스스로 채우는데 코드에 그 속성이 없으면, 매 refresh 마다 실제 상태와
+  # 코드가 어긋나 apply 가 이 버킷을 항상 "변경됨"으로 잡는다(실제로 두 번 연속
+  # 같은 5건이 왕복했다). bucket_key_enabled 도 실제 false / 코드 미지정으로 같은 상황.
+  # rule 은 집합 원소로 비교되므로 둘 중 하나만 맞춰서는 diff 가 남는다 — 둘 다 적는다.
+  #
+  # 값 자체는 현재 AWS 실제 상태 그대로다. SSE-C(고객 제공 키) 차단은 유지하는 편이
+  # 안전하고, 안 적으면 apply 마다 벗겨진다.
+  #
+  # 무관한 변경 5줄이 매번 뜨면 진짜 변경을 가린다. 항상 켜져 있는 경고등은 꺼진
+  # 경고등과 같다 — ELOG-027 이 5개월간 안 보였던 것과 같은 종류의 마모다. #1171
   rule {
+    bucket_key_enabled       = false
+    blocked_encryption_types = ["SSE-C"]
+
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }


### PR DESCRIPTION
## 이슈
closes #1171
## 작업 내용
- `infra/terraform/modules/s3/main.tf` — `rule`에 `blocked_encryption_types = ["SSE-C"]` · `bucket_key_enabled = false` 명시

**설정을 바꾸는 PR이 아니라 영구 diff를 멈추는 PR이다.** 값은 현재 AWS 실제 상태 그대로다.

### 왜 두 속성 다인가

`rule`은 집합(set) 원소로 비교되므로 원소 하나라도 다르면 블록 전체가 `- rule {} + rule {}`로 교체된다. 실제 diff에서 어긋나는 건 두 개다:

| 속성 | AWS 실제 | 기존 코드 |
|---|---|---|
| `blocked_encryption_types` | `["SSE-C"]` | `[]` (미지정) |
| `bucket_key_enabled` | `false` | `null` (미지정) |

`blocked_encryption_types`만 고치면 `bucket_key_enabled` 때문에 diff가 남는다.

### 왜 고치는가 — 절감이 아니라 감시 마모다

Epic #1148의 #1149·#1150은 **"머지 후 apply 성공을 눈으로 확인한다"**를 게이트로 삼는데, 매 apply마다 뜨는 무관한 5줄이 진짜 변경을 가린다. [ELOG-027](https://github.com/wcorn/orino/wiki/ELOG-027-s3-polling-loops-loki-retention)의 실패가 정확히 이 종류였다 — 선언된 정책이 안 도는 걸 아무도 안 봐서 5개월이 갔다. **항상 켜져 있는 경고등은 꺼진 경고등과 같다.**

부수적으로 SSE-C 차단이 apply마다 벗겨지던 것도 멈춘다.

### 왕복이라는 근거

두 번의 apply에서 같은 5건이 반복됐다:

| apply | 결과 |
|---|---|
| [31455785577](https://github.com/wcorn/orino/actions/runs/31455785577) (#1149 머지) | `0 added, 7 changed` — 5건이 SSE |
| [31459156203](https://github.com/wcorn/orino/actions/runs/31459156203) (#1150 머지) | `3 added, 5 changed` — **같은 5건이 또** |

첫 apply에서 `[]`로 바꿨는데 두 번째에서 다시 `["SSE-C"] → []`가 잡혔다 = AWS가 도로 채워 넣는다.

## 확인
- [x] `terraform fmt -check -recursive` 통과
- [x] `terraform validate` 통과
- [x] 두 속성이 provider에서 실제로 설정 가능한지 격리 config로 확인(스키마상 존재만이 아니라 `validate` 통과)
- [ ] **PR plan에서 SSE 5건이 사라지는지 확인 — 이게 완료 판정이다**
- [ ] 머지 후 apply에서 `5 changed`가 없어졌는지 확인
- [ ] 다음 무관한 apply 한 번에서 재발하지 않는지 재확인 — 한 번 조용한 것으로 왕복이 멈췄다고 단정하지 않는다
