### PR TITLE
fix : 숙소 배지에서 "오늘"을 뺀다

### DIFF
--- a/fe/e2e/travel-stay.spec.ts
+++ b/fe/e2e/travel-stay.spec.ts
@@ -171,7 +171,7 @@ test.describe("숙소", () => {
 
     // 저장 → 보드 무효화 → 배지. 체크인하는 날이라 시각이 함께 붙는다.
     const badge = page.getByRole("button", {
-      name: "숙소 도톤보리 호텔 · 오늘 체크인 15:00",
+      name: "숙소 도톤보리 호텔 · 체크인 15:00",
     });
     await expect(badge).toBeVisible();
 

--- a/fe/src/features/travel/api/activities.ts
+++ b/fe/src/features/travel/api/activities.ts
@@ -101,7 +101,7 @@ export interface BoardDay {
   arrivingFromWeather?: DailyWeather | null;
   /** 오늘 밤 자는 곳(`checkIn <= date < checkOut`). 없으면 null. */
   stayTonight: StayTonight | null;
-  /** 오늘 체크아웃하는 곳. 없으면 null. */
+  /** 그날 체크아웃하는 곳. 없으면 null. */
   stayCheckout: StayCheckout | null;
 }
 
@@ -117,7 +117,7 @@ export interface StayTonight {
   sameCity: boolean;
   /** 벽시계 시각(`15:00`). 없으면 null. */
   checkInTime: string | null;
-  /** 오늘 체크인하는 날인가 — 배지에 시각을 함께 보여줄지 가른다. */
+  /** 그날 체크인하는 날인가 — 배지에 시각을 함께 보여줄지 가른다. */
   isCheckInDay: boolean;
 }
 

--- a/fe/src/features/travel/lib/stayBadge.test.ts
+++ b/fe/src/features/travel/lib/stayBadge.test.ts
@@ -43,8 +43,8 @@ describe("숙소 배지", () => {
     );
 
     expect(items).toEqual([
-      { stayId: 76, name: "도톤보리 호텔", note: "오늘 체크아웃 11:00" },
-      { stayId: 77, name: "교토 게스트하우스", note: "오늘 체크인 15:00" },
+      { stayId: 76, name: "도톤보리 호텔", note: "체크아웃 11:00" },
+      { stayId: 77, name: "교토 게스트하우스", note: "체크인 15:00" },
     ]);
   });
 
@@ -74,7 +74,7 @@ describe("숙소 배지", () => {
       day({ stayTonight: { ...KYOTO, checkInTime: null } }),
     );
 
-    expect(items[0].note).toBe("오늘 체크인");
+    expect(items[0].note).toBe("체크인");
   });
 
   it("체크아웃 시각을 몰라도 체크아웃이라고 말한다 — 시각을 지어내지 않는다", () => {
@@ -82,7 +82,7 @@ describe("숙소 배지", () => {
       day({ stayCheckout: { ...DOTONBORI, checkOutTime: null } }),
     );
 
-    expect(items[0].note).toBe("오늘 체크아웃");
+    expect(items[0].note).toBe("체크아웃");
   });
 
   it("이어서 묵는 날에는 꼬리표를 붙이지 않는다 — 체크인은 지난 일이다", () => {
@@ -97,7 +97,7 @@ describe("숙소 배지", () => {
     const items = stayBadges(day({ stayCheckout: DOTONBORI }));
 
     expect(items).toHaveLength(1);
-    expect(items[0].note).toBe("오늘 체크아웃 11:00");
+    expect(items[0].note).toBe("체크아웃 11:00");
   });
 
   it("둘 다 없으면 비어 있다 — 화면은 그 자리에 `숙소 추가`를 세운다", () => {

--- a/fe/src/features/travel/lib/stayBadge.ts
+++ b/fe/src/features/travel/lib/stayBadge.ts
@@ -4,7 +4,7 @@ import type { BoardDay } from "@/features/travel/api/activities";
 export interface StayBadgeItem {
   stayId: number;
   name: string;
-  /** `오늘 체크아웃 11:00`처럼 붙는 꼬리표. 붙일 게 없으면 null. */
+  /** `체크아웃 11:00`처럼 붙는 꼬리표. 붙일 게 없으면 null. */
   note: string | null;
 }
 
@@ -16,7 +16,12 @@ export interface StayBadgeItem {
  * 읽혔다. 숙소는 하루의 <b>테두리</b>지 일정 사이의 칸막이가 아니다.
  *
  * <p>순서는 <b>체크아웃이 먼저</b>다(§3.5). 아침에 이 화면을 열었을 때 급한 정보는
- * "오늘 어디서 자나"가 아니라 "몇 시에 나가야 하나"다.
+ * "어디서 자나"가 아니라 "몇 시에 나가야 하나"다.
+ *
+ * <p>꼬리표에 <b>"오늘"을 붙이지 않는다.</b> 이 배지는 오늘이 아니라 <b>보고 있는 날짜</b>의
+ * 것이다 — 일정은 여행 당일에만 보는 게 아니라 평소에 미리 짜고 고친다. 출발 2주 전에 3일차를
+ * 열었는데 "오늘 체크인"이라고 하면 읽는 사람과 화면이 서로 다른 날을 가리킨다.
+ * 어느 날인지는 달력 헤더가 이미 말한다.
  */
 export function stayBadges(day: BoardDay | null): StayBadgeItem[] {
   const badges = [checkoutItem(day), tonightItem(day)].filter(
@@ -34,7 +39,7 @@ function checkoutItem(day: BoardDay | null): StayBadgeItem | null {
   return {
     stayId,
     name,
-    note: withTime("오늘 체크아웃", checkOutTime),
+    note: withTime("체크아웃", checkOutTime),
   };
 }
 
@@ -46,8 +51,8 @@ function tonightItem(day: BoardDay | null): StayBadgeItem | null {
     name,
     // 체크인하는 날은 <b>시각을 몰라도</b> 체크인이라고 말한다 — 체크아웃 쪽과 같은 규칙이다.
     // 한쪽만 꼬리표가 붙으면 나가는 곳인지 들어가는 곳인지를 이름으로 추측하게 된다.
-    // 이어서 묵는 날은 붙일 말이 없다(체크인은 지난 일이고 체크아웃은 오늘이 아니다).
-    note: isCheckInDay ? withTime("오늘 체크인", checkInTime) : null,
+    // 이어서 묵는 날은 붙일 말이 없다(체크인은 지난 날이고 체크아웃은 아직이다).
+    note: isCheckInDay ? withTime("체크인", checkInTime) : null,
   };
 }
 

--- a/fe/src/features/travel/lib/stayForDay.ts
+++ b/fe/src/features/travel/lib/stayForDay.ts
@@ -7,7 +7,7 @@
  *
  * ```
  * stayTonight(day)  = checkInDate <= day <  checkOutDate   오늘 밤 자는 곳
- * stayCheckout(day) = checkOutDate == day                  오늘 체크아웃하는 곳
+ * stayCheckout(day) = checkOutDate == day                  그날 체크아웃하는 곳
  * ```
  *
  * 보드 응답의 `stayTonight`·`stayCheckout`은 서버가 **같은 규칙으로** 채워 보낸다. 여기 규칙이

--- a/fe/src/pages/travel/TripBoardPage.test.tsx
+++ b/fe/src/pages/travel/TripBoardPage.test.tsx
@@ -2036,7 +2036,7 @@ describe("TripBoardPage", () => {
       // 위는 체크아웃 — 급한 정보가 먼저다.
       expect(
         await screen.findByRole("button", {
-          name: "숙소 도톤보리 호텔 · 오늘 체크아웃 11:00",
+          name: "숙소 도톤보리 호텔 · 체크아웃 11:00",
         }),
       ).toBeInTheDocument();
     });
@@ -2058,12 +2058,12 @@ describe("TripBoardPage", () => {
 
       expect(
         screen.getByRole("button", {
-          name: "숙소 도톤보리 호텔 · 오늘 체크아웃 11:00",
+          name: "숙소 도톤보리 호텔 · 체크아웃 11:00",
         }),
       ).toBeInTheDocument();
       expect(
         screen.getByRole("button", {
-          name: "숙소 교토 게스트하우스 · 오늘 체크인 15:00",
+          name: "숙소 교토 게스트하우스 · 체크인 15:00",
         }),
       ).toBeInTheDocument();
     });


### PR DESCRIPTION
## 이슈
closes #1228

## 작업 내용

숙소 배지가 `오늘 체크아웃 11:00` · `오늘 체크인 15:00`처럼 **오늘**을 붙여 말했다.
이 배지는 오늘이 아니라 **보고 있는 날짜**의 것이다 — 일정은 여행 당일에만 보는 게 아니라
평소에 미리 짜고 고친다. 출발 2주 전에 3일차를 열어도 `오늘 체크인`이라고 나오니
읽는 사람과 화면이 서로 다른 날을 가리켰다. 어느 날인지는 달력 헤더가 이미 말한다.

| 전 | 후 |
|---|---|
| `오늘 체크아웃 11:00` | `체크아웃 11:00` |
| `오늘 체크인` | `체크인` |

- 다시 붙이지 않도록 `stayBadge.ts` 주석에 이유를 남겼다
- 같은 혼동이 코드에도 있었다 — `stayCheckout`/`isCheckInDay`의 API 주석이 "오늘"이라고
  적혀 있어 "그날"로 바꿨다(주석만)
- 홈 카드·여행 목록의 `오늘`은 실제로 오늘을 뜻하므로 건드리지 않았다

## 확인

- `stayBadge` 8개 · `TripBoardPage` 95개, FE 전체 1067개 통과
- **E2E 99개 통과** — `travel-stay.spec.ts`가 실제 브라우저에서 숙소를 저장한 뒤
  배지 이름 `숙소 도톤보리 호텔 · 체크인 15:00`을 직접 단정한다
- `format:check` · `lint` · `build` 통과