### PR TITLE
chore : CloudWatch health check용 logs 권한 1개 추가

### DIFF
--- a/infra/helm/kube-prometheus-stack/values.yaml
+++ b/infra/helm/kube-prometheus-stack/values.yaml
@@ -124,6 +124,11 @@ kube-prometheus-stack:
       # 패널 period를 3600s로 고정하고 대시보드 refresh도 5m 이상으로 둔다.
       # 애초에 BucketSizeBytes·NumberOfObjects는 CloudWatch가 하루 1회 게시하는
       # 지표라 더 자주 조회해도 같은 값만 다시 받는다 — 돈만 쓰고 얻는 게 없다.
+      #
+      # ⚠️ 이 데이터소스로 CloudWatch Logs 조회는 되지 않는다. 의도한 것이다.
+      #   IAM 키에 logs:DescribeLogGroups 만 있고(health check 통과용) Logs Insights
+      #   계열은 없다 — 그쪽이 스캔 GB 당 과금되는 경로라 일부러 막아 뒀다.
+      #   로그는 Loki 데이터소스를 쓴다. 자세한 근거는 infra/terraform/cloudwatch.tf. #1179
       - name: CloudWatch
         type: cloudwatch
         uid: cloudwatch

--- a/infra/terraform/cloudwatch.tf
+++ b/infra/terraform/cloudwatch.tf
@@ -36,6 +36,25 @@ resource "aws_iam_user_policy" "cloudwatch_readonly" {
         ]
         Resource = "*"
       },
+      # Grafana 의 CloudWatch health check 는 metrics 와 logs 를 둘 다 검사한다.
+      # 이 액션이 없으면 패널이 멀쩡히 동작해도 데이터소스가 **영구히 빨간 ERROR** 로
+      # 보인다. 항상 켜져 있는 경고등은 꺼진 경고등과 같다 — 이 프로젝트가 알림에
+      # 대해 세운 원칙이 상태 표시에도 그대로 적용된다. 게다가 그 빨간 배지를 보고
+      # 누군가 logs:* 를 통째로 붙이는 게 진짜 위험이다.
+      #
+      # 부르는 API 가 DescribeLogGroups 하나뿐인 것은 CloudTrail 로 확인했다(#1179).
+      #
+      # ⚠️ Logs Insights 계열(StartQuery·GetQueryResults·FilterLogEvents)은 일부러
+      # 주지 않는다. 그쪽이 **스캔 GB 당 과금**되는 경로다 — Grafana 에서 실수로
+      # 로그 쿼리를 돌려 요금이 나가는 길을 열지 않는다. 관측이 과금을 만드는
+      # 함정을 이 프로젝트는 두 번 겪었다.
+      # 결과적으로 health check 는 통과하고(배지 초록), 유료 경로는 닫혀 있다.
+      {
+        Sid      = "CloudWatchLogsHealthCheckOnly"
+        Effect   = "Allow"
+        Action   = ["logs:DescribeLogGroups"]
+        Resource = "*"
+      },
     ]
   })
 }


### PR DESCRIPTION
## 이슈
closes #1179
## 작업 내용
- `cloudwatch.tf` — IAM 정책에 `logs:DescribeLogGroups` **1개** 추가
- `values.yaml` — CloudWatch Logs 조회가 안 되는 게 의도임을 명시

> 최초엔 "ERROR 배지는 정상"이라고 주석만 다는 방향이었는데, 리뷰에서 **"logs도 주면 되는 것 아니냐"**는 지적을 받고 방향을 바꿨다. 그 지적이 맞다.

## 왜 방향을 바꿨나

영구히 빨간 배지는 그 자체가 비용이다. 이 프로젝트가 알림에 대해 세운 원칙 — **무시하게 되는 알림은 없는 알림과 같다** — 은 상태 표시에도 그대로 적용된다. 항상 켜져 있는 경고등은 꺼진 경고등과 같다.

그리고 주석으로 막으려던 위험("배지 보고 `logs:*` 붙이기")은, **배지를 초록으로 만들면 애초에 생기지 않는다.** 주석은 사람이 읽어야 작동하고, 반년 뒤 처음 보는 사람은 안 읽는다.

## 액션 1개만 준다 — 추측이 아니라 CloudTrail로 확인했다

`logs:*`가 아니라 정확히 무엇이 필요한지 CloudTrail에서 확인했다:

```
Event               Src                  Time
DescribeLogGroups   logs.amazonaws.com   2026-08-11T14:44:38+09:00   <- health check
ListBuckets         s3.amazonaws.com     ...                          <- 최소권한 테스트(내가 호출)
PutMetricAlarm      monitoring...        ...                          <- 최소권한 테스트(내가 호출)
```

logs 계열 호출은 `DescribeLogGroups` **하나뿐**이다. 그것만 준다.

## 유료 경로는 계속 닫아 둔다

`logs:StartQuery`·`GetQueryResults`·`FilterLogEvents`는 **주지 않는다.** Logs Insights는 **스캔 GB당 과금**되는 경로다 — Grafana에서 누군가 실수로 로그 쿼리를 돌려 요금이 나가는 길을 열 이유가 없다. 관측이 과금을 만드는 함정을 이 프로젝트는 두 번 겪었다.

결과: **health check 통과(배지 초록) + 유료 경로 차단**. 둘 다 얻는다.

> 참고: 계정에 로그 그룹이 하나 있다(`/aws/lambda/test_cralwer`, 예전 Lambda 잔재). `DescribeLogGroups`는 이 **이름만** 보이게 하고 내용은 못 읽는다.

## 확인
- [x] `terraform fmt -check -recursive` · `validate` 통과
- [x] `yamllint` · `helm lint` 통과
- [x] 필요한 액션이 `DescribeLogGroups` 하나뿐임을 CloudTrail로 확인
- [ ] 머지 후 apply 성공 확인
- [ ] **Grafana에서 데이터소스 health check가 초록으로 바뀌는지 확인** — 이게 완료 판정이다
- [ ] 패널이 계속 정상 동작하는지 (권한 추가가 기존 경로를 건드리지 않았는지)
