### PR TITLE
fix : 일정을 저장하면 장소가 사라진다

### DIFF
--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/activity/controller/ActivityControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/activity/controller/ActivityControllerTest.java
@@ -197,6 +197,44 @@ class ActivityControllerTest extends ApiTestSupport {
         }
 
         @Test
+        @DisplayName("수정은 전체 교체다 — placeId를 빼면 장소가 해제된다")
+        void omittingPlaceIdClearsPlace() throws Exception {
+            long placeId = createPoi("센소지", "다이토구");
+            long id = createActivityWithPlace("센소지", DAY1, placeId);
+
+            // 시각만 바꾸려던 요청이라도 placeId가 없으면 장소가 떨어진다. 부분 수정이 아니다.
+            mockMvc.perform(put("/api/travel/activities/" + id)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "센소지", "activityDate": "%s", "startTime": "09:00"}
+                                    """.formatted(DAY1)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.place").doesNotExist());
+
+            assertThat(activityRepository.findById(id).orElseThrow().getPlaceId()).isNull();
+        }
+
+        @Test
+        @DisplayName("placeId를 함께 보내면 장소가 그대로 남는다 — 화면은 이 경로로 저장한다(#1197)")
+        void keepsPlaceWhenPlaceIdIsSent() throws Exception {
+            long placeId = createPoi("센소지", "다이토구");
+            long id = createActivityWithPlace("센소지", DAY1, placeId);
+
+            mockMvc.perform(put("/api/travel/activities/" + id)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "센소지", "activityDate": "%s", "startTime": "09:00",
+                                     "placeId": %d}
+                                    """.formatted(DAY1, placeId)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.startTime").value("09:00"))
+                    .andExpect(jsonPath("$.data.place.id").value(placeId))
+                    .andExpect(jsonPath("$.data.place.address").value("다이토구"));
+        }
+
+        @Test
         @DisplayName("시각 없이 알림을 켜도 저장은 된다(알림 생성 여부는 3단계 판정)")
         void allowsNotifyWithoutTime() throws Exception {
             long id = createActivity("쇼핑", DAY1);
@@ -449,6 +487,32 @@ class ActivityControllerTest extends ApiTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"title\": \"%s\"%s}".formatted(title, dateField)))
                 .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    /** 구글을 타지 않는 직접 입력 장소. 담긴 장소가 수정에 살아남는지 보려면 하나 있어야 한다. */
+    private long createPoi(String name, String address) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/places")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name": "%s", "address": "%s"}
+                                """.formatted(name, address)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return ((Number) JsonPath.read(body, "$.data.id")).longValue();
+    }
+
+    private long createActivityWithPlace(String title, String date, long placeId) throws Exception {
+        String body = mockMvc.perform(post("/api/travel/trips/" + tripId + "/activities")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "%s", "activityDate": "%s", "placeId": %d}
+                                """.formatted(title, date, placeId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.place.id").value(placeId))
                 .andReturn().getResponse().getContentAsString();
         return ((Number) JsonPath.read(body, "$.data.id")).longValue();
     }

--- a/fe/src/features/travel/lib/activityWriteBody.test.ts
+++ b/fe/src/features/travel/lib/activityWriteBody.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import type { Activity } from "@/features/travel/api/activities";
+
+import { activityWriteBodyFrom } from "./activityWriteBody";
+
+const SENSOJI: Activity = {
+  id: 11,
+  tripId: 1,
+  title: "센소지",
+  activityDate: "2026-10-24",
+  startTime: "09:00",
+  place: {
+    id: 77,
+    name: "센소지",
+    address: "다이토구",
+    lat: 35.7148,
+    lng: 139.7967,
+    cityName: "도쿄도",
+    cityPlaceRef: "ChIJ_tokyo",
+  },
+  memo: "가미나리몬 앞에서 만나기",
+  url: "https://www.senso-ji.jp",
+  notifyEnabled: true,
+  notifyMinutes: 30,
+  departureNotifyEnabled: true,
+  outOfBaseCity: false,
+  canDepartureNotify: true,
+  sortOrder: 0,
+  log: null,
+  hasLog: false,
+};
+
+describe("일정 수정 바디", () => {
+  it("장소를 placeId로 실어 보낸다 — 빠뜨리면 서버가 장소를 지운다(#1197)", () => {
+    expect(activityWriteBodyFrom(SENSOJI).placeId).toBe(77);
+  });
+
+  it("아무것도 안 바꾸면 지금 상태 그대로다", () => {
+    expect(activityWriteBodyFrom(SENSOJI)).toEqual({
+      title: "센소지",
+      activityDate: "2026-10-24",
+      startTime: "09:00",
+      placeId: 77,
+      memo: "가미나리몬 앞에서 만나기",
+      url: "https://www.senso-ji.jp",
+      notifyEnabled: true,
+      notifyMinutes: 30,
+      departureNotifyEnabled: true,
+    });
+  });
+
+  it("날짜만 바꿔도 장소·메모·링크·알림설정은 그대로 간다", () => {
+    const body = activityWriteBodyFrom(SENSOJI, { activityDate: "2026-10-25" });
+
+    expect(body.activityDate).toBe("2026-10-25");
+    expect(body.placeId).toBe(77);
+    expect(body.startTime).toBe("09:00");
+    expect(body.memo).toBe("가미나리몬 앞에서 만나기");
+    expect(body.url).toBe("https://www.senso-ji.jp");
+    expect(body.notifyEnabled).toBe(true);
+    expect(body.notifyMinutes).toBe(30);
+    expect(body.departureNotifyEnabled).toBe(true);
+  });
+
+  it("보관함으로 내려도 알림 설정은 남는다 — 날짜를 다시 주면 그대로 되살아난다", () => {
+    // 서버는 날짜 없는 일정의 예약만 접는다. 여기서 플래그까지 꺼 버리면
+    // 되돌려 놓았을 때 알림이 조용히 사라진 채로 남는다.
+    const body = activityWriteBodyFrom(SENSOJI, { activityDate: null });
+
+    expect(body.activityDate).toBeNull();
+    expect(body.notifyEnabled).toBe(true);
+    expect(body.notifyMinutes).toBe(30);
+  });
+
+  it("장소 없는 일정은 placeId가 null이다", () => {
+    const body = activityWriteBodyFrom({ ...SENSOJI, place: null });
+
+    expect(body.placeId).toBeNull();
+  });
+
+  it("googlePlaceId는 담지 않는다 — 이미 담긴 장소를 다시 조회하면 과금된다", () => {
+    const body = activityWriteBodyFrom(SENSOJI);
+
+    expect(body.googlePlaceId).toBeUndefined();
+    expect(body.cityPlaceId).toBeUndefined();
+  });
+});

--- a/fe/src/features/travel/lib/activityWriteBody.ts
+++ b/fe/src/features/travel/lib/activityWriteBody.ts
@@ -1,0 +1,34 @@
+import type { Activity, ActivityWriteRequest } from "../api/activities";
+
+/**
+ * 일정 수정 요청 바디를 <b>지금 상태 전체</b>로 채운다.
+ *
+ * <p>`PUT /travel/activities/{id}`는 부분 수정이 아니라 <b>전체 교체</b>다 — 보내지 않은
+ * 필드는 서버가 지운다. 그래서 "날짜만 바꾼다" 같은 수정도 나머지 필드를 전부 실어 보내야
+ * 하는데, 호출부마다 손으로 나열하면 <b>반드시 빠뜨린다</b>. 실제로 네 호출부가 전부
+ * `placeId`를 빠뜨려 저장할 때마다 장소가 사라졌다(#1197).
+ *
+ * <p>바꾸려는 것만 {@link overrides}로 넘긴다. 나머지는 서버가 마지막으로 알려준 값
+ * 그대로 되돌아간다.
+ *
+ * <p>`googlePlaceId`·`cityPlaceId`는 담지 않는다 — 검색 결과를 처음 담을 때 장소를
+ * upsert 하려고 쓰는 입력이고, 이미 담긴 일정의 장소는 `placeId`로 가리켜져 있다.
+ * 함께 보내면 서버가 같은 장소를 다시 조회한다(호출당 과금).
+ */
+export function activityWriteBodyFrom(
+  activity: Activity,
+  overrides: Partial<ActivityWriteRequest> = {},
+): ActivityWriteRequest {
+  return {
+    title: activity.title,
+    activityDate: activity.activityDate,
+    startTime: activity.startTime,
+    placeId: activity.place?.id ?? null,
+    memo: activity.memo,
+    url: activity.url,
+    notifyEnabled: activity.notifyEnabled,
+    notifyMinutes: activity.notifyMinutes,
+    departureNotifyEnabled: activity.departureNotifyEnabled,
+    ...overrides,
+  };
+}

--- a/fe/src/pages/travel/ActivityDetailPage.test.tsx
+++ b/fe/src/pages/travel/ActivityDetailPage.test.tsx
@@ -199,6 +199,35 @@ describe("ActivityDetailPage", () => {
     expect(seen[0].startTime).toBeNull();
   });
 
+  it("시각을 넣고 저장해도 장소가 살아남는다 — 수정은 전체 교체다(#1197)", async () => {
+    // 이 화면의 장소 블록은 읽기 전용이라 사용자가 장소를 지울 방법이 없다.
+    // `placeId`를 빠뜨리면 서버가 place_id를 NULL로 덮어 이름·주소·좌표가 다 사라진다.
+    mockDetail({
+      startTime: null,
+      place: {
+        id: 10,
+        name: "센소지",
+        address: "다이토구",
+        lat: 35.7147651,
+        lng: 139.7966553,
+        cityName: "도쿄",
+        cityPlaceRef: "ChIJ_tokyo",
+      },
+    });
+    const seen = captureSave();
+    renderDetail();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("시작 시각")).toHaveValue("");
+    });
+    await userEvent.type(screen.getByLabelText("시작 시각"), "09:00");
+    await userEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() => expect(seen).toHaveLength(1));
+    expect(seen[0].startTime).toBe("09:00");
+    expect(seen[0].placeId).toBe(10);
+  });
+
   it("시각은 문자열 그대로 보낸다 — 기기 타임존으로 변환하지 않는다", async () => {
     mockDetail();
     const seen = captureSave();

--- a/fe/src/pages/travel/ActivityDetailPage.tsx
+++ b/fe/src/pages/travel/ActivityDetailPage.tsx
@@ -34,6 +34,7 @@ import { useUpdateActivity } from "@/features/travel/hooks/useActivityMutations"
 import { useBoard } from "@/features/travel/hooks/useBoard";
 import { usePlaceDetail } from "@/features/travel/hooks/usePlaceDetail";
 import { useTrip } from "@/features/travel/hooks/useTrip";
+import { activityWriteBodyFrom } from "@/features/travel/lib/activityWriteBody";
 import { cityOn } from "@/features/travel/lib/baseCity";
 import { cityLabelOf } from "@/features/travel/lib/cityLabel";
 import { NOTIFY_MINUTES_OPTIONS } from "@/features/travel/lib/destinations";
@@ -230,7 +231,9 @@ export function ActivityDetailPage() {
     try {
       await updateActivity.mutateAsync({
         activityId,
-        body: {
+        // 폼에 없는 필드(장소)는 지금 값 그대로 되돌려 보낸다 — 수정은 전체 교체라
+        // 빠뜨리면 서버가 지운다. 이 화면의 장소 블록은 읽기 전용이다(#1197).
+        body: activityWriteBodyFrom(activity, {
           title: form.title.trim(),
           activityDate: form.day === ARCHIVE_VALUE ? null : form.day,
           // 문자열 그대로 보낸다. 시각이 없으면 null이고 그건 정상이다.
@@ -241,7 +244,7 @@ export function ActivityDetailPage() {
           notifyEnabled: form.notifyEnabled,
           notifyMinutes: form.notifyMinutes ? Number(form.notifyMinutes) : null,
           departureNotifyEnabled: form.departureNotifyEnabled,
-        },
+        }),
       });
       toast("일정을 저장했어요.", "success");
       // 옮겼다면 옮겨간 날짜의 탭으로 간다.

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -346,7 +346,11 @@ describe("TripBoardPage", () => {
       );
 
       await waitFor(() => expect(seen).toHaveLength(1));
-      expect(seen[0]).toMatchObject({ activityDate: "2026-10-25" });
+      // 날짜만 바꾸는 수정이지만 `PUT`은 전체 교체다 — 장소를 빼면 서버가 지운다(#1197).
+      expect(seen[0]).toMatchObject({
+        activityDate: "2026-10-25",
+        placeId: 109,
+      });
     });
 
     it("빈 보관함 문구는 그대로다", async () => {
@@ -789,11 +793,27 @@ describe("TripBoardPage", () => {
       expect(await screen.findByLabelText("장소 검색")).toBeInTheDocument();
     });
 
-    it("보관함 일정을 지금 보는 날짜로 가져온다", async () => {
+    it("보관함 일정을 지금 보는 날짜로 가져온다 — 장소·메모·알림도 함께 온다", async () => {
       mockBoard({
         byDate: { "2026-10-24": [] },
         archive: [
-          activity({ id: 9, title: "가고 싶은 라멘집", activityDate: null }),
+          activity({
+            id: 9,
+            title: "가고 싶은 라멘집",
+            activityDate: null,
+            place: {
+              id: 42,
+              name: "이치란 시부야",
+              address: "시부야구",
+              lat: 35.6595,
+              lng: 139.7005,
+              cityName: "도쿄",
+              cityPlaceRef: "ChIJ_tokyo",
+            },
+            memo: "1층 자판기",
+            notifyEnabled: true,
+            notifyMinutes: 20,
+          }),
         ],
       });
       const seen: Record<string, unknown>[] = [];
@@ -814,7 +834,14 @@ describe("TripBoardPage", () => {
       );
 
       await waitFor(() => expect(seen).toHaveLength(1));
-      expect(seen[0]).toMatchObject({ activityDate: "2026-10-24" });
+      // 담아 둘 때 붙여 놓은 것들이 날짜를 정하는 순간 사라지면 안 된다(#1197).
+      expect(seen[0]).toMatchObject({
+        activityDate: "2026-10-24",
+        placeId: 42,
+        memo: "1층 자판기",
+        notifyEnabled: true,
+        notifyMinutes: 20,
+      });
     });
 
     it("보관함을 보고 있으면 '가져오기'를 띄우지 않는다", async () => {
@@ -865,6 +892,53 @@ describe("TripBoardPage", () => {
         await screen.findByRole("button", { name: /실행취소/ }),
       ).toBeInTheDocument();
       expect(puts).toHaveLength(0);
+    });
+
+    it("보관함으로 내려도 장소·메모·알림은 그대로다 — 되돌려 놓을 때 필요하다", async () => {
+      // 보관함행은 `activityDate`만 null로 바꾸는 수정인데, `PUT`이 전체 교체라
+      // 나머지를 안 보내면 담아 둔 장소까지 함께 지워졌다(#1197).
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      mockBoard({
+        byDate: {
+          "2026-10-24": [
+            activity({
+              place: {
+                id: 42,
+                name: "센소지 본당",
+                address: "다이토구",
+                lat: 35.7148,
+                lng: 139.7967,
+                cityName: "도쿄",
+                cityPlaceRef: "ChIJ_tokyo",
+              },
+              memo: "가미나리몬 앞",
+              notifyEnabled: true,
+              notifyMinutes: 20,
+            }),
+          ],
+        },
+      });
+      const { puts } = captureWrites();
+
+      renderBoard();
+      await screen.findByText("센소지");
+      await userEvent.click(screen.getByLabelText("센소지 보관함으로"));
+      await screen.findByRole("button", { name: /실행취소/ });
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      await waitFor(() => expect(puts).toHaveLength(1));
+      expect(puts[0]).toMatchObject({
+        activityDate: null,
+        placeId: 42,
+        startTime: "09:00",
+        memo: "가미나리몬 앞",
+        notifyEnabled: true,
+        notifyMinutes: 20,
+      });
+      vi.useRealTimers();
     });
 
     it("실행취소를 누르면 요청이 아예 나가지 않고 일정이 돌아온다", async () => {

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -69,6 +69,7 @@ import {
   useUpdateStay,
 } from "@/features/travel/hooks/useStays";
 import { useUpdateDay } from "@/features/travel/hooks/useUpdateDay";
+import { activityWriteBodyFrom } from "@/features/travel/lib/activityWriteBody";
 import {
   daysForPlace,
   groupArchiveByCity,
@@ -289,7 +290,7 @@ export function TripBoardPage() {
   const pickFromArchive = async (activity: Activity) => {
     await updateActivity.mutateAsync({
       activityId: activity.id,
-      body: { title: activity.title, activityDate: selectedDate },
+      body: activityWriteBodyFrom(activity, { activityDate: selectedDate }),
     });
     setSheetOpen(false);
   };
@@ -305,11 +306,7 @@ export function TripBoardPage() {
       run: () =>
         updateActivity.mutateAsync({
           activityId: activity.id,
-          body: {
-            title: activity.title,
-            activityDate: null,
-            startTime: activity.startTime,
-          },
+          body: activityWriteBodyFrom(activity, { activityDate: null }),
         }),
     });
 
@@ -344,11 +341,7 @@ export function TripBoardPage() {
     if (target === selectedDate) return;
     await updateActivity.mutateAsync({
       activityId: activity.id,
-      body: {
-        title: activity.title,
-        activityDate: target,
-        startTime: activity.startTime,
-      },
+      body: activityWriteBodyFrom(activity, { activityDate: target }),
     });
     toast(
       target === null ? "보관함으로 옮겼어요." : "다른 날짜로 옮겼어요.",


### PR DESCRIPTION
## 이슈
closes #1197
## 작업 내용
- 일정 수정 `PUT`은 [스펙](https://github.com/wcorn/orino/wiki/Travel-API-Spec)상 **전체 교체**인데 FE가 부분 바디를 보내, 저장할 때마다 서버가 `place_id`를 NULL로 덮고 있었다. 시각 때문이 아니라 **저장 자체가 원인**이라 메모만 고쳐도 사라졌다
- 같은 원인으로 **네 호출부가 전부** 틀려 있었다

  | 위치 | 동작 | 날아가던 것 |
  |---|---|---|
  | `ActivityDetailPage` | 상세 저장 | 장소 |
  | `TripBoardPage` | 보관함에서 가져오기 | 장소 · 시각 · 메모 · 링크 · 알림설정 |
  | `TripBoardPage` | 스와이프로 보관함 내리기 | 장소 · 메모 · 링크 · 알림설정 |
  | `TripBoardPage` | 다른 날짜로 옮기기 | 장소 · 메모 · 링크 · 알림설정 |

- **BE 계약은 그대로 뒀다.** "null이면 유지"로 바꾸면 스펙과 어긋나고 나중에 `장소 지우기`를 넣을 길이 막힌다
- 대신 지금 상태 전체를 채우는 `activityWriteBodyFrom(activity, overrides)` 헬퍼를 두고 네 호출부를 교체했다. 호출부마다 9개 필드를 손으로 나열하게 두면 또 빠뜨린다 — 네 곳이 전부 틀렸던 것이 그 증거다
- 보관함으로 내릴 때 알림 플래그를 끄지 않는다. 서버는 날짜 없는 일정의 **예약만** 접으므로, 날짜를 다시 주면 알림이 그대로 되살아난다

### 테스트
- `activityWriteBody` 단위 테스트 6건
- MSW로 **요청 바디**를 검증하는 통합 테스트 4건 — 네 경로 각각. 응답만 보면 잡히지 않는 종류다
  - 수정을 되돌리면 4건 모두 실패하는 것을 확인했다
- BE 통합 테스트 2건 — `placeId` 생략 시 장소가 해제되는 계약과, 함께 보내면 남는 것

### 로컬 확인
- BE `bootRun` + MySQL/Redis 컨테이너로 실제 앱에서 재현·수정 확인
  - 상세 화면에서 시각을 넣고 저장 → 주소 유지, 보드에 `09:00` 표시
  - 스와이프로 보관함에 내림 → `place_id` 유지
- 게이트: `./gradlew check` · `format:check` · `lint` · `npm test`(1025건) · `npm run build` 모두 통과

---
- [ ] (해당 시) S3 또는 유료 외부 API를 호출하는 컴포넌트를 추가했다면 — 주기 플래그를 values에 명시했고, 비용 대시보드에 나타나는가? ([주기 루프 인벤토리](https://github.com/wcorn/orino/wiki/Periodic-Loops))
