### PR TITLE
chore : Longhorn 버킷에 request metrics 3일 한시 활성화

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -2,6 +2,22 @@ module "longhorn_backup" {
   source = "./modules/s3"
 
   bucket_name = "orino-longhorn-backup"
+
+  # ⏱️ 한시적 — 2026-08-18 켬 / **2026-08-21 끈다**. 끄는 작업은 #1211.
+  #
+  # Tier1 잔여 약 44k/day(월 $6.6)가 소거 끝에 이 버킷 하나로 몰렸다. #1198 에서
+  # Loki 버킷을 실측해 실청구 14,486 vs 계측 14,494(오차 0.06%)로 증폭을 반증했고,
+  # 나머지는 객체 수로 상한이 막힌다 — thanos 226 · tempo 691 · state 42 · mysql 30.
+  # 여기만 281,442 객체이고 **클라이언트 계측이 없는 유일한 버킷**이다.
+  #
+  # 다만 알려진 Tier1 경로는 전부 닫혀 있다. 폴링은 ELOG-008 에서 5m→0 으로 껐고
+  # (backuptargets.longhorn.io/default pollInterval=0), 업로드는 하루 2,050 객체라
+  # 자릿수가 다르며, 블록 존재 확인은 HeadObject(Tier2)로 #1156 에서 반증됐다.
+  # 그래서 위치는 소거로 좁혀졌지만 메커니즘은 모른다 — 실측만이 남은 수단이다.
+  #
+  # 3일 프로레이트 약 $0.48. 기한을 넘기면 아끼려던 $6.6/월을 측정비가 먹는다 —
+  # 하루 $0.16 씩이다. 이 줄과 이 주석은 #1211 에서 통째로 지운다.
+  request_metrics_enabled = true
 }
 
 # IAM user for Longhorn S3 access


### PR DESCRIPTION
## 이슈
closes #1211 의 첫 단계 (측정 활성화). **끄는 작업이 남아 있으므로 이슈는 닫지 않는다.**

## 작업 내용
- `orino-longhorn-backup`에 `request_metrics_enabled = true`를 **3일 시한**으로 켠다
- 시한(2026-08-21)과 판단 근거를 코드 주석에 박는다 — #1198과 같은 방식이다

### 왜 여기만 켜는가

#1198에서 Loki 버킷을 실측해 **증폭 없음**을 확정한 뒤(실청구 14,486 vs 계측 14,494, 오차 0.06%),
잔여가 소거로 이 버킷 하나에 몰렸다.

| 버킷 | 객체 | 배제 근거 |
|---|---:|---|
| **orino-longhorn-backup** | **281,442** | **남는 하나 — 클라이언트 계측이 없는 유일한 버킷** |
| orino-loki-logs | 80,268 | 실측 완료 (14.5k/day) |
| orino-tempo-traces | 691 | 객체 수가 상한을 막는다 |
| orino-thanos-metrics | 226 | `thanos_objstore_bucket_operations_total`상 `iter`+`upload` 270/day |
| orino-terraform-state | 42 | 객체 수가 상한을 막는다 |
| orino-mysql-backup | 30 | 〃 |

잔여는 **약 44k/day (월 $6.6)** 이고, #1156 시점(33,941/day)보다 **늘었다.**

### 알려진 경로는 이미 다 닫혀 있다

그래서 추측이 아니라 실측이 필요하다.

- **폴링 아님** — `backuptargets.longhorn.io/default`의 `pollInterval: 0` ([ELOG-008](https://github.com/wcorn/orino/wiki/ELOG-008-s3-request-cost) 조치 유지 중)
- **업로드 아님** — 객체가 하루 약 2,050개씩 는다. 44k와 자릿수가 다르다
- **블록 존재 확인 아님** — HeadObject는 Tier2다 (#1156에서 반증)

### 비용과 시한

| | |
|---|---|
| 과금 | 버킷당 $4.8/월 → 3일 프로레이트 **약 $0.48** |
| 켠 날 | 이 PR 머지일 (예정 **2026-08-18**) |
| **끄는 기한** | **2026-08-21** — 머지가 밀리면 기한도 같이 민다 |
| 넘길 때마다 | **하루 $0.16** |

측정 범위는 `EntireBucket` 필터 **1개**다. 접두사별 분리는 필터당 과금이라 하지 않는다.

---
- [x] (해당 시) S3 또는 유료 외부 API를 호출하는 컴포넌트를 추가했다면 — 주기 플래그를 values에 명시했고, 비용 대시보드에 나타나는가? ([주기 루프 인벤토리](https://github.com/wcorn/orino/wiki/Periodic-Loops))
  - 호출 컴포넌트가 아니라 **한시 측정 설정**이다. 끄는 작업을 #1211로 열어 두었다

관련: Epic #1148 (G4) · #1198 · #1156 · [ELOG-029](https://github.com/wcorn/orino/wiki/ELOG-029-s3-tier1-loki-bucket-cleared)
