### PR TITLE
feat : 유료 외부 API 호출을 메트릭으로 본다

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/metrics/ExternalApiMetrics.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/metrics/ExternalApiMetrics.java
@@ -1,0 +1,87 @@
+package ds.project.orino.planner.travel.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+/**
+ * 외부 API 호출 계측(#1158).
+ *
+ * <p><b>총 호출 수만 세면 캐시가 죽어도 그래프가 안 변한다</b> — 사용자 조작이 는 건지 캐시가
+ * 깨진 건지 구분이 안 된다. 그래서 캐시 히트까지 함께 센다.
+ *
+ * <p>[ELOG-023](https://github.com/wcorn/orino/wiki/ELOG-023-travel-external-api-call-cost)은
+ * 캐시가 호출을 줄이는지를 <b>통합 테스트의 스텁 카운터</b>로 고정했다. 테스트는 회귀를 막지만
+ * 운영에서 실제로 몇 번 나갔는지는 말해 주지 않는다.
+ *
+ * <p><b>라벨은 enum으로만 받는다.</b> 검색어·좌표·장소 id가 라벨에 들어가면 시계열이 폭발하고,
+ * Prometheus 저장이 늘어 Thanos S3 PUT까지 는다 — 관측이 과금을 만드는 그 함정이다. 문자열을
+ * 받지 않으면 그 실수를 <b>애초에 쓸 수 없다.</b>
+ */
+@Component
+public class ExternalApiMetrics {
+
+    private static final String COUNTER = "orino.external.api.calls";
+
+    /** 어떤 외부 API인가. 값이 고정돼 있어 시계열 수가 {@code Api × Result}로 묶인다. */
+    public enum Api {
+        /** 장소 검색(S-06). 유료. */
+        PLACES_SEARCH("places_search"),
+        /** 도시 검색(S-03 구간 입력). 유료. */
+        PLACES_CITY("places_city"),
+        /** 장소 상세 — 영업시간·전화. 유료. */
+        PLACES_DETAILS("places_details"),
+        /** 이동시간. 유료. */
+        ROUTES("routes"),
+        /** 날씨. 무료지만 도시 단위 캐시가 실제로 도는지 봐야 한다. */
+        WEATHER("weather"),
+        /** 환율. 무료. */
+        FX("fx");
+
+        private final String tag;
+
+        Api(String tag) {
+            this.tag = tag;
+        }
+    }
+
+    /**
+     * 호출의 결말.
+     *
+     * <p>{@code miss + error}가 <b>실제로 나간 호출 수</b>다 — 청구서에 오르는 값이 그것이다.
+     * {@code hit / (hit + miss + error)}가 히트율이다.
+     */
+    public enum Result {
+        /** 캐시에서 답했다. 외부 호출이 없다. */
+        HIT("hit"),
+        /** 외부로 나갔고 쓸 값을 받았다. */
+        MISS("miss"),
+        /**
+         * 외부로 나갔는데 쓸 값이 없었다.
+         *
+         * <p>실패와 "결과 0건"을 구분하지 못한다 — 클라이언트가 둘 다 빈 값으로 돌려주기
+         * 때문이다(§4.7의 실패 처리). 비용 관점에서는 어차피 같은 한 번의 호출이다.
+         */
+        ERROR("error");
+
+        private final String tag;
+
+        Result(String tag) {
+            this.tag = tag;
+        }
+    }
+
+    private final MeterRegistry registry;
+
+    public ExternalApiMetrics(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void record(Api api, Result result) {
+        registry.counter(COUNTER, "api", api.tag, "result", result.tag).increment();
+    }
+
+    /** 나간 호출 한 건 — 쓸 값을 받았으면 {@code miss}, 비었으면 {@code error}. */
+    public void recordFetch(Api api, boolean usable) {
+        record(api, usable ? Result.MISS : Result.ERROR);
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/place/service/PlaceService.java
@@ -12,6 +12,7 @@ import ds.project.orino.planner.travel.place.client.PlacesClient;
 import ds.project.orino.planner.travel.place.config.PlacesProperties;
 import ds.project.orino.planner.travel.place.dto.CityResponse;
 import ds.project.orino.planner.travel.place.dto.PlaceCreateRequest;
+import ds.project.orino.planner.travel.metrics.ExternalApiMetrics;
 import ds.project.orino.planner.travel.place.dto.PlaceDetail;
 import ds.project.orino.planner.travel.place.dto.PlaceSearchResult;
 import ds.project.orino.redis.planner.travel.PlaceSearchCacheRepository;
@@ -50,6 +51,7 @@ public class PlaceService {
     private final PlacesProperties props;
     private final ObjectMapper objectMapper;
     private final Clock clock;
+    private final ExternalApiMetrics metrics;
 
     public PlaceService(PlacesClient placesClient,
                         PlaceSearchCacheRepository cache,
@@ -58,7 +60,8 @@ public class PlaceService {
                         TripDayService tripDayService,
                         PlacesProperties props,
                         ObjectMapper objectMapper,
-                        Clock clock) {
+                        Clock clock,
+                        ExternalApiMetrics metrics) {
         this.placesClient = placesClient;
         this.cache = cache;
         this.placeRepository = placeRepository;
@@ -67,13 +70,14 @@ public class PlaceService {
         this.props = props;
         this.objectMapper = objectMapper;
         this.clock = clock;
+        this.metrics = metrics;
     }
 
     /**
      * S-03 목적지 검색. 도시와 함께 <b>타임존·통화를 확정해서</b> 준다.
      */
     public List<CityResponse> searchCities(String query) {
-        List<PlaceResult> results = cached(
+        List<PlaceResult> results = cached(ExternalApiMetrics.Api.PLACES_CITY,
                 () -> cache.findCity(query),
                 json -> cache.saveCity(query, json, props.searchTtl()),
                 () -> placesClient.searchCities(query));
@@ -97,7 +101,7 @@ public class PlaceService {
         PlacesClient.Coordinates bias = biasOf(memberId, tripId, cityPlaceId);
         String biasKey = bias == null ? "none" : bias.lat() + "," + bias.lng();
 
-        List<PlaceResult> results = cached(
+        List<PlaceResult> results = cached(ExternalApiMetrics.Api.PLACES_SEARCH,
                 () -> cache.findSearch(query, biasKey),
                 json -> cache.saveSearch(query, biasKey, json, props.searchTtl()),
                 () -> placesClient.searchPlaces(query, bias));
@@ -122,11 +126,17 @@ public class PlaceService {
                 .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PLACE_NOT_FOUND));
 
         if (place.getGooglePlaceId() != null && place.needsDetailsRefresh(clock.instant())) {
-            placesClient.fetchDetails(place.getGooglePlaceId()).ifPresent(fresh -> {
+            Optional<PlaceResult> refreshed = placesClient.fetchDetails(place.getGooglePlaceId());
+            metrics.recordFetch(ExternalApiMetrics.Api.PLACES_DETAILS, refreshed.isPresent());
+            refreshed.ifPresent(fresh -> {
                 place.updateBasics(fresh.address(), fresh.lat(), fresh.lng(),
                         fresh.category(), fresh.rating());
                 place.updateDetails(fresh.phone(), fresh.openingHours(), clock.instant());
             });
+        } else if (place.getGooglePlaceId() != null) {
+            // 상세 캐시는 Redis가 아니라 행의 갱신 시각이다(30일, §4.7) — 갱신이 필요 없었다는
+            // 것이 곧 히트다. 세지 않으면 이 계열의 히트율이 영영 0으로 보인다.
+            metrics.record(ExternalApiMetrics.Api.PLACES_DETAILS, ExternalApiMetrics.Result.HIT);
         }
         return PlaceDetail.from(place);
     }
@@ -153,9 +163,13 @@ public class PlaceService {
         if (existing.isPresent()) {
             // 이미 담긴 장소의 도시는 덮지 않는다 — 나중에 다른 도시 칩으로 다시 담았다고
             // 처음 알던 도시가 바뀌면, 그 장소가 붙은 다른 날짜의 판정까지 조용히 흔들린다.
+            // 행 하나로 호출 한 번을 아낀 것이라 히트로 센다.
+            metrics.record(ExternalApiMetrics.Api.PLACES_DETAILS, ExternalApiMetrics.Result.HIT);
             return existing.get();
         }
-        PlaceResult fresh = placesClient.fetchDetails(googlePlaceId)
+        Optional<PlaceResult> detail = placesClient.fetchDetails(googlePlaceId);
+        metrics.recordFetch(ExternalApiMetrics.Api.PLACES_DETAILS, detail.isPresent());
+        PlaceResult fresh = detail
                 .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PLACE_NOT_FOUND));
 
         TravelPlace place = TravelPlace.fromGoogle(memberId, googlePlaceId, fresh.name());
@@ -188,7 +202,10 @@ public class PlaceService {
                     place.getTimezone(), place.getCurrency());
             return place;
         }
-        PlaceResult fresh = placesClient.fetchDetails(googlePlaceId)
+        // 같은 경로에서 상세를 두 번째로 부르는 자리다 — 계측이 없으면 이 한 번이 안 보인다.
+        Optional<PlaceResult> detail = placesClient.fetchDetails(googlePlaceId);
+        metrics.recordFetch(ExternalApiMetrics.Api.PLACES_DETAILS, detail.isPresent());
+        PlaceResult fresh = detail
                 .orElseThrow(() -> new CustomException(ErrorCode.TRAVEL_PLACE_NOT_FOUND));
         place.promoteToCity(place.getName(), fresh.timezone(), currencyOf(fresh.countryCode()));
         place.updateCityInfo(place.getName(), googlePlaceId, fresh.countryCode());
@@ -244,19 +261,25 @@ public class PlaceService {
      * <p>빈 결과는 캐시하지 않는다 — 일시적 실패(타임아웃·쿼터)도 빈 목록으로 떨어지는데,
      * 그걸 한 시간 동안 물고 있으면 복구된 뒤에도 계속 빈 화면이 된다.
      */
-    private List<PlaceResult> cached(Supplier<Optional<String>> read,
+    private List<PlaceResult> cached(ExternalApiMetrics.Api api,
+                                     Supplier<Optional<String>> read,
                                      java.util.function.Consumer<String> write,
                                      Supplier<List<PlaceResult>> fetch) {
         Optional<String> hit = read.get();
         if (hit.isPresent()) {
             try {
-                return objectMapper.readValue(hit.get(), new TypeReference<List<PlaceResult>>() {
-                });
+                List<PlaceResult> cachedResults =
+                        objectMapper.readValue(hit.get(), new TypeReference<List<PlaceResult>>() {
+                        });
+                metrics.record(api, ExternalApiMetrics.Result.HIT);
+                return cachedResults;
             } catch (Exception e) {
+                // 히트로 세지 않는다 — 아래에서 실제로 나가므로 miss가 뒤따른다.
                 log.warn("장소 캐시 역직렬화 실패, 새로 조회한다: {}", e.getMessage());
             }
         }
         List<PlaceResult> fresh = fetch.get();
+        metrics.recordFetch(api, !fresh.isEmpty());
         if (!fresh.isEmpty()) {
             write.accept(objectMapper.writeValueAsString(fresh));
         }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/service/TravelTimeService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/route/service/TravelTimeService.java
@@ -5,6 +5,7 @@ import ds.project.orino.common.exception.ErrorCode;
 import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.entity.TripActivity;
 import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
+import ds.project.orino.planner.travel.metrics.ExternalApiMetrics;
 import ds.project.orino.planner.travel.route.client.RoutesClient;
 import ds.project.orino.planner.travel.route.client.TravelMode;
 import ds.project.orino.planner.travel.route.config.RoutesProperties;
@@ -37,17 +38,20 @@ public class TravelTimeService {
     private final RouteCacheRepository cacheRepository;
     private final RoutesProperties props;
     private final ObjectMapper objectMapper;
+    private final ExternalApiMetrics metrics;
 
     public TravelTimeService(TravelPlaceRepository placeRepository,
                              RoutesClient routesClient,
                              RouteCacheRepository cacheRepository,
                              RoutesProperties props,
-                             ObjectMapper objectMapper) {
+                             ObjectMapper objectMapper,
+                             ExternalApiMetrics metrics) {
         this.placeRepository = placeRepository;
         this.routesClient = routesClient;
         this.cacheRepository = cacheRepository;
         this.props = props;
         this.objectMapper = objectMapper;
+        this.metrics = metrics;
     }
 
     /**
@@ -243,12 +247,14 @@ public class TravelTimeService {
         String key = travelTimeKey(from, to, mode);
         Optional<String> hit = cacheRepository.find(key);
         if (hit.isPresent()) {
+            metrics.record(ExternalApiMetrics.Api.ROUTES, ExternalApiMetrics.Result.HIT);
             return Optional.of(objectMapper.readValue(hit.get(), RoutesClient.Route.class));
         }
         Optional<RoutesClient.Route> fresh = routesClient.route(
                 new RoutesClient.Coordinates(from.lat(), from.lng()),
                 new RoutesClient.Coordinates(to.lat(), to.lng()),
                 mode);
+        metrics.recordFetch(ExternalApiMetrics.Api.ROUTES, fresh.isPresent());
         // 실패는 캐시하지 않는다 — 일시적 실패를 붙들고 있으면 복구된 뒤에도 계속 fallback이다.
         fresh.ifPresent(r ->
                 cacheRepository.save(key, objectMapper.writeValueAsString(r), props.cacheTtl()));

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/ExchangeRateService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/ExchangeRateService.java
@@ -2,6 +2,7 @@ package ds.project.orino.planner.travel.tools.service;
 
 import ds.project.orino.common.exception.CustomException;
 import ds.project.orino.common.exception.ErrorCode;
+import ds.project.orino.planner.travel.metrics.ExternalApiMetrics;
 import ds.project.orino.planner.travel.tools.client.EcbRates;
 import ds.project.orino.planner.travel.tools.client.EcbRatesClient;
 import ds.project.orino.planner.travel.tools.config.ToolsProperties;
@@ -32,17 +33,20 @@ public class ExchangeRateService {
     private final ToolsProperties props;
     private final ObjectMapper objectMapper;
     private final Clock clock;
+    private final ExternalApiMetrics metrics;
 
     public ExchangeRateService(EcbRatesClient ratesClient,
                                ToolsCacheRepository cacheRepository,
                                ToolsProperties props,
                                ObjectMapper objectMapper,
-                               Clock clock) {
+                               Clock clock,
+                               ExternalApiMetrics metrics) {
         this.ratesClient = ratesClient;
         this.cacheRepository = cacheRepository;
         this.props = props;
         this.objectMapper = objectMapper;
         this.clock = clock;
+        this.metrics = metrics;
     }
 
     public ExchangeRateResponse rate(String base, String quote) {
@@ -63,9 +67,11 @@ public class ExchangeRateService {
     private Optional<EcbRates> cached() {
         Optional<String> hit = cacheRepository.findRates();
         if (hit.isPresent()) {
+            metrics.record(ExternalApiMetrics.Api.FX, ExternalApiMetrics.Result.HIT);
             return Optional.of(objectMapper.readValue(hit.get(), EcbRates.class));
         }
         Optional<EcbRates> fresh = ratesClient.latest();
+        metrics.recordFetch(ExternalApiMetrics.Api.FX, fresh.isPresent());
         fresh.ifPresent(rates -> cacheRepository.saveRates(
                 objectMapper.writeValueAsString(rates), props.fxTtl()));
         return fresh;

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/WeatherService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/WeatherService.java
@@ -6,6 +6,7 @@ import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.entity.Trip;
 import ds.project.orino.domain.planner.travel.repository.TripRepository;
 import ds.project.orino.planner.travel.day.service.TripDayService;
+import ds.project.orino.planner.travel.metrics.ExternalApiMetrics;
 import ds.project.orino.planner.travel.tools.client.WeatherClient;
 import ds.project.orino.planner.travel.tools.config.ToolsProperties;
 import ds.project.orino.planner.travel.tools.dto.WeatherResponse;
@@ -40,6 +41,7 @@ public class WeatherService {
     private final ToolsProperties props;
     private final ObjectMapper objectMapper;
     private final Clock clock;
+    private final ExternalApiMetrics metrics;
 
     public WeatherService(TripRepository tripRepository,
                           TripDayService tripDayService,
@@ -47,7 +49,8 @@ public class WeatherService {
                           ToolsCacheRepository cacheRepository,
                           ToolsProperties props,
                           ObjectMapper objectMapper,
-                          Clock clock) {
+                          Clock clock,
+                          ExternalApiMetrics metrics) {
         this.tripRepository = tripRepository;
         this.tripDayService = tripDayService;
         this.weatherClient = weatherClient;
@@ -55,6 +58,7 @@ public class WeatherService {
         this.props = props;
         this.objectMapper = objectMapper;
         this.clock = clock;
+        this.metrics = metrics;
     }
 
     public WeatherResponse forTrip(Long memberId, Long tripId) {
@@ -147,10 +151,12 @@ public class WeatherService {
         String key = "%s,%s:%s".formatted(city.getLat(), city.getLng(), city.getTimezone());
         Optional<String> hit = cacheRepository.findWeather(key);
         if (hit.isPresent()) {
+            metrics.record(ExternalApiMetrics.Api.WEATHER, ExternalApiMetrics.Result.HIT);
             return objectMapper.readValue(hit.get(), new TypeReference<WeatherResponse>() { });
         }
         Optional<WeatherResponse> fresh =
                 weatherClient.forecast(city.getLat(), city.getLng(), city.getTimezone());
+        metrics.recordFetch(ExternalApiMetrics.Api.WEATHER, fresh.isPresent());
         // 실패는 캐시하지 않는다 — 6시간 동안 날씨가 통째로 비어 보인다.
         fresh.ifPresent(response -> cacheRepository.saveWeather(
                 key, objectMapper.writeValueAsString(response), props.weatherTtl()));

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/place/PlaceControllerTest.java
@@ -5,6 +5,7 @@ import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.repository.TravelPlaceRepository;
 import ds.project.orino.planner.travel.place.client.PlaceResult;
 import ds.project.orino.planner.travel.place.client.PlacesClient;
+import io.micrometer.core.instrument.MeterRegistry;
 import ds.project.orino.support.ApiTestSupport;
 import ds.project.orino.support.AuthFixture;
 import ds.project.orino.support.DbCleaner;
@@ -55,6 +56,8 @@ class PlaceControllerTest extends ApiTestSupport {
     private DbCleaner dbCleaner;
     @Autowired
     private PlacesClient placesClient;
+    @Autowired
+    private MeterRegistry meterRegistry;
 
     private StubPlacesClient stub;
     private String authHeader;
@@ -435,6 +438,86 @@ class PlaceControllerTest extends ApiTestSupport {
                             .header(HttpHeaders.AUTHORIZATION, otherAuthHeader))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value("TRAVEL-ERR-008"));
+        }
+    }
+
+    @Nested
+    @DisplayName("호출 계측 (#1158)")
+    class Metrics {
+
+        private double count(String api, String result) {
+            return meterRegistry.find("orino.external.api.calls")
+                    .tag("api", api).tag("result", result)
+                    .counters().stream()
+                    .mapToDouble(c -> c.count())
+                    .sum();
+        }
+
+        @Test
+        @DisplayName("같은 검색 3회면 miss 1 · hit 2 — 스텁 호출 수와 맞는다")
+        void countsHitAndMiss() throws Exception {
+            String query = uniqueQuery("라멘");
+            stub.placeResults = List.of(place("ChIJ_senso", "센소지"));
+            double missBefore = count("places_search", "miss");
+            double hitBefore = count("places_search", "hit");
+
+            for (int i = 0; i < 3; i++) {
+                mockMvc.perform(get("/api/travel/places/search").param("q", query)
+                                .header(HttpHeaders.AUTHORIZATION, authHeader))
+                        .andExpect(status().isOk());
+            }
+
+            assertThat(count("places_search", "miss") - missBefore).isEqualTo(1);
+            assertThat(count("places_search", "hit") - hitBefore).isEqualTo(2);
+            // 계측과 실제 호출이 어긋나면 그래프가 거짓말을 한다.
+            assertThat(stub.placeSearches).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("빈 결과는 캐시하지 않으므로 error가 쌓인다 — 히트로 감춰지지 않는다")
+        void countsEmptyAsError() throws Exception {
+            String query = uniqueQuery("없는곳");
+            stub.placeResults = List.of();
+            double before = count("places_search", "error");
+
+            for (int i = 0; i < 2; i++) {
+                mockMvc.perform(get("/api/travel/places/search").param("q", query)
+                                .header(HttpHeaders.AUTHORIZATION, authHeader))
+                        .andExpect(status().isOk());
+            }
+
+            // 두 번 다 나갔다 — 빈 결과를 캐시하지 않는다는 설계가 비용으로 보이는 자리다.
+            assertThat(count("places_search", "error") - before).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("도시 검색은 장소 검색과 다른 계열로 센다")
+        void separatesCityFromPlaceSearch() throws Exception {
+            String query = uniqueQuery("도쿄");
+            stub.cityResults = List.of(city("ChIJ_tokyo", "도쿄", "Asia/Tokyo", "JP"));
+            double before = count("places_city", "miss");
+
+            mockMvc.perform(get("/api/travel/places/cities").param("q", query)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk());
+
+            assertThat(count("places_city", "miss") - before).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("이미 담긴 장소를 다시 담으면 상세를 사지 않는다 — hit으로 센다")
+        void countsPlaceReuseAsHit() throws Exception {
+            long tripId = createTripWithCoordinates();
+            stub.detailResult = Optional.of(place("ChIJ_senso", "센소지"));
+            double missBefore = count("places_details", "miss");
+            double hitBefore = count("places_details", "hit");
+
+            for (String title : List.of("아침 센소지", "저녁 센소지")) {
+                addPlaceToTrip(tripId, "ChIJ_senso", ", \"title\": \"%s\"".formatted(title));
+            }
+
+            assertThat(count("places_details", "miss") - missBefore).isEqualTo(1);
+            assertThat(count("places_details", "hit") - hitBefore).isEqualTo(1);
         }
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/ExchangeRateServiceTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/ExchangeRateServiceTest.java
@@ -1,7 +1,9 @@
 package ds.project.orino.planner.travel.tools;
 
 import ds.project.orino.common.exception.CustomException;
+import ds.project.orino.planner.travel.metrics.ExternalApiMetrics;
 import ds.project.orino.planner.travel.tools.config.ToolsProperties;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import ds.project.orino.planner.travel.tools.service.ExchangeRateService;
 import ds.project.orino.redis.planner.travel.ToolsCacheRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,13 +57,19 @@ class ExchangeRateServiceTest {
 
     private StubEcbRatesClient client;
     private ExchangeRateService service;
+    private SimpleMeterRegistry registry;
 
     @BeforeEach
     void setUp() {
         client = new StubEcbRatesClient();
+        registry = new SimpleMeterRegistry();
         service = new ExchangeRateService(client, new InMemoryCache(), PROPS,
                 new ObjectMapper(), Clock.fixed(Instant.parse("2026-08-08T00:00:00Z"),
-                ZoneOffset.UTC));
+                ZoneOffset.UTC), new ExternalApiMetrics(registry));
+    }
+
+    private double calls(String result) {
+        return registry.counter("orino.external.api.calls", "api", "fx", "result", result).count();
     }
 
     @Test
@@ -72,6 +80,34 @@ class ExchangeRateServiceTest {
         service.rate("EUR", "JPY");
 
         assertThat(client.calls).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("히트와 미스를 나눠 센다 — 총 호출만 세면 캐시가 죽어도 그래프가 안 변한다")
+    void countsHitAndMiss() {
+        service.rate("JPY", "KRW");
+        service.rate("USD", "KRW");
+        service.rate("EUR", "JPY");
+
+        assertThat(calls("miss")).isEqualTo(1);
+        assertThat(calls("hit")).isEqualTo(2);
+        // 계측과 실제 호출이 어긋나면 그래프가 거짓말을 한다.
+        assertThat(client.calls).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("고시를 못 얻으면 error로 센다 — 나간 호출이라 청구에는 오른다")
+    void countsFailureAsError() {
+        client.result = Optional.empty();
+
+        try {
+            service.rate("JPY", "KRW");
+        } catch (RuntimeException expected) {
+            // 503으로 떨어지는 것은 아래 테스트가 본다.
+        }
+
+        assertThat(calls("error")).isEqualTo(1);
+        assertThat(calls("hit")).isZero();
     }
 
     @Test

--- a/infra/helm/kube-prometheus-stack/grafana-dashboards/travel-external-api.json
+++ b/infra/helm/kube-prometheus-stack/grafana-dashboards/travel-external-api.json
@@ -1,0 +1,228 @@
+{
+  "uid": "travel-external-api",
+  "title": "여행 외부 API 호출",
+  "tags": ["orino", "cost", "travel"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "1m",
+  "time": { "from": "now-24h", "to": "now" },
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "유료 호출 일 환산 (Places + Routes)",
+      "description": "실제로 밖으로 나간 호출(miss + error)만 센다 — 청구서에 오르는 값이 그것이다. 현재 rate × 86400이라 달력일 합계가 아니라 '지금 속도가 하루 유지되면' 값이다.",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 5 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(orino_external_api_calls_total{api=~\"places_.*|routes\", result=~\"miss|error\"}[30m])) * 86400",
+          "legendFormat": "유료 호출",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1000 },
+              { "color": "red", "value": 5000 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "전체 캐시 히트율",
+      "description": "hit / (hit + miss + error). ELOG-023이 통합 테스트로 고정한 캐시가 운영에서도 도는지를 보는 값이다. 이 값이 떨어지는데 호출 수가 늘면 사용자가 는 게 아니라 캐시가 깨진 것이다.",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 5 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(orino_external_api_calls_total{result=\"hit\"}[30m])) / sum(rate(orino_external_api_calls_total[30m]))",
+          "legendFormat": "히트율",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "green", "value": 0.8 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "결과 없는 호출 비율",
+      "description": "error / (miss + error). 나갔는데 쓸 값이 없었던 비율이다. 클라이언트가 실패와 '결과 0건'을 둘 다 빈 값으로 돌려주므로 구분되지 않는다 — 어느 쪽이든 돈은 나갔다. 이 값이 높으면 호출 조건 자체를 의심한다(#1192가 그 사례다).",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 5 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(orino_external_api_calls_total{result=\"error\"}[30m])) / sum(rate(orino_external_api_calls_total{result=~\"miss|error\"}[30m]))",
+          "legendFormat": "결과 없음",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.2 },
+              { "color": "red", "value": 0.5 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "무료 호출 일 환산 (날씨 + 환율)",
+      "description": "돈은 안 들지만 캐시가 도는지는 같은 방식으로 본다. 날씨는 도시 단위 캐시라 열흘 여행이 열 번 나가면 안 된다.",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 5 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(orino_external_api_calls_total{api=~\"weather|fx\", result=~\"miss|error\"}[30m])) * 86400",
+          "legendFormat": "무료 호출",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0 }
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "API별 실제 호출 rate (miss + error)",
+      "description": "계열별로 나눠 본다. 어떤 계열이 늘었는지 보이지 않으면 원인을 좁힐 수 없다 — 장소 검색이 는 것과 상세 조회가 는 것은 대처가 다르다.",
+      "gridPos": { "x": 0, "y": 5, "w": 12, "h": 9 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (api) (rate(orino_external_api_calls_total{result=~\"miss|error\"}[5m]))",
+          "legendFormat": "{{api}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 3,
+          "custom": { "fillOpacity": 10, "lineWidth": 2, "showPoints": "never" }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "API별 캐시 히트율",
+      "description": "계열마다 캐시 수명이 다르다 — 장소 상세는 RDB 30일, 검색·경로·날씨는 Redis다. 한 계열만 히트율이 무너지면 그 캐시만 문제다.",
+      "gridPos": { "x": 12, "y": 5, "w": 12, "h": 9 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (api) (rate(orino_external_api_calls_total{result=\"hit\"}[30m])) / sum by (api) (rate(orino_external_api_calls_total[30m]))",
+          "legendFormat": "{{api}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "min": 0,
+          "max": 1,
+          "custom": { "fillOpacity": 0, "lineWidth": 2, "showPoints": "never" }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "min"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "결말별 호출 rate",
+      "description": "hit·miss·error를 겹쳐 쌓아 전체 흐름을 본다. 전체가 그대로인데 hit이 miss로 옮겨가면 그게 캐시가 죽은 모양이다.",
+      "gridPos": { "x": 0, "y": 14, "w": 24, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(orino_external_api_calls_total[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 3,
+          "custom": {
+            "fillOpacity": 30,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": { "mode": "normal", "group": "A" }
+          }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    }
+  ]
+}

--- a/infra/helm/kube-prometheus-stack/templates/dashboard-travel-external-api.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/dashboard-travel-external-api.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-travel-external-api
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  travel-external-api.json: |-
+{{ .Files.Get "grafana-dashboards/travel-external-api.json" | indent 4 }}


### PR DESCRIPTION
closes #1158

## 무엇을

`orino_external_api_calls_total{api, result}` 카운터를 추가하고 Grafana 대시보드를 붙였다.

ELOG-023은 캐시가 호출을 줄이는지를 **통합 테스트의 스텁 카운터**로 고정했다. 테스트는 회귀를 막지만 운영에서 실제로 몇 번 나갔는지는 말해 주지 않는다. 이제 나간 호출과 캐시가 막은 호출이 같은 그래프에 있다.

| 라벨 | 값 |
|---|---|
| `api` | `places_search` · `places_city` · `places_details` · `routes` · `weather` · `fx` |
| `result` | `hit`(캐시) · `miss`(나갔고 값 받음) · `error`(나갔는데 값 없음) |

`miss + error`가 청구서에 오르는 수, `hit / 전체`가 히트율이다.

## 이슈 본문과 다르게 한 것

**`places_photo`는 만들지 않았다 — 그런 호출이 없다.** 이슈는 이걸 "가장 중요한 계열"이라고 썼지만, `GooglePlacesClient`의 필드마스크(검색·상세 양쪽)에 `photos`가 없고 Google 사진 URL을 부르는 코드도 없다. `planner/travel/photo/`는 사용자가 올린 MinIO 사진이라 유료 API와 무관하다. 없는 계열을 만들면 "0이니까 안전하다"는 잘못된 안심을 준다. 나중에 사진을 실제로 받게 되면 `Api` enum에 한 줄 추가하면 된다.

**`weather` · `fx`를 더 넣었다.** 이슈 목록엔 없지만 무료 API도 캐시가 도는지는 봐야 한다 — 리허설(#1176)이 "도시 단위 날씨 캐시가 실제로 호출을 줄이는가"에 답하지 못했다. 유료/무료는 패널에서 갈라 놓았다.

## 카디널리티

`record(Api, Result)`가 **enum만** 받는다. 검색어·좌표·장소 id를 넘기려면 컴파일이 안 된다 — 규칙을 문서가 아니라 시그니처가 강제한다. 시계열 수는 `6 × 3`으로 묶인다.

## 계측 지점

캐시 분기점에서만 센다.

- `PlaceService.cached()` — 검색·도시. 역직렬화가 성공해야 `hit`이다(실패하면 그대로 흘러가 `miss`가 되므로 이중 계수가 없다)
- `PlaceService.detail()` / `upsertFromGoogle` — 상세는 Redis가 아니라 **RDB의 30일 타임스탬프**가 캐시라 분기가 따로다
- `TravelTimeService.route()` · `WeatherService.cached()` · `ExchangeRateService.cached()`

## 검증

- 통합 테스트: 같은 검색 3회 → `miss=1, hit=2`이고 **스텁 호출 카운터도 1**이라 둘이 일치한다. 결과 0건 → `error`, 도시 검색은 다른 계열, 장소 재사용 → `places_details` hit
- `./gradlew check` 통과
- 로컬 bootRun + 실호출로 노출 확인 (관리 포트는 **9090**, 경로는 `/prometheus`):
  ```
  orino_external_api_calls_total{api="fx",result="miss"} 1.0
  orino_external_api_calls_total{api="fx",result="hit"} 2.0
  ```
  ECB를 실제로 한 번 부르고 두 번은 캐시가 막았다.
- `yamllint` · `helm lint` · `helm template` 렌더링 확인 (패널 7개)