### PR TITLE
chore : GCP CI에 BigQuery 데이터셋 권한 추가

### DIFF
--- a/infra/terraform/gcp-cicd.tf
+++ b/infra/terraform/gcp-cicd.tf
@@ -51,6 +51,12 @@ resource "google_project_iam_member" "terraform_apply" {
     "roles/iam.workloadIdentityPoolAdmin",   # WIF 풀·provider
     "roles/iam.serviceAccountAdmin",         # 서비스 계정과 그 IAM 정책
     "roles/resourcemanager.projectIamAdmin", # 프로젝트 역할 바인딩
+    # 결제 내보내기 데이터셋(#1157). dataOwner 는 datasets create·get·update·delete 를
+    # 다 주면서 bigquery.jobs.create 는 주지 않는다 — 즉 쿼리를 못 돌린다.
+    # bigquery.user 를 쓰면 create 는 되지만 jobs.create 가 딸려오는데, BigQuery
+    # 쿼리는 스캔 GB 당 과금이다. CI 가 실수로 유료 쿼리를 돌 수 있게 만들 이유가 없다
+    # (#1149 에서 ce:GetCostAndUsage 를 주지 않은 것과 같은 판단). #1186
+    "roles/bigquery.dataOwner",
   ])
 
   project = var.gcp_project_id
@@ -75,6 +81,9 @@ resource "google_project_iam_member" "terraform_plan" {
     "roles/iam.workloadIdentityPoolViewer",
     # 서비스 계정과 프로젝트 IAM 정책 읽기. 이게 없으면 plan이 403으로 깨진다.
     "roles/iam.securityReviewer",
+    # 결제 내보내기 데이터셋 refresh 용 datasets.get. 이 역할에도 jobs.create 는
+    # 없어서 미신뢰 PR 이 유료 쿼리를 돌릴 수 없다. #1186
+    "roles/bigquery.metadataViewer",
   ])
 
   project = var.gcp_project_id


### PR DESCRIPTION
## 이슈
closes #1186
## 작업 내용
- `gcp-cicd.tf` apply SA — `roles/bigquery.dataOwner` 추가
- `gcp-cicd.tf` plan SA — `roles/bigquery.metadataViewer` 추가

## 왜 별도 PR인가

#1157(BigQuery 결제 내보내기)의 **순수 선행**이다. GCP CI 서비스 계정의 실제 바인딩을 확인해 보니 BigQuery 역할이 하나도 없다:

```
roles/iam.serviceAccountAdmin
roles/iam.workloadIdentityPoolAdmin
roles/resourcemanager.projectIamAdmin
roles/serviceusage.apiKeysAdmin
roles/serviceusage.serviceUsageAdmin
```

이 상태로 `google_bigquery_dataset`을 올리면 apply가 권한 오류로 깨진다. #1149(AWS Budgets 권한)와 같은 구조이고, 같은 이유로 분리했다 — 권한 추가와 리소스 생성을 한 PR에 넣으면 apply 순서가 보장되지 않는다. GCP IAM은 전파가 즉시가 아니라 `depends_on`을 걸어도 바인딩 직후 생성이 403을 받을 수 있다.

**이 PR 머지 → apply 성공 확인 → 그 다음 #1157 본체.**

## `roles/bigquery.user`를 기각한 이유

`bigquery.user`도 `datasets.create`를 주지만 **`bigquery.jobs.create`가 딸려온다 — 쿼리 실행 권한이고 BigQuery 쿼리는 스캔 GB당 과금이다.** #1149에서 `ce:GetCostAndUsage`(건당 $0.01)를 apply role에 주지 않은 것과 같은 판단이다.

`gcloud iam roles describe`로 대조해 확인했다:

| 역할 | datasets.create | update | delete | **jobs.create** | |
|---|---|---|---|---|---|
| `bigquery.dataOwner` | ✅ | ✅ | ✅ | **없음** | ← apply |
| `bigquery.user` | ✅ | 없음 | 없음 | **있음** | ← 기각 |
| `bigquery.metadataViewer` | 없음 | ✅(get) | 없음 | 없음 | ← plan |

`dataOwner`가 정확히 필요한 것만 준다: 데이터셋 라이프사이클 전체 + 쿼리 불가.

> 커스텀 역할이 더 좁겠지만 `google_project_iam_custom_role` 생성에는 `roles/iam.roleAdmin`이 필요한데 SA에 없다. 그걸 주려면 SA가 자기에게 더 센 역할을 부여해야 해서 순환이다 — 사전 정의 역할 중 쿼리 권한이 없는 것을 고르는 쪽이 실질적으로 더 좁다.

## 확인
- [x] `terraform fmt -check -recursive` 통과
- [x] `terraform validate` 통과
- [x] 역할별 권한을 `gcloud iam roles describe`로 실측 대조 (위 표)
- [x] BigQuery API가 이미 활성 상태인지 확인 (`bigquery.googleapis.com` 켜져 있음)
- [ ] PR plan 확인
- [ ] **머지 후 apply 성공 확인** — 이게 되어야 #1157 본체를 연다
