### PR TITLE
fix : 이미 숙소에 있으면 숙소 이동 행을 만들지 않는다

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/service/TravelTimeService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/service/TravelTimeService.java
@@ -107,8 +107,8 @@ public class TravelTimeService {
             return Optional.empty();
         }
         Located from = located.get(located.size() - 1);
-        Located to = new Located(null, destination.getLat(), destination.getLng(),
-                destination.getCityPlaceRef());
+        Located to = new Located(null, destination.getId(), destination.getLat(),
+                destination.getLng(), destination.getCityPlaceRef());
         if (crossesCity(from, to)) {
             return Optional.of(Move.crossingCity());
         }
@@ -117,6 +117,27 @@ public class TravelTimeService {
                 .map(r -> new Move(mode, Math.round(r.durationSeconds() / 60f), false))
                 // 실패해도 수단은 남긴다 — 거리만 아는 상태와 아무것도 모르는 상태는 다르다.
                 .orElseGet(() -> new Move(mode, null, false)));
+    }
+
+    /**
+     * 그날 <b>마지막 일정이 이미 그 장소인가.</b> 숙소 이동 행(§3.5)이 "이동이 있기는 한가"를
+     * 묻는 자리다.
+     *
+     * <p>비교 대상은 마지막 일정이 아니라 <b>좌표를 가진 마지막 일정</b>이다 — 이동시간이
+     * 출발지로 삼는 것이 그 일정이라, 뒤에 장소 없는 일정("짐 정리")이 끼어도 판정이 밀리면
+     * 안 된다.
+     *
+     * <p>같은 장소끼리는 Routes가 경로를 주지 않아 소요 시간이 비고, 화면은 그것을 "시간을
+     * 모르는 이동"으로 읽어 <b>이미 그곳인 사람에게 이동하라고 말한다.</b> 게다가 실패는
+     * 캐시하지 않으므로 그 날짜를 열 때마다 결과 없는 유료 호출이 되풀이된다 — 여기서
+     * 걸러내면 호출 자체가 사라진다.
+     */
+    public boolean alreadyAt(List<TripActivity> ordered, TravelPlace destination) {
+        List<Located> located = locate(ordered);
+        if (located.isEmpty() || destination.getId() == null) {
+            return false;
+        }
+        return destination.getId().equals(located.get(located.size() - 1).placeId());
     }
 
     /**
@@ -175,8 +196,8 @@ public class TravelTimeService {
             if (place == null || place.getLat() == null || place.getLng() == null) {
                 continue;
             }
-            located.add(new Located(activity.getId(), place.getLat(), place.getLng(),
-                    place.getCityPlaceRef()));
+            located.add(new Located(activity.getId(), place.getId(), place.getLat(),
+                    place.getLng(), place.getCityPlaceRef()));
         }
         return located;
     }
@@ -248,6 +269,7 @@ public class TravelTimeService {
         return value.setScale(5, java.math.RoundingMode.HALF_UP).stripTrailingZeros();
     }
 
-    private record Located(Long activityId, BigDecimal lat, BigDecimal lng, String cityPlaceRef) {
+    private record Located(Long activityId, Long placeId, BigDecimal lat, BigDecimal lng,
+                          String cityPlaceRef) {
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/stay/service/StayBoardAssembler.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/stay/service/StayBoardAssembler.java
@@ -80,6 +80,11 @@ public class StayBoardAssembler {
         }
         TripStay stay = tonight.get();
         TravelPlace stayPlace = stays.placeOf(stay);
+        // 마지막 일정이 이미 그 숙소면 이동이 없다 — 행도 없다. 억지로 그리면 "이미 그곳인데
+        // 이동하라"가 되고, 같은 좌표라 Routes도 답을 못 줘 결과 없는 호출만 되풀이된다.
+        if (stayPlace != null && travelTimeService.alreadyAt(ordered, stayPlace)) {
+            return null;
+        }
         if (stayPlace == null) {
             // 숙소에 장소가 안 붙어 있으면 좌표도 도시도 없다 — 행만 남긴다.
             return new BoardResponse.StayMove(stay.getId(), true, null, null);

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/stay/StayControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/stay/StayControllerTest.java
@@ -9,6 +9,8 @@ import ds.project.orino.domain.planner.travel.repository.TripStayRepository;
 import ds.project.orino.planner.travel.place.StubPlacesClient;
 import ds.project.orino.planner.travel.place.client.PlaceResult;
 import ds.project.orino.planner.travel.place.client.PlacesClient;
+import ds.project.orino.planner.travel.route.StubRoutesClient;
+import ds.project.orino.planner.travel.route.client.RoutesClient;
 import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
@@ -60,8 +62,11 @@ class StayControllerTest extends ApiTestSupport {
     private DbCleaner dbCleaner;
     @Autowired
     private PlacesClient placesClient;
+    @Autowired
+    private RoutesClient routesClient;
 
     private StubPlacesClient placesStub;
+    private StubRoutesClient routesStub;
     private String authHeader;
     private String otherAuthHeader;
     private long tripId;
@@ -72,6 +77,8 @@ class StayControllerTest extends ApiTestSupport {
         dbCleaner.clean();
         placesStub = (StubPlacesClient) placesClient;
         placesStub.reset();
+        routesStub = (StubRoutesClient) routesClient;
+        routesStub.reset();
         memberRepository.save(MemberFixture.create());
         memberRepository.save(MemberFixture.create("other", "password"));
         authHeader = "Bearer " + AuthFixture.loginAndGetAccessToken(mockMvc);
@@ -366,6 +373,49 @@ class StayControllerTest extends ApiTestSupport {
                     .andExpect(jsonPath("$.data.stayMove.sameCity").value(false))
                     .andExpect(jsonPath("$.data.stayMove.mode").doesNotExist())
                     .andExpect(jsonPath("$.data.stayMove.durationMinutes").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("마지막 일정이 이미 그 숙소면 이동 행을 만들지 않는다 — 외부 호출도 없다")
+        void noMoveWhenAlreadyAtStay() throws Exception {
+            withCityRef(osaka, "ChIJ_osaka");
+            long hotel = poiInCity("난바 호텔", "ChIJ_osaka");
+            // `일정으로 추가`가 만드는 체크인 일정 — 그 장소가 곧 숙소다.
+            createActivity("난바 호텔 체크인", "2026-10-24", hotel);
+            createStayWithPlace("난바 호텔", "2026-10-24", "2026-10-26", hotel);
+
+            board("2026-10-24")
+                    .andExpect(jsonPath("$.data.stayMove").doesNotExist());
+
+            // 같은 좌표끼리는 Routes가 답을 못 준다. 물어볼 이유가 없다.
+            assertThat(routesStub.calls).isEmpty();
+        }
+
+        @Test
+        @DisplayName("장소 없는 일정이 뒤에 끼어도 판정이 밀리지 않는다")
+        void looksAtLastLocatedActivity() throws Exception {
+            withCityRef(osaka, "ChIJ_osaka");
+            long hotel = poiInCity("난바 호텔", "ChIJ_osaka");
+            createActivity("난바 호텔 체크인", "2026-10-24", hotel);
+            // 좌표가 없어 이동시간 계산에서 건너뛰는 일정이다.
+            createActivityWithoutPlace("짐 정리", "2026-10-24");
+            createStayWithPlace("난바 호텔", "2026-10-24", "2026-10-26", hotel);
+
+            board("2026-10-24")
+                    .andExpect(jsonPath("$.data.stayMove").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("다른 장소에서 숙소로 가는 날은 그대로 계산한다")
+        void stillComputesFromAnotherPlace() throws Exception {
+            withCityRef(osaka, "ChIJ_osaka");
+            createActivity("구로몬 시장", "2026-10-24", poiInCity("구로몬 시장", "ChIJ_osaka"));
+            createStayWithPlace("난바 호텔", "2026-10-24", "2026-10-26",
+                    poiInCity("난바 호텔", "ChIJ_osaka"));
+
+            board("2026-10-24")
+                    .andExpect(jsonPath("$.data.stayMove.sameCity").value(true))
+                    .andExpect(jsonPath("$.data.stayMove.mode").exists());
         }
 
         @Test


### PR DESCRIPTION
## 이슈
closes #1191

## 작업 내용

**이미 숙소에 있는 사람에게 "숙소로 이동"이라고 말하던 것을 고쳤다.** 1차 리허설(#1176)에서 실환경으로 드러났다.

닛코 날짜에 도쿄 호텔을 잡고 `일정으로 추가`로 체크인 일정을 만들면, 그 일정의 장소가 **바로 그 숙소인데도** 리스트 맨 아래에 `숙소로 이동`이 붙었다.

```json
"stayMove": { "stayId": 2, "sameCity": true, "mode": "WALK", "durationMinutes": null }
```

`sameCity`도 `mode`도 맞다. 소요 시간만 비어 있고, 화면은 시간을 모를 때 `숙소로 이동`으로 떨어진다(#1143) — 그래서 **이동이 없는데 이동하라고 읽힌다.**

## 왜 비어 있었나

출발지와 목적지가 **같은 좌표**라 Routes가 경로를 주지 않는다. 그리고 실패는 캐시하지 않으므로(일시적 장애를 붙들면 복구 뒤에도 fallback이 남는다, §4.4) **그 날짜를 열 때마다 결과 없는 유료 호출이 되풀이됐다.** 보드는 날짜 탭을 넘길 때마다 조회된다.

## 고친 방법

좌표 있는 마지막 일정이 곧 숙소 장소면 **행을 만들지 않는다.** 이동이 없으니 행도 없다.

- 판정은 `place_id` 비교라 좌표도 외부 호출도 필요 없고, **Routes 호출 자체가 사라진다**
- 비교 대상은 "마지막 일정"이 아니라 **좌표를 가진 마지막 일정**이다 — 이동시간이 출발지로 삼는 것이 그 일정이라, 뒤에 장소 없는 일정("짐 정리")이 끼어도 판정이 밀리면 안 된다. 그 판단은 이미 `TravelTimeService.locate`가 갖고 있어 거기에 물었다

## 판단이 갈릴 수 있는 곳

**행을 비우지 않고 아예 없앴다.** `숙소까지 0분`도, 시간 없는 행도 아니다 — 둘 다 "이동이 있다"고 말하는데 실제로는 없다. 없는 것은 그리지 않는 편이 맞다고 봤다.

## 검증

- BE 3종 — 같은 장소면 행이 없고 **Routes 호출 0회** · 장소 없는 일정이 뒤에 끼어도 판정이 안 밀린다 · 다른 장소에서 오는 날은 그대로 계산
- **리허설 환경에서 직접 확인** — 같은 여행·같은 날짜의 응답이 `stayMove: null`로 바뀌었고 Routes 호출이 나가지 않는다

## 게이트

- `cd be && ./gradlew check` ✅
- FE 변경 없음

> 6단계(리허설 문제만 수정) 범위다.
