### PR TITLE
feat : GCP 메서드별 일일 할당량 하드캡

### DIFF
--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -44,6 +44,26 @@ provider "registry.terraform.io/hashicorp/google" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:P2GiUJM1frlPtBViwKn1A9V2dVBdGuWcX80w9TdH8ZE=",
+    "zh:18b442bd0a05321d39dda1e9e3f1bdede4e61bc2ac62cc7a67037a3864f75101",
+    "zh:2e387c51455862828bec923a3ec81abf63a4d998da470cf00e09003bda53d668",
+    "zh:3942e708fa84ebe54996086f4b1398cb747fe19cbcd0be07ace528291fb35dee",
+    "zh:496287dd48b34ae6197cb1f887abeafd07c33f389dbe431bb01e24846754cfdd",
+    "zh:6eca885419969ce5c2a706f34dce1f10bde9774757675f2d8a92d12e5a1be390",
+    "zh:710dbef826c3fe7f76f844dae47937e8e4c1279dd9205ec4610be04cf3327244",
+    "zh:777ebf44b24bfc7bdbf770dc089f1a72f143b4718fdedb8c6bd75983115a1ec2",
+    "zh:9c8703bba37b8c7ad857efc3513392c5a096c519397c1cb822d7612f38e4262f",
+    "zh:c4f1d3a73de2702277c99d5348ad6d374705bcfdd367ad964ff4cfd2cf06c281",
+    "zh:eca8df11af3f5a948492d5b8b5d01b4ec705aad10bc30ec1524205508ae28393",
+    "zh:f41e7fd5f2628e8fd6b8ea136366923858f54428d1729898925469b862c275c2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.9.0"
   constraints = "~> 3.6"

--- a/infra/terraform/gcp-quota.tf
+++ b/infra/terraform/gcp-quota.tf
@@ -1,0 +1,126 @@
+# GCP 메서드별 일일 할당량 하드캡 (#1151 · Epic #1148).
+#
+# 예산 알림은 지출을 멈추지 않는다. 이건 멈춘다.
+# 10/24 도쿄에서는 시차·로밍·이동 때문에 알림을 받고도 대응할 수 없는 시간대가 있다.
+# 일일 할당량 override 는 무료이고, Google 이 서버 측에서 집행하고, 자는 동안에도 작동한다.
+#
+# ── 캡은 API 가 아니라 메서드 단위로만 걸린다 ────────────────────────────────
+# `1/d/{project}` 단위가 붙은 메트릭에만 override 를 걸 수 있다. gcloud 로 실측해
+# 확인했다(2026-08-11). limit 은 그 단위를 URL 인코딩한 "%2Fd%2Fproject" 이고,
+# metric 이름도 "/" 를 인코딩해야 한다 — plan 이 이상하면 여기부터 본다.
+#
+# ── force = true 가 필요한 이유 ──────────────────────────────────────────────
+# 기존 한도를 10% 넘게 깎으면 API 가 요청을 거부한다. 75,000 -> 500 은 99% 감소라
+# force 없이는 apply 가 깨진다.
+#
+# ── 지금은 넉넉하게 건다 ─────────────────────────────────────────────────────
+# ⚠️ 캡에 걸리면 앱은 429/403 을 받는다. 여행 중 앱이 죽으면 안 된다. 여기서는
+# 30일 실측의 100배 이상 여유를 둔 값만 걸고, 실제로 조이는 것은 #1160 에서
+# graceful degradation(#1159)과 예상 청구 산출을 마친 뒤에 한다.
+
+locals {
+  # 앱이 실제로 부르는 메서드. 30일 실측(Places 96 · Routes 21 · Maps JS 14)의
+  # 100배 이상 여유를 둔 값이다.
+  #
+  # GetPhotoMediaRequest 가 이 목록의 숨은 핵심이다. 지금 사용량은 0 이지만,
+  # ELOG-023 이 "같은 함정의 가장 큰 버전"이라고 부른 것 — 검색 결과 20개를
+  # 그리면서 사진을 매번 받으면 화면당 20 유료 호출 — 을 계측(#1158)은 사후에
+  # 알려주고 이 캡은 사전에 막는다.
+  gcp_quota_caps_used = {
+    places_search_text = {
+      service = "places.googleapis.com"
+      metric  = "places.googleapis.com/SearchTextRequest"
+      value   = "500" # 기본 75,000
+    }
+    places_get_place = {
+      service = "places.googleapis.com"
+      metric  = "places.googleapis.com/GetPlaceRequest"
+      value   = "500" # 기본 125,000
+    }
+    places_get_photo = {
+      service = "places.googleapis.com"
+      metric  = "places.googleapis.com/GetPhotoMediaRequest"
+      value   = "200" # 기본 175,000, 실측 0
+    }
+    routes_compute = {
+      service = "routes.googleapis.com"
+      metric  = "routes.googleapis.com/compute_routes_requests"
+      value   = "200" # 기본 무제한
+    }
+    maps_js = {
+      service = "maps-backend.googleapis.com"
+      metric  = "maps-backend.googleapis.com/billable_default"
+      value   = "1000" # 기본 무제한
+    }
+  }
+
+  # 앱이 부르지 않지만 켜져 있어서 부를 수 있는 유료 메서드.
+  #
+  # 이 이슈의 위협 모델은 "키 유출"이다 — Maps JS 브라우저 키는 FE 번들에 그대로
+  # 들어가 있고 리퍼러 제한은 서버 간 호출에서 위조 가능하다. 그런데 유출된 키를
+  # 쥔 쪽은 우리가 쓰는 메서드만 골라 부를 이유가 없다. 쓰는 것만 막고 나머지를
+  # 열어 두면 캡을 우회하는 문이 그대로 남는다.
+  #
+  # compute_route_matrix_elements 가 특히 위험하다 — 요청이 아니라 **원소(출발지 ×
+  # 도착지) 단위로 과금**되므로 한 번의 호출로 수천 건이 청구될 수 있는데 기본이
+  # 무제한이다. computeRoutes 를 200 으로 조이면서 이쪽을 열어 두는 건 앞문만
+  # 잠그는 것이다.
+  #
+  # 값을 0 이 아니라 100 으로 두는 이유: 나중에 이 메서드를 쓰는 기능을 붙일 때
+  # 0 이면 개발 첫 호출부터 막혀 원인을 찾느라 헤맨다. 100 이면 개발은 되고
+  # 폭주는 막힌다. 실제로 쓰기 시작하면 그때 위 목록으로 옮긴다.
+  gcp_quota_caps_unused = {
+    places_autocomplete = {
+      service = "places.googleapis.com"
+      metric  = "places.googleapis.com/AutocompletePlacesRequest"
+      value   = "100" # 기본 175,000
+    }
+    places_search_nearby = {
+      service = "places.googleapis.com"
+      metric  = "places.googleapis.com/SearchNearbyRequest"
+      value   = "100" # 기본 75,000
+    }
+    places_search_media = {
+      service = "places.googleapis.com"
+      metric  = "places.googleapis.com/SearchMediaRequest"
+      value   = "100" # 기본 무제한
+    }
+    places_search_review_posts = {
+      service = "places.googleapis.com"
+      metric  = "places.googleapis.com/SearchReviewPostsRequest"
+      value   = "100" # 기본 무제한
+    }
+    routes_matrix_elements = {
+      service = "routes.googleapis.com"
+      metric  = "routes.googleapis.com/compute_route_matrix_elements"
+      value   = "100" # 기본 무제한. 원소 단위 과금이라 가장 위험하다
+    }
+    maps_js_3d = {
+      service = "maps-backend.googleapis.com"
+      metric  = "maps-backend.googleapis.com/3d_billable_default"
+      value   = "100" # 기본 무제한
+    }
+  }
+
+  gcp_quota_caps = merge(local.gcp_quota_caps_used, local.gcp_quota_caps_unused)
+}
+
+resource "google_service_usage_consumer_quota_override" "daily" {
+  # 이 리소스는 GA provider 에 없다 — google-beta 전용이다(providers.tf 주석 참고).
+  provider = google-beta
+
+  for_each = local.gcp_quota_caps
+
+  project        = var.gcp_project_id
+  service        = each.value.service
+  metric         = urlencode(each.value.metric)
+  limit          = urlencode("/d/project")
+  override_value = each.value.value
+
+  # 기존 한도를 10% 넘게 깎는 override 는 force 없이는 거부된다.
+  force = true
+
+  # places·routes 는 이 리소스가 활성화한다. 활성화 전에 override 를 걸면 깨진다.
+  # (maps-backend 는 Terraform 관리 밖이지만 이미 활성 상태다 — gcloud 로 확인)
+  depends_on = [google_project_service.travel]
+}

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -14,6 +14,14 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 6.0"
     }
+    # 할당량 override(#1151)는 GA provider 에 없는 리소스다 —
+    # google_service_usage_consumer_quota_override 는 google-beta 전용이다.
+    # (GA 6.50.0 바이너리에 해당 리소스 문자열이 없는 것을 확인했다)
+    # 자격증명은 GA 와 같은 ADC 를 쓰므로 CI 인증 설정은 그대로다.
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
   }
 
   backend "s3" {
@@ -30,5 +38,10 @@ provider "aws" {
 # 여행 모듈의 Places/Routes·예산(#1050). 자격증명은 CI가 Workload Identity Federation으로
 # 주입한다 — 서비스 계정 키 파일을 만들지 않는다(AWS를 OIDC로만 쓰는 것과 같은 이유).
 provider "google" {
+  project = var.gcp_project_id
+}
+
+# 할당량 override 전용. 별도 자격증명 없이 GA 와 같은 ADC 를 쓴다.
+provider "google-beta" {
   project = var.gcp_project_id
 }


### PR DESCRIPTION
## 이슈
closes #1151
## 작업 내용
- `infra/terraform/gcp-quota.tf` — `google_service_usage_consumer_quota_override` **11개**
- `providers.tf` — `google-beta` provider 추가

## 이슈 표의 5개 값은 실측과 일치했다

`gcloud alpha services quota list`로 직접 확인했다(2026-08-11):

| 메트릭 | 현재 한도 | 캡 |
|---|---:|---:|
| `SearchTextRequest` | 75,000 | 500 |
| `GetPlaceRequest` | 125,000 | 500 |
| `GetPhotoMediaRequest` | 175,000 | **200** |
| `compute_routes_requests` | 무제한 | 200 |
| `billable_default` | 무제한 | 1,000 |

앱이 실제로 부르는 경로도 코드에서 확인했다 — `/v1/places:searchText`, `/v1/places/{id}`, `/directions/v2:computeRoutes`, Maps JS(`libraries=marker`). 이슈 목록과 일치한다.

## ⚠️ 이슈에 없는 캡 6개를 추가했다

실측 중에 **앱이 안 쓰지만 켜져 있어 부를 수 있는 유료 메서드**가 무제한으로 열려 있는 걸 발견했다:

| 메트릭 | 현재 한도 | 캡 |
|---|---:|---:|
| `compute_route_matrix_elements` | **무제한** | 100 |
| `AutocompletePlacesRequest` | 175,000 | 100 |
| `SearchNearbyRequest` | 75,000 | 100 |
| `SearchMediaRequest` | **무제한** | 100 |
| `SearchReviewPostsRequest` | **무제한** | 100 |
| `3d_billable_default` | **무제한** | 100 |

**이 이슈의 위협 모델은 키 유출이다.** 이슈 본문 그대로 — "Maps JS 브라우저 키는 FE 번들에 그대로 들어가 있고 HTTP 리퍼러 제한이 유일한 방어선인데, 리퍼러 헤더는 서버 간 호출에서 위조 가능하다."

그런데 **유출된 키를 쥔 쪽은 우리가 쓰는 메서드만 골라 부를 이유가 없다.** 쓰는 것만 막고 나머지를 열어 두면 캡을 우회하는 문이 그대로 남는다.

특히 `compute_route_matrix_elements`가 위험하다 — 요청이 아니라 **원소(출발지 × 도착지) 단위로 과금**되므로 한 번의 호출로 수천 건이 청구될 수 있는데 기본이 무제한이다. `computeRoutes`를 200으로 조이면서 이쪽을 열어 두는 건 앞문만 잠그는 것이다.

**값을 0이 아니라 100으로 둔 이유**: 나중에 이 메서드를 쓰는 기능을 붙일 때 0이면 개발 첫 호출부터 막혀 원인을 찾느라 헤맨다. 100이면 개발은 되고 폭주는 막힌다. 실제로 쓰기 시작하면 `gcp_quota_caps_used` 쪽으로 옮긴다.

> 목록을 `used` / `unused` 두 local로 나눠 뒀다 — 어느 쪽이 실사용이고 어느 쪽이 예방인지가 코드에서 보여야 나중에 조일 때 헷갈리지 않는다.

## 구현 함정 2개

**1. GA provider에 이 리소스가 없다.** `google_service_usage_consumer_quota_override`는 `google-beta` 전용이다. GA 6.50.0 바이너리에 해당 리소스 문자열이 아예 없는 것을 확인했다. `google-beta`를 추가했고, 자격증명은 GA와 같은 ADC를 쓰므로 **CI 인증 설정 변경은 없다.**

**2. `force = true`가 필수다.** 기존 한도를 10% 넘게 깎으면 API가 거부한다. 75,000 → 500은 99% 감소다.

metric·limit 모두 `urlencode()`를 통과시킨다(`/` → `%2F`). limit 단위는 실측으로 확인한 `1/d/{project}`다.

## 지금은 넉넉하게 건다

⚠️ 캡에 걸리면 앱은 429/403을 받는다. **여행 중 앱이 죽으면 안 된다.** 실측의 100배 이상 여유를 둔 값만 걸고, 실제로 조이는 것은 #1160에서 graceful degradation(#1159)과 예상 청구 산출을 마친 뒤에 한다.

## 확인
- [x] `terraform fmt -check -recursive` 통과
- [x] `terraform validate` 통과 (google-beta 추가 후)
- [x] 5개 메트릭의 현재 한도를 `gcloud`로 실측 대조
- [x] 앱이 실제로 부르는 엔드포인트를 코드에서 확인
- [x] `maps-backend`·`places`·`routes` 모두 활성 상태 확인
- [ ] PR plan 확인 (11개 create)
- [ ] 머지 후 apply 성공 확인
- [ ] **`gcloud alpha services quota list`로 effectiveLimit이 실제로 바뀌었는지 확인** — 선언이 아니라 집행을 본다(ELOG-027의 교훈)
- [ ] 설정값을 Epic #1148 코멘트로 기록 — #1160에서 조일 때 기준선이 된다
