### PR TITLE
feat : 도시가 바뀌는 날은 두 도시에 속한다

### DIFF
--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/activity/dto/ActivityResponse.java
@@ -1,11 +1,11 @@
 package ds.project.orino.planner.travel.activity.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import ds.project.orino.domain.planner.travel.entity.TravelPlace;
 import ds.project.orino.domain.planner.travel.entity.TripActivity;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Set;
 
 /**
  * 일정 하나. 보드 목록과 상세가 같은 형태를 쓴다.
@@ -15,8 +15,11 @@ import java.time.LocalTime;
  * @param sortOrder    같은 날짜(또는 보관함) 안에서의 순서. 정렬의 유일한 기준이다
  * @param log          사후 기록(평점·메모). 아직 기록이 없으면 null
  * @param hasLog       기록 존재 여부. 목록은 {@code log}를 다 펼치지 않고 이 표시만 쓴다
- * @param outOfBaseCity      (v2.1) 그날 기준 도시와 <b>다른 도시</b>의 장소다 → 화면이 경고색으로
- *                           도시명을 덧붙인다. 판정은 {@code place.cityPlaceRef}로만 한다
+ * @param outOfBaseCity      (v2.1) 그날 <b>있어도 되는 어느 도시에도</b> 속하지 않는 장소다 →
+ *                           화면이 경고색으로 도시명을 덧붙인다. 판정은
+ *                           {@code place.cityPlaceRef}로만 한다. 도시가 바뀌는 날은 떠나온
+ *                           도시도 함께 통과시킨다(D-25) — 이동일 오전 일정은 잘못 담은 것이
+ *                           아니다
  * @param canDepartureNotify (v2.1) 출발 알림을 켤 수 있는가. <b>직전에 장소 있는 일정이 있고</b>
  *                           그 사이가 <b>도시를 넘지 않아야</b> 한다 — 도시를 넘는 이동은 계산
  *                           대상이 아니라 언제 나서야 하는지 정할 수 없다(§3.4)
@@ -58,13 +61,13 @@ public record ActivityResponse(
     }
 
     /**
-     * 그날 기준 도시와 견줘 도시 이탈 여부를 붙인다. 보드만 아는 값이라(상세 화면에는 "그날"이
-     * 없다) 조립을 마친 뒤 덧씌운다.
+     * 그날 있어도 되는 도시들과 견줘 도시 이탈 여부를 붙인다. 보드만 아는 값이라(상세 화면에는
+     * "그날"이 없다) 조립을 마친 뒤 덧씌운다.
      */
-    public ActivityResponse withBaseCity(String baseCityPlaceRef) {
+    public ActivityResponse withBaseCities(Set<String> baseCityPlaceRefs) {
         return new ActivityResponse(id, tripId, title, activityDate, startTime, place,
                 memo, url, notifyEnabled, notifyMinutes, departureNotifyEnabled,
-                sortOrder, log, hasLog, isOutOf(baseCityPlaceRef), canDepartureNotify);
+                sortOrder, log, hasLog, isOutOf(baseCityPlaceRefs), canDepartureNotify);
     }
 
     /**
@@ -78,11 +81,12 @@ public record ActivityResponse(
     }
 
     /**
-     * <b>식별자가 둘 다 있고 서로 다를 때만</b> 다른 도시로 본다. 한쪽이라도 모르면 판정하지
-     * 않는다 — 모르는 것을 "다르다"로 답하면 멀쩡한 일정에 경고가 붙는다.
+     * <b>양쪽 식별자를 다 알 때만</b> 다른 도시로 본다. 장소에 도시 식별자가 없거나 그날의
+     * 도시를 하나도 모르면(집합이 비면) 판정하지 않는다 — 모르는 것을 "다르다"로 답하면
+     * 멀쩡한 일정에 경고가 붙는다(D-23).
      */
-    private boolean isOutOf(String baseCityPlaceRef) {
-        return TravelPlace.crossesCity(
-                place == null ? null : place.cityPlaceRef(), baseCityPlaceRef);
+    private boolean isOutOf(Set<String> baseCityPlaceRefs) {
+        String ref = place == null ? null : place.cityPlaceRef();
+        return ref != null && !baseCityPlaceRefs.isEmpty() && !baseCityPlaceRefs.contains(ref);
     }
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/dto/BoardResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/dto/BoardResponse.java
@@ -65,10 +65,17 @@ public record BoardResponse(
      * @param dayIndex      1부터 시작하는 일차
      * @param weekday       한국어 요일 한 글자("금")
      * @param activityCount 그 날짜의 일정 수
-     * @param baseCity      그날의 기준 도시 — 타임존·통화·날씨 좌표가 전부 여기서 나온다
+     * @param baseCity      그날의 기준 도시 — 타임존·통화·날씨 좌표가 전부 여기서 나온다.
+     *                      도시가 바뀌는 날이면 <b>도착한 쪽</b>이다
      * @param cityChanged   직전 날짜와 도시가 다르다 → 탭 왼쪽에 구분선
+     * @param arrivingFrom  (D-25) 그날 <b>떠나온 도시</b>. 도시가 바뀌는 날에만 있다.
+     *                      화면은 날짜 탭을 {@code 오사카 → 교토}로 그리고, 그날 오전
+     *                      일정에는 도시 경고를 붙이지 않는다
      * @param legIndex      이 날짜가 속한 구간 번호(1부터). 저장값이 아니라 파생이다
      * @param weather       날씨 요약. 예보 범위(16일) 밖이면 null이다
+     * @param arrivingFromWeather 떠나온 도시의 그날 날씨. 도시가 바뀌는 날에만 있다 —
+     *                      오전을 보낸 도시의 날씨도 알아야 아침에 뭘 입을지 정한다.
+     *                      날씨는 도시 단위로 조회하므로 이 값 때문에 호출이 늘지 않는다
      * @param stayTonight   오늘 밤 자는 곳({@code checkIn <= date < checkOut})
      * @param stayCheckout  오늘 체크아웃하는 곳
      */
@@ -80,9 +87,11 @@ public record BoardResponse(
             long activityCount,
             BaseCityResponse baseCity,
             boolean cityChanged,
+            BaseCityResponse arrivingFrom,
             int legIndex,
             String cityMemo,
             WeatherResponse.DailyWeather weather,
+            WeatherResponse.DailyWeather arrivingFromWeather,
             StayTonight stayTonight,
             StayCheckout stayCheckout
     ) {

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/board/service/BoardService.java
@@ -16,11 +16,11 @@ import ds.project.orino.planner.travel.activity.dto.ActivityResponse;
 import ds.project.orino.planner.travel.board.dto.BoardResponse;
 import ds.project.orino.planner.travel.day.dto.BaseCityResponse;
 import ds.project.orino.planner.travel.day.service.LegDeriver;
+import ds.project.orino.planner.travel.day.service.TransitionDays;
 import ds.project.orino.planner.travel.day.service.TripClock;
 import ds.project.orino.planner.travel.day.service.TripDayService;
 import ds.project.orino.planner.travel.route.service.TravelTimeService;
 import ds.project.orino.planner.travel.stay.service.StayBoardAssembler;
-import ds.project.orino.planner.travel.tools.dto.WeatherResponse;
 import ds.project.orino.planner.travel.tools.service.WeatherService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,11 +30,13 @@ import java.time.LocalDate;
 import java.time.format.TextStyle;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -95,17 +97,23 @@ public class BoardService {
                 : activityRepository.findAllByTripIdAndActivityDateOrderBySortOrderAscIdAsc(
                         tripId, selectedDate);
 
-        // 선택한 날짜의 기준 도시. 도시 이탈 판정이 이 도시와 견준다.
+        List<TripDay> dayRows = dayRepository.findAllByTripIdOrderByDayDateAsc(trip.getId());
+        // 도시가 바뀌는 날 → 떠나온 도시. 날짜 탭과 도시 이탈 판정이 같은 파생을 쓴다.
+        Map<LocalDate, TravelPlace> departedCities = departedCitiesOf(dayRows, cities);
+
+        // 선택한 날짜에 있어도 되는 도시들. 이동일이면 떠나온 도시도 함께 통과시킨다(D-25).
         TravelPlace selectedCity = selectedDate == null ? null : cities.get(selectedDate);
+        TravelPlace departedCity = selectedDate == null ? null : departedCities.get(selectedDate);
         // 숙소는 여행 전체를 한 번에 읽는다 — 날짜 탭마다 조회하면 기간만큼 쿼리가 는다.
         StayBoardAssembler.Stays stays = stayAssembler.of(tripId);
 
         return new BoardResponse(
                 buildTrip(trip, cities, status),
-                buildDays(trip, cities, stays),
+                buildDays(trip, dayRows, cities, departedCities, stays),
                 selectedDate,
                 activityRepository.countUnscheduled(tripId),
-                withCityRules(activityService.toResponses(activities), selectedCity,
+                withCityRules(activityService.toResponses(activities),
+                        TransitionDays.cityRefsOf(selectedCity, departedCity),
                         // 보관함 일정은 날짜가 없어 출발 알림 시각 자체가 서지 않는다.
                         selectedDate == null ? Set.of()
                                 : travelTimeService.departureNotifiable(activities)),
@@ -140,19 +148,42 @@ public class BoardService {
     }
 
     /**
-     * 일정마다 도시 관련 판정을 붙인다 — 기준 도시 이탈, 그리고 출발 알림 가능 여부.
+     * 일정마다 도시 관련 판정을 붙인다 — 도시 이탈, 그리고 출발 알림 가능 여부.
      *
      * <p>둘 다 <b>그날 전체를 봐야</b> 나오는 값이라 일정 하나를 조립할 때는 알 수 없다.
      * 조립을 마친 뒤 덧씌운다.
+     *
+     * @param cityRefs 그날 있어도 되는 도시들. 이동일이면 둘이다(D-25)
      */
     private static List<ActivityResponse> withCityRules(List<ActivityResponse> activities,
-                                                        TravelPlace baseCity,
+                                                        Set<String> cityRefs,
                                                         Set<Long> departureNotifiable) {
-        String ref = baseCity == null ? null : baseCity.getCityPlaceRef();
         return activities.stream()
-                .map(activity -> activity.withBaseCity(ref)
+                .map(activity -> activity.withBaseCities(cityRefs)
                         .withCanDepartureNotify(departureNotifiable.contains(activity.id())))
                 .toList();
+    }
+
+    /**
+     * 도시가 바뀌는 날 → 떠나온 도시. {@link TransitionDays}가 장소 id로 답하는 것을 그날의
+     * 장소로 풀어 둔다 — 날짜 탭과 일정 판정이 같은 값을 쓴다.
+     *
+     * <p>이미 읽어 둔 {@code cities}로 장소를 푼다 — 날짜 탭이 쓰는 도시와 같은 객체라
+     * 조회가 늘지 않는다. {@code cityChanged}도 이 맵의 {@code containsKey}로 답한다.
+     */
+    private static Map<LocalDate, TravelPlace> departedCitiesOf(
+            List<TripDay> dayRows, Map<LocalDate, TravelPlace> cities) {
+        Map<Long, TravelPlace> byPlaceId = cities.values().stream()
+                .collect(Collectors.toMap(TravelPlace::getId, Function.identity(),
+                        (kept, duplicate) -> kept));
+        Map<LocalDate, TravelPlace> departed = new LinkedHashMap<>();
+        TransitionDays.departedByDate(dayRows).forEach((date, placeId) -> {
+            TravelPlace city = byPlaceId.get(placeId);
+            if (city != null) {
+                departed.put(date, city);
+            }
+        });
+        return departed;
     }
 
     /**
@@ -178,24 +209,29 @@ public class BoardService {
      * <p>날짜마다 기준 도시와 구간 번호가 붙는다. {@code cityChanged}는 <b>직전 날짜와 도시가
      * 다른가</b>이고, 화면은 그 자리에 구분선을 긋는다 — 도시가 바뀌는 지점이 한눈에 보여야
      * 며칠씩 이어지는 일정에서 길을 잃지 않는다.
+     *
+     * <p>그 날짜에는 <b>떠나온 도시도 함께</b> 붙는다(D-25). 탭이 {@code 오사카 → 교토}로
+     * 그려지고 날씨도 두 도시가 나온다 — 이동일 오전은 아직 그 도시에 있기 때문이다.
      */
     private List<BoardResponse.BoardDay> buildDays(Trip trip,
+                                                   List<TripDay> dayRows,
                                                    Map<LocalDate, TravelPlace> cities,
+                                                   Map<LocalDate, TravelPlace> departedCities,
                                                    StayBoardAssembler.Stays stays) {
         Map<LocalDate, Long> counts = activityRepository.countByDate(trip.getId()).stream()
                 .collect(Collectors.toMap(ActivityDateCount::activityDate, ActivityDateCount::count));
         // 날짜 탭이 전부 필요로 하므로 여행 기간을 한 번에 받는다(§S-08).
         // 도시별로 한 번씩만 조회한다 — 열흘짜리 여행이 열 번을 부르면 안 된다.
-        Map<LocalDate, WeatherResponse.DailyWeather> weather =
-                weatherService.dailyByDate(trip, cities);
-        List<TripDay> dayRows = dayRepository.findAllByTripIdOrderByDayDateAsc(trip.getId());
+        WeatherService.DailyForecasts weather =
+                weatherService.dailyByDate(cities, departedCities);
         Map<LocalDate, Integer> legIndexes = legIndexByDate(dayRows);
 
         List<BoardResponse.BoardDay> days = new ArrayList<>();
-        Long previousCity = null;
         for (TripDay row : dayRows) {
             LocalDate date = row.getDayDate();
             TravelPlace city = cities.get(date);
+            // 도시가 바뀐 날에만 키가 있다 — cityChanged와 arrivingFrom이 한 파생에서 나온다.
+            TravelPlace from = departedCities.get(date);
             days.add(new BoardResponse.BoardDay(
                     row.getId(),
                     trip.dayNumberOf(date),
@@ -203,15 +239,15 @@ public class BoardService {
                     date.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN),
                     counts.getOrDefault(date, 0L),
                     city == null ? null : BaseCityResponse.from(city),
-                    // 첫날은 "바뀐 것"이 아니다 — 비교할 앞 날짜가 없다.
-                    previousCity != null && !previousCity.equals(row.getBasePlaceId()),
+                    departedCities.containsKey(date),
+                    from == null ? null : BaseCityResponse.from(from),
                     legIndexes.getOrDefault(date, 1),
                     row.getCityMemo(),
                     // 예보 범위(오늘부터 16일) 밖이면 null이다 — 화면이 그 자리를 비운다.
-                    weather.get(date),
+                    weather.arrived().get(date),
+                    weather.departed().get(date),
                     stayAssembler.tonight(stays, date, city),
                     stayAssembler.checkout(stays, date)));
-            previousCity = row.getBasePlaceId();
         }
         return days;
     }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/dto/TripDayResponse.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/dto/TripDayResponse.java
@@ -10,6 +10,8 @@ import java.time.LocalDate;
  * @param weekday      한국어 요일 한 글자("화")
  * @param legIndex     이 날짜가 속한 구간 번호(1부터). 저장된 값이 아니라 파생이다
  * @param cityChanged  직전 날짜와 기준 도시가 다르다 — 날짜 탭 왼쪽에 구분선이 붙는다
+ * @param arrivingFrom (D-25) 그날 떠나온 도시. 도시가 바뀌는 날에만 있다 — 구간 편집기가
+ *                     구간 카드 사이에 {@code 10.28 오사카 → 교토} 이동 줄을 그린다
  */
 public record TripDayResponse(
         Long dayId,
@@ -19,6 +21,7 @@ public record TripDayResponse(
         int legIndex,
         boolean cityChanged,
         String cityMemo,
-        BaseCityResponse baseCity
+        BaseCityResponse baseCity,
+        BaseCityResponse arrivingFrom
 ) {
 }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/TransitionDays.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/TransitionDays.java
@@ -1,0 +1,68 @@
+package ds.project.orino.planner.travel.day.service;
+
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.entity.TripDay;
+
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 도시가 바뀌는 날 — <b>그 하루는 두 도시에 속한다</b>(D-25).
+ *
+ * <p>오사카 구간이 10.27에 끝나고 교토 구간이 10.28에 시작하면, 10.28은 오전엔 오사카고
+ * 오후엔 교토다. 그날의 기준 도시는 <b>도착한 도시 하나</b>로 두되(시계가 둘이면 "오늘"의
+ * 정의가 무너진다), 어디에 있었는지를 묻는 판정은 <b>떠나온 도시도 함께</b> 본다.
+ *
+ * <p><b>저장하지 않는다.</b> 떠나온 도시는 직전 날짜의 기준 도시일 뿐이라 {@code trip_day}만
+ * 있으면 매번 나온다. 구간을 박(night) 단위로 저장해 경계일을 공유시키는 안도 검토했지만,
+ * 그러면 SSOT가 날짜에서 구간으로 옮겨 가고({@link LegDeriver} 참조) <b>당일치기를 표현하지
+ * 못한다</b> — 도쿄에 자면서 닛코에 다녀오는 날은 자는 도시가 도쿄라 닛코가 사라진다. 박은
+ * {@code trip_stay}가 이미 정확히 안다.
+ */
+public final class TransitionDays {
+
+    private TransitionDays() {
+    }
+
+    /**
+     * 도시가 바뀌는 날 → <b>떠나온 도시</b>의 장소 id.
+     *
+     * <p>바뀌지 않는 날은 키 자체가 없다 — 그래서 {@code containsKey}가 곧 "도시가 바뀌었나"다.
+     * 첫날은 비교할 앞 날짜가 없으므로 바뀐 것이 아니다.
+     *
+     * @param days <b>날짜 오름차순</b>으로 정렬된 여행 날짜. 순서가 어긋나면 판정도 어긋난다
+     */
+    public static Map<LocalDate, Long> departedByDate(Iterable<TripDay> days) {
+        Map<LocalDate, Long> departed = new LinkedHashMap<>();
+        TripDay previous = null;
+        for (TripDay day : days) {
+            if (previous != null && !previous.getBasePlaceId().equals(day.getBasePlaceId())) {
+                departed.put(day.getDayDate(), previous.getBasePlaceId());
+            }
+            previous = day;
+        }
+        return departed;
+    }
+
+    /**
+     * 그날 <b>있어도 되는 도시</b>의 식별자들. 일정이 이 중 어디에도 속하지 않을 때만 다른
+     * 도시로 본다.
+     *
+     * <p>식별자가 없는 도시(직접 입력한 도시)는 넣지 않는다. 전부 빠져 집합이 비면 판정 자체를
+     * 하지 않는다 — 모르는 것을 "다르다"로 답하면 멀쩡한 일정에 경고가 붙는다(D-23).
+     *
+     * @param cities 도착한 도시와 떠나온 도시. {@code null}은 건너뛴다
+     */
+    public static Set<String> cityRefsOf(TravelPlace... cities) {
+        Set<String> refs = new LinkedHashSet<>();
+        for (TravelPlace city : cities) {
+            if (city != null && city.getCityPlaceRef() != null) {
+                refs.add(city.getCityPlaceRef());
+            }
+        }
+        return refs;
+    }
+}

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/TripDayQueryService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/TripDayQueryService.java
@@ -50,21 +50,25 @@ public class TripDayQueryService {
         Map<Long, TravelPlace> cities = citiesOf(days);
         Map<LocalDate, Integer> legIndexes = legIndexByDate(days);
 
+        // 도시가 바뀌는 날 → 떠나온 도시. 키가 있다는 것 자체가 "바뀌었다"이므로
+        // cityChanged와 arrivingFrom이 한 곳에서 나온다 — 둘이 어긋날 수 없다.
+        Map<LocalDate, Long> departed = TransitionDays.departedByDate(days);
+
         List<TripDayResponse> responses = new ArrayList<>();
-        Long previousCity = null;
         for (TripDay day : days) {
             TravelPlace city = cities.get(day.getBasePlaceId());
+            Long departedId = departed.get(day.getDayDate());
+            TravelPlace from = departedId == null ? null : cities.get(departedId);
             responses.add(new TripDayResponse(
                     day.getId(),
                     trip.dayNumberOf(day.getDayDate()),
                     day.getDayDate(),
                     weekdayOf(day.getDayDate()),
                     legIndexes.getOrDefault(day.getDayDate(), 1),
-                    // 첫날은 "바뀐 것"이 아니다 — 비교할 앞 날짜가 없다.
-                    previousCity != null && !previousCity.equals(day.getBasePlaceId()),
+                    departed.containsKey(day.getDayDate()),
                     day.getCityMemo(),
-                    city == null ? null : BaseCityResponse.from(city)));
-            previousCity = day.getBasePlaceId();
+                    city == null ? null : BaseCityResponse.from(city),
+                    from == null ? null : BaseCityResponse.from(from)));
         }
         return responses;
     }

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/TripDayService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/day/service/TripDayService.java
@@ -142,6 +142,29 @@ public class TripDayService {
     }
 
     /**
+     * 도시가 바뀌는 날 → <b>떠나온 도시</b>(D-25). 그 외 날짜는 키가 없다.
+     *
+     * <p>이동일 오전은 아직 떠나온 도시에 있다. 그날 있어도 되는 도시를 묻는 쪽(도시 이탈
+     * 판정·날씨)이 이 값을 {@link #baseCitiesOf}와 함께 본다.
+     */
+    public Map<LocalDate, TravelPlace> departedCitiesOf(Long tripId) {
+        List<TripDay> days = dayRepository.findAllByTripIdOrderByDayDateAsc(tripId);
+        Map<Long, TravelPlace> places = placeRepository
+                .findAllById(days.stream().map(TripDay::getBasePlaceId).distinct().toList())
+                .stream()
+                .collect(Collectors.toMap(TravelPlace::getId, Function.identity()));
+
+        Map<LocalDate, TravelPlace> departed = new LinkedHashMap<>();
+        TransitionDays.departedByDate(days).forEach((date, placeId) -> {
+            TravelPlace city = places.get(placeId);
+            if (city != null) {
+                departed.put(date, city);
+            }
+        });
+        return departed;
+    }
+
+    /**
      * 여행 여럿의 <b>날짜별</b> 기준 도시를 한 번에. 상태 판정은 오늘에 해당하는 날짜의
      * 타임존으로 하므로 첫날만으로는 부족하다.
      *

--- a/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/WeatherService.java
+++ b/be/orino-app-api/src/main/java/ds/project/orino/planner/travel/tools/service/WeatherService.java
@@ -73,34 +73,58 @@ public class WeatherService {
      * <p>날짜마다 조회하면 열흘짜리 여행이 열 번을 부른다. 도시 단위로 묶으면 오사카 3일
      * 여행은 1회, 도쿄 → 닛코 → 도쿄는 2회다(같은 도시는 캐시를 공유한다).
      *
+     * <p><b>도시가 바뀌는 날은 두 도시를 준다</b>(D-25) — 오전을 보낸 도시의 날씨도 알아야
+     * 아침에 뭘 입을지 정한다. 떠나온 도시는 <b>반드시 다른 날짜의 기준 도시</b>이므로 예보를
+     * 이미 읽어 둔 상태고, 그래서 이 값 때문에 조회가 늘지 않는다.
+     *
      * <p>기준 도시 좌표가 없으면(직접 입력한 도시) 그 날짜만 날씨가 없다 — 다른 도시 날짜는
      * 멀쩡히 나온다.
+     *
+     * @param departedCities 도시가 바뀌는 날 → 떠나온 도시. 그 외 날짜는 키가 없다
      */
-    public Map<LocalDate, WeatherResponse.DailyWeather> dailyByDate(
-            Trip trip, Map<LocalDate, TravelPlace> cities) {
+    public DailyForecasts dailyByDate(Map<LocalDate, TravelPlace> cities,
+                                      Map<LocalDate, TravelPlace> departedCities) {
+        // 두 갈래가 같은 조회 결과를 나눠 쓴다 — 따로 돌면 떠나온 도시를 한 번 더 읽는다.
+        Map<Long, WeatherResponse> byCity = new HashMap<>();
+        return new DailyForecasts(dayByDate(cities, byCity),
+                dayByDate(departedCities, byCity));
+    }
+
+    /**
+     * 날짜를 순서대로 훑으며 그날 그 도시의 예보를 뽑는다. 도시별로 한 번만 조회하도록
+     * {@code byCity}에 묶어 둔다 — 도쿄 → 닛코 → 도쿄는 2회다.
+     */
+    private Map<LocalDate, WeatherResponse.DailyWeather> dayByDate(
+            Map<LocalDate, TravelPlace> cities, Map<Long, WeatherResponse> byCity) {
         Map<LocalDate, WeatherResponse.DailyWeather> byDate = new HashMap<>();
-        walkByCity(cities, (date, city, forecast) -> dayOf(forecast, date)
-                .ifPresent(day -> byDate.put(date, day.in(cityNameOf(city)))));
+        cities.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> dayIn(entry.getKey(), entry.getValue(), byCity)
+                        .ifPresent(day -> byDate.put(entry.getKey(), day)));
         return byDate;
     }
 
     /**
-     * 날짜를 순서대로 훑으며 <b>그날 기준 도시의 예보</b>를 넘긴다. 도시별로 한 번만
-     * 조회하도록 여기서 묶는다 — 도쿄 → 닛코 → 도쿄는 2회다.
+     * 그날 그 도시의 예보 한 줄. 같은 도시를 다시 물으면 {@code byCity}에서 꺼내 쓴다 —
+     * 도시가 바뀌는 날의 떠나온 도시는 <b>다른 날짜의 기준 도시이기도 해서</b> 이미 읽혀 있다.
      */
-    private void walkByCity(Map<LocalDate, TravelPlace> cities, DayForecast consumer) {
-        Map<Long, WeatherResponse> byCity = new HashMap<>();
-        cities.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey())
-                .forEach(entry -> {
-                    TravelPlace city = entry.getValue();
-                    consumer.accept(entry.getKey(), city,
-                            byCity.computeIfAbsent(city.getId(), id -> forecastOf(city)));
-                });
+    private Optional<WeatherResponse.DailyWeather> dayIn(LocalDate date, TravelPlace city,
+                                                         Map<Long, WeatherResponse> byCity) {
+        WeatherResponse forecast =
+                byCity.computeIfAbsent(city.getId(), id -> forecastOf(city));
+        return dayOf(forecast, date).map(day -> day.in(cityNameOf(city)));
     }
 
-    private interface DayForecast {
-        void accept(LocalDate date, TravelPlace city, WeatherResponse forecast);
+    /**
+     * 날짜 탭의 날씨.
+     *
+     * @param arrived  그날 기준 도시(도시가 바뀌는 날이면 도착한 쪽)의 날씨
+     * @param departed 도시가 바뀌는 날의 <b>떠나온 도시</b> 날씨. 그 외 날짜는 키가 없다
+     */
+    public record DailyForecasts(
+            Map<LocalDate, WeatherResponse.DailyWeather> arrived,
+            Map<LocalDate, WeatherResponse.DailyWeather> departed
+    ) {
     }
 
     private static Optional<WeatherResponse.DailyWeather> dayOf(WeatherResponse forecast,
@@ -126,18 +150,34 @@ public class WeatherService {
      *
      * <p>첫날 도시 하나로 보면 다구간 여행에서 교토 날짜에 도쿄 날씨가 뜬다 — 같은 나라
      * 안에서도 산간·해안은 몇 도씩 갈린다. 날짜 목록이 곧 기간이라 따로 잘라낼 것도 없다.
+     *
+     * <p><b>도시가 바뀌는 날은 줄이 둘이다</b>(D-25) — 떠나온 도시가 먼저, 도착한 도시가
+     * 다음이다. 화면의 날씨 행에 도시명 열이 있어 두 줄이 그대로 읽힌다. 시간대별 예보는
+     * 그날의 기준 도시(도착한 쪽) 하나만 둔다 — 하루에 시계가 둘일 수는 없다.
      */
     private WeatherResponse forecastOf(Trip trip) {
+        Map<LocalDate, TravelPlace> cities = tripDayService.baseCitiesOf(trip.getId());
+        Map<LocalDate, TravelPlace> departed = tripDayService.departedCitiesOf(trip.getId());
         List<WeatherResponse.DailyWeather> daily = new ArrayList<>();
         Map<LocalDate, List<WeatherResponse.HourlyWeather>> hourly = new HashMap<>();
+        Map<Long, WeatherResponse> byCity = new HashMap<>();
 
-        walkByCity(tripDayService.baseCitiesOf(trip.getId()), (date, city, forecast) -> {
-            dayOf(forecast, date).ifPresent(day -> daily.add(day.in(cityNameOf(city))));
-            List<WeatherResponse.HourlyWeather> hours = forecast.hourly().get(date);
-            if (hours != null) {
-                hourly.put(date, hours);
-            }
-        });
+        cities.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> {
+                    LocalDate date = entry.getKey();
+                    TravelPlace city = entry.getValue();
+                    TravelPlace from = departed.get(date);
+                    if (from != null) {
+                        dayIn(date, from, byCity).ifPresent(daily::add);
+                    }
+                    dayIn(date, city, byCity).ifPresent(daily::add);
+                    List<WeatherResponse.HourlyWeather> hours =
+                            byCity.get(city.getId()).hourly().get(date);
+                    if (hours != null) {
+                        hourly.put(date, hours);
+                    }
+                });
         return new WeatherResponse(WeatherResponse.SOURCE, WeatherResponse.LICENSE,
                 clock.instant(), daily, hourly);
     }

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardV21Test.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/board/controller/BoardV21Test.java
@@ -289,6 +289,145 @@ class BoardV21Test extends ApiTestSupport {
         }
     }
 
+    /**
+     * 도시가 바뀌는 날은 <b>그 하루가 두 도시에 속한다</b>(D-25). 오전엔 아직 떠나온 도시에
+     * 있고 오후에 도착한다.
+     *
+     * <p>이 규칙이 없으면 이동일 오전 일정에 전부 경고가 붙는다 — 7구간 여행이면 이동일이
+     * 여섯 번이라 <b>여섯 날의 오전이 통째로 잘못 담은 것처럼 보인다.</b>
+     */
+    @Nested
+    @DisplayName("도시가 바뀌는 날 — 그 하루는 두 도시에 속한다")
+    class TransitionDay {
+
+        @Test
+        @DisplayName("이동일 오전, 떠나온 도시의 일정에는 경고가 붙지 않는다")
+        void keepsActivityInDepartedCity() throws Exception {
+            long tripId = transitionTrip();
+            long placeId = poiInCity("센소지", "도쿄", "ChIJ_tokyo");
+            createActivity(tripId, "센소지", transitionDate(), placeId);
+
+            board(tripId, transitionDate())
+                    .andExpect(jsonPath("$.data.activities[0].outOfBaseCity").value(false));
+        }
+
+        @Test
+        @DisplayName("도착한 도시의 일정도 물론 경고가 없다")
+        void keepsActivityInArrivedCity() throws Exception {
+            long tripId = transitionTrip();
+            long placeId = poiInCity("도쇼구", "닛코", "ChIJ_nikko");
+            createActivity(tripId, "도쇼구", transitionDate(), placeId);
+
+            board(tripId, transitionDate())
+                    .andExpect(jsonPath("$.data.activities[0].outOfBaseCity").value(false));
+        }
+
+        /**
+         * 두 도시를 통과시키는 것이 <b>판정을 끄는 것이 아니다.</b> 여기서 경고가 사라지면
+         * 경고 기능 자체가 죽은 것이고, 잘못 담은 장소를 영영 알 수 없다.
+         */
+        @Test
+        @DisplayName("두 도시 어디도 아니면 이동일에도 경고가 선다")
+        void stillFlagsAThirdCity() throws Exception {
+            long tripId = transitionTrip();
+            long placeId = poiInCity("오사카성", "오사카", "ChIJ_osaka");
+            createActivity(tripId, "오사카성", transitionDate(), placeId);
+
+            board(tripId, transitionDate())
+                    .andExpect(jsonPath("$.data.activities[0].outOfBaseCity").value(true));
+        }
+
+        /**
+         * 규칙이 이동일에만 걸리는지 보는 자리다. 날짜와 무관하게 전날 도시를 통과시키면
+         * 닛코 이틀째에 도쿄 장소를 담아도 조용해진다 — 그건 실제로 잘못 담은 것이다.
+         */
+        @Test
+        @DisplayName("이동일이 아닌 날은 전날 도시를 통과시키지 않는다")
+        void doesNotLeakIntoTheNextDay() throws Exception {
+            long tripId = transitionTrip();
+            String afterTransition = START.plusDays(3).toString();
+            long placeId = poiInCity("센소지", "도쿄", "ChIJ_tokyo");
+            createActivity(tripId, "센소지", afterTransition, placeId);
+
+            board(tripId, afterTransition)
+                    .andExpect(jsonPath("$.data.activities[0].outOfBaseCity").value(true));
+        }
+
+        @Test
+        @DisplayName("이동일에만 arrivingFrom이 붙는다 — 탭이 오사카 → 교토로 그려진다")
+        void carriesArrivingFrom() throws Exception {
+            long tripId = transitionTrip();
+
+            board(tripId)
+                    // 첫날은 바뀐 것이 아니다 — 떠나온 도시도 없다.
+                    .andExpect(jsonPath("$.data.days[0].arrivingFrom").doesNotExist())
+                    .andExpect(jsonPath("$.data.days[1].arrivingFrom").doesNotExist())
+                    .andExpect(jsonPath("$.data.days[2].cityChanged").value(true))
+                    .andExpect(jsonPath("$.data.days[2].arrivingFrom.name").value("도쿄"))
+                    .andExpect(jsonPath("$.data.days[2].baseCity.name").value("닛코"))
+                    // 도착한 다음 날은 이미 그 도시에 있다.
+                    .andExpect(jsonPath("$.data.days[3].arrivingFrom").doesNotExist());
+        }
+
+        /**
+         * 당일치기 — 도쿄에 자면서 닛코에 다녀오는 날. 박(night) 단위로 구간을 저장하면
+         * 자는 도시가 도쿄라 닛코가 통째로 사라지는데, 날짜 기준이라 <b>앞뒤로 이동일이 두
+         * 번</b> 서면서 그대로 표현된다(D-25).
+         */
+        @Test
+        @DisplayName("당일치기는 갈 때와 돌아올 때 두 번 다 이동일이다")
+        void dayTripTransitionsBothWays() throws Exception {
+            long tripId = createTrip(leg(tokyo, 1), leg(nikko, 1), leg(tokyo, 2));
+
+            board(tripId)
+                    .andExpect(jsonPath("$.data.days[1].arrivingFrom.name").value("도쿄"))
+                    .andExpect(jsonPath("$.data.days[2].arrivingFrom.name").value("닛코"))
+                    .andExpect(jsonPath("$.data.days[3].arrivingFrom").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("이동일엔 떠나온 도시 날씨도 온다 — 오전에 뭘 입을지는 그 도시가 정한다")
+        void showsWeatherOfBothCities() throws Exception {
+            LocalDate today = LocalDate.now(java.time.ZoneId.of("Asia/Tokyo"));
+            weatherStub.byCoordinates = coords -> forecast(today,
+                    coords.startsWith(tokyoLat) ? 20 : 10);
+            long tripId = createTripFrom(today, leg(tokyo, 1), leg(nikko, 1));
+
+            board(tripId, today.toString())
+                    .andExpect(jsonPath("$.data.days[1].weather.tempMax").value(10))
+                    .andExpect(jsonPath("$.data.days[1].arrivingFromWeather.tempMax").value(20))
+                    .andExpect(jsonPath("$.data.days[1].arrivingFromWeather.cityName")
+                            .value("도쿄"))
+                    // 도착한 날은 이동일이 아니다 — 떠나온 도시가 없다.
+                    .andExpect(jsonPath("$.data.days[0].arrivingFromWeather").doesNotExist());
+        }
+
+        /**
+         * 떠나온 도시는 <b>반드시 다른 날짜의 기준 도시</b>라 예보를 이미 읽어 둔 상태다.
+         * 여기서 숫자가 늘면 이동일마다 유료 호출이 하나씩 더 붙는다는 뜻이다.
+         */
+        @Test
+        @DisplayName("두 도시를 보여줘도 날씨 조회는 늘지 않는다")
+        void doesNotAddWeatherCalls() throws Exception {
+            long tripId = createTrip(leg(tokyo, 1), leg(nikko, 1), leg(tokyo, 2));
+
+            board(tripId).andExpect(status().isOk());
+
+            assertThat(weatherStub.calls).hasSize(2);
+        }
+
+        /** 도쿄 2일 → 닛코 2일. 3일차(START+2)가 이동일이다. */
+        private long transitionTrip() throws Exception {
+            withCityRef(tokyo, "ChIJ_tokyo");
+            withCityRef(nikko, "ChIJ_nikko");
+            return createTrip(leg(tokyo, 2), leg(nikko, 2));
+        }
+
+        private String transitionDate() {
+            return START.plusDays(2).toString();
+        }
+    }
+
     @Nested
     @DisplayName("기준 도시 변경 — 검색 결과 그대로")
     class ChangeBaseCityFromSearch {
@@ -396,11 +535,15 @@ class BoardV21Test extends ApiTestSupport {
 
     /** 도시 식별자를 가진 일반 장소. 도시 이탈 판정은 이 값만 본다. */
     private long poiInCity(String name, String cityPlaceRef) {
+        return poiInCity(name, "오사카", cityPlaceRef);
+    }
+
+    private long poiInCity(String name, String cityName, String cityPlaceRef) {
         Long memberId = memberRepository.findAll().get(0).getId();
         TravelPlace place = placeRepository.save(
                 TravelPlace.fromGoogle(memberId, "g-" + UUID.randomUUID(), name));
         place.updateBasics(null, new BigDecimal("35.71"), new BigDecimal("139.79"), null, null);
-        place.updateCityInfo(cityPlaceRef == null ? null : "오사카", cityPlaceRef, "JP");
+        place.updateCityInfo(cityPlaceRef == null ? null : cityName, cityPlaceRef, "JP");
         return placeRepository.saveAndFlush(place).getId();
     }
 

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/day/TransitionDaysTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/day/TransitionDaysTest.java
@@ -1,0 +1,115 @@
+package ds.project.orino.planner.travel.day;
+
+import ds.project.orino.domain.planner.travel.entity.TravelPlace;
+import ds.project.orino.domain.planner.travel.entity.TripDay;
+import ds.project.orino.planner.travel.day.service.TransitionDays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 도시가 바뀌는 날의 파생 규칙을 고정한다. 이동일은 저장되지 않으므로(D-25) <b>이 계산이 곧
+ * "그 하루가 두 도시에 속한다"의 정의</b>다.
+ */
+class TransitionDaysTest {
+
+    private static final LocalDate OCT24 = LocalDate.of(2026, 10, 24);
+    private static final Long OSAKA = 1L;
+    private static final Long KYOTO = 2L;
+    private static final Long TOKYO = 3L;
+
+    @Test
+    @DisplayName("도시가 바뀌는 날에 떠나온 도시가 붙는다 — 그 하루는 두 도시에 속한다")
+    void marksDepartedCity() {
+        Map<LocalDate, Long> departed =
+                TransitionDays.departedByDate(days(OSAKA, OSAKA, KYOTO, KYOTO));
+
+        assertThat(departed).containsExactly(Map.entry(OCT24.plusDays(2), OSAKA));
+    }
+
+    @Test
+    @DisplayName("첫날은 바뀐 것이 아니다 — 비교할 앞 날짜가 없다")
+    void firstDayIsNotATransition() {
+        assertThat(TransitionDays.departedByDate(days(OSAKA, OSAKA)))
+                .doesNotContainKey(OCT24);
+    }
+
+    /**
+     * 당일치기가 박 기준 구간으로는 표현되지 않는 자리다 — 그날 밤은 도쿄에서 자므로 숙박으로
+     * 보면 닛코가 사라진다. 날짜 기준이라 <b>앞뒤로 이동일이 두 번</b> 선다.
+     */
+    @Test
+    @DisplayName("당일치기는 앞뒤 두 날이 모두 이동일이다")
+    void dayTripMakesTwoTransitions() {
+        Map<LocalDate, Long> departed =
+                TransitionDays.departedByDate(days(TOKYO, KYOTO, TOKYO, TOKYO));
+
+        assertThat(departed).containsExactly(
+                Map.entry(OCT24.plusDays(1), TOKYO),
+                Map.entry(OCT24.plusDays(2), KYOTO));
+    }
+
+    @Test
+    @DisplayName("도시가 한 번도 안 바뀌면 이동일이 없다")
+    void singleCityHasNoTransition() {
+        assertThat(TransitionDays.departedByDate(days(OSAKA, OSAKA, OSAKA))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("날짜가 없으면 이동일도 없다")
+    void emptyDays() {
+        assertThat(TransitionDays.departedByDate(List.of())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("두 도시의 식별자를 모은다 — 이동일에 있어도 되는 곳이 둘이다")
+    void collectsBothCityRefs() {
+        assertThat(TransitionDays.cityRefsOf(cityRef("ChIJ_kyoto"), cityRef("ChIJ_osaka")))
+                .containsExactly("ChIJ_kyoto", "ChIJ_osaka");
+    }
+
+    @Test
+    @DisplayName("떠나온 도시가 없으면(이동일이 아니면) 도착 도시 하나뿐이다")
+    void singleCityRefWhenNotTransition() {
+        assertThat(TransitionDays.cityRefsOf(cityRef("ChIJ_kyoto"), null))
+                .containsExactly("ChIJ_kyoto");
+    }
+
+    /**
+     * 식별자가 없는 도시(직접 입력)는 비교할 값이 없다. 집합이 비면 판정 자체를 하지 않아야
+     * 하므로, 여기서 빈 집합이 나오는 것이 곧 "판정하지 않는다"의 입구다(D-23).
+     */
+    @Test
+    @DisplayName("식별자 없는 도시는 넣지 않는다 — 모르는 것으로 판정하지 않는다")
+    void skipsCitiesWithoutIdentifier() {
+        assertThat(TransitionDays.cityRefsOf(cityRef(null), null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("같은 도시로 되돌아오는 날은 식별자가 하나로 합쳐진다")
+    void deduplicatesSameCity() {
+        assertThat(TransitionDays.cityRefsOf(cityRef("ChIJ_tokyo"), cityRef("ChIJ_tokyo")))
+                .containsExactly("ChIJ_tokyo");
+    }
+
+    /** 10.24부터 하루씩, 주어진 순서대로 기준 도시를 붙인 날짜들. */
+    private static List<TripDay> days(Long... basePlaceIds) {
+        List<TripDay> days = new ArrayList<>();
+        for (int i = 0; i < basePlaceIds.length; i++) {
+            days.add(new TripDay(1L, OCT24.plusDays(i), basePlaceIds[i]));
+        }
+        return days;
+    }
+
+    private static TravelPlace cityRef(String cityPlaceRef) {
+        TravelPlace city = TravelPlace.fromGoogle(1L, "g-city", "도시");
+        city.updateCityInfo("도시", cityPlaceRef, "JP");
+        return city;
+    }
+}

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/day/TripDayControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/day/TripDayControllerTest.java
@@ -92,7 +92,28 @@ class TripDayControllerTest extends ApiTestSupport {
                     .andExpect(jsonPath("$.data[0].legIndex").value(1))
                     // 첫날은 "바뀐 것"이 아니다 — 비교할 앞 날짜가 없다.
                     .andExpect(jsonPath("$.data[0].cityChanged").value(false))
+                    .andExpect(jsonPath("$.data[0].arrivingFrom").doesNotExist())
                     .andExpect(jsonPath("$.data[3].dayIndex").value(4));
+        }
+
+        /**
+         * 구간 편집기(S-03)가 구간 카드 사이에 {@code 10.28 도쿄 → 닛코} 이동 줄을 그린다 —
+         * 경계일이 어느 날인지가 보여야 "그날 오전은 아직 도쿄"라는 것이 읽힌다(D-25).
+         */
+        @Test
+        @DisplayName("도시가 바뀌는 날에는 떠나온 도시가 함께 온다")
+        void carriesDepartedCityOnTransitionDay() throws Exception {
+            changeBaseCity(dayIdAt(2), nikko);
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/days")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data[1].arrivingFrom").doesNotExist())
+                    .andExpect(jsonPath("$.data[2].cityChanged").value(true))
+                    .andExpect(jsonPath("$.data[2].baseCity.name").value("닛코"))
+                    .andExpect(jsonPath("$.data[2].arrivingFrom.name").value("도쿄"))
+                    // 닛코에서 도쿄로 돌아오는 날도 이동일이다.
+                    .andExpect(jsonPath("$.data[3].arrivingFrom.name").value("닛코"));
         }
 
         @Test

--- a/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/ToolsControllerTest.java
+++ b/be/orino-app-api/src/test/java/ds/project/orino/planner/travel/tools/ToolsControllerTest.java
@@ -151,11 +151,39 @@ class ToolsControllerTest extends ApiTestSupport {
             mockMvc.perform(get("/api/travel/trips/" + tripId + "/weather")
                             .header(HttpHeaders.AUTHORIZATION, authHeader))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.daily", hasSize(2)))
-                    // 2일차는 닛코(36.x) 예보여야 한다. 도쿄 것이면 25도가 온다.
-                    .andExpect(jsonPath("$.data.daily[1].tempMax").value(9))
                     .andExpect(jsonPath("$.data.daily[0].cityName").value("도쿄"))
-                    .andExpect(jsonPath("$.data.daily[1].cityName").value("닛코"));
+                    // 2일차는 닛코(36.x) 예보여야 한다. 도쿄 것이면 25도가 온다.
+                    .andExpect(jsonPath("$.data.daily[2].tempMax").value(9))
+                    .andExpect(jsonPath("$.data.daily[2].cityName").value("닛코"));
+        }
+
+        /**
+         * 도시가 바뀌는 날은 줄이 둘이다(D-25) — 그날 오전은 아직 떠나온 도시에 있다. 도착
+         * 도시 하나만 보여주면 아침에 뭘 입을지를 <b>가 보지도 않은 도시의 날씨로</b> 정하게
+         * 된다.
+         */
+        @Test
+        @DisplayName("도시가 바뀌는 날은 두 줄 — 떠나온 도시가 먼저다")
+        void showsBothCitiesOnTransitionDay() throws Exception {
+            long tripId = createTwoCityTrip();
+            weatherStub.byCoordinates = key -> new WeatherResponse(
+                    WeatherResponse.SOURCE, WeatherResponse.LICENSE,
+                    java.time.Instant.parse("2026-08-08T00:00:00Z"),
+                    List.of(day("2026-10-24", WeatherIcon.CLEAR, 20, 10, 0),
+                            day("2026-10-25", WeatherIcon.RAIN,
+                                    key.startsWith("36.") ? 9 : 25, 5, 80)),
+                    java.util.Map.of());
+
+            mockMvc.perform(get("/api/travel/trips/" + tripId + "/weather")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader))
+                    .andExpect(status().isOk())
+                    // 10-24 도쿄 / 10-25 도쿄(오전) / 10-25 닛코(오후)
+                    .andExpect(jsonPath("$.data.daily", hasSize(3)))
+                    .andExpect(jsonPath("$.data.daily[1].date").value("2026-10-25"))
+                    .andExpect(jsonPath("$.data.daily[1].cityName").value("도쿄"))
+                    .andExpect(jsonPath("$.data.daily[1].tempMax").value(25))
+                    .andExpect(jsonPath("$.data.daily[2].date").value("2026-10-25"))
+                    .andExpect(jsonPath("$.data.daily[2].cityName").value("닛코"));
         }
 
         @Test

--- a/fe/src/features/travel/api/activities.ts
+++ b/fe/src/features/travel/api/activities.ts
@@ -81,14 +81,24 @@ export interface BoardDay {
   date: string;
   weekday: string;
   activityCount: number;
+  /** 그날의 기준 도시. 도시가 바뀌는 날이면 **도착한 쪽**이다. */
   baseCity: BaseCity | null;
   /** 직전 날짜와 도시가 다르다 → 탭 왼쪽에 구분선. */
   cityChanged: boolean;
+  /**
+   * 그날 **떠나온 도시**. 도시가 바뀌는 날에만 있다(D-25) — 그 하루는 두 도시에 속한다.
+   *
+   * <p>오프라인 캐시(Workbox)에 이 필드가 생기기 전 응답이 남아 있을 수 있어 선택이다.
+   * 없으면 이동일 표시가 빠질 뿐, 화면은 그대로 산다.
+   */
+  arrivingFrom?: BaseCity | null;
   /** 이 날짜가 속한 구간 번호(1부터). 저장값이 아니라 파생이다. */
   legIndex: number;
   cityMemo: string | null;
   /** 예보 범위(16일) 밖이면 null이다 — 오류가 아니라 "아직 모름"이다. */
   weather: DailyWeather | null;
+  /** 떠나온 도시의 그날 날씨. 이동일에만 있다 — 오전에 뭘 입을지는 그 도시가 정한다. */
+  arrivingFromWeather?: DailyWeather | null;
   /** 오늘 밤 자는 곳(`checkIn <= date < checkOut`). 없으면 null. */
   stayTonight: StayTonight | null;
   /** 오늘 체크아웃하는 곳. 없으면 null. */

--- a/fe/src/features/travel/api/days.ts
+++ b/fe/src/features/travel/api/days.ts
@@ -20,6 +20,11 @@ export interface TripDay {
   cityChanged: boolean;
   cityMemo: string | null;
   baseCity: BaseCity | null;
+  /**
+   * 그날 떠나온 도시. 도시가 바뀌는 날에만 있다(D-25) — 구간 편집기가 구간 카드 사이에
+   * `10.28 오사카 → 교토` 이동 줄을 그린다.
+   */
+  arrivingFrom?: BaseCity | null;
 }
 
 /**

--- a/fe/src/features/travel/board/CityMoveLine.tsx
+++ b/fe/src/features/travel/board/CityMoveLine.tsx
@@ -1,0 +1,69 @@
+import { ArrowRight } from "lucide-react";
+
+import type { BoardDay } from "@/features/travel/api/activities";
+import type { DailyWeather } from "@/features/travel/api/tools";
+import { iconFor, needsUmbrella } from "@/features/travel/tools/weatherIcon";
+import { cn } from "@/lib/utils";
+
+interface CityMoveLineProps {
+  /** 보고 있는 날짜. 보관함이면 null이다. */
+  day: BoardDay | null | undefined;
+}
+
+/**
+ * 도시가 바뀌는 날의 한 줄 — `오사카 18°/11° → 교토 16°/9°`.
+ *
+ * <p>그 하루는 두 도시에 속한다(D-25). 날짜 탭은 도착 도시의 날씨만 보여주는데, 아침에 뭘
+ * 입을지는 <b>오전을 보낼 도시</b>가 정한다 — 오사카에 비가 오면 교토가 맑아도 우산을 든다.
+ *
+ * <p>이동일이 아니면 아무것도 그리지 않는다. 안 바뀌는 날에 빈 자리를 남기지 않는다.
+ */
+export function CityMoveLine({ day }: CityMoveLineProps) {
+  const from = day?.arrivingFrom;
+  if (!day || !from || !day.baseCity) {
+    return null;
+  }
+  return (
+    <p
+      className="bg-muted flex items-center gap-2 rounded-lg px-3 py-2 text-[13px]"
+      aria-label={`${from.name}에서 ${day.baseCity.name}로 이동하는 날`}
+    >
+      <CityWeather name={from.name} weather={day.arrivingFromWeather} />
+      <ArrowRight
+        className="text-muted-foreground size-3.5 shrink-0"
+        aria-hidden="true"
+      />
+      <CityWeather name={day.baseCity.name} weather={day.weather} />
+    </p>
+  );
+}
+
+/** 도시명 + 그 도시의 그날 기온. 예보 범위(16일) 밖이면 이름만 남는다. */
+function CityWeather({
+  name,
+  weather,
+}: {
+  name: string;
+  weather?: DailyWeather | null;
+}) {
+  const Glyph = weather
+    ? iconFor(weather.icon, weather.precipProbability)
+    : null;
+  const alert = weather ? needsUmbrella(weather.precipProbability) : false;
+  return (
+    <span className="flex min-w-0 items-center gap-1">
+      <span className="truncate">{name}</span>
+      {weather && Glyph && (
+        <span
+          className={cn(
+            "flex shrink-0 items-center gap-0.5 text-xs tabular-nums",
+            alert ? "text-warning" : "text-muted-foreground",
+          )}
+        >
+          <Glyph className="size-3" />
+          {weather.tempMax ?? "–"}°/{weather.tempMin ?? "–"}°
+        </span>
+      )}
+    </span>
+  );
+}

--- a/fe/src/features/travel/board/DayTabs.tsx
+++ b/fe/src/features/travel/board/DayTabs.tsx
@@ -61,12 +61,8 @@ export function DayTabs({
           <Chip
             dropId={droppable ? `day:${day.date}` : undefined}
             active={selectedDate === day.date}
-            label={
-              singleCity || !day.baseCity
-                ? `${day.dayIndex}일차`
-                : `${day.dayIndex} ${day.baseCity.name}`
-            }
-            wide={!singleCity && day.baseCity !== null}
+            label={labelOf(day, singleCity)}
+            width={widthOf(day, singleCity)}
             sub={`${formatShortDate(day.date)} ${day.weekday}`}
             weather={day.weather}
             onClick={() => onSelectDate(day.date)}
@@ -86,12 +82,54 @@ export function DayTabs({
   );
 }
 
+/**
+ * 탭 글자. 도시가 하나뿐인 여행은 `N일차`, 아니면 `N 교토`다.
+ *
+ * <p><b>도시가 바뀌는 날은 두 도시를 다 쓴다</b> — `5 오사카 → 교토`(D-25). 도착 도시만
+ * 쓰면 그날 오전에 오사카에 있었다는 사실이 화면에서 사라져, 오전 일정이 왜 거기 있는지
+ * 설명되지 않는다. 옆의 구분선은 "여기서 옮긴다"만 말하고 어디서 오는지는 말하지 않는다.
+ */
+function labelOf(day: BoardDay, singleCity: boolean): string {
+  if (singleCity || !day.baseCity) {
+    return `${day.dayIndex}일차`;
+  }
+  const from = day.arrivingFrom;
+  return from
+    ? `${day.dayIndex} ${from.name} → ${day.baseCity.name}`
+    : `${day.dayIndex} ${day.baseCity.name}`;
+}
+
+/**
+ * 칩 너비. 도시명이 붙으면 넓히고, <b>도시가 둘이면 한 번 더 넓힌다</b> — `5 오사카 → 교토`가
+ * 좁은 칸에서 잘리면 정작 알려야 할 "어디서 어디로"가 사라진다.
+ */
+function widthOf(day: BoardDay, singleCity: boolean): ChipWidth {
+  if (singleCity || !day.baseCity) {
+    return "narrow";
+  }
+  return day.arrivingFrom ? "widest" : "wide";
+}
+
+type ChipWidth = "narrow" | "wide" | "widest";
+
+const CHIP_WIDTH: Record<ChipWidth, string> = {
+  narrow: "min-w-[78px]",
+  wide: "min-w-[92px]",
+  widest: "min-w-[132px]",
+};
+
+const LABEL_WIDTH: Record<ChipWidth, string> = {
+  narrow: "max-w-[110px]",
+  wide: "max-w-[110px]",
+  widest: "max-w-[160px]",
+};
+
 interface ChipProps {
   active: boolean;
   label: string;
   sub: string;
   /** 도시명이 붙는 칩은 조금 넓다. 짧은 도시명에서 칸이 들쭉날쭉해지지 않게. */
-  wide?: boolean;
+  width?: ChipWidth;
   /** 예보 범위(16일) 밖이면 없다 — 그 자리를 비운다. */
   weather?: DailyWeather | null;
   icon?: React.ReactNode;
@@ -106,7 +144,7 @@ function Chip({
   active,
   label,
   sub,
-  wide = false,
+  width = "narrow",
   weather,
   icon,
   onClick,
@@ -139,7 +177,7 @@ function Chip({
       {...longPress}
       className={cn(
         "flex shrink-0 flex-col items-start gap-0.5 rounded-lg border px-2.5 py-2 transition-colors",
-        wide ? "min-w-[92px]" : "min-w-[78px]",
+        CHIP_WIDTH[width],
         active
           ? "bg-accent text-accent-foreground border-primary"
           : "bg-card border-border hover:bg-muted",
@@ -147,7 +185,12 @@ function Chip({
         isOver && "border-primary ring-primary bg-accent ring-2",
       )}
     >
-      <span className="flex max-w-[110px] items-center gap-1 truncate text-[13px] font-semibold">
+      <span
+        className={cn(
+          "flex items-center gap-1 truncate text-[13px] font-semibold",
+          LABEL_WIDTH[width],
+        )}
+      >
         {icon}
         {label}
       </span>

--- a/fe/src/features/travel/tools/WeatherCard.tsx
+++ b/fe/src/features/travel/tools/WeatherCard.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
 
 import { LoadingText } from "@/components/ui/loading-text";
-import type { WeatherForecast } from "@/features/travel/api/tools";
+import type {
+  DailyWeather,
+  WeatherForecast,
+} from "@/features/travel/api/tools";
 import { iconFor, needsUmbrella } from "@/features/travel/tools/weatherIcon";
 
 interface WeatherCardProps {
@@ -14,6 +17,15 @@ function temperature(value: number | null): string {
 }
 
 /**
+ * 한 줄의 정체는 <b>날짜가 아니라 (날짜, 도시)</b>다 — 도시가 바뀌는 날은 같은 날짜로 줄이
+ * 둘이라(D-25) 날짜만으로는 두 줄이 구별되지 않는다. 날짜를 키로 쓰면 리스트 키가 겹치고,
+ * 한 줄을 눌렀을 때 나머지 한 줄까지 같이 눌린 것처럼 보인다.
+ */
+function rowKey(day: DailyWeather): string {
+  return `${day.date}·${day.cityName ?? ""}`;
+}
+
+/**
  * 날씨(§S-08).
  *
  * <p>예보가 비는 것은 오류가 아니다 — Open-Meteo는 <b>16일까지만</b> 준다. 여행이 아직
@@ -22,7 +34,11 @@ function temperature(value: number | null): string {
 export function WeatherCard({ forecast, loading }: WeatherCardProps) {
   const [selected, setSelected] = useState<string | null>(null);
   const daily = forecast?.daily ?? [];
-  const activeDate = selected ?? daily[0]?.date ?? null;
+  const activeRow = selected ?? (daily[0] ? rowKey(daily[0]) : null);
+  // 시간대별 예보는 <b>날짜당 하나</b>다(그날 기준 도시 것). 이동일의 두 줄은 어느 쪽을
+  // 눌러도 같은 시간대별을 편다 — 하루에 시계가 둘일 수는 없다.
+  const activeDate =
+    daily.find((day) => rowKey(day) === activeRow)?.date ?? null;
   const hourly = activeDate ? (forecast?.hourly[activeDate] ?? []) : [];
 
   return (
@@ -40,20 +56,22 @@ export function WeatherCard({ forecast, loading }: WeatherCardProps) {
             {daily.map((day) => {
               const Icon = iconFor(day.icon, day.precipProbability);
               const alert = needsUmbrella(day.precipProbability);
+              const key = rowKey(day);
               return (
-                <li key={day.date}>
+                <li key={key}>
                   <button
                     type="button"
-                    onClick={() => setSelected(day.date)}
-                    aria-pressed={day.date === activeDate}
+                    onClick={() => setSelected(key)}
+                    aria-pressed={key === activeRow}
                     className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left ${
-                      day.date === activeDate ? "bg-muted" : "hover:bg-muted"
+                      key === activeRow ? "bg-muted" : "hover:bg-muted"
                     }`}
                   >
                     <span className="w-[38px] shrink-0 text-[13px] tabular-nums">
                       {day.date.slice(5)}
                     </span>
-                    {/* 도시명은 값과 함께 온다(§3.7) — 날짜마다 다른 도시의 예보다. */}
+                    {/* 도시명은 값과 함께 온다(§3.7) — 날짜마다 다른 도시의 예보고,
+                        도시가 바뀌는 날은 같은 날짜에 줄이 둘이라 여기서만 갈린다. */}
                     {day.cityName && (
                       <span className="text-muted-foreground w-[66px] shrink-0 truncate text-[13px]">
                         {day.cityName}

--- a/fe/src/features/travel/trip/LegMoveRow.tsx
+++ b/fe/src/features/travel/trip/LegMoveRow.tsx
@@ -1,0 +1,33 @@
+import { ArrowRight } from "lucide-react";
+
+import { formatShortDate } from "@/features/travel/lib/tripStatus";
+
+interface LegMoveRowProps {
+  /** 도시가 바뀌는 날 — 다음 구간이 시작하는 날짜다. */
+  date: string;
+  fromCity: string;
+  toCity: string;
+}
+
+/**
+ * 구간 사이의 이동 줄 — `10.28 오사카 → 교토`.
+ *
+ * <p>구간을 일 단위로 배타적으로 나누면 <b>이동일이 어느 구간에도 안 보인다.</b> 오사카가
+ * 10.27에 끝나고 교토가 10.28에 시작하는데, 카드만 보면 10.28 오전에 아직 오사카에 있다는
+ * 사실이 어디에도 없다. 그 하루가 두 도시에 속한다는 것을 여기서 말한다(D-25).
+ *
+ * <p>날짜는 <b>다음 구간의 첫날</b>이다. 기준 도시는 도착한 쪽이라 그날이 곧 이동일이다.
+ */
+export function LegMoveRow({ date, fromCity, toCity }: LegMoveRowProps) {
+  return (
+    <li
+      className="text-muted-foreground flex items-center gap-1.5 py-0.5 pl-[34px] text-xs"
+      aria-label={`${formatShortDate(date)} ${fromCity}에서 ${toCity}로 이동`}
+    >
+      <span className="tabular-nums">{formatShortDate(date)}</span>
+      <span className="truncate">{fromCity}</span>
+      <ArrowRight className="size-3 shrink-0" aria-hidden="true" />
+      <span className="truncate">{toCity}</span>
+    </li>
+  );
+}

--- a/fe/src/pages/travel/TravelToolsPage.test.tsx
+++ b/fe/src/pages/travel/TravelToolsPage.test.tsx
@@ -461,6 +461,73 @@ describe("TravelToolsPage", () => {
       expect(await screen.findByText("도쿄")).toBeInTheDocument();
       expect(screen.getByText("닛코")).toBeInTheDocument();
     });
+
+    /**
+     * 도시가 바뀌는 날은 <b>같은 날짜로 줄이 둘</b>이다(D-25) — 떠나온 도시가 먼저. 한 줄의
+     * 정체가 날짜가 아니라 (날짜, 도시)라서, 날짜로 묶거나 중복을 지우면 오전 도시가 사라진다.
+     */
+    it("도시가 바뀌는 날은 같은 날짜로 줄이 둘이다 — 떠나온 도시가 먼저", async () => {
+      mockWeather([
+        {
+          date: "2026-10-24",
+          cityName: "오사카",
+          icon: "RAIN",
+          tempMax: 18,
+          tempMin: 11,
+          precipProbability: 70,
+        },
+        {
+          date: "2026-10-24",
+          cityName: "교토",
+          icon: "CLOUD",
+          tempMax: 16,
+          tempMin: 9,
+          precipProbability: 30,
+        },
+      ]);
+
+      renderTools();
+
+      await screen.findByText("오사카");
+      expect(screen.getAllByText("10-24")).toHaveLength(2);
+      expect(screen.getByText("교토")).toBeInTheDocument();
+      // 첫 줄만 눌린 상태다. 날짜를 선택 키로 쓰면 두 줄이 함께 눌린다.
+      const pressed = screen
+        .getAllByRole("button")
+        .filter((row) => row.getAttribute("aria-pressed") === "true");
+      expect(pressed).toHaveLength(1);
+      expect(pressed[0]).toHaveTextContent("오사카");
+    });
+
+    it("한 줄을 눌러도 나머지 한 줄은 눌리지 않는다", async () => {
+      mockWeather([
+        {
+          date: "2026-10-24",
+          cityName: "오사카",
+          icon: "RAIN",
+          tempMax: 18,
+          tempMin: 11,
+          precipProbability: 70,
+        },
+        {
+          date: "2026-10-24",
+          cityName: "교토",
+          icon: "CLOUD",
+          tempMax: 16,
+          tempMin: 9,
+          precipProbability: 30,
+        },
+      ]);
+
+      renderTools();
+      await userEvent.click(await screen.findByText("교토"));
+
+      const pressed = screen
+        .getAllByRole("button")
+        .filter((row) => row.getAttribute("aria-pressed") === "true");
+      expect(pressed).toHaveLength(1);
+      expect(pressed[0]).toHaveTextContent("교토");
+    });
   });
 
   describe("보드에서 들어오기", () => {

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -396,6 +396,109 @@ describe("TripBoardPage", () => {
       expect(tabs[2]).toHaveTextContent("3 도쿄");
     });
 
+    /**
+     * 도시가 바뀌는 날은 그 하루가 두 도시에 속한다(D-25). 구분선은 "여기서 옮긴다"만
+     * 말하고 <b>어디서 오는지는 말하지 않는다</b> — 그날 오전 일정이 왜 거기 있는지가
+     * 탭에서 읽혀야 한다.
+     */
+    it("도시가 바뀌는 날은 탭이 `N 도쿄 → 닛코`를 쓴다", async () => {
+      mockBoard({
+        byDate: { "2026-10-24": [], "2026-10-25": [], "2026-10-26": [] },
+        trip: { singleCity: false, cityCount: 2 },
+        days: [
+          day(1, "2026-10-24", "토", 0),
+          day(2, "2026-10-25", "일", 0, {
+            baseCity: NIKKO,
+            cityChanged: true,
+            arrivingFrom: TOKYO,
+            legIndex: 2,
+          }),
+          day(3, "2026-10-26", "월", 0, {
+            cityChanged: true,
+            arrivingFrom: NIKKO,
+            legIndex: 3,
+          }),
+        ],
+      });
+
+      renderBoard();
+
+      const tabs = await screen.findAllByRole("tab");
+      // 첫날은 떠나온 도시가 없다 — 비교할 앞 날짜가 없다.
+      expect(tabs[0]).toHaveTextContent("1 도쿄");
+      expect(tabs[1]).toHaveTextContent("2 도쿄 → 닛코");
+      // 당일치기라 돌아오는 날도 이동일이다.
+      expect(tabs[2]).toHaveTextContent("3 닛코 → 도쿄");
+    });
+
+    /**
+     * 아침에 뭘 입을지는 <b>오전을 보낼 도시</b>가 정한다 — 오사카에 비가 오면 교토가
+     * 맑아도 우산을 든다. 탭은 도착 도시의 날씨만 보여주므로 그 값이 여기 있어야 한다.
+     */
+    it("이동일에는 두 도시와 두 날씨가 한 줄로 선다", async () => {
+      mockBoard({
+        byDate: { "2026-10-24": [], "2026-10-25": [] },
+        trip: { singleCity: false, cityCount: 2 },
+        days: [
+          day(1, "2026-10-24", "토", 0),
+          day(2, "2026-10-25", "일", 0, {
+            baseCity: NIKKO,
+            cityChanged: true,
+            arrivingFrom: TOKYO,
+            legIndex: 2,
+            weather: {
+              date: "2026-10-25",
+              cityName: "닛코",
+              icon: "CLOUD",
+              tempMax: 16,
+              tempMin: 9,
+              precipProbability: 30,
+            },
+            arrivingFromWeather: {
+              date: "2026-10-25",
+              cityName: "도쿄",
+              icon: "RAIN",
+              tempMax: 18,
+              tempMin: 11,
+              precipProbability: 70,
+            },
+          }),
+        ],
+      });
+
+      // `?day=`는 날짜가 아니라 탭 인덱스다 — 1이 둘째 날(이동일)이다.
+      renderBoard("/travel/trips/3/board?day=1");
+      await screen.findAllByRole("tab");
+
+      const line = await screen.findByLabelText("도쿄에서 닛코로 이동하는 날");
+      // 떠나온 도시가 먼저다 — 그날은 그 도시에서 시작한다.
+      expect(line).toHaveTextContent("도쿄18°/11°");
+      expect(line).toHaveTextContent("닛코16°/9°");
+    });
+
+    it("도시가 안 바뀌는 날에는 그 줄이 없다 — 빈 자리를 남기지 않는다", async () => {
+      mockMultiCity();
+
+      renderBoard();
+      await screen.findAllByRole("tab");
+
+      expect(screen.queryByLabelText(/이동하는 날$/)).not.toBeInTheDocument();
+    });
+
+    /**
+     * 오프라인 캐시(Workbox)에는 이 필드가 생기기 전 응답이 남아 있을 수 있다. 없다고
+     * 화면이 죽으면 비행기 모드에서 보드가 통째로 사라진다.
+     */
+    it("떠나온 도시가 없는 응답이면 도착 도시만 쓴다", async () => {
+      mockMultiCity();
+
+      renderBoard();
+
+      const tabs = await screen.findAllByRole("tab");
+      expect(tabs[1]).toHaveTextContent("2 닛코");
+      expect(tabs[1]).not.toHaveTextContent("→");
+    });
+
     it("전 기간 한 도시면 도시명을 감추고 `N일차`로 쓴다 — 반복은 정보가 아니다", async () => {
       mockBoard({ byDate: { "2026-10-24": [] } });
 

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -46,6 +46,7 @@ import { deleteTrip } from "@/features/travel/api/travel";
 import { ActivityRow } from "@/features/travel/board/ActivityRow";
 import { AddSheet } from "@/features/travel/board/AddSheet";
 import { BaseCitySheet } from "@/features/travel/board/BaseCitySheet";
+import { CityMoveLine } from "@/features/travel/board/CityMoveLine";
 import { DayTabs } from "@/features/travel/board/DayTabs";
 import { DragModeBar } from "@/features/travel/board/DragModeBar";
 import { LocalClockLine } from "@/features/travel/board/LocalClockLine";
@@ -605,6 +606,10 @@ export function TripBoardPage() {
           // 드래그 중이 아닐 때는 아무 영향도 없으므로 항상 켜 둔다.
           droppable
         />
+
+        {/* 도시가 바뀌는 날이면 어디서 어디로 옮기는지 + 두 도시의 날씨(D-25).
+            오전을 보낼 도시의 날씨는 탭에 없다 — 탭은 도착 도시만 말한다. */}
+        {!isArchive && <CityMoveLine day={selectedDay} />}
 
         {/* 도시 메모는 있을 때만 한 줄. 없는 날짜에 빈 자리를 남기지 않는다. */}
         {selectedDay?.cityMemo && (

--- a/fe/src/pages/travel/TripFormPage.test.tsx
+++ b/fe/src/pages/travel/TripFormPage.test.tsx
@@ -307,6 +307,58 @@ describe("TripFormPage", () => {
       expect(screen.getByText("10.26 – 10.27")).toBeInTheDocument();
     });
 
+    /**
+     * 구간을 일 단위로 배타적으로 나누면 <b>이동일이 어느 카드에도 안 보인다.</b> 도쿄가
+     * 10.25에 끝나고 교토가 10.26에 시작하는데, 카드만 보면 10.26 오전에 아직 도쿄에
+     * 있다는 사실이 어디에도 없다(D-25).
+     */
+    it("구간 사이에 이동 줄이 서서 경계일을 말한다", async () => {
+      renderApp("/travel/trips/new");
+      await screen.findByLabelText("여행 제목");
+
+      await fillPeriod("2026-10-24", "2026-10-27");
+      mockCities([TOKYO_CITY]);
+      await addLeg("도쿄");
+      await userEvent.click(
+        screen.getByRole("button", { name: /도쿄 일수 늘리기/ }),
+      );
+      mockCities([KYOTO_CITY]);
+      await addLeg("교토");
+
+      // 교토 구간의 첫날이 곧 이동일이다.
+      expect(
+        await screen.findByLabelText("10.26 도쿄에서 교토로 이동"),
+      ).toBeInTheDocument();
+    });
+
+    it("구간이 하나면 이동 줄이 없다 — 옮길 곳이 없다", async () => {
+      renderApp("/travel/trips/new");
+      await screen.findByLabelText("여행 제목");
+
+      await fillPeriod("2026-10-24", "2026-10-27");
+      await addLeg("도쿄");
+
+      expect(await screen.findByText("10.24 – 10.27")).toBeInTheDocument();
+      expect(screen.queryByLabelText(/로 이동$/)).not.toBeInTheDocument();
+    });
+
+    it("잘린 구간으로는 이동 줄을 그리지 않는다 — 그 이동은 일어나지 않는다", async () => {
+      renderApp("/travel/trips/new");
+      await screen.findByLabelText("여행 제목");
+
+      await fillPeriod("2026-10-24", "2026-10-25");
+      mockCities([TOKYO_CITY]);
+      await addLeg("도쿄");
+      await userEvent.click(
+        screen.getByRole("button", { name: /도쿄 일수 늘리기/ }),
+      );
+      mockCities([KYOTO_CITY]);
+      await addLeg("교토");
+
+      expect(await screen.findByText("기간을 넘겨 잘려요")).toBeInTheDocument();
+      expect(screen.queryByLabelText(/로 이동$/)).not.toBeInTheDocument();
+    });
+
     it("합계가 기간과 다르면 무슨 일이 일어날지 미리 말한다 — 저장을 막지는 않는다", async () => {
       renderApp("/travel/trips/new");
       await screen.findByLabelText("여행 제목");

--- a/fe/src/pages/travel/TripFormPage.tsx
+++ b/fe/src/pages/travel/TripFormPage.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, Info, Plus } from "lucide-react";
-import { type FormEvent, useEffect, useId, useState } from "react";
+import { type FormEvent, Fragment, useEffect, useId, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -36,6 +36,7 @@ import {
   legFromManualCity,
   legFromSaved,
 } from "@/features/travel/trip/legDraft";
+import { LegMoveRow } from "@/features/travel/trip/LegMoveRow";
 import { LegRow } from "@/features/travel/trip/LegRow";
 import { LegSumBar } from "@/features/travel/trip/LegSumBar";
 import { toast } from "@/shared/lib/toast";
@@ -315,24 +316,38 @@ export function TripFormPage() {
           </h2>
           {form.legs.length > 0 && (
             <ul className="flex flex-col gap-2">
-              {form.legs.map((leg, index) => (
-                <LegRow
-                  key={leg.key}
-                  index={index}
-                  cityName={leg.cityName}
-                  days={leg.days}
-                  dates={plan.dates[index]}
-                  onPickCity={() => setPickingKey(leg.key)}
-                  onChangeDays={(days) =>
-                    updateLeg(leg.key, { days: Math.max(1, days) })
-                  }
-                  onMove={(direction) => moveLeg(index, direction)}
-                  onRemove={() => removeLeg(leg.key)}
-                  canMoveUp={index > 0}
-                  canMoveDown={index < form.legs.length - 1}
-                  canRemove={form.legs.length > 1}
-                />
-              ))}
+              {form.legs.map((leg, index) => {
+                // 이 구간이 끝나고 다음 구간이 시작하는 날 = 이동일. 다음 구간이 기간을
+                // 넘겨 잘렸으면(dates가 null) 이동 자체가 일어나지 않는다.
+                const next = form.legs[index + 1];
+                const moveDate = plan.dates[index + 1]?.startDate;
+                return (
+                  <Fragment key={leg.key}>
+                    <LegRow
+                      index={index}
+                      cityName={leg.cityName}
+                      days={leg.days}
+                      dates={plan.dates[index]}
+                      onPickCity={() => setPickingKey(leg.key)}
+                      onChangeDays={(days) =>
+                        updateLeg(leg.key, { days: Math.max(1, days) })
+                      }
+                      onMove={(direction) => moveLeg(index, direction)}
+                      onRemove={() => removeLeg(leg.key)}
+                      canMoveUp={index > 0}
+                      canMoveDown={index < form.legs.length - 1}
+                      canRemove={form.legs.length > 1}
+                    />
+                    {next && moveDate && leg.cityName && next.cityName && (
+                      <LegMoveRow
+                        date={moveDate}
+                        fromCity={leg.cityName}
+                        toCity={next.cityName}
+                      />
+                    )}
+                  </Fragment>
+                );
+              })}
             </ul>
           )}
 


### PR DESCRIPTION
## 이슈
closes #1205

## 작업 내용

**도시가 바뀌는 날은 두 도시에 속한다.** 오사카 구간이 10.27에 끝나고 교토 구간이 10.28에 시작하면 10.28은 오전엔 오사카, 오후엔 교토다. 기준 도시가 도착지 하나뿐이라 **그날 오전 일정에 전부 도시 경고가 붙었다** — 7구간이면 이동일이 여섯 번이라 여섯 날의 오전이 통째로 잘못 담은 것처럼 보인다.

떠나온 도시는 **직전 날짜의 기준 도시**일 뿐이라 저장 없이 나온다. 컬럼도 테이블도 늘리지 않았다.

### BE
- `TransitionDays` 신설 — 도시가 바뀌는 날 → 떠나온 도시. `cityChanged`와 `arrivingFrom`이 **같은 파생에서** 나와 둘이 어긋날 수 없다
- `ActivityResponse.withBaseCity(String)` → `withBaseCities(Set<String>)`. 이동일엔 두 도시를 다 통과시킨다. **양쪽 식별자를 다 알 때만 판정**하는 D-23은 그대로다
- 보드 응답에 `arrivingFrom` · `arrivingFromWeather`, 날짜 응답에 `arrivingFrom`
- 이동일 날씨는 두 도시 — 떠나온 도시는 **반드시 다른 날짜의 기준 도시**라 예보를 이미 읽어 둔 상태다. 조회가 늘지 않는 것을 테스트로 고정(`doesNotAddWeatherCalls`)
- S-08 `daily`는 이동일에 `(날짜, 도시)` 두 줄. 떠나온 도시가 먼저다

### FE
- 날짜 탭이 이동일에 `3 오사카 → 교토`. 구분선은 "여기서 옮긴다"만 말하고 **어디서 오는지는 말하지 않는다**
- 보드에 도시 이동 줄 — 두 도시와 두 날씨. 아침에 뭘 입을지는 오전을 보낼 도시가 정한다
- 구간 편집기 카드 사이에 `8.17 오사카 → 교토` 이동 줄. `합계 N일 / 기간 N일` 불변식은 그대로
- S-08 한 줄의 정체를 날짜 → `(날짜, 도시)`로. 날짜를 키로 쓰면 리스트 키가 겹치고 한 줄을 눌렀을 때 **나머지 한 줄까지 같이 눌린다**
- 새 필드는 선택(`?`)이다 — 오프라인 캐시(Workbox)에 이 필드가 생기기 전 응답이 남아 있을 수 있다

### 저장을 늘리지 않은 이유 (D-25)

구간을 **박(night) 단위로 저장**해 경계일을 공유시키는 안(`end_date == 다음 start_date`)을 검토했고 채택하지 않았다.

- 구간 테이블은 **존재하지 않는다.** `LegDeriver`가 `trip_day.base_place_id`에서 매번 파생한다(D-21) — 마이그레이션이 아니라 **SSOT를 날짜에서 구간으로 옮기는 일**이다
- 옮기면 #1133의 하루 단위 기준 도시 변경이 한 행 UPDATE에서 **저장된 구간을 셋으로 쪼개는 쓰기**가 된다
- 박 단위 반열린 구간은 **이미 `trip_stay`가 그 모양**(`[checkIn, checkOut)`)이다
- 결정적으로 **박은 "자는 도시"만 안다.** 도쿄에 자면서 닛코에 다녀오는 당일치기를 표현하지 못한다 — 기준 도시와 숙소를 분리한 이유가 정확히 그것이다(§2.4)

구간 표기를 `N일` → `N박`으로 바꾸는 것도 검토했고 **같은 이유로 뺐다.** 도쿄/닛코 당일치기/도쿄에서 닛코 구간이 `1박`으로 파생되는데 그날 밤은 도쿄에서 잔다. **일 단위는 구간이, 박 단위는 숙소가** 각자 갖는다.

### 로컬 확인 (bootRun + 실제 Open-Meteo)

오사카 2일 → 교토 2일 여행을 API로 만들고 이동일에 세 도시 일정을 담아 확인했다.

| 확인 | 결과 |
|---|---|
| 이동일 `arrivingFrom` | 오사카 |
| 이동일 오전 오사카 일정 | `outOfBaseCity=false` — **오탐 제거** |
| 이동일 교토 일정 | `false` |
| 이동일 도쿄 일정 | `true` — **판정이 죽지 않았다** |
| 이동일 날씨 | 교토 29° + 오사카 30° (실제 예보) |
| **다음 날** 오사카 일정 | `true` — **규칙이 이동일에만 걸린다** |
| S-08 `daily` | 이동일이 두 줄(오사카 → 교토), 한 줄만 선택됨 |

화면 3곳(날짜 탭 · 구간 편집기 · 도구 날씨)을 실제 브라우저에서 확인했다.

### 범위 밖
- **여행 첫날·마지막날의 국제 이동** — 전날이 없어 여전히 경고가 뜬다. 리허설(#1176)에서 실제 빈도를 세어 보고 정한다
- **하루 3도시 이상** — 표현하지 않는다

### 문서
[Travel-Open-Items D-25](https://github.com/wcorn/orino/wiki/Travel-Open-Items) · [Travel-Spec-v2-1 §2.5](https://github.com/wcorn/orino/wiki/Travel-Spec-v2-1) · [Travel-API-Spec](https://github.com/wcorn/orino/wiki/Travel-API-Spec) 반영 완료

---
- [x] (해당 시) S3 또는 유료 외부 API를 호출하는 컴포넌트를 추가했다면 — 주기 플래그를 values에 명시했고, 비용 대시보드에 나타나는가? ([주기 루프 인벤토리](https://github.com/wcorn/orino/wiki/Periodic-Loops))
  - **해당 없음 — 호출이 늘지 않는다.** 떠나온 도시의 날씨는 이미 읽어 둔 예보를 나눠 쓰고, Places·Routes는 건드리지 않았다. `doesNotAddWeatherCalls`가 이 성질을 고정한다
