### PR TITLE
feat : 장소를 담을 때 보던 날짜를 이어받고 상세를 적은 뒤 저장한다

### DIFF
--- a/fe/e2e/travel-search-city.spec.ts
+++ b/fe/e2e/travel-search-city.spec.ts
@@ -179,10 +179,9 @@ test.describe("검색 기준 도시", () => {
 
     // 담으면 그 도시 식별자가 함께 저장된다 — 보관함 도시 그룹이 여기서 살아난다.
     await page.getByRole("button", { name: "담기" }).click();
-    await page
-      .getByRole("dialog")
-      .getByRole("button", { name: /2일차/ })
-      .click();
+    await page.getByRole("combobox", { name: "날짜" }).click();
+    await page.getByRole("option", { name: /2일차/ }).click();
+    await page.getByRole("button", { name: "저장" }).click();
 
     await expect.poll(() => created.length).toBe(1);
     expect(created[0].cityPlaceId).toBe(22);

--- a/fe/src/features/travel/places/PlaceAddSheet.tsx
+++ b/fe/src/features/travel/places/PlaceAddSheet.tsx
@@ -1,0 +1,153 @@
+import { type FormEvent, useEffect, useState } from "react";
+
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { Select, type SelectOption } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import type { BoardDay } from "@/features/travel/api/activities";
+
+/** 날짜 자리에 쓰는 `보관함` 값. 날짜 문자열과 섞이지 않는 값이어야 한다. */
+const ARCHIVE = "archive";
+
+export interface PlaceAddInput {
+  title: string;
+  /** null이면 보관함이다. */
+  date: string | null;
+  startTime: string | null;
+  memo: string | null;
+}
+
+interface PlaceAddSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** 담을 장소 이름. 제목의 기본값이다. */
+  placeName: string | null;
+  days: BoardDay[];
+  /** 처음 골라 둘 날짜 — <b>보고 있던 날짜</b>다. null이면 보관함. */
+  defaultDate: string | null;
+  onSave: (input: PlaceAddInput) => void;
+  pending?: boolean;
+}
+
+/**
+ * 장소를 일정으로 담는 시트(§S-06).
+ *
+ * <p><b>고르자마자 담지 않는다.</b> 검색 결과를 누르는 순간 담기면, 시각이나 메모를 넣으려면
+ * 보드로 돌아가 그 일정을 다시 찾아 열어야 한다 — 담는 김에 적는 것이 자연스럽다.
+ * 저장을 누를 때만 만든다.
+ *
+ * <p>날짜는 <b>보고 있던 날짜로 미리 채운다.</b> 3일차를 짜다가 검색으로 들어왔으면 담을 곳도
+ * 3일차다. 매번 고르게 하면 같은 답을 반복해서 입력하게 된다. 물론 바꿀 수 있고,
+ * `보관함`도 그대로 선택지에 있다 — "가고 싶다"는 "언제 갈지"보다 먼저 정해지기 때문이다.
+ */
+export function PlaceAddSheet({
+  open,
+  onOpenChange,
+  placeName,
+  days,
+  defaultDate,
+  onSave,
+  pending = false,
+}: PlaceAddSheetProps) {
+  const [title, setTitle] = useState("");
+  const [date, setDate] = useState<string>(ARCHIVE);
+  const [startTime, setStartTime] = useState("");
+  const [memo, setMemo] = useState("");
+
+  // 열 때마다 이 장소·이 날짜로 되돌린다 — 지난번 입력이 남아 있으면 실수로 저장된다.
+  useEffect(() => {
+    if (!open) return;
+    setTitle(placeName ?? "");
+    setDate(defaultDate ?? ARCHIVE);
+    setStartTime("");
+    setMemo("");
+  }, [open, placeName, defaultDate]);
+
+  const options: SelectOption<string>[] = [
+    ...days.map((day) => ({
+      value: day.date,
+      // 어느 도시의 날짜인지가 몇 일차인지만큼 중요하다 — 다구간 여행에서
+      // "3일차"만으로는 어디인지 알 수 없다.
+      label: `${day.dayIndex}일차${day.baseCity ? ` · ${day.baseCity.name}` : ""} (${day.date.slice(5)} ${day.weekday})`,
+    })),
+    { value: ARCHIVE, label: "보관함 · 날짜는 나중에" },
+  ];
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    onSave({
+      title: trimmed,
+      date: date === ARCHIVE ? null : date,
+      startTime: startTime || null,
+      memo: memo.trim() || null,
+    });
+  };
+
+  return (
+    <BottomSheet
+      open={open}
+      onOpenChange={onOpenChange}
+      title="일정으로 담기"
+      description={placeName ?? undefined}
+    >
+      <form className="flex flex-col gap-3" onSubmit={submit}>
+        <FormField label="일정 제목" htmlFor="placeAddTitle">
+          <Input
+            id="placeAddTitle"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={100}
+          />
+        </FormField>
+
+        <FormField label="날짜" labelId="placeAddDate">
+          <Select
+            ariaLabelledby="placeAddDate"
+            value={date}
+            onValueChange={setDate}
+            options={options}
+          />
+        </FormField>
+
+        <FormField label="시각 (선택)" htmlFor="placeAddTime">
+          <Input
+            id="placeAddTime"
+            type="time"
+            value={startTime}
+            onChange={(e) => setStartTime(e.target.value)}
+            // 보관함에는 순서가 없다 — 시각을 받아도 쓸 자리가 없다.
+            disabled={date === ARCHIVE}
+          />
+        </FormField>
+
+        <FormField label="메모 (선택)" htmlFor="placeAddMemo">
+          <Textarea
+            id="placeAddMemo"
+            value={memo}
+            onChange={(e) => setMemo(e.target.value)}
+            placeholder="예약 번호, 가는 길 메모"
+            maxLength={1000}
+            rows={2}
+          />
+        </FormField>
+
+        <div className="flex justify-end gap-2 pt-1">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            취소
+          </Button>
+          <Button type="submit" disabled={pending || !title.trim()}>
+            저장
+          </Button>
+        </div>
+      </form>
+    </BottomSheet>
+  );
+}

--- a/fe/src/pages/travel/PlaceSearchPage.test.tsx
+++ b/fe/src/pages/travel/PlaceSearchPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -298,7 +298,14 @@ describe("PlaceSearchPage", () => {
       renderSearch("/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80");
 
       await user.click(await screen.findByRole("button", { name: "담기" }));
-      await user.click(await screen.findByRole("button", { name: /2일차/ }));
+
+      // 고른 순간 담기지 않는다 — 저장을 눌러야 만들어진다.
+      expect(await screen.findByRole("dialog")).toBeInTheDocument();
+      expect(bodies).toHaveLength(0);
+
+      await user.click(screen.getByRole("combobox", { name: "날짜" }));
+      await user.click(await screen.findByRole("option", { name: /2일차/ }));
+      await user.click(screen.getByRole("button", { name: "저장" }));
 
       await waitFor(() => expect(bodies).toHaveLength(1));
       expect(bodies[0]).toMatchObject({
@@ -307,6 +314,92 @@ describe("PlaceSearchPage", () => {
         googlePlaceId: "ChIJ_senso",
       });
       expect(await screen.findByText("2일차에 담았어요")).toBeInTheDocument();
+    });
+
+    it("보던 날짜가 미리 골라져 있다 — 3일차를 짜다 들어왔으면 담을 곳도 그 날짜다", async () => {
+      mockSearch();
+      const bodies: unknown[] = [];
+      server.use(
+        http.post(
+          `${API_BASE}/travel/trips/:tripId/activities`,
+          async ({ request }) => {
+            bodies.push(await request.json());
+            return HttpResponse.json({ code: "OK", data: { id: 11 } });
+          },
+        ),
+      );
+      const user = userEvent.setup();
+      // 보드가 넘겨주는 형태 그대로다(`?date=`).
+      renderSearch(
+        "/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80&date=2026-10-25",
+      );
+
+      await user.click(await screen.findByRole("button", { name: "담기" }));
+      // 날짜를 고르지 않고 곧바로 저장한다.
+      await user.click(await screen.findByRole("button", { name: "저장" }));
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      expect(bodies[0]).toMatchObject({ activityDate: "2026-10-25" });
+    });
+
+    it("시각과 메모를 담는 김에 같이 적는다 — 담고 나서 다시 찾아 열지 않게", async () => {
+      mockSearch();
+      const bodies: unknown[] = [];
+      server.use(
+        http.post(
+          `${API_BASE}/travel/trips/:tripId/activities`,
+          async ({ request }) => {
+            bodies.push(await request.json());
+            return HttpResponse.json({ code: "OK", data: { id: 11 } });
+          },
+        ),
+      );
+      const user = userEvent.setup();
+      renderSearch(
+        "/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80&date=2026-10-24",
+      );
+
+      await user.click(await screen.findByRole("button", { name: "담기" }));
+      const title = await screen.findByLabelText("일정 제목");
+      await user.clear(title);
+      await user.type(title, "센소지 야경");
+      fireEvent.change(screen.getByLabelText("시각 (선택)"), {
+        target: { value: "18:30" },
+      });
+      await user.type(screen.getByLabelText("메모 (선택)"), "나카미세 통과");
+      await user.click(screen.getByRole("button", { name: "저장" }));
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      expect(bodies[0]).toMatchObject({
+        title: "센소지 야경",
+        activityDate: "2026-10-24",
+        startTime: "18:30",
+        memo: "나카미세 통과",
+      });
+    });
+
+    it("여행에 없는 날짜가 넘어오면 무시하고 보관함으로 둔다 — URL을 그대로 믿지 않는다", async () => {
+      mockSearch();
+      const bodies: unknown[] = [];
+      server.use(
+        http.post(
+          `${API_BASE}/travel/trips/:tripId/activities`,
+          async ({ request }) => {
+            bodies.push(await request.json());
+            return HttpResponse.json({ code: "OK", data: { id: 11 } });
+          },
+        ),
+      );
+      const user = userEvent.setup();
+      renderSearch(
+        "/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80&date=1999-01-01",
+      );
+
+      await user.click(await screen.findByRole("button", { name: "담기" }));
+      await user.click(await screen.findByRole("button", { name: "저장" }));
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      expect(bodies[0]).toMatchObject({ activityDate: null });
     });
 
     it("보관함을 고르면 날짜 없이 담는다 — 갈지는 정했는데 언제인지는 아직일 때", async () => {
@@ -325,7 +418,9 @@ describe("PlaceSearchPage", () => {
       renderSearch("/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80");
 
       await user.click(await screen.findByRole("button", { name: "담기" }));
-      await user.click(await screen.findByRole("button", { name: /보관함/ }));
+      await user.click(await screen.findByRole("combobox", { name: "날짜" }));
+      await user.click(await screen.findByRole("option", { name: /보관함/ }));
+      await user.click(screen.getByRole("button", { name: "저장" }));
 
       await waitFor(() => expect(bodies).toHaveLength(1));
       expect(bodies[0]).toMatchObject({ activityDate: null });
@@ -343,7 +438,9 @@ describe("PlaceSearchPage", () => {
       renderSearch("/travel/trips/3/places?q=%EC%84%BC%EC%86%8C%EC%A7%80");
 
       await user.click(await screen.findByRole("button", { name: "담기" }));
-      await user.click(await screen.findByRole("button", { name: /1일차/ }));
+      await user.click(await screen.findByRole("combobox", { name: "날짜" }));
+      await user.click(await screen.findByRole("option", { name: /1일차/ }));
+      await user.click(screen.getByRole("button", { name: "저장" }));
 
       expect(await screen.findByText(/담지 못했어요/)).toBeInTheDocument();
     });
@@ -382,8 +479,10 @@ describe("PlaceSearchPage", () => {
       );
       await user.click(screen.getByRole("button", { name: "만들기" }));
 
-      // 장소만 만들고 끝나면 어디에도 보이지 않는다 — 바로 날짜를 물어야 한다.
-      await user.click(await screen.findByRole("button", { name: /1일차/ }));
+      // 장소만 만들고 끝나면 어디에도 보이지 않는다 — 바로 담기 시트를 열어야 한다.
+      await user.click(await screen.findByRole("combobox", { name: "날짜" }));
+      await user.click(await screen.findByRole("option", { name: /1일차/ }));
+      await user.click(screen.getByRole("button", { name: "저장" }));
 
       await waitFor(() => expect(bodies).toHaveLength(1));
       expect(bodies[0]).toMatchObject({
@@ -412,6 +511,40 @@ describe("PlaceSearchPage", () => {
       );
 
       expect(await screen.findByLabelText("장소 검색")).toBeInTheDocument();
+    });
+
+    it("보던 날짜를 들고 와 담기 시트에 미리 골라 둔다", async () => {
+      mockSearch();
+      const bodies: unknown[] = [];
+      server.use(
+        http.post(
+          `${API_BASE}/travel/trips/:tripId/activities`,
+          async ({ request }) => {
+            bodies.push(await request.json());
+            return HttpResponse.json({ code: "OK", data: { id: 11 } });
+          },
+        ),
+      );
+      const user = userEvent.setup();
+      // 2일차를 보다가 검색으로 들어간다.
+      renderWithRouter(
+        <Providers>
+          <AppRouter />
+        </Providers>,
+        { initialEntries: ["/travel/trips/3/board?day=1"] },
+      );
+
+      await user.click(
+        await screen.findByRole("button", { name: "장소 검색" }),
+      );
+      await user.type(await screen.findByLabelText("장소 검색"), "센소지");
+      await user.keyboard("{Enter}");
+
+      await user.click(await screen.findByRole("button", { name: "담기" }));
+      await user.click(await screen.findByRole("button", { name: "저장" }));
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      expect(bodies[0]).toMatchObject({ activityDate: "2026-10-25" });
     });
 
     it("보던 날짜의 도시를 들고 온다 — 이 화면의 기본 조회로는 알 수 없는 값이다", async () => {
@@ -502,8 +635,9 @@ describe("PlaceSearchPage", () => {
       renderSearch("/travel/trips/3/places?q=센소지&city=22");
 
       await user.click(await screen.findByRole("button", { name: "담기" }));
-      const sheet = await screen.findByRole("dialog");
-      await user.click(within(sheet).getByRole("button", { name: /1일차/ }));
+      await user.click(await screen.findByRole("combobox", { name: "날짜" }));
+      await user.click(await screen.findByRole("option", { name: /1일차/ }));
+      await user.click(screen.getByRole("button", { name: "저장" }));
 
       await waitFor(() => expect(created).toHaveLength(1));
       expect(created[0].googlePlaceId).toBe("ChIJ_senso");
@@ -517,13 +651,12 @@ describe("PlaceSearchPage", () => {
       renderSearch("/travel/trips/3/places?q=센소지&city=22");
 
       await user.click(await screen.findByRole("button", { name: "담기" }));
-      const sheet = await screen.findByRole("dialog");
+      await user.click(await screen.findByRole("combobox", { name: "날짜" }));
 
-      const dayButtons = within(sheet)
-        .getAllByRole("button")
-        .map((button) => button.textContent ?? "")
+      const options = (await screen.findAllByRole("option"))
+        .map((option) => option.textContent ?? "")
         .filter((text) => text.includes("일차"));
-      expect(dayButtons[0]).toContain("2일차");
+      expect(options[0]).toContain("2일차");
     });
   });
 });

--- a/fe/src/pages/travel/PlaceSearchPage.tsx
+++ b/fe/src/pages/travel/PlaceSearchPage.tsx
@@ -23,7 +23,10 @@ import {
 } from "@/features/travel/lib/recentSearches";
 import { failureOf } from "@/features/travel/lib/searchFailure";
 import { GoogleAttribution } from "@/features/travel/places/GoogleAttribution";
-import { PickDaySheet } from "@/features/travel/places/PickDaySheet";
+import {
+  type PlaceAddInput,
+  PlaceAddSheet,
+} from "@/features/travel/places/PlaceAddSheet";
 import { PlaceCard } from "@/features/travel/places/PlaceCard";
 import { SearchCityChip } from "@/features/travel/places/SearchCityChip";
 import { SearchUnavailable } from "@/features/travel/places/SearchUnavailable";
@@ -53,6 +56,11 @@ export function PlaceSearchPage() {
   const [draft, setDraft] = useState(query);
   /** 기준 도시도 URL이 소유한다(§9.7) — 새로고침·뒤로가기에서 살아남아야 한다. */
   const cityParam = Number(searchParams.get("city"));
+  /**
+   * 보드에서 보고 있던 날짜(`?date=YYYY-MM-DD`, 보관함이면 `archive`).
+   * 담기 시트의 기본 날짜가 된다 — 3일차를 짜다 들어왔으면 담을 곳도 3일차다.
+   */
+  const dateParam = searchParams.get("date");
   const [citySheetOpen, setCitySheetOpen] = useState(false);
 
   const [recent, setRecent] = useState<string[]>(() =>
@@ -68,13 +76,18 @@ export function PlaceSearchPage() {
 
   const { data: board, isPending: boardPending } = useBoard(tripId, {});
   const cities = tripCities(board?.days ?? []);
+  /** 넘어온 날짜가 이 여행의 날짜일 때만 쓴다 — 손으로 고친 URL을 그대로 믿지 않는다. */
+  const viewingDate =
+    dateParam !== null && board?.days.some((day) => day.date === dateParam)
+      ? dateParam
+      : null;
   /**
    * 검색이 기준으로 삼는 도시. `?city=`가 있으면 그 도시, 없으면 <b>보고 있던 날짜의</b>
    * 도시다 — 교토 날짜를 보다가 검색으로 들어왔으면 교토가 기준이어야 한다.
    */
   const city =
     cities.find((c) => c.placeId === cityParam) ??
-    cityOn(board?.days ?? [], board?.selectedDate ?? "") ??
+    cityOn(board?.days ?? [], viewingDate ?? board?.selectedDate ?? "") ??
     cities[0] ??
     null;
 
@@ -113,12 +126,14 @@ export function PlaceSearchPage() {
     setParams({ city: next.placeId });
   };
 
-  const add = (date: string | null) => {
+  const add = ({ title, date, startTime, memo }: PlaceAddInput) => {
     if (!target) return;
     createActivity.mutate(
       {
-        title: target.name,
+        title,
         activityDate: date,
+        startTime,
+        memo,
         ...(target.kind === "google"
           ? // 어느 도시를 기준으로 찾았는지 함께 보낸다 — 그래야 담은 장소가 보관함
             // 도시 그룹과 도시 이탈 표시에서 `도시 없음`으로 떨어지지 않는다.
@@ -273,13 +288,14 @@ export function PlaceSearchPage() {
         </div>
       )}
 
-      <PickDaySheet
+      <PlaceAddSheet
         open={target !== null}
         onOpenChange={(open) => !open && setTarget(null)}
         placeName={target?.name ?? null}
         // 기준 도시가 곧 그 장소의 도시다 — 그 도시인 날짜를 위로 올린다(#1134).
         days={daysForPlace(board?.days ?? [], city?.cityPlaceRef)}
-        onPick={add}
+        defaultDate={viewingDate}
+        onSave={add}
         pending={createActivity.isPending}
       />
 

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -267,13 +267,16 @@ export function TripBoardPage() {
    * 장소 검색으로 넘어간다. <b>보고 있던 날짜의 도시를 들고 간다</b>(§2.7) — 교토 날짜를
    * 보다가 검색으로 들어왔으면 교토 가게가 나와야 한다. 보관함에는 날짜가 없어 그냥 간다.
    */
+  /**
+   * 장소 검색(S-06)으로 나간다. <b>보고 있던 날짜를 함께 넘긴다</b> — 담기 시트가 그 날짜를
+   * 미리 골라 두므로, 3일차를 짜다 들어온 사람이 날짜를 다시 고를 일이 없다.
+   */
   const searchPlaces = () => {
-    const city = selectedCity;
-    navigate(
-      city
-        ? `/travel/trips/${tripId}/places?city=${city.placeId}`
-        : `/travel/trips/${tripId}/places`,
-    );
+    const params = new URLSearchParams();
+    if (selectedCity) params.set("city", String(selectedCity.placeId));
+    if (selectedDate) params.set("date", selectedDate);
+    const query = params.toString();
+    navigate(`/travel/trips/${tripId}/places${query ? `?${query}` : ""}`);
   };
 
   /** 보관함은 순서가 아니라 도시로 읽는다. 보고 있지 않으면 계산할 이유가 없다. */


### PR DESCRIPTION
## 이슈
closes #1221

## 작업 내용

### 보던 날짜를 이어받는다

보드가 `장소 검색`으로 나갈 때 보고 있던 날짜를 함께 넘긴다(`?date=2026-10-25`).
담기 시트가 그 날짜를 미리 골라 두므로, 3일차를 짜다 들어온 사람이 날짜를 다시 고를 일이 없다.
여행에 없는 날짜가 넘어오면 무시하고 보관함으로 둔다 — 손으로 고친 URL을 그대로 믿지 않는다.
검색 기준 도시 판정도 넘어온 날짜를 따른다.

### 고르는 순간이 아니라 저장할 때 담긴다

`어느 날에 담을까요?`(PickDaySheet)를 상세 입력 시트(`PlaceAddSheet`)로 바꿨다.

- **제목** — 장소 이름으로 채워져 있고 고칠 수 있다 (`니조 성` → `니조 성 야경`)
- **날짜** — 보던 날짜가 미리 골라져 있다. `보관함 · 날짜는 나중에`도 그대로 있다
- **시각 (선택)** — 보관함을 고르면 비활성이다. 보관함에는 순서가 없어 쓸 자리가 없다
- **메모 (선택)**
- **저장**을 눌러야 만들어진다

담고 나서 시각·메모를 넣으려고 보드로 돌아가 그 일정을 다시 찾아 열 필요가 없어진다.

`PickDaySheet`는 보드의 "보관함 일정을 날짜로 옮기기"에서 계속 쓰이므로 그대로 둔다.

### 확인

목킹한 보드에서 2일차(교토) → `장소 검색` → `담기`까지 실제로 눌러 확인했다.

```
URL              ?city=22&date=2026-10-25&q=니조
제목             니조 성
미리 골라진 날짜   2일차 · 교토시 (10-25 일)
```

- 새 테스트 4개: 보던 날짜가 미리 골라짐 · 시각/메모 함께 저장 · 없는 날짜 무시 ·
  보드에서 넘어온 날짜로 담김
- 기존 담기 테스트는 새 흐름(저장 버튼)으로 갱신했고, "고른 순간에는 담기지 않는다"를 함께 단정한다
- `PlaceSearchPage` 25개 · `TripBoardPage` 91개 통과, FE 전체 1064개
- `format:check` · `lint` · `build` 통과
