### PR TITLE
chore : 시각을 벽시계 그대로 저장하게 타임존 설정을 걷어낸다

### DIFF
--- a/be/orino-app-api/src/main/resources/application-mysql.yml
+++ b/be/orino-app-api/src/main/resources/application-mysql.yml
@@ -1,19 +1,22 @@
+# `hibernate.jdbc.time_zone`을 두지 않는다. 이 애플리케이션은 일정 시각을 **벽시계 시각**
+# (`DATE` + `TIME`)으로 저장하는데, 그 속성이 붙으면 Hibernate가 `LocalTime`을 JVM 기본
+# 타임존으로 해석해 설정한 타임존으로 환산해 넣는다. JVM TZ가 UTC가 아닌 순간 `TIME` 값이
+# 통째로 밀린다(#1201). `Instant`(`created_at`)는 이 속성 없이도 UTC로 저장되므로 잃는 것이 없다.
+#
+# JDBC URL에 `serverTimezone`도 두지 않는다. 서버는 UTC인데 `Asia/Seoul`이라 선언하고 있었고,
+# 실측 결과 이 파라미터는 위 현상에 아무 영향이 없었다 — 사실과 다른 선언만 남는다.
 spring:
   config:
     activate:
       on-profile: prod
   datasource:
-    url: jdbc:mysql://${MYSQL_HOST}/${DB_NAME}?useUnicode=true&charset=utf8mb4&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://${MYSQL_HOST}/${DB_NAME}?useUnicode=true&charset=utf8mb4
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: validate
-    properties:
-      hibernate:
-        jdbc:
-          time_zone: UTC
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
 ---
@@ -22,7 +25,7 @@ spring:
     activate:
       on-profile: local
   datasource:
-    url: jdbc:mysql://${MYSQL_HOST}/${DB_NAME}?useUnicode=true&charset=utf8mb4&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://${MYSQL_HOST}/${DB_NAME}?useUnicode=true&charset=utf8mb4
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -34,8 +37,6 @@ spring:
         format_sql: true
         highlight_sql: true
         generate_statistics: true
-        jdbc:
-          time_zone: UTC
   liquibase:
     enabled: true
     change-log: classpath:db/changelog/db.changelog-master.yaml
@@ -65,10 +66,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-    properties:
-      hibernate:
-        jdbc:
-          time_zone: UTC
   liquibase:
     enabled: true
     change-log: classpath:db/changelog/db.changelog-master.yaml

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/activity/controller/ActivityControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/activity/controller/ActivityControllerTest.java
@@ -18,9 +18,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,6 +51,9 @@ class ActivityControllerTest extends ApiTestSupport {
     private TripActivityRepository activityRepository;
     @Autowired
     private DbCleaner dbCleaner;
+    /** 컬럼에 실제로 무엇이 들어갔는지 보려면 엔티티를 거치지 않고 읽어야 한다(#1201). */
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     private String authHeader;
     private String otherAuthHeader;
@@ -232,6 +237,37 @@ class ActivityControllerTest extends ApiTestSupport {
                     .andExpect(jsonPath("$.data.startTime").value("09:00"))
                     .andExpect(jsonPath("$.data.place.id").value(placeId))
                     .andExpect(jsonPath("$.data.place.address").value("다이토구"));
+        }
+
+        @Test
+        @DisplayName("JVM 기본 타임존이 UTC가 아니어도 시각은 벽시계 그대로 저장된다(#1201)")
+        void storesWallClockTimeRegardlessOfJvmTimeZone() throws Exception {
+            // `hibernate.jdbc.time_zone`이 붙어 있으면 Hibernate가 LocalTime을 JVM 기본
+            // 타임존으로 해석해 환산해 넣는다 — 파드에 TZ=Asia/Seoul을 주는 순간 모든 TIME이
+            // 9시간 밀린다. 화면은 읽을 때 되돌려 읽어 왕복이 맞아 보여서 아무도 모른다.
+            TimeZone original = TimeZone.getDefault();
+            long id;
+            try {
+                TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+                id = createActivity("센소지", DAY1);
+                mockMvc.perform(put("/api/travel/activities/" + id)
+                                .header(HttpHeaders.AUTHORIZATION, authHeader)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {"title": "센소지", "activityDate": "%s", "startTime": "09:00"}
+                                        """.formatted(DAY1)))
+                        .andExpect(status().isOk());
+            } finally {
+                TimeZone.setDefault(original);
+            }
+
+            // 엔티티로 읽으면 같은 환산이 반대로 걸려 밀린 값도 09:00으로 보인다.
+            // 컬럼을 문자열로 직접 읽어야 실제로 무엇이 들어갔는지 드러난다.
+            String stored = jdbcTemplate.queryForObject(
+                    "SELECT CAST(start_time AS CHAR) FROM trip_activity WHERE id = ?",
+                    String.class, id);
+
+            assertThat(stored).isEqualTo("09:00:00");
         }
 
         @Test

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/activity/controller/ActivityControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/activity/controller/ActivityControllerTest.java
@@ -10,6 +10,7 @@ import ds.project.orino.support.DbCleaner;
 import ds.project.orino.support.FixedClockConfig;
 import ds.project.orino.support.MemberFixture;
 import ds.project.orino.support.TravelCityFixture;
+import jakarta.persistence.EntityManagerFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -22,7 +23,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.TimeZone;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,6 +54,8 @@ class ActivityControllerTest extends ApiTestSupport {
     /** 컬럼에 실제로 무엇이 들어갔는지 보려면 엔티티를 거치지 않고 읽어야 한다(#1201). */
     @Autowired
     private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
 
     private String authHeader;
     private String otherAuthHeader;
@@ -240,29 +242,20 @@ class ActivityControllerTest extends ApiTestSupport {
         }
 
         @Test
-        @DisplayName("JVM 기본 타임존이 UTC가 아니어도 시각은 벽시계 그대로 저장된다(#1201)")
-        void storesWallClockTimeRegardlessOfJvmTimeZone() throws Exception {
-            // `hibernate.jdbc.time_zone`이 붙어 있으면 Hibernate가 LocalTime을 JVM 기본
-            // 타임존으로 해석해 환산해 넣는다 — 파드에 TZ=Asia/Seoul을 주는 순간 모든 TIME이
-            // 9시간 밀린다. 화면은 읽을 때 되돌려 읽어 왕복이 맞아 보여서 아무도 모른다.
-            TimeZone original = TimeZone.getDefault();
-            long id;
-            try {
-                TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
-                id = createActivity("센소지", DAY1);
-                mockMvc.perform(put("/api/travel/activities/" + id)
-                                .header(HttpHeaders.AUTHORIZATION, authHeader)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content("""
-                                        {"title": "센소지", "activityDate": "%s", "startTime": "09:00"}
-                                        """.formatted(DAY1)))
-                        .andExpect(status().isOk());
-            } finally {
-                TimeZone.setDefault(original);
-            }
+        @DisplayName("시각은 컬럼에 벽시계 그대로 들어간다 — 엔티티로 읽으면 환산이 상쇄돼 안 보인다")
+        void storesStartTimeAsWallClock() throws Exception {
+            long id = createActivity("센소지", DAY1);
 
-            // 엔티티로 읽으면 같은 환산이 반대로 걸려 밀린 값도 09:00으로 보인다.
-            // 컬럼을 문자열로 직접 읽어야 실제로 무엇이 들어갔는지 드러난다.
+            mockMvc.perform(put("/api/travel/activities/" + id)
+                            .header(HttpHeaders.AUTHORIZATION, authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"title": "센소지", "activityDate": "%s", "startTime": "09:00"}
+                                    """.formatted(DAY1)))
+                    .andExpect(status().isOk());
+
+            // 엔티티로 읽으면 쓸 때의 환산이 읽을 때 반대로 걸려 밀린 값도 09:00으로 보인다.
+            // 컬럼을 문자열로 직접 읽어야 실제로 무엇이 들어갔는지 드러난다(#1201).
             String stored = jdbcTemplate.queryForObject(
                     "SELECT CAST(start_time AS CHAR) FROM trip_activity WHERE id = ?",
                     String.class, id);
@@ -497,6 +490,25 @@ class ActivityControllerTest extends ApiTestSupport {
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value("TRAVEL-ERR-001"));
         }
+    }
+
+    /**
+     * 시각을 밀리게 하는 설정이 다시 들어오지 않게 막는다(#1201).
+     *
+     * <p>{@code hibernate.jdbc.time_zone}이 붙으면 Hibernate가 {@code LocalTime}을 <b>JVM 기본
+     * 타임존</b>으로 해석해 설정한 타임존으로 환산해 넣는다. 파드에 {@code TZ=Asia/Seoul}을 주는
+     * 순간 모든 {@code TIME}이 9시간 밀리는데, 읽을 때 같은 환산이 반대로 걸려 화면은 멀쩡해
+     * 보인다 — 그래서 동작 테스트로는 잡히지 않고 설정 자체를 막아야 한다.
+     *
+     * <p>동작 자체는 boot jar로 JVM {@code TZ}를 바꿔 가며 실측해 확인했다. 그 조건을 테스트로
+     * 옮기려면 JVM을 따로 띄워야 한다 — 드라이버가 <b>접속 시점의</b> 기본 타임존을 붙들고 있어
+     * 실행 중에 바꿔 봐야 풀에 남은 커넥션에는 반영되지 않는다.
+     */
+    @Test
+    @DisplayName("hibernate.jdbc.time_zone을 두지 않는다 — 붙으면 TIME이 JVM 타임존만큼 밀린다")
+    void doesNotConfigureJdbcTimeZone() {
+        assertThat(entityManagerFactory.getProperties())
+                .doesNotContainKey("hibernate.jdbc.time_zone");
     }
 
     // ---------------- helpers ----------------


### PR DESCRIPTION
## 이슈
closes #1201
## 작업 내용

**오늘 동작은 바뀌지 않는다.** 운영은 JVM·MySQL 모두 UTC라 이미 정상이다. 이 PR은 그 정상이 **우연이 아니라 보장이 되게** 한다.

### 조사 — 범인은 URL이 아니었다

이슈에는 `serverTimezone=Asia/Seoul`을 의심해 적었는데, 실측해 보니 아니었다. 운영과 같은 아티팩트(boot jar)로 MySQL(UTC) 상대로 조합을 돌렸다. `startTime: "09:00"` 저장 후 컬럼을 문자열로 직접 읽은 값:

| 후보 | JVM TZ | 저장된 `start_time` |
|---|---|---|
| 현행 (`serverTimezone=Asia/Seoul` + `hib UTC`) | Asia/Seoul | `00:00:00` ❌ |
| 현행 | UTC | `09:00:00` ✅ |
| URL에서 `serverTimezone` 제거 | Asia/Seoul | `00:00:00` ❌ |
| `connectionTimeZone=SERVER` | Asia/Seoul | `00:00:00` ❌ |
| `connectionTimeZone=UTC` | Asia/Seoul | `00:00:00` ❌ |
| **`hibernate.jdbc.time_zone` 제거** | **Asia/Seoul** | **`09:00:00`** ✅ |
| **`hibernate.jdbc.time_zone` 제거** | **UTC** | **`09:00:00`** ✅ |

URL 파라미터는 무엇을 넣든 결과가 같았다. 지렛대는 **`hibernate.jdbc.time_zone: UTC`** 하나였다 — Hibernate가 `LocalTime`을 JVM 기본 타임존으로 해석한 뒤 이 값으로 환산해 넣는다.

### 제거해도 잃는 게 없다

`Instant`까지 흔들리면 곤란하니 함께 쟀다. JVM=Asia/Seoul, 실제 UTC `07:14`:

| 설정 | `created_at` | `start_time` | `activity_date` |
|---|---|---|---|
| 현행 | `07:14` (UTC ✅) | `00:00:00` ❌ | `2026-10-24` ✅ |
| 제거 후 | `07:14` (UTC ✅) | `09:00:00` ✅ | `2026-10-24` ✅ |

`Instant`는 이 속성 없이도 UTC로 저장된다. `DATE`는 애초에 영향받지 않았다. **밀리던 것은 `TIME`뿐이고, 제거는 그것만 고친다.**

### 변경

- `hibernate.jdbc.time_zone: UTC` 제거 (prod · local · test)
- JDBC URL의 `serverTimezone=Asia/Seoul` 제거 — 서버는 UTC인데 사실과 다르게 선언하고 있었다. 위 표대로 이 현상과는 무관하지만, 거짓 선언을 남겨 둘 이유가 없다
- 왜 두지 않는지를 파일 상단 주석으로 남겼다. 안 그러면 다음 사람이 "UTC로 못 박는 게 안전하지 않나" 하고 되돌린다

### 테스트 — 두 개로 나눴다

1. **컬럼에 벽시계 그대로 들어가는지** — 엔티티로 읽으면 쓸 때의 환산이 읽을 때 반대로 걸려 밀린 값도 `09:00`으로 보인다. 컬럼을 문자열로 직접 읽어야 드러난다
2. **`hibernate.jdbc.time_zone` 설정 자체를 금지하는 가드** — 이게 실제 회귀 가드다. 되살려 놓으면 `FAILED` 나는 것을 확인했다

처음엔 테스트 안에서 `TimeZone.setDefault`로 비UTC 조건을 만들었는데, **JVM 기본 TZ에 따라 통과했다 실패했다 했다** — 로컬(KST) 통과, CI(UTC) 실패. 드라이버가 **접속 시점의** 기본 타임존을 캐시해서, 실행 중에 바꿔도 풀에 남은 커넥션엔 반영되지 않기 때문이다.

풀을 비워 새로 맺게 하는 방법도 시도했지만 쓰지 않았다 — TestContainers가 마지막 커넥션이 닫히면 컨테이너를 내려 다른 테스트가 무더기로 깨진다.

비UTC JVM에서의 동작은 boot jar 실측(위 표)으로 확인했다. 이 조건을 테스트로 옮기려면 JVM을 따로 띄워야 하고, 그러면 컨테이너가 하나 더 떠 CI가 몇 분 늘어난다 — 이득 대비 비용이 맞지 않아 근거를 주석으로 남겼다.

컨텍스트를 늘리지 않으려 둘 다 기존 `ActivityControllerTest`에 넣었다.

### 확인

- `./gradlew check` 통과 (테스트 + Checkstyle)
- 테스트를 JVM TZ `UTC`·`Asia/Seoul` 양쪽에서 돌려 결과가 같은 것을 확인 (`--rerun-tasks`)
- boot jar 실사 — 새 설정으로 JVM TZ `Asia/Seoul` · `UTC` 양쪽 모두 `09:00:00` 저장
- 마이그레이션 불필요 — 지금 저장된 값은 밀려 있지 않다

---
- [ ] (해당 시) S3 또는 유료 외부 API를 호출하는 컴포넌트를 추가했다면 — 주기 플래그를 values에 명시했고, 비용 대시보드에 나타나는가? ([주기 루프 인벤토리](https://github.com/wcorn/orino/wiki/Periodic-Loops))
