### PR TITLE
test : 다른 여행이 같은 두 장소를 이어도 새로 부르지 않는다

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -49,6 +49,18 @@ subprojects {
     tasks.withType(Test).configureEach {
         useJUnitPlatform()
         finalizedBy jacocoTestReport
+        /*
+         * 테스트 JVM의 한계를 선언한 적이 없어 Gradle 기본값(힙 512m)으로 돌고 있었다.
+         * 스프링 컨텍스트가 다섯 벌 캐시되고 jacoco가 전 클래스를 계측하는 스위트라,
+         * 남는 여유는 "지금 이 기계에 램이 얼마나 있는가"에 달려 있었다 — 로컬은 통과하고
+         * CI에서만 테스트 JVM이 클래스 로딩 중 OutOfMemoryError로 죽은 이유가 그것이다.
+         *
+         * 테스트를 줄여 512m에 맞출 값이 아니라, 처음부터 정했어야 할 값이다.
+         * 메타스페이스도 함께 준다 — 컨텍스트마다 프록시 클래스가 쌓이는 쪽이 힙보다 먼저
+         * 바닥나고, 그때 나는 오류는 힙 부족과 구분되지 않는다.
+         */
+        maxHeapSize = '2g'
+        jvmArgs '-XX:MaxMetaspaceSize=1g'
     }
 
     jacocoTestReport {

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/TravelTimeIntegrationTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/route/TravelTimeIntegrationTest.java
@@ -368,6 +368,26 @@ class TravelTimeIntegrationTest extends ApiTestSupport {
             assertThat(stub.calls).hasSize(2);
             assertThat(stub.calls.get(1).destination().lat()).isEqualByComparingTo(aLat);
         }
+
+        @Test
+        @DisplayName("다른 여행이 같은 두 장소를 이어도 새로 부르지 않는다 — 키에 여행 id가 없다")
+        void sharesCacheAcrossTrips() throws Exception {
+            // 이 설계 덕분에 같은 일정을 다시 만들어도 비용이 다시 들지 않는다(#1160).
+            // 좌표 쌍이 키라, 여행을 지우고 다시 짜는 흔한 행동이 공짜가 된다.
+            Long from = placeAt("센소지", jitter(SENSOJI_LAT), jitter(SENSOJI_LNG));
+            Long to = placeAt("스카이트리", jitter(SKYTREE_LAT), jitter(SKYTREE_LNG));
+            addActivity("센소지", from);
+            addActivity("스카이트리", to);
+            board().andExpect(jsonPath("$.data.travelTimes[0].durationMinutes").value(12));
+            assertThat(stub.calls).hasSize(1);
+
+            tripId = createTrip();
+            addActivity("센소지", from);
+            addActivity("스카이트리", to);
+
+            board().andExpect(jsonPath("$.data.travelTimes[0].durationMinutes").value(12));
+            assertThat(stub.calls).hasSize(1);
+        }
     }
 
     @Nested


### PR DESCRIPTION
#1160 의 Todo 한 줄을 닫는다 (이슈 자체는 BigQuery 실단가(#1157)가 있어야 끝난다).

## 무엇을

**"캐시 키에 여행 id를 넣지 않았다"는 설계가 실제로 호출을 아끼는지**를 테스트로 고정했다. 같은 두 장소를 다른 여행에서 이어도 Routes 호출이 늘지 않는다.

#1160 은 이 확인을 리허설(#1176)에서 손으로 하기로 했지만, 이건 **여행을 두 번 만들어야 보이는 것**이라 리허설 한 번으로는 나오지 않는다. 테스트가 더 정확하고, 회귀도 막는다.

## 리허설 항목 문구에 대한 지적

#1160·#1118 의 해당 항목은 이렇게 적혀 있다.

> 같은 좌표쌍을 **순서만 바꿔** 재입력했을 때 추가 호출 **0** (캐시 키에 여행 id를 넣지 않은 설계 검증)

**괄호 안과 앞부분이 서로 다른 것을 말한다.** 캐시 키는 `출발좌표:도착좌표:수단`이라 **방향이 들어 있다** — 일정 순서를 뒤집으면 A→B가 B→A가 되고, 이건 일방통행 때문에 실제로 다른 이동이다. 그래서 순서를 뒤집으면 **호출이 는다. 그게 맞는 동작이고**, `reversedOrderIsDifferentTravelTime` 테스트가 이미 그렇게 고정해 두었다.

리허설에서 이 문구대로 확인하면 **정상 동작을 설계 실패로 오독**하게 된다. 검증하려던 실제 성질(여행 id가 키에 없다)은 이 PR의 테스트가 본다.

## 검증

`./gradlew :orino-app-api:test --tests '*TravelTimeIntegrationTest*'` 통과.
