### PR TITLE
chore : 주기 루프 인벤토리 + PR 체크리스트

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,7 @@
 ## 이슈
 closes #
 ## 작업 내용
-- 
+-
+
+---
+- [ ] (해당 시) S3 또는 유료 외부 API를 호출하는 컴포넌트를 추가했다면 — 주기 플래그를 values에 명시했고, 비용 대시보드에 나타나는가? ([주기 루프 인벤토리](https://github.com/wcorn/orino/wiki/Periodic-Loops))


### PR DESCRIPTION
## 이슈
closes #1161
## 작업 내용
- `.github/PULL_REQUEST_TEMPLATE.md` — 주기 루프 체크 항목 1줄 추가
- Wiki [주기 루프 인벤토리](https://github.com/wcorn/orino/wiki/Periodic-Loops) 신규 작성 (커밋 `523c326`)
- Wiki [Observability](https://github.com/wcorn/orino/wiki/Observability) 컴포넌트 스택에서 링크

## 🔴 조사에서 미선언 기본값 2개가 나왔다

**values.yaml만 보면 절반을 놓친다.** 가장 위험한 루프는 아무 데도 안 적혀 있는 것이고, 그 기본값은 대개 짧다. 그래서 차트 values가 아니라 **런타임 설정**(`/config`, `/status/config`, 컨테이너 args)을 덤프해 조사했다.

| 루프 | 기본값 | 하루 횟수 | 선언 위치 |
|---|---|---|---|
| `loki compactor.compaction_interval` | **10m** | 144회 | **어디에도 없음** |
| `tempo storage.trace.blocklist_poll` | **5m** | 288회 | **어디에도 없음** |

tempo 쪽은 `blocklist_poll_concurrency: 50`이라 한 번에 여러 요청이 나간다. 둘 다 S3를 두드린다 — ELOG-027이 잡은 것과 같은 종류다.

**여기서 값을 바꾸지 않았다.** 실측 Tier1은 15.8k/day이고 남은 절감 여지는 월 $2.8 미만이라, 조정 여부는 대시보드에서 이 둘의 기여분을 본 뒤 판단할 일이다(취미 클러스터 과투자 금지). 이 이슈의 목적은 **"안 적혀 있어서 안 보이던 상태"를 끝내는 것**이고 그건 끝났다.

## 오해를 막는 칸도 뒀다

도는데 S3는 안 두드리는 것들이 있다. 이걸 안 적으면 다음 사람이 헛다리를 짚는다.

| 설정 | 값 | 왜 무해한가 |
|---|---|---|
| `loki boltdb_shipper.resync_interval` | 5m | **boltdb_shipper를 안 쓴다**(tsdb + schema v13). LIST할 테이블이 없다 |
| `loki ruler.poll_interval` | 1m | 룰 저장소가 `local`(ConfigMap)이라 S3가 아니다 |
| `loki table_manager.poll_interval` | 2m | compactor retention을 쓰므로 비활성 경로 |
| `argocd timeout.reconciliation` | 120s | Git 폴링 |

`boltdb_shipper`의 5m은 특히 헷갈린다 — #1114에서 고친 `tsdb_shipper`(30m)와 이름이 같아서 "고친 게 안 먹었나?"로 보인다.

## 체크 항목을 주석이 아니라 체크박스로 넣은 이유

HTML 주석으로 넣으면 렌더링된 PR에는 안 보인다. 작성 중에만 보이므로 노이즈가 없다는 장점이 있지만, **이 저장소의 PR은 대부분 `gh pr create --body-file`로 만들어져 템플릿 자체를 거치지 않는다.** 주석이면 사람이 웹 UI로 열 때만 보이고 그마저도 흔적이 안 남는다.

보이는 체크박스로 두되 `(해당 시)`를 앞에 붙여, 무관한 PR에서 기계적으로 체크하는 습관이 들지 않게 했다.

## 문서를 얇게 유지했다

상세 문서를 만들면 썩는다 — 반년 뒤 값이 안 맞는 표는 없느니만 못하다. 그래서 문서 맨 위에 이렇게 적었다:

> 이 표는 지도일 뿐이다. 진짜 감시는 S3 비용 대시보드와 `S3RequestRateSurge` 알림이 한다.
> 표의 값은 조사 시점의 것이고 반년 뒤에는 틀릴 수 있다. **값을 믿지 말고 "어디를 봐야 하는지"만 가져가라.**

조사 방법(런타임 설정 덤프 명령 3종)도 함께 적어 뒀다. 값은 썩어도 방법은 안 썩는다.

## 확인
- [x] 관측성·백업 컴포넌트 주기 플래그 전수 조사 (런타임 설정 기준)
- [x] Wiki 표 1장 작성 — 컴포넌트 / 설정 / 현재값 / 선언 위치 / S3 호출 여부
- [x] Observability 문서에서 링크
- [x] PR 템플릿 체크 항목 추가
- [x] 타임박스 1시간 내 완료
