### PR TITLE
fix : 같은 도시가 화면마다 다른 글자로 보이던 것

### DIFF
--- a/fe/src/features/travel/board/ActivityRow.tsx
+++ b/fe/src/features/travel/board/ActivityRow.tsx
@@ -15,7 +15,8 @@ import type { PointerEvent as ReactPointerEvent } from "react";
 import { Link } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
-import type { Activity } from "@/features/travel/api/activities";
+import type { Activity, BaseCity } from "@/features/travel/api/activities";
+import { cityLabelOf } from "@/features/travel/lib/cityLabel";
 import { cn } from "@/lib/utils";
 
 import { useLongPress } from "./useLongPress";
@@ -23,6 +24,11 @@ import { useSwipeAction } from "./useSwipeAction";
 
 interface ActivityRowProps {
   activity: Activity;
+  /**
+   * 이 여행에 등장하는 도시들. 도시 이탈 꼬리표를 <b>날짜 탭과 같은 이름</b>으로 쓰기 위해
+   * 받는다 — 장소가 들고 온 이름은 다른 Google 필드에서 와서 표기가 갈린다.
+   */
+  cities: BaseCity[];
   /** 보관함을 보고 있으면 "보관함으로"를 감춘다(이미 거기 있다). */
   inArchive: boolean;
   dragMode: boolean;
@@ -49,6 +55,7 @@ interface ActivityRowProps {
  */
 export function ActivityRow({
   activity,
+  cities,
   inArchive,
   dragMode,
   offline,
@@ -61,6 +68,8 @@ export function ActivityRow({
   onDelete,
   onEnterDragMode,
 }: ActivityRowProps) {
+  // 날짜 탭이 쓰는 것과 같은 이름으로 — 같은 도시가 화면마다 다른 글자면 안 된다.
+  const cityLabel = cityLabelOf(activity.place, cities);
   // 드래그는 모드에 들어온 뒤에만 활성화한다 — 그 전에는 목록을 세로로 스크롤해야 한다.
   const {
     attributes,
@@ -160,10 +169,8 @@ export function ActivityRow({
                 <span className="truncate">{activity.place.name}</span>
                 {/* 그날 기준 도시와 다른 도시의 장소다. 막지 않고 알려만 준다 —
                     오사카 가게를 교토 날짜에 두는 건 사용자의 선택이다. */}
-                {activity.outOfBaseCity && activity.place.cityName && (
-                  <span className="text-warning shrink-0">
-                    · {activity.place.cityName}
-                  </span>
+                {activity.outOfBaseCity && cityLabel && (
+                  <span className="text-warning shrink-0">· {cityLabel}</span>
                 )}
               </span>
             )}

--- a/fe/src/features/travel/lib/archiveGroups.ts
+++ b/fe/src/features/travel/lib/archiveGroups.ts
@@ -3,6 +3,7 @@ import type {
   BaseCity,
   BoardDay,
 } from "@/features/travel/api/activities";
+import { cityLabelOf } from "@/features/travel/lib/cityLabel";
 
 export interface ArchiveGroup {
   /** 목록 key. 도시 식별자이거나 `other`·`none`이다. */
@@ -44,7 +45,12 @@ export function groupArchiveByCity(
     const ref = activity.place?.cityPlaceRef ?? null;
     const city = ref === null ? undefined : cities.get(ref);
     const key = city ? ref! : ref === null ? NONE : OTHER;
-    const label = city ? city.name : ref === null ? "도시 없음" : "기타";
+    // 그룹 이름도 같은 규칙을 탄다 — 여기만 맞고 일정 행이 어긋나면 그게 더 헷갈린다.
+    const label = city
+      ? (cityLabelOf(activity.place, [city]) ?? city.name)
+      : ref === null
+        ? "도시 없음"
+        : "기타";
     const group = groups.get(key) ?? { key, label, activities: [] };
     group.activities.push(activity);
     groups.set(key, group);

--- a/fe/src/features/travel/lib/cityLabel.test.ts
+++ b/fe/src/features/travel/lib/cityLabel.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import type { BaseCity } from "@/features/travel/api/activities";
+
+import { cityLabelOf } from "./cityLabel";
+
+function city(placeId: number, name: string, cityPlaceRef: string): BaseCity {
+  return {
+    placeId,
+    name,
+    timezone: "Asia/Tokyo",
+    currency: "JPY",
+    countryCode: "JP",
+    cityPlaceRef,
+    lat: null,
+    lng: null,
+  };
+}
+
+const TRIP_CITIES = [
+  city(1, "오사카시", "ChIJ_osaka"),
+  city(2, "교토시", "ChIJ_kyoto"),
+];
+
+describe("도시 표시명", () => {
+  it("여행 도시와 맞으면 그 도시 이름을 쓴다 — 날짜 탭과 같은 글자여야 한다", () => {
+    // 장소는 `Osaka`라고 들고 왔지만 탭은 `오사카시`라고 부른다.
+    const label = cityLabelOf(
+      { cityName: "Osaka", cityPlaceRef: "ChIJ_osaka" },
+      TRIP_CITIES,
+    );
+
+    expect(label).toBe("오사카시");
+  });
+
+  it("구 단위로 온 이름도 도시 이름으로 바로잡는다", () => {
+    // 신주쿠 호텔의 주소 구성요소는 `Shinjuku City`로 온다.
+    const label = cityLabelOf(
+      { cityName: "Shinjuku City", cityPlaceRef: "ChIJ_kyoto" },
+      TRIP_CITIES,
+    );
+
+    expect(label).toBe("교토시");
+  });
+
+  it("여행에 없는 도시면 장소가 준 이름을 쓴다 — 그게 가진 전부다", () => {
+    const label = cityLabelOf(
+      { cityName: "Nagoya", cityPlaceRef: "ChIJ_nagoya" },
+      TRIP_CITIES,
+    );
+
+    expect(label).toBe("Nagoya");
+  });
+
+  it("식별자를 모르면 이름으로 맞추지 않는다 — 표기 흔들림에 깨진다(D-23)", () => {
+    const label = cityLabelOf(
+      { cityName: "오사카시", cityPlaceRef: null },
+      TRIP_CITIES,
+    );
+
+    // 이름이 같아도 식별자로 맞추지 않았으므로 장소가 준 값 그대로다(결과는 같지만
+    // 경로가 다르다 — 여기서 이름 비교를 하면 `Osaka`는 못 맞춘다).
+    expect(label).toBe("오사카시");
+  });
+
+  it("이름조차 없으면 null — 화면이 그 자리를 비운다", () => {
+    expect(
+      cityLabelOf({ cityName: null, cityPlaceRef: null }, TRIP_CITIES),
+    ).toBeNull();
+  });
+
+  it("장소가 없으면 null", () => {
+    expect(cityLabelOf(null, TRIP_CITIES)).toBeNull();
+  });
+});

--- a/fe/src/features/travel/lib/cityLabel.ts
+++ b/fe/src/features/travel/lib/cityLabel.ts
@@ -1,0 +1,44 @@
+import type { BaseCity, BoardDay } from "@/features/travel/api/activities";
+
+/** 도시 판정에 필요한 최소한. 일정의 장소든 숙소의 장소든 이 둘만 있으면 된다. */
+export interface PlaceCity {
+  cityName: string | null;
+  cityPlaceRef: string | null;
+}
+
+/**
+ * 장소가 속한 도시의 <b>표시명</b>.
+ *
+ * <p>여행 도시 중 식별자가 맞는 것이 있으면 <b>그 도시의 이름</b>을 쓴다. 날짜 탭·구간
+ * 리스트·보관함 그룹이 쓰는 것과 같은 이름이라, 화면 안에서 같은 도시가 같은 글자로 보인다.
+ *
+ * <p>맞추지 않고 장소가 준 이름을 그대로 쓰면 표기가 갈린다 — 두 값이 서로 다른 Google
+ * 필드에서 오기 때문이다. 도시 검색은 도시 장소의 표시명(`오사카시`)을, 장소 상세는 주소
+ * 구성요소의 `locality`(`Osaka`, 때로는 구 단위인 `Shinjuku City`)를 준다.
+ *
+ * <p>못 맞추면 장소가 들고 온 이름으로 떨어진다 — 여행에 없는 도시일 수 있고, 그때는 그
+ * 이름이 우리가 가진 전부다. 이름조차 없으면 null이라 화면이 그 자리를 비운다.
+ *
+ * <p>비교는 <b>식별자로만</b> 한다(D-23). 이름으로 맞추면 바로 그 표기 흔들림에 깨진다.
+ */
+export function cityLabelOf(
+  place: PlaceCity | null | undefined,
+  cities: BaseCity[],
+): string | null {
+  if (!place) return null;
+  const known = place.cityPlaceRef
+    ? cities.find((city) => city.cityPlaceRef === place.cityPlaceRef)
+    : undefined;
+  return known?.name ?? place.cityName;
+}
+
+/** 날짜 목록에서 바로 부르는 자리용. 도시 목록을 따로 만들지 않아도 된다. */
+export function cityLabelOfDays(
+  place: PlaceCity | null | undefined,
+  days: BoardDay[],
+): string | null {
+  return cityLabelOf(
+    place,
+    days.flatMap((day) => (day.baseCity ? [day.baseCity] : [])),
+  );
+}

--- a/fe/src/pages/travel/ActivityDetailPage.tsx
+++ b/fe/src/pages/travel/ActivityDetailPage.tsx
@@ -35,6 +35,7 @@ import { useBoard } from "@/features/travel/hooks/useBoard";
 import { usePlaceDetail } from "@/features/travel/hooks/usePlaceDetail";
 import { useTrip } from "@/features/travel/hooks/useTrip";
 import { cityOn } from "@/features/travel/lib/baseCity";
+import { cityLabelOf } from "@/features/travel/lib/cityLabel";
 import { NOTIFY_MINUTES_OPTIONS } from "@/features/travel/lib/destinations";
 import { placeDirectionsUrl } from "@/features/travel/lib/mapsLink";
 import { todayOpeningHours } from "@/features/travel/lib/openingHours";
@@ -163,11 +164,21 @@ export function ActivityDetailPage() {
       : undefined;
   /** 도시 경계를 넘어 들어오는가. 판정은 읽어 오기만 한다(D-23). */
   const crossCity = incoming?.crossCity === true;
-  /** 그 경계의 출발 쪽 도시 — 안내 문구의 `오사카 → 교토`에서 앞자리다. */
+  /**
+   * 경계 양쪽 도시 이름 — 안내 문구의 `오사카시 → 교토시`.
+   *
+   * <p>날짜 탭·부제와 <b>같은 이름</b>을 쓴다. 장소가 들고 온 이름을 그대로 쓰면 부제는
+   * `교토시`인데 안내는 `Kyoto`가 되어, 같은 도시를 가리키는지 붙지 않는다.
+   */
+  const tripCityList =
+    board?.days.flatMap((d) => (d.baseCity ? [d.baseCity] : [])) ?? [];
   const fromCityName = crossCity
-    ? (board?.activities.find((a) => a.id === incoming?.fromActivityId)?.place
-        ?.cityName ?? null)
+    ? cityLabelOf(
+        board?.activities.find((a) => a.id === incoming?.fromActivityId)?.place,
+        tripCityList,
+      )
     : null;
+  const toCityName = cityLabelOf(activity.place, tripCityList);
   /** 이 날짜의 기준 도시. 부제·알림 타임존이 쓴다. */
   const dayCity = cityOn(board?.days ?? [], activity.activityDate ?? "");
   const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
@@ -336,8 +347,8 @@ export function ActivityDetailPage() {
             {crossCity && (
               <p className="bg-muted text-muted-foreground flex items-center gap-2 rounded-lg px-2.5 py-[7px] text-xs">
                 <TrainFront className="size-[13px] shrink-0" />
-                {fromCityName && activity.place.cityName
-                  ? `${fromCityName} → ${activity.place.cityName} · 도시 경계를 넘어 이동시간을 계산하지 않아요`
+                {fromCityName && toCityName
+                  ? `${fromCityName} → ${toCityName} · 도시 경계를 넘어 이동시간을 계산하지 않아요`
                   : "도시 경계를 넘어 이동시간을 계산하지 않아요"}
               </p>
             )}

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -645,6 +645,7 @@ export function TripBoardPage() {
                   <ActivityRow
                     key={activity.id}
                     activity={activity}
+                    cities={cities}
                     inArchive
                     dragMode={false}
                     offline={!online}
@@ -680,6 +681,7 @@ export function TripBoardPage() {
                   )}
                   <ActivityRow
                     activity={activity}
+                    cities={cities}
                     inArchive={selectedDate === null}
                     dragMode={dragMode}
                     offline={!online}

--- a/fe/src/pages/travel/TripMapPage.tsx
+++ b/fe/src/pages/travel/TripMapPage.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { LoadingText } from "@/components/ui/loading-text";
 import { useBoard } from "@/features/travel/hooks/useBoard";
 import { useCityLegs } from "@/features/travel/hooks/useCityLegs";
+import { cityLabelOfDays } from "@/features/travel/lib/cityLabel";
 import { cityMarkers, legPath } from "@/features/travel/lib/cityMarkers";
 import { formatShortDate } from "@/features/travel/lib/tripStatus";
 import { toMapped } from "@/features/travel/map/toMapped";
@@ -227,7 +228,10 @@ export function TripMapPage() {
                 <p className="text-muted-foreground text-xs tabular-nums">
                   {[
                     selectedActivity.activity.startTime,
-                    selectedActivity.activity.place?.cityName,
+                    cityLabelOfDays(
+                      selectedActivity.activity.place,
+                      board.days,
+                    ),
                   ]
                     .filter(Boolean)
                     .join(" · ")}


### PR DESCRIPTION
## 이슈
closes #1185

## 작업 내용

**같은 도시가 화면마다 다른 글자로 보이던 것을 고쳤다.** 1차 리허설(#1176)에서 실환경으로 드러난 문제다.

| 자리 | 전 | 후 |
|---|---|---|
| 일정 행 도시 이탈 꼬리표 | `· Osaka` | `· 오사카시` |
| S-07 도시 경계 안내 | `Kyoto → Osaka` | `교토시 → 오사카시` |
| S-05 `이 날짜` 카드 | `Osaka` | `오사카시` |

일정 상세는 부제가 `4일차 · 교토시`인데 바로 아래 안내가 `Kyoto → Osaka`였다. 같은 도시를 가리키는지 한눈에 붙지 않았다.

## 왜 갈렸나

**두 값이 서로 다른 Google 필드에서 온다.** 도시 검색은 도시 장소의 표시명(`오사카시`)을, 장소 상세는 주소 구성요소의 `locality`를 준다. 후자는 한국어 표기가 없으면 영어로 떨어지고, 도쿄의 호텔에서는 아예 구(區) 단위(`Shinjuku City`)로 온다. `languageCode=ko`로 불러도 그렇다.

## 고친 방법

```
장소의 cityPlaceRef가 여행 도시 중 하나와 맞으면 → 그 도시의 name
못 맞추면 → 장소가 들고 온 cityName (여행 밖 도시일 수 있다)
둘 다 없으면 → 표시하지 않는다
```

**새 규칙이 아니다.** `lib/archiveGroups.ts`가 이미 이렇게 하고 있었다(보관함 그룹만 한국어로 맞았다). 인라인으로 있던 그 판단을 `lib/cityLabel.ts`로 빼고, 어긋나 있던 세 곳과 보관함이 **같은 함수**를 쓰게 했다.

비교는 식별자로만 한다(D-23) — 이름으로 맞추면 바로 그 표기 흔들림에 깨진다. 보드가 `days[].baseCity`를 이미 들고 있어 **추가 조회가 없다**.

## 판단이 갈릴 수 있는 곳

**여행 밖 도시는 장소가 준 이름을 그대로 쓴다.** 나고야 가게를 담으면 `Nagoya`로 보인다. 우리가 가진 이름이 그것뿐이라 대안이 없고, 여행 도시가 아니면 어차피 탭·구간 리스트와 나란히 놓일 일이 없다.

## 검증

- 단위 6종 — 여행 도시와 맞으면 그 이름 · **구 단위(`Shinjuku City`)도 바로잡힌다** · 여행 밖 도시는 장소 이름 · 식별자 없으면 장소 이름 · 이름조차 없으면 null
- **리허설 환경에서 직접 확인** — 실제 BE·실제 Google 키로 만든 7구간 여행에서 `· Osaka` → `· 오사카시`, `Kyoto → Osaka` → `교토시 → 오사카시`로 바뀌는 것을 브라우저에서 봤다

## 게이트

- `cd fe && npm run format:check && npm run lint && npm test && npm run build` ✅ (1014 tests)
- `npx playwright test` ✅ (92 passed)
- BE 변경 없음

> 6단계(리허설 문제만 수정) 범위다.
