### PR TITLE
feat : S3 비용 대시보드 + 급증 감시 알림 (1차)

### DIFF
--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/s3-cost-overview.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/s3-cost-overview.json
@@ -1,0 +1,171 @@
+{
+  "uid": "s3-cost-overview",
+  "title": "S3 비용 개요",
+  "tags": ["orino", "cost"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "5m",
+  "time": { "from": "now-7d", "to": "now" },
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Tier1 일 환산 요청 수 (PUT·POST·LIST)",
+      "description": "현재 rate × 86400. 달력일 합계가 아니라 지금 속도가 하루 유지될 때의 값이다 — ELOG-027이 '277k/day'라고 부른 것과 같은 단위. 청구서와 대조할 때 이 숫자를 본다.",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 5 },
+      "datasource": { "type": "prometheus", "uid": "thanos" },
+      "targets": [
+        {
+          "expr": "sum(\n  label_replace(rate(thanos_objstore_bucket_operations_total{operation=~\"upload|iter\"}[30m]), \"tier\", \"tier1\", \"\", \"\")\n  or\n  label_replace(rate(loki_s3_request_duration_seconds_count{operation=~\"S3\\\\.(PutObject|List)\"}[30m]), \"tier\", \"tier1\", \"\", \"\")\n  or\n  label_replace(rate(tempodb_backend_request_duration_seconds_count{operation=~\"PUT|POST\"}[30m]), \"tier\", \"tier1\", \"\", \"\")\n) * 86400",
+          "legendFormat": "Tier1",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 60000 },
+              { "color": "red", "value": 150000 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Tier2 일 환산 요청 수 (GET·HEAD)",
+      "description": "ELOG-027 조치 전 277k/day → 조치 후 18k/day. 이 값이 다시 6자리로 올라가면 새 폴링 루프를 의심한다.",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 5 },
+      "datasource": { "type": "prometheus", "uid": "thanos" },
+      "targets": [
+        {
+          "expr": "sum(\n  label_replace(rate(thanos_objstore_bucket_operations_total{operation=~\"get|get_range|exists\"}[30m]), \"tier\", \"tier2\", \"\", \"\")\n  or\n  label_replace(rate(loki_s3_request_duration_seconds_count{operation=\"S3.GetObject\"}[30m]), \"tier\", \"tier2\", \"\", \"\")\n  or\n  label_replace(rate(tempodb_backend_request_duration_seconds_count{operation=\"GET\"}[30m]), \"tier\", \"tier2\", \"\", \"\")\n) * 86400",
+          "legendFormat": "Tier2",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50000 },
+              { "color": "red", "value": 200000 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Tier1 / Tier2 일 환산 요청 수 추이",
+      "description": "청구서와 대조 가능한 형태. Tier1(PUT·POST·LIST)과 Tier2(GET·HEAD)는 단가가 10배 이상 다르므로 합치지 않는다. DELETE는 무과금이라 제외.",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 10 },
+      "datasource": { "type": "prometheus", "uid": "thanos" },
+      "targets": [
+        {
+          "expr": "sum(\n  rate(thanos_objstore_bucket_operations_total{operation=~\"upload|iter\"}[30m])\n  or\n  rate(loki_s3_request_duration_seconds_count{operation=~\"S3\\\\.(PutObject|List)\"}[30m])\n  or\n  rate(tempodb_backend_request_duration_seconds_count{operation=~\"PUT|POST\"}[30m])\n) * 86400",
+          "legendFormat": "Tier1 (PUT·POST·LIST)",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(\n  rate(thanos_objstore_bucket_operations_total{operation=~\"get|get_range|exists\"}[30m])\n  or\n  rate(loki_s3_request_duration_seconds_count{operation=\"S3.GetObject\"}[30m])\n  or\n  rate(tempodb_backend_request_duration_seconds_count{operation=\"GET\"}[30m])\n) * 86400",
+          "legendFormat": "Tier2 (GET·HEAD)",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "showPoints": "never" }
+        }
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "max"] } }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "컴포넌트별 S3 operation rate",
+      "description": "어느 컴포넌트가 요청을 만드는가. 급증이 보이면 그 컴포넌트의 주기 플래그(interval)부터 본다 — ELOG-027의 thanos compact는 독립 루프가 4개였다.\n\n⚠️ Loki·Tempo는 2026-08-11에 스크랩을 켰다(#1152). 그 이전 구간은 데이터가 없는 게 정상이며, 8/9 급감은 Thanos 계열에서만 소급 확인된다.",
+      "gridPos": { "x": 0, "y": 5, "w": 12, "h": 10 },
+      "datasource": { "type": "prometheus", "uid": "thanos" },
+      "targets": [
+        {
+          "expr": "sum by (operation) (rate(thanos_objstore_bucket_operations_total{operation=~\"upload|iter|get|get_range|exists\"}[30m]))",
+          "legendFormat": "thanos {{operation}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (operation) (rate(loki_s3_request_duration_seconds_count{operation=~\"S3\\\\.(PutObject|List|GetObject)\"}[30m]))",
+          "legendFormat": "loki {{operation}}",
+          "refId": "B"
+        },
+        {
+          "expr": "sum by (operation) (rate(tempodb_backend_request_duration_seconds_count{operation=~\"PUT|POST|GET\"}[30m]))",
+          "legendFormat": "tempo {{operation}}",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 4,
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never" }
+        }
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last"] } }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "급증 감시 — 현재 rate vs 7일 기준선",
+      "description": "S3RequestRateSurge 알림이 보는 것과 같은 값. 현재(30m)가 7일 평균의 3배를 넘고 절대값이 0.05 ops/s를 넘으면 30분 뒤 발동한다.\n\n기준선은 avg_over_time이라 존재하는 표본만 평균한다 — 배포 직후에는 현재값과 거의 같아 조용하고, 날이 지나며 진짜 7일 평균으로 자란다. 첫 일주일은 그만큼 민감도가 낮다.",
+      "gridPos": { "x": 0, "y": 15, "w": 24, "h": 9 },
+      "datasource": { "type": "prometheus", "uid": "thanos" },
+      "targets": [
+        {
+          "expr": "orino:s3_ops:rate30m",
+          "legendFormat": "현재 {{component}}/{{tier}}",
+          "refId": "A"
+        },
+        {
+          "expr": "3 * orino:s3_ops:avg7d",
+          "legendFormat": "발동선(7일×3) {{component}}/{{tier}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 4,
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never" }
+        }
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last"] } }
+    }
+  ]
+}

--- a/infra/helm/kube-prometheus-stack/templates/alertmanagerconfig-discord.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/alertmanagerconfig-discord.yaml
@@ -21,10 +21,31 @@ spec:
     groupWait: 30s
     groupInterval: 5m
     repeatInterval: 4h
+    routes:
+      # 비용 알림(#1153)은 전용 채널로 뺀다. 파드 재시작·노드 알림과 성격이 달라
+      # 같은 채널에 섞이면 묻힌다 — 묻힌 알림은 없는 알림과 같다.
+      # 부모 route의 severity 매처를 이미 통과한 뒤라 category만 본다.
+      - receiver: discord-cost
+        matchers:
+          - name: category
+            value: cost
+        groupBy:
+          - alertname
+          - component
+        groupWait: 30s
+        groupInterval: 5m
+        # 비용은 즉시 대응할 성질이 아니다. 4h마다 다시 알릴 이유가 없어 12h로 늘린다.
+        repeatInterval: 12h
   receivers:
     - name: discord
       discordConfigs:
         - apiURL:
             name: alertmanager-discord-secret
+            key: DISCORD_WEBHOOK_URL
+          sendResolved: true
+    - name: discord-cost
+      discordConfigs:
+        - apiURL:
+            name: alertmanager-discord-cost-secret
             key: DISCORD_WEBHOOK_URL
           sendResolved: true

--- a/infra/helm/kube-prometheus-stack/templates/dashboard-s3-cost.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/dashboard-s3-cost.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-s3-cost-overview
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  s3-cost-overview.json: |-
+{{ .Files.Get "grafana-dashboards/s3-cost-overview.json" | indent 4 }}

--- a/infra/helm/kube-prometheus-stack/templates/prometheusrule-s3-cost.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/prometheusrule-s3-cost.yaml
@@ -1,0 +1,101 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: orino-s3-cost
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    # 세 컴포넌트가 서로 다른 이름·라벨로 S3 요청을 센다. 대시보드·알림·#1156 차분식이
+    # 매번 이 차이를 다시 쓰지 않도록 (component, tier) 두 라벨로 정규화해 둔다.
+    #
+    # 메트릭명은 실측으로 확인했다 — Epic #1148 이 전제한
+    # *_objstore_bucket_operations_total 을 내는 건 Thanos 뿐이다:
+    #   Thanos  thanos_objstore_bucket_operations_total{operation="upload|iter|get|..."}
+    #   Loki    loki_s3_request_duration_seconds_count{operation="S3.PutObject|S3.List|..."}
+    #   Tempo   tempodb_backend_request_duration_seconds_count{operation="PUT|GET|..."}
+    #
+    # 티어는 청구 기준이다: PUT/POST/LIST = Tier1, GET/HEAD = Tier2.
+    # DELETE 는 무과금이라 셀렉터에서 뺀다(넣으면 Loki 의 S3.DeleteObject 51k 가
+    # 요청 수를 통째로 왜곡한다).
+    #
+    # ⚠️ 이 카운터는 클라이언트 라이브러리 호출 수고 청구는 HTTP 요청 수다.
+    # 멀티파트 업로드 1회는 PUT 여러 건, 페이지네이션 LIST 1회도 여러 건으로 과금된다
+    # — 실측 Tier1 15.8k/day vs CE 51.7k/day 차이의 일부가 이 증폭이다(#1156).
+    - name: s3-cost-recording
+      interval: 1m
+      rules:
+        - record: orino:s3_ops:rate30m
+          expr: |
+            sum by (component, tier) (
+              label_replace(label_replace(label_replace(
+                rate(thanos_objstore_bucket_operations_total{operation=~"upload|iter|get|get_range|exists"}[30m]),
+                "component", "thanos", "", ""),
+                "tier", "tier1", "operation", "upload|iter"),
+                "tier", "tier2", "operation", "get|get_range|exists")
+            )
+            or
+            sum by (component, tier) (
+              label_replace(label_replace(label_replace(
+                rate(loki_s3_request_duration_seconds_count{operation=~"S3\\.(PutObject|List|GetObject)"}[30m]),
+                "component", "loki", "", ""),
+                "tier", "tier1", "operation", "S3\\.(PutObject|List)"),
+                "tier", "tier2", "operation", "S3\\.GetObject")
+            )
+            or
+            sum by (component, tier) (
+              label_replace(label_replace(label_replace(
+                rate(tempodb_backend_request_duration_seconds_count{operation=~"PUT|POST|GET"}[30m]),
+                "component", "tempo", "", ""),
+                "tier", "tier1", "operation", "PUT|POST"),
+                "tier", "tier2", "operation", "GET")
+            )
+
+    # 7일 기준선.
+    #
+    # ⚠️ rate(...[7d]) 를 쓰지 않는다. 그렇게 짜면 배포 직후 오탐이 확정이다 —
+    # 실제로 배포 전에 두 식을 라이브 Prometheus 에 던져 확인했다:
+    #   loki tier1  현재 0.1741 ops/s vs rate[7d] 기준선 0.0017 ops/s (100배)
+    # Loki·Tempo 스크랩은 2026-08-11 에 켰는데(#1152) rate 는 7일 창 전체로 나누므로
+    # "데이터가 없던 기간 = 요청이 없던 기간"으로 계산된다. 반대로 Thanos tier2 는
+    # 창에 ELOG-027 조치 이전(277k/day)이 남아 기준선이 부풀어 오탐이 아니라
+    # 미탐(놓침)을 만든다. 양방향으로 틀린다.
+    #
+    # avg_over_time 은 존재하는 표본만 평균한다 — 이력이 4시간뿐이면 4시간 평균이라
+    # 비율이 1 근처가 되어 조용하고, 날이 지나며 진짜 7일 평균으로 자란다.
+    # 세 번의 7d rate 스캔이 레코딩 룰 1개 참조로 바뀌어 비용도 훨씬 싸다.
+    #
+    # 대가: 배포 후 첫 일주일은 기준선이 짧아 민감도가 낮다. 그 기간에 새 루프를
+    # 놓칠 수 있지만, 매일 울려서 무시하게 되는 알림보다 낫다.
+    - name: s3-cost-recording-baseline
+      interval: 5m
+      rules:
+        - record: orino:s3_ops:avg7d
+          expr: avg_over_time(orino:s3_ops:rate30m[7d])
+
+    - name: s3-cost-alerts
+      rules:
+        # 새 폴링 루프가 생기면 다음 청구서가 아니라 당일 안다.
+        # ELOG-027 의 thanos compact 루프는 5개월간 아무도 몰랐다.
+        #
+        # 절대 하한 0.05 ops/s(≈4,320회/day)를 함께 건다. 비율만 보면 thanos tier1
+        # (실측 0.0011 ops/s = 98회/day)처럼 작은 계열이 몇 배로 튀어도 금액은
+        # 무의미한데 매번 발동한다 — 무시하게 되는 알림은 없는 알림과 같다.
+        # 하한 4,320회/day 는 Tier1 단가로 월 $0.65 수준이고, 잡으려는 대상인
+        # ELOG-027 급 루프(+277k/day)보다 두 자릿수 아래라 놓치지 않는다.
+        - alert: S3RequestRateSurge
+          expr: |
+            orino:s3_ops:rate30m > 0.05
+            and
+            orino:s3_ops:rate30m > 3 * orino:s3_ops:avg7d
+          for: 30m
+          labels:
+            severity: warning
+            category: cost
+          annotations:
+            summary: "S3 요청 급증 — {{ "{{" }} $labels.component {{ "}}" }} {{ "{{" }} $labels.tier {{ "}}" }}"
+            description: >-
+              7일 평균 대비 3배 이상. 현재 {{ "{{" }} $value | printf "%.3f" {{ "}}" }} ops/s
+              (일 환산 {{ "{{" }} $value | humanize {{ "}}" }}×86400회).
+              새 폴링 루프나 주기 설정 변경을 의심한다 — 해당 컴포넌트의 interval 플래그부터 본다.

--- a/infra/helm/kube-prometheus-stack/templates/sealedsecret-discord-cost.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/sealedsecret-discord-cost.yaml
@@ -1,0 +1,15 @@
+# 비용 알림 전용 Discord 웹훅 (#1153). 기존 alertmanager-discord-secret 과 별개다 —
+# 비용 알림은 성격이 달라 같은 채널에 섞이면 파드 재시작 알림에 묻힌다.
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: alertmanager-discord-cost-secret
+  namespace: monitoring
+spec:
+  encryptedData:
+    DISCORD_WEBHOOK_URL: AgAWI8lg7W2Sjd97m7icolNBQTSnI6oaZ8yg9a5f8BMqRJ2QtiuqNqYj95SUBIvgMlNmTPIvbNx3J72eXnEQfOclSDCfAn/8CETE58gnZKMAxQeMdud+YZqb+sD5msYCe3ByZmc2yEQyJG8IUI1DXKZx+BSkViCXRAQlT6dFhPTjQyjBphvTChfAopbgFyrIiBr63h/RHh/YDoumUHTgmuL6CayEI+xYCbDphZqeCklB6Wrbx64OMYI+9JJ0Fy+G9zrpTPfcjsfxzmgDSzyaIk58nZeeTqLQjQG0Z+06ylR3xv6bCKlMM2Zp1xJyfgY70h1+rXijabwVdjA8XWL1b50Z+j7V5myOKhFvk65i3JPlohRW3Sy6zXM/VRbk0pJaf0Cpt75Tm19CW4yKw+XWwHb4k6+D3FRX/YjGtuFNj6h+5WkljESPuOS1J4s+D0p9S/LLxwdaBAyhdoL02ayKqjYdOhLVpIeQUc4xFHENrzIepodmOcOCCTkw1XQmQRnGgGyeof8JUYauSliJoKF6S6sAAFYP7xYinbUhWM2NlvAjXvSK0UkuoaGceGGBzMjdBejyS/M29JZ3uFX0GL6ep6FnZz3gIGmIBqtx5SVPFY4xHK7jeOgCtLmgVKuaBni4ZE+BuqnZt8M6TSadTRPAU4lWwG2BKuhwIon5aaD6LC9r/9zZPPBjvUHADunKAJeMGnQd5OxkoJvZ42vaqTDLwYSN+Q8pX0c7HYfsPF3ZvuQWTlQW+6U8VEQPxVzjhfpMyn7HO88x9wgRrqIHVxOXzLvz0PX0MDqUd19Oywj5k/ChGt964iMBcjB87NO7qvMbdOdVLCnO2fHMyk+zYl2BlA7mvn2/QZdtgnsC
+  template:
+    metadata:
+      name: alertmanager-discord-cost-secret
+      namespace: monitoring
+    type: Opaque

--- a/infra/helm/kube-prometheus-stack/values.yaml
+++ b/infra/helm/kube-prometheus-stack/values.yaml
@@ -93,6 +93,11 @@ kube-prometheus-stack:
               urlDisplayLabel: Tempo
       - name: Thanos
         type: prometheus
+        # uid 고정 — 대시보드 JSON이 datasource를 uid로 참조한다. 비워 두면 Grafana가
+        # 매번 임의 uid를 만들어 stateless 재기동 때마다 패널이 데이터소스를 잃는다.
+        # (S3 비용 대시보드는 7일 넘는 추이를 봐야 해서 Prometheus 로컬 retention이
+        #  아닌 Thanos를 봐야 한다 — #1153)
+        uid: thanos
         url: http://thanos-query.monitoring.svc.cluster.local:9090
         access: proxy
         isDefault: false

--- a/infra/terraform/cloudwatch.tf
+++ b/infra/terraform/cloudwatch.tf
@@ -1,0 +1,56 @@
+# Grafana CloudWatch 데이터소스용 읽기 전용 자격증명 (#1153 · Epic #1148).
+#
+# 버킷 객체 수·용량(BucketSizeBytes · NumberOfObjects)은 Prometheus 로 알 수 없다 —
+# Loki retention 이 5개월간 집행되지 않은 걸 아무도 못 본 게 이 지표가 없어서였다
+# (ELOG-027). 객체 수 추이를 봐야 "선언된 정책이 실제로 도는지"가 보인다.
+#
+# ⚠️ 기존 observability-s3 키를 재사용하지 않는다. 그 키는 S3 읽기·쓰기 권한이 있고
+# Loki/Thanos/Tempo 가 쓰는 운영 키다. 대시보드가 읽기만 하면 되는데 쓰기 권한을 가진
+# 키를 Grafana 에 넣을 이유가 없다.
+#
+# ⚠️ GetMetricData 는 metric 당 과금($0.01/1,000)이다. 버킷 6개 × 2메트릭 = 12 를
+# 1시간 주기로 조회하면 월 8,640건 = $0.09, 1분 주기면 월 $5 로 남은 절감 여지
+# 전체($2.8/월)를 넘어선다. 주기 제한은 Grafana 쪽(데이터소스·알림 평가 주기)에서
+# 건다 — IAM 으로는 호출 빈도를 제한할 수 없다. 관측이 과금을 만드는 함정을
+# 이 프로젝트는 두 번 겪었다.
+resource "aws_iam_user" "cloudwatch_readonly" {
+  name = "grafana-cloudwatch-readonly"
+}
+
+resource "aws_iam_user_policy" "cloudwatch_readonly" {
+  name = "grafana-cloudwatch-readonly"
+  user = aws_iam_user.cloudwatch_readonly.name
+
+  # cloudwatch:* 를 쓰지 않는다. 대시보드가 실제로 부르는 3개만 —
+  # 알람 생성·삭제(PutMetricAlarm 등)나 지표 쓰기(PutMetricData)는 필요 없다.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "CloudWatchRead"
+        Effect = "Allow"
+        Action = [
+          "cloudwatch:GetMetricData",
+          "cloudwatch:GetMetricStatistics",
+          "cloudwatch:ListMetrics",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_access_key" "cloudwatch_readonly" {
+  user = aws_iam_user.cloudwatch_readonly.name
+}
+
+output "cloudwatch_readonly_access_key_id" {
+  description = "Grafana CloudWatch 데이터소스용 access key ID"
+  value       = aws_iam_access_key.cloudwatch_readonly.id
+}
+
+output "cloudwatch_readonly_secret_access_key" {
+  description = "Grafana CloudWatch 데이터소스용 secret access key (SealedSecret 로 봉인해 사용)"
+  value       = aws_iam_access_key.cloudwatch_readonly.secret
+  sensitive   = true
+}


### PR DESCRIPTION
## 이슈
#1153 (1차 — CloudWatch 부분은 키 봉인 후 2차 PR)
## 작업 내용
- `grafana-dashboards/s3-cost-overview.json` + ConfigMap — 패널 5종, Thanos 데이터소스
- `prometheusrule-s3-cost.yaml` — 컴포넌트·티어 정규화 레코딩 룰 2개 + `S3RequestRateSurge` 알림
- `alertmanagerconfig-discord.yaml` — 비용 알림 전용 route 추가
- `sealedsecret-discord-cost.yaml` — 비용 채널 웹훅 (note1에서 kubeseal, `.secrets` 기록 완료)
- `values.yaml` — Thanos 데이터소스 `uid: thanos` 고정
- `cloudwatch.tf` — 읽기 전용 IAM 사용자 (`GetMetricData`·`GetMetricStatistics`·`ListMetrics`만)

## 🔴 테스트로 잡은 버그 — 이 PR의 핵심

처음엔 이슈 문구대로 "7일 이동평균 대비 3배"를 `rate(metric[7d])`로 짰다. 배포 전에 라이브 Prometheus에 두 식을 직접 던져 보니 **배포 즉시 오탐이 확정이었다**:

```
🔥 발동: loki/tier1  0.1741 ops/s
   현재(30m) 0.1741  vs  rate[7d] 기준선 0.0017   → 100배
```

`rate`는 7일 창 **전체**로 나눈다. Loki·Tempo 스크랩은 오늘(#1152) 켰으므로 "데이터가 없던 6일 = 요청이 없던 6일"로 계산된다. 반대 방향으로도 틀린다 — Thanos tier2는 창에 ELOG-027 조치 이전(277k/day)이 남아 기준선이 **부풀어** 오탐이 아니라 **미탐**을 만든다(실측 `rate[7d]` 181,818/day vs 현재 4,052/day).

**→ `avg_over_time(orino:s3_ops:rate30m[7d])`로 교체.** 존재하는 표본만 평균하므로 이력이 4시간뿐이면 4시간 평균이 되어 비율이 1 근처 → 조용하고, 날이 지나며 진짜 7일 평균으로 자란다. 세 번의 7d 스캔이 레코딩 룰 1개 참조로 바뀌어 비용도 싸다.

**대가**: 첫 일주일은 기준선이 짧아 민감도가 낮다. 그 기간 새 루프를 놓칠 수 있지만, **매일 울려서 무시하게 되는 알림보다 낫다** — 무시되는 알림은 없는 알림과 같다.

## 설계 판단

**절대 하한 `> 0.05 ops/s`를 병행한다.** 비율만 보면 thanos tier1(실측 98회/day)처럼 작은 계열이 몇 배 튀어도 금액이 무의미한데 매번 발동한다. 하한 4,320회/day는 Tier1 단가로 월 $0.65 수준이고, 잡으려는 대상(ELOG-027급 +277k/day)보다 두 자릿수 아래라 놓치지 않는다.

**레코딩 룰로 (component, tier) 정규화.** 세 컴포넌트가 이름·라벨이 전부 다르다. 대시보드·알림·#1156 차분식이 매번 이 차이를 다시 쓰지 않도록 한 번만 정의한다. DELETE는 무과금이라 제외했다 — 넣으면 Loki의 `S3.DeleteObject` 51k가 요청 수를 통째로 왜곡한다.

**Thanos 데이터소스 + uid 고정.** 이 대시보드는 retention 집행 감시가 목적이라 7일 넘는 추이를 봐야 하는데 Prometheus 로컬 retention이 7d다. uid를 비워 두면 Grafana가 매번 임의 uid를 만들어, persistence가 꺼진(stateless) 이 Grafana에서는 재기동마다 패널이 데이터소스를 잃는다.

**비용 알림은 전용 채널로.** 파드 재시작·노드 알림과 성격이 달라 같은 채널에 섞이면 묻힌다. `repeatInterval`도 4h → 12h(비용은 즉시 대응할 성질이 아니다).

## ⚠️ DoD 정정 — 소급 확인은 Thanos 몫만 가능하다

이슈 DoD는 "8/9 Tier2 급감(277k → 18k/day)이 대시보드에서 눈으로 보인다"인데, **Loki·Tempo는 오늘 스크랩을 켜서 그 이전 데이터가 아예 없다.** 277k→18k는 세 컴포넌트 합산 수치였으므로 그 숫자 그대로는 소급 재현이 불가능하다.

Thanos 계열에서는 선명하게 보인다(실측):

| 날짜 | Thanos S3 ops |
|---|---|
| 08-08 | 3.24/s |
| **08-09** | **0.45/s (−86%)** |

패널 4 설명에 이 한계를 적어 두었다 — 반년 뒤 "왜 8월 초 Loki 선이 없지?"로 헤매지 않도록.

## 확인
- [x] `terraform fmt -check -recursive` · `validate` 통과
- [x] `yamllint -c .yamllint.yml infra/` 통과
- [x] `helm lint kube-prometheus-stack` 통과
- [x] `helm template` 렌더링 확인 — 대시보드 JSON이 파싱되고 `legendFormat`의 `{{operation}}` 5개가 **살아서** 나온다(Helm이 먹지 않았다)
- [x] `kubectl apply --dry-run=server`로 **실제 CRD 스키마 검증** — ConfigMap·AlertmanagerConfig·PrometheusRule·SealedSecret 4종 통과
- [x] **모든 PromQL을 라이브 Prometheus에 던져 값 확인** — 레코딩 룰 6시리즈, 대시보드 패널 쿼리 9개 중 7개가 값 반환(나머지 2개는 레코딩 룰 참조라 배포 후 생성)
- [ ] ArgoCD 동기화 후 대시보드가 Grafana에 뜨는지 확인
- [ ] 레코딩 룰이 실제로 평가돼 `orino:s3_ops:rate30m`·`avg7d` 시리즈가 생기는지 확인
- [ ] 배포 후 알림이 **조용한지** 확인 (오탐 수정이 실제로 먹었는지)
- [ ] 알림 실사 테스트 — 임계를 일시 조작해 Discord 비용 채널에 실제로 오는지 확인 후 원복

## 다음 (2차 PR)
CloudWatch 패널 2종(버킷 객체 수·용량)과 알림 2번(객체 수 단조 증가)은 **IAM 키가 있어야** 한다. 이 PR 머지 → apply로 키 생성 → `terraform output`으로 값 확인 → `kubeseal` 봉인 → 2차 PR에서 데이터소스·패널·알림 추가.

이슈의 알림 2종 중 **재발 감시(객체 수 단조 증가)가 2차에 들어간다** — ELOG-027의 실패가 "선언된 정책이 안 도는 걸 아무도 안 봐서"였으니 그게 진짜 핵심이다. 1차만으로 이슈를 닫지 않는다.
