### PR TITLE
fix : Space로 답 열기 테스트의 포커스 경합을 없앤다

### DIFF
--- a/fe/src/pages/planner/ReviewSessionPage.test.tsx
+++ b/fe/src/pages/planner/ReviewSessionPage.test.tsx
@@ -365,11 +365,14 @@ describe("ReviewSessionPage", () => {
       const user = userEvent.setup();
       renderPage();
 
-      await waitFor(() => {
-        expect(screen.getByText("질문 1")).toBeInTheDocument();
-      });
+      // 자동 포커스는 useEffect에서 일어난다(ReviewCard). React는 DOM 반영과 패시브 이펙트를
+      // 따로 흘리므로, 화면에 질문이 보인다고 해서 포커스가 이미 들어온 것은 아니다.
+      // 들어오기 전에 빼면 blur가 헛돌고, 뒤늦게 들어온 포커스가 Space를 삼킨다.
+      const note = await screen.findByLabelText("내 답");
+      await waitFor(() => expect(note).toHaveFocus());
+
       // 자동 포커스된 입력칸에서 포커스를 뺀다(기존 Space 단축키가 그대로 사는지)
-      (document.activeElement as HTMLElement | null)?.blur();
+      note.blur();
 
       await user.keyboard(" ");
       expect(await screen.findByText("답 1")).toBeInTheDocument();


### PR DESCRIPTION
## 이슈
closes #1225

## 작업 내용

`입력칸 밖에 포커스가 있으면 Space로도 답이 열린다`가 CI에서 간헐적으로 실패했다(#1220).
코드 변경 없이 재실행하면 통과했다.

원인은 **테스트가 포커스를 기다리지 않는 것**이다.

```ts
await waitFor(() => expect(screen.getByText("질문 1")).toBeInTheDocument());
(document.activeElement as HTMLElement | null)?.blur();   // ← 아직 안 들어왔을 수 있다
await user.keyboard(" ");
```

`ReviewCard`는 카드가 뜨면 **useEffect에서** 입력칸에 포커스를 준다(`ReviewCard.tsx:74-79`).
화면에 질문이 보이는 시점과 그 이펙트가 flush되는 시점은 같지 않다. 포커스가 `blur()` **뒤**,
`keyboard(" ")` **앞**에 들어오면

1. `blur()`가 헛돌고 (뺄 포커스가 아직 없다)
2. 뒤늦게 입력칸이 포커스를 받고
3. Space가 입력칸으로 들어가 `isTypingTarget`에 걸려 무시된다 → 답이 안 열림

**포커스가 들어온 것을 확인한 뒤 빼도록** 고쳤다.

## 재현과 확인

추측으로 끝내지 않고, 그 창을 실제로 열어 재현했다 —
`ReviewCard`의 포커스를 한 틱 미루고(`setTimeout(..., 0)`) 돌렸다.

| | 기존 테스트 | 이 PR |
|---|---|---|
| 포커스 한 틱 지연 | **실패** — `Unable to find ... 답 1` (1052ms) | 통과 |
| 지연 없음 | 통과 | 통과 |

실패 메시지와 소요 시간(1052ms)이 CI에서 났던 것(1047ms)과 같다 — 같은 실패다.
확인 뒤 지연 주입은 되돌렸고, 이 PR은 **테스트 파일 한 개만** 바꾼다.

- `ReviewSessionPage` 15개, FE 전체 1067개 통과
- `format:check` · `lint` 통과
