### PR TITLE
feat : 데스크톱에서는 모드 없이 손잡이로 일정 순서를 바꾼다

### DIFF
--- a/fe/e2e/travel-board-drag.spec.ts
+++ b/fe/e2e/travel-board-drag.spec.ts
@@ -8,6 +8,10 @@ import { expect, type Page, test } from "@playwright/test";
  * 400ms 롱프레스와 드롭을 재현하고, 서버로 나가는 순서 배열까지 확인한다.
  *
  * (터치 감각 자체는 Android Chrome 실기기 확인이 따로 필요하다 — 자동화로 대체할 수 없다.)
+ *
+ * <p><b>터치 전용 스펙이다</b>(#1223). 길게 눌러 모드에 들어가는 길은 손가락에만 있다 —
+ * 스크롤과 집어 올리기를 가를 방법이 그것뿐이기 때문이다. 마우스는 모드 없이 손잡이로 끌고,
+ * 그쪽은 travel-mouse-reorder.spec.ts가 본다. 그래서 이 파일은 mobile-touch 프로젝트에서만 돈다.
  */
 
 const TRIP_ID = 1;

--- a/fe/e2e/travel-day-city.spec.ts
+++ b/fe/e2e/travel-day-city.spec.ts
@@ -194,7 +194,7 @@ test.describe("날짜 달력 · 기준 도시", () => {
     await expect(sheet).toContainText("지금은 도쿄");
   });
 
-  test("일정 행을 누르면 드래그 모드일 뿐 도시 시트는 열리지 않는다", async ({
+  test("일정 행을 길게 눌러도 도시 시트는 열리지 않는다 — 시트는 날짜 칸의 것이다", async ({
     page,
   }) => {
     await mockBoard(page);
@@ -203,8 +203,10 @@ test.describe("날짜 달력 · 기준 도시", () => {
 
     await press(page, 'text="센소지"', 600);
 
-    await expect(page.getByRole("button", { name: "완료" })).toBeVisible();
     await expect(page.getByRole("dialog")).toBeHidden();
+    // 데스크톱에는 들어갈 드래그 모드가 없다(#1223) — 길게 눌러도 아무 일도 일어나지 않는다.
+    // 손가락으로 길게 눌러 모드에 들어가는 쪽은 travel-board-drag.spec.ts가 본다.
+    await expect(page.getByRole("button", { name: "완료" })).toBeHidden();
   });
 
   test("시트에서 도시를 고르면 그 날짜만 바꾸는 요청이 나간다", async ({

--- a/fe/e2e/travel-mouse-reorder.spec.ts
+++ b/fe/e2e/travel-mouse-reorder.spec.ts
@@ -1,0 +1,237 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * 마우스로 일정 순서 바꾸기(#1223).
+ *
+ * <p>데스크톱에는 <b>드래그 모드가 없다.</b> 롱프레스는 스크롤과 집어 올리기를 가르기 위한
+ * 손가락의 관용구고, 마우스에는 그 문제가 없어 배운 적 없는 동작이 된다. 대신 행에 마우스를
+ * 올리면 손잡이가 나오고 거기서 곧바로 끈다.
+ *
+ * <p>이 파일은 chromium(데스크톱) 프로젝트에서만 돈다 — mobile-touch에서는 `(pointer: fine)`이
+ * 거짓이라 손잡이 자체가 없다. 터치 쪽은 travel-board-drag.spec.ts가 본다.
+ */
+
+const TRIP_ID = 1;
+
+const TOKYO = {
+  placeId: 21,
+  name: "도쿄",
+  timezone: "Asia/Tokyo",
+  currency: "JPY",
+  countryCode: "JP",
+  cityPlaceRef: null,
+  lat: null,
+  lng: null,
+};
+
+const DAYS = [
+  {
+    dayId: 501,
+    dayIndex: 1,
+    date: "2026-10-24",
+    weekday: "토",
+    activityCount: 3,
+    baseCity: TOKYO,
+    cityChanged: false,
+    legIndex: 1,
+    cityMemo: null,
+    weather: null,
+    stayTonight: null,
+    stayCheckout: null,
+  },
+  {
+    dayId: 502,
+    dayIndex: 2,
+    date: "2026-10-25",
+    weekday: "일",
+    activityCount: 0,
+    baseCity: TOKYO,
+    cityChanged: false,
+    legIndex: 1,
+    cityMemo: null,
+    weather: null,
+    stayTonight: null,
+    stayCheckout: null,
+  },
+];
+
+const ok = (data: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ code: "OK", data }),
+});
+
+function activity(id: number, title: string, sortOrder: number) {
+  return {
+    id,
+    tripId: TRIP_ID,
+    title,
+    activityDate: "2026-10-24",
+    startTime: null,
+    place: null,
+    memo: null,
+    url: null,
+    notifyEnabled: false,
+    notifyMinutes: null,
+    departureNotifyEnabled: false,
+    sortOrder,
+    hasLog: false,
+  };
+}
+
+interface Captured {
+  orders: { date: string | null; activityIds: number[] }[][];
+}
+
+async function mockBoard(page: Page): Promise<Captured> {
+  const captured: Captured = { orders: [] };
+
+  await page.route("**/api/auth/reissue", (route) =>
+    route.fulfill(ok({ accessToken: "mock-access-token" })),
+  );
+  await page.route("**/api/planner/reviews/summary", (route) =>
+    route.fulfill(
+      ok({
+        today: "2026-10-24",
+        counts: { now: 0, overdue: 0, upcoming: 0, doneToday: 0 },
+        estimatedMinutes: 0,
+        materials: [],
+      }),
+    ),
+  );
+  await page.route("**/api/travel/summary", (route) =>
+    route.fulfill(ok({ ongoing: null, next: null, recentCompleted: null })),
+  );
+  await page.route("**/api/travel/trips/*/stays", (route) =>
+    route.fulfill(ok([])),
+  );
+
+  await page.route(
+    `**/api/travel/trips/${TRIP_ID}/activities/order`,
+    async (route) => {
+      const body = route.request().postDataJSON() as {
+        moves: { date: string | null; activityIds: number[] }[];
+      };
+      captured.orders.push(body.moves);
+      return route.fulfill(ok({ moves: [] }));
+    },
+  );
+
+  await page.route(`**/api/travel/trips/${TRIP_ID}/board*`, (route) => {
+    const url = new URL(route.request().url());
+    const isArchive = url.searchParams.get("archive") === "true";
+    const date = url.searchParams.get("date") ?? DAYS[0].date;
+    return route.fulfill(
+      ok({
+        trip: {
+          id: TRIP_ID,
+          title: "도쿄 3박 4일",
+          startDate: DAYS[0].date,
+          endDate: DAYS[1].date,
+          status: "UPCOMING",
+          recordMode: false,
+          cityCount: 1,
+          countryCount: 1,
+          singleCity: true,
+        },
+        days: DAYS,
+        selectedDate: isArchive ? null : date,
+        archiveCount: 0,
+        activities:
+          isArchive || date !== DAYS[0].date
+            ? []
+            : [
+                activity(1, "센소지", 0),
+                activity(2, "우에노", 1),
+                activity(3, "디즈니씨", 2),
+              ],
+        moves: [],
+        stayMove: null,
+      }),
+    );
+  });
+
+  return captured;
+}
+
+async function openBoard(page: Page) {
+  await page.goto(`/travel/trips/${TRIP_ID}/board`);
+  await expect(page.getByText("센소지", { exact: true })).toBeVisible();
+}
+
+test.describe("마우스로 순서 바꾸기", () => {
+  test("행에 마우스를 올리면 손잡이가 나온다 — 길게 누를 필요가 없다", async ({
+    page,
+  }) => {
+    await mockBoard(page);
+    await openBoard(page);
+
+    const handle = page.getByRole("button", { name: "센소지 순서 바꾸기" });
+    await expect(handle).toBeAttached();
+    // 평소엔 투명하다 — 줄마다 아이콘이 늘어서 있으면 목록이 읽히지 않는다.
+    // (포커스로도 나와야 해서 감추는 대신 투명하게 둔다 — DOM에는 늘 있다.)
+    const tools = page.locator("[data-row-tools]").first();
+    await expect(tools).toHaveCSS("opacity", "0");
+
+    await page.getByText("센소지", { exact: true }).hover();
+    await expect(tools).toHaveCSS("opacity", "1");
+
+    // 데스크톱에는 들어갈 모드가 없다.
+    await expect(page.getByText("드래그 모드 · 순서를 바꾸면")).toBeHidden();
+  });
+
+  test("손잡이를 끌면 그 날짜의 전체 배열이 서버로 간다", async ({ page }) => {
+    const captured = await mockBoard(page);
+    await openBoard(page);
+
+    const first = page.getByText("센소지", { exact: true });
+    const third = page.getByText("디즈니씨", { exact: true });
+    await first.hover();
+
+    const handle = page.getByRole("button", { name: "센소지 순서 바꾸기" });
+    const from = await handle.boundingBox();
+    const to = await third.boundingBox();
+    if (!from || !to) throw new Error("손잡이나 목표 행을 찾지 못했다");
+
+    await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+    await page.mouse.down();
+    // 여러 번 나눠 움직여야 dnd-kit의 충돌 판정이 중간 위치를 인식한다.
+    for (let i = 1; i <= 5; i++) {
+      await page.mouse.move(
+        from.x + from.width / 2,
+        from.y + from.height / 2 + ((to.y - from.y) * i) / 5,
+        { steps: 4 },
+      );
+    }
+    await page.mouse.up();
+
+    await expect.poll(() => captured.orders.length).toBe(1);
+    expect(captured.orders[0]).toEqual([
+      { date: "2026-10-24", activityIds: [2, 3, 1] },
+    ]);
+  });
+
+  test("끌지 않고 버튼으로도 옮긴다 — 끌기의 대안이다 (WCAG 2.5.7)", async ({
+    page,
+  }) => {
+    const captured = await mockBoard(page);
+    await openBoard(page);
+
+    await page.getByText("센소지", { exact: true }).hover();
+    await page.getByRole("button", { name: "센소지 아래로" }).click();
+
+    await expect.poll(() => captured.orders.length).toBe(1);
+    expect(captured.orders[0]).toEqual([
+      { date: "2026-10-24", activityIds: [2, 1, 3] },
+    ]);
+  });
+
+  test("행 본문을 누르면 상세로 간다 — 손잡이만 끌기다", async ({ page }) => {
+    await mockBoard(page);
+    await openBoard(page);
+
+    await page.getByText("센소지", { exact: true }).click();
+
+    await expect(page).toHaveURL(/\/travel\/activities\/1/);
+  });
+});

--- a/fe/playwright.config.ts
+++ b/fe/playwright.config.ts
@@ -12,7 +12,9 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      testIgnore: /(service-worker|offline)\.spec\.ts/,
+      // 길게 눌러 드래그 모드에 들어가는 길은 <b>터치 전용</b>이다(#1223) — 마우스는 모드 없이
+      // 손잡이로 끈다. 데스크톱 쪽은 travel-mouse-reorder.spec.ts가 본다.
+      testIgnore: /(service-worker|offline|travel-board-drag)\.spec\.ts/,
       use: { browserName: "chromium" },
     },
     // SW·precache는 빌드 결과에서만 확인된다. dev 서버에는 SW가 없다.

--- a/fe/src/features/travel/board/ActivityRow.tsx
+++ b/fe/src/features/travel/board/ActivityRow.tsx
@@ -45,6 +45,11 @@ interface ActivityRowProps {
   onDelete: () => void;
   /** 400ms 길게 눌러 드래그 모드로 들어간다. */
   onEnterDragMode: () => void;
+  /**
+   * 마우스·트랙패드인가. 그러면 <b>모드 없이</b> 손잡이로 곧바로 끈다 —
+   * 롱프레스는 스크롤과 구분해야 하는 손가락의 관용구지, 마우스가 배운 동작이 아니다.
+   */
+  pointerFine: boolean;
 }
 
 /**
@@ -67,25 +72,51 @@ export function ActivityRow({
   onPickDay,
   onDelete,
   onEnterDragMode,
+  pointerFine,
 }: ActivityRowProps) {
   // 날짜 탭이 쓰는 것과 같은 이름으로 — 같은 도시가 화면마다 다른 글자면 안 된다.
   const cityLabel = cityLabelOf(activity.place, cities);
-  // 드래그는 모드에 들어온 뒤에만 활성화한다 — 그 전에는 목록을 세로로 스크롤해야 한다.
+  /**
+   * 손가락은 <b>모드에 들어온 뒤에만</b> 끌 수 있다 — 그 전에는 목록을 세로로 스크롤해야 하고,
+   * 두 손짓을 가를 방법이 롱프레스뿐이다. 마우스는 그 문제가 없어 언제나 끌 수 있고,
+   * 대신 <b>손잡이에서만</b> 시작한다(본문 클릭은 상세로 가야 한다).
+   */
+  const handleDrag = pointerFine && !dragMode && !offline;
   const {
     attributes,
     listeners,
     setNodeRef,
+    setActivatorNodeRef,
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: activity.id, disabled: !dragMode });
+  } = useSortable({ id: activity.id, disabled: !dragMode && !handleDrag });
 
-  const longPress = useLongPress(onEnterDragMode, !dragMode && !offline);
+  // 데스크톱에는 들어갈 모드가 없다.
+  const longPress = useLongPress(
+    onEnterDragMode,
+    !dragMode && !offline && !pointerFine,
+  );
 
   // 드래그 모드가 아니면 dnd 속성을 아예 붙이지 않는다. `disabled`인 sortable은
   // `role="button" aria-disabled="true"`를 남기는데, 그러면 행 전체가 "비활성 버튼"으로
   // 읽혀 안의 링크를 누를 수 없다(스크린리더에도 그렇게 들린다).
   const dragProps = dragMode ? { ...attributes, ...listeners } : {};
+
+  /**
+   * 손잡이에 붙는 것들. 행이 아니라 여기서만 드래그가 시작된다.
+   *
+   * <p>포인터를 행으로 흘려보내지 않는다 — 흘리면 스와이프(좌우)가 같이 깨어나 세로로 끄는
+   * 동안 행이 옆으로 밀린다. 손잡이 자신의 리스너는 이미 이 시점에 실행된 뒤다.
+   */
+  const handleProps = {
+    ...attributes,
+    ...listeners,
+    onPointerDown: (e: ReactPointerEvent) => {
+      listeners?.onPointerDown?.(e);
+      e.stopPropagation();
+    },
+  };
 
   /**
    * 버튼 위에서 시작한 포인터는 드래그로 넘기지 않는다.
@@ -117,7 +148,7 @@ export function ActivityRow({
       <div
         style={{ transform: `translateX(${swipe.offset}px)` }}
         className={cn(
-          "hover:bg-muted bg-background grid grid-cols-[52px_1fr_auto] items-start gap-2 rounded-lg px-2 py-2.5",
+          "group/row hover:bg-muted bg-background grid grid-cols-[52px_1fr_auto] items-start gap-2 rounded-lg px-2 py-2.5",
           !swipe.dragging && "transition-transform",
           isDragging && "bg-card ring-primary scale-[1.01] shadow-lg ring-2",
         )}
@@ -208,6 +239,47 @@ export function ActivityRow({
             </>
           ) : (
             <>
+              {/* 데스크톱 전용 순서 조작. 평소엔 숨어 있다가 행에 마우스를 올리거나
+                  키보드 포커스가 들어오면 나온다 — 늘 떠 있으면 줄마다 아이콘이 다섯 개다.
+                  위/아래 버튼은 장식이 아니라 <b>끌기의 대안</b>이다(WCAG 2.2 SC 2.5.7):
+                  끌기로 되는 일은 단일 포인터로도 돼야 한다. */}
+              {handleDrag && (
+                <span
+                  data-row-tools=""
+                  className="flex items-center opacity-0 transition-opacity group-hover/row:opacity-100 focus-within:opacity-100"
+                >
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label={`${activity.title} 위로`}
+                    disabled={!canMoveUp}
+                    onClick={onMoveUp}
+                    {...stopDrag}
+                  >
+                    <ChevronUp className="size-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label={`${activity.title} 아래로`}
+                    disabled={!canMoveDown}
+                    onClick={onMoveDown}
+                    {...stopDrag}
+                  >
+                    <ChevronDown className="size-4" />
+                  </Button>
+                  {/* 손잡이는 버튼이다 — 키보드로 잡고(Space) 화살표로 옮길 수 있어야 한다. */}
+                  <button
+                    ref={setActivatorNodeRef}
+                    type="button"
+                    aria-label={`${activity.title} 순서 바꾸기`}
+                    className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 flex size-8 cursor-grab items-center justify-center rounded-md focus-visible:ring-2 focus-visible:outline-none active:cursor-grabbing"
+                    {...handleProps}
+                  >
+                    <GripVertical className="size-4" />
+                  </button>
+                </span>
+              )}
               {activity.notifyEnabled && (
                 <Bell
                   aria-label="알림 켜짐"

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -966,6 +966,112 @@ describe("TripBoardPage", () => {
     });
   });
 
+  describe("마우스로 순서 바꾸기 (#1223)", () => {
+    /**
+     * 주 입력 장치를 마우스로 바꾼다. 폭이 아니라 <b>입력 장치</b>가 기준이므로
+     * 뷰포트는 건드리지 않는다.
+     */
+    function setFinePointer() {
+      const original = window.matchMedia;
+      window.matchMedia = ((query: string) => ({
+        matches: query.includes("pointer: fine"),
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      })) as unknown as typeof window.matchMedia;
+      return () => {
+        window.matchMedia = original;
+      };
+    }
+
+    it("길게 누르지 않아도 손잡이와 이동 버튼이 있다 — 모드에 들어갈 필요가 없다", async () => {
+      const restore = setFinePointer();
+      try {
+        mockBoard({
+          byDate: {
+            "2026-10-24": [
+              activity(),
+              activity({ id: 2, title: "디즈니씨", sortOrder: 1 }),
+            ],
+          },
+        });
+
+        renderBoard();
+
+        expect(
+          await screen.findByRole("button", { name: "센소지 순서 바꾸기" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("button", { name: "센소지 아래로" }),
+        ).toBeEnabled();
+        // 첫 줄은 더 올라갈 곳이 없다.
+        expect(
+          screen.getByRole("button", { name: "센소지 위로" }),
+        ).toBeDisabled();
+        // 드래그 모드에 들어간 적이 없으므로 모드 바도 없다.
+        expect(
+          screen.queryByRole("button", { name: "완료" }),
+        ).not.toBeInTheDocument();
+      } finally {
+        restore();
+      }
+    });
+
+    it("이동 버튼을 누르면 그 날짜의 순서가 서버로 간다 — 끌기의 대안이다 (SC 2.5.7)", async () => {
+      const restore = setFinePointer();
+      try {
+        const moves: unknown[] = [];
+        server.use(
+          http.put(
+            `${API_BASE}/travel/trips/:tripId/activities/order`,
+            async ({ request }) => {
+              moves.push(await request.json());
+              return HttpResponse.json({ code: "OK", data: { moves: [] } });
+            },
+          ),
+        );
+        mockBoard({
+          byDate: {
+            "2026-10-24": [
+              activity(),
+              activity({ id: 2, title: "디즈니씨", sortOrder: 1 }),
+            ],
+          },
+        });
+
+        renderBoard();
+        await userEvent.click(
+          await screen.findByRole("button", { name: "센소지 아래로" }),
+        );
+
+        await waitFor(() => expect(moves).toHaveLength(1));
+        expect(moves[0]).toEqual({
+          moves: [{ date: "2026-10-24", activityIds: [2, 1] }],
+        });
+      } finally {
+        restore();
+      }
+    });
+
+    it("손가락에는 손잡이를 내주지 않는다 — 길게 눌러 모드로 들어가는 길이 그대로다", async () => {
+      mockBoard({ byDate: { "2026-10-24": [activity()] } });
+
+      renderBoard();
+      await screen.findByText("센소지");
+
+      expect(
+        screen.queryByRole("button", { name: "센소지 순서 바꾸기" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "센소지 아래로" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe("빈 상태", () => {
     it("일정 없는 날짜와 빈 보관함의 문구가 다르다", async () => {
       mockBoard({ byDate: { "2026-10-24": [] }, archive: [] });

--- a/fe/src/pages/travel/TripBoardPage.tsx
+++ b/fe/src/pages/travel/TripBoardPage.tsx
@@ -88,6 +88,7 @@ import { StayFormSheet } from "@/features/travel/stay/StayFormSheet";
 import { StaySheet } from "@/features/travel/stay/StaySheet";
 import { toast } from "@/shared/lib/toast";
 import { useOnline } from "@/shared/lib/useOnline";
+import { usePointerFine } from "@/shared/lib/usePointerFine";
 
 /** `?day=` 값 — 0부터 시작하는 일차 인덱스, 또는 보관함. */
 const ARCHIVE = "archive";
@@ -161,6 +162,8 @@ export function TripBoardPage() {
   const [stayError, setStayError] = useState<string | null>(null);
   // 오프라인은 조회 전용이다(§4.6). 편집을 막는 게 아니라 진입 자체를 없앤다.
   const online = useOnline();
+  // 마우스면 드래그 모드 없이 손잡이로 끈다 — 롱프레스는 손가락의 관용구다.
+  const pointerFine = usePointerFine();
 
   // 숙소는 여행 전체를 한 번에 읽는다 — 어느 날짜에 붙는지는 기간에서 파생한다.
   const { data: stays } = useStays(tripId);
@@ -666,6 +669,7 @@ export function TripBoardPage() {
                     onPickDay={() => setPickingDayFor(activity)}
                     onDelete={() => removeActivityDeferred(activity)}
                     onEnterDragMode={() => {}}
+                    pointerFine={pointerFine}
                   />
                 ))}
               </ul>
@@ -701,6 +705,7 @@ export function TripBoardPage() {
                     onArchive={() => archiveActivity(activity)}
                     onDelete={() => removeActivityDeferred(activity)}
                     onEnterDragMode={enterDragMode}
+                    pointerFine={pointerFine}
                   />
                 </Fragment>
               ))}

--- a/fe/src/shared/lib/usePointerFine.ts
+++ b/fe/src/shared/lib/usePointerFine.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+
+/**
+ * 주 입력 장치가 정밀 포인터(마우스·트랙패드)인가.
+ *
+ * <p>화면 <b>폭</b>이 아니라 <b>입력 장치</b>로 갈라야 하는 자리가 있다. 길게 눌러 무언가를
+ * 시작하는 제스처가 그렇다 — 롱프레스는 터치의 관용구다. 손가락은 스크롤과 집어 올리기를
+ * 구분할 방법이 그것뿐이지만, 마우스에는 그 문제가 없어서 배운 적 없는 동작이 된다.
+ *
+ * <p>폭으로 가르면 마우스를 붙인 태블릿이나 좁게 띄운 데스크톱 창에서 어긋난다.
+ */
+const FINE_POINTER_QUERY = "(pointer: fine)";
+
+/**
+ * 마우스·트랙패드면 true. 장치를 바꿔 꽂으면 따라 바뀐다.
+ * matchMedia가 없는 환경(테스트 jsdom)은 <b>터치로 간주</b>한다(false) — 손가락 쪽이
+ * 제약이 많은 입력이라, 모르면 그쪽에 맞추는 편이 안전하다.
+ */
+export function usePointerFine(): boolean {
+  const [fine, setFine] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia(FINE_POINTER_QUERY).matches,
+  );
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const mq = window.matchMedia(FINE_POINTER_QUERY);
+    const handler = () => setFine(mq.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  return fine;
+}


### PR DESCRIPTION
## 이슈
closes #1223

## 작업 내용

마우스에는 "스크롤하려는 손짓"과 "집어 올리는 손짓"의 모호함이 없다. 롱프레스는 그 모호함을
가르기 위한 **손가락의 관용구**라, 데스크톱에서는 해결하는 문제가 없는 제약이었다.

### 입력 장치로 가른다 — 화면 폭이 아니라

`usePointerFine()` = `matchMedia("(pointer: fine)")`. 폭으로 가르면 마우스를 붙인 태블릿이나
좁게 띄운 데스크톱 창에서 어긋난다. `matchMedia`가 없는 환경(jsdom)은 **터치로 간주**한다 —
제약이 많은 쪽에 맞추는 편이 안전하다.

### 데스크톱: 모드 없이 손잡이

- 행에 마우스를 올리면 손잡이(⠿)와 위/아래 버튼이 드러난다. 평소엔 투명하다 —
  늘 떠 있으면 줄마다 아이콘이 다섯 개다. **포커스로도 드러나므로** 감추지 않고 투명하게 둔다
- 드래그 소스는 **손잡이뿐**이다. 행 본문 클릭은 그대로 상세로 간다
- 손잡이는 `<button>` + `setActivatorNodeRef`라 키보드로 잡고(Space) 화살표로 옮길 수 있다
- 손잡이의 포인터는 행으로 흘려보내지 않는다 — 흘리면 스와이프가 같이 깨어나 세로로 끄는 동안
  행이 옆으로 밀린다

### 끌기의 대안을 데스크톱에도 (WCAG 2.2 SC 2.5.7, AA)

끌기로 되는 일은 단일 포인터로도 돼야 한다. 위/아래 버튼이 지금까지 **드래그 모드 안에만**
있어서, 모드를 없애면 그 대안까지 사라진다. 손잡이 옆에 함께 세웠다.

### 터치는 그대로

롱프레스 → 드래그 모드 → 행 전체가 드래그 소스. 스크롤과 가를 방법이 그것뿐이다.

### 센서는 그대로 뒀다

조사 단계에서는 `MouseSensor`/`TouchSensor` 분리를 후보로 봤는데, 이 앱에서 갈리는 것은
**활성화 조건(distance 8)이 아니라 무엇이 드래그 소스인가**(손잡이 vs 행)와 **모드가 필요한가**다.
둘 다 같은 constraint를 쓰므로 `PointerSensor` 하나를 유지했다 — 센서를 쪼개도 동작이 같고
움직이는 부품만 늘어난다.

## 확인

### E2E를 입력 장치별로 갈랐다

- `travel-board-drag.spec.ts` → **mobile-touch 전용**(chromium에서 제외). 롱프레스로 모드에
  들어가는 길은 손가락에만 있다
- `travel-mouse-reorder.spec.ts` **신설**(chromium 전용) — 실제 마우스로:
  - hover 전 `opacity: 0` → hover 시 `1`, 드래그 모드 바는 없음
  - 손잡이를 끌면 그 날짜의 전체 배열이 서버로 감 (`[2, 3, 1]`)
  - 버튼으로도 옮김 (`[2, 1, 3]`) — SC 2.5.7 대안
  - 행 본문 클릭은 상세로
- `travel-day-city.spec.ts`의 "행을 누르면 드래그 모드" 단정을 데스크톱 사실에 맞췄다.
  이 테스트가 지키려던 것(행을 눌러도 **도시 시트**가 열리지 않는다)은 그대로 단정한다

### 통과

- 단위 3개 추가(손잡이·이동 버튼 노출 / 이동 버튼 → 순서 요청 / 터치에는 손잡이 없음)
- `TripBoardPage` 94개, FE 전체 1062개
- E2E 99개(chromium + built + mobile-touch) 전부 통과
- `format:check` · `lint` · `build` 통과
