### PR TITLE
docs : FE 품질 게이트에 E2E를 넣는다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,10 +108,15 @@ npm run test:e2e:ui   # E2E tests with UI
 |---|---|
 | BE | `cd be && ./gradlew check` (테스트 + Checkstyle, 경고 0) |
 | FE | `cd fe && npm run format:check && npm run lint && npm test && npm run build` |
+| FE (E2E) | `cd fe && npm run test:e2e` — **화면·상호작용을 바꿨다면 전체로** |
 | Infra (YAML) | `yamllint -c .yamllint.yml infra/` |
 | Infra (Helm) | `helm lint infra/helm/<app>` · `helm template infra/helm/<app> \| kubeconform -strict` |
 | Terraform | `cd infra/terraform && terraform fmt -check -recursive` |
 
+- FE CI는 유닛 뒤에 **E2E까지** 돌린다. 바꾼 화면 이름으로 스펙을 골라 일부만 돌리면 놓친다 —
+  다른 스펙이 그 화면을 지나갈 수 있다(전체 실행 ~50초).
+- `playwright.config.ts`는 chromium(데스크톱) · built(preview) · mobile-touch 세 프로젝트다.
+  입력 장치나 화면 폭으로 갈리는 동작을 넣으면 같은 스펙이 프로젝트마다 다르게 돈다.
 - pre-commit 훅(husky + lint-staged, BE Checkstyle)을 `--no-verify`로 우회하지 않는다.
 - CI는 경로별로 나뉜다: `be/**` → BE CI(Gradle build + Trivy), `fe/**` → FE CI,
   `infra/**` → Infra CI(yamllint · helm lint · kubeconform), `infra/terraform/**` → Terraform,


### PR DESCRIPTION
## 이슈

관련 이슈 없음 — #1222 CI 실패에서 드러난 문서 누락을 바로잡는다.

## 작업 내용

FE CI는 `fe-ci.yml`에서 유닛·빌드 뒤에 **`npm run test:e2e`까지** 돌리는데,
CLAUDE.md의 품질 게이트 표에는 그 줄이 없었다. 표만 보고 로컬 검증을 끝내면 E2E는 CI에서 처음 돈다.

- 게이트 표에 `FE (E2E)` 줄을 추가한다
- **바꾼 화면 이름으로 스펙을 골라 일부만 돌리지 말 것**을 적는다.
  #1222에서 담기 시트를 바꾸고 관련 스펙 3개만 돌렸는데, 손대지 않은 `travel-search-city.spec.ts`가
  그 시트를 지나가며 CI에서 깨졌다. 전체 실행은 ~50초다
- `playwright.config.ts`가 chromium · built · mobile-touch 세 프로젝트라,
  입력 장치·화면 폭으로 갈리는 동작은 프로젝트마다 다르게 돈다는 점도 적는다(#1224에서 실제로 갈렸다)

문서만 바뀐다.