### PR TITLE
fix : 숙소 배지를 리스트 위로 모으고 담기를 보고 있는 날짜로 옮긴다

### DIFF
--- a/fe/src/features/travel/lib/stayActivity.test.ts
+++ b/fe/src/features/travel/lib/stayActivity.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import type { Stay } from "@/features/travel/api/stays";
+
+import { stayActivityTime, stayActivityTitle } from "./stayActivity";
+
+const STAY: Stay = {
+  stayId: 77,
+  name: "교토 게스트하우스",
+  placeId: 5,
+  checkInDate: "2026-10-25",
+  checkOutDate: "2026-10-28",
+  checkInTime: "15:00",
+  checkOutTime: "11:00",
+  bookingUrl: null,
+  memo: null,
+  nights: 3,
+};
+
+describe("숙소를 일정으로 담을 때", () => {
+  it("체크인하는 날이면 체크인이라고 적는다", () => {
+    expect(stayActivityTitle(STAY, "2026-10-25")).toBe(
+      "교토 게스트하우스 체크인",
+    );
+    expect(stayActivityTime(STAY, "2026-10-25")).toBe("15:00");
+  });
+
+  it("나가는 날이면 체크아웃이라고 적는다", () => {
+    expect(stayActivityTitle(STAY, "2026-10-28")).toBe(
+      "교토 게스트하우스 체크아웃",
+    );
+    expect(stayActivityTime(STAY, "2026-10-28")).toBe("11:00");
+  });
+
+  it("묵는 날에는 숙소 이름만 — 지난 체크인을 오늘 할 일처럼 적지 않는다", () => {
+    expect(stayActivityTitle(STAY, "2026-10-26")).toBe("교토 게스트하우스");
+    expect(stayActivityTime(STAY, "2026-10-26")).toBeNull();
+  });
+
+  it("시각을 모르는 숙소는 시각 없이 담는다 — 지어내면 순서가 틀어진다", () => {
+    const noTime = { ...STAY, checkInTime: null, checkOutTime: null };
+
+    expect(stayActivityTime(noTime, "2026-10-25")).toBeNull();
+    expect(stayActivityTime(noTime, "2026-10-28")).toBeNull();
+  });
+});

--- a/fe/src/features/travel/lib/stayActivity.ts
+++ b/fe/src/features/travel/lib/stayActivity.ts
@@ -1,0 +1,24 @@
+import type { Stay } from "@/features/travel/api/stays";
+
+/**
+ * 숙소를 <b>보고 있는 날짜</b>의 일정으로 담을 때 붙일 이름.
+ *
+ * <p>그 날짜가 숙소에게 무슨 날인지를 이름이 말한다 — 체크인하는 날이면 `체크인`,
+ * 나가는 날이면 `체크아웃`, 그 사이의 묵는 날이면 숙소 이름만. 묵는 날에 `체크인`이 붙으면
+ * 이미 지난 일을 오늘 할 일처럼 적게 된다.
+ */
+export function stayActivityTitle(stay: Stay, date: string): string {
+  if (date === stay.checkInDate) return `${stay.name} 체크인`;
+  if (date === stay.checkOutDate) return `${stay.name} 체크아웃`;
+  return stay.name;
+}
+
+/**
+ * 그 일정에 넣을 시각. 체크인·체크아웃 날에만 아는 시각이 있고, 묵는 날에는 없다.
+ * 모르면 비운다 — 지어낸 시각은 일정 순서를 틀리게 만든다.
+ */
+export function stayActivityTime(stay: Stay, date: string): string | null {
+  if (date === stay.checkInDate) return stay.checkInTime;
+  if (date === stay.checkOutDate) return stay.checkOutTime;
+  return null;
+}

--- a/fe/src/features/travel/lib/stayBadge.test.ts
+++ b/fe/src/features/travel/lib/stayBadge.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { BoardDay } from "@/features/travel/api/activities";
 
-import { badgeAboveList, badgeBelowList } from "./stayBadge";
+import { stayBadges } from "./stayBadge";
 
 function day(overrides: Partial<BoardDay> = {}): BoardDay {
   return {
@@ -36,64 +36,72 @@ const KYOTO = {
   isCheckInDay: true,
 };
 
-describe("리스트 위 배지", () => {
-  it("체크아웃이 먼저다 — 아침에 급한 정보는 몇 시에 나가야 하나다", () => {
-    const item = badgeAboveList(
+describe("숙소 배지", () => {
+  it("숙소를 옮기는 날엔 둘 다 위에 선다 — 일정이 두 숙소 사이에 끼지 않게", () => {
+    const items = stayBadges(
       day({ stayCheckout: DOTONBORI, stayTonight: KYOTO }),
     );
 
-    expect(item).toEqual({
-      stayId: 76,
-      name: "도톤보리 호텔",
-      note: "오늘 체크아웃 11:00",
-    });
+    expect(items).toEqual([
+      { stayId: 76, name: "도톤보리 호텔", note: "오늘 체크아웃 11:00" },
+      { stayId: 77, name: "교토 게스트하우스", note: "오늘 체크인 15:00" },
+    ]);
   });
 
-  it("체크아웃 시각을 모르면 시각 없이 말한다 — 지어내지 않는다", () => {
-    const item = badgeAboveList(
+  it("체크아웃이 먼저다 — 아침에 급한 정보는 몇 시에 나가야 하나다", () => {
+    const items = stayBadges(
+      day({ stayCheckout: DOTONBORI, stayTonight: KYOTO }),
+    );
+
+    expect(items[0].stayId).toBe(76);
+  });
+
+  it("이어서 묵는 날은 한 줄이다 — 같은 숙소를 두 번 쓰면 소음이다", () => {
+    const sameStay = day({
+      stayCheckout: {
+        stayId: 77,
+        name: "교토 게스트하우스",
+        checkOutTime: null,
+      },
+      stayTonight: { ...KYOTO, isCheckInDay: false },
+    });
+
+    expect(stayBadges(sameStay)).toHaveLength(1);
+  });
+
+  it("체크인하는 날은 시각을 몰라도 체크인이라고 말한다 — 체크아웃과 같은 규칙", () => {
+    const items = stayBadges(
+      day({ stayTonight: { ...KYOTO, checkInTime: null } }),
+    );
+
+    expect(items[0].note).toBe("오늘 체크인");
+  });
+
+  it("체크아웃 시각을 몰라도 체크아웃이라고 말한다 — 시각을 지어내지 않는다", () => {
+    const items = stayBadges(
       day({ stayCheckout: { ...DOTONBORI, checkOutTime: null } }),
     );
 
-    expect(item?.note).toBe("오늘 체크아웃");
+    expect(items[0].note).toBe("오늘 체크아웃");
   });
 
-  it("체크아웃이 없으면 오늘 밤 숙소를 보여준다", () => {
-    const item = badgeAboveList(day({ stayTonight: KYOTO }));
-
-    expect(item).toEqual({
-      stayId: 77,
-      name: "교토 게스트하우스",
-      note: "오늘 체크인 15:00",
-    });
-  });
-
-  it("이어서 묵는 날에는 체크인 시각을 붙이지 않는다 — 지난 정보다", () => {
-    const item = badgeAboveList(
+  it("이어서 묵는 날에는 꼬리표를 붙이지 않는다 — 체크인은 지난 일이다", () => {
+    const items = stayBadges(
       day({ stayTonight: { ...KYOTO, isCheckInDay: false } }),
     );
 
-    expect(item?.note).toBeNull();
+    expect(items[0].note).toBeNull();
   });
 
-  it("둘 다 없으면 null — 화면은 그 자리에 `숙소 추가`를 세운다", () => {
-    expect(badgeAboveList(day())).toBeNull();
-    expect(badgeAboveList(null)).toBeNull();
-  });
-});
+  it("체크아웃만 하는 마지막 날은 한 줄이다", () => {
+    const items = stayBadges(day({ stayCheckout: DOTONBORI }));
 
-describe("리스트 아래 배지", () => {
-  it("숙소를 옮기는 날에만 나온다 — 위는 체크아웃, 아래는 오늘 밤", () => {
-    const target = day({ stayCheckout: DOTONBORI, stayTonight: KYOTO });
-
-    expect(badgeAboveList(target)?.stayId).toBe(76);
-    expect(badgeBelowList(target)?.stayId).toBe(77);
+    expect(items).toHaveLength(1);
+    expect(items[0].note).toBe("오늘 체크아웃 11:00");
   });
 
-  it("위 배지와 같은 숙소면 그리지 않는다 — 같은 것을 두 번 쓰면 소음이다", () => {
-    expect(badgeBelowList(day({ stayTonight: KYOTO }))).toBeNull();
-  });
-
-  it("오늘 밤 숙소가 없으면 없다 — 체크아웃만 하는 마지막 날", () => {
-    expect(badgeBelowList(day({ stayCheckout: DOTONBORI }))).toBeNull();
+  it("둘 다 없으면 비어 있다 — 화면은 그 자리에 `숙소 추가`를 세운다", () => {
+    expect(stayBadges(day())).toEqual([]);
+    expect(stayBadges(null)).toEqual([]);
   });
 });

--- a/fe/src/features/travel/lib/stayBadge.ts
+++ b/fe/src/features/travel/lib/stayBadge.ts
@@ -9,34 +9,33 @@ export interface StayBadgeItem {
 }
 
 /**
- * 리스트 **위** 배지 — <b>체크아웃이 먼저다</b>(§3.5).
+ * 그날의 숙소 배지들 — <b>모두 리스트 위</b>에 선다.
  *
- * <p>아침에 이 화면을 열었을 때 급한 정보는 "오늘 어디서 자나"가 아니라 "몇 시에 나가야
- * 하나"다. 체크아웃하는 날에 오늘 밤 숙소를 위에 띄우면, 정작 시간에 쫓기는 정보가 아래로
- * 밀린다.
+ * <p>숙소를 옮기는 날에는 나가는 곳과 들어가는 곳이 둘 다 나온다. 예전에는 하나를 리스트
+ * <b>아래</b>에 뒀는데, 그러면 일정이 두 숙소 사이에 끼어 "이 일정은 어느 숙소에 속하나"처럼
+ * 읽혔다. 숙소는 하루의 <b>테두리</b>지 일정 사이의 칸막이가 아니다.
+ *
+ * <p>순서는 <b>체크아웃이 먼저</b>다(§3.5). 아침에 이 화면을 열었을 때 급한 정보는
+ * "오늘 어디서 자나"가 아니라 "몇 시에 나가야 하나"다.
  */
-export function badgeAboveList(day: BoardDay | null): StayBadgeItem | null {
-  if (day?.stayCheckout) {
-    const { stayId, name, checkOutTime } = day.stayCheckout;
-    return {
-      stayId,
-      name,
-      note: checkOutTime ? `오늘 체크아웃 ${checkOutTime}` : "오늘 체크아웃",
-    };
-  }
-  return tonightItem(day);
+export function stayBadges(day: BoardDay | null): StayBadgeItem[] {
+  const badges = [checkoutItem(day), tonightItem(day)].filter(
+    (item): item is StayBadgeItem => item !== null,
+  );
+  // 나가는 곳과 자는 곳이 같으면(= 이어서 묵는 날) 한 줄이면 된다.
+  return badges.length === 2 && badges[0].stayId === badges[1].stayId
+    ? [badges[0]]
+    : badges;
 }
 
-/**
- * 리스트 **아래** 배지 — 위 배지와 <b>다를 때만</b>(= 숙소를 옮기는 날).
- *
- * <p>같으면 같은 숙소를 한 화면에 두 번 쓰는 것이라 정보가 아니라 소음이다. 다를 때만
- * 그리면 그 자리에 배지가 있다는 것 자체가 "오늘 숙소를 옮긴다"는 뜻이 된다.
- */
-export function badgeBelowList(day: BoardDay | null): StayBadgeItem | null {
-  const tonight = tonightItem(day);
-  if (tonight === null) return null;
-  return badgeAboveList(day)?.stayId === tonight.stayId ? null : tonight;
+function checkoutItem(day: BoardDay | null): StayBadgeItem | null {
+  if (!day?.stayCheckout) return null;
+  const { stayId, name, checkOutTime } = day.stayCheckout;
+  return {
+    stayId,
+    name,
+    note: withTime("오늘 체크아웃", checkOutTime),
+  };
 }
 
 function tonightItem(day: BoardDay | null): StayBadgeItem | null {
@@ -45,7 +44,13 @@ function tonightItem(day: BoardDay | null): StayBadgeItem | null {
   return {
     stayId,
     name,
-    // 체크인하는 날에만 시각을 붙인다 — 이어서 묵는 날에 체크인 시각은 지난 정보다.
-    note: isCheckInDay && checkInTime ? `오늘 체크인 ${checkInTime}` : null,
+    // 체크인하는 날은 <b>시각을 몰라도</b> 체크인이라고 말한다 — 체크아웃 쪽과 같은 규칙이다.
+    // 한쪽만 꼬리표가 붙으면 나가는 곳인지 들어가는 곳인지를 이름으로 추측하게 된다.
+    // 이어서 묵는 날은 붙일 말이 없다(체크인은 지난 일이고 체크아웃은 오늘이 아니다).
+    note: isCheckInDay ? withTime("오늘 체크인", checkInTime) : null,
   };
+}
+
+function withTime(label: string, time: string | null): string {
+  return time ? `${label} ${time}` : label;
 }

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -2142,13 +2142,52 @@ describe("TripBoardPage", () => {
         within(sheet).getByRole("button", { name: /일정으로 추가/ }),
       );
 
-      await waitFor(() => expect(created).toHaveLength(2));
-      expect(created.map((body) => body.title)).toEqual([
-        "도톤보리 호텔 체크인",
-        "도톤보리 호텔 체크아웃",
-      ]);
+      // 보고 있는 날짜(1일차 = 체크인 날)에 한 벌만 만든다.
+      await waitFor(() => expect(created).toHaveLength(1));
+      expect(created[0].title).toBe("도톤보리 호텔 체크인");
       expect(created[0].activityDate).toBe("2026-10-24");
-      expect(created[1].activityDate).toBe("2026-10-26");
+      expect(created[0].startTime).toBe("15:00");
+    });
+
+    it("묵는 날에 담으면 그 날짜에 숙소 이름으로 담긴다 — 체크아웃 날로 새지 않는다", async () => {
+      const created: Record<string, unknown>[] = [];
+      server.use(
+        http.post(
+          `${API_BASE}/travel/trips/:tripId/activities`,
+          async ({ request }) => {
+            created.push((await request.json()) as Record<string, unknown>);
+            return HttpResponse.json({ code: "OK", data: activity() });
+          },
+        ),
+      );
+      mockBoard({
+        days: [
+          DAYS[0],
+          day(2, "2026-10-25", "일", 0, {
+            // 이어서 묵는 날 — 체크인도 체크아웃도 아니다.
+            stayTonight: tonight(76, "도톤보리 호텔"),
+          }),
+          ...DAYS.slice(2),
+        ],
+        stays: [DOTONBORI],
+      });
+
+      const user = userEvent.setup();
+      // 2일차를 보고 있다.
+      renderBoard("/travel/trips/3/board?day=1");
+      await user.click(
+        await screen.findByRole("button", { name: /^숙소 도톤보리 호텔/ }),
+      );
+      const sheet = await screen.findByRole("dialog");
+      await user.click(
+        within(sheet).getByRole("button", { name: /일정으로 추가/ }),
+      );
+
+      await waitFor(() => expect(created).toHaveLength(1));
+      expect(created[0].title).toBe("도톤보리 호텔");
+      expect(created[0].activityDate).toBe("2026-10-25");
+      // 묵는 날에는 아는 시각이 없다.
+      expect(created[0].startTime).toBeNull();
     });
 
     it("겹치는 기간은 저장을 누르기 전에 막고 어느 숙소와 겹치는지 말한다", async () => {

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -78,9 +78,10 @@ import {
 } from "@/features/travel/lib/archiveGroups";
 import { tripCities } from "@/features/travel/lib/baseCity";
 import {
-  badgeAboveList,
-  badgeBelowList,
-} from "@/features/travel/lib/stayBadge";
+  stayActivityTime,
+  stayActivityTitle,
+} from "@/features/travel/lib/stayActivity";
+import { stayBadges } from "@/features/travel/lib/stayBadge";
 import { overlapMessage } from "@/features/travel/lib/stayForDay";
 import { PickDaySheet } from "@/features/travel/places/PickDaySheet";
 import { StayBadge } from "@/features/travel/stay/StayBadge";
@@ -254,6 +255,8 @@ export function TripBoardPage() {
   /** 보고 있는 날짜. 보관함을 보고 있으면 없다. */
   const selectedDay =
     board.days.find((day) => day.date === selectedDate) ?? null;
+  /** 그날의 숙소 배지들. 옮기는 날이면 나가는 곳과 자는 곳이 함께 온다. */
+  const dayStays = stayBadges(selectedDay);
   /** 보고 있는 날짜의 기준 도시. 보관함에는 날짜가 없어 첫날로 떨어진다. */
   const selectedCity = (selectedDay ?? board.days[0])?.baseCity ?? null;
 
@@ -488,30 +491,25 @@ export function TripBoardPage() {
   };
 
   /**
-   * 체크인·체크아웃을 일정으로 만든다 — <b>누를 때만</b>. 자동 생성하면 지워도 다음 조회에
-   * 되살아나는 일정이 되고, 그 뒤로는 사용자가 지운 것을 앱이 되돌리는 셈이다.
+   * 숙소를 일정으로 만든다 — <b>누를 때만</b>. 자동 생성하면 지워도 다음 조회에 되살아나는
+   * 일정이 되고, 그 뒤로는 사용자가 지운 것을 앱이 되돌리는 셈이다.
+   *
+   * <p><b>보고 있는 날짜에 담는다.</b> 예전에는 체크인·체크아웃 날짜에 한 벌씩 만들었는데,
+   * 그러면 3박짜리 숙소를 둘째 날 화면에서 담아도 그 날짜에는 아무것도 생기지 않았다 —
+   * 누른 사람 입장에서는 담기지 않은 것과 같다.
    *
    * <p>만든 뒤로는 숙소와 아무 관계가 없는 보통 일정이다 — 숙소를 지워도 남는다.
    */
-  const addStayActivities = async (stay: Stay) => {
-    await Promise.all(
-      [
-        {
-          title: `${stay.name} 체크인`,
-          activityDate: stay.checkInDate,
-          startTime: stay.checkInTime,
-        },
-        {
-          title: `${stay.name} 체크아웃`,
-          activityDate: stay.checkOutDate,
-          startTime: stay.checkOutTime,
-        },
-      ].map((input) =>
-        createActivity.mutateAsync({ ...input, placeId: stay.placeId }),
-      ),
-    );
+  const addStayActivity = async (stay: Stay) => {
+    if (selectedDate === null) return;
+    await createActivity.mutateAsync({
+      title: stayActivityTitle(stay, selectedDate),
+      activityDate: selectedDate,
+      startTime: stayActivityTime(stay, selectedDate),
+      placeId: stay.placeId,
+    });
     setOpenStayId(null);
-    toast("체크인·체크아웃을 일정으로 추가했어요.", "success");
+    toast("일정으로 추가했어요.", "success");
   };
 
   return (
@@ -630,15 +628,28 @@ export function TripBoardPage() {
           </p>
         )}
 
-        {/* 숙소 배지 — 체크아웃이 먼저다(§3.5). 보관함에는 "그날 밤"이 없다. */}
-        {!isArchive && (
-          <StayBadge
-            item={badgeAboveList(selectedDay)}
-            onOpen={openStay}
-            onAdd={startAddStay}
-            offline={!online}
-          />
-        )}
+        {/* 숙소 배지 — 체크아웃이 먼저다(§3.5). 보관함에는 "그날 밤"이 없다.
+            옮기는 날의 두 숙소를 모두 여기 세운다. 하나를 리스트 아래에 두면 일정이
+            두 숙소 사이에 끼어 "이 일정은 어느 숙소에 속하나"처럼 읽힌다. */}
+        {!isArchive &&
+          (dayStays.length > 0 ? (
+            dayStays.map((item) => (
+              <StayBadge
+                key={item.stayId}
+                item={item}
+                onOpen={openStay}
+                onAdd={startAddStay}
+                offline={!online}
+              />
+            ))
+          ) : (
+            <StayBadge
+              item={null}
+              onOpen={openStay}
+              onAdd={startAddStay}
+              offline={!online}
+            />
+          ))}
 
         {/* 보관함은 도시별로 묶는다 — 그 도시 날짜를 짜는 동안 볼 것이 한 덩어리가 된다.
             순서가 없는 목록이라 드래그 정렬도 없다. */}
@@ -714,17 +725,6 @@ export function TripBoardPage() {
               )}
             </ul>
           </SortableContext>
-        )}
-
-        {/* 숙소를 옮기는 날에만 — 위 배지(체크아웃)와 다른 숙소일 때다. 같으면 소음이다. */}
-        {!isArchive && badgeBelowList(selectedDay) && (
-          <StayBadge
-            item={badgeBelowList(selectedDay)}
-            onOpen={openStay}
-            onAdd={startAddStay}
-            offline={!online}
-            hideAdd
-          />
         )}
       </DndContext>
 
@@ -817,7 +817,7 @@ export function TripBoardPage() {
           setOpenStayId(null);
           setDeletingStay(stay);
         }}
-        onAddActivity={(stay) => void addStayActivities(stay)}
+        onAddActivity={(stay) => void addStayActivity(stay)}
         offline={!online}
         addingActivity={createActivity.isPending}
       />


### PR DESCRIPTION
## 이슈
closes #1219

## 작업 내용

### 1. 숙소 배지를 모두 리스트 위로

`badgeAboveList`/`badgeBelowList`를 `stayBadges(day): StayBadgeItem[]` 하나로 합쳤다.
옮기는 날에는 나가는 곳과 자는 곳이 위에 나란히 서고, 같은 숙소면(이어서 묵는 날) 한 줄만 남는다.
순서는 그대로 **체크아웃이 먼저**다(§3.5) — 아침에 급한 정보는 "몇 시에 나가야 하나"다.

### 2. 체크인 표기 통일

`isCheckInDay && checkInTime`이 조건이라 **시각을 모르는 숙소는 꼬리표가 통째로 빠졌다.**
한쪽만 붙으니 어느 쪽이 나가는 곳인지 이름으로 추측해야 했다.
체크아웃과 같은 규칙으로 바꿔, 시각을 몰라도 `오늘 체크인`이라고 말한다.
이어서 묵는 날은 붙일 말이 없어 그대로 비운다(체크인은 지난 일, 체크아웃은 오늘이 아니다).

### 3. `일정으로 추가`를 보고 있는 날짜로

체크인 날짜와 체크아웃 날짜에 **한 벌씩** 만들던 것을, 보고 있는 날짜에 **한 벌만** 만들도록 바꿨다.
3박 숙소를 둘째 날 화면에서 담으면 그 날짜에는 아무것도 안 생기고 엉뚱하게 체크아웃 날에 하나 늘었다.
그 날짜가 체크인/체크아웃 날이면 이름과 시각에 반영한다(`stayActivity.ts`).

| 보고 있는 날짜 | 담기는 이름 | 시각 |
|---|---|---|
| 체크인 날 | `{숙소} 체크인` | checkInTime |
| 묵는 날 | `{숙소}` | 없음 |
| 체크아웃 날 | `{숙소} 체크아웃` | checkOutTime |

### 확인

목킹한 보드(오사카 → 교토, 체크아웃 10:00 / 체크인 시각 없음)에서 실제 화면으로 확인했다.

```
숙소 토요코인 오사카 덴진바시스지로쿠초메 · 오늘 체크아웃 10:00
숙소 토요코인 교토 니조조 미나미 · 오늘 체크인
(그 아래에 일정 목록)
```

- `stayBadge` 8개 · 새 `stayActivity` 4개 · 보드 통합 92개 통과
- FE 전체 1060개, `format:check` · `lint` · `build` 통과
