### PR TITLE
fix : 날짜를 옮길 때 보드가 통째로 다시 그려지지 않게 한다

### DIFF
--- a/fe/src/features/travel/hooks/useBoard.ts
+++ b/fe/src/features/travel/hooks/useBoard.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
 import { fetchBoard } from "../api/activities";
 import { travelKeys } from "../queryKeys";
@@ -20,6 +20,10 @@ export function useBoard(
       params.archive ? "archive" : params.date,
     ),
     queryFn: () => fetchBoard(tripId, params),
+    // 날짜를 옮기면 쿼리 키가 바뀐다. 그때 data가 undefined로 떨어지면 보드가 통째로
+    // 언마운트되어 <b>페이지를 새로고침한 것처럼</b> 보인다 — 방금 누른 날짜 칸까지 사라진다.
+    // 이전 응답을 붙들고 있다가 새 응답으로 갈아끼운다(그 사이 무엇을 감출지는 화면이 정한다).
+    placeholderData: keepPreviousData,
     staleTime: 10 * 1000,
     enabled: options.enabled ?? true,
   });

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -111,14 +111,17 @@ function mockBoard(options: {
   stayMove?: unknown;
   /** `GET /trips/{id}/stays` 응답. 상세 시트·겹침 미리보기가 이 목록을 읽는다. */
   stays?: unknown[];
+  /** 그 날짜의 응답을 붙잡아 둔다. 응답 전 화면을 확인할 때 쓴다. */
+  hold?: (date: string) => Promise<void> | null;
 }) {
   const byDate = options.byDate ?? {};
   const archive = options.archive ?? [];
   server.use(
-    http.get(`${API_BASE}/travel/trips/:tripId/board`, ({ request }) => {
+    http.get(`${API_BASE}/travel/trips/:tripId/board`, async ({ request }) => {
       const url = new URL(request.url);
       const isArchive = url.searchParams.get("archive") === "true";
       const date = url.searchParams.get("date") ?? DAYS[0].date;
+      await options.hold?.(date);
       return HttpResponse.json({
         code: "OK",
         data: {
@@ -233,6 +236,38 @@ describe("TripBoardPage", () => {
 
       expect(await screen.findByText("디즈니씨")).toBeInTheDocument();
       expect(screen.getByText("10.25")).toBeInTheDocument();
+    });
+
+    it("날짜를 옮기는 동안 달력과 헤더가 그대로 있다 — 새로고침처럼 보이지 않게", async () => {
+      // 새 날짜 응답을 붙잡아 둔다. 그 사이 화면이 어떻게 보이는지가 이 테스트의 전부다.
+      let release = () => {};
+      const held = new Promise<void>((resolve) => {
+        release = () => resolve();
+      });
+      mockBoard({
+        byDate: { "2026-10-24": [activity()], "2026-10-25": [] },
+        hold: (date) => (date === "2026-10-25" ? held : null),
+      });
+
+      renderBoard();
+      await screen.findByText("센소지");
+
+      await userEvent.click(screen.getByRole("button", { name: "다음 날짜" }));
+
+      // 응답을 기다리는 동안 — 달력·헤더는 그대로다(전체 로딩으로 갈아치우지 않는다).
+      expect(screen.getAllByRole("tab").length).toBeGreaterThan(1);
+      expect(screen.getByText("도쿄 3박 4일")).toBeInTheDocument();
+      // 선택 표시는 응답을 기다리지 않는다 — 누른 칸이 곧바로 켜진다.
+      expect(screen.getByRole("tab", { selected: true })).toHaveTextContent(
+        "25",
+      );
+      // 앞 날짜의 일정을 그 날의 것처럼 남겨두지도 않는다. 기다리는 건 목록뿐이다.
+      expect(screen.queryByText("센소지")).not.toBeInTheDocument();
+      expect(screen.getByText("불러오는 중…")).toBeInTheDocument();
+
+      release();
+      // 응답이 오면 그 날짜의 빈 상태로 바뀐다.
+      expect(await screen.findByText("일정이 없어요")).toBeInTheDocument();
     });
 
     it("달력을 접어도 선택일은 남는다 — 긴 여행에서 자리를 돌려준다", async () => {

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -138,7 +138,9 @@ export function TripBoardPage() {
     isArchive ? { archive: true } : { date: requestedDate },
     { enabled: needsOwnQuery },
   );
-  const board = needsOwnQuery ? dayBoard : base;
+  // 아직 그 날짜의 응답이 없으면 기본 조회로 버틴다. 날짜 목록·여행 정보는 어느 응답에나
+  // 같이 들어 있어, 이것만으로 화면 뼈대(헤더·달력)가 그대로 선다 — 목록만 기다리면 된다.
+  const board = (needsOwnQuery ? dayBoard : base) ?? base;
 
   const [sheetOpen, setSheetOpen] = useState(false);
   const [deletingTrip, setDeletingTrip] = useState(false);
@@ -197,10 +199,19 @@ export function TripBoardPage() {
     );
   }
 
-  const selectedDate = isArchive ? null : board.selectedDate;
+  /**
+   * 고른 날짜. <b>응답이 아니라 URL이 정한다</b> — 날짜별 일정은 새로 받아와야 하지만
+   * "어느 날을 골랐는가"는 이미 알고 있다. 응답을 기다렸다 표시하면 달력 하이라이트가
+   * 한 박자 늦게 따라와, 누른 곳과 켜지는 곳이 어긋나 보인다.
+   */
+  const selectedDate = isArchive ? null : (requestedDate ?? board.selectedDate);
+  /** 아직 고른 날짜의 일정이 오지 않았다. 앞 날짜의 목록을 그 날의 것처럼 보여줄 수는 없다. */
+  const loadingDay = board.selectedDate !== selectedDate;
   const selectedIndex = board.days.findIndex((d) => d.date === selectedDate);
   // 실행취소를 기다리는 동안에는 이미 사라진 것처럼 보여야 한다(낙관적 반영).
-  const activities = board.activities.filter((a) => !pendingIds.includes(a.id));
+  const activities = loadingDay
+    ? []
+    : board.activities.filter((a) => !pendingIds.includes(a.id));
   /**
    * 구간을 <b>도착</b> 일정 id로 걸어 둔다 — 행을 그 일정 <b>바로 앞</b>에 그리기 위해서다.
    *
@@ -242,7 +253,7 @@ export function TripBoardPage() {
 
   /** 보고 있는 날짜. 보관함을 보고 있으면 없다. */
   const selectedDay =
-    board.days.find((day) => day.date === board.selectedDate) ?? null;
+    board.days.find((day) => day.date === selectedDate) ?? null;
   /** 보고 있는 날짜의 기준 도시. 보관함에는 날짜가 없어 첫날로 떨어진다. */
   const selectedCity = (selectedDay ?? board.days[0])?.baseCity ?? null;
 
@@ -719,7 +730,14 @@ export function TripBoardPage() {
 
       {dragMode && <DragModeBar onDone={() => setDragMode(false)} />}
 
-      {activities.length === 0 && (
+      {/* 날짜를 옮기는 중 — 목록만 비운다. 달력·헤더는 그대로 두어야 화면이 튀지 않는다. */}
+      {loadingDay && (
+        <EmptyState className="min-h-[30svh]">
+          <LoadingText />
+        </EmptyState>
+      )}
+
+      {!loadingDay && activities.length === 0 && (
         <EmptyState className="min-h-[30svh]">
           <p className="text-muted-foreground text-sm">
             {selectedDate === null


### PR DESCRIPTION
## 이슈
closes #1217

## 작업 내용

달력에서 다른 날짜를 누르면 **헤더·달력까지 사라지고 화면 전체가 "불러오는 중…"으로 바뀌었다.**
새로고침이 일어난 것은 아니고(`setSearchParams`로 URL만 바꾼다), 로딩 처리가 원인이었다.

- 날짜별 보드는 날짜마다 쿼리 키가 다르다. 처음 여는 날짜는 캐시가 없어 응답 전까지 `dayBoard`가 `undefined`이고,
  `if (isPending || !board) return <LoadingText />`가 **보드 전체를 갈아치웠다** — 방금 누른 날짜 칸까지 사라진다
- 응답이 아직 없으면 **기본 조회로 버틴다**(`(needsOwnQuery ? dayBoard : base) ?? base`).
  날짜 목록·여행 정보는 어느 응답에나 같이 들어 있어 이것만으로 헤더·달력이 그대로 선다
- **고른 날짜를 URL에서 바로 계산한다.** "어느 날을 골랐는가"는 이미 아는 값이라 응답을 기다릴 이유가 없다 —
  기다리면 하이라이트가 한 박자 늦어 누른 곳과 켜지는 곳이 어긋나 보인다.
  도시·메모·숙소 배지도 `board.days`에서 오므로 함께 즉시 바뀐다
- 기다리는 동안 **목록만** 로딩으로 두고 앞 날짜의 일정은 지운다 — 남겨두면 그 날짜의 일정처럼 읽힌다
- `useBoard`에 `keepPreviousData`를 둬, 같은 쿼리 안에서 날짜가 바뀔 때도 데이터가 `undefined`로 떨어지지 않게 한다

### 확인

목킹한 보드에서 둘째 날 응답을 2.5초 붙잡아 두고, 그 사이 화면을 찍었다(412×915).

| | 수정 전 | 수정 후 |
|---|---|---|
| 헤더 | 사라짐 | 그대로 |
| 달력 | 사라짐 | 그대로 |
| 선택 표시 | (화면 없음) | 누른 날짜가 즉시 켜짐 |
| 목록 | — | "불러오는 중…" |

수정 전에는 상단 앱바만 남고 본문이 백지가 된다. 수정 후에는 껍데기가 유지되고 목록 자리에만 로딩이 뜬다.

- 재현 테스트 추가: 응답을 붙잡은 상태에서 달력·헤더가 남아 있고, 선택 표시가 즉시 따라오며,
  앞 날짜 일정이 남지 않는지 확인한다
- `TripBoardPage` 91개 통과, FE 전체 1055개 통과, `format:check` · `lint` · `build` 통과
- 여행 보드 E2E(`travel-day-city` · `travel-board-drag` · `travel-city-move`) 13개 통과
