### PR TITLE
fix : 실사 테스트가 드러낸 알림 결함 3건 수정 + 임계 원복

### DIFF
--- a/infra/helm/kube-prometheus-stack/templates/prometheusrule-s3-cost.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/prometheusrule-s3-cost.yaml
@@ -84,23 +84,23 @@ spec:
         # 무의미한데 매번 발동한다 — 무시하게 되는 알림은 없는 알림과 같다.
         # 하한 4,320회/day 는 Tier1 단가로 월 $0.65 수준이고, 잡으려는 대상인
         # ELOG-027 급 루프(+277k/day)보다 두 자릿수 아래라 놓치지 않는다.
-        # 🔴 실사 테스트 중 — 임계 임시 인하 (원래: > 0.05 / 3배 / for 30m). #1181
-        # 현재값은 기준선의 0.5배를 항상 넘으므로 5분 뒤 발동한다.
-        # Discord 비용 채널 수신을 확인한 뒤 **별도 PR로 되돌린다.**
         - alert: S3RequestRateSurge
           expr: |
-            orino:s3_ops:rate30m > 0
+            orino:s3_ops:rate30m > 0.05
             and
-            orino:s3_ops:rate30m > 0.5 * orino:s3_ops:avg7d
-          for: 5m
+            orino:s3_ops:rate30m > 3 * orino:s3_ops:avg7d
+          for: 30m
           labels:
             severity: warning
             category: cost
           annotations:
             summary: "S3 요청 급증 — {{ "{{" }} $labels.component {{ "}}" }} {{ "{{" }} $labels.tier {{ "}}" }}"
+            # "일 환산 N회"를 넣으려다 뺐다 — Prometheus 알림 템플릿에는 산술 함수가
+            # 없어서 $value × 86400 을 계산할 수 없다. humanize 를 쓰면 0.180 이
+            # "180.5m"(밀리)로 렌더링돼 실사 테스트에서 "180.5m×86400회"라는
+            # 뜻 모를 문구가 실제로 나갔다. 일 환산 수치는 대시보드에서 본다.
             description: >-
-              7일 평균 대비 3배 이상. 현재 {{ "{{" }} $value | printf "%.3f" {{ "}}" }} ops/s
-              (일 환산 {{ "{{" }} $value | humanize {{ "}}" }}×86400회).
+              7일 평균 대비 3배 이상. 현재 {{ "{{" }} $value | printf "%.4f" {{ "}}" }} ops/s.
               새 폴링 루프나 주기 설정 변경을 의심한다 — 해당 컴포넌트의 interval 플래그부터 본다.
 
         # ELOG-027 재발 감시. 그 실패는 "lifecycle이 없어서"가 아니라
@@ -115,17 +115,29 @@ spec:
         # 객체 수·용량 추이는 대시보드 패널로 계속 본다 — "삭제는 도는데 증가를
         # 못 따라가는" 경우는 눈으로 잡는다.
         #
+        # sum() 과 `or vector(0)` 두 가지는 실사 테스트(#1181)에서 드러난 결함을 고친 것이다.
+        #
+        # 1) sum() — 원시 메트릭을 그대로 쓰면 파드·인스턴스 라벨 11개(cluster·container·
+        #    endpoint·instance·job·namespace·operation·pod·prometheus·service·status_code)가
+        #    Discord 메시지에 그대로 붙는다. 실제로 그렇게 나갔다. 이 알림은 "삭제가
+        #    도는가" 하나만 말하면 되므로 전부 합친다.
+        #
+        # 2) `or vector(0)` — 이게 없으면 **정작 필요할 때 침묵한다.** `== 0` 은 시리즈가
+        #    존재해야 매칭된다. Loki 가 재시작한 뒤 삭제를 한 번도 안 하면 DeleteObject
+        #    시리즈 자체가 없어서 비교 대상이 사라진다 — retention 이 완전히 죽은
+        #    상황이 바로 이 알림이 있어야 할 상황인데 그때 안 울린다.
+        #    부재를 0 으로 바꿔야 "없음"도 잡힌다.
+        #    (Loki 가 통째로 죽어도 발동한다. retention 이 안 도는 건 사실이므로 맞다.)
+        #
         # 창을 48h 로 잡는 이유: compactor 의 apply_retention_interval 이 24h 라
         # 삭제가 하루 1회 몰아서 난다. 24h 창이면 정상 동작에도 경계에서 깜빡인다.
-        # 🔴 실사 테스트 중 — 비교를 == 0 에서 >= 0 으로 임시 반전 (원래: == 0 / for 1h). #1181
-        # 창을 줄이는 방식(예: [1s])은 표본이 없어 결과 자체가 안 나와 발동하지 않는다.
-        # 비교를 뒤집어야 시리즈가 있는 동안 확실히 발동한다.
-        # ⚠️ 이 상태에서는 알림 문구가 사실과 반대다("48시간간 삭제 0건" — 실제로는 돌고 있다).
-        # Discord 수신과 문구 형태만 확인하고 **별도 PR로 되돌린다.**
         - alert: S3RetentionNotExecuting
           expr: |
-            increase(loki_s3_request_duration_seconds_count{operation="S3.DeleteObject"}[48h]) >= 0
-          for: 5m
+            (
+              sum(increase(loki_s3_request_duration_seconds_count{operation="S3.DeleteObject"}[48h]))
+              or vector(0)
+            ) == 0
+          for: 1h
           labels:
             severity: warning
             category: cost


### PR DESCRIPTION
## 이슈
#1181 (예산 원복이 남아 아직 닫지 않는다)
## 작업 내용
Discord 수신을 확인했으므로 알림 임계를 원복한다. **그리고 실사 테스트가 드러낸 결함 3건을 함께 고친다.**

임계만 되돌리고 끝냈으면 세 결함이 그대로 남았을 것이다. 실사 테스트의 값이 여기 있다.

## 🔴 결함 3건

### 1. `== 0`이 정작 필요할 때 침묵한다 (가장 심각)

`== 0`은 **시리즈가 존재할 때만** 매칭된다. Loki가 재시작한 뒤 삭제를 한 번도 안 하면 `S3.DeleteObject` 시리즈 자체가 없어 비교 대상이 사라진다. **retention이 완전히 죽은 상황이 바로 이 알림이 있어야 할 상황인데, 그때 안 울린다.**

`or vector(0)`으로 부재를 0으로 바꿔 고쳤다. 라이브 Prometheus에서 존재하지 않는 시리즈로 양쪽을 비교해 실증했다:

```
or vector(0) 있음: 발동 ✅ (부재를 잡는다)
or vector(0) 없음: 침묵 ❌ (원래 버그 재현)
```

### 2. Discord 메시지에 라벨이 10개 붙는다

원시 메트릭을 그대로 쓰니 파드·인스턴스 라벨이 전부 따라왔다. 실제로 이렇게 나갔다:

```
cluster, container, endpoint, instance, job, namespace,
operation, pod, prometheus, service, status_code
```

이 알림은 "삭제가 도는가" 하나만 말하면 된다. `sum()`으로 집계해 라벨을 없앴다(집계 후 `{}` 확인).

### 3. 설명 문구가 깨져 나갔다

```
현재 0.180 ops/s (일 환산 180.5m×86400회)
```

`humanize`가 0.180을 `180.5m`(밀리)로 렌더링해 뜻 모를 문구가 됐다. Prometheus 알림 템플릿에는 **산술 함수가 없어** `$value × 86400`을 계산할 수 없다. 괄호 부분을 제거하고 `%.4f`로 정밀도만 올렸다 — 일 환산 수치는 대시보드에서 본다.

## 원복 내용

| 대상 | 테스트값 | 원복 |
|---|---|---|
| `S3RequestRateSurge` | `> 0` / 0.5배 / `for 5m` | `> 0.05` / 3배 / `for 30m` |
| `S3RetentionNotExecuting` | `>= 0` / `for 5m` | `== 0` / `for 1h` (+위 수정) |
| `aws_budget_usd` | **1 (유지)** | — 메일 수신 확인 후 별도 PR |

## 실사 테스트가 확인해 준 것

- **route 분리 동작** — 비용 알림은 `discord-cost`, 기존 파드 알림은 `discord`로 갈렸다
- **하한 0.05의 가치** — `loki/tier2`(0.003 ops/s)가 15분 만에 FIRING→Resolved로 깜빡였다. 원래 임계에는 하한이 있어 이런 잔값은 애초에 안 걸린다

## 확인
- [x] `yamllint` · `helm lint` 통과
- [x] 원복된 급증 알림이 현재 **조용한지** 라이브 확인
- [x] 고친 retention 알림이 현재 **조용한지** 확인 (48h 삭제 22건 관측)
- [x] `sum()` 후 라벨이 `{}`로 비는지 확인 (집계 전 10개)
- [x] `or vector(0)` 유무에 따른 침묵/발동 차이 실증 (위 출력)
- [ ] 머지 후 발동 중이던 알림이 **Resolved로 정리되는지** 확인
- [ ] 하루 뒤 AWS 예산 메일 수신 확인 → **예산 원복 PR**
