### PR TITLE
feat : S-08 도구 · S-09 설정 — 첫날이 아니라 오늘 도시를 따라간다

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/client/OpenMeteoClient.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/client/OpenMeteoClient.java
@@ -96,6 +96,8 @@ public class OpenMeteoClient implements WeatherClient {
         for (int i = 0; i < times.size(); i++) {
             days.add(new WeatherResponse.DailyWeather(
                     LocalDate.parse(times.get(i).asString()),
+                    // 어느 도시의 예보인지는 부르는 쪽이 안다 — 클라이언트는 좌표만 받았다.
+                    null,
                     icon(node.get("weather_code"), i),
                     rounded(node.get("temperature_2m_max"), i),
                     rounded(node.get("temperature_2m_min"), i),

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/dto/WeatherResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/dto/WeatherResponse.java
@@ -31,15 +31,24 @@ public record WeatherResponse(
     }
 
     /**
+     * @param cityName          (v2.1) <b>그 날짜의 기준 도시</b>. 날짜마다 다른 도시의 예보가
+     *                          섞여 오므로, 어느 도시 것인지가 값과 함께 다녀야 한다 —
+     *                          화면이 날짜만 보고 짐작하면 도쿄 예보에 "교토"를 붙이게 된다
      * @param precipProbability 강수확률(%). 60% 이상 강조는 <b>화면 규칙</b>이라 여기서 판정하지 않는다
      */
     public record DailyWeather(
             LocalDate date,
+            String cityName,
             WeatherIcon icon,
             Integer tempMax,
             Integer tempMin,
             Integer precipProbability
     ) {
+
+        /** 도시를 아는 자리에서 이름을 덧씌운다. 예보 자체는 도시를 모른 채 만들어진다. */
+        public DailyWeather in(String city) {
+            return new DailyWeather(date, city, icon, tempMax, tempMin, precipProbability);
+        }
     }
 
     /** @param time 여행 타임존의 벽시계 시각("09:00") */

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/WeatherService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/WeatherService.java
@@ -17,11 +17,11 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * 여행 기간의 날씨(§S-08).
@@ -74,17 +74,39 @@ public class WeatherService {
      */
     public Map<LocalDate, WeatherResponse.DailyWeather> dailyByDate(
             Trip trip, Map<LocalDate, TravelPlace> cities) {
-        Map<Long, WeatherResponse> byCity = new HashMap<>();
         Map<LocalDate, WeatherResponse.DailyWeather> byDate = new HashMap<>();
-
-        cities.forEach((date, city) -> {
-            WeatherResponse forecast = byCity.computeIfAbsent(city.getId(), id -> forecastOf(city));
-            forecast.daily().stream()
-                    .filter(day -> day.date().equals(date))
-                    .findFirst()
-                    .ifPresent(day -> byDate.put(date, day));
-        });
+        walkByCity(cities, (date, city, forecast) -> dayOf(forecast, date)
+                .ifPresent(day -> byDate.put(date, day.in(cityNameOf(city)))));
         return byDate;
+    }
+
+    /**
+     * 날짜를 순서대로 훑으며 <b>그날 기준 도시의 예보</b>를 넘긴다. 도시별로 한 번만
+     * 조회하도록 여기서 묶는다 — 도쿄 → 닛코 → 도쿄는 2회다.
+     */
+    private void walkByCity(Map<LocalDate, TravelPlace> cities, DayForecast consumer) {
+        Map<Long, WeatherResponse> byCity = new HashMap<>();
+        cities.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> {
+                    TravelPlace city = entry.getValue();
+                    consumer.accept(entry.getKey(), city,
+                            byCity.computeIfAbsent(city.getId(), id -> forecastOf(city)));
+                });
+    }
+
+    private interface DayForecast {
+        void accept(LocalDate date, TravelPlace city, WeatherResponse forecast);
+    }
+
+    private static Optional<WeatherResponse.DailyWeather> dayOf(WeatherResponse forecast,
+                                                                LocalDate date) {
+        return forecast.daily().stream().filter(day -> day.date().equals(date)).findFirst();
+    }
+
+    /** 도시 표시명. 도시 장소는 자기 이름이 곧 도시명이라 비어 있으면 이름으로 떨어진다. */
+    private static String cityNameOf(TravelPlace city) {
+        return city.getCityName() != null ? city.getCityName() : city.getName();
     }
 
     /** 그 도시의 예보. 좌표가 없으면 조회 자체를 하지 않는다. */
@@ -95,25 +117,25 @@ public class WeatherService {
         return cached(city);
     }
 
-    /** 도구 화면(§S-08)이 쓰는 여행 단위 예보. 지금은 첫날 기준 도시로 본다. */
+    /**
+     * 도구 화면(§S-08)이 쓰는 여행 단위 예보. <b>날짜마다 그날 기준 도시로 본다</b>(v2.1 §3.7).
+     *
+     * <p>첫날 도시 하나로 보면 다구간 여행에서 교토 날짜에 도쿄 날씨가 뜬다 — 같은 나라
+     * 안에서도 산간·해안은 몇 도씩 갈린다. 날짜 목록이 곧 기간이라 따로 잘라낼 것도 없다.
+     */
     private WeatherResponse forecastOf(Trip trip) {
-        return clampToTrip(forecastOf(tripDayService.primaryCity(trip.getId())), trip);
-    }
+        List<WeatherResponse.DailyWeather> daily = new ArrayList<>();
+        Map<LocalDate, List<WeatherResponse.HourlyWeather>> hourly = new HashMap<>();
 
-    /** 예보 전체에서 <b>여행 기간</b>만 남긴다. 그 밖의 날짜는 화면이 쓸 일이 없다. */
-    private static WeatherResponse clampToTrip(WeatherResponse forecast, Trip trip) {
-        List<WeatherResponse.DailyWeather> daily = forecast.daily().stream()
-                .filter(day -> !day.date().isBefore(trip.getStartDate())
-                        && !day.date().isAfter(trip.getEndDate()))
-                .toList();
-        Map<LocalDate, List<WeatherResponse.HourlyWeather>> hourly = forecast.hourly().entrySet()
-                .stream()
-                .filter(entry -> !entry.getKey().isBefore(trip.getStartDate())
-                        && !entry.getKey().isAfter(trip.getEndDate()))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-        return new WeatherResponse(forecast.source(), forecast.license(),
-                forecast.fetchedAt(), daily, hourly);
+        walkByCity(tripDayService.baseCitiesOf(trip.getId()), (date, city, forecast) -> {
+            dayOf(forecast, date).ifPresent(day -> daily.add(day.in(cityNameOf(city))));
+            List<WeatherResponse.HourlyWeather> hours = forecast.hourly().get(date);
+            if (hours != null) {
+                hourly.put(date, hours);
+            }
+        });
+        return new WeatherResponse(WeatherResponse.SOURCE, WeatherResponse.LICENSE,
+                clock.instant(), daily, hourly);
     }
 
     /**

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardV21Test.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardV21Test.java
@@ -476,8 +476,8 @@ class BoardV21Test extends ApiTestSupport {
 
     private static WeatherResponse forecast(LocalDate from, int tempMax) {
         List<WeatherResponse.DailyWeather> daily = List.of(
-                new WeatherResponse.DailyWeather(from, WeatherIcon.CLEAR, tempMax, 5, 10),
-                new WeatherResponse.DailyWeather(from.plusDays(1), WeatherIcon.CLEAR,
+                new WeatherResponse.DailyWeather(from, null, WeatherIcon.CLEAR, tempMax, 5, 10),
+                new WeatherResponse.DailyWeather(from.plusDays(1), null, WeatherIcon.CLEAR,
                         tempMax, 5, 10));
         return new WeatherResponse(WeatherResponse.SOURCE, WeatherResponse.LICENSE,
                 java.time.Instant.now(), daily, java.util.Map.of());

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/ToolsControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/ToolsControllerTest.java
@@ -93,9 +93,30 @@ class ToolsControllerTest extends ApiTestSupport {
         return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
     }
 
+    /** 도쿄 1일 → 닛코 1일. 날짜마다 도시가 다른 가장 작은 여행이다. */
+    private long createTwoCityTrip() throws Exception {
+        long tokyo = TravelCityFixture.createCity(mockMvc, authHeader, "도쿄", "Asia/Tokyo", "JPY",
+                jitter("35.6764").toPlainString(), jitter("139.6500").toPlainString());
+        long nikko = TravelCityFixture.createCity(mockMvc, authHeader, "닛코", "Asia/Tokyo", "JPY",
+                jitter("36.7500").toPlainString(), jitter("139.6000").toPlainString());
+        String body = mockMvc.perform(post("/api/travel/trips")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "도쿄",
+                                 "startDate": "2026-10-24", "endDate": "2026-10-25",
+                                 "legs": [{"cityPlaceId": %d, "days": 1},
+                                          {"cityPlaceId": %d, "days": 1}]}
+                                """.formatted(tokyo, nikko)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) com.jayway.jsonpath.JsonPath.read(body, "$.data.id")).longValue();
+    }
+
     private static WeatherResponse.DailyWeather day(String date, WeatherIcon icon,
                                                     int max, int min, int precip) {
-        return new WeatherResponse.DailyWeather(LocalDate.parse(date), icon, max, min, precip);
+        return new WeatherResponse.DailyWeather(
+                LocalDate.parse(date), null, icon, max, min, precip);
     }
 
     @Nested
@@ -112,6 +133,42 @@ class ToolsControllerTest extends ApiTestSupport {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.source").value("Open-Meteo"))
                     .andExpect(jsonPath("$.data.license").value("CC BY 4.0"));
+        }
+
+        @Test
+        @DisplayName("날짜마다 그날 기준 도시로 본다 — 첫날 도시 하나로 보지 않는다(v2.1 §3.7)")
+        void looksUpEachDaysOwnCity() throws Exception {
+            long tripId = createTwoCityTrip();
+            // 좌표마다 다른 예보를 준다 — 같은 값이면 어느 도시 것이 붙었는지 알 수 없다.
+            weatherStub.byCoordinates = key -> new WeatherResponse(
+                    WeatherResponse.SOURCE, WeatherResponse.LICENSE,
+                    java.time.Instant.parse("2026-08-08T00:00:00Z"),
+                    List.of(day("2026-10-24", WeatherIcon.CLEAR, 20, 10, 0),
+                            day("2026-10-25", WeatherIcon.RAIN,
+                                    key.startsWith("36.") ? 9 : 25, 5, 80)),
+                    java.util.Map.of());
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/weather")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.daily", hasSize(2)))
+                    // 2일차는 닛코(36.x) 예보여야 한다. 도쿄 것이면 25도가 온다.
+                    .andExpect(jsonPath("$.data.daily[1].tempMax").value(9))
+                    .andExpect(jsonPath("$.data.daily[0].cityName").value("도쿄"))
+                    .andExpect(jsonPath("$.data.daily[1].cityName").value("닛코"));
+        }
+
+        @Test
+        @DisplayName("같은 도시를 오가면 조회는 도시 수만큼만 한다")
+        void asksOncePerCity() throws Exception {
+            long tripId = createTwoCityTrip();
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/weather")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk());
+
+            // 이틀짜리 여행이지만 도시는 둘이다 — 날짜마다 부르면 여기서 어긋난다.
+            assertThat(weatherStub.calls).hasSize(2);
         }
 
         @Test

--- a/fe/src/features/travel/api/tools.ts
+++ b/fe/src/features/travel/api/tools.ts
@@ -10,6 +10,11 @@ export type WeatherIcon = "CLEAR" | "CLOUD" | "RAIN" | "SNOW";
 
 export interface DailyWeather {
   date: string;
+  /**
+   * (v2.1) 그 날짜의 기준 도시. 날짜마다 다른 도시의 예보가 섞여 오므로 어느 도시 것인지가
+   * 값과 함께 다닌다 — 날짜만 보고 짐작하면 도쿄 예보에 `교토`를 붙이게 된다.
+   */
+  cityName: string | null;
   icon: WeatherIcon;
   tempMax: number | null;
   tempMin: number | null;

--- a/fe/src/features/travel/tools/ExchangeRateCard.tsx
+++ b/fe/src/features/travel/tools/ExchangeRateCard.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightLeft } from "lucide-react";
+import { ArrowRightLeft, MapPin } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
@@ -7,9 +7,9 @@ import { LoadingText } from "@/components/ui/loading-text";
 import { Select } from "@/components/ui/select";
 import type { ExchangeRate } from "@/features/travel/api/tools";
 import {
-  CURRENCIES,
   type Currency,
   currencyName,
+  orderedCurrencies,
 } from "@/features/travel/tools/currencies";
 import {
   convert,
@@ -23,12 +23,11 @@ interface ExchangeRateCardProps {
   online: boolean;
   currency: Currency;
   onCurrencyChange: (currency: Currency) => void;
+  /** 지금 기준으로 삼는 도시. 어느 도시의 통화인지 화면이 말한다(§9.5). */
+  cityName?: string | null;
+  /** 이 여행에 등장하는 통화 — 목록 맨 앞으로 올린다. */
+  tripCurrencies?: string[];
 }
-
-const CURRENCY_OPTIONS = CURRENCIES.map((code) => ({
-  value: code,
-  label: `${code} · ${currencyName(code)}`,
-}));
 
 /** 현지에서 자주 쓰는 액수(§1.8). */
 const PRESETS = [1000, 5000, 10000];
@@ -43,11 +42,18 @@ export function ExchangeRateCard({
   rate,
   loading,
   online,
+  cityName,
+  tripCurrencies = [],
   currency,
   onCurrencyChange,
 }: ExchangeRateCardProps) {
   const [baseInput, setBaseInput] = useState("");
   const [quoteInput, setQuoteInput] = useState("");
+  // 여행에 등장하는 통화가 먼저 — 고를 일이 가장 많은 것이 지금 가는 나라들의 돈이다.
+  const currencyOptions = orderedCurrencies(tripCurrencies).map((code) => ({
+    value: code,
+    label: `${code} · ${currencyName(code)}`,
+  }));
 
   // 환율이 바뀌면(통화 변경·재조회) 계산을 다시 맞춘다.
   useEffect(() => {
@@ -76,7 +82,15 @@ export function ExchangeRateCard({
   return (
     <section className="border-border bg-card flex flex-col gap-3 rounded-xl border p-4">
       <div className="flex items-center gap-2">
-        <h2 className="text-heading flex-1 font-medium">환율</h2>
+        <h2 className="text-heading font-medium">환율</h2>
+        {/* 어느 도시를 기준으로 잡았는지 말한다 — 다구간에서는 날마다 달라진다. */}
+        {cityName && (
+          <span className="bg-muted text-muted-foreground flex shrink-0 items-center gap-1 rounded-full px-2.5 py-[3px] text-xs">
+            <MapPin className="size-[11px] shrink-0" />
+            {cityName} · {currency}
+          </span>
+        )}
+        <span className="flex-1" />
         {/* 캐시된 값이라는 걸 숨기지 않는다 — 환율은 돈이 걸린 숫자다. */}
         {!online && <Badge variant="secondary">최신 아님</Badge>}
         {/* 여행 통화가 기본이지만 경유지에서 다른 돈을 쓰기도 한다. */}
@@ -86,7 +100,7 @@ export function ExchangeRateCard({
         <Select
           value={currency}
           onValueChange={onCurrencyChange}
-          options={CURRENCY_OPTIONS}
+          options={currencyOptions}
           ariaLabelledby="fx-currency-label"
           disabled={!online}
         />

--- a/fe/src/features/travel/tools/WeatherCard.tsx
+++ b/fe/src/features/travel/tools/WeatherCard.tsx
@@ -50,9 +50,15 @@ export function WeatherCard({ forecast, loading }: WeatherCardProps) {
                       day.date === activeDate ? "bg-muted" : "hover:bg-muted"
                     }`}
                   >
-                    <span className="w-[74px] shrink-0 text-[13px]">
+                    <span className="w-[38px] shrink-0 text-[13px] tabular-nums">
                       {day.date.slice(5)}
                     </span>
+                    {/* 도시명은 값과 함께 온다(§3.7) — 날짜마다 다른 도시의 예보다. */}
+                    {day.cityName && (
+                      <span className="text-muted-foreground w-[66px] shrink-0 truncate text-[13px]">
+                        {day.cityName}
+                      </span>
+                    )}
                     <Icon
                       className={`size-4 shrink-0 ${alert ? "text-warning" : "text-muted-foreground"}`}
                     />
@@ -97,7 +103,9 @@ export function WeatherCard({ forecast, loading }: WeatherCardProps) {
       )}
 
       {/* Open-Meteo는 출처 표기가 필수다. 데이터가 없어도 남긴다. */}
-      <p className="text-muted-foreground text-xs">Open-Meteo · CC BY 4.0</p>
+      <p className="text-muted-foreground text-xs">
+        도시별로 따로 조회해요 · Open-Meteo · CC BY 4.0
+      </p>
     </section>
   );
 }

--- a/fe/src/features/travel/tools/currencies.ts
+++ b/fe/src/features/travel/tools/currencies.ts
@@ -61,3 +61,17 @@ export function defaultCurrency(tripCurrency: string | undefined): Currency {
     ? (code as Currency)
     : CURRENCIES[0];
 }
+
+/**
+ * <b>여행에 등장하는 통화를 먼저</b>, 그다음 나머지(§3.7).
+ *
+ * <p>고를 일이 가장 많은 것이 지금 가는 나라들의 통화다. 목록 밖 통화(TWD 등)는 조용히
+ * 빠진다 — 고를 수 있게 두면 서버가 거절하고 사용자는 이유를 모른다.
+ */
+export function orderedCurrencies(tripCurrencies: string[]): Currency[] {
+  const first = tripCurrencies
+    .map((code) => code.toUpperCase())
+    .filter((code): code is Currency => CURRENCIES.includes(code as Currency));
+  const seen = new Set(first);
+  return [...new Set(first), ...CURRENCIES.filter((code) => !seen.has(code))];
+}

--- a/fe/src/features/travel/tools/translateLink.ts
+++ b/fe/src/features/travel/tools/translateLink.ts
@@ -25,17 +25,56 @@ const LANGUAGE_BY_TIMEZONE: Record<string, string> = {
   "Europe/Amsterdam": "nl",
 };
 
+/**
+ * (v2.1) 목적지 언어는 <b>기준 도시의 국가</b>를 따라간다(§3.7).
+ *
+ * <p>국가 코드가 타임존보다 정확하다 — `Asia/Tokyo`는 일본에만 쓰이지만 `Asia/Bangkok`은
+ * 베트남·캄보디아 일부도 쓰고, 도시를 옮기는 여행에서는 그 차이가 실제로 드러난다.
+ * 국가를 모르면 타임존으로 떨어진다(그 전까지 쓰던 길이다).
+ */
+const LANGUAGE_BY_COUNTRY: Record<string, string> = {
+  JP: "ja",
+  KR: "ko",
+  CN: "zh-CN",
+  TW: "zh-TW",
+  HK: "zh-TW",
+  TH: "th",
+  VN: "vi",
+  ID: "id",
+  PH: "tl",
+  FR: "fr",
+  DE: "de",
+  ES: "es",
+  IT: "it",
+  PT: "pt",
+  NL: "nl",
+};
+
 const FALLBACK = "en";
 
-export function destinationLanguage(timezone: string): string {
+/**
+ * 목적지 언어. <b>국가 → 타임존 → 영어</b> 순으로 찾는다.
+ *
+ * <p>틀려도 막다른 길이 아니다 — 구글 번역 화면에서 언어를 바꿀 수 있다.
+ */
+export function destinationLanguage(
+  timezone: string,
+  countryCode?: string | null,
+): string {
+  if (countryCode && LANGUAGE_BY_COUNTRY[countryCode]) {
+    return LANGUAGE_BY_COUNTRY[countryCode];
+  }
   return LANGUAGE_BY_TIMEZONE[timezone] ?? FALLBACK;
 }
 
 /** 한국어 → 목적지 언어. 앱이 없으면 웹으로 열린다. */
-export function translateUrl(timezone: string): string {
+export function translateUrl(
+  timezone: string,
+  countryCode?: string | null,
+): string {
   const params = new URLSearchParams({
     sl: "ko",
-    tl: destinationLanguage(timezone),
+    tl: destinationLanguage(timezone, countryCode),
   });
   return `https://translate.google.com/?${params.toString()}`;
 }

--- a/fe/src/pages/travel/TravelSettingsPage.test.tsx
+++ b/fe/src/pages/travel/TravelSettingsPage.test.tsx
@@ -157,7 +157,9 @@ describe("TravelSettingsPage", () => {
 
       expect(await screen.findByText("아침 요약 알림")).toBeInTheDocument();
       expect(
-        screen.getByText("여행 기간 중 매일 현지 08:00"),
+        screen.getByText(
+          "그날 기준 도시의 현지 08:00 · 도시가 바뀌는 날은 전날 도시 08:00",
+        ),
       ).toBeInTheDocument();
       // 어느 여행에 적용되는지 밝힌다 — 설정이 여행 단위라서다.
       expect(screen.getByText(/도쿄 3박 4일에 적용됩니다/)).toBeInTheDocument();
@@ -190,6 +192,31 @@ describe("TravelSettingsPage", () => {
       });
       // 구간은 보내지 않는다 — 알림 스위치 하나가 날짜별 기준 도시를 되감으면 안 된다.
       expect(bodies[0]).not.toHaveProperty("legs");
+    });
+
+    it("켜져 있으면 어떤 요약이 오는지 미리 보여준다", async () => {
+      mockSummary();
+      mockPublicKey("key");
+      // 미리보기는 켜져 있을 때만 나온다 — 끈 사람에게 보여줄 이유가 없다.
+      server.use(
+        http.get(`${API_BASE}/travel/trips/:tripId`, () =>
+          HttpResponse.json({
+            code: "OK",
+            data: { ...TRIP, morningSummaryEnabled: true },
+          }),
+        ),
+      );
+
+      renderSettings();
+      await screen.findByText("아침 요약 알림");
+
+      // 문구만으로는 두 형태가 그려지지 않는다.
+      expect(
+        screen.getByText("교토 · 오늘 일정 4개 · 첫 일정 09:00"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("오사카 → 교토 · 오늘 일정 3개"),
+      ).toBeInTheDocument();
     });
 
     it("여행이 없으면 설정할 것이 없다고 알린다", async () => {

--- a/fe/src/pages/travel/TravelSettingsPage.tsx
+++ b/fe/src/pages/travel/TravelSettingsPage.tsx
@@ -181,8 +181,11 @@ export function TravelSettingsPage() {
             <div className="flex items-center gap-3">
               <div className="min-w-0 flex-1">
                 <p className="text-sm font-medium">아침 요약 알림</p>
+                {/* 언제 오는지가 도시마다 다르다(§3.6) — "매일 현지 08:00"만으로는
+                    이동일에 왜 일찍 오는지 알 수 없다. */}
                 <p className="text-muted-foreground text-xs">
-                  여행 기간 중 매일 현지 08:00
+                  그날 기준 도시의 현지 08:00 · 도시가 바뀌는 날은 전날 도시
+                  08:00
                 </p>
               </div>
               <Switch
@@ -193,6 +196,14 @@ export function TravelSettingsPage() {
                 aria-label="아침 요약 알림"
               />
             </div>
+
+            {/* 켜 두면 무엇이 오는지 보여준다 — 문구만으로는 두 형태가 그려지지 않는다. */}
+            {trip.morningSummaryEnabled && (
+              <div className="bg-muted text-muted-foreground flex flex-col gap-1 rounded-lg px-3 py-2 text-xs">
+                <p>교토 · 오늘 일정 4개 · 첫 일정 09:00</p>
+                <p>오사카 → 교토 · 오늘 일정 3개</p>
+              </div>
+            )}
             <p className="text-muted-foreground text-xs">
               {trip.title}에 적용됩니다
             </p>

--- a/fe/src/pages/travel/TravelToolsPage.test.tsx
+++ b/fe/src/pages/travel/TravelToolsPage.test.tsx
@@ -73,6 +73,89 @@ function mockWeather(daily: unknown[], hourly: Record<string, unknown[]> = {}) {
   );
 }
 
+/**
+ * 오늘(또는 첫날) 기준 도시를 정하는 것은 <b>보드</b>다 — 여행 상세의 통화·타임존은 첫날
+ * 도시에서 파생된 값이라 도시를 옮긴 날짜에서 조용히 틀린다.
+ */
+function mockBoardCity(city: {
+  name: string;
+  currency: string;
+  countryCode: string;
+  timezone: string;
+}) {
+  server.use(
+    http.get(`${API_BASE}/travel/trips/:tripId/board`, () =>
+      HttpResponse.json({
+        code: "OK",
+        data: {
+          trip: {
+            id: 3,
+            title: "일본",
+            startDate: "2026-10-24",
+            endDate: "2026-10-25",
+            status: "ONGOING",
+            recordMode: false,
+            cityCount: 2,
+            countryCount: 2,
+            singleCity: false,
+          },
+          days: [
+            {
+              dayId: 1,
+              dayIndex: 1,
+              date: "2026-10-24",
+              weekday: "토",
+              activityCount: 0,
+              baseCity: {
+                placeId: 21,
+                name: "도쿄",
+                timezone: "Asia/Tokyo",
+                currency: "JPY",
+                countryCode: "JP",
+                cityPlaceRef: "ChIJ_tokyo",
+                lat: null,
+                lng: null,
+              },
+              cityChanged: false,
+              legIndex: 1,
+              cityMemo: null,
+              weather: null,
+              stayTonight: null,
+              stayCheckout: null,
+            },
+            {
+              dayId: 2,
+              dayIndex: 2,
+              date: "2026-10-25",
+              weekday: "일",
+              activityCount: 0,
+              baseCity: {
+                placeId: 22,
+                ...city,
+                cityPlaceRef: "ChIJ_other",
+                lat: null,
+                lng: null,
+              },
+              cityChanged: true,
+              legIndex: 2,
+              cityMemo: null,
+              weather: null,
+              stayTonight: null,
+              stayCheckout: null,
+            },
+          ],
+          // 오늘이 2일차다 — 서버가 진행 중 여행의 오늘을 골라 준다.
+          selectedDate: "2026-10-25",
+          archiveCount: 0,
+          activities: [],
+          travelTimes: [],
+          stayMove: null,
+        },
+      }),
+    ),
+  );
+}
+
 function renderTools() {
   return renderWithRouter(
     <Providers>
@@ -249,7 +332,9 @@ describe("TravelToolsPage", () => {
       renderTools();
 
       expect(
-        await screen.findByText("Open-Meteo · CC BY 4.0"),
+        await screen.findByText(
+          "도시별로 따로 조회해요 · Open-Meteo · CC BY 4.0",
+        ),
       ).toBeInTheDocument();
     });
   });
@@ -269,6 +354,112 @@ describe("TravelToolsPage", () => {
         "_blank",
         "noopener",
       );
+    });
+  });
+
+  describe("오늘 도시를 따라간다 (§3.7)", () => {
+    const BANGKOK = {
+      name: "방콕",
+      currency: "THB",
+      countryCode: "TH",
+      timezone: "Asia/Bangkok",
+    };
+
+    it("기본 통화는 첫날이 아니라 오늘 도시의 것이다", async () => {
+      const calls: URL[] = [];
+      server.use(
+        http.get(`${API_BASE}/travel/fx`, ({ request }) => {
+          calls.push(new URL(request.url));
+          return HttpResponse.json({
+            code: "OK",
+            data: {
+              base: "THB",
+              quote: "KRW",
+              rate: 38.5,
+              source: "ECB",
+              referenceDate: "2026-08-07",
+              fetchedAt: "2026-08-08T00:00:00Z",
+            },
+          });
+        }),
+      );
+      mockBoardCity(BANGKOK);
+
+      renderTools();
+
+      // 여행 상세는 JPY(첫날 도쿄)라고 말한다. 오늘은 방콕이다.
+      await waitFor(() =>
+        expect(calls[calls.length - 1]?.searchParams.get("base")).toBe("THB"),
+      );
+    });
+
+    it("기준 도시 칩이 어느 도시의 통화인지 말한다", async () => {
+      mockBoardCity(BANGKOK);
+
+      renderTools();
+
+      expect(await screen.findByText("방콕 · THB")).toBeInTheDocument();
+    });
+
+    it("통화 목록은 여행에 등장하는 통화가 먼저다", async () => {
+      mockBoardCity(BANGKOK);
+
+      renderTools();
+      await screen.findByText("방콕 · THB");
+      await userEvent.click(
+        screen.getByRole("combobox", { name: "기준 통화" }),
+      );
+
+      const options = (await screen.findAllByRole("option")).map(
+        (o) => o.textContent,
+      );
+      // 도쿄(JPY)·방콕(THB)이 앞줄에 선다. 순서는 구간 순서를 따른다.
+      expect(options.slice(0, 2)).toEqual(["JPY · 일본 엔", "THB · 태국 바트"]);
+    });
+
+    it("번역 목적 언어는 기준 도시 국가를 따라간다", async () => {
+      const open = vi.spyOn(window, "open").mockImplementation(() => null);
+      mockBoardCity(BANGKOK);
+
+      renderTools();
+      await screen.findByText("방콕 · THB");
+      await userEvent.click(
+        screen.getByRole("button", { name: /구글 번역 열기/ }),
+      );
+
+      // 타임존만 보면 Asia/Bangkok → th로 같지만, 국가가 언어를 정하는 것이 규칙이다.
+      expect(open).toHaveBeenCalledWith(
+        expect.stringContaining("tl=th"),
+        "_blank",
+        "noopener",
+      );
+      open.mockRestore();
+    });
+
+    it("날씨 행에 그날 도시명이 붙는다", async () => {
+      mockWeather([
+        {
+          date: "2026-10-24",
+          cityName: "도쿄",
+          icon: "CLEAR",
+          tempMax: 20,
+          tempMin: 13,
+          precipProbability: 10,
+        },
+        {
+          date: "2026-10-25",
+          cityName: "닛코",
+          icon: "RAIN",
+          tempMax: 9,
+          tempMin: 3,
+          precipProbability: 80,
+        },
+      ]);
+
+      renderTools();
+
+      expect(await screen.findByText("도쿄")).toBeInTheDocument();
+      expect(screen.getByText("닛코")).toBeInTheDocument();
     });
   });
 

--- a/fe/src/pages/travel/TravelToolsPage.tsx
+++ b/fe/src/pages/travel/TravelToolsPage.tsx
@@ -6,8 +6,10 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { LoadingText } from "@/components/ui/loading-text";
 import { fetchExchangeRate, fetchWeather } from "@/features/travel/api/tools";
+import { useBoard } from "@/features/travel/hooks/useBoard";
 import { useTravelSummary } from "@/features/travel/hooks/useTravelSummary";
 import { useTrip } from "@/features/travel/hooks/useTrip";
+import { cityOn, tripCities } from "@/features/travel/lib/baseCity";
 import { travelKeys } from "@/features/travel/queryKeys";
 import {
   type Currency,
@@ -40,6 +42,21 @@ export function TravelToolsPage() {
     : (summary?.ongoing?.id ?? summary?.next?.id ?? null);
 
   const { data: trip, isPending: loadingTrip } = useTrip(tripId);
+  /**
+   * 그날의 보드 — <b>오늘 어느 도시에 있는지</b>가 여기에만 있다. 날짜를 지정하지 않으면
+   * 서버가 진행 중일 때 오늘을, 아니면 1일차를 고른다(§4.1).
+   *
+   * <p>여행 상세의 {@code trip.currency}·{@code trip.timezone}으로는 안 된다 — 서버가
+   * <b>첫날</b> 기준 도시에서 파생해 채워 준 값이라, 교토에 있는 날에도 오사카의 통화·언어를
+   * 말한다. 같은 엔·같은 나라라 눈에 안 띌 뿐이고 국가를 넘으면 곧바로 틀린다.
+   */
+  const { data: board } = useBoard(
+    tripId ?? 0,
+    {},
+    { enabled: tripId !== null },
+  );
+  /** 오늘(또는 첫날) 기준 도시. 통화·언어·칩이 전부 여기서 나온다. */
+  const todayCity = cityOn(board?.days ?? [], board?.selectedDate ?? "");
 
   const { data: weather, isPending: loadingWeather } = useQuery({
     queryKey: travelKeys.weather(tripId ?? 0),
@@ -49,14 +66,14 @@ export function TravelToolsPage() {
     staleTime: 30 * 60 * 1000,
   });
 
-  // 여행 통화가 기본이되 바꿀 수 있다 — 경유지에서 다른 돈을 쓰기도 한다.
+  // 오늘 도시의 통화가 기본이되 바꿀 수 있다 — 경유지에서 다른 돈을 쓰기도 한다.
   const [currency, setCurrency] = useState<Currency>(() =>
-    defaultCurrency(trip?.currency),
+    defaultCurrency(todayCity?.currency),
   );
-  // 여행이 늦게 도착하거나(로딩) 다른 여행으로 바뀌면 그 여행 통화로 다시 맞춘다.
+  // 보드가 늦게 도착하거나(로딩) 다른 여행으로 바뀌면 그 도시 통화로 다시 맞춘다.
   useEffect(() => {
-    setCurrency(defaultCurrency(trip?.currency));
-  }, [trip?.currency]);
+    setCurrency(defaultCurrency(todayCity?.currency));
+  }, [todayCity?.currency]);
 
   const { data: rate, isPending: loadingRate } = useQuery({
     queryKey: travelKeys.fx(currency, HOME_CURRENCY),
@@ -99,6 +116,10 @@ export function TravelToolsPage() {
             online={online}
             currency={currency}
             onCurrencyChange={setCurrency}
+            cityName={todayCity?.name}
+            tripCurrencies={tripCities(board?.days ?? []).map(
+              (c) => c.currency,
+            )}
           />
           <WeatherCard forecast={weather ?? null} loading={loadingWeather} />
 
@@ -111,7 +132,15 @@ export function TravelToolsPage() {
             <Button
               variant="outline"
               onClick={() =>
-                window.open(translateUrl(trip.timezone), "_blank", "noopener")
+                window.open(
+                  // 목적 언어는 기준 도시 <b>국가</b>를 따라간다(§3.7).
+                  translateUrl(
+                    todayCity?.timezone ?? trip.timezone,
+                    todayCity?.countryCode,
+                  ),
+                  "_blank",
+                  "noopener",
+                )
               }
             >
               <Languages className="size-4" />


### PR DESCRIPTION
## 이슈
closes #1169

## 작업 내용

**도구가 첫날 도시가 아니라 오늘 도시를 따라간다.**

- 환율 기본 통화 · 기준 도시 칩(`방콕 · THB`) · 통화 목록 우선순위 → **오늘 날짜 기준 도시**
- 번역 목적 언어 → **기준 도시 국가**(타임존은 폴백)
- 날씨 행에 **도시명 열** + 출처 문구 `도시별로 따로 조회해요 · Open-Meteo · CC BY 4.0`
- S-09 아침 요약 보조 문구 + 미리보기 (#1167 동작에 맞췄다)

## 이슈 본문에서 내가 틀렸던 것 — 날씨는 BE가 도시별이 아니었다

이슈를 쓰면서 "날씨는 BE가 이미 도시별이다, 남은 것은 화면이 말하는 것뿐"이라고 적었는데 **절반만 맞았다.**

| 경로 | 상태 |
|---|---|
| 보드 날짜 탭 (`days[].weather` ← `dailyByDate`) | 도시별 ✅ |
| **도구 화면 (`GET /trips/{id}/weather` ← `forecastOf(Trip)`)** | **첫날 도시 하나** ❌ |

도구 화면이 쓰는 쪽은 `primaryCity`(첫날 기준 도시)로 예보를 받아 기간만 잘라내고 있었다. **[API 명세는 이미 날짜별 도시와 `cityName`을 요구하고 있었고**, v2.1 작업에서 보드만 고쳐지고 이쪽이 남았다 — 같은 나라 안에서는 몇 도 차이라 화면이 멀쩡해 보였기 때문이다.

**도시명 열만 붙이면 더 나빠진다** — 도쿄 예보에 "교토"라는 이름표를 다는 셈이다. 그래서 데이터부터 고쳤다. 그 결과 이 PR은 FE 전용이 아니라 BE를 포함한다.

## 판단이 갈릴 수 있는 곳 (리뷰 요청)

**1. 오늘 도시를 `useBoard(tripId, {})`에서 읽는다.** 날짜를 지정하지 않으면 서버가 진행 중일 때 오늘을, 아니면 1일차를 고른다 — 필요한 의미가 정확히 그것이다. `trip.cities.today*`(요약 응답에 있는 값)를 쓰지 않은 이유는 **여행 상세에는 그 필드가 없기 때문**이다(아래 참고).

**2. `cityPlaceRef`는 안 넣었다.** 명세 초안의 `daily[]`에는 있지만, 이 화면은 도시를 *표시*할 뿐 *일치 판정*을 하지 않아 쓸 곳이 없다. 판정이 필요해지면 그때 더하는 편이 낫다고 봤다.

**3. 번역은 국가 → 타임존 → 영어 순으로 찾는다.** 명세는 "기준 도시 국가를 따라간다"인데, 국가를 모르는 도시(직접 입력)가 있어 기존 타임존 경로를 폴백으로 남겼다. 없애면 그런 도시에서 영어로 떨어진다.

## 남겨 둔 것 — FE 타입이 서버와 다르다

`TripDetail extends TripSummary`라 **`trip.cities`가 타입상으로는 있지만 런타임에는 `undefined`다.** BE `TripDetail` 레코드에 `cities` 필드가 없다. 이번엔 `trip.cities`를 쓰지 않게 되어 사고가 나지 않았지만, 다음 사람이 믿고 쓰면 조용히 터진다. 이 PR에서 고치면 범위가 번지고(타입을 바꿀지 BE에 필드를 더할지가 별개 판단이다) 별도로 다루는 편이 낫다고 봤다 — **필요하면 후속 이슈로 열겠다.**

## 테스트

- BE — **날짜마다 그날 도시로 조회한다**(닛코 날짜에 닛코 기온) · `cityName`이 날짜별로 붙는다 · **같은 도시를 오가면 조회는 도시 수만큼만**(이틀·두 도시 → 2회)
- FE — 기본 통화가 첫날이 아니라 오늘 도시 것(`base=THB`) · 기준 도시 칩 · **통화 목록 맨 앞이 여행 통화** · 번역이 국가를 따라감 · 날씨 행 도시명 · 설정 미리보기
- 기존 테스트 2개는 문구가 바뀌어 고쳤다(출처 한 줄, 아침 요약 보조)

## 게이트

- `cd be && ./gradlew check` ✅
- `cd fe && npm run format:check && npm run lint && npm test && npm run build` ✅ (1005 tests)
- `npx playwright test` ✅ (92 passed)

## 위키

[Travel-API-Spec 날씨](https://github.com/wcorn/orino/wiki/Travel-API-Spec) — 구현이 명세를 따라가지 못했던 사실과 `cityPlaceRef` 제외 근거 · [Travel-UI-Design §9.5](https://github.com/wcorn/orino/wiki/Travel-UI-Design) — 오늘 도시를 보드에서 읽는 이유
