### PR TITLE
feat : S-07 도시 경계 안내 · 출발 알림 차단 · 알림 타임존 표기

### DIFF
--- a/fe/e2e/travel-activity-city.spec.ts
+++ b/fe/e2e/travel-activity-city.spec.ts
@@ -1,0 +1,227 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 일정 상세의 도시 경계 안내(S-07, #1168).
+ *
+ * <p>여기서 확인하는 것은 <b>못 켜는 스위치가 실제로 안 눌리는가</b>다. `disabled` 속성만
+ * 보는 검사는 눌렀을 때 상태가 바뀌지 않는지까지는 말해 주지 않는다.
+ */
+
+const D1 = "2026-10-24";
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+const OSAKA_PLACE = {
+  id: 12,
+  name: "구로몬 시장",
+  address: "오사카시",
+  lat: 34.6656,
+  lng: 135.5061,
+  cityName: "오사카",
+  cityPlaceRef: "ChIJ_osaka",
+};
+
+const KYOTO_PLACE = {
+  id: 11,
+  name: "기요미즈데라",
+  address: "교토시",
+  lat: 34.9949,
+  lng: 135.785,
+  cityName: "교토",
+  cityPlaceRef: "ChIJ_kyoto",
+};
+
+function activity(id: number, title: string, place: unknown) {
+  return {
+    id,
+    tripId: 3,
+    title,
+    activityDate: D1,
+    startTime: "09:00",
+    place,
+    memo: null,
+    url: null,
+    notifyEnabled: false,
+    notifyMinutes: null,
+    departureNotifyEnabled: false,
+    sortOrder: id,
+    log: null,
+    hasLog: false,
+    outOfBaseCity: true,
+    // 도시를 넘어 들어오는 일정이라 서버가 false로 내려준다(#1142).
+    canDepartureNotify: false,
+  };
+}
+
+async function mockTrip(page: Page) {
+  const saved: Record<string, unknown>[] = [];
+
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/planner/reviews/summary", (route) =>
+    route.fulfill(
+      ok({
+        today: D1,
+        counts: { now: 0, overdue: 0, upcoming: 0, doneToday: 0 },
+        estimatedMinutes: 0,
+        materials: [],
+      }),
+    ),
+  );
+  await page.route("**/api/travel/summary", (route) =>
+    route.fulfill(ok({ ongoing: null, next: null, recentCompleted: null })),
+  );
+  await page.route("**/api/travel/trips/*/stays", (route) =>
+    route.fulfill(ok([])),
+  );
+  await page.route("**/api/travel/places/*", (route) =>
+    route.fulfill(
+      ok({
+        ...KYOTO_PLACE,
+        googlePlaceId: null,
+        openingHours: null,
+        phone: null,
+        category: null,
+        rating: null,
+        manualEntry: false,
+      }),
+    ),
+  );
+
+  await page.route("**/api/travel/activities/1", (route) => {
+    if (route.request().method() === "PUT") {
+      saved.push(route.request().postDataJSON() as Record<string, unknown>);
+      return route.fulfill(ok(activity(1, "기요미즈데라", KYOTO_PLACE)));
+    }
+    return route.fulfill(ok(activity(1, "기요미즈데라", KYOTO_PLACE)));
+  });
+
+  await page.route("**/api/travel/trips/3", (route) =>
+    route.fulfill(
+      ok({
+        id: 3,
+        title: "일본",
+        destinationName: "오사카",
+        destinationPlaceId: null,
+        startDate: D1,
+        endDate: D1,
+        timezone: "Asia/Tokyo",
+        currency: "JPY",
+        lat: null,
+        lng: null,
+        defaultNotifyMinutes: 15,
+        morningSummaryEnabled: true,
+        status: "UPCOMING",
+        dDay: 10,
+        totalDays: 1,
+        activityCount: 2,
+        cities: {
+          names: ["오사카", "교토"],
+          count: 2,
+          today: null,
+          movedFrom: null,
+          todayDayIndex: null,
+          todayTimezone: null,
+          todayCurrency: null,
+        },
+      }),
+    ),
+  );
+
+  await page.route("**/api/travel/trips/3/board*", (route) =>
+    route.fulfill(
+      ok({
+        trip: {
+          id: 3,
+          title: "일본",
+          startDate: D1,
+          endDate: D1,
+          status: "UPCOMING",
+          recordMode: false,
+          cityCount: 2,
+          countryCount: 1,
+          singleCity: false,
+        },
+        days: [
+          {
+            dayId: 1,
+            dayIndex: 1,
+            date: D1,
+            weekday: "토",
+            activityCount: 2,
+            baseCity: {
+              placeId: 21,
+              name: "교토",
+              timezone: "Asia/Tokyo",
+              currency: "JPY",
+              countryCode: "JP",
+              cityPlaceRef: "ChIJ_kyoto",
+              lat: null,
+              lng: null,
+            },
+            cityChanged: false,
+            legIndex: 1,
+            cityMemo: null,
+            weather: null,
+            stayTonight: null,
+            stayCheckout: null,
+          },
+        ],
+        selectedDate: D1,
+        archiveCount: 0,
+        activities: [
+          activity(9, "구로몬 시장", OSAKA_PLACE),
+          activity(1, "기요미즈데라", KYOTO_PLACE),
+        ],
+        // 서버가 계산하지 않은 구간(#1142).
+        travelTimes: [
+          {
+            fromActivityId: 9,
+            toActivityId: 1,
+            mode: null,
+            durationMinutes: null,
+            distanceM: 42800,
+            fallback: false,
+            crossCity: true,
+          },
+        ],
+        stayMove: null,
+      }),
+    ),
+  );
+
+  return saved;
+}
+
+test.describe("일정 상세 · 도시 경계", () => {
+  test("도시를 넘는 일정은 출발 알림을 눌러도 켜지지 않고, 왜인지 적혀 있다", async ({
+    page,
+  }) => {
+    await mockTrip(page);
+    await page.goto("/travel/activities/1");
+
+    // 부제가 며칠째의 어느 도시인지 말한다.
+    await expect(page.getByText("1일차 · 교토 · 10.24")).toBeVisible();
+    await expect(
+      page.getByText(
+        "오사카 → 교토 · 도시 경계를 넘어 이동시간을 계산하지 않아요",
+      ),
+    ).toBeVisible();
+    await expect(
+      page.getByText("도시 간 이동은 출발 알림을 계산할 수 없어요"),
+    ).toBeVisible();
+
+    // 일정 알림은 그대로 켤 수 있다 — 막힌 것은 출발 알림뿐이다.
+    const departure = page.getByRole("switch", { name: "출발 알림" });
+    await expect(departure).toBeDisabled();
+    await departure.click({ force: true });
+    await expect(departure).toHaveAttribute("aria-checked", "false");
+
+    await expect(page.getByRole("switch", { name: "일정 알림" })).toBeEnabled();
+  });
+});

--- a/fe/src/pages/travel/ActivityDetailPage.test.tsx
+++ b/fe/src/pages/travel/ActivityDetailPage.test.tsx
@@ -48,6 +48,9 @@ function activity(overrides: Record<string, unknown> = {}) {
     sortOrder: 0,
     log: null,
     hasLog: false,
+    outOfBaseCity: false,
+    // 서버가 판정해 내려주는 값(#1142). 화면은 읽기만 한다.
+    canDepartureNotify: true,
     ...overrides,
   };
 }
@@ -132,6 +135,35 @@ describe("ActivityDetailPage", () => {
     expect(
       screen.getByRole("option", { name: "보관함 (미배정)" }),
     ).toBeInTheDocument();
+  });
+
+  it("날짜 선택지에 도시명이 붙는다 — `4일차`만으로는 어디로 옮기는지 모른다", async () => {
+    mockDetail();
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByLabelText("제목")).toHaveValue("센소지");
+    });
+
+    await userEvent.click(screen.getByRole("combobox", { name: "날짜" }));
+
+    // 기본 보드 목이 1일차를 도쿄로 준다.
+    expect(
+      await screen.findByRole("option", { name: "1일차 · 도쿄 (10.24)" }),
+    ).toBeInTheDocument();
+  });
+
+  it("헤더 부제가 며칠째의 어느 도시인지 말한다", async () => {
+    mockDetail();
+    renderDetail();
+
+    expect(await screen.findByText("1일차 · 도쿄 · 10.24")).toBeInTheDocument();
+  });
+
+  it("보관함 일정은 날짜가 없다고 말한다", async () => {
+    mockDetail({ activityDate: null });
+    renderDetail();
+
+    expect(await screen.findByText("보관함 · 날짜 미정")).toBeInTheDocument();
   });
 
   it("보관함을 고르면 activityDate를 null로 저장한다", async () => {
@@ -342,7 +374,83 @@ describe("ActivityDetailPage", () => {
       address: "다이토구",
       lat: 35.7147651,
       lng: 139.7966553,
+      cityName: "도쿄",
+      cityPlaceRef: "ChIJ_tokyo",
     };
+
+    const KYOTO_PLACE = {
+      ...PLACE,
+      id: 11,
+      name: "기요미즈데라",
+      cityName: "교토",
+      cityPlaceRef: "ChIJ_kyoto",
+    };
+
+    /**
+     * 그날 보드 — 상세 화면이 <b>날짜가 갖는 것들</b>을 여기서 읽는다.
+     *
+     * <p>도시 경계 판정은 서버가 내려준 `travelTimes[].crossCity`다. 화면이 좌표로 다시
+     * 따지지 않는지 보려면 목이 그 값을 쥐고 있어야 한다.
+     */
+    function mockDayBoard({ crossCity = true }: { crossCity?: boolean } = {}) {
+      server.use(
+        http.get(`${API_BASE}/travel/trips/:tripId/board`, () =>
+          HttpResponse.json({
+            code: "OK",
+            data: {
+              trip: { ...TRIP, recordMode: false, singleCity: false },
+              days: [
+                {
+                  dayId: 1,
+                  dayIndex: 1,
+                  date: "2026-10-24",
+                  weekday: "토",
+                  activityCount: 2,
+                  baseCity: {
+                    placeId: 21,
+                    name: "교토",
+                    timezone: "Asia/Tokyo",
+                    currency: "JPY",
+                    countryCode: "JP",
+                    cityPlaceRef: "ChIJ_kyoto",
+                    lat: null,
+                    lng: null,
+                  },
+                  cityChanged: false,
+                  legIndex: 1,
+                  cityMemo: null,
+                  weather: null,
+                  stayTonight: null,
+                  stayCheckout: null,
+                },
+              ],
+              selectedDate: "2026-10-24",
+              archiveCount: 0,
+              activities: [
+                activity({
+                  id: 9,
+                  title: "구로몬 시장",
+                  place: { ...PLACE, id: 12, cityName: "오사카" },
+                }),
+                activity({ id: 1, place: KYOTO_PLACE }),
+              ],
+              travelTimes: [
+                {
+                  fromActivityId: 9,
+                  toActivityId: 1,
+                  mode: crossCity ? null : "WALK",
+                  durationMinutes: crossCity ? null : 12,
+                  distanceM: 42800,
+                  fallback: false,
+                  crossCity,
+                },
+              ],
+              stayMove: null,
+            },
+          }),
+        ),
+      );
+    }
 
     it("시각이 없으면 통째로 비활성이다 — 언제 보낼지 정할 수 없다", async () => {
       mockDetail({ startTime: null });
@@ -413,6 +521,47 @@ describe("ActivityDetailPage", () => {
       });
     });
 
+    it("도시를 넘어 들어오면 출발 알림을 켤 수 없고 왜인지 말한다", async () => {
+      mockDetail({ place: KYOTO_PLACE, canDepartureNotify: false });
+      mockDayBoard();
+
+      renderDetail();
+      await screen.findByLabelText("제목");
+
+      expect(screen.getByRole("switch", { name: "출발 알림" })).toBeDisabled();
+      // "시각과 이전 장소가 필요해요"는 고칠 수 없는 것을 고치라는 말이 된다.
+      expect(
+        screen.getByText("도시 간 이동은 출발 알림을 계산할 수 없어요"),
+      ).toBeInTheDocument();
+    });
+
+    it("장소 블록에 어디서 어디로 넘는지 적는다", async () => {
+      mockDetail({ place: KYOTO_PLACE, canDepartureNotify: false });
+      mockDayBoard();
+
+      renderDetail();
+      await screen.findByLabelText("제목");
+
+      expect(
+        screen.getByText(
+          "오사카 → 교토 · 도시 경계를 넘어 이동시간을 계산하지 않아요",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("같은 도시 안이면 안내도 없고 스위치도 살아 있다", async () => {
+      mockDetail({ place: PLACE });
+      mockDayBoard({ crossCity: false });
+
+      renderDetail();
+      await screen.findByLabelText("제목");
+
+      expect(screen.queryByText(/도시 경계를 넘어/)).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("switch", { name: "출발 알림" }),
+      ).not.toBeDisabled();
+    });
+
     it("알림 시점을 비우면 여행 기본값을 따른다", async () => {
       mockDetail({ notifyEnabled: true, notifyMinutes: 30 });
       const bodies: Record<string, unknown>[] = [];
@@ -426,7 +575,8 @@ describe("ActivityDetailPage", () => {
       const user = userEvent.setup();
       renderDetail();
       await screen.findByLabelText("제목");
-      expect(screen.getByText("시작 30분 전")).toBeInTheDocument();
+      // 타임존을 함께 말한다 — 09:00이 어느 도시의 09:00인지가 매번 달라진다.
+      expect(screen.getByText("시작 30분 전 · Asia/Tokyo")).toBeInTheDocument();
 
       await user.click(screen.getByRole("button", { name: "저장" }));
 

--- a/fe/src/pages/travel/ActivityDetailPage.tsx
+++ b/fe/src/pages/travel/ActivityDetailPage.tsx
@@ -4,6 +4,7 @@ import {
   MapPin,
   Navigation,
   Phone,
+  TrainFront,
   Trash2,
 } from "lucide-react";
 import {
@@ -30,8 +31,10 @@ import {
 import { useUndoableAction } from "@/features/travel/board/useUndoableAction";
 import { useActivity } from "@/features/travel/hooks/useActivity";
 import { useUpdateActivity } from "@/features/travel/hooks/useActivityMutations";
+import { useBoard } from "@/features/travel/hooks/useBoard";
 import { usePlaceDetail } from "@/features/travel/hooks/usePlaceDetail";
 import { useTrip } from "@/features/travel/hooks/useTrip";
+import { cityOn } from "@/features/travel/lib/baseCity";
 import { NOTIFY_MINUTES_OPTIONS } from "@/features/travel/lib/destinations";
 import { placeDirectionsUrl } from "@/features/travel/lib/mapsLink";
 import { todayOpeningHours } from "@/features/travel/lib/openingHours";
@@ -87,6 +90,20 @@ export function ActivityDetailPage() {
   const { data: activity, isPending } = useActivity(activityId);
   const { data: placeDetail } = usePlaceDetail(activity?.place?.id ?? null);
   const { data: trip } = useTrip(activity?.tripId ?? null);
+  /**
+   * 그날의 보드. <b>날짜가 갖는 것들</b>이 여기에만 있다 — 기준 도시·타임존과, 앞뒤 일정
+   * 사이의 도시 경계 판정({@code travelTimes[].crossCity})이다.
+   *
+   * <p>여행 상세({@code trip.timezone})로는 안 된다. 그 값은 <b>첫날</b> 기준 도시에서
+   * 파생된 것이라, 도시를 옮긴 날짜에서 조용히 틀린 타임존을 말한다.
+   *
+   * <p>보드에서 들어오는 경로가 대부분이라 대개 캐시가 이미 따뜻하다.
+   */
+  const { data: board } = useBoard(
+    activity?.tripId ?? 0,
+    { date: activity?.activityDate ?? undefined },
+    { enabled: activity !== undefined },
+  );
   const updateActivity = useUpdateActivity(activity?.tripId ?? 0);
   const undoable = useUndoableAction(activity?.tripId ?? 0);
 
@@ -131,22 +148,70 @@ export function ActivityDetailPage() {
   const boardPath = boardPathFor(form.day);
   // 시각이 없으면 언제 보낼지 정할 수 없다(§1.2) — 서버도 같은 규칙이다.
   const hasStartTime = form.startTime !== "";
-  // 출발 알림은 직전 장소 있는 일정이 필요하다. 그건 보드가 아는 값이라
-  // 여기서는 "이 일정에 장소가 있는가"까지만 본다 — 없으면 구간 자체가 안 생긴다.
-  const canNotifyDeparture = hasStartTime && activity.place !== null;
+  /**
+   * 출발 알림을 켤 수 있는가. <b>판정은 서버가 한다</b>({@code canDepartureNotify}, #1142) —
+   * 직전에 장소 있는 일정이 있고 그 사이가 도시를 넘지 않아야 한다. 화면이 좌표로 다시
+   * 따지면 보드와 답이 갈린다.
+   */
+  const canNotifyDeparture =
+    hasStartTime && activity.place !== null && activity.canDepartureNotify;
+  /** 이 일정으로 <b>들어오는</b> 이동. 도시를 넘으면 서버가 계산하지 않은 구간이다. */
+  const incoming =
+    activity.activityDate !== null &&
+    board?.selectedDate === activity.activityDate
+      ? board.travelTimes.find((t) => t.toActivityId === activity.id)
+      : undefined;
+  /** 도시 경계를 넘어 들어오는가. 판정은 읽어 오기만 한다(D-23). */
+  const crossCity = incoming?.crossCity === true;
+  /** 그 경계의 출발 쪽 도시 — 안내 문구의 `오사카 → 교토`에서 앞자리다. */
+  const fromCityName = crossCity
+    ? (board?.activities.find((a) => a.id === incoming?.fromActivityId)?.place
+        ?.cityName ?? null)
+    : null;
+  /** 이 날짜의 기준 도시. 부제·알림 타임존이 쓴다. */
+  const dayCity = cityOn(board?.days ?? [], activity.activityDate ?? "");
   const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
     setForm((prev) => (prev ? { ...prev, [key]: value } : prev));
 
-  // 1일차~N일차 + 보관함. 여행 기간을 알아야 만들 수 있어 상세를 함께 읽는다.
+  /**
+   * 1일차~N일차 + 보관함. 여행 기간을 알아야 만들 수 있어 상세를 함께 읽는다.
+   *
+   * <p>날짜마다 도시를 붙인다 — 다구간 여행에서 "4일차"만으로는 어디로 옮기는지 알 수 없다.
+   * 아직 도시를 못 읽었으면 요일로 대신한다(빈 자리를 남기지 않는다).
+   */
   const dayOptions = [
     ...(trip
-      ? dayChips(trip.startDate, trip.endDate).map((chip) => ({
-          value: chip.date,
-          label: `${chip.dayIndex}일차 · ${formatShortDate(chip.date)} ${chip.weekday}`,
-        }))
+      ? dayChips(trip.startDate, trip.endDate).map((chip) => {
+          const city = cityOn(board?.days ?? [], chip.date);
+          const where = city ? city.name : chip.weekday;
+          return {
+            value: chip.date,
+            label: `${chip.dayIndex}일차 · ${where} (${formatShortDate(chip.date)})`,
+          };
+        })
       : []),
     { value: ARCHIVE_VALUE, label: "보관함 (미배정)" },
   ];
+
+  /**
+   * 헤더 부제 — 며칠째의 어느 도시인가. 보관함 일정에는 날짜가 없다.
+   *
+   * <p>아직 못 읽은 조각은 <b>빼고 잇는다.</b> 자리를 비워 두거나 `?일차`로 채우면 로딩 중
+   * 화면이 고장난 것처럼 보인다.
+   */
+  const dayIndex = board?.days.find(
+    (d) => d.date === activity.activityDate,
+  )?.dayIndex;
+  const subtitle =
+    activity.activityDate === null
+      ? "보관함 · 날짜 미정"
+      : [
+          dayIndex === undefined ? null : `${dayIndex}일차`,
+          dayCity?.name,
+          formatShortDate(activity.activityDate),
+        ]
+          .filter(Boolean)
+          .join(" · ");
 
   const save = async (event: FormEvent) => {
     event.preventDefault();
@@ -196,9 +261,14 @@ export function ActivityDetailPage() {
         >
           <ArrowLeft className="size-4" />
         </Button>
-        <h1 className="text-heading min-w-0 flex-1 truncate font-semibold">
-          {activity.title}
-        </h1>
+        <div className="min-w-0 flex-1">
+          <h1 className="text-heading truncate font-semibold">
+            {activity.title}
+          </h1>
+          <p className="text-caption text-muted-foreground truncate">
+            {subtitle}
+          </p>
+        </div>
         <Button
           variant="ghost"
           size="icon-sm"
@@ -260,6 +330,17 @@ export function ActivityDetailPage() {
                 )}
               </div>
             </div>
+
+            {/* 도시 경계 안내(§9.4) — 판정은 서버가 한 것을 읽기만 한다(D-23).
+                여기서 좌표로 다시 따지면 보드의 `도시 이동` 행과 답이 갈린다. */}
+            {crossCity && (
+              <p className="bg-muted text-muted-foreground flex items-center gap-2 rounded-lg px-2.5 py-[7px] text-xs">
+                <TrainFront className="size-[13px] shrink-0" />
+                {fromCityName && activity.place.cityName
+                  ? `${fromCityName} → ${activity.place.cityName} · 도시 경계를 넘어 이동시간을 계산하지 않아요`
+                  : "도시 경계를 넘어 이동시간을 계산하지 않아요"}
+              </p>
+            )}
 
             {/* 영업시간·전화는 상세 조회에서 온다. 서버가 30일 캐시한다(§4.7). */}
             {openingToday && (
@@ -328,10 +409,17 @@ export function ActivityDetailPage() {
           <div className="flex items-center gap-3 border-b pb-3">
             <div className="min-w-0 flex-1">
               <p className="text-sm font-medium">일정 알림</p>
+              {/* 타임존을 함께 말한다(§9.4) — `09:00`이 어느 도시의 09:00인지가
+                  도시를 옮기는 여행에서는 매번 달라진다. */}
               <p className="text-muted-foreground text-xs">
-                {form.notifyMinutes
-                  ? `시작 ${form.notifyMinutes}분 전`
-                  : "여행 기본값"}
+                {[
+                  form.notifyMinutes
+                    ? `시작 ${form.notifyMinutes}분 전`
+                    : "여행 기본값",
+                  dayCity?.timezone,
+                ]
+                  .filter(Boolean)
+                  .join(" · ")}
               </p>
             </div>
             <Select
@@ -358,10 +446,14 @@ export function ActivityDetailPage() {
           <div className="flex items-center gap-3">
             <div className="min-w-0 flex-1">
               <p className="text-sm font-medium">출발 알림</p>
+              {/* 못 켜는 이유를 구분해 말한다 — "시각과 이전 장소가 필요해요"는 도시를
+                  넘어서 막힌 사람에게 고칠 수 없는 것을 고치라는 말이 된다. */}
               <p className="text-muted-foreground text-xs">
                 {canNotifyDeparture
                   ? "시작시각 − 이동시간 − 5분"
-                  : "시각과 이전 장소가 필요해요"}
+                  : crossCity
+                    ? "도시 간 이동은 출발 알림을 계산할 수 없어요"
+                    : "시각과 이전 장소가 필요해요"}
               </p>
             </div>
             <Switch


### PR DESCRIPTION
## 이슈
closes #1168

## 작업 내용

**켤 수 없는 스위치를 켤 수 있는 것처럼 보여주지 않는다.** 판정은 #1142에서 서버가 이미 끝냈고, 화면만 그 값을 읽지 않고 있었다.

- **출발 알림** — `canDepartureNotify`가 false면 비활성. **못 켜는 이유를 구분해서** 말한다
- **도시 경계 안내** — 장소 블록에 `오사카 → 교토 · 도시 경계를 넘어 이동시간을 계산하지 않아요`
- **헤더 부제** `1일차 · 교토 · 10.24` (보관함이면 `보관함 · 날짜 미정`)
- **날짜 Select** `4일차 · 교토 (10.27)`
- **알림 보조에 타임존** `시작 15분 전 · Asia/Tokyo`

## 판단이 갈릴 수 있는 곳 (리뷰 요청)

**1. 경계 판정을 좌표로 다시 하지 않고 `travelTimes[].crossCity`를 읽는다.** 설계 문구는 "직전 장소와 도시가 다르면"인데, 그 판정은 이미 서버가 내려주는 값이다(#1142). FE가 따로 계산하면 보드의 `도시 이동` 행과 상세의 안내가 갈릴 수 있고, D-23이 막으려는 것이 정확히 그 두 벌이다.

**2. 못 켜는 이유를 두 문구로 나눴다.** 기존 `시각과 이전 장소가 필요해요`를 그대로 쓰면 도시를 넘어 막힌 사람에게 **고칠 수 없는 것을 고치라는 말**이 된다. 그래서 cross-city일 때만 전용 문구를 쓴다.

**3. 상세 화면이 보드를 함께 읽는다(`useBoard(tripId, { date })`).** 날짜가 갖는 것들(기준 도시·타임존·경계 판정)이 거기에만 있다. 여행 상세의 `trip.timezone`은 **첫날** 도시에서 파생된 값이라 도시를 옮긴 날짜에서 조용히 틀린다. 보드에서 들어오는 경로가 대부분이라 대개 캐시가 따뜻하고, 아니어도 요청 하나다.

**4. 헤더 부제는 못 읽은 조각을 빼고 잇는다.** 로딩 중 `?일차`나 빈 자리를 보여주면 화면이 고장난 것처럼 읽힌다.

## 범위 밖이라 하지 않은 것

**`outOfBaseCity`는 상세에서 여전히 안 쓴다.** 보드 행(`ActivityRow`)이 이미 `· 오사카`를 경고색으로 붙이고 있고, 상세에는 그 표시가 설계에 없다. 경계 안내가 더 구체적인 정보라 중복이기도 하다.

## 테스트

- 통합 6종 추가 — 도시 넘는 일정의 스위치 비활성 + 전용 문구 · `오사카 → 교토` 안내 · **같은 도시면 안내도 없고 스위치도 살아 있다** · 헤더 부제 · 보관함 부제 · 날짜 선택지 도시명
- 기존 18종 유지. 그중 셋이 이번 변경으로 깨져서 고쳤다 — 픽스처에 `canDepartureNotify`가 없어 `undefined`(=막힘)였고, 알림 보조 문구에 타임존이 붙었다
- E2E — **실제 브라우저에서** 비활성 스위치를 `force: true`로 눌러 **정말 안 켜지는지** 확인. `disabled` 속성만 보는 검사는 눌렀을 때 상태가 안 바뀌는지까지는 말해 주지 않는다

## 게이트

- `cd fe && npm run format:check && npm run lint && npm test && npm run build` ✅ (999 tests)
- `npx playwright test` ✅ (92 passed)
- BE 변경 없음

## 위키

[Travel-UI-Design §9.4](https://github.com/wcorn/orino/wiki/Travel-UI-Design) — 판정 출처와 문구를 나눈 이유
