### PR TITLE
fix : 새 버전 토스트를 설치가 끝나기 전에 띄운다

### DIFF
--- a/fe/src/main.tsx
+++ b/fe/src/main.tsx
@@ -16,11 +16,20 @@ installChunkReloadHandler();
 
 // SW는 앱 전체에 걸린다. 새 버전을 말없이 적용하면 보고 있던 화면이 갈아치워지므로
 // 안내하고 사용자가 새로고침하게 한다(무기한 대기 — 지금 하던 일을 끊지 않는다).
-registerServiceWorker((applyUpdate) => {
-  useToastStore.getState().show("새 버전이 있어요.", {
-    action: { label: "새로고침", onAction: applyUpdate },
-    durationMs: Number.POSITIVE_INFINITY,
-  });
+registerServiceWorker({
+  onUpdateFound(applyUpdate) {
+    useToastStore.getState().show("새 버전이 있어요.", {
+      action: { label: "새로고침", onAction: applyUpdate },
+      durationMs: Number.POSITIVE_INFINITY,
+    });
+  },
+  // 안내는 내려받기가 끝나기 전에 뜬다. 그 사이에 누르면 새로고침까지 잠깐 걸리므로,
+  // 아무 반응이 없는 것처럼 보이지 않게 알린다(끝나면 페이지가 새로고침되며 사라진다).
+  onApplying() {
+    useToastStore.getState().show("새 버전을 준비하고 있어요…", {
+      durationMs: Number.POSITIVE_INFINITY,
+    });
+  },
 });
 
 createRoot(document.getElementById("root")!).render(

--- a/fe/src/shared/lib/serviceWorker.ts
+++ b/fe/src/shared/lib/serviceWorker.ts
@@ -1,5 +1,14 @@
 import { registerSW } from "virtual:pwa-register";
 
+import { createUpdateWatcher } from "./swUpdate";
+
+export interface RegisterServiceWorkerOptions {
+  /** 새 버전을 발견했을 때 호출. 인자를 실행하면 적용하고 새로고침한다. */
+  onUpdateFound: (applyUpdate: () => void) => void;
+  /** 적용을 눌렀지만 아직 내려받는 중일 때 호출. 잠깐 걸린다는 걸 알린다. */
+  onApplying?: () => void;
+}
+
 /**
  * Service Worker 등록.
  *
@@ -7,15 +16,43 @@ import { registerSW } from "virtual:pwa-register";
  * 계속 떠서, 사용자는 이미 고친 버그를 계속 본다. 그래서 새 버전을 <b>말없이 적용하지 않고</b>
  * 안내한 뒤 사용자가 새로고침하게 한다.
  *
- * @param onNeedRefresh 새 버전이 대기 중일 때 호출. 인자를 실행하면 적용하고 새로고침한다
+ * <p>안내는 <b>install이 끝나기 전</b>에 뜬다({@link ./swUpdate}). 플러그인의
+ * {@code onNeedRefresh}만 쓰면 precache를 다 받은 뒤라 몇 초가 비고, 그 사이 사용자는
+ * 옛 화면을 보며 하드 리로드를 하게 된다.
  */
 export function registerServiceWorker(
-  onNeedRefresh: (applyUpdate: () => void) => void,
+  options: RegisterServiceWorkerOptions,
 ): void {
+  const watcher = createUpdateWatcher({
+    isControlled: () => navigator.serviceWorker.controller != null,
+    applyUpdate: () => {
+      // 새 SW가 페이지를 넘겨받는 순간 새로고침한다. 플러그인도 같은 일을 하지만
+      // 그건 workbox의 waiting 이벤트를 본 방문에서만이고, 브라우저가 우리보다 먼저
+      // 업데이트를 찾아낸 방문에는 그 이벤트가 없다 — 그러면 적용만 되고 화면은 옛것으로 남는다.
+      navigator.serviceWorker.addEventListener(
+        "controllerchange",
+        () => window.location.reload(),
+        { once: true },
+      );
+      void update(true);
+    },
+    ...options,
+  });
+
   const update = registerSW({
     immediate: true,
-    onNeedRefresh() {
-      onNeedRefresh(() => void update(true));
+    onRegisteredSW(_swUrl, registration) {
+      if (registration) watcher.watch(registration);
     },
+    // 아래 이른 감시가 updatefound를 놓쳤을 때의 뒷받침. 설치가 끝난 뒤에 불린다.
+    onNeedRefresh() {
+      watcher.notifyReady();
+    },
+  });
+
+  // onRegisteredSW는 register()가 끝난 뒤에 온다. updatefound는 그보다 먼저 일어날 수 있어서,
+  // 이미 등록돼 있으면(= 업데이트가 일어나는 바로 그 경우) 등록 객체를 미리 잡아 붙는다.
+  void navigator.serviceWorker?.getRegistration().then((registration) => {
+    if (registration) watcher.watch(registration);
   });
 }

--- a/fe/src/shared/lib/swUpdate.test.ts
+++ b/fe/src/shared/lib/swUpdate.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createUpdateWatcher, type UpdateWatcherOptions } from "./swUpdate";
+
+/** state를 바꾸면 statechange를 쏘는 최소한의 가짜 SW. */
+class FakeWorker extends EventTarget {
+  state: ServiceWorkerState = "installing";
+
+  moveTo(state: ServiceWorkerState) {
+    this.state = state;
+    this.dispatchEvent(new Event("statechange"));
+  }
+}
+
+class FakeRegistration extends EventTarget {
+  installing: FakeWorker | null = null;
+  waiting: FakeWorker | null = null;
+
+  /** 새 SW의 설치가 시작된 상황. */
+  startInstalling(worker: FakeWorker) {
+    this.installing = worker;
+    this.dispatchEvent(new Event("updatefound"));
+  }
+}
+
+function setup(overrides: Partial<UpdateWatcherOptions> = {}) {
+  const applyUpdate = vi.fn();
+  const onApplying = vi.fn();
+  const reload = vi.fn();
+  // 인자로 받은 apply를 붙잡아 둔다 — "새로고침"을 누른 상황을 테스트에서 재현한다.
+  let apply: (() => void) | null = null;
+  const onUpdateFound = vi.fn((fn: () => void) => {
+    apply = fn;
+  });
+
+  const watcher = createUpdateWatcher({
+    isControlled: () => true,
+    applyUpdate,
+    onUpdateFound,
+    onApplying,
+    reload,
+    ...overrides,
+  });
+
+  const registration = new FakeRegistration();
+
+  return {
+    watcher,
+    registration,
+    applyUpdate,
+    onApplying,
+    onUpdateFound,
+    reload,
+    /** 안내가 뜬 뒤 사용자가 "새로고침"을 누른다. */
+    clickRefresh: () => {
+      if (!apply) throw new Error("아직 안내가 뜨지 않았다");
+      apply();
+    },
+    watch: () =>
+      watcher.watch(registration as unknown as ServiceWorkerRegistration),
+  };
+}
+
+describe("createUpdateWatcher", () => {
+  it("설치가 끝나기 전에 알린다 — 이게 이 감시의 존재 이유다", () => {
+    const { watch, registration, onUpdateFound } = setup();
+    watch();
+
+    const worker = new FakeWorker();
+    registration.startInstalling(worker);
+
+    expect(onUpdateFound).toHaveBeenCalledTimes(1);
+    // 아직 내려받는 중인데도 알렸다.
+    expect(worker.state).toBe("installing");
+  });
+
+  it("첫 설치는 알리지 않는다 — 교체가 아니라 처음 얹는 것이다", () => {
+    const { watch, registration, onUpdateFound } = setup({
+      isControlled: () => false,
+    });
+    watch();
+
+    registration.startInstalling(new FakeWorker());
+
+    expect(onUpdateFound).not.toHaveBeenCalled();
+  });
+
+  it("감시를 붙이기 전에 설치가 시작됐어도 알린다 — updatefound를 놓친 방문", () => {
+    // 제어 중인 페이지로 이동하면 브라우저가 앱보다 먼저 sw.js를 확인한다.
+    // 그 방문에서는 updatefound가 이미 지나가 있어서, 이벤트만 기다리면 영영 알리지 못한다.
+    const { watch, registration, onUpdateFound, clickRefresh, applyUpdate } =
+      setup();
+    const worker = new FakeWorker();
+    registration.installing = worker;
+
+    watch();
+
+    expect(onUpdateFound).toHaveBeenCalledTimes(1);
+    // 놓쳤어도 적용 흐름은 같다 — 설치가 끝난 뒤에 적용한다.
+    clickRefresh();
+    expect(applyUpdate).not.toHaveBeenCalled();
+    worker.moveTo("installed");
+    expect(applyUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("설치가 시작돼 있어도 첫 설치면 알리지 않는다", () => {
+    const { watch, registration, onUpdateFound } = setup({
+      isControlled: () => false,
+    });
+    registration.installing = new FakeWorker();
+
+    watch();
+
+    expect(onUpdateFound).not.toHaveBeenCalled();
+  });
+
+  it("이미 대기 중인 새 SW가 있으면 감시를 붙이는 즉시 알린다", () => {
+    const { watch, registration, onUpdateFound } = setup();
+    registration.waiting = new FakeWorker();
+    registration.waiting.state = "installed";
+
+    watch();
+
+    expect(onUpdateFound).toHaveBeenCalledTimes(1);
+  });
+
+  it("내려받는 중에 누르면 준비 중임을 알리고, 끝난 뒤에 적용한다", () => {
+    const { watch, registration, clickRefresh, applyUpdate, onApplying } =
+      setup();
+    watch();
+    const worker = new FakeWorker();
+    registration.startInstalling(worker);
+
+    clickRefresh();
+
+    // 지금 보내면 workbox가 조용히 무시한다(waiting이 없다). 그래서 기다린다.
+    expect(onApplying).toHaveBeenCalledTimes(1);
+    expect(applyUpdate).not.toHaveBeenCalled();
+
+    worker.moveTo("installed");
+
+    expect(applyUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("이미 대기 중이면 곧바로 적용한다 — 기다린다는 안내를 띄우지 않는다", () => {
+    const { watch, registration, clickRefresh, applyUpdate, onApplying } =
+      setup();
+    registration.waiting = new FakeWorker();
+    registration.waiting.state = "installed";
+    watch();
+
+    clickRefresh();
+
+    expect(applyUpdate).toHaveBeenCalledTimes(1);
+    expect(onApplying).not.toHaveBeenCalled();
+  });
+
+  it("기다리던 설치가 깨지면 새로고침으로 떨어진다", () => {
+    const { watch, registration, clickRefresh, applyUpdate, reload } = setup();
+    watch();
+    const worker = new FakeWorker();
+    registration.startInstalling(worker);
+    clickRefresh();
+
+    worker.moveTo("redundant");
+
+    expect(applyUpdate).not.toHaveBeenCalled();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("같은 등록을 두 번 감시해도 한 번만 알린다", () => {
+    const { watch, registration, onUpdateFound } = setup();
+    watch();
+    watch();
+
+    registration.startInstalling(new FakeWorker());
+
+    expect(onUpdateFound).toHaveBeenCalledTimes(1);
+  });
+
+  it("뒷받침 경로(onNeedRefresh)가 이어 붙어도 안내는 하나다", () => {
+    const { watch, watcher, registration, onUpdateFound } = setup();
+    watch();
+    registration.startInstalling(new FakeWorker());
+
+    // 설치가 끝나면 플러그인이 onNeedRefresh를 부른다 — 이미 알린 뒤다.
+    watcher.notifyReady();
+
+    expect(onUpdateFound).toHaveBeenCalledTimes(1);
+  });
+
+  it("감시가 updatefound를 놓쳤으면 뒷받침 경로가 알리고, 곧바로 적용된다", () => {
+    const { watcher, clickRefresh, onUpdateFound, applyUpdate } = setup();
+
+    watcher.notifyReady();
+
+    expect(onUpdateFound).toHaveBeenCalledTimes(1);
+    clickRefresh();
+    expect(applyUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/fe/src/shared/lib/swUpdate.ts
+++ b/fe/src/shared/lib/swUpdate.ts
@@ -1,0 +1,104 @@
+/**
+ * Service Worker 업데이트 감시.
+ *
+ * <p><b>왜 따로 있나</b> — 알림 시점을 <b>install이 끝나기 전으로</b> 당기기 위해서다.
+ * {@code virtual:pwa-register}가 주는 {@code onNeedRefresh}는 workbox의 {@code waiting}
+ * 이벤트, 즉 새 SW가 precache 전체(모든 JS 청크·CSS·폰트·이미지)를 다 내려받은 뒤에 불린다.
+ * 배포가 클수록 오래 걸리고, 그동안 화면은 옛 버전이라 사용자는 안내를 못 본 채 하드 리로드를 한다.
+ *
+ * <p>새 버전이 있다는 <b>사실</b>은 그보다 훨씬 이른 {@code updatefound}(= {@code /sw.js}를 받아
+ * 바뀐 걸 안 순간)에 알 수 있다. 그래서 감시는 등록 객체에 직접 붙고, 알림은 그 시점에 한다.
+ *
+ * <p>{@code virtual:pwa-register}는 빌드 타임 가상 모듈이라 테스트에서 불러올 수 없다.
+ * 이 파일은 그 의존을 빼서 순수 로직만 담는다 — 배선은 {@link ./serviceWorker}가 한다.
+ */
+
+export interface UpdateWatcherOptions {
+  /**
+   * 이 페이지를 제어 중인 SW가 있는가. 없으면 첫 설치이므로 "새 버전"이 아니다
+   * (알리면 처음 방문한 사람에게 다짜고짜 새로고침을 권하게 된다).
+   */
+  isControlled: () => boolean;
+  /** 대기 중인 새 SW에 SKIP_WAITING을 보내고 새로고침시킨다(`registerSW`가 돌려준 `updateSW(true)`). */
+  applyUpdate: () => void;
+  /** 새 버전을 발견했을 때. 인자를 실행하면 적용한다. */
+  onUpdateFound: (applyUpdate: () => void) => void;
+  /** 적용을 눌렀지만 아직 내려받는 중이라 곧바로 새로고침하지 못할 때. */
+  onApplying?: () => void;
+  /** 내려받기가 끝나기 전에 적용을 눌렀는데 그 설치가 깨졌을 때의 최후 수단. */
+  reload?: () => void;
+}
+
+export interface UpdateWatcher {
+  /** 등록 객체를 감시한다. 같은 객체로 여러 번 불러도 한 번만 붙는다. */
+  watch: (registration: ServiceWorkerRegistration) => void;
+  /**
+   * 감시가 {@code updatefound}를 놓쳤을 때를 위한 직접 알림.
+   * 플러그인의 {@code onNeedRefresh}(= 이미 설치가 끝난 상태)를 여기에 잇는다.
+   */
+  notifyReady: () => void;
+}
+
+export function createUpdateWatcher({
+  isControlled,
+  applyUpdate,
+  onUpdateFound,
+  onApplying,
+  reload = () => window.location.reload(),
+}: UpdateWatcherOptions): UpdateWatcher {
+  const watched = new WeakSet<ServiceWorkerRegistration>();
+  // 경로가 여럿이라(이른 감시 · 플러그인 콜백 · onNeedRefresh) 같은 배포를 두 번 알릴 수 있다.
+  let notified = false;
+
+  function notify(installing: ServiceWorker | null): void {
+    if (notified) return;
+    notified = true;
+    onUpdateFound(() => apply(installing));
+  }
+
+  function apply(installing: ServiceWorker | null): void {
+    // 이미 대기 중이면 곧바로 적용된다.
+    if (!installing || installing.state !== "installing") {
+      applyUpdate();
+      return;
+    }
+
+    // 아직 내려받는 중이다. 지금 보내면 <b>조용히 사라진다</b> —
+    // workbox의 messageSkipWaiting()은 registration.waiting이 있을 때만 메시지를 보내서,
+    // 이 시점에 부르면 아무 일도 일어나지 않고 사용자는 버튼이 먹통이라고 느낀다.
+    onApplying?.();
+    installing.addEventListener("statechange", () => {
+      if (installing.state === "installed") applyUpdate();
+      // 설치가 깨지면 적용할 대상이 없다. 사용자는 "새로고침"을 눌렀으니 새로고침은 해 준다
+      // (옛 SW가 그대로 제어하므로 화면은 그대로지만, 눌러도 아무 일 없는 것보다는 낫다).
+      else if (installing.state === "redundant") reload();
+    });
+  }
+
+  return {
+    watch(registration) {
+      if (watched.has(registration)) return;
+      watched.add(registration);
+
+      // <b>이벤트를 기다리기 전에 지금 상태부터 본다.</b> 제어 중인 페이지로 이동하면
+      // 브라우저가 우리 코드보다 먼저 sw.js를 확인하므로, 앱이 뜰 때는 updatefound가
+      // 이미 지나가 있을 수 있다. 그때 이벤트만 기다리면 이 방문에서는 아무것도 알리지 못한다
+      // (workbox도 register() 시점에 waiting만 보고 installing은 보지 않아 같은 구멍이 있다).
+      if (isControlled()) {
+        if (registration.waiting) notify(null);
+        else if (registration.installing) notify(registration.installing);
+      }
+
+      registration.addEventListener("updatefound", () => {
+        const installing = registration.installing;
+        // 첫 설치는 교체가 아니다.
+        if (!installing || !isControlled()) return;
+        notify(installing);
+      });
+    },
+
+    notifyReady() {
+      notify(null);
+    },
+  };
+}


### PR DESCRIPTION
## 이슈
closes #1215

## 작업 내용

- 새 버전 안내 시점을 **`updatefound`**(= `/sw.js`를 받아 바뀐 걸 안 순간)로 당긴다.
  기존에는 `virtual:pwa-register`의 `onNeedRefresh` = workbox의 `waiting` 이벤트,
  즉 **새 SW가 precache를 전부 내려받은 뒤**라 그만큼 늦었다
- 감시를 붙이기 전에 이미 설치가 시작됐을 수 있으므로, 이벤트를 기다리기 전에
  `registration`의 `waiting`·`installing` 상태를 먼저 본다
  (workbox도 `register()` 시점에 `waiting`만 보고 `installing`은 보지 않는다 — `Workbox.ts:145`)
- 설치가 끝나기 전에 "새로고침"을 누른 경우를 처리한다. 이때 workbox의
  `messageSkipWaiting()`은 `registration.waiting`이 없으면 **아무것도 보내지 않고 끝난다**
  (`Workbox.ts:325`) — 눌러도 반응이 없다. 설치 완료를 기다렸다 적용하고,
  그동안 "새 버전을 준비하고 있어요…"로 알린다
- 적용할 때 `controllerchange`에서 직접 새로고침한다. 플러그인의 새로고침은
  workbox가 `waiting` 이벤트를 본 방문에서만 걸리므로, 그렇지 않은 경로에서는
  적용만 되고 화면이 옛것으로 남는다
- 로직을 `swUpdate.ts`로 분리했다. `virtual:pwa-register`는 빌드 타임 가상 모듈이라
  테스트에서 불러올 수 없어, 배선(`serviceWorker.ts`)과 판단(`swUpdate.ts`)을 나눴다

### 측정 (preview 빌드 + 로그인 상태, 같은 스크립트로 전후 비교)

배포 후 새로고침 1회 기준, 새로고침 시점부터의 경과 시간:

| | 토스트 | SW `waiting` 도달 |
|---|---|---|
| 기존 | 1935ms | 1728ms (토스트가 **뒤**) |
| 변경 | 1607 / 1611ms | 1733 / 1714ms (토스트가 **앞**) |

- 안내가 설치 완료보다 먼저 뜨는 것으로 순서가 뒤집혔다
- 절대 이득(약 320ms)은 **install 시간만큼**이다. 로컬은 바뀐 청크가 적고 지연도 없어
  install이 100ms대라 작게 나오며, 바뀐 파일이 많은 배포일수록 커진다
- "새로고침"을 누르면 실제로 새 번들로 갈아타는 것까지 확인했다
  (`index-gw8751CF.js` → `index-CouwE3cH.js`)

### 남는 것

- 새로고침까지의 대기 대부분은 **앱 부팅 시간**(약 1.6초)이고 이건 이 변경으로 줄지 않는다.
  안내는 앱이 떠야 뜬다
- 안내 토스트는 `AppLayout` 안에서만 렌더된다 — 로그인/랜딩 화면에는 Toaster가 없어
  새 버전 안내가 뜨지 않는다. 별도 이슈로 볼 문제다
- 자동 적용(`registerType: "autoUpdate"`)은 채택하지 않았다. 편집 중 화면이 말없이
  리로드되고(노트 자동저장은 2초 debounce라 미저장분이 날아간다),
  `injectManifest` + 커스텀 `sw.ts`에서는 플러그인이 `skipWaiting`을 넣어주지 않아
  플래그만 바꾸면 대기 상태로 멈춘다

### 테스트

- `swUpdate.test.ts` 11개 추가 (설치 전 알림 · 첫 설치 제외 · 놓친 `updatefound` ·
  설치 중 적용 대기 · 설치 실패 시 폴백 · 중복 알림 방지)
- FE 전체 1054개 통과, `format:check` · `lint` · `build` 통과
