### PR TITLE
chore : 표본이 적을 때 튀는 istio 알림 2종을 건수 기준으로

### DIFF
--- a/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
+++ b/infra/helm/kube-prometheus-stack/templates/prometheusrule.yaml
@@ -402,30 +402,68 @@ spec:
             summary: "BE DB 커넥션 풀 고갈 임박"
             description: "HikariCP active / max 비율이 5분간 90% 초과 (현재: {{ "{{" }} $value | printf \"%.2f\" {{ "}}" }})"
 
+    # 이 클러스터의 트래픽은 희박하다 — 7일 실측에서 be 는 5분 창 1,690개 중
+    # **6.6%** 에만 요청이 있었고, 있을 때도 최대 0.43 req/s(130건/5분)다. 나머지
+    # 93.4% 는 요청 0건이다.
+    #
+    # 그래서 여기서는 **비율과 분위수를 그대로 쓰면 안 된다.** 표본이 한 자릿수면
+    # 비율은 한 건에 튀고 분위수는 최악값과 같아진다. 두 룰 모두 "무엇이 나빠졌나"가
+    # 아니라 "느리거나 실패한 요청이 **몇 건** 있었나"를 절대 건수로 본다. #1204
     - name: istio
       rules:
+        # 비율만 보면 5분에 8건 받는 서비스에서 **5xx 한 건이 12.5%** 라 곧바로 임계를
+        # 넘는다. 절대 건수 가드를 and 로 붙여, 비율이 높아도 실제 실패가 3건 미만이면
+        # 울리지 않게 한다.
+        #
+        # 건수 쪽에 increase 를 쓰는 이유는 rate(req/s)로 쓰면 임계가 0.01 같은 값이 되어
+        # 읽는 사람이 "5분에 몇 건인가"를 암산해야 하기 때문이다. increase[5m] 은 그
+        # 자체가 5분간 건수다.
         - alert: IstioServiceErrorRateHigh
           expr: |
             sum by (destination_service) (rate(istio_requests_total{reporter="destination",response_code=~"5.."}[5m]))
               / sum by (destination_service) (rate(istio_requests_total{reporter="destination"}[5m])) > 0.05
+            and
+            sum by (destination_service) (increase(istio_requests_total{reporter="destination",response_code=~"5.."}[5m])) >= 3
           for: 5m
           labels:
             severity: warning
           annotations:
             summary: "Istio 서비스 5xx 비율 높음: {{ "{{" }} $labels.destination_service {{ "}}" }}"
-            description: "destination 5xx 비율이 5분간 5% 초과 (현재: {{ "{{" }} $value | printf \"%.2f\" {{ "}}" }})"
+            description: "destination 5xx 비율이 5분간 5% 초과 + 실제 5xx 3건 이상 (현재 비율: {{ "{{" }} $value | printf \"%.2f\" {{ "}}" }})"
 
-        - alert: IstioServiceLatencyP99High
+        # 이전 룰은 histogram_quantile(0.99, ...) > 2000 이었다. 두 가지가 틀렸다.
+        #
+        # 1) **2000ms 자리에는 버킷 경계가 없다.** 실측한 le 경계는 … 1000, 2500 … 이라
+        #    2000 은 폭 1,500ms 짜리 버킷 **안쪽**이고, 나온 값은 측정이 아니라 그
+        #    구간의 선형 보간이다. 2026-08-16 발화의 "p99 2387ms" 가 그 보간값이었고
+        #    같은 기간 **2.5초를 넘은 요청은 7일간 0건**이었다.
+        # 2) 표본이 8건이면 p99 는 통계량이 아니라 가장 느린 한 건이다.
+        #
+        # 요청량 가드(and rate > N)를 붙이는 방법은 검토했다가 **버렸다.** 실측상
+        # 0.2 req/s 가드는 평가되는 창을 1,690개 중 7개(0.4%)로 줄여 알림을 사실상
+        # 끄는 것과 같았다. 분위수를 유지하려면 이 트래픽에서는 끄는 수밖에 없다.
+        #
+        # 그래서 분위수를 버리고 **실재하는 버킷 경계(1000ms)를 넘은 요청 건수**를 센다.
+        # 보간이 없고 표본 수와 무관하다.
+        #
+        # ⚠️ le 는 문자열 라벨이고 실제 값은 "1000.0" 이다. le="1000" 으로 쓰면
+        # **조용히 아무것도 매칭되지 않아** 뺄셈이 빈 벡터가 되고 알림이 영영 울리지
+        # 않는다. 울리지 않는 알림은 틀린 알림보다 나쁘다 — 반드시 실측한 문자열을 쓴다.
+        #
+        # 임계 5건/5분 + for 10m 은 7일 실측에서 발화 0회다(1초 초과가 1건 이상인 창
+        # 자체가 7개뿐이고 최대가 8건, 그나마 10분을 잇지 않았다). 지속되는 저하만
+        # 잡고 실사용 중의 산발적 느린 요청은 넘긴다.
+        - alert: IstioServiceSlowRequests
           expr: |
-            histogram_quantile(0.99,
-              sum by (destination_service, le) (rate(istio_request_duration_milliseconds_bucket{reporter="destination"}[5m]))
-            ) > 2000
+            sum by (destination_service) (increase(istio_request_duration_milliseconds_bucket{reporter="destination",le="+Inf"}[5m]))
+              - sum by (destination_service) (increase(istio_request_duration_milliseconds_bucket{reporter="destination",le="1000.0"}[5m]))
+              > 5
           for: 10m
           labels:
             severity: warning
           annotations:
-            summary: "Istio 서비스 p99 지연 높음: {{ "{{" }} $labels.destination_service {{ "}}" }}"
-            description: "p99 레이턴시가 10분간 2초 초과 (현재: {{ "{{" }} $value | printf \"%.0f\" {{ "}}" }}ms)"
+            summary: "Istio 느린 요청 다발: {{ "{{" }} $labels.destination_service {{ "}}" }}"
+            description: "1초를 넘은 요청이 10분간 5분당 5건 초과 (현재: {{ "{{" }} $value | printf \"%.0f\" {{ "}}" }}건/5분)"
 
     - name: observability-self
       rules:


### PR DESCRIPTION
## 이슈
closes #1204
## 작업 내용
- `IstioServiceLatencyP99High` → **`IstioServiceSlowRequests`** 로 대체. 분위수 대신 **1초(실재 버킷 경계) 초과 요청 건수**를 센다
- `IstioServiceErrorRateHigh` 에 **5xx 절대 건수 3건 가드**를 `and` 로 추가
- 판단 근거와 `le` 문자열 함정을 룰 주석으로 남김

### 이슈가 제안한 "요청량 가드"는 실측 후 버렸다

이슈는 `and rate(istio_requests_total[5m]) > 0.2` 같은 가드를 제안했다. 7일치를 재 보니 **그 방법으로는 안 된다.**

| 가드 | be 가 평가되는 5분 창 |
|---|---|
| 없음 | 112 / 1,690 (6.6%) |
| 0.05 req/s | 58 (3.4%) |
| 0.10 req/s | 26 (1.5%) |
| **0.20 req/s** | **7 (0.4%)** |
| 0.33 req/s (p99에 표본 100건) | 2 (0.1%) |

be 는 **1,690개 창 중 6.6%에만 요청이 있고**, 있을 때도 최대 0.43 req/s(130건/5분)다. 분위수를 통계량으로 만들 만한 표본이 이 클러스터에는 아예 없다. 가드를 의미 있게 걸면 알림을 끄는 것과 같아진다.

### 기존 룰은 그보다 더 근본적으로 틀렸다

**2000ms 자리에는 버킷 경계가 없다.** 실측한 `le` 경계는 `… 500, 1000, 2500, 5000 …` 이라 2000은 폭 1,500ms 버킷의 **안쪽**이다. `histogram_quantile` 이 그 안에서 선형 보간한 값이 임계와 비교되고 있었다.

2026-08-16 발화의 "p99 2387ms"가 바로 그 보간값이다. 같은 기간 실제로 **2.5초를 넘은 요청은 7일간 0건**이었다.

### 그래서 분위수를 버렸다

```promql
sum by (destination_service) (increase(...{le="+Inf"}[5m]))
  - sum by (destination_service) (increase(...{le="1000.0"}[5m])) > 5
```

보간이 없고 표본 수와 무관하다. `increase[5m]` 은 그 자체가 "5분간 건수"라 임계값(5)을 읽는 사람이 암산할 필요도 없다.

> ⚠️ **`le` 는 문자열이고 실제 값은 `"1000.0"` 이다.** 작업 중 `le="2500"` 으로 먼저 써 봤다가 **아무것도 매칭되지 않아** 빈 벡터가 나오는 걸 확인했다. 그대로 배포했다면 알림이 영영 울리지 않았을 것이다 — 울리지 않는 알림은 틀린 알림보다 나쁘다. 주석에 남겼다.

### 5xx 비율 알림도 같은 병이었다

5분에 8건 받는 서비스에서 **5xx 한 건 = 12.5%** 로 임계(5%)를 즉시 넘는다. 비율은 유지하되 실제 실패 3건 미만이면 울리지 않게 `and` 를 붙였다.

### 검증

`helm template` 으로 렌더링한 **expr 문자열을 그대로** 라이브 Prometheus 에 던졌다(추정으로 넘기지 않는다).

- 두 룰 모두 파싱 OK, 현재 매칭 0건
- 새 식이 '항상 0'이 아님을 백테스트로 확인 — 7일간 1초 초과가 있던 창 7개를 정확히 집어냈다

| 시각(KST) | 1초 초과 건수/5분 |
|---|---:|
| 08-09 14:15 | 1.1 |
| 08-10 15:45 | 1.1 |
| 08-11 10:40 | 0.8 |
| 08-13 12:35 | 3.3 |
| 08-14 14:40 | 2.2 |
| 08-16 00:25 | 1.1 |
| **08-16 00:30** | **7.8** ← 임계 초과 |

**새 룰은 7일간 한 번도 발화하지 않는다 — 08-16 사건 때도 포함해서다.** 7.8건이 임계를 넘긴 창은 하나뿐이고 `for: 10m` 이 요구하는 지속성을 만족하지 못한다.

이건 의도한 결과다. 그 사건은 5분짜리 버스트였고 스스로 해소됐으며, 근본 원인은 #1203(경로 없는 구간을 매번 다시 호출)으로 따로 잡는다. **지속되는 저하만 잡고 실사용 중의 산발적 느린 요청은 넘긴다** — 매번 울려서 무시하게 되는 알림보다 낫다.

`yamllint` 통과. `helm template` 렌더링 확인 완료. kubeconform·helm lint 는 CI 가 돌린다.

### 머지 후 확인

- Prometheus `/rules` 에서 두 룰이 새 식으로 올라왔는지
- `IstioServiceLatencyP99High` 가 사라졌는지 (이름이 바뀌었으므로 기존 알림은 자동 해소된다)

---
- [x] (해당 시) S3 또는 유료 외부 API를 호출하는 컴포넌트를 추가했다면 — 주기 플래그를 values에 명시했고, 비용 대시보드에 나타나는가? ([주기 루프 인벤토리](https://github.com/wcorn/orino/wiki/Periodic-Loops)) — 해당 없음(알림 룰 식 변경, 새 컴포넌트·주기 호출 없음). 오히려 `rate[7d]` 같은 장기 스캔을 쓰지 않아 조회 비용도 늘지 않는다
