### PR TITLE
feat : 숙소에 장소 연결 — 검색으로 담고 도시 식별자까지 저장

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/stay/dto/StayRequest.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/stay/dto/StayRequest.java
@@ -11,9 +11,16 @@ import java.time.LocalTime;
 /**
  * 숙소 등록·수정. 생성과 수정이 같은 형태를 쓴다(전체 수정).
  *
- * @param placeId      좌표·도시 판정에 쓴다. 직접 입력한 숙소면 생략한다 — 그때는 이동시간도
- *                     도시 일치 판정도 하지 않는다
- * @param checkInTime  벽시계 시각. UTC로 바꾸지 않는다 — 15:00 체크인은 어느 도시에서든 15:00이다
+ * @param placeId       좌표·도시 판정에 쓴다. 직접 입력한 숙소면 생략한다 — 그때는 이동시간도
+ *                      도시 일치 판정도 하지 않는다
+ * @param googlePlaceId 검색 결과를 그대로 담을 때. 서버가 장소를 upsert해 {@code placeId}로
+ *                      연결한다 — 화면이 장소를 먼저 만들고 id를 들고 오지 않아도 되게.
+ *                      {@code placeId}와 함께 보내지 않는다(일정 담기와 같은 규칙)
+ * @param cityPlaceId   이 숙소가 <b>어느 도시에 있는지</b>. 새로 담기는 장소에 그 도시의
+ *                      식별자를 함께 저장해 숙소 이동의 도시 경계 판정이 성립하게 한다(§3.4).
+ *                      기준 도시에서 넘겨받지 않고 <b>사용자가 고른다</b> — 닛코 당일치기 날의
+ *                      기준 도시는 닛코지만 자는 곳은 도쿄일 수 있다
+ * @param checkInTime   벽시계 시각. UTC로 바꾸지 않는다 — 15:00 체크인은 어느 도시에서든 15:00이다
  */
 public record StayRequest(
         @NotBlank(message = "숙소 이름을 입력해 주세요.")
@@ -21,6 +28,10 @@ public record StayRequest(
         String name,
 
         Long placeId,
+
+        String googlePlaceId,
+
+        Long cityPlaceId,
 
         @NotNull(message = "체크인 날짜를 입력해 주세요.")
         LocalDate checkInDate,

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/stay/service/StayService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/stay/service/StayService.java
@@ -7,6 +7,7 @@ import ds.project.orino.domain.planner.travel.entity.TripStay;
 import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
 import ds.project.orino.domain.planner.travel.repository.TripRepository;
 import ds.project.orino.domain.planner.travel.repository.TripStayRepository;
+import ds.project.orino.planner.travel.place.service.PlaceService;
 import ds.project.orino.planner.travel.stay.dto.StayOverlapResponse;
 import ds.project.orino.planner.travel.stay.dto.StayRequest;
 import ds.project.orino.planner.travel.stay.dto.StayResponse;
@@ -34,13 +35,16 @@ public class StayService {
     private final TripRepository tripRepository;
     private final TripStayRepository stayRepository;
     private final TravelPlaceRepository placeRepository;
+    private final PlaceService placeService;
 
     public StayService(TripRepository tripRepository,
                        TripStayRepository stayRepository,
-                       TravelPlaceRepository placeRepository) {
+                       TravelPlaceRepository placeRepository,
+                       PlaceService placeService) {
         this.tripRepository = tripRepository;
         this.stayRepository = stayRepository;
         this.placeRepository = placeRepository;
+        this.placeService = placeService;
     }
 
     public List<StayResponse> list(Long memberId, Long tripId) {
@@ -58,7 +62,7 @@ public class StayService {
 
         TripStay stay = new TripStay(tripId, request.name().trim(),
                 request.checkInDate(), request.checkOutDate());
-        stay.updateBasics(request.name().trim(), request.placeId(),
+        stay.updateBasics(request.name().trim(), resolvePlaceId(memberId, request),
                 request.checkInDate(), request.checkOutDate());
         stay.updateDetails(request.checkInTime(), request.checkOutTime(),
                 request.bookingUrl(), request.memo());
@@ -73,7 +77,7 @@ public class StayService {
         // 자기 자신과는 겹칠 수 없다 — 기간을 그대로 두고 이름만 고치는 요청이 막히면 안 된다.
         requireNoOverlap(stay.getTripId(), request, stayId);
 
-        stay.updateBasics(request.name().trim(), request.placeId(),
+        stay.updateBasics(request.name().trim(), resolvePlaceId(memberId, request),
                 request.checkInDate(), request.checkOutDate());
         stay.updateDetails(request.checkInTime(), request.checkOutTime(),
                 request.bookingUrl(), request.memo());
@@ -103,6 +107,21 @@ public class StayService {
         tripRepository.findByIdAndMemberId(stay.getTripId(), memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_STAY_NOT_FOUND));
         return stay;
+    }
+
+    /**
+     * 요청의 장소를 내부 id로 정규화한다 — 일정 담기(§5)와 같은 규칙이다.
+     *
+     * <p>검색 결과를 그대로 보내면 여기서 upsert한다. 어느 도시의 숙소인지를 함께 넘겨
+     * <b>도시 식별자까지</b> 채운다 — 없으면 숙소 이동이 도시를 넘는지 판정할 수 없어
+     * "모르면 같은 도시"로 떨어지고, 오사카 가게에서 도쿄 숙소까지 자동차 시간이 붙는다.
+     */
+    private Long resolvePlaceId(Long memberId, StayRequest request) {
+        if (request.googlePlaceId() != null && !request.googlePlaceId().isBlank()) {
+            return placeService.upsertFromGoogle(memberId, request.googlePlaceId(),
+                    request.cityPlaceId()).getId();
+        }
+        return request.placeId();
     }
 
     /**

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/stay/StayControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/stay/StayControllerTest.java
@@ -3,7 +3,12 @@ package ds.project.orino.planner.travel.stay;
 import com.jayway.jsonpath.JsonPath;
 import ds.project.orino.domain.member.repository.MemberRepository;
 import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.entity.TripStay;
 import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.domain.planner.travel.repository.TripStayRepository;
+import ds.project.orino.planner.travel.place.StubPlacesClient;
+import ds.project.orino.planner.travel.place.client.PlaceResult;
+import ds.project.orino.planner.travel.place.client.PlacesClient;
 import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
@@ -20,8 +25,11 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -47,8 +55,13 @@ class StayControllerTest extends ApiTestSupport {
     @Autowired
     private TravelPlaceRepository placeRepository;
     @Autowired
+    private TripStayRepository stayRepository;
+    @Autowired
     private DbCleaner dbCleaner;
+    @Autowired
+    private PlacesClient placesClient;
 
+    private StubPlacesClient placesStub;
     private String authHeader;
     private String otherAuthHeader;
     private long tripId;
@@ -57,6 +70,8 @@ class StayControllerTest extends ApiTestSupport {
     @BeforeEach
     void setUp() throws Exception {
         dbCleaner.clean();
+        placesStub = (StubPlacesClient) placesClient;
+        placesStub.reset();
         memberRepository.save(MemberFixture.create());
         memberRepository.save(MemberFixture.create("other", "password"));
         authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
@@ -192,6 +207,67 @@ class StayControllerTest extends ApiTestSupport {
             mockMvc.perform(get("/api/travel/trips/" + tripId + "/stays")
                             .header(HttpHeaders.AUTHORIZATION, authHeader))
                     .andExpect(jsonPath("$.data", hasSize(0)));
+        }
+
+        @Test
+        @DisplayName("검색 결과를 그대로 담으면 장소를 만들어 붙인다")
+        void upsertsPlaceFromGoogle() throws Exception {
+            placesStub.detailResult = Optional.of(hotelResult());
+
+            long stayId = stayId(mockMvc.perform(post("/api/travel/trips/" + tripId + "/stays")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "난바 호텔", "googlePlaceId": "ChIJ_namba",
+                                     "checkInDate": "2026-10-24", "checkOutDate": "2026-10-26"}
+                                    """))
+                    .andExpect(status().isOk()));
+
+            TripStay stay = stayRepository.findById(stayId).orElseThrow();
+            assertThat(stay.getPlaceId()).isNotNull();
+            // 좌표가 붙어야 숙소 이동 시간이 계산된다.
+            assertThat(placeRepository.findById(stay.getPlaceId()).orElseThrow().getLat())
+                    .isNotNull();
+        }
+
+        @Test
+        @DisplayName("어느 도시인지 함께 주면 도시 식별자까지 채운다 — 경계 판정이 여기서 산다")
+        void savesCityIdentifier() throws Exception {
+            placesStub.detailResult = Optional.of(hotelResult());
+            withCityRef(osaka, "ChIJ_osaka");
+
+            long stayId = stayId(mockMvc.perform(post("/api/travel/trips/" + tripId + "/stays")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "난바 호텔", "googlePlaceId": "ChIJ_namba",
+                                     "cityPlaceId": %d,
+                                     "checkInDate": "2026-10-24", "checkOutDate": "2026-10-26"}
+                                    """.formatted(osaka)))
+                    .andExpect(status().isOk()));
+
+            TripStay stay = stayRepository.findById(stayId).orElseThrow();
+            assertThat(placeRepository.findById(stay.getPlaceId()).orElseThrow()
+                    .getCityPlaceRef()).isEqualTo("ChIJ_osaka");
+        }
+
+        @Test
+        @DisplayName("도시를 안 주면 식별자도 없다 — 좌표로 도시를 추측하지 않는다(D-23)")
+        void leavesCityIdentifierEmptyWithoutCity() throws Exception {
+            placesStub.detailResult = Optional.of(hotelResult());
+
+            long stayId = stayId(mockMvc.perform(post("/api/travel/trips/" + tripId + "/stays")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "난바 호텔", "googlePlaceId": "ChIJ_namba",
+                                     "checkInDate": "2026-10-24", "checkOutDate": "2026-10-26"}
+                                    """))
+                    .andExpect(status().isOk()));
+
+            TripStay stay = stayRepository.findById(stayId).orElseThrow();
+            assertThat(placeRepository.findById(stay.getPlaceId()).orElseThrow()
+                    .getCityPlaceRef()).isNull();
         }
 
         @Test
@@ -357,6 +433,14 @@ class StayControllerTest extends ApiTestSupport {
                                  "placeId": %d}
                                 """.formatted(name, checkIn, checkOut, placeId)))
                 .andExpect(status().isOk());
+    }
+
+    /** 검색으로 고른 호텔. 좌표가 있어야 숙소 이동 시간이 계산된다. */
+    private static PlaceResult hotelResult() {
+        return new PlaceResult("ChIJ_namba", "난바 호텔", "오사카시 주오구",
+                new BigDecimal("34.6656"), new BigDecimal("135.5061"), "호텔",
+                new BigDecimal("4.2"), null, null, "Asia/Tokyo", "오사카", "JP",
+                List.of("lodging"));
     }
 
     private static long stayId(org.springframework.test.web.servlet.ResultActions result)

--- a/fe/src/features/travel/api/stays.ts
+++ b/fe/src/features/travel/api/stays.ts
@@ -33,6 +33,19 @@ export interface Stay {
 export interface StayWriteRequest {
   name: string;
   placeId?: number | null;
+  /**
+   * 검색 결과를 그대로 담을 때. 서버가 장소를 upsert해 `placeId`로 연결한다 —
+   * 프론트가 장소를 먼저 만들 필요가 없다. `placeId`와 함께 보내지 않는다.
+   */
+  googlePlaceId?: string | null;
+  /**
+   * 이 숙소가 **어느 도시에 있는지**. 새로 담기는 장소에 그 도시 식별자가 함께 저장돼
+   * 숙소 이동의 도시 경계 판정이 성립한다(§3.4).
+   *
+   * <p>기준 도시에서 가져오지 않고 **사용자가 고른다** — 닛코 당일치기 날의 기준 도시는
+   * 닛코지만 자는 곳은 도쿄일 수 있다.
+   */
+  cityPlaceId?: number | null;
   checkInDate: string;
   checkOutDate: string;
   checkInTime?: string | null;

--- a/fe/src/features/travel/stay/StayFormSheet.tsx
+++ b/fe/src/features/travel/stay/StayFormSheet.tsx
@@ -6,9 +6,12 @@ import { FieldError } from "@/components/ui/field-error";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import type { BaseCity } from "@/features/travel/api/activities";
 import type { Stay, StayWriteRequest } from "@/features/travel/api/stays";
 import { overlapMessage, overlaps } from "@/features/travel/lib/stayForDay";
 import { formatShortDate } from "@/features/travel/lib/tripStatus";
+import type { PickedPlace } from "@/features/travel/stay/StayPlacePicker";
+import { StayPlacePicker } from "@/features/travel/stay/StayPlacePicker";
 
 interface StayFormSheetProps {
   open: boolean;
@@ -18,6 +21,11 @@ interface StayFormSheetProps {
   tripEndDate: string;
   /** 이미 있는 숙소들 — 겹침을 <b>서버에 묻기 전에</b> 답하는 데 쓴다. */
   stays: Stay[];
+  tripId: number;
+  /** 이 여행에 등장하는 도시들. 숙소가 어느 도시에 있는지 여기서 고른다. */
+  cities: BaseCity[];
+  /** 기본값 — 보고 있던 날짜의 도시. 숙소를 그 날짜 근처에 잡는 경우가 대부분이다. */
+  defaultCity: BaseCity | null;
   onOpenChange: (open: boolean) => void;
   /** 저장. 실패하면 던져야 한다 — 시트가 열린 채 사유를 보여준다. */
   onSubmit: (body: StayWriteRequest) => Promise<void>;
@@ -59,6 +67,9 @@ export function StayFormSheet({
   tripStartDate,
   tripEndDate,
   stays,
+  tripId,
+  cities,
+  defaultCity,
   onOpenChange,
   onSubmit,
   pending,
@@ -66,11 +77,21 @@ export function StayFormSheet({
 }: StayFormSheetProps) {
   const [draft, setDraft] = useState<Draft>(EMPTY);
   const [error, setError] = useState<string | null>(null);
+  /** 새로 고른 장소. 수정에서 손대지 않으면 null이고, 그때는 붙어 있던 장소를 그대로 둔다. */
+  const [picked, setPicked] = useState<PickedPlace | null>(null);
+  /**
+   * 사용자가 고른 도시. 안 골랐으면 보던 날짜의 도시로 떨어진다 — 상태로 굳히지 않는 이유는
+   * 시트를 열 때마다 그 날짜를 따라가야 하기 때문이다.
+   */
+  const [pickedCity, setPickedCity] = useState<BaseCity | null>(null);
+  const city = pickedCity ?? defaultCity ?? cities[0] ?? null;
 
   // 다른 숙소를 열면 이전 입력이 남아 있으면 안 된다.
   useEffect(() => {
     if (!open) return;
     setError(null);
+    setPicked(null);
+    setPickedCity(null);
     setDraft(
       stay === null
         ? EMPTY
@@ -123,9 +144,11 @@ export function StayFormSheet({
     // 빈 문자열은 "지움"이다 — 선택 항목을 비워 저장하면 실제로 비워져야 한다.
     await onSubmit({
       name: draft.name.trim(),
-      // 수정은 전체 교체라 붙어 있던 장소를 그대로 실어 보낸다. 빼면 좌표가 사라져
-      // 숙소 이동 시간이 계산되지 않는다.
-      placeId: stay?.placeId ?? null,
+      // 새로 골랐으면 그것으로 바꾸고, 아니면 붙어 있던 장소를 그대로 실어 보낸다 —
+      // 수정은 전체 교체라 빼면 좌표가 사라져 숙소 이동 시간이 계산되지 않는다.
+      ...(picked
+        ? { googlePlaceId: picked.googlePlaceId, cityPlaceId: city?.placeId }
+        : { placeId: stay?.placeId ?? null }),
       checkInDate: draft.checkInDate,
       checkOutDate: draft.checkOutDate,
       checkInTime: draft.checkInTime || null,
@@ -153,6 +176,22 @@ export function StayFormSheet({
             value={draft.name}
             onChange={(e) => set("name", e.target.value)}
             placeholder="도톤보리 호텔"
+          />
+        </FormField>
+
+        {/* 장소는 선택이다 — 붙이면 이동시간과 길찾기가 살아나고, 없어도 숙소는 저장된다. */}
+        <FormField label="장소 (선택)">
+          <StayPlacePicker
+            tripId={tripId}
+            picked={picked}
+            onPick={(place) => {
+              setPicked(place);
+              // 이름을 아직 안 적었으면 고른 장소 이름으로 채운다.
+              if (place && !draft.name.trim()) set("name", place.name);
+            }}
+            city={city}
+            cities={cities}
+            onCityChange={setPickedCity}
           />
         </FormField>
 

--- a/fe/src/features/travel/stay/StayPlacePicker.tsx
+++ b/fe/src/features/travel/stay/StayPlacePicker.tsx
@@ -1,0 +1,177 @@
+import { MapPin, Search, X } from "lucide-react";
+import { type FormEvent, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { BaseCity } from "@/features/travel/api/activities";
+import type { PlaceSearchResult } from "@/features/travel/api/places";
+import { searchPlaces } from "@/features/travel/api/places";
+
+/** 고른 숙소 장소. 저장할 때 `googlePlaceId`로 넘어간다. */
+export interface PickedPlace {
+  googlePlaceId: string;
+  name: string;
+  address: string | null;
+}
+
+interface StayPlacePickerProps {
+  tripId: number;
+  picked: PickedPlace | null;
+  onPick: (place: PickedPlace | null) => void;
+  /** 이 숙소가 있는 도시. 검색 편향이자 <b>저장될 도시 식별자</b>다. */
+  city: BaseCity | null;
+  cities: BaseCity[];
+  onCityChange: (city: BaseCity) => void;
+}
+
+/**
+ * 숙소에 붙일 장소를 찾는다(§9.6).
+ *
+ * <p><b>도시를 사용자가 고른다.</b> 그날 기준 도시에서 자동으로 가져오면 닛코 당일치기 날의
+ * 도쿄 숙소가 "닛코 숙소"로 저장된다 — 숙소는 기준 도시와 무관하다는 것이 v2.1의 전제고
+ * (§3.5), 그 전제를 저장 시점에 깨면 이동시간 판정이 그대로 틀어진다.
+ *
+ * <p>고른 도시는 검색 편향에도 쓴다. 교토 호텔을 찾는데 오사카 좌표로 물어볼 이유가 없다.
+ */
+export function StayPlacePicker({
+  tripId,
+  picked,
+  onPick,
+  city,
+  cities,
+  onCityChange,
+}: StayPlacePickerProps) {
+  const [draft, setDraft] = useState("");
+  const [results, setResults] = useState<PlaceSearchResult[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const search = async (event: FormEvent) => {
+    event.preventDefault();
+    const q = draft.trim();
+    if (!q) return;
+    setSearching(true);
+    setFailed(false);
+    try {
+      setResults(await searchPlaces(q, tripId, city?.placeId));
+    } catch {
+      setResults(null);
+      setFailed(true);
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  if (picked) {
+    return (
+      <div className="border-border bg-card flex items-center gap-2 rounded-lg border px-3 py-2.5">
+        <MapPin className="text-primary size-4 shrink-0" />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium">{picked.name}</p>
+          {picked.address && (
+            <p className="text-muted-foreground truncate text-xs">
+              {picked.address}
+            </p>
+          )}
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="장소 지우기"
+          onClick={() => onPick(null)}
+        >
+          <X className="size-4" />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* 도시가 둘 이상일 때만 고를 것이 있다. */}
+      {cities.length > 1 && (
+        <div className="flex flex-wrap gap-1.5">
+          {cities.map((candidate) => (
+            <button
+              key={candidate.placeId}
+              type="button"
+              aria-pressed={candidate.placeId === city?.placeId}
+              onClick={() => onCityChange(candidate)}
+              className={`flex items-center gap-1 rounded-full border px-2.5 py-1 text-[13px] ${
+                candidate.placeId === city?.placeId
+                  ? "border-primary bg-accent font-medium"
+                  : "border-border hover:bg-accent"
+              }`}
+            >
+              <MapPin className="size-[13px] shrink-0" />
+              {candidate.name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder={city ? `${city.name} 숙소 검색` : "숙소 검색"}
+          aria-label="숙소 장소 검색"
+          // 시트 안이라 Enter가 바깥 폼을 제출해 버린다 — 여기서 가로챈다.
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void search(e);
+          }}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={searching}
+          onClick={(e) => void search(e)}
+        >
+          <Search className="size-3.5" />
+          검색
+        </Button>
+      </div>
+
+      {failed && (
+        <p className="text-muted-foreground text-xs">
+          검색하지 못했어요. 잠시 후 다시 시도해 주세요.
+        </p>
+      )}
+      {results !== null && results.length === 0 && !searching && (
+        // 장소 없이도 숙소는 저장된다 — 이동시간과 길찾기만 없다.
+        <p className="text-muted-foreground text-xs">
+          검색 결과가 없어요. 장소 없이 저장해도 됩니다.
+        </p>
+      )}
+
+      {results !== null && results.length > 0 && (
+        <ul className="flex max-h-[180px] flex-col gap-1 overflow-y-auto">
+          {results.slice(0, 5).map((place) => (
+            <li key={place.googlePlaceId}>
+              <button
+                type="button"
+                onClick={() =>
+                  onPick({
+                    googlePlaceId: place.googlePlaceId,
+                    name: place.name,
+                    address: place.address,
+                  })
+                }
+                className="hover:bg-accent flex w-full flex-col items-start rounded-lg px-2.5 py-2 text-left"
+              >
+                <span className="text-sm">{place.name}</span>
+                {place.address && (
+                  <span className="text-muted-foreground text-xs">
+                    {place.address}
+                  </span>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/fe/src/features/travel/stay/StaySheet.tsx
+++ b/fe/src/features/travel/stay/StaySheet.tsx
@@ -2,12 +2,16 @@ import {
   CalendarPlus,
   Hotel,
   Link as LinkIcon,
+  MapPin,
+  Navigation,
   StickyNote,
 } from "lucide-react";
 
 import { BottomSheet } from "@/components/ui/bottom-sheet";
 import { Button } from "@/components/ui/button";
+import type { PlaceDetail } from "@/features/travel/api/places";
 import type { Stay } from "@/features/travel/api/stays";
+import { placeDirectionsUrl } from "@/features/travel/lib/mapsLink";
 import { formatShortDate } from "@/features/travel/lib/tripStatus";
 
 interface StaySheetProps {
@@ -21,6 +25,8 @@ interface StaySheetProps {
   offline: boolean;
   /** 일정 생성 중. 두 번 눌러 일정이 두 벌 생기면 안 된다. */
   addingActivity: boolean;
+  /** 붙어 있는 장소의 상세. 주소·좌표는 여기서만 온다 — 숙소 자체는 id만 들고 있다. */
+  place: PlaceDetail | null;
 }
 
 /**
@@ -38,7 +44,9 @@ export function StaySheet({
   onAddActivity,
   offline,
   addingActivity,
+  place,
 }: StaySheetProps) {
+  const mapsUrl = place ? placeDirectionsUrl(place) : null;
   return (
     <BottomSheet
       open={stay !== null}
@@ -52,6 +60,14 @@ export function StaySheet({
             <Hotel className="size-[17px] shrink-0" />
             {stay.name}
           </p>
+
+          {/* 주소·도시는 붙어 있는 장소에서 온다. 장소 없는 숙소는 이 줄이 없다. */}
+          {place?.address && (
+            <p className="text-muted-foreground flex items-start gap-1.5 text-xs">
+              <MapPin className="mt-px size-3 shrink-0" />
+              {place.address}
+            </p>
+          )}
 
           <div className="flex gap-2">
             <TimeBox
@@ -83,6 +99,19 @@ export function StaySheet({
               <LinkIcon className="size-3.5 shrink-0" />
               예약 확인
             </a>
+          )}
+
+          {/* 좌표가 있어야 길찾기가 성립한다 — 이름만으로는 엉뚱한 곳을 연다. */}
+          {mapsUrl && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full"
+              onClick={() => window.open(mapsUrl, "_blank", "noopener")}
+            >
+              <Navigation className="size-3.5" />
+              구글 지도에서 길찾기 (대중교통)
+            </Button>
           )}
 
           {!offline && (

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -1869,6 +1869,136 @@ describe("TripBoardPage", () => {
       await waitFor(() => expect(deleted).toEqual(["76"]));
     });
 
+    it("숙소 폼에서 장소를 검색해 붙이면 googlePlaceId와 도시를 함께 보낸다", async () => {
+      const posted: Record<string, unknown>[] = [];
+      server.use(
+        http.get(`${API_BASE}/travel/places/search`, () =>
+          HttpResponse.json({
+            code: "OK",
+            data: [
+              {
+                id: null,
+                googlePlaceId: "ChIJ_namba",
+                name: "난바 호텔",
+                category: "호텔",
+                address: "오사카시 주오구",
+                rating: 4.2,
+                lat: 34.6656,
+                lng: 135.5061,
+              },
+            ],
+          }),
+        ),
+        http.post(
+          `${API_BASE}/travel/trips/:tripId/stays`,
+          async ({ request }) => {
+            posted.push((await request.json()) as Record<string, unknown>);
+            return HttpResponse.json({ code: "OK", data: DOTONBORI });
+          },
+        ),
+      );
+      mockBoard({ stays: [] });
+
+      const user = userEvent.setup();
+      renderBoard();
+      await user.click(
+        await screen.findByRole("button", { name: "숙소 추가" }),
+      );
+
+      const sheet = await screen.findByRole("dialog");
+      await user.type(
+        within(sheet).getByLabelText("숙소 장소 검색"),
+        "난바 호텔",
+      );
+      await user.click(within(sheet).getByRole("button", { name: /검색/ }));
+      await user.click(await within(sheet).findByText("난바 호텔"));
+
+      // 이름이 비어 있으면 고른 장소 이름으로 채운다.
+      expect(within(sheet).getByLabelText("이름")).toHaveValue("난바 호텔");
+
+      fireEvent.change(within(sheet).getByLabelText("체크인"), {
+        target: { value: "2026-10-24" },
+      });
+      fireEvent.change(within(sheet).getByLabelText("체크아웃"), {
+        target: { value: "2026-10-25" },
+      });
+      await user.click(within(sheet).getByRole("button", { name: "저장" }));
+
+      await waitFor(() => expect(posted).toHaveLength(1));
+      expect(posted[0].googlePlaceId).toBe("ChIJ_namba");
+      // 도시는 보던 날짜의 것으로 떨어진다 — 숙소는 기준 도시와 무관하지만 기본값은 필요하다.
+      expect(posted[0].cityPlaceId).toBe(21);
+    });
+
+    it("장소가 붙은 숙소는 상세에 주소와 길찾기가 나온다", async () => {
+      server.use(
+        http.get(`${API_BASE}/travel/places/:placeId`, () =>
+          HttpResponse.json({
+            code: "OK",
+            data: {
+              id: 31,
+              googlePlaceId: "ChIJ_namba",
+              name: "난바 호텔",
+              address: "오사카시 주오구",
+              lat: 34.6656,
+              lng: 135.5061,
+              category: "호텔",
+              phone: null,
+              rating: null,
+              openingHours: null,
+              manualEntry: false,
+            },
+          }),
+        ),
+      );
+      mockBoard({
+        days: [
+          day(1, "2026-10-24", "토", 0, {
+            stayTonight: tonight(76, "도톤보리 호텔", true),
+          }),
+          ...DAYS.slice(1),
+        ],
+        stays: [{ ...DOTONBORI, placeId: 31 }],
+      });
+
+      const user = userEvent.setup();
+      renderBoard();
+      await user.click(
+        await screen.findByRole("button", { name: /^숙소 도톤보리 호텔/ }),
+      );
+
+      const sheet = await screen.findByRole("dialog");
+      expect(
+        await within(sheet).findByText("오사카시 주오구"),
+      ).toBeInTheDocument();
+      expect(
+        within(sheet).getByRole("button", { name: /구글 지도에서 길찾기/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("장소 없는 숙소에는 길찾기가 없다 — 이름만으로는 엉뚱한 곳을 연다", async () => {
+      mockBoard({
+        days: [
+          day(1, "2026-10-24", "토", 0, {
+            stayTonight: tonight(76, "도톤보리 호텔", true),
+          }),
+          ...DAYS.slice(1),
+        ],
+        stays: [DOTONBORI],
+      });
+
+      const user = userEvent.setup();
+      renderBoard();
+      await user.click(
+        await screen.findByRole("button", { name: /^숙소 도톤보리 호텔/ }),
+      );
+
+      const sheet = await screen.findByRole("dialog");
+      expect(
+        within(sheet).queryByRole("button", { name: /구글 지도에서 길찾기/ }),
+      ).not.toBeInTheDocument();
+    });
+
     it("보관함에는 그날 밤이 없다 — 배지도 숙소 이동도 없다", async () => {
       mockBoard({
         archive: [activity()],

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -61,6 +61,7 @@ import {
   useUpdateActivity,
 } from "@/features/travel/hooks/useActivityMutations";
 import { useBoard } from "@/features/travel/hooks/useBoard";
+import { usePlaceDetail } from "@/features/travel/hooks/usePlaceDetail";
 import {
   useCreateStay,
   useDeleteStay,
@@ -161,6 +162,11 @@ export function TripBoardPage() {
   const createStay = useCreateStay(tripId);
   const updateStay = useUpdateStay(tripId);
   const removeStay = useDeleteStay(tripId);
+
+  // 숙소 상세 시트가 열렸을 때만 그 장소를 읽는다 — 닫혀 있으면 부를 이유가 없다.
+  const { data: openStayPlace } = usePlaceDetail(
+    stays?.find((stay) => stay.stayId === openStayId)?.placeId ?? null,
+  );
 
   const createActivity = useCreateActivity(tripId);
   const updateActivity = useUpdateActivity(tripId);
@@ -415,6 +421,9 @@ export function TripBoardPage() {
    * 배지가 아는 것은 숙소 id뿐이다(보드 응답이 이름·시각만 싣는다) — 상세는 숙소 목록에서
    * 찾는다. 오프라인이면 그 목록이 없어 열 수 없고, 왜 안 열리는지 말해 준다.
    */
+  /** 열려 있는 숙소. 주소·길찾기는 붙어 있는 장소의 상세에서만 온다(§9.6). */
+  const openStayDetail = stays?.find((stay) => stay.stayId === openStayId);
+
   const openStay = (stayId: number) => {
     if (!stays?.some((stay) => stay.stayId === stayId)) {
       toast("숙소 정보를 불러오지 못했어요.", "error");
@@ -773,7 +782,8 @@ export function TripBoardPage() {
       />
 
       <StaySheet
-        stay={stays?.find((stay) => stay.stayId === openStayId) ?? null}
+        stay={openStayDetail ?? null}
+        place={openStayPlace ?? null}
         onOpenChange={(open) => !open && setOpenStayId(null)}
         onEdit={startEditStay}
         onDelete={(stay) => {
@@ -791,6 +801,9 @@ export function TripBoardPage() {
         tripStartDate={board.trip.startDate}
         tripEndDate={board.trip.endDate}
         stays={stays ?? []}
+        tripId={tripId}
+        cities={cities}
+        defaultCity={selectedCity}
         onOpenChange={(open) => !open && setStayFormOpen(false)}
         onSubmit={saveStay}
         pending={createStay.isPending || updateStay.isPending}


### PR DESCRIPTION
## 이슈
closes #1155

## 작업 내용

**숙소에 장소를 붙일 수 있게 됐다.** #1143에서 배지·시트·폼을 만들면서 드러난 구멍이다 — `StayRequest`가 내부 `placeId`만 받아서, 검색 결과를 붙일 길이 없었다.

- BE — `StayRequest`에 `googlePlaceId`·`cityPlaceId`. 일정 담기(§5)와 **같은 규칙**이다
- FE — 숙소 폼에 장소 검색 + 도시 칩
- FE — 상세 시트에 주소 · `구글 지도에서 길찾기` 복원

이걸로 세 가지가 살아난다: **숙소 이동 시간 계산**(좌표) · **도시 경계 판정**(도시 식별자) · **상세 시트의 주소·길찾기**.

## 판단이 갈릴 수 있는 곳 (리뷰 요청)

**1. 숙소의 도시를 기준 도시에서 가져오지 않고 사용자가 고른다.** 체크인 날짜의 기준 도시를 그냥 쓰면 편하지만, **닛코 당일치기 날의 도쿄 숙소가 "닛코 숙소"로 저장된다.** "숙소는 기준 도시와 무관하다"가 v2.1의 전제고(§3.5), 그 전제를 저장 시점에 깨면 이동시간 판정이 그대로 틀어진다. 그래서 도시 칩을 두고, **보던 날짜의 도시를 기본값**으로만 넣었다.

**2. 도시를 안 고르면 식별자도 없다.** 좌표로 도시를 되짚지 않는다(D-23). 그 경우 좌표만 붙어 **소요 시간까지만** 살아나고 경계 판정은 "모르면 같은 도시"로 떨어진다 — 기존과 같은 상태다.

**3. 도시 칩은 여행 도시가 둘 이상일 때만 그린다.** 하나뿐이면 고를 것이 없다.

**4. 검색 입력의 Enter를 가로챈다.** 시트 안의 폼이라 그냥 두면 Enter가 숙소 저장을 제출한다.

## 테스트

- BE — 검색 결과로 담으면 장소가 만들어져 붙는다(좌표 포함) · **도시를 함께 주면 식별자까지 채운다** · 도시를 안 주면 식별자도 없다
- FE — 폼에서 검색 → 선택 → `googlePlaceId`·`cityPlaceId`가 함께 나간다(이름도 자동으로 채워진다) · 장소 붙은 숙소 상세에 주소·길찾기 · **장소 없는 숙소에는 길찾기가 없다**

## 게이트

- `cd be && ./gradlew check` ✅
- `cd fe && npm run format:check && npm run lint && npm test && npm run build` ✅ (1008 tests)
- `npx playwright test` ✅ (92 passed)

## 남은 제약

이번에도 **도시 이름은 구글 상세 것을, 식별자는 사용자가 고른 도시 것을** 쓴다(#1145와 같은 절충). 검색은 필터가 아니라 편향이라 교토 칩으로 오사카 호텔이 나올 수도 있고, 그때 식별자가 실제와 어긋난다. 구글 상세 응답이 도시의 장소 id를 주지 않는 한 이 절충은 남는다.
